### PR TITLE
fix: add checksum verification to PowerShell installer

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -15,8 +15,10 @@ $Tag = if ($args.Count -gt 0) { $args[0] } else { "latest" }
 
 if ($Tag -eq "latest") {
     $DownloadUrl = "https://github.com/$Repo/releases/latest/download/$Binary"
+    $ChecksumUrl = "https://github.com/$Repo/releases/latest/download/checksums.txt"
 } else {
     $DownloadUrl = "https://github.com/$Repo/releases/download/$Tag/$Binary"
+    $ChecksumUrl = "https://github.com/$Repo/releases/download/$Tag/checksums.txt"
 }
 
 if (!(Test-Path $InstallDir)) {
@@ -24,9 +26,39 @@ if (!(Test-Path $InstallDir)) {
 }
 
 $OutFile = Join-Path $InstallDir "agentikit.exe"
+$ChecksumFile = Join-Path $env:TEMP "agentikit-checksums.txt"
 
 Write-Host "Downloading $Binary..."
 Invoke-WebRequest -Uri $DownloadUrl -OutFile $OutFile -UseBasicParsing
+
+Write-Host "Downloading checksums..."
+Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumFile -UseBasicParsing
+
+$ExpectedHash = $null
+foreach ($line in (Get-Content $ChecksumFile)) {
+    if ($line -match "^(\S+)\s+$([regex]::Escape($Binary))$") {
+        $ExpectedHash = $Matches[1]
+        break
+    }
+}
+
+Remove-Item $ChecksumFile -ErrorAction SilentlyContinue
+
+if (-not $ExpectedHash) {
+    Remove-Item $OutFile -ErrorAction SilentlyContinue
+    Write-Error "Error: checksum not found for $Binary"
+    exit 1
+}
+
+$ActualHash = (Get-FileHash -Path $OutFile -Algorithm SHA256).Hash.ToLower()
+
+if ($ExpectedHash -ne $ActualHash) {
+    Remove-Item $OutFile -ErrorAction SilentlyContinue
+    Write-Error "Error: checksum verification failed for $Binary"
+    exit 1
+}
+
+Write-Host "Checksum verified for $Binary."
 
 # Add to user PATH if not already present
 $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")


### PR DESCRIPTION
The bash installer (install.sh) verifies downloaded binaries against checksums.txt, but install.ps1 was missing this security check. Added SHA256 checksum download and verification to match.

https://claude.ai/code/session_012RiSi5SjDgCD6iJreHNifN