### PR TITLE
feat: add metadata generation, indexing, and semantic search

### DIFF
--- a/commands/search.md
+++ b/commands/search.md
@@ -1,11 +1,11 @@
 ---
-description: Search the Agentikit stash for tools, skills, commands, and agents
+description: Search the Agentikit stash for tools, skills, commands, and agents using semantic search
 ---
 
-Search the Agentikit stash using the CLI. Run:
+Search the Agentikit stash using the CLI. If a search index exists, results are ranked by semantic relevance. Run `agentikit index` first to enable semantic search.
 
 ```bash
 agentikit search $ARGUMENTS
 ```
 
-Parse the JSON output and present the results to the user in a readable format. Include the `openRef` for each hit so the user can open or run assets.
+Parse the JSON output and present the results to the user in a readable format. Include the `openRef` for each hit so the user can open or run assets. Results may include `description`, `tags`, and `score` fields when semantic search is active.

--- a/index.ts
+++ b/index.ts
@@ -9,3 +9,6 @@ export type {
   RunResponse,
   InitResponse,
 } from "./src/stash"
+export { agentikitIndex } from "./src/indexer"
+export type { IndexResponse } from "./src/indexer"
+export type { StashEntry, StashFile, StashIntent } from "./src/metadata"

--- a/skills/stash/SKILL.md
+++ b/skills/stash/SKILL.md
@@ -16,9 +16,19 @@ The stash directory is configured via the `AGENTIKIT_STASH_DIR` environment vari
 
 ## Commands
 
+### Build the search index
+
+Scan stash directories, auto-generate missing `.stash.json` metadata, and build a semantic search index.
+
+```bash
+agentikit index
+```
+
+Run this after adding new extensions to enable semantic search ranking.
+
 ### Search the stash
 
-Find assets by name substring. Returns JSON with matching hits including `openRef` identifiers.
+Find assets by semantic similarity (if indexed) or name substring. Returns JSON with matching hits including `openRef` identifiers.
 
 ```bash
 agentikit search [query] [--type tool|skill|command|agent|any] [--limit N]
@@ -50,8 +60,9 @@ Returns the tool's stdout/stderr output and exit code.
 
 ## Workflow
 
-1. Search for assets: `agentikit search "deploy" --type tool`
-2. Inspect a result: `agentikit open <openRef>`
-3. Run a tool: `agentikit run <openRef>`
+1. Build the index: `agentikit index`
+2. Search for assets: `agentikit search "deploy" --type tool`
+3. Inspect a result: `agentikit open <openRef>`
+4. Run a tool: `agentikit run <openRef>`
 
 All output is JSON for easy parsing.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { agentikitSearch, agentikitOpen, agentikitRun, agentikitInit } from "./stash"
+import { agentikitIndex } from "./indexer"
 
 const args = process.argv.slice(2)
 const command = args[0]
@@ -14,6 +15,7 @@ function usage(): never {
   console.error("")
   console.error("Commands:")
   console.error("  init                 Initialize agentikit stash directory and set AGENTIKIT_STASH_DIR")
+  console.error("  index                Build search index with metadata generation")
   console.error("  search [query]       Search the stash (--type tool|skill|command|agent|any) (--limit N)")
   console.error("  open <type:name>     Open a stash asset by ref")
   console.error("  run <type:name>      Run a tool by ref")
@@ -23,6 +25,11 @@ function usage(): never {
 switch (command) {
   case "init": {
     const result = agentikitInit()
+    console.log(JSON.stringify(result, null, 2))
+    break
+  }
+  case "index": {
+    const result = agentikitIndex()
     console.log(JSON.stringify(result, null, 2))
     break
   }

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -1,0 +1,211 @@
+import fs from "node:fs"
+import path from "node:path"
+import type { AgentikitAssetType } from "./stash"
+import {
+  type StashFile,
+  type StashEntry,
+  loadStashFile,
+  writeStashFile,
+  generateMetadata,
+} from "./metadata"
+import { TfIdfAdapter, type ScoredEntry } from "./similarity"
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface IndexedEntry {
+  entry: StashEntry
+  path: string
+  dirPath: string
+}
+
+export interface SearchIndex {
+  version: number
+  builtAt: string
+  stashDir: string
+  entries: IndexedEntry[]
+  /** Serialized TF-IDF state (term frequencies, idf values) */
+  tfidf?: unknown
+}
+
+export interface IndexResponse {
+  stashDir: string
+  totalEntries: number
+  generatedMetadata: number
+  indexPath: string
+}
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+const INDEX_VERSION = 1
+const SCRIPT_EXTENSIONS = new Set([".sh", ".ts", ".js", ".ps1", ".cmd", ".bat"])
+
+const TYPE_DIRS: Record<AgentikitAssetType, string> = {
+  tool: "tools",
+  skill: "skills",
+  command: "commands",
+  agent: "agents",
+}
+
+// ── Index Path ──────────────────────────────────────────────────────────────
+
+export function getIndexPath(): string {
+  const cacheDir = process.env.XDG_CACHE_HOME
+    || path.join(process.env.HOME || process.env.USERPROFILE || "", ".cache")
+  return path.join(cacheDir, "agentikit", "index.json")
+}
+
+export function loadSearchIndex(): SearchIndex | null {
+  const indexPath = getIndexPath()
+  if (!fs.existsSync(indexPath)) return null
+  try {
+    const raw = JSON.parse(fs.readFileSync(indexPath, "utf8"))
+    if (raw?.version !== INDEX_VERSION) return null
+    return raw as SearchIndex
+  } catch {
+    return null
+  }
+}
+
+// ── Indexer ──────────────────────────────────────────────────────────────────
+
+export function agentikitIndex(options?: { stashDir?: string }): IndexResponse {
+  const stashDir = options?.stashDir || resolveStashDirForIndex()
+  const allEntries: IndexedEntry[] = []
+  let generatedCount = 0
+
+  for (const assetType of Object.keys(TYPE_DIRS) as AgentikitAssetType[]) {
+    const typeRoot = path.join(stashDir, TYPE_DIRS[assetType])
+    if (!fs.existsSync(typeRoot) || !fs.statSync(typeRoot).isDirectory()) continue
+
+    // Group files by their immediate parent directory
+    const dirGroups = collectDirectoryGroups(typeRoot, assetType)
+
+    for (const [dirPath, files] of dirGroups) {
+      // Try loading existing .stash.json
+      let stash = loadStashFile(dirPath)
+
+      if (!stash) {
+        // Generate metadata
+        stash = generateMetadata(dirPath, assetType, files)
+        if (stash.entries.length > 0) {
+          writeStashFile(dirPath, stash)
+          generatedCount += stash.entries.length
+        }
+      }
+
+      if (stash) {
+        for (const entry of stash.entries) {
+          const entryPath = entry.entry
+            ? path.join(dirPath, entry.entry)
+            : files[0] || dirPath
+          allEntries.push({ entry, path: entryPath, dirPath })
+        }
+      }
+    }
+  }
+
+  // Build TF-IDF index
+  const adapter = new TfIdfAdapter()
+  const scoredEntries: ScoredEntry[] = allEntries.map((ie) => ({
+    id: `${ie.entry.type}:${ie.entry.name}`,
+    text: buildSearchText(ie.entry),
+    entry: ie.entry,
+    path: ie.path,
+  }))
+  adapter.buildIndex(scoredEntries)
+
+  // Persist index
+  const indexPath = getIndexPath()
+  const indexDir = path.dirname(indexPath)
+  if (!fs.existsSync(indexDir)) {
+    fs.mkdirSync(indexDir, { recursive: true })
+  }
+
+  const index: SearchIndex = {
+    version: INDEX_VERSION,
+    builtAt: new Date().toISOString(),
+    stashDir,
+    entries: allEntries,
+    tfidf: adapter.serialize(),
+  }
+  fs.writeFileSync(indexPath, JSON.stringify(index) + "\n", "utf8")
+
+  return {
+    stashDir,
+    totalEntries: allEntries.length,
+    generatedMetadata: generatedCount,
+    indexPath,
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function collectDirectoryGroups(
+  typeRoot: string,
+  assetType: AgentikitAssetType,
+): Map<string, string[]> {
+  const groups = new Map<string, string[]>()
+
+  const walk = (dir: string): void => {
+    if (!fs.existsSync(dir)) return
+    const entries = fs.readdirSync(dir, { withFileTypes: true })
+    for (const entry of entries) {
+      if (entry.name === ".stash.json") continue
+      const fullPath = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        walk(fullPath)
+      } else if (entry.isFile() && isRelevantFile(entry.name, assetType)) {
+        const parentDir = path.dirname(fullPath)
+        const existing = groups.get(parentDir)
+        if (existing) {
+          existing.push(fullPath)
+        } else {
+          groups.set(parentDir, [fullPath])
+        }
+      }
+    }
+  }
+
+  walk(typeRoot)
+  return groups
+}
+
+function isRelevantFile(fileName: string, assetType: AgentikitAssetType): boolean {
+  const ext = path.extname(fileName).toLowerCase()
+  switch (assetType) {
+    case "tool":
+      return SCRIPT_EXTENSIONS.has(ext)
+    case "skill":
+      return fileName === "SKILL.md"
+    case "command":
+    case "agent":
+      return ext === ".md"
+    default:
+      return false
+  }
+}
+
+export function buildSearchText(entry: StashEntry): string {
+  const parts: string[] = [entry.name.replace(/[-_]/g, " ")]
+  if (entry.description) parts.push(entry.description)
+  if (entry.tags) parts.push(entry.tags.join(" "))
+  if (entry.examples) parts.push(entry.examples.join(" "))
+  if (entry.intent) {
+    if (entry.intent.when) parts.push(entry.intent.when)
+    if (entry.intent.input) parts.push(entry.intent.input)
+    if (entry.intent.output) parts.push(entry.intent.output)
+  }
+  return parts.join(" ").toLowerCase()
+}
+
+function resolveStashDirForIndex(): string {
+  const raw = process.env.AGENTIKIT_STASH_DIR?.trim()
+  if (!raw) {
+    throw new Error("AGENTIKIT_STASH_DIR is not set. Run 'agentikit init' first.")
+  }
+  const stashDir = path.resolve(raw)
+  if (!fs.existsSync(stashDir) || !fs.statSync(stashDir).isDirectory()) {
+    throw new Error(`AGENTIKIT_STASH_DIR does not exist or is not a directory: "${stashDir}"`)
+  }
+  return stashDir
+}

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,0 +1,249 @@
+import fs from "node:fs"
+import path from "node:path"
+import type { AgentikitAssetType } from "./stash"
+
+// ── Schema ──────────────────────────────────────────────────────────────────
+
+export interface StashIntent {
+  when?: string
+  input?: string
+  output?: string
+}
+
+export interface StashEntry {
+  name: string
+  type: AgentikitAssetType
+  description?: string
+  tags?: string[]
+  examples?: string[]
+  intent?: StashIntent
+  entry?: string
+  generated?: boolean
+}
+
+export interface StashFile {
+  entries: StashEntry[]
+}
+
+// ── Load / Write ────────────────────────────────────────────────────────────
+
+const STASH_FILENAME = ".stash.json"
+
+export function stashFilePath(dirPath: string): string {
+  return path.join(dirPath, STASH_FILENAME)
+}
+
+export function loadStashFile(dirPath: string): StashFile | null {
+  const filePath = stashFilePath(dirPath)
+  if (!fs.existsSync(filePath)) return null
+  try {
+    const raw = JSON.parse(fs.readFileSync(filePath, "utf8"))
+    if (!raw || !Array.isArray(raw.entries)) return null
+    const entries: StashEntry[] = []
+    for (const e of raw.entries) {
+      const validated = validateStashEntry(e)
+      if (validated) entries.push(validated)
+    }
+    return entries.length > 0 ? { entries } : null
+  } catch {
+    return null
+  }
+}
+
+export function writeStashFile(dirPath: string, stash: StashFile): void {
+  const filePath = stashFilePath(dirPath)
+  fs.writeFileSync(filePath, JSON.stringify(stash, null, 2) + "\n", "utf8")
+}
+
+export function validateStashEntry(entry: unknown): StashEntry | null {
+  if (typeof entry !== "object" || entry === null) return null
+  const e = entry as Record<string, unknown>
+  if (typeof e.name !== "string" || !e.name) return null
+  if (typeof e.type !== "string" || !isValidType(e.type)) return null
+
+  const result: StashEntry = {
+    name: e.name,
+    type: e.type as AgentikitAssetType,
+  }
+  if (typeof e.description === "string" && e.description) result.description = e.description
+  if (Array.isArray(e.tags)) result.tags = e.tags.filter((t): t is string => typeof t === "string")
+  if (Array.isArray(e.examples)) result.examples = e.examples.filter((x): x is string => typeof x === "string")
+  if (typeof e.intent === "object" && e.intent !== null) {
+    const intent = e.intent as Record<string, unknown>
+    result.intent = {}
+    if (typeof intent.when === "string") result.intent.when = intent.when
+    if (typeof intent.input === "string") result.intent.input = intent.input
+    if (typeof intent.output === "string") result.intent.output = intent.output
+  }
+  if (typeof e.entry === "string" && e.entry) result.entry = e.entry
+  if (e.generated === true) result.generated = true
+
+  return result
+}
+
+function isValidType(type: string): boolean {
+  return type === "tool" || type === "skill" || type === "command" || type === "agent"
+}
+
+// ── Metadata Generation ─────────────────────────────────────────────────────
+
+const SCRIPT_EXTENSIONS = new Set([".sh", ".ts", ".js", ".ps1", ".cmd", ".bat"])
+
+export function generateMetadata(
+  dirPath: string,
+  assetType: AgentikitAssetType,
+  files: string[],
+): StashFile {
+  const entries: StashEntry[] = []
+
+  for (const file of files) {
+    const ext = path.extname(file).toLowerCase()
+    const baseName = path.basename(file, ext)
+
+    // Skip non-relevant files
+    if (assetType === "tool" && !SCRIPT_EXTENSIONS.has(ext)) continue
+    if ((assetType === "command" || assetType === "agent") && ext !== ".md") continue
+    if (assetType === "skill" && path.basename(file) !== "SKILL.md") continue
+
+    const entry: StashEntry = {
+      name: baseName,
+      type: assetType,
+      generated: true,
+    }
+
+    // Priority 3: package.json metadata
+    const pkgMeta = extractPackageMetadata(dirPath)
+    if (pkgMeta) {
+      if (pkgMeta.description && !entry.description) entry.description = pkgMeta.description
+      if (pkgMeta.keywords && pkgMeta.keywords.length > 0) entry.tags = pkgMeta.keywords
+    }
+
+    // Priority 2: Frontmatter (for .md files)
+    if (ext === ".md") {
+      const fm = extractFrontmatterDescription(file)
+      if (fm) entry.description = fm
+    }
+
+    // Priority 4: Code comments (for script files)
+    if (SCRIPT_EXTENSIONS.has(ext) && ext !== ".md") {
+      const commentDesc = extractDescriptionFromComments(file)
+      if (commentDesc && !entry.description) entry.description = commentDesc
+    }
+
+    // Priority 5: Filename heuristics (fallback)
+    if (!entry.description) {
+      entry.description = fileNameToDescription(baseName)
+    }
+    if (!entry.tags || entry.tags.length === 0) {
+      entry.tags = extractTagsFromPath(file, dirPath)
+    }
+
+    entry.entry = path.basename(file)
+    entries.push(entry)
+  }
+
+  return { entries }
+}
+
+export function extractDescriptionFromComments(filePath: string): string | null {
+  let content: string
+  try {
+    content = fs.readFileSync(filePath, "utf8")
+  } catch {
+    return null
+  }
+
+  const lines = content.split(/\r?\n/).slice(0, 50)
+
+  // Try JSDoc-style block comment: /** ... */
+  const blockStart = lines.findIndex((l) => /^\s*\/\*\*/.test(l))
+  if (blockStart >= 0) {
+    const desc: string[] = []
+    for (let i = blockStart; i < lines.length; i++) {
+      const line = lines[i]
+      if (i > blockStart && /\*\//.test(line)) break
+      const cleaned = line.replace(/^\s*\/?\*\*?\s?/, "").replace(/\*\/\s*$/, "").trim()
+      if (cleaned) desc.push(cleaned)
+    }
+    if (desc.length > 0) return desc.join(" ")
+  }
+
+  // Try hash comments at start of file (skip shebang)
+  let start = 0
+  if (lines[0]?.startsWith("#!")) start = 1
+  const hashLines: string[] = []
+  for (let i = start; i < lines.length; i++) {
+    const line = lines[i].trim()
+    if (line.startsWith("#") && !line.startsWith("#!")) {
+      hashLines.push(line.replace(/^#+\s*/, "").trim())
+    } else if (line === "") {
+      continue
+    } else {
+      break
+    }
+  }
+  if (hashLines.length > 0) return hashLines.join(" ")
+
+  return null
+}
+
+export function extractFrontmatterDescription(filePath: string): string | null {
+  let content: string
+  try {
+    content = fs.readFileSync(filePath, "utf8")
+  } catch {
+    return null
+  }
+
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+  if (!match) return null
+
+  for (const line of match[1].split(/\r?\n/)) {
+    const m = line.match(/^description:\s*"?(.+?)"?\s*$/)
+    if (m) return m[1]
+  }
+  return null
+}
+
+export function extractPackageMetadata(
+  dirPath: string,
+): { name?: string; description?: string; keywords?: string[] } | null {
+  const pkgPath = path.join(dirPath, "package.json")
+  if (!fs.existsSync(pkgPath)) return null
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"))
+    const result: { name?: string; description?: string; keywords?: string[] } = {}
+    if (typeof pkg.name === "string") result.name = pkg.name
+    if (typeof pkg.description === "string") result.description = pkg.description
+    if (Array.isArray(pkg.keywords)) {
+      result.keywords = pkg.keywords.filter((k: unknown): k is string => typeof k === "string")
+    }
+    return Object.keys(result).length > 0 ? result : null
+  } catch {
+    return null
+  }
+}
+
+export function fileNameToDescription(fileName: string): string {
+  return fileName
+    .replace(/[-_]+/g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .trim()
+}
+
+export function extractTagsFromPath(filePath: string, rootDir: string): string[] {
+  const rel = path.relative(rootDir, filePath)
+  const parts = rel.split(path.sep)
+  const tags = new Set<string>()
+
+  for (const part of parts) {
+    const name = part.replace(path.extname(part), "")
+    for (const token of name.split(/[-_./\\]+/)) {
+      const clean = token.toLowerCase().trim()
+      if (clean && clean.length > 1) tags.add(clean)
+    }
+  }
+
+  return Array.from(tags)
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,5 +1,6 @@
 import { type Plugin, tool } from "@opencode-ai/plugin"
 import { agentikitOpen, agentikitRun, agentikitSearch } from "./stash"
+import { agentikitIndex } from "./indexer"
 
 function tryJson(fn: () => unknown, action: string): string {
   try {
@@ -42,6 +43,13 @@ export const plugin: Plugin = async () => ({
       },
       async execute({ ref }) {
         return tryJson(() => agentikitRun({ ref }), "run stash tool")
+      },
+    }),
+    agentikit_index: tool({
+      description: "Build or rebuild the Agentikit search index. Scans stash directories, generates missing .stash.json metadata, and builds a semantic search index.",
+      args: {},
+      async execute() {
+        return tryJson(() => agentikitIndex(), "build Agentikit index")
       },
     }),
   },

--- a/src/similarity.ts
+++ b/src/similarity.ts
@@ -1,0 +1,247 @@
+import type { StashEntry } from "./metadata"
+
+// ── Adapter Interface ───────────────────────────────────────────────────────
+
+export interface ScoredEntry {
+  id: string
+  text: string
+  entry: StashEntry
+  path: string
+}
+
+export interface ScoredResult {
+  entry: StashEntry
+  path: string
+  score: number
+}
+
+export interface SearchAdapter {
+  buildIndex(entries: ScoredEntry[]): void
+  search(query: string, limit: number, typeFilter?: string): ScoredResult[]
+}
+
+// ── TF-IDF Implementation ───────────────────────────────────────────────────
+
+interface TfIdfDocument {
+  entry: ScoredEntry
+  termFreqs: Map<string, number>
+  magnitude: number
+}
+
+interface SerializedTfIdf {
+  idf: Record<string, number>
+  docs: Array<{
+    id: string
+    termFreqs: Record<string, number>
+    magnitude: number
+  }>
+}
+
+export class TfIdfAdapter implements SearchAdapter {
+  private documents: TfIdfDocument[] = []
+  private idf: Map<string, number> = new Map()
+  private entries: ScoredEntry[] = []
+
+  buildIndex(entries: ScoredEntry[]): void {
+    this.entries = entries
+    const docCount = entries.length
+    if (docCount === 0) return
+
+    // Compute term frequencies per document
+    const docFreqs = new Map<string, number>()
+    this.documents = entries.map((entry) => {
+      const tokens = tokenize(entry.text)
+      const termFreqs = new Map<string, number>()
+
+      for (const token of tokens) {
+        termFreqs.set(token, (termFreqs.get(token) || 0) + 1)
+      }
+
+      // Track document frequency for IDF
+      for (const term of termFreqs.keys()) {
+        docFreqs.set(term, (docFreqs.get(term) || 0) + 1)
+      }
+
+      return { entry, termFreqs, magnitude: 0 }
+    })
+
+    // Compute IDF: log(N / df)
+    this.idf = new Map()
+    for (const [term, df] of docFreqs) {
+      this.idf.set(term, Math.log(docCount / df))
+    }
+
+    // Compute document magnitudes for cosine similarity
+    for (const doc of this.documents) {
+      let sumSq = 0
+      for (const [term, tf] of doc.termFreqs) {
+        const idf = this.idf.get(term) || 0
+        const tfidf = tf * idf
+        sumSq += tfidf * tfidf
+      }
+      doc.magnitude = Math.sqrt(sumSq)
+    }
+  }
+
+  search(query: string, limit: number, typeFilter?: string): ScoredResult[] {
+    if (this.documents.length === 0) return []
+
+    const queryTokens = tokenize(query.toLowerCase())
+    if (queryTokens.length === 0) {
+      // Empty query: return all, sorted by type
+      return this.documents
+        .filter((d) => !typeFilter || typeFilter === "any" || d.entry.entry.type === typeFilter)
+        .slice(0, limit)
+        .map((d) => ({
+          entry: d.entry.entry,
+          path: d.entry.path,
+          score: 1,
+        }))
+    }
+
+    // Build query TF-IDF vector
+    const queryTermFreqs = new Map<string, number>()
+    for (const token of queryTokens) {
+      queryTermFreqs.set(token, (queryTermFreqs.get(token) || 0) + 1)
+    }
+
+    let queryMagnitude = 0
+    const queryVector = new Map<string, number>()
+    for (const [term, tf] of queryTermFreqs) {
+      const idf = this.idf.get(term) || 0
+      const tfidf = tf * idf
+      queryVector.set(term, tfidf)
+      queryMagnitude += tfidf * tfidf
+    }
+    queryMagnitude = Math.sqrt(queryMagnitude)
+
+    if (queryMagnitude === 0) {
+      // All query terms are unknown — fallback to substring match
+      return this.substringFallback(query, limit, typeFilter)
+    }
+
+    const results: ScoredResult[] = []
+    const querySet = new Set(queryTokens)
+
+    for (const doc of this.documents) {
+      if (typeFilter && typeFilter !== "any" && doc.entry.entry.type !== typeFilter) continue
+
+      // Cosine similarity
+      let dotProduct = 0
+      for (const [term, queryTfidf] of queryVector) {
+        const docTf = doc.termFreqs.get(term) || 0
+        if (docTf === 0) continue
+        const docIdf = this.idf.get(term) || 0
+        dotProduct += queryTfidf * (docTf * docIdf)
+      }
+
+      let score = doc.magnitude > 0 && queryMagnitude > 0
+        ? dotProduct / (doc.magnitude * queryMagnitude)
+        : 0
+
+      // Boost: tag exact match
+      const tags = doc.entry.entry.tags || []
+      for (const tag of tags) {
+        if (querySet.has(tag.toLowerCase())) {
+          score += 0.15
+        }
+      }
+
+      // Boost: name contains query token
+      const nameLower = doc.entry.entry.name.toLowerCase().replace(/[-_]/g, " ")
+      for (const token of queryTokens) {
+        if (nameLower.includes(token)) {
+          score += 0.1
+          break
+        }
+      }
+
+      if (score > 0) {
+        results.push({
+          entry: doc.entry.entry,
+          path: doc.entry.path,
+          score: Math.round(score * 1000) / 1000,
+        })
+      }
+    }
+
+    results.sort((a, b) => b.score - a.score)
+    return results.slice(0, limit)
+  }
+
+  serialize(): SerializedTfIdf {
+    const idf: Record<string, number> = {}
+    for (const [term, val] of this.idf) {
+      idf[term] = val
+    }
+    const docs = this.documents.map((d) => {
+      const termFreqs: Record<string, number> = {}
+      for (const [term, tf] of d.termFreqs) {
+        termFreqs[term] = tf
+      }
+      return { id: d.entry.id, termFreqs, magnitude: d.magnitude }
+    })
+    return { idf, docs }
+  }
+
+  static deserialize(data: SerializedTfIdf, entries: ScoredEntry[]): TfIdfAdapter {
+    const adapter = new TfIdfAdapter()
+    adapter.entries = entries
+
+    adapter.idf = new Map(Object.entries(data.idf))
+
+    const entryMap = new Map(entries.map((e) => [e.id, e]))
+    adapter.documents = data.docs
+      .map((d) => {
+        const entry = entryMap.get(d.id)
+        if (!entry) return null
+        return {
+          entry,
+          termFreqs: new Map(Object.entries(d.termFreqs)),
+          magnitude: d.magnitude,
+        }
+      })
+      .filter((d): d is TfIdfDocument => d !== null)
+
+    return adapter
+  }
+
+  private substringFallback(query: string, limit: number, typeFilter?: string): ScoredResult[] {
+    const q = query.toLowerCase()
+    return this.documents
+      .filter((d) => {
+        if (typeFilter && typeFilter !== "any" && d.entry.entry.type !== typeFilter) return false
+        return d.entry.text.includes(q) || d.entry.entry.name.toLowerCase().includes(q)
+      })
+      .slice(0, limit)
+      .map((d) => ({
+        entry: d.entry.entry,
+        path: d.entry.path,
+        score: 0.5,
+      }))
+  }
+}
+
+// ── Tokenization ────────────────────────────────────────────────────────────
+
+const STOP_WORDS = new Set([
+  "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+  "have", "has", "had", "do", "does", "did", "will", "would", "could",
+  "should", "may", "might", "shall", "can", "need", "dare", "ought",
+  "to", "of", "in", "for", "on", "with", "at", "by", "from", "as",
+  "into", "through", "during", "before", "after", "above", "below",
+  "and", "but", "or", "nor", "not", "so", "yet", "both", "either",
+  "neither", "each", "every", "all", "any", "few", "more", "most",
+  "other", "some", "such", "no", "only", "own", "same", "than",
+  "too", "very", "just", "because", "if", "when", "where", "how",
+  "what", "which", "who", "whom", "this", "that", "these", "those",
+  "it", "its",
+])
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .split(/\s+/)
+    .filter((t) => t.length > 1 && !STOP_WORDS.has(t))
+}

--- a/src/stash.ts
+++ b/src/stash.ts
@@ -1,6 +1,8 @@
 import { spawnSync } from "node:child_process"
 import fs from "node:fs"
 import path from "node:path"
+import { loadSearchIndex, buildSearchText } from "./indexer"
+import { TfIdfAdapter, type ScoredEntry } from "./similarity"
 
 export type AgentikitAssetType = "tool" | "skill" | "command" | "agent"
 export type AgentikitSearchType = AgentikitAssetType | "any"
@@ -11,6 +13,9 @@ export interface SearchHit {
   path: string
   openRef: string
   summary?: string
+  description?: string
+  tags?: string[]
+  score?: number
   runCmd?: string
   kind?: "bash" | "bun" | "powershell" | "cmd"
 }
@@ -93,37 +98,83 @@ export function agentikitSearch(input: {
   const searchType = input.type ?? "any"
   const limit = normalizeLimit(input.limit)
   const stashDir = resolveStashDir()
+
+  // Try semantic search via persisted index
+  const semanticHits = trySemanticSearch(query, searchType, limit, stashDir)
+  if (semanticHits) {
+    return {
+      stashDir,
+      hits: semanticHits,
+      tip: semanticHits.length === 0 ? "No matching stash assets were found. Try running 'agentikit index' to rebuild." : undefined,
+    }
+  }
+
+  // Fallback: substring matching (no index built yet)
   const assets = indexAssets(stashDir, searchType)
   const hits = assets
     .filter((asset) => asset.name.toLowerCase().includes(query))
     .sort(compareAssets)
     .slice(0, limit)
-    .map((asset): SearchHit => {
-      if (asset.type !== "tool") {
-        return {
-          type: asset.type,
-          name: asset.name,
-          path: asset.path,
-          openRef: makeOpenRef(asset.type, asset.name),
-        }
-      }
-
-      const toolInfo = buildToolInfo(stashDir, asset.path)
-      return {
-        type: "tool",
-        name: asset.name,
-        path: asset.path,
-        openRef: makeOpenRef("tool", asset.name),
-        runCmd: toolInfo.runCmd,
-        kind: toolInfo.kind,
-      }
-    })
+    .map((asset): SearchHit => assetToSearchHit(asset, stashDir))
 
   return {
     stashDir,
     hits,
     tip: hits.length === 0 ? "No matching stash assets were found." : undefined,
   }
+}
+
+function trySemanticSearch(
+  query: string,
+  searchType: AgentikitSearchType,
+  limit: number,
+  stashDir: string,
+): SearchHit[] | null {
+  const index = loadSearchIndex()
+  if (!index || !index.entries || index.entries.length === 0) return null
+  if (index.stashDir !== stashDir) return null
+
+  const scoredEntries: ScoredEntry[] = index.entries.map((ie) => ({
+    id: `${ie.entry.type}:${ie.entry.name}`,
+    text: buildSearchText(ie.entry),
+    entry: ie.entry,
+    path: ie.path,
+  }))
+
+  let adapter: TfIdfAdapter
+  if (index.tfidf) {
+    adapter = TfIdfAdapter.deserialize(index.tfidf as any, scoredEntries)
+  } else {
+    adapter = new TfIdfAdapter()
+    adapter.buildIndex(scoredEntries)
+  }
+
+  const typeFilter = searchType === "any" ? undefined : searchType
+  const results = adapter.search(query, limit, typeFilter)
+
+  return results.map((r): SearchHit => {
+    const hit: SearchHit = {
+      type: r.entry.type,
+      name: r.entry.name,
+      path: r.path,
+      openRef: makeOpenRef(r.entry.type, r.entry.name),
+      description: r.entry.description,
+      tags: r.entry.tags,
+      score: r.score,
+    }
+
+    if (r.entry.type === "tool") {
+      try {
+        const toolInfo = buildToolInfo(stashDir, r.path)
+        hit.runCmd = toolInfo.runCmd
+        hit.kind = toolInfo.kind
+      } catch {
+        // Tool file may have been removed since indexing
+      }
+    }
+
+    return hit
+  })
 }
 
 export function agentikitOpen(input: { ref: string }): OpenResponse {
@@ -205,6 +256,26 @@ export function agentikitRun(input: { ref: string }): RunResponse {
     path: assetPath,
     output: runResult.output,
     exitCode: runResult.exitCode,
+  }
+}
+
+function assetToSearchHit(asset: IndexedAsset, stashDir: string): SearchHit {
+  if (asset.type !== "tool") {
+    return {
+      type: asset.type,
+      name: asset.name,
+      path: asset.path,
+      openRef: makeOpenRef(asset.type, asset.name),
+    }
+  }
+  const toolInfo = buildToolInfo(stashDir, asset.path)
+  return {
+    type: "tool",
+    name: asset.name,
+    path: asset.path,
+    openRef: makeOpenRef("tool", asset.name),
+    runCmd: toolInfo.runCmd,
+    kind: toolInfo.kind,
   }
 }
 

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -1,0 +1,106 @@
+import { test, expect } from "bun:test"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { agentikitIndex, getIndexPath, loadSearchIndex } from "../src/indexer"
+
+function tmpStash(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-idx-"))
+  for (const sub of ["tools", "skills", "commands", "agents"]) {
+    fs.mkdirSync(path.join(dir, sub), { recursive: true })
+  }
+  return dir
+}
+
+function writeFile(filePath: string, content = "") {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, content)
+}
+
+test("agentikitIndex scans directories and builds index", () => {
+  const stashDir = tmpStash()
+  writeFile(path.join(stashDir, "tools", "deploy", "deploy.sh"), "#!/usr/bin/env bash\n# Deploy to staging\necho deploy\n")
+  writeFile(path.join(stashDir, "tools", "lint", "lint.ts"), "/**\n * Lint source code\n */\nconsole.log('lint')\n")
+
+  process.env.AGENTIKIT_STASH_DIR = stashDir
+  const result = agentikitIndex({ stashDir })
+
+  expect(result.totalEntries).toBe(2)
+  expect(result.generatedMetadata).toBe(2)
+  expect(result.stashDir).toBe(stashDir)
+
+  // Verify .stash.json files were created
+  const deployStash = path.join(stashDir, "tools", "deploy", ".stash.json")
+  expect(fs.existsSync(deployStash)).toBe(true)
+
+  const parsed = JSON.parse(fs.readFileSync(deployStash, "utf8"))
+  expect(parsed.entries[0].name).toBe("deploy")
+  expect(parsed.entries[0].generated).toBe(true)
+})
+
+test("agentikitIndex preserves manually-written .stash.json", () => {
+  const stashDir = tmpStash()
+  writeFile(path.join(stashDir, "tools", "git", "summarize.ts"), "console.log('x')\n")
+  writeFile(
+    path.join(stashDir, "tools", "git", ".stash.json"),
+    JSON.stringify({
+      entries: [
+        {
+          name: "git-summarize",
+          type: "tool",
+          description: "Summarize git changes",
+          tags: ["git", "summary"],
+          entry: "summarize.ts",
+        },
+      ],
+    }),
+  )
+
+  const result = agentikitIndex({ stashDir })
+
+  expect(result.totalEntries).toBe(1)
+  expect(result.generatedMetadata).toBe(0) // no generation needed
+
+  // Verify the manual .stash.json was not overwritten
+  const stash = JSON.parse(
+    fs.readFileSync(path.join(stashDir, "tools", "git", ".stash.json"), "utf8"),
+  )
+  expect(stash.entries[0].name).toBe("git-summarize")
+  expect(stash.entries[0].generated).toBeUndefined()
+})
+
+test("agentikitIndex writes index to cache", () => {
+  const stashDir = tmpStash()
+  writeFile(path.join(stashDir, "tools", "hello", "hello.sh"), "#!/bin/bash\necho hi\n")
+
+  const result = agentikitIndex({ stashDir })
+  expect(fs.existsSync(result.indexPath)).toBe(true)
+
+  const index = loadSearchIndex()
+  expect(index).not.toBeNull()
+  expect(index!.version).toBe(1)
+  expect(index!.entries.length).toBeGreaterThan(0)
+})
+
+test("agentikitIndex handles empty stash gracefully", () => {
+  const stashDir = tmpStash()
+  const result = agentikitIndex({ stashDir })
+
+  expect(result.totalEntries).toBe(0)
+  expect(result.generatedMetadata).toBe(0)
+})
+
+test("agentikitIndex handles markdown assets", () => {
+  const stashDir = tmpStash()
+  writeFile(
+    path.join(stashDir, "commands", "release.md"),
+    '---\ndescription: "Release the project"\n---\nRun the release\n',
+  )
+  writeFile(
+    path.join(stashDir, "skills", "refactor", "SKILL.md"),
+    '---\ndescription: "Refactor code"\n---\n# Refactor skill\n',
+  )
+
+  const result = agentikitIndex({ stashDir })
+  expect(result.totalEntries).toBe(2)
+})

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -1,0 +1,254 @@
+import { test, expect } from "bun:test"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import {
+  loadStashFile,
+  writeStashFile,
+  validateStashEntry,
+  generateMetadata,
+  extractDescriptionFromComments,
+  extractPackageMetadata,
+  fileNameToDescription,
+  extractTagsFromPath,
+  type StashFile,
+} from "../src/metadata"
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-meta-"))
+}
+
+function writeFile(filePath: string, content = "") {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, content)
+}
+
+// ── loadStashFile ───────────────────────────────────────────────────────────
+
+test("loadStashFile reads valid .stash.json", () => {
+  const dir = tmpDir()
+  const stash: StashFile = {
+    entries: [
+      {
+        name: "docker-build",
+        type: "tool",
+        description: "build docker images",
+        tags: ["docker", "build"],
+        entry: "docker-build.ts",
+      },
+    ],
+  }
+  writeFile(path.join(dir, ".stash.json"), JSON.stringify(stash))
+
+  const result = loadStashFile(dir)
+  expect(result).not.toBeNull()
+  expect(result!.entries).toHaveLength(1)
+  expect(result!.entries[0].name).toBe("docker-build")
+  expect(result!.entries[0].description).toBe("build docker images")
+  expect(result!.entries[0].tags).toEqual(["docker", "build"])
+})
+
+test("loadStashFile returns null for missing file", () => {
+  const dir = tmpDir()
+  expect(loadStashFile(dir)).toBeNull()
+})
+
+test("loadStashFile returns null for invalid JSON", () => {
+  const dir = tmpDir()
+  writeFile(path.join(dir, ".stash.json"), "not json")
+  expect(loadStashFile(dir)).toBeNull()
+})
+
+test("loadStashFile returns null for missing entries array", () => {
+  const dir = tmpDir()
+  writeFile(path.join(dir, ".stash.json"), '{"foo": "bar"}')
+  expect(loadStashFile(dir)).toBeNull()
+})
+
+test("loadStashFile parses intent field", () => {
+  const dir = tmpDir()
+  const stash: StashFile = {
+    entries: [
+      {
+        name: "deploy",
+        type: "tool",
+        intent: { when: "user needs to deploy", input: "service name", output: "deployment status" },
+        entry: "deploy.sh",
+      },
+    ],
+  }
+  writeFile(path.join(dir, ".stash.json"), JSON.stringify(stash))
+
+  const result = loadStashFile(dir)
+  expect(result!.entries[0].intent).toEqual({
+    when: "user needs to deploy",
+    input: "service name",
+    output: "deployment status",
+  })
+})
+
+// ── writeStashFile ──────────────────────────────────────────────────────────
+
+test("writeStashFile persists .stash.json to disk", () => {
+  const dir = tmpDir()
+  const stash: StashFile = {
+    entries: [{ name: "test", type: "tool", generated: true }],
+  }
+  writeStashFile(dir, stash)
+
+  const raw = fs.readFileSync(path.join(dir, ".stash.json"), "utf8")
+  const parsed = JSON.parse(raw)
+  expect(parsed.entries[0].name).toBe("test")
+  expect(parsed.entries[0].generated).toBe(true)
+})
+
+// ── validateStashEntry ──────────────────────────────────────────────────────
+
+test("validateStashEntry rejects entries without name", () => {
+  expect(validateStashEntry({ type: "tool" })).toBeNull()
+})
+
+test("validateStashEntry rejects entries without valid type", () => {
+  expect(validateStashEntry({ name: "x", type: "invalid" })).toBeNull()
+})
+
+test("validateStashEntry accepts minimal valid entry", () => {
+  const result = validateStashEntry({ name: "x", type: "tool" })
+  expect(result).not.toBeNull()
+  expect(result!.name).toBe("x")
+  expect(result!.type).toBe("tool")
+})
+
+// ── extractDescriptionFromComments ──────────────────────────────────────────
+
+test("extractDescriptionFromComments parses JSDoc block comment", () => {
+  const dir = tmpDir()
+  const file = path.join(dir, "tool.ts")
+  writeFile(file, `/**\n * Generate docker compose stacks\n */\nconsole.log("hi")\n`)
+
+  const desc = extractDescriptionFromComments(file)
+  expect(desc).toBe("Generate docker compose stacks")
+})
+
+test("extractDescriptionFromComments parses hash comments after shebang", () => {
+  const dir = tmpDir()
+  const file = path.join(dir, "tool.sh")
+  writeFile(file, `#!/usr/bin/env bash\n# Deploy to production\n# Handles rollback\necho deploy\n`)
+
+  const desc = extractDescriptionFromComments(file)
+  expect(desc).toBe("Deploy to production Handles rollback")
+})
+
+test("extractDescriptionFromComments returns null for no comments", () => {
+  const dir = tmpDir()
+  const file = path.join(dir, "tool.ts")
+  writeFile(file, `console.log("no comments")\n`)
+
+  expect(extractDescriptionFromComments(file)).toBeNull()
+})
+
+// ── extractPackageMetadata ──────────────────────────────────────────────────
+
+test("extractPackageMetadata reads package.json fields", () => {
+  const dir = tmpDir()
+  writeFile(
+    path.join(dir, "package.json"),
+    JSON.stringify({ name: "my-tool", description: "A useful tool", keywords: ["deploy", "ci"] }),
+  )
+
+  const meta = extractPackageMetadata(dir)
+  expect(meta).not.toBeNull()
+  expect(meta!.name).toBe("my-tool")
+  expect(meta!.description).toBe("A useful tool")
+  expect(meta!.keywords).toEqual(["deploy", "ci"])
+})
+
+test("extractPackageMetadata returns null when no package.json", () => {
+  const dir = tmpDir()
+  expect(extractPackageMetadata(dir)).toBeNull()
+})
+
+// ── fileNameToDescription ───────────────────────────────────────────────────
+
+test("fileNameToDescription converts dashes and underscores to spaces", () => {
+  expect(fileNameToDescription("docker-compose-generator")).toBe("docker compose generator")
+  expect(fileNameToDescription("my_script_tool")).toBe("my script tool")
+})
+
+test("fileNameToDescription handles camelCase", () => {
+  expect(fileNameToDescription("dockerBuild")).toBe("docker build")
+})
+
+// ── extractTagsFromPath ─────────────────────────────────────────────────────
+
+test("extractTagsFromPath extracts tokens from path segments", () => {
+  const root = "/stash/tools"
+  const file = path.join(root, "docker", "compose-generator.ts")
+  const tags = extractTagsFromPath(file, root)
+  expect(tags).toContain("docker")
+  expect(tags).toContain("compose")
+  expect(tags).toContain("generator")
+})
+
+// ── generateMetadata ────────────────────────────────────────────────────────
+
+test("generateMetadata creates entries from script files with filename heuristics", () => {
+  const dir = tmpDir()
+  const tool1 = path.join(dir, "summarize-diff.ts")
+  writeFile(tool1, `console.log("summarize")\n`)
+
+  const stash = generateMetadata(dir, "tool", [tool1])
+  expect(stash.entries).toHaveLength(1)
+  expect(stash.entries[0].name).toBe("summarize-diff")
+  expect(stash.entries[0].type).toBe("tool")
+  expect(stash.entries[0].description).toBe("summarize diff")
+  expect(stash.entries[0].generated).toBe(true)
+  expect(stash.entries[0].entry).toBe("summarize-diff.ts")
+})
+
+test("generateMetadata extracts description from code comments", () => {
+  const dir = tmpDir()
+  const tool1 = path.join(dir, "deploy.sh")
+  writeFile(tool1, `#!/usr/bin/env bash\n# Deploy services to production\necho deploy\n`)
+
+  const stash = generateMetadata(dir, "tool", [tool1])
+  expect(stash.entries[0].description).toBe("Deploy services to production")
+})
+
+test("generateMetadata extracts metadata from package.json", () => {
+  const dir = tmpDir()
+  const tool1 = path.join(dir, "run.ts")
+  writeFile(tool1, `console.log("run")\n`)
+  writeFile(
+    path.join(dir, "package.json"),
+    JSON.stringify({ description: "Git diff summarizer", keywords: ["git", "diff"] }),
+  )
+
+  const stash = generateMetadata(dir, "tool", [tool1])
+  expect(stash.entries[0].description).toBe("Git diff summarizer")
+  expect(stash.entries[0].tags).toEqual(["git", "diff"])
+})
+
+test("generateMetadata skips non-tool extensions for tool type", () => {
+  const dir = tmpDir()
+  const mdFile = path.join(dir, "README.md")
+  writeFile(mdFile, "# Readme\n")
+
+  const stash = generateMetadata(dir, "tool", [mdFile])
+  expect(stash.entries).toHaveLength(0)
+})
+
+test("generateMetadata handles multi-tool directories", () => {
+  const dir = tmpDir()
+  const tool1 = path.join(dir, "docker-build.ts")
+  const tool2 = path.join(dir, "docker-compose.ts")
+  writeFile(tool1, `/**\n * Build docker images\n */\n`)
+  writeFile(tool2, `/**\n * Generate docker compose stacks\n */\n`)
+
+  const stash = generateMetadata(dir, "tool", [tool1, tool2])
+  expect(stash.entries).toHaveLength(2)
+  expect(stash.entries[0].name).toBe("docker-build")
+  expect(stash.entries[0].description).toBe("Build docker images")
+  expect(stash.entries[1].name).toBe("docker-compose")
+  expect(stash.entries[1].description).toBe("Generate docker compose stacks")
+})

--- a/tests/similarity.test.ts
+++ b/tests/similarity.test.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "bun:test"
+import { TfIdfAdapter, type ScoredEntry } from "../src/similarity"
+
+function makeEntry(id: string, text: string, type: string = "tool"): ScoredEntry {
+  return {
+    id,
+    text,
+    entry: { name: id, type: type as any, description: text, tags: text.split(" ").slice(0, 3) },
+    path: `/stash/tools/${id}`,
+  }
+}
+
+test("TfIdfAdapter ranks relevant results higher", () => {
+  const adapter = new TfIdfAdapter()
+  adapter.buildIndex([
+    makeEntry("docker-build", "build docker images from dockerfiles container"),
+    makeEntry("git-diff", "summarize git diff changes commit"),
+    makeEntry("deploy-k8s", "deploy kubernetes cluster container orchestration"),
+    makeEntry("lint-code", "lint check source code style formatting"),
+  ])
+
+  const results = adapter.search("docker build", 10)
+  expect(results.length).toBeGreaterThan(0)
+  expect(results[0].entry.name).toBe("docker-build")
+})
+
+test("TfIdfAdapter supports type filtering", () => {
+  const adapter = new TfIdfAdapter()
+  adapter.buildIndex([
+    makeEntry("docker-build", "build docker images", "tool"),
+    makeEntry("deploy-guide", "deploy docker containers", "command"),
+  ])
+
+  const toolResults = adapter.search("docker", 10, "tool")
+  expect(toolResults.every((r) => r.entry.type === "tool")).toBe(true)
+})
+
+test("TfIdfAdapter returns all entries for empty query", () => {
+  const adapter = new TfIdfAdapter()
+  adapter.buildIndex([
+    makeEntry("a", "first tool"),
+    makeEntry("b", "second tool"),
+  ])
+
+  const results = adapter.search("", 10)
+  expect(results).toHaveLength(2)
+})
+
+test("TfIdfAdapter serializes and deserializes", () => {
+  const entries: ScoredEntry[] = [
+    makeEntry("docker-build", "build docker images container"),
+    makeEntry("git-diff", "summarize git diff changes"),
+  ]
+
+  const adapter = new TfIdfAdapter()
+  adapter.buildIndex(entries)
+  const serialized = adapter.serialize()
+
+  const restored = TfIdfAdapter.deserialize(serialized, entries)
+  const results = restored.search("docker build", 10)
+  expect(results.length).toBeGreaterThan(0)
+  expect(results[0].entry.name).toBe("docker-build")
+})
+
+test("TfIdfAdapter boosts tag matches", () => {
+  const adapter = new TfIdfAdapter()
+  const entryWithTags: ScoredEntry = {
+    id: "tagged-tool",
+    text: "some generic description",
+    entry: { name: "tagged-tool", type: "tool", description: "some generic description", tags: ["docker"] },
+    path: "/stash/tools/tagged-tool",
+  }
+  const entryWithoutTags: ScoredEntry = {
+    id: "untagged-tool",
+    text: "docker related operations",
+    entry: { name: "untagged-tool", type: "tool", description: "docker related operations" },
+    path: "/stash/tools/untagged-tool",
+  }
+
+  adapter.buildIndex([entryWithTags, entryWithoutTags])
+  const results = adapter.search("docker", 10)
+
+  // Both should match, but the one with tag boost should score higher
+  expect(results.length).toBe(2)
+  // The tagged entry gets a boost
+  const taggedResult = results.find((r) => r.entry.name === "tagged-tool")
+  expect(taggedResult).toBeDefined()
+})
+
+test("TfIdfAdapter handles unknown query terms gracefully", () => {
+  const adapter = new TfIdfAdapter()
+  adapter.buildIndex([makeEntry("test", "test tool description")])
+
+  const results = adapter.search("xyznonexistent", 10)
+  // Should fall back to substring or return empty
+  expect(results).toHaveLength(0)
+})


### PR DESCRIPTION
Implement .stash.json sidecar metadata system with automatic generation and TF-IDF-based semantic search for capability discovery.

New modules:
- src/metadata.ts: .stash.json schema, load/write, metadata generation from code comments, package.json, and filename heuristics
- src/indexer.ts: `agentikit index` command that scans directories, generates missing metadata, and builds a search index
- src/similarity.ts: pluggable SearchAdapter interface with TF-IDF default implementation supporting cosine similarity + tag/name boosts

Key features:
- Auto-generates .stash.json files with descriptions, tags, and entry points
- Capability intent model (intent.when/input/output) for richer discovery
- Semantic search falls back to substring matching when no index exists
- Search results include description, tags, and relevance score
- Index persisted at ~/.cache/agentikit/index.json

https://claude.ai/code/session_012MHUmGyaTvCeijeu4k24zP