### PR TITLE
feat: add knowledge directory support with structured content retrieval

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,9 +8,12 @@ export type {
   OpenResponse,
   RunResponse,
   InitResponse,
+  KnowledgeView,
 } from "./src/stash"
 export { agentikitIndex } from "./src/indexer"
 export type { IndexResponse } from "./src/indexer"
 export type { StashEntry, StashFile, StashIntent } from "./src/metadata"
 export { resolveRg, isRgAvailable, ensureRg } from "./src/ripgrep"
 export type { EnsureRgResult } from "./src/ripgrep"
+export { parseMarkdownToc, extractSection, extractLineRange, extractFrontmatterOnly, formatToc } from "./src/markdown"
+export type { TocHeading, KnowledgeToc } from "./src/markdown"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { agentikitSearch, agentikitOpen, agentikitRun, agentikitInit } from "./stash"
+import { agentikitSearch, agentikitOpen, agentikitRun, agentikitInit, type KnowledgeView } from "./stash"
 import { agentikitIndex } from "./indexer"
 
 const args = process.argv.slice(2)
@@ -16,8 +16,12 @@ function usage(): never {
   console.error("Commands:")
   console.error("  init                 Initialize agentikit stash directory and set AGENTIKIT_STASH_DIR")
   console.error("  index                Build search index with metadata generation")
-  console.error("  search [query]       Search the stash (--type tool|skill|command|agent|any) (--limit N)")
+  console.error("  search [query]       Search the stash (--type tool|skill|command|agent|knowledge|any) (--limit N)")
   console.error("  open <type:name>     Open a stash asset by ref")
+  console.error("       Knowledge view options: --view full|toc|frontmatter|section|lines")
+  console.error("         --heading <text>   Section heading (for --view section)")
+  console.error("         --start <N>        Start line (for --view lines)")
+  console.error("         --end <N>          End line (for --view lines)")
   console.error("  run <type:name>      Run a tool by ref")
   process.exit(1)
 }
@@ -44,7 +48,27 @@ switch (command) {
   case "open": {
     const ref = args[1]
     if (!ref) { console.error("Error: missing ref argument\n"); usage() }
-    console.log(JSON.stringify(agentikitOpen({ ref }), null, 2))
+    const viewMode = flag("--view")
+    let view: KnowledgeView | undefined
+    if (viewMode) {
+      switch (viewMode) {
+        case "section":
+          view = { mode: "section", heading: flag("--heading") ?? "" }
+          break
+        case "lines":
+          view = { mode: "lines", start: Number(flag("--start") ?? "1"), end: Number(flag("--end") ?? "Infinity") }
+          break
+        case "toc":
+        case "frontmatter":
+        case "full":
+          view = { mode: viewMode }
+          break
+        default:
+          console.error(`Unknown view mode: ${viewMode}`)
+          usage()
+      }
+    }
+    console.log(JSON.stringify(agentikitOpen({ ref, view }), null, 2))
     break
   }
   case "run": {

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -44,6 +44,7 @@ const TYPE_DIRS: Record<AgentikitAssetType, string> = {
   skill: "skills",
   command: "commands",
   agent: "agents",
+  knowledge: "knowledge",
 }
 
 // ── Index Path ──────────────────────────────────────────────────────────────
@@ -179,6 +180,7 @@ function isRelevantFile(fileName: string, assetType: AgentikitAssetType): boolea
       return fileName === "SKILL.md"
     case "command":
     case "agent":
+    case "knowledge":
       return ext === ".md"
     default:
       return false
@@ -194,6 +196,9 @@ export function buildSearchText(entry: StashEntry): string {
     if (entry.intent.when) parts.push(entry.intent.when)
     if (entry.intent.input) parts.push(entry.intent.input)
     if (entry.intent.output) parts.push(entry.intent.output)
+  }
+  if (entry.toc) {
+    parts.push(entry.toc.map((h) => h.text).join(" "))
   }
   return parts.join(" ").toLowerCase()
 }

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,0 +1,111 @@
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface TocHeading {
+  level: number
+  text: string
+  line: number
+}
+
+export interface KnowledgeToc {
+  headings: TocHeading[]
+  totalLines: number
+}
+
+// ── Parsing ─────────────────────────────────────────────────────────────────
+
+export function parseMarkdownToc(content: string): KnowledgeToc {
+  const lines = content.split(/\r?\n/)
+  const headings: TocHeading[] = []
+
+  // Skip frontmatter block
+  let start = 0
+  if (lines[0]?.trimEnd() === "---") {
+    for (let i = 1; i < lines.length; i++) {
+      if (lines[i].trimEnd() === "---") {
+        start = i + 1
+        break
+      }
+    }
+  }
+
+  for (let i = start; i < lines.length; i++) {
+    const match = lines[i].match(/^(#{1,6})\s+(.+)$/)
+    if (match) {
+      headings.push({
+        level: match[1].length,
+        text: match[2].replace(/\s+#+\s*$/, "").trim(),
+        line: i + 1,
+      })
+    }
+  }
+
+  return { headings, totalLines: lines.length }
+}
+
+// ── Extraction ──────────────────────────────────────────────────────────────
+
+export function extractSection(
+  content: string,
+  heading: string,
+): { content: string; startLine: number; endLine: number } | null {
+  const lines = content.split(/\r?\n/)
+  const target = heading.toLowerCase()
+
+  let startIdx = -1
+  let startLevel = 0
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(/^(#{1,6})\s+(.+)$/)
+    if (!match) continue
+    const text = match[2].replace(/\s+#+\s*$/, "").trim()
+    if (text.toLowerCase() === target && startIdx === -1) {
+      startIdx = i
+      startLevel = match[1].length
+    } else if (startIdx !== -1 && match[1].length <= startLevel) {
+      return {
+        content: lines.slice(startIdx, i).join("\n"),
+        startLine: startIdx + 1,
+        endLine: i,
+      }
+    }
+  }
+
+  if (startIdx === -1) return null
+
+  return {
+    content: lines.slice(startIdx).join("\n"),
+    startLine: startIdx + 1,
+    endLine: lines.length,
+  }
+}
+
+export function extractLineRange(content: string, start: number, end: number): string {
+  const lines = content.split(/\r?\n/)
+  const s = Math.max(1, Math.min(start, lines.length))
+  const e = Math.max(s, Math.min(end, lines.length))
+  return lines.slice(s - 1, e).join("\n")
+}
+
+export function extractFrontmatterOnly(content: string): string | null {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+  return match ? match[1] : null
+}
+
+// ── Formatting ──────────────────────────────────────────────────────────────
+
+export function formatToc(toc: KnowledgeToc): string {
+  if (toc.headings.length === 0) {
+    return `(no headings found — ${toc.totalLines} lines total)`
+  }
+
+  const lineWidth = String(toc.totalLines).length
+  const parts = toc.headings.map((h) => {
+    const lineNum = `L${String(h.line).padStart(lineWidth)}`
+    const indent = "  ".repeat(h.level - 1)
+    const prefix = "#".repeat(h.level)
+    return `${lineNum}  ${indent}${prefix} ${h.text}`
+  })
+
+  parts.push(`\n${toc.totalLines} lines total`)
+  return parts.join("\n")
+}

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs"
 import path from "node:path"
 import type { AgentikitAssetType } from "./stash"
+import { parseMarkdownToc, type TocHeading } from "./markdown"
 
 // ── Schema ──────────────────────────────────────────────────────────────────
 
@@ -19,6 +20,7 @@ export interface StashEntry {
   intent?: StashIntent
   entry?: string
   generated?: boolean
+  toc?: TocHeading[]
 }
 
 export interface StashFile {
@@ -77,12 +79,22 @@ export function validateStashEntry(entry: unknown): StashEntry | null {
   }
   if (typeof e.entry === "string" && e.entry) result.entry = e.entry
   if (e.generated === true) result.generated = true
+  if (Array.isArray(e.toc)) {
+    const validated = e.toc.filter(
+      (h: unknown): h is TocHeading =>
+        typeof h === "object" && h !== null
+        && typeof (h as any).level === "number"
+        && typeof (h as any).text === "string"
+        && typeof (h as any).line === "number",
+    )
+    if (validated.length > 0) result.toc = validated
+  }
 
   return result
 }
 
 function isValidType(type: string): boolean {
-  return type === "tool" || type === "skill" || type === "command" || type === "agent"
+  return type === "tool" || type === "skill" || type === "command" || type === "agent" || type === "knowledge"
 }
 
 // ── Metadata Generation ─────────────────────────────────────────────────────
@@ -102,7 +114,7 @@ export function generateMetadata(
 
     // Skip non-relevant files
     if (assetType === "tool" && !SCRIPT_EXTENSIONS.has(ext)) continue
-    if ((assetType === "command" || assetType === "agent") && ext !== ".md") continue
+    if ((assetType === "command" || assetType === "agent" || assetType === "knowledge") && ext !== ".md") continue
     if (assetType === "skill" && path.basename(file) !== "SKILL.md") continue
 
     const entry: StashEntry = {
@@ -122,6 +134,17 @@ export function generateMetadata(
     if (ext === ".md") {
       const fm = extractFrontmatterDescription(file)
       if (fm) entry.description = fm
+    }
+
+    // Knowledge entries: generate TOC from headings
+    if (assetType === "knowledge") {
+      try {
+        const mdContent = fs.readFileSync(file, "utf8")
+        const toc = parseMarkdownToc(mdContent)
+        if (toc.headings.length > 0) entry.toc = toc.headings
+      } catch {
+        // Non-fatal: skip TOC if file can't be read
+      }
     }
 
     // Priority 4: Code comments (for script files)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,5 +1,5 @@
 import { type Plugin, tool } from "@opencode-ai/plugin"
-import { agentikitOpen, agentikitRun, agentikitSearch } from "./stash"
+import { agentikitOpen, agentikitRun, agentikitSearch, type KnowledgeView } from "./stash"
 import { agentikitIndex } from "./indexer"
 
 function tryJson(fn: () => unknown, action: string): string {
@@ -14,11 +14,11 @@ function tryJson(fn: () => unknown, action: string): string {
 export const plugin: Plugin = async () => ({
   tool: {
     agentikit_search: tool({
-      description: "Search the Agentikit stash for tools, skills, commands, and agents.",
+      description: "Search the Agentikit stash for tools, skills, commands, agents, and knowledge.",
       args: {
         query: tool.schema.string().describe("Case-insensitive substring search."),
         type: tool.schema
-          .enum(["tool", "skill", "command", "agent", "any"])
+          .enum(["tool", "skill", "command", "agent", "knowledge", "any"])
           .optional()
           .describe("Optional type filter. Defaults to 'any'."),
         limit: tool.schema.number().optional().describe("Maximum number of hits to return. Defaults to 20."),
@@ -28,12 +28,35 @@ export const plugin: Plugin = async () => ({
       },
     }),
     agentikit_open: tool({
-      description: "Open a stash asset from an openRef returned by agentikit_search.",
+      description: "Open a stash asset by ref. For knowledge assets, use view_mode to retrieve specific content (toc, section, lines, frontmatter).",
       args: {
         ref: tool.schema.string().describe("Open reference returned by agentikit_search."),
+        view_mode: tool.schema
+          .enum(["full", "toc", "frontmatter", "section", "lines"])
+          .optional()
+          .describe("View mode for knowledge assets. Defaults to 'full'. Ignored for other types."),
+        heading: tool.schema.string().optional()
+          .describe("Section heading to extract (required when view_mode is 'section')."),
+        start_line: tool.schema.number().optional()
+          .describe("Start line number, 1-based (for view_mode 'lines')."),
+        end_line: tool.schema.number().optional()
+          .describe("End line number, 1-based inclusive (for view_mode 'lines')."),
       },
-      async execute({ ref }) {
-        return tryJson(() => agentikitOpen({ ref }), "open stash asset")
+      async execute({ ref, view_mode, heading, start_line, end_line }) {
+        let view: KnowledgeView | undefined
+        if (view_mode) {
+          switch (view_mode) {
+            case "section":
+              view = { mode: "section", heading: heading ?? "" }
+              break
+            case "lines":
+              view = { mode: "lines", start: start_line ?? 1, end: end_line ?? Infinity }
+              break
+            default:
+              view = { mode: view_mode } as KnowledgeView
+          }
+        }
+        return tryJson(() => agentikitOpen({ ref, view }), "open stash asset")
       },
     }),
     agentikit_run: tool({

--- a/src/stash.ts
+++ b/src/stash.ts
@@ -4,8 +4,9 @@ import path from "node:path"
 import { loadSearchIndex, buildSearchText } from "./indexer"
 import { TfIdfAdapter, type ScoredEntry } from "./similarity"
 import { rgFilterCandidates, ensureRg } from "./ripgrep"
+import { parseMarkdownToc, extractSection, extractLineRange, extractFrontmatterOnly, formatToc } from "./markdown"
 
-export type AgentikitAssetType = "tool" | "skill" | "command" | "agent"
+export type AgentikitAssetType = "tool" | "skill" | "command" | "agent" | "knowledge"
 export type AgentikitSearchType = AgentikitAssetType | "any"
 
 export interface SearchHit {
@@ -48,6 +49,13 @@ export interface RunResponse {
   output: string
   exitCode: number
 }
+
+export type KnowledgeView =
+  | { mode: "full" }
+  | { mode: "toc" }
+  | { mode: "frontmatter" }
+  | { mode: "section"; heading: string }
+  | { mode: "lines"; start: number; end: number }
 
 type IndexedAsset = {
   type: AgentikitAssetType
@@ -228,7 +236,7 @@ function deriveOpenRefName(
   return toPosix(path.relative(root, filePath))
 }
 
-export function agentikitOpen(input: { ref: string }): OpenResponse {
+export function agentikitOpen(input: { ref: string; view?: KnowledgeView }): OpenResponse {
   const parsed = parseOpenRef(input.ref)
   const stashDir = resolveStashDir()
   const assetPath = resolveAssetPath(stashDir, parsed.type, parsed.name)
@@ -274,11 +282,41 @@ export function agentikitOpen(input: { ref: string }): OpenResponse {
         kind: toolInfo.kind,
       }
     }
+    case "knowledge": {
+      const v = input.view ?? { mode: "full" }
+      switch (v.mode) {
+        case "toc": {
+          const toc = parseMarkdownToc(content)
+          return { type: "knowledge", name: parsed.name, path: assetPath, content: formatToc(toc) }
+        }
+        case "frontmatter": {
+          const fm = extractFrontmatterOnly(content)
+          return { type: "knowledge", name: parsed.name, path: assetPath, content: fm ?? "(no frontmatter)" }
+        }
+        case "section": {
+          const section = extractSection(content, v.heading)
+          if (!section) throw new Error(`Section "${v.heading}" not found in ${parsed.name}`)
+          return { type: "knowledge", name: parsed.name, path: assetPath, content: section.content }
+        }
+        case "lines": {
+          return { type: "knowledge", name: parsed.name, path: assetPath, content: extractLineRange(content, v.start, v.end) }
+        }
+        default: {
+          return { type: "knowledge", name: parsed.name, path: assetPath, content }
+        }
+      }
+    }
   }
 }
 
 export function agentikitRun(input: { ref: string }): RunResponse {
   const parsed = parseOpenRef(input.ref)
+  if (parsed.type === "knowledge") {
+    throw new Error(
+      `Knowledge assets are read-only. Use agentikitOpen with ref "${input.ref}" instead.`
+      + ` You can pass a view parameter to retrieve specific sections, line ranges, or the table of contents.`,
+    )
+  }
   if (parsed.type !== "tool") {
     throw new Error(`agentikitRun only supports tool refs. Got: "${parsed.type}".`)
   }
@@ -368,6 +406,13 @@ const ASSET_INDEXERS: Record<AgentikitAssetType, { dir: string; collect: (root: 
       return { type: "agent", name: toPosix(path.relative(root, file)), path: file }
     },
   },
+  knowledge: {
+    dir: "knowledge",
+    collect(root, file) {
+      if (path.extname(file).toLowerCase() !== ".md") return undefined
+      return { type: "knowledge", name: toPosix(path.relative(root, file)), path: file }
+    },
+  },
 }
 
 function indexAssets(stashDir: string, type: AgentikitSearchType): IndexedAsset[] {
@@ -442,7 +487,7 @@ function makeOpenRef(type: AgentikitAssetType, name: string): string {
 }
 
 function resolveAssetPath(stashDir: string, type: AgentikitAssetType, name: string): string {
-  const root = path.join(stashDir, type === "tool" ? "tools" : `${type}s`)
+  const root = path.join(stashDir, ASSET_INDEXERS[type].dir)
   const target = type === "skill" ? path.join(root, name, "SKILL.md") : path.join(root, name)
   const resolvedRoot = resolveAndValidateTypeRoot(root, type, name)
   const resolvedTarget = path.resolve(target)
@@ -614,7 +659,7 @@ function parseYamlScalar(value: string): unknown {
 }
 
 function isAssetType(type: string): type is AgentikitAssetType {
-  return type === "tool" || type === "skill" || type === "command" || type === "agent"
+  return type === "tool" || type === "skill" || type === "command" || type === "agent" || type === "knowledge"
 }
 
 function toStringOrUndefined(value: unknown): string | undefined {
@@ -704,7 +749,7 @@ export function agentikitInit(): InitResponse {
     created = true
   }
 
-  for (const sub of ["tools", "skills", "commands", "agents"]) {
+  for (const sub of ["tools", "skills", "commands", "agents", "knowledge"]) {
     const subDir = path.join(stashDir, sub)
     if (!fs.existsSync(subDir)) {
       fs.mkdirSync(subDir, { recursive: true })

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -2,11 +2,11 @@ import { test, expect } from "bun:test"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
-import { agentikitIndex, getIndexPath, loadSearchIndex } from "../src/indexer"
+import { agentikitIndex, getIndexPath, loadSearchIndex, buildSearchText } from "../src/indexer"
 
 function tmpStash(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-idx-"))
-  for (const sub of ["tools", "skills", "commands", "agents"]) {
+  for (const sub of ["tools", "skills", "commands", "agents", "knowledge"]) {
     fs.mkdirSync(path.join(dir, sub), { recursive: true })
   }
   return dir
@@ -103,4 +103,39 @@ test("agentikitIndex handles markdown assets", () => {
 
   const result = agentikitIndex({ stashDir })
   expect(result.totalEntries).toBe(2)
+})
+
+test("agentikitIndex generates TOC in stash.json for knowledge entries", () => {
+  const stashDir = tmpStash()
+  writeFile(
+    path.join(stashDir, "knowledge", "guide.md"),
+    "---\ndescription: \"A guide\"\n---\n# Getting Started\n\nIntro.\n\n## Installation\n\nInstall steps.\n",
+  )
+
+  const result = agentikitIndex({ stashDir })
+  expect(result.totalEntries).toBe(1)
+
+  const stashJson = JSON.parse(
+    fs.readFileSync(path.join(stashDir, "knowledge", ".stash.json"), "utf8"),
+  )
+  expect(stashJson.entries[0].toc).toBeDefined()
+  expect(stashJson.entries[0].toc.length).toBe(2)
+  expect(stashJson.entries[0].toc[0].text).toBe("Getting Started")
+  expect(stashJson.entries[0].toc[1].text).toBe("Installation")
+})
+
+test("buildSearchText includes TOC heading text for knowledge entries", () => {
+  const entry = {
+    name: "guide",
+    type: "knowledge" as const,
+    description: "A guide",
+    toc: [
+      { level: 1, text: "Getting Started", line: 4 },
+      { level: 2, text: "Installation", line: 8 },
+    ],
+  }
+
+  const text = buildSearchText(entry)
+  expect(text).toContain("getting started")
+  expect(text).toContain("installation")
 })

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -1,0 +1,145 @@
+import { test, expect } from "bun:test"
+import {
+  parseMarkdownToc,
+  extractSection,
+  extractLineRange,
+  extractFrontmatterOnly,
+  formatToc,
+} from "../src/markdown"
+
+const SAMPLE_DOC = `---
+title: Guide
+description: "A test guide"
+---
+# Getting Started
+
+Welcome to the guide.
+
+## Installation
+
+Run \`npm install\` to get started.
+
+## Configuration
+
+Set up your config file.
+
+### Advanced Config
+
+For power users.
+
+# API Reference
+
+The API docs.
+
+## Endpoints
+
+List of endpoints.
+`
+
+test("parseMarkdownToc extracts headings with correct levels and line numbers", () => {
+  const toc = parseMarkdownToc(SAMPLE_DOC)
+  expect(toc.headings.length).toBe(6)
+  expect(toc.headings[0]).toEqual({ level: 1, text: "Getting Started", line: 5 })
+  expect(toc.headings[1]).toEqual({ level: 2, text: "Installation", line: 9 })
+  expect(toc.headings[2]).toEqual({ level: 2, text: "Configuration", line: 13 })
+  expect(toc.headings[3]).toEqual({ level: 3, text: "Advanced Config", line: 17 })
+  expect(toc.headings[4]).toEqual({ level: 1, text: "API Reference", line: 21 })
+  expect(toc.headings[5]).toEqual({ level: 2, text: "Endpoints", line: 25 })
+})
+
+test("parseMarkdownToc skips frontmatter block", () => {
+  const doc = "---\ntitle: Test\n---\n# Heading\n"
+  const toc = parseMarkdownToc(doc)
+  expect(toc.headings.length).toBe(1)
+  expect(toc.headings[0].text).toBe("Heading")
+})
+
+test("parseMarkdownToc handles document without frontmatter", () => {
+  const doc = "# Title\n\nSome text\n\n## Section\n"
+  const toc = parseMarkdownToc(doc)
+  expect(toc.headings.length).toBe(2)
+  expect(toc.headings[0]).toEqual({ level: 1, text: "Title", line: 1 })
+  expect(toc.headings[1]).toEqual({ level: 2, text: "Section", line: 5 })
+})
+
+test("parseMarkdownToc handles empty content", () => {
+  const toc = parseMarkdownToc("")
+  expect(toc.headings).toEqual([])
+  expect(toc.totalLines).toBe(1)
+})
+
+test("parseMarkdownToc strips trailing hash markers", () => {
+  const doc = "# Heading ##\n## Another ###\n"
+  const toc = parseMarkdownToc(doc)
+  expect(toc.headings[0].text).toBe("Heading")
+  expect(toc.headings[1].text).toBe("Another")
+})
+
+test("extractSection returns content from heading to next same-or-higher level", () => {
+  const result = extractSection(SAMPLE_DOC, "Installation")
+  expect(result).not.toBeNull()
+  expect(result!.content).toContain("npm install")
+  expect(result!.content).not.toContain("Configuration")
+})
+
+test("extractSection returns content including sub-headings", () => {
+  const result = extractSection(SAMPLE_DOC, "Configuration")
+  expect(result).not.toBeNull()
+  expect(result!.content).toContain("Advanced Config")
+  expect(result!.content).not.toContain("API Reference")
+})
+
+test("extractSection is case-insensitive", () => {
+  const result = extractSection(SAMPLE_DOC, "installation")
+  expect(result).not.toBeNull()
+  expect(result!.content).toContain("npm install")
+})
+
+test("extractSection returns null for non-existent heading", () => {
+  const result = extractSection(SAMPLE_DOC, "Nonexistent")
+  expect(result).toBeNull()
+})
+
+test("extractSection handles last section (no following heading)", () => {
+  const result = extractSection(SAMPLE_DOC, "Endpoints")
+  expect(result).not.toBeNull()
+  expect(result!.content).toContain("List of endpoints")
+})
+
+test("extractLineRange returns correct lines (1-based inclusive)", () => {
+  const content = "line1\nline2\nline3\nline4\nline5"
+  expect(extractLineRange(content, 2, 4)).toBe("line2\nline3\nline4")
+})
+
+test("extractLineRange clamps to valid range", () => {
+  const content = "line1\nline2\nline3"
+  expect(extractLineRange(content, 0, 100)).toBe("line1\nline2\nline3")
+  expect(extractLineRange(content, 2, 2)).toBe("line2")
+})
+
+test("extractFrontmatterOnly returns YAML block", () => {
+  const fm = extractFrontmatterOnly(SAMPLE_DOC)
+  expect(fm).not.toBeNull()
+  expect(fm).toContain("title: Guide")
+  expect(fm).toContain('description: "A test guide"')
+})
+
+test("extractFrontmatterOnly returns null when no frontmatter", () => {
+  expect(extractFrontmatterOnly("# Just a heading\n")).toBeNull()
+})
+
+test("formatToc produces readable output with line numbers", () => {
+  const toc = parseMarkdownToc(SAMPLE_DOC)
+  const output = formatToc(toc)
+  expect(output).toContain("# Getting Started")
+  expect(output).toContain("## Installation")
+  expect(output).toContain("### Advanced Config")
+  expect(output).toContain("lines total")
+  expect(output).toMatch(/L\s*\d+/)
+})
+
+test("formatToc handles empty headings", () => {
+  const output = formatToc({ headings: [], totalLines: 5 })
+  expect(output).toContain("no headings found")
+  expect(output).toContain("5 lines total")
+})

--- a/tests/stash.test.ts
+++ b/tests/stash.test.ts
@@ -6,6 +6,7 @@ import {
   agentikitSearch,
   agentikitOpen,
   agentikitRun,
+  agentikitInit,
   type SearchHit,
 } from "../src/stash"
 
@@ -158,4 +159,144 @@ test("agentikitOpen blocks symlink escapes outside stash type root", () => {
 
   process.env.AGENTIKIT_STASH_DIR = stashDir
   expect(() => agentikitOpen({ ref: "tool:link.sh" })).toThrow(/Ref resolves outside the stash root/)
+})
+
+// ── Knowledge tests ─────────────────────────────────────────────────────────
+
+const KNOWLEDGE_DOC = `---
+title: API Guide
+description: "API documentation"
+---
+# Overview
+
+This is the API guide.
+
+## Authentication
+
+Use bearer tokens.
+
+## Endpoints
+
+### GET /users
+
+Returns all users.
+
+### POST /users
+
+Creates a user.
+`
+
+test("agentikitSearch finds knowledge assets", () => {
+  const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-stash-"))
+  writeFile(path.join(stashDir, "knowledge", "api-guide.md"), KNOWLEDGE_DOC)
+
+  process.env.AGENTIKIT_STASH_DIR = stashDir
+  const result = agentikitSearch({ query: "", type: "knowledge" })
+
+  expect(result.hits.length).toBe(1)
+  expect(result.hits[0].type).toBe("knowledge")
+  expect(result.hits[0].name).toBe("api-guide.md")
+})
+
+test("agentikitOpen returns full content for knowledge by default", () => {
+  const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-stash-"))
+  writeFile(path.join(stashDir, "knowledge", "api-guide.md"), KNOWLEDGE_DOC)
+
+  process.env.AGENTIKIT_STASH_DIR = stashDir
+  const result = agentikitOpen({ ref: "knowledge:api-guide.md" })
+
+  expect(result.type).toBe("knowledge")
+  expect(result.content).toContain("# Overview")
+  expect(result.content).toContain("## Authentication")
+})
+
+test("agentikitOpen returns TOC for knowledge with view toc", () => {
+  const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-stash-"))
+  writeFile(path.join(stashDir, "knowledge", "api-guide.md"), KNOWLEDGE_DOC)
+
+  process.env.AGENTIKIT_STASH_DIR = stashDir
+  const result = agentikitOpen({ ref: "knowledge:api-guide.md", view: { mode: "toc" } })
+
+  expect(result.type).toBe("knowledge")
+  expect(result.content).toContain("# Overview")
+  expect(result.content).toContain("## Authentication")
+  expect(result.content).toContain("## Endpoints")
+  expect(result.content).toContain("lines total")
+})
+
+test("agentikitOpen extracts section for knowledge", () => {
+  const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-stash-"))
+  writeFile(path.join(stashDir, "knowledge", "api-guide.md"), KNOWLEDGE_DOC)
+
+  process.env.AGENTIKIT_STASH_DIR = stashDir
+  const result = agentikitOpen({ ref: "knowledge:api-guide.md", view: { mode: "section", heading: "Authentication" } })
+
+  expect(result.type).toBe("knowledge")
+  expect(result.content).toContain("bearer tokens")
+  expect(result.content).not.toContain("Endpoints")
+})
+
+test("agentikitOpen extracts line range for knowledge", () => {
+  const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-stash-"))
+  writeFile(path.join(stashDir, "knowledge", "api-guide.md"), KNOWLEDGE_DOC)
+
+  process.env.AGENTIKIT_STASH_DIR = stashDir
+  const result = agentikitOpen({ ref: "knowledge:api-guide.md", view: { mode: "lines", start: 5, end: 7 } })
+
+  expect(result.type).toBe("knowledge")
+  expect(result.content).toContain("# Overview")
+})
+
+test("agentikitOpen extracts frontmatter for knowledge", () => {
+  const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-stash-"))
+  writeFile(path.join(stashDir, "knowledge", "api-guide.md"), KNOWLEDGE_DOC)
+
+  process.env.AGENTIKIT_STASH_DIR = stashDir
+  const result = agentikitOpen({ ref: "knowledge:api-guide.md", view: { mode: "frontmatter" } })
+
+  expect(result.type).toBe("knowledge")
+  expect(result.content).toContain("title: API Guide")
+  expect(result.content).not.toContain("# Overview")
+})
+
+test("agentikitOpen returns no-frontmatter message when missing", () => {
+  const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-stash-"))
+  writeFile(path.join(stashDir, "knowledge", "plain.md"), "# Just a heading\nSome text.\n")
+
+  process.env.AGENTIKIT_STASH_DIR = stashDir
+  const result = agentikitOpen({ ref: "knowledge:plain.md", view: { mode: "frontmatter" } })
+
+  expect(result.content).toBe("(no frontmatter)")
+})
+
+test("agentikitOpen throws for missing section in knowledge", () => {
+  const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-stash-"))
+  writeFile(path.join(stashDir, "knowledge", "api-guide.md"), KNOWLEDGE_DOC)
+
+  process.env.AGENTIKIT_STASH_DIR = stashDir
+  expect(() =>
+    agentikitOpen({ ref: "knowledge:api-guide.md", view: { mode: "section", heading: "Nonexistent" } }),
+  ).toThrow(/Section "Nonexistent" not found/)
+})
+
+test("agentikitRun throws helpful error for knowledge refs", () => {
+  const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-stash-"))
+  writeFile(path.join(stashDir, "knowledge", "doc.md"), "# Doc\n")
+
+  process.env.AGENTIKIT_STASH_DIR = stashDir
+  expect(() => agentikitRun({ ref: "knowledge:doc.md" })).toThrow(/Knowledge assets are read-only/)
+})
+
+test("agentikitInit creates knowledge directory", () => {
+  const origHome = process.env.HOME
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-home-"))
+  process.env.HOME = tmpHome
+  delete process.env.AGENTIKIT_STASH_DIR
+
+  try {
+    const result = agentikitInit()
+    expect(fs.existsSync(path.join(result.stashDir, "knowledge"))).toBe(true)
+  } finally {
+    process.env.HOME = origHome
+  }
 })


### PR DESCRIPTION
Add a new "knowledge" asset type for markdown reference documents with optional frontmatter. Unlike other asset types, knowledge entries support structured retrieval via a view parameter: full content, table of contents, specific sections by heading, line ranges, or frontmatter only. The index stores a TOC with line numbers and section headings, making section titles searchable via TF-IDF.

https://claude.ai/code/session_0117Cn2erbQXxnNqYk3t4z38