### PR TITLE
Phase 9: Rebrand agentikit → akm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-03-10
+
+Major internal overhaul and rebrand. This release simplifies the asset model,
+cleans up the CLI surface, and renames the package from `agentikit` to `akm-cli`.
+
 ### Added
+- `--verbose` flag on `search` for detailed scoring output
+- ExecHints system (`run`, `cwd`, `setup`) for script assets, replacing the old tool-runner
+- New environment variable overrides: `AKM_CONFIG_DIR`, `AKM_CACHE_DIR`, `AKM_STASH_DIR`
 - CI workflow running lint, type-check, and tests on every push/PR
 - Biome linter and formatter configuration
 - README badges (npm version, CI status, license)
 
-### Fixed
-- CLI crash on macOS when running as compiled binary (`package.json` not embedded)
-
 ### Changed
+- **Rebrand**: npm package `agentikit` renamed to `akm-cli`; binary remains `akm`
+- **Rebrand**: config field `"agentikit"` renamed to `"akm"` in `package.json`
+- **Rebrand**: plugin `agentikit-opencode` renamed to `akm-opencode`
+- **Rebrand**: registry `agentikit-registry` renamed to `akm-registry`
+- **Rebrand**: default paths changed (`~/agentikit` to `~/akm`, `~/.config/agentikit` to `~/.config/akm`)
+- **Rebrand**: environment variables `AGENTIKIT_*` renamed to `AKM_*`
+- Merged `tool` type into `script` (tool is now a transparent alias)
+- `.stash.json` field renames: `intents` to `searchHints`, `entry` to `filename`; removed `generated` boolean
+- `show` command: `--view` flag replaced with positional syntax (`akm show <ref> toc`)
+- Collapsed `AssetTypeHandler` handlers into a unified renderer pipeline
+- Dropped provider presets (raw JSON config only)
 - Pinned `sqlite-vec` to exact version `0.1.7-alpha.2` (removed caret range)
 - Replaced `(Bun as any).YAML` cast with proper type guard in CLI
 - Version now injected at compile time via `--define AKM_VERSION` with safe runtime fallback
+
+### Removed
+- `submit` command
+- Provider presets (configure providers with raw JSON)
+- `generated` boolean from `.stash.json`
+
+### Fixed
+- CLI crash on macOS when running as compiled binary (`package.json` not embedded)
+- Cleaned up search output formatting
 
 ## [0.0.13] - 2026-03-09
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
-# Agent-i-Kit
+# akm — the Agent-i-Kit Manager
 
-[![npm version](https://img.shields.io/npm/v/agentikit)](https://www.npmjs.com/package/agentikit)
+[![npm version](https://img.shields.io/npm/v/akm-cli)](https://www.npmjs.com/package/akm-cli)
 [![CI](https://github.com/itlackey/agentikit/actions/workflows/ci.yml/badge.svg)](https://github.com/itlackey/agentikit/actions/workflows/ci.yml)
-[![license](https://img.shields.io/npm/l/agentikit)](LICENSE)
+[![license](https://img.shields.io/npm/l/akm-cli)](LICENSE)
 
 A package manager for AI agent capabilities — tools, skills, commands, agents,
 knowledge, and scripts — that works with any AI coding assistant that can run
 shell commands.
 
-You build up useful scripts, prompts, and agent configs. Agent-i-Kit lets you
-organize them into a searchable **stash**, share them as installable **kits**,
-and give any model a way to discover and use them through `akm` (Agent Kit
-Manager). No plugins required — just CLI output any tool-calling model can read.
+You build up useful scripts, prompts, and agent configs. `akm` (the Agent-i-Kit
+Manager) lets you organize them into a searchable **stash**, share them as
+installable **kits**, and give any model a way to discover and use them. No
+plugins required — just CLI output any tool-calling model can read.
 
 ## Requirements
 
-Agent-i-Kit requires [Bun](https://bun.sh) v1.0+ as its runtime. It uses
-Bun-specific APIs (`bun:sqlite`) that are **not available in Node.js**.
+`akm` requires [Bun](https://bun.sh) v1.0+ as its runtime. It uses Bun-specific
+APIs (`bun:sqlite`) that are **not available in Node.js**.
 
 ## Quick Start
 
 ```sh
 # Install (requires Bun v1.0+)
-bun install -g agentikit
+bun install -g akm-cli
 
 # Initialize your stash
 akm init
@@ -42,8 +42,8 @@ akm show script:deploy.sh
 
 ## Using With Any AI Agent
 
-Agent-i-Kit is platform agnostic. Any model that can execute shell commands can
-search your stash and use what it finds. The workflow is three commands:
+`akm` is platform agnostic. Any model that can execute shell commands can search
+your stash and use what it finds. The workflow is three commands:
 
 1. `akm search "what you need"` — find relevant assets (returns JSON)
 2. `akm show <openRef>` — get the details (run command, instructions, prompt, etc.)
@@ -98,11 +98,11 @@ For tighter integration, plugins are available for some platforms. These add
 native tool bindings so the agent doesn't need to shell out, but they're
 purely optional — the CLI works everywhere.
 
-**OpenCode** — Add the [OpenCode plugin](https://github.com/itlackey/agentikit-plugins?tab=readme-ov-file#agentikit-opencode) to your `opencode.json`:
+**OpenCode** — Add the [OpenCode plugin](https://github.com/itlackey/agentikit-plugins?tab=readme-ov-file#akm-opencode) to your `opencode.json`:
 
 ```json
 {
-  "plugin": ["agentikit-opencode"]
+  "plugin": ["akm-opencode"]
 }
 ```
 
@@ -115,8 +115,8 @@ Add the prompt snippet to whatever instruction mechanism your platform uses.
 ## What's In a Kit?
 
 A kit is a directory of assets you can share and install. There's no required
-structure — agentikit classifies assets by **file extension and content**, not
-by directory name. A `.sh` file is a script whether it lives in `scripts/`,
+structure — `akm` classifies assets by **file extension and content**, not by
+directory name. A `.sh` file is a script whether it lives in `scripts/`,
 `deploy/`, or at the root. A `.md` file with `tools` in its frontmatter is an
 agent definition wherever you put it.
 
@@ -234,22 +234,22 @@ akm clone tool:deploy.sh        # Fork an asset into your stash for editing
 
 1. Organize your assets (directory conventions are optional)
 2. Add `"akm"` to `keywords` in `package.json` or add the `akm` topic to your GitHub repo
-3. Optionally add `agentikit.include` to control what gets installed
+3. Optionally add `akm.include` in `package.json` to control what gets installed
 4. Publish to npm or push to GitHub
 
 See the [Kit Maker's Guide](docs/kit-makers.md) for a full walkthrough.
 
 ## Installation
 
-Agent-i-Kit requires [Bun](https://bun.sh) v1.0+ as its runtime. It uses
-Bun-specific APIs (`bun:sqlite`) that are not available in Node.js.
+`akm` requires [Bun](https://bun.sh) v1.0+ as its runtime. It uses Bun-specific
+APIs (`bun:sqlite`) that are not available in Node.js.
 
 ```sh
 # Install Bun if you don't have it
 curl -fsSL https://bun.sh/install | bash
 
-# Install agentikit
-bun install -g agentikit
+# Install akm
+bun install -g akm-cli
 ```
 
 ### Standalone binary
@@ -289,8 +289,8 @@ akm upgrade --check   # Check for updates without installing
 
 ## Status
 
-Agent-i-Kit is approaching v1.0. The core CLI, stash model, and registry are
-stable and in daily use. Feedback, issues, and PRs welcome — especially around
+`akm` is approaching v1.0. The core CLI, stash model, and registry are stable
+and in daily use. Feedback, issues, and PRs welcome — especially around
 real-world usage patterns and integrations with different AI coding assistants.
 
 ## License

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,6 +1,6 @@
 # Concepts
 
-Agentikit is a capability discovery system for AI agents. Instead of searching
+Agent-i-Kit (akm) is a capability discovery system for AI agents. Instead of searching
 files, agents discover capabilities -- tools, skills, commands, agents,
 knowledge, and scripts -- through indexed metadata and hybrid search.
 
@@ -30,7 +30,7 @@ described below.
 
 ## Asset Types
 
-Agentikit organizes capabilities into five primary asset types:
+akm organizes capabilities into five primary asset types:
 
 | Type | Classified by | Preferred Directory | Purpose |
 | --- | --- | --- | --- |
@@ -57,7 +57,7 @@ Organize your kit however makes sense for your project.
 
 ## Asset Classification
 
-Agentikit uses a two-layer classification system: **matchers** determine
+akm uses a two-layer classification system: **matchers** determine
 what an asset is, and **renderers** determine how it is presented.
 
 ### Matchers
@@ -133,7 +133,7 @@ See [filesystem.md](filesystem.md) for the full field reference.
 
 ## Script Execution (ExecHints)
 
-For script assets, agentikit resolves execution hints with three
+For script assets, akm resolves execution hints with three
 levels of precedence:
 
 1. **`.stash.json`** fields (`run`/`setup`/`cwd`) take highest priority

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,11 +1,13 @@
 # Configuration
 
-Agentikit stores configuration in a platform-standard config directory:
+akm stores configuration in a platform-standard config directory:
 
 | Platform | Path |
 | --- | --- |
-| Linux / macOS | `$XDG_CONFIG_HOME/agentikit/config.json` (default `~/.config/agentikit/config.json`) |
-| Windows | `%APPDATA%\agentikit\config.json` |
+| Linux / macOS | `$XDG_CONFIG_HOME/akm/config.json` (default `~/.config/akm/config.json`) |
+| Windows | `%APPDATA%\akm\config.json` |
+
+Override with `AKM_CONFIG_DIR`.
 
 ## Managing Config
 
@@ -33,7 +35,7 @@ Two backends are supported for generating search embeddings.
 
 ### Local (default)
 
-When `embedding` is not configured (null), Agentikit uses `@xenova/transformers`
+When `embedding` is not configured (null), akm uses `@xenova/transformers`
 with the `Xenova/all-MiniLM-L6-v2` model. Runs on CPU with no external
 dependencies. Produces 384-dimensional vectors.
 
@@ -89,7 +91,7 @@ API. After installing Ollama:
 ollama pull nomic-embed-text
 ollama pull llama3.2
 
-# Configure agentikit
+# Configure akm
 akm config set embedding '{"endpoint":"http://localhost:11434/v1/embeddings","model":"nomic-embed-text","dimension":384}'
 akm config set llm '{"endpoint":"http://localhost:11434/v1/chat/completions","model":"llama3.2","temperature":0.3,"maxTokens":512}'
 
@@ -99,7 +101,7 @@ akm index --full
 
 ## sqlite-vec Extension
 
-Agentikit uses [sqlite-vec](https://github.com/asg017/sqlite-vec) for fast
+akm uses [sqlite-vec](https://github.com/asg017/sqlite-vec) for fast
 vector similarity search. When sqlite-vec is not available (common in compiled
 binaries on macOS), semantic search falls back to a pure JS implementation
 that computes cosine similarity over BLOB-stored embeddings.
@@ -119,7 +121,7 @@ bun add sqlite-vec
 ```
 
 On macOS, Apple's built-in SQLite disables extension loading. If you installed
-agentikit as a compiled binary, you may need to install a full SQLite build
+akm as a compiled binary, you may need to install a full SQLite build
 (e.g. via Homebrew) and point Bun to it:
 
 ```sh

--- a/docs/filesystem.md
+++ b/docs/filesystem.md
@@ -1,6 +1,6 @@
 # Filesystem Layout
 
-Quick reference for where agentikit stores files.
+Quick reference for where akm stores files.
 
 ## Stash Directory
 
@@ -9,8 +9,8 @@ The main working directory for all assets.
 | Env / Default | Path |
 |---|---|
 | `AKM_STASH_DIR` | User-defined |
-| Linux / macOS | `~/agentikit` |
-| Windows | `%USERPROFILE%\Documents\agentikit` |
+| Linux / macOS | `~/akm` |
+| Windows | `%USERPROFILE%\Documents\akm` |
 
 ### Preferred Directories
 
@@ -127,8 +127,10 @@ Stored outside the stash directory, following XDG conventions.
 
 | Platform | Path |
 |---|---|
-| Linux / macOS | `$XDG_CONFIG_HOME/agentikit/config.json` (default `~/.config/agentikit/config.json`) |
-| Windows | `%APPDATA%\agentikit\config.json` |
+| Linux / macOS | `$XDG_CONFIG_HOME/akm/config.json` (default `~/.config/akm/config.json`) |
+| Windows | `%APPDATA%\akm\config.json` |
+
+Override with `AKM_CONFIG_DIR`.
 
 ## Cache
 
@@ -136,5 +138,7 @@ Used for SQLite indexes and registry downloads.
 
 | Purpose | Path |
 |---|---|
-| Index DB | `$XDG_CACHE_HOME/agentikit/` (default `~/.cache/agentikit/`) |
-| Registry cache | `~/.cache/agentikit/registry/` |
+| Index DB | `$XDG_CACHE_HOME/akm/` (default `~/.cache/akm/`) |
+| Registry cache | `~/.cache/akm/registry/` |
+
+Override with `AKM_CACHE_DIR`.

--- a/docs/kit-makers.md
+++ b/docs/kit-makers.md
@@ -5,7 +5,7 @@ can install it with `akm add`.
 
 ## Step 1: Organize Your Assets
 
-You can organize a kit however you like. Agentikit classifies assets by
+You can organize a kit however you like. akm classifies assets by
 **file extension and content**, so directory names are not required to
 follow any particular pattern.
 
@@ -247,7 +247,7 @@ akm show script:deploy.sh
    ```
 
 2. If your repo contains files that should not be part of the kit (source
-   code, tests, CI config), use `agentikit.include` to declare which paths
+   code, tests, CI config), use `akm.include` to declare which paths
    to ship:
 
    ```json
@@ -255,7 +255,7 @@ akm show script:deploy.sh
      "name": "@your-scope/my-kit",
      "version": "1.0.0",
      "keywords": ["akm"],
-     "agentikit": {
+     "akm": {
        "include": ["tools", "skills", "knowledge"]
      }
    }
@@ -301,7 +301,7 @@ search paths.
    akm config set searchPaths '["/mnt/shared/team-kit"]'
    ```
 
-   Or add it directly to `~/.config/agentikit/config.json`:
+   Or add it directly to `~/.config/akm/config.json`:
 
    ```json
    {

--- a/docs/registry-index.schema.json
+++ b/docs/registry-index.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Agentikit Registry Index",
+  "title": "akm Registry Index",
   "description": "Static index of discoverable kits for akm search --source registry",
   "type": "object",
   "required": ["version", "updatedAt", "kits"],

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -23,7 +23,7 @@ Registry search queries npm and GitHub in parallel.
 
 ### Filtering
 
-Not every npm package or GitHub repo is an agentikit kit. To keep results
+Not every npm package or GitHub repo is an akm kit. To keep results
 relevant, the registry enforces tag-based filtering:
 
 - **npm** -- Only packages whose `keywords` array in `package.json` includes
@@ -100,14 +100,14 @@ akm add file:///absolute/path/to/kit
    tarball URL is resolved. For GitHub, the latest release tarball is used, or
    the default branch if no releases exist. For git, the repo is shallow-cloned.
 3. **Download and extract** -- The tarball is downloaded (or repo cloned) to a
-   cache directory under `~/.cache/agentikit/registry/` and extracted securely
+   cache directory under `~/.cache/akm/registry/` and extracted securely
    (path traversal is rejected).
 4. **Stash root detection** -- The extracted contents are scanned for asset
    type directories (`tools/`, `skills/`, etc.) or a `.stash/` marker. If the
    kit nests its stash under an `opencode/` subdirectory, that is detected
    automatically.
 5. **Selective include** -- If the package's `package.json` contains an
-   `agentikit.include` array, only the listed paths are copied into the
+   `akm.include` array, only the listed paths are copied into the
    install cache. This lets a kit ship a subset of its repo as the stash.
 6. **Config registration** -- The installed entry is saved to
    `config.registry.installed` with its id, source, ref, resolved version,
@@ -121,7 +121,7 @@ A kit can declare which paths to include via `package.json`:
 
 ```jsonc
 {
-  "agentikit": {
+  "akm": {
     "include": [
       "tools",
       "skills",
@@ -218,15 +218,15 @@ can submit kits by opening a pull request directly against the
 
 ## Cache Layout
 
-Installed kits are cached under `~/.cache/agentikit/registry/`:
+Installed kits are cached under `~/.cache/akm/registry/`:
 
 ```
-~/.cache/agentikit/registry/
+~/.cache/akm/registry/
   npm-@scope-my-kit/
     <timestamp>-<random>/
       artifact.tar.gz     # Downloaded archive
       extracted/           # Extracted contents
-      selected/            # Subset from agentikit.include (if applicable)
+      selected/            # Subset from akm.include (if applicable)
 ```
 
 Each install creates a new timestamped directory. Previous versions are

--- a/docs/search.md
+++ b/docs/search.md
@@ -5,7 +5,7 @@ the most relevant assets for a query.
 
 ## Indexed Search (primary)
 
-When an index exists (`~/.cache/agentikit/index.db`), two strategies run in
+When an index exists (`~/.cache/akm/index.db`), two strategies run in
 parallel:
 
 1. **FTS5 (lexical)** -- SQLite full-text search with Porter stemming.

--- a/docs/test-coverage-guide.md
+++ b/docs/test-coverage-guide.md
@@ -22,7 +22,7 @@ import os from "node:os"
 import path from "node:path"
 
 const createdTmpDirs: string[] = []
-function tmpDir(prefix = "agentikit-test-"): string {
+function tmpDir(prefix = "akm-test-"): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
   createdTmpDirs.push(dir)
   return dir
@@ -127,7 +127,7 @@ async function buildTestIndex(stashDir: string, files: Record<string, string>) {
   }
   process.env.AKM_STASH_DIR = stashDir
   saveConfig({ semanticSearch: false, searchPaths: [] })
-  await agentikitIndex({ stashDir, full: true })
+  await akmIndex({ stashDir, full: true })
 }
 ```
 
@@ -157,7 +157,7 @@ async function buildTestIndex(stashDir: string, files: Record<string, string>) {
 ### 2.3 Substring fallback
 
 - `falls back to substring search when no index exists` -- Do NOT call
-  `agentikitIndex`. Search, verify results come from filesystem walk.
+  `akmIndex`. Search, verify results come from filesystem walk.
 - `substring search is case-insensitive` -- Create `Deploy.sh`, search for
   "deploy", verify match.
 
@@ -292,20 +292,20 @@ import { toolHandler } from "../src/handlers/tool-handler"
 
 These tests require careful isolation since they mutate config.
 
-### 6.1 agentikitList
+### 6.1 akmList
 
 - `returns empty list when no registry installed` -- Load default config,
-  call `agentikitList`. Verify `totalInstalled` is 0.
+  call `akmList`. Verify `totalInstalled` is 0.
 - `returns installed entries with status` -- Save a config with one installed
-  entry pointing to real dirs. Call `agentikitList`. Verify the entry and its
+  entry pointing to real dirs. Call `akmList`. Verify the entry and its
   `cacheDirExists`/`stashRootExists` flags.
 - `reports missing directories in status` -- Save config with entries pointing
   to non-existent dirs. Verify `cacheDirExists: false`.
 
-### 6.2 agentikitRemove
+### 6.2 akmRemove
 
 - `removes entry by id` -- Save config with an installed entry. Call
-  `agentikitRemove({ target: entry.id })`. Verify config no longer contains it.
+  `akmRemove({ target: entry.id })`. Verify config no longer contains it.
 - `removes entry by ref` -- Same but pass the ref string.
 - `throws for unknown target` -- Pass a target that doesn't match any entry.
 - `cleans up cache directory` -- Verify the cache dir is deleted.

--- a/install.ps1
+++ b/install.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = "Stop"
 
 $Repo = "itlackey/agentikit"
-$InstallDir = if ($env:AGENTIKIT_INSTALL_DIR) { $env:AGENTIKIT_INSTALL_DIR } else { Join-Path $env:LOCALAPPDATA "agentikit" }
+$InstallDir = if ($env:AKM_INSTALL_DIR) { $env:AKM_INSTALL_DIR } else { Join-Path $env:LOCALAPPDATA "akm" }
 
 # Detect architecture
 $Arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO="itlackey/agentikit"
-INSTALL_DIR="${AGENTIKIT_INSTALL_DIR:-/usr/local/bin}"
+INSTALL_DIR="${AKM_INSTALL_DIR:-/usr/local/bin}"
 
 # Detect OS
 OS="$(uname -s)"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "agentikit",
-  "version": "0.0.15",
+  "name": "akm-cli",
+  "version": "0.1.0",
   "type": "module",
-  "description": "CLI tool to search, open, and run extension assets from an agentikit stash directory.",
+  "description": "CLI tool to search, open, and run extension assets from an akm stash directory.",
   "keywords": [
-    "agentikit",
+    "akm",
+    "agent-i-kit",
     "ai-agent",
     "agent-framework",
     "developer-tools",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -233,7 +233,7 @@ const initCommand = defineCommand({
     description: "Initialize Agent-i-Kit's working stash directory and persist stashDir in config",
   },
   args: {
-    dir: { type: "string", description: "Custom stash directory path (default: ~/agentikit)" },
+    dir: { type: "string", description: "Custom stash directory path (default: ~/akm)" },
   },
   async run({ args }) {
     await runWithJsonErrors(async () => {

--- a/src/common.ts
+++ b/src/common.ts
@@ -32,7 +32,7 @@ export function isAssetType(type: string): type is AgentikitAssetType {
  * Resolve the stash directory using a three-level fallback chain:
  *   1. AKM_STASH_DIR environment variable (override for CI/scripts)
  *   2. stashDir field in config.json
- *   3. Platform default (~/agentikit or ~/Documents/agentikit on Windows)
+ *   3. Platform default (~/akm or ~/Documents/akm on Windows)
  *
  * Throws if no valid stash directory is found.
  */

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,7 +46,7 @@ export interface AgentikitConfig {
   llm?: LlmConnectionConfig;
   /** Installed registry sources and local cache metadata */
   registry?: RegistryConfig;
-  /** Registry index URLs for kit discovery. Default: official agentikit-registry on GitHub */
+  /** Registry index URLs for kit discovery. Default: official akm-registry on GitHub */
   registryUrls?: string[];
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -4,7 +4,7 @@ export function githubHeaders(): HeadersInit {
   const token = process.env.GITHUB_TOKEN?.trim();
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
-    "User-Agent": "agentikit-registry",
+    "User-Agent": "akm-registry",
   };
   if (token) headers.Authorization = `Bearer ${token}`;
   return headers;

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -141,7 +141,7 @@ export async function agentikitIndex(options?: { stashDir?: string; full?: boole
   }
 }
 
-// ── Extracted helpers for agentikitIndex ─────────────────────────────────────
+// ── Extracted helpers for indexing ────────────────────────────────────────────
 
 function indexEntries(
   db: import("bun:sqlite").Database,

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,5 +1,5 @@
 /**
- * Agentikit initialization logic.
+ * akm initialization logic.
  *
  * Creates the working stash directory structure, persists the stashDir
  * in config.json, and ensures ripgrep is available.

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -1,5 +1,5 @@
 /**
- * Built-in asset matchers for the agentikit file classification system.
+ * Built-in asset matchers for the akm file classification system.
  *
  * Four matchers are registered at module load time, each at a different
  * specificity level. Extension and content determine type; directories are

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,5 +1,5 @@
 /**
- * Centralized path resolution for all agentikit directories.
+ * Centralized path resolution for all akm directories.
  *
  * Provides platform-aware paths for config, cache, and stash directories,
  * following XDG Base Directory conventions on Unix and standard locations
@@ -14,25 +14,28 @@ const IS_WINDOWS = process.platform === "win32";
 // ── Config directory ─────────────────────────────────────────────────────────
 
 export function getConfigDir(env: NodeJS.ProcessEnv = process.env, platform = process.platform): string {
+  const override = env.AKM_CONFIG_DIR?.trim();
+  if (override) return override;
+
   if (platform === "win32") {
     const appData = env.APPDATA?.trim();
-    if (appData) return path.join(appData, "agentikit");
+    if (appData) return path.join(appData, "akm");
 
     const userProfile = env.USERPROFILE?.trim();
     if (!userProfile) {
       throw new ConfigError("Unable to determine config directory. Set APPDATA or USERPROFILE.");
     }
-    return path.join(userProfile, "AppData", "Roaming", "agentikit");
+    return path.join(userProfile, "AppData", "Roaming", "akm");
   }
 
   const xdgConfigHome = env.XDG_CONFIG_HOME?.trim();
-  if (xdgConfigHome) return path.join(xdgConfigHome, "agentikit");
+  if (xdgConfigHome) return path.join(xdgConfigHome, "akm");
 
   const home = env.HOME?.trim();
   if (!home) {
     throw new ConfigError("Unable to determine config directory. Set XDG_CONFIG_HOME or HOME.");
   }
-  return path.join(home, ".config", "agentikit");
+  return path.join(home, ".config", "akm");
 }
 
 export function getConfigPath(): string {
@@ -42,27 +45,30 @@ export function getConfigPath(): string {
 // ── Cache directory ──────────────────────────────────────────────────────────
 
 export function getCacheDir(): string {
+  const override = process.env.AKM_CACHE_DIR?.trim();
+  if (override) return override;
+
   if (IS_WINDOWS) {
     const localAppData = process.env.LOCALAPPDATA?.trim();
-    if (localAppData) return path.join(localAppData, "agentikit");
+    if (localAppData) return path.join(localAppData, "akm");
 
     const userProfile = process.env.USERPROFILE?.trim();
-    if (userProfile) return path.join(userProfile, "AppData", "Local", "agentikit");
+    if (userProfile) return path.join(userProfile, "AppData", "Local", "akm");
 
     const appData = process.env.APPDATA?.trim();
     if (!appData) {
       throw new ConfigError("Unable to determine cache directory. Set LOCALAPPDATA, USERPROFILE, or APPDATA.");
     }
-    return path.join(appData, "..", "Local", "agentikit");
+    return path.join(appData, "..", "Local", "akm");
   }
 
   const xdgCacheHome = process.env.XDG_CACHE_HOME?.trim();
-  if (xdgCacheHome) return path.join(xdgCacheHome, "agentikit");
+  if (xdgCacheHome) return path.join(xdgCacheHome, "akm");
 
   const home = process.env.HOME?.trim();
-  if (!home) return path.join("/tmp", "agentikit-cache");
+  if (!home) return path.join("/tmp", "akm-cache");
 
-  return path.join(home, ".cache", "agentikit");
+  return path.join(home, ".cache", "akm");
 }
 
 export function getDbPath(): string {
@@ -84,15 +90,18 @@ export function getBinDir(): string {
 // ── Default stash directory ──────────────────────────────────────────────────
 
 export function getDefaultStashDir(): string {
+  const override = process.env.AKM_STASH_DIR?.trim();
+  if (override) return override;
+
   if (IS_WINDOWS) {
     const userProfile = process.env.USERPROFILE?.trim();
-    if (userProfile) return path.join(userProfile, "Documents", "agentikit");
-    return path.join("C:\\", "agentikit");
+    if (userProfile) return path.join(userProfile, "Documents", "akm");
+    return path.join("C:\\", "akm");
   }
 
   const home = process.env.HOME?.trim();
   if (!home) {
     throw new ConfigError("Unable to determine default stash directory. Set HOME.");
   }
-  return path.join(home, "agentikit");
+  return path.join(home, "akm");
 }

--- a/src/registry-install.ts
+++ b/src/registry-install.ts
@@ -418,10 +418,10 @@ function readAgentikitIncludeConfigAtDir(dirPath: string): { baseDir: string; in
   }
   if (typeof pkg !== "object" || pkg === null || Array.isArray(pkg)) return undefined;
 
-  const agentikit = (pkg as Record<string, unknown>).agentikit;
-  if (typeof agentikit !== "object" || agentikit === null || Array.isArray(agentikit)) return undefined;
+  const akmConfig = (pkg as Record<string, unknown>).akm;
+  if (typeof akmConfig !== "object" || akmConfig === null || Array.isArray(akmConfig)) return undefined;
 
-  const include = (agentikit as Record<string, unknown>).include;
+  const include = (akmConfig as Record<string, unknown>).include;
   if (!Array.isArray(include)) return undefined;
 
   const parsedInclude = include
@@ -455,10 +455,10 @@ function copyIncludedPaths(baseDir: string, include: string[], destinationDir: s
   for (const entry of include) {
     const resolvedSource = path.resolve(baseDir, entry);
     if (!isWithin(resolvedSource, baseDir)) {
-      throw new Error(`Path in agentikit.include escapes the package root: ${entry}`);
+      throw new Error(`Path in akm.include escapes the package root: ${entry}`);
     }
     if (!fs.existsSync(resolvedSource)) {
-      throw new Error(`Path in agentikit.include does not exist: ${entry}`);
+      throw new Error(`Path in akm.include does not exist: ${entry}`);
     }
     if (path.basename(resolvedSource) === ".git") {
       continue;

--- a/src/registry-search.ts
+++ b/src/registry-search.ts
@@ -7,7 +7,7 @@ import type { RegistrySearchHit, RegistrySearchResponse } from "./registry-types
 // ── Constants ───────────────────────────────────────────────────────────────
 
 /** Default registry index URL. Override via config or AKM_REGISTRY_URL env var. */
-const DEFAULT_REGISTRY_URL = "https://raw.githubusercontent.com/itlackey/agentikit-registry/main/index.json";
+const DEFAULT_REGISTRY_URL = "https://raw.githubusercontent.com/itlackey/akm-registry/main/index.json";
 
 /** Cache TTL in milliseconds (1 hour). */
 const CACHE_TTL_MS = 60 * 60 * 1000;

--- a/src/self-update.ts
+++ b/src/self-update.ts
@@ -66,7 +66,7 @@ export async function performUpgrade(
       newVersion: latestVersion,
       upgraded: false,
       installMethod,
-      message: `akm installed via npm. Run: bun install -g agentikit@latest`,
+      message: `akm installed via npm. Run: bun install -g akm-cli@latest`,
     };
   }
 

--- a/src/stash-resolve.ts
+++ b/src/stash-resolve.ts
@@ -68,7 +68,7 @@ function resolveInTypeDir(stashDir: string, typeDir: string, type: AgentikitAsse
   if (!isRelevantAssetFile(relevanceType, path.basename(resolvedTarget))) {
     if (type === "tool" || type === "script") {
       throw new NotFoundError(
-        "Script ref must resolve to a file with a supported script extension. Refer to the Agentikit documentation for the complete list of supported script extensions.",
+        "Script ref must resolve to a file with a supported script extension. Refer to the akm documentation for the complete list of supported script extensions.",
       );
     }
     throw new NotFoundError(`Stash asset not found for ref: ${normalizeAssetType(type)}:${name}`);

--- a/src/walker.ts
+++ b/src/walker.ts
@@ -1,5 +1,5 @@
 /**
- * Shared filesystem walker for agentikit stash directories.
+ * Shared filesystem walker for akm stash directories.
  *
  * Provides a single implementation used by both the search fallback
  * (stash.ts) and the indexer (indexer.ts) to walk type-specific asset

--- a/tests/common.test.ts
+++ b/tests/common.test.ts
@@ -13,7 +13,7 @@ describe("resolveStashDir", () => {
   let testConfigHome: string;
 
   beforeEach(() => {
-    testConfigHome = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-common-test-config-"));
+    testConfigHome = fs.mkdtempSync(path.join(os.tmpdir(), "akm-common-test-config-"));
     process.env.XDG_CONFIG_HOME = testConfigHome;
   });
 
@@ -40,8 +40,8 @@ describe("resolveStashDir", () => {
 
   test("throws when no stash dir is configured and default does not exist", () => {
     delete process.env.AKM_STASH_DIR;
-    // Point HOME to a tmp dir without an agentikit subdirectory
-    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-common-test-home-"));
+    // Point HOME to a tmp dir without an akm subdirectory
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "akm-common-test-home-"));
     process.env.HOME = tmpHome;
     try {
       expect(() => resolveStashDir()).toThrow("No stash directory found");
@@ -56,7 +56,7 @@ describe("resolveStashDir", () => {
   });
 
   test("throws when AKM_STASH_DIR path is a file, not a directory", () => {
-    const tmpFile = path.join(os.tmpdir(), `agentikit-common-test-file-${Date.now()}`);
+    const tmpFile = path.join(os.tmpdir(), `akm-common-test-file-${Date.now()}`);
     fs.writeFileSync(tmpFile, "not a directory");
     try {
       process.env.AKM_STASH_DIR = tmpFile;
@@ -67,7 +67,7 @@ describe("resolveStashDir", () => {
   });
 
   test("returns resolved path for valid AKM_STASH_DIR", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-common-test-"));
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-common-test-"));
     try {
       process.env.AKM_STASH_DIR = tmpDir;
       const result = resolveStashDir();
@@ -79,9 +79,9 @@ describe("resolveStashDir", () => {
 
   test("reads stashDir from config.json when env var is not set", () => {
     delete process.env.AKM_STASH_DIR;
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-common-test-stash-"));
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-common-test-stash-"));
     try {
-      const configDir = path.join(testConfigHome, "agentikit");
+      const configDir = path.join(testConfigHome, "akm");
       fs.mkdirSync(configDir, { recursive: true });
       fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ stashDir: tmpDir }));
       const result = resolveStashDir();
@@ -93,8 +93,8 @@ describe("resolveStashDir", () => {
 
   test("uses default stash dir when it exists", () => {
     delete process.env.AKM_STASH_DIR;
-    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-common-test-home-"));
-    const defaultStash = path.join(tmpHome, "agentikit");
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "akm-common-test-home-"));
+    const defaultStash = path.join(tmpHome, "akm");
     fs.mkdirSync(defaultStash, { recursive: true });
     process.env.HOME = tmpHome;
     try {
@@ -106,12 +106,12 @@ describe("resolveStashDir", () => {
   });
 
   test("env var takes precedence over config.json stashDir", () => {
-    const envDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-common-test-env-"));
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-common-test-cfg-"));
+    const envDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-common-test-env-"));
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-common-test-cfg-"));
     try {
       process.env.AKM_STASH_DIR = envDir;
 
-      const configRoot = path.join(testConfigHome, "agentikit");
+      const configRoot = path.join(testConfigHome, "akm");
       fs.mkdirSync(configRoot, { recursive: true });
       fs.writeFileSync(path.join(configRoot, "config.json"), JSON.stringify({ stashDir: configDir }));
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { DEFAULT_CONFIG, getConfigDir, getConfigPath, loadConfig, saveConfig, updateConfig } from "../src/config";
 
 function makeTmpDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-config-test-"));
+  return fs.mkdtempSync(path.join(os.tmpdir(), "akm-config-test-"));
 }
 
 function cleanup(dir: string): void {
@@ -56,31 +56,31 @@ afterEach(() => {
 
 describe("getConfigPath", () => {
   test("returns config.json under XDG_CONFIG_HOME", () => {
-    expect(getConfigPath()).toBe(path.join(testConfigHome, "agentikit", "config.json"));
+    expect(getConfigPath()).toBe(path.join(testConfigHome, "akm", "config.json"));
   });
 
-  test("defaults to ~/.config/agentikit when XDG_CONFIG_HOME is unset", () => {
+  test("defaults to ~/.config/akm when XDG_CONFIG_HOME is unset", () => {
     const home = makeTmpDir();
     delete process.env.XDG_CONFIG_HOME;
     process.env.HOME = home;
 
-    expect(getConfigPath()).toBe(path.join(home, ".config", "agentikit", "config.json"));
+    expect(getConfigPath()).toBe(path.join(home, ".config", "akm", "config.json"));
 
     cleanup(home);
   });
 
   test("uses APPDATA on Windows", () => {
     const appData = String.raw`C:\Users\alice\AppData\Roaming`;
-    expect(getConfigDir({ APPDATA: appData }, "win32")).toBe(path.join(appData, "agentikit"));
+    expect(getConfigDir({ APPDATA: appData }, "win32")).toBe(path.join(appData, "akm"));
     expect(path.join(getConfigDir({ APPDATA: appData }, "win32"), "config.json")).toBe(
-      path.join(appData, "agentikit", "config.json"),
+      path.join(appData, "akm", "config.json"),
     );
   });
 
   test("falls back to USERPROFILE AppData Roaming on Windows", () => {
     const userProfile = String.raw`C:\Users\alice`;
     expect(getConfigDir({ USERPROFILE: userProfile }, "win32")).toBe(
-      path.join(userProfile, "AppData", "Roaming", "agentikit"),
+      path.join(userProfile, "AppData", "Roaming", "akm"),
     );
   });
 

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -28,7 +28,7 @@ import type { StashEntry } from "../src/metadata";
 const createdTmpDirs: string[] = [];
 
 function tmpDir(label = "db"): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `agentikit-${label}-`));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `akm-${label}-`));
   createdTmpDirs.push(dir);
   return dir;
 }

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1,5 +1,5 @@
 /**
- * End-to-end tests that replicate real-world usage of agentikit.
+ * End-to-end tests that replicate real-world usage of akm.
  *
  * Uses realistic fixtures in tests/fixtures/ representing a typical user's
  * stash directory with tools, skills, commands, and agents.
@@ -32,7 +32,7 @@ const FIXTURES = path.join(__dirname, "fixtures");
 const CLI = path.join(__dirname, "..", "src", "cli.ts");
 
 function copyFixturesToTmp(): string {
-  const tmpStash = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-e2e-"));
+  const tmpStash = fs.mkdtempSync(path.join(os.tmpdir(), "akm-e2e-"));
   copyDirRecursive(FIXTURES, tmpStash);
   return tmpStash;
 }
@@ -97,12 +97,12 @@ let testCacheDir = "";
 let testConfigDir = "";
 
 beforeAll(async () => {
-  testCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-e2e-cache-"));
+  testCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-e2e-cache-"));
   process.env.XDG_CACHE_HOME = testCacheDir;
 });
 
 beforeEach(() => {
-  testConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-e2e-config-"));
+  testConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-e2e-config-"));
   process.env.XDG_CONFIG_HOME = testConfigDir;
 });
 
@@ -371,7 +371,7 @@ describe("Scenario: Mixed local + registry search compatibility", () => {
   // aren't shadowed by a cached index from a previous test.
   beforeEach(() => {
     savedCacheDir = process.env.XDG_CACHE_HOME ?? "";
-    process.env.XDG_CACHE_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-e2e-reg-cache-"));
+    process.env.XDG_CACHE_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "akm-e2e-reg-cache-"));
   });
 
   afterEach(() => {
@@ -731,7 +731,7 @@ describe("Scenario: CLI subprocess execution", () => {
 
 describe("Scenario: Registry lifecycle CLI (no network)", () => {
   test("cli: akm list returns empty installed set when none configured", async () => {
-    const stashDir = createEmptyStashDir("agentikit-e2e-registry-empty-");
+    const stashDir = createEmptyStashDir("akm-e2e-registry-empty-");
     process.env.AKM_STASH_DIR = stashDir;
     saveConfig({ semanticSearch: false, searchPaths: [] });
 
@@ -748,9 +748,9 @@ describe("Scenario: Registry lifecycle CLI (no network)", () => {
   });
 
   test("cli: akm remove resolves parsed ref id and removes cache directory", async () => {
-    const stashDir = createEmptyStashDir("agentikit-e2e-registry-remove-");
+    const stashDir = createEmptyStashDir("akm-e2e-registry-remove-");
     const stashRoot = path.join(stashDir, "registry-kit");
-    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-e2e-cache-remove-"));
+    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-e2e-cache-remove-"));
     fs.mkdirSync(path.join(stashRoot, "tools"), { recursive: true });
     process.env.AKM_STASH_DIR = stashDir;
 
@@ -791,7 +791,7 @@ describe("Scenario: Registry lifecycle CLI (no network)", () => {
   });
 
   test("cli: akm update requires target or --all", async () => {
-    const stashDir = createEmptyStashDir("agentikit-e2e-registry-update-");
+    const stashDir = createEmptyStashDir("akm-e2e-registry-update-");
     process.env.AKM_STASH_DIR = stashDir;
     saveConfig({ semanticSearch: false, searchPaths: [] });
 
@@ -806,7 +806,7 @@ describe("Scenario: Registry lifecycle CLI (no network)", () => {
   });
 
   test("cli: akm update rejects target with --all", async () => {
-    const stashDir = createEmptyStashDir("agentikit-e2e-registry-update-both-");
+    const stashDir = createEmptyStashDir("akm-e2e-registry-update-both-");
     process.env.AKM_STASH_DIR = stashDir;
     saveConfig({ semanticSearch: false, searchPaths: [] });
 
@@ -821,7 +821,7 @@ describe("Scenario: Registry lifecycle CLI (no network)", () => {
   });
 
   test("cli: akm update missing target returns stable not-installed error", async () => {
-    const stashDir = createEmptyStashDir("agentikit-e2e-registry-missing-");
+    const stashDir = createEmptyStashDir("akm-e2e-registry-missing-");
     process.env.AKM_STASH_DIR = stashDir;
     saveConfig({ semanticSearch: false, searchPaths: [] });
 
@@ -877,7 +877,7 @@ describe("Scenario: upgrade and update --force (no network)", () => {
   });
 
   test("cli: akm update --force requires target or --all", async () => {
-    const stashDir = createEmptyStashDir("agentikit-e2e-update-force-");
+    const stashDir = createEmptyStashDir("akm-e2e-update-force-");
     process.env.AKM_STASH_DIR = stashDir;
     saveConfig({ semanticSearch: false, mountedStashDirs: [] });
 
@@ -983,7 +983,7 @@ describe("Scenario: Zero-config progressive improvement", () => {
   let stashDir: string;
 
   beforeAll(async () => {
-    stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-e2e-prog-"));
+    stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-e2e-prog-"));
     for (const sub of ["tools", "skills", "commands", "agents"]) {
       fs.mkdirSync(path.join(stashDir, sub), { recursive: true });
     }
@@ -1204,8 +1204,8 @@ describe("Scenario: Error handling and edge cases", () => {
     const orig = process.env.AKM_STASH_DIR;
     const origHome = process.env.HOME;
     delete process.env.AKM_STASH_DIR;
-    // Point HOME somewhere without an agentikit directory to force the "no stash" error
-    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-e2e-nohome-"));
+    // Point HOME somewhere without an akm directory to force the "no stash" error
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "akm-e2e-nohome-"));
     process.env.HOME = tmpHome;
     try {
       await expect(agentikitSearch({ query: "test" })).rejects.toThrow(/No stash directory found/);
@@ -1219,7 +1219,7 @@ describe("Scenario: Error handling and edge cases", () => {
   });
 
   test("show with invalid ref format throws", async () => {
-    const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-e2e-err-"));
+    const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-e2e-err-"));
     process.env.AKM_STASH_DIR = stashDir;
     try {
       await expect(agentikitShow({ ref: "badref" })).rejects.toThrow(/Invalid ref/);
@@ -1229,7 +1229,7 @@ describe("Scenario: Error handling and edge cases", () => {
   });
 
   test("show with unknown type throws", async () => {
-    const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-e2e-err-"));
+    const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-e2e-err-"));
     process.env.AKM_STASH_DIR = stashDir;
     try {
       await expect(agentikitShow({ ref: "widget:foo" })).rejects.toThrow(/Invalid asset type/);
@@ -1239,7 +1239,7 @@ describe("Scenario: Error handling and edge cases", () => {
   });
 
   test("show with path traversal attempt throws", async () => {
-    const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-e2e-err-"));
+    const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-e2e-err-"));
     fs.mkdirSync(path.join(stashDir, "tools"), { recursive: true });
     process.env.AKM_STASH_DIR = stashDir;
     try {
@@ -1250,7 +1250,7 @@ describe("Scenario: Error handling and edge cases", () => {
   });
 
   test("search on empty stash returns no hits with tip", async () => {
-    const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-e2e-empty-"));
+    const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-e2e-empty-"));
     for (const sub of ["tools", "skills", "commands", "agents"]) {
       fs.mkdirSync(path.join(stashDir, sub), { recursive: true });
     }
@@ -1265,7 +1265,7 @@ describe("Scenario: Error handling and edge cases", () => {
   });
 
   test("index on empty stash succeeds with zero entries", async () => {
-    const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-e2e-empty-"));
+    const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-e2e-empty-"));
     for (const sub of ["tools", "skills", "commands", "agents"]) {
       fs.mkdirSync(path.join(stashDir, sub), { recursive: true });
     }

--- a/tests/file-context.test.ts
+++ b/tests/file-context.test.ts
@@ -11,7 +11,7 @@ import { walkStashFlat } from "../src/walker";
 
 const createdTmpDirs: string[] = [];
 
-function tmpDir(prefix = "agentikit-fc-"): string {
+function tmpDir(prefix = "akm-fc-"): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   createdTmpDirs.push(dir);
   return dir;

--- a/tests/fixtures/tools/lint/package.json
+++ b/tests/fixtures/tools/lint/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agentikit-eslint",
+  "name": "akm-eslint",
   "description": "ESLint integration for checking code quality and style",
   "keywords": [
     "eslint",

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -28,7 +28,7 @@ describe("githubHeaders", () => {
     delete process.env.GITHUB_TOKEN;
     const headers = githubHeaders() as Record<string, string>;
     expect(headers.Accept).toBe("application/vnd.github+json");
-    expect(headers["User-Agent"]).toBe("agentikit-registry");
+    expect(headers["User-Agent"]).toBe("akm-registry");
   });
 
   test("does not include Authorization when GITHUB_TOKEN is unset", () => {

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
 });
 
 function tmpStash(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-idx-"));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-idx-"));
   for (const sub of ["tools", "skills", "commands", "agents", "knowledge", "scripts"]) {
     fs.mkdirSync(path.join(dir, sub), { recursive: true });
   }

--- a/tests/issue-36-repro.test.ts
+++ b/tests/issue-36-repro.test.ts
@@ -22,7 +22,7 @@ import type { LocalSearchHit } from "../src/stash-types";
 
 const createdTmpDirs: string[] = [];
 
-function createTmpDir(prefix = "agentikit-issue36-"): string {
+function createTmpDir(prefix = "akm-issue36-"): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   createdTmpDirs.push(dir);
   return dir;
@@ -42,7 +42,7 @@ function writeFile(filePath: string, content = "") {
 }
 
 function tmpStash(): string {
-  const dir = createTmpDir("agentikit-issue36-stash-");
+  const dir = createTmpDir("akm-issue36-stash-");
   for (const sub of ["tools", "skills", "commands", "agents", "knowledge", "scripts"]) {
     fs.mkdirSync(path.join(dir, sub), { recursive: true });
   }
@@ -69,8 +69,8 @@ let testCacheDir = "";
 let testConfigDir = "";
 
 beforeEach(() => {
-  testCacheDir = createTmpDir("agentikit-issue36-cache-");
-  testConfigDir = createTmpDir("agentikit-issue36-config-");
+  testCacheDir = createTmpDir("akm-issue36-cache-");
+  testConfigDir = createTmpDir("akm-issue36-config-");
   process.env.XDG_CACHE_HOME = testCacheDir;
   process.env.XDG_CONFIG_HOME = testConfigDir;
 });

--- a/tests/lockfile.test.ts
+++ b/tests/lockfile.test.ts
@@ -11,11 +11,11 @@ const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
 let testConfigDir = "";
 
 function makeTmpDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-lockfile-test-"));
+  return fs.mkdtempSync(path.join(os.tmpdir(), "akm-lockfile-test-"));
 }
 
 function getLockfilePath(): string {
-  return path.join(testConfigDir, "agentikit", "stash.lock");
+  return path.join(testConfigDir, "akm", "stash.lock");
 }
 
 function writeRawLockfile(content: string): void {

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -19,7 +19,7 @@ import {
 const createdTmpDirs: string[] = [];
 
 function tmpDir(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-meta-"));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-meta-"));
   createdTmpDirs.push(dir);
   return dir;
 }

--- a/tests/origin-resolve.test.ts
+++ b/tests/origin-resolve.test.ts
@@ -10,7 +10,7 @@ import type { StashSource } from "../src/stash-source";
 let tmpDirs: string[] = [];
 
 function makeTmpDir(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-origin-test-"));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-origin-test-"));
   tmpDirs.push(dir);
   return dir;
 }

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -15,7 +15,17 @@ import {
 
 const savedEnv: Record<string, string | undefined> = {};
 
-const envKeys = ["XDG_CONFIG_HOME", "XDG_CACHE_HOME", "HOME", "APPDATA", "LOCALAPPDATA", "USERPROFILE"];
+const envKeys = [
+  "XDG_CONFIG_HOME",
+  "XDG_CACHE_HOME",
+  "HOME",
+  "APPDATA",
+  "LOCALAPPDATA",
+  "USERPROFILE",
+  "AKM_CONFIG_DIR",
+  "AKM_CACHE_DIR",
+  "AKM_STASH_DIR",
+];
 
 function saveEnv(): void {
   for (const key of envKeys) {
@@ -44,12 +54,12 @@ afterEach(() => {
 describe("getConfigDir", () => {
   test("uses XDG_CONFIG_HOME on Unix", () => {
     const result = getConfigDir({ XDG_CONFIG_HOME: "/custom/config" }, "linux");
-    expect(result).toBe(path.join("/custom/config", "agentikit"));
+    expect(result).toBe(path.join("/custom/config", "akm"));
   });
 
   test("falls back to HOME/.config on Unix when XDG_CONFIG_HOME is unset", () => {
     const result = getConfigDir({ HOME: "/home/user" }, "linux");
-    expect(result).toBe(path.join("/home/user", ".config", "agentikit"));
+    expect(result).toBe(path.join("/home/user", ".config", "akm"));
   });
 
   test("throws on Unix when HOME and XDG_CONFIG_HOME are both unset", () => {
@@ -60,12 +70,12 @@ describe("getConfigDir", () => {
 
   test("uses APPDATA on Windows", () => {
     const result = getConfigDir({ APPDATA: String.raw`C:\Users\user\AppData\Roaming` }, "win32");
-    expect(result).toBe(path.join(String.raw`C:\Users\user\AppData\Roaming`, "agentikit"));
+    expect(result).toBe(path.join(String.raw`C:\Users\user\AppData\Roaming`, "akm"));
   });
 
   test("falls back to USERPROFILE on Windows when APPDATA is unset", () => {
     const result = getConfigDir({ USERPROFILE: String.raw`C:\Users\user` }, "win32");
-    expect(result).toBe(path.join(String.raw`C:\Users\user`, "AppData", "Roaming", "agentikit"));
+    expect(result).toBe(path.join(String.raw`C:\Users\user`, "AppData", "Roaming", "akm"));
   });
 
   test("throws on Windows when APPDATA and USERPROFILE are both unset", () => {
@@ -76,33 +86,38 @@ describe("getConfigDir", () => {
 
   test("trims whitespace from XDG_CONFIG_HOME", () => {
     const result = getConfigDir({ XDG_CONFIG_HOME: "  /trimmed  " }, "linux");
-    expect(result).toBe(path.join("/trimmed", "agentikit"));
+    expect(result).toBe(path.join("/trimmed", "akm"));
   });
 
   test("trims whitespace from HOME", () => {
     const result = getConfigDir({ HOME: "  /home/user  " }, "linux");
-    expect(result).toBe(path.join("/home/user", ".config", "agentikit"));
+    expect(result).toBe(path.join("/home/user", ".config", "akm"));
   });
 
   test("ignores empty XDG_CONFIG_HOME and falls back to HOME", () => {
     const result = getConfigDir({ XDG_CONFIG_HOME: "  ", HOME: "/home/user" }, "linux");
-    expect(result).toBe(path.join("/home/user", ".config", "agentikit"));
+    expect(result).toBe(path.join("/home/user", ".config", "akm"));
   });
 
   test("ignores empty APPDATA on Windows and falls back to USERPROFILE", () => {
     const result = getConfigDir({ APPDATA: "  ", USERPROFILE: String.raw`C:\Users\user` }, "win32");
-    expect(result).toBe(path.join(String.raw`C:\Users\user`, "AppData", "Roaming", "agentikit"));
+    expect(result).toBe(path.join(String.raw`C:\Users\user`, "AppData", "Roaming", "akm"));
   });
 
   test("uses default process.env when env argument omitted", () => {
     process.env.XDG_CONFIG_HOME = "/test-xdg";
     const result = getConfigDir();
-    expect(result).toBe(path.join("/test-xdg", "agentikit"));
+    expect(result).toBe(path.join("/test-xdg", "akm"));
   });
 
   test("uses darwin platform same as linux (XDG path)", () => {
     const result = getConfigDir({ XDG_CONFIG_HOME: "/darwin/cfg" }, "darwin");
-    expect(result).toBe(path.join("/darwin/cfg", "agentikit"));
+    expect(result).toBe(path.join("/darwin/cfg", "akm"));
+  });
+
+  test("AKM_CONFIG_DIR overrides all other paths", () => {
+    const result = getConfigDir({ AKM_CONFIG_DIR: "/override/config", HOME: "/home/user" }, "linux");
+    expect(result).toBe("/override/config");
   });
 });
 
@@ -111,7 +126,7 @@ describe("getConfigDir", () => {
 describe("getConfigPath", () => {
   test("returns config.json under config dir", () => {
     process.env.XDG_CONFIG_HOME = "/test-cfg";
-    expect(getConfigPath()).toBe(path.join("/test-cfg", "agentikit", "config.json"));
+    expect(getConfigPath()).toBe(path.join("/test-cfg", "akm", "config.json"));
   });
 });
 
@@ -119,23 +134,32 @@ describe("getConfigPath", () => {
 
 describe("getCacheDir", () => {
   test("uses XDG_CACHE_HOME on Unix", () => {
+    delete process.env.AKM_CACHE_DIR;
     process.env.XDG_CACHE_HOME = "/custom/cache";
     const result = getCacheDir();
-    expect(result).toBe(path.join("/custom/cache", "agentikit"));
+    expect(result).toBe(path.join("/custom/cache", "akm"));
   });
 
   test("falls back to HOME/.cache on Unix when XDG_CACHE_HOME is unset", () => {
+    delete process.env.AKM_CACHE_DIR;
     delete process.env.XDG_CACHE_HOME;
     process.env.HOME = "/home/user";
     const result = getCacheDir();
-    expect(result).toBe(path.join("/home/user", ".cache", "agentikit"));
+    expect(result).toBe(path.join("/home/user", ".cache", "akm"));
   });
 
-  test("falls back to /tmp/agentikit-cache when HOME is also unset", () => {
+  test("falls back to /tmp/akm-cache when HOME is also unset", () => {
+    delete process.env.AKM_CACHE_DIR;
     delete process.env.XDG_CACHE_HOME;
     delete process.env.HOME;
     const result = getCacheDir();
-    expect(result).toBe(path.join("/tmp", "agentikit-cache"));
+    expect(result).toBe(path.join("/tmp", "akm-cache"));
+  });
+
+  test("AKM_CACHE_DIR overrides all other paths", () => {
+    process.env.AKM_CACHE_DIR = "/override/cache";
+    const result = getCacheDir();
+    expect(result).toBe("/override/cache");
   });
 });
 
@@ -144,7 +168,7 @@ describe("getCacheDir", () => {
 describe("getDbPath", () => {
   test("returns index.db under cache dir", () => {
     process.env.XDG_CACHE_HOME = "/cache";
-    expect(getDbPath()).toBe(path.join("/cache", "agentikit", "index.db"));
+    expect(getDbPath()).toBe(path.join("/cache", "akm", "index.db"));
   });
 });
 
@@ -153,7 +177,7 @@ describe("getDbPath", () => {
 describe("getRegistryCacheDir", () => {
   test("returns registry subdir under cache dir", () => {
     process.env.XDG_CACHE_HOME = "/cache";
-    expect(getRegistryCacheDir()).toBe(path.join("/cache", "agentikit", "registry"));
+    expect(getRegistryCacheDir()).toBe(path.join("/cache", "akm", "registry"));
   });
 });
 
@@ -162,7 +186,7 @@ describe("getRegistryCacheDir", () => {
 describe("getRegistryIndexCacheDir", () => {
   test("returns registry-index subdir under cache dir", () => {
     process.env.XDG_CACHE_HOME = "/cache";
-    expect(getRegistryIndexCacheDir()).toBe(path.join("/cache", "agentikit", "registry-index"));
+    expect(getRegistryIndexCacheDir()).toBe(path.join("/cache", "akm", "registry-index"));
   });
 });
 
@@ -171,21 +195,29 @@ describe("getRegistryIndexCacheDir", () => {
 describe("getBinDir", () => {
   test("returns bin subdir under cache dir", () => {
     process.env.XDG_CACHE_HOME = "/cache";
-    expect(getBinDir()).toBe(path.join("/cache", "agentikit", "bin"));
+    expect(getBinDir()).toBe(path.join("/cache", "akm", "bin"));
   });
 });
 
 // ── getDefaultStashDir ──────────────────────────────────────────────────────
 
 describe("getDefaultStashDir", () => {
-  test("returns HOME/agentikit on Unix", () => {
+  test("returns HOME/akm on Unix", () => {
+    delete process.env.AKM_STASH_DIR;
     process.env.HOME = "/home/user";
     const result = getDefaultStashDir();
-    expect(result).toBe(path.join("/home/user", "agentikit"));
+    expect(result).toBe(path.join("/home/user", "akm"));
   });
 
   test("throws when HOME is unset on Unix", () => {
+    delete process.env.AKM_STASH_DIR;
     delete process.env.HOME;
     expect(() => getDefaultStashDir()).toThrow("Unable to determine default stash directory. Set HOME.");
+  });
+
+  test("AKM_STASH_DIR overrides all other paths", () => {
+    process.env.AKM_STASH_DIR = "/override/stash";
+    const result = getDefaultStashDir();
+    expect(result).toBe("/override/stash");
   });
 });

--- a/tests/registry-install.test.ts
+++ b/tests/registry-install.test.ts
@@ -39,7 +39,7 @@ const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
 let testConfigDir = "";
 
 beforeEach(() => {
-  testConfigDir = makeTempDir("agentikit-registry-config-");
+  testConfigDir = makeTempDir("akm-registry-config-");
   process.env.XDG_CONFIG_HOME = testConfigDir;
 });
 
@@ -57,8 +57,8 @@ afterEach(() => {
 
 function initGitRepo(repoDir: string): void {
   runGit(["init"], repoDir);
-  runGit(["config", "user.name", "Agentikit Tests"], repoDir);
-  runGit(["config", "user.email", "agentikit@example.test"], repoDir);
+  runGit(["config", "user.name", "AKM Tests"], repoDir);
+  runGit(["config", "user.email", "akm@example.test"], repoDir);
   runGit(["config", "commit.gpgsign", "false"], repoDir);
   runGit(["add", "."], repoDir);
   runGit(["commit", "-m", "initial"], repoDir);
@@ -111,9 +111,9 @@ function createTarGz(sourceDir: string, archivePath: string): void {
 
 describe("local directory installs", () => {
   test("agentikitAdd installs a subdirectory inside a git repository", async () => {
-    const stashDir = createEmptyStashDir("agentikit-git-stash-");
-    const cacheHome = makeTempDir("agentikit-git-cache-");
-    const repoDir = makeTempDir("agentikit-git-repo-");
+    const stashDir = createEmptyStashDir("akm-git-stash-");
+    const cacheHome = makeTempDir("akm-git-cache-");
+    const repoDir = makeTempDir("akm-git-repo-");
     const kitDir = path.join(repoDir, "kits", "sample");
     writeFile(path.join(kitDir, "tools", "hello.sh"), "#!/usr/bin/env bash\necho hello\n");
     writeFile(path.join(repoDir, "README.md"), "# Example repo\n");
@@ -144,16 +144,16 @@ describe("local directory installs", () => {
     }
   });
 
-  test("agentikitAdd honors package.json agentikit.include during install", async () => {
-    const stashDir = createEmptyStashDir("agentikit-include-stash-");
-    const cacheHome = makeTempDir("agentikit-include-cache-");
-    const repoDir = makeTempDir("agentikit-include-repo-");
+  test("agentikitAdd honors package.json akm.include during install", async () => {
+    const stashDir = createEmptyStashDir("akm-include-stash-");
+    const cacheHome = makeTempDir("akm-include-cache-");
+    const repoDir = makeTempDir("akm-include-repo-");
     writeFile(
       path.join(repoDir, "package.json"),
       JSON.stringify(
         {
           name: "include-kit",
-          agentikit: {
+          akm: {
             include: ["tools", "README.md"],
           },
         },
@@ -183,9 +183,9 @@ describe("local directory installs", () => {
   });
 
   test("agentikitAdd installs a plain directory without git", async () => {
-    const stashDir = createEmptyStashDir("agentikit-nogit-stash-");
-    const cacheHome = makeTempDir("agentikit-nogit-cache-");
-    const kitDir = makeTempDir("agentikit-nogit-kit-");
+    const stashDir = createEmptyStashDir("akm-nogit-stash-");
+    const cacheHome = makeTempDir("akm-nogit-cache-");
+    const kitDir = makeTempDir("akm-nogit-kit-");
     writeFile(path.join(kitDir, "tools", "hello.sh"), "#!/usr/bin/env bash\necho hello\n");
 
     try {
@@ -204,7 +204,7 @@ describe("local directory installs", () => {
   });
 
   test("parseRegistryRef ignores non-path-like local directory names", () => {
-    const tempDir = makeTempDir("agentikit-parse-registry-");
+    const tempDir = makeTempDir("akm-parse-registry-");
     const previousCwd = process.cwd();
     fs.mkdirSync(path.join(tempDir, "local-kit"));
 
@@ -220,7 +220,7 @@ describe("local directory installs", () => {
   });
 
   test("parseRegistryRef rejects missing explicit local paths", () => {
-    const tempDir = makeTempDir("agentikit-missing-local-path-");
+    const tempDir = makeTempDir("akm-missing-local-path-");
     const previousCwd = process.cwd();
 
     try {
@@ -270,7 +270,7 @@ describe("local directory installs", () => {
   });
 
   test("parseRegistryRef parses file: prefix as local source", () => {
-    const tempDir = makeTempDir("agentikit-file-uri-");
+    const tempDir = makeTempDir("akm-file-uri-");
     try {
       const parsed = parseRegistryRef(`file:${tempDir}`);
       expect(parsed.source).toBe("local");
@@ -283,7 +283,7 @@ describe("local directory installs", () => {
   });
 
   test("parseRegistryRef parses file:/// absolute URI as local source", () => {
-    const tempDir = makeTempDir("agentikit-file-abs-uri-");
+    const tempDir = makeTempDir("akm-file-abs-uri-");
     try {
       const parsed = parseRegistryRef(`file://${tempDir}`);
       expect(parsed.source).toBe("local");
@@ -296,9 +296,9 @@ describe("local directory installs", () => {
   });
 
   test("applies include from nearest package.json for nested kit roots", async () => {
-    const cacheHome = makeTempDir("agentikit-nested-include-cache-");
-    const packageDir = makeTempDir("agentikit-nested-include-package-");
-    const archivePath = path.join(makeTempDir("agentikit-nested-archive-"), "kit.tgz");
+    const cacheHome = makeTempDir("akm-nested-include-cache-");
+    const packageDir = makeTempDir("akm-nested-include-package-");
+    const archivePath = path.join(makeTempDir("akm-nested-archive-"), "kit.tgz");
     const tarRoot = path.join(packageDir, "kit");
     fs.mkdirSync(path.join(tarRoot, "opencode", "tools"), { recursive: true });
     fs.mkdirSync(path.join(tarRoot, "opencode", "docs"), { recursive: true });
@@ -307,7 +307,7 @@ describe("local directory installs", () => {
       JSON.stringify(
         {
           name: "nested-kit",
-          agentikit: {
+          akm: {
             include: ["tools"],
           },
         },

--- a/tests/registry-search.test.ts
+++ b/tests/registry-search.test.ts
@@ -64,7 +64,7 @@ const FIXTURE_INDEX: RegistryIndex = {
 
 const createdTmpDirs: string[] = [];
 
-function createTmpDir(prefix = "agentikit-search-"): string {
+function createTmpDir(prefix = "akm-search-"): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   createdTmpDirs.push(dir);
   return dir;
@@ -112,7 +112,7 @@ const originalRegistryUrl = process.env.AKM_REGISTRY_URL;
 
 beforeEach(() => {
   // Isolate cache per test
-  process.env.XDG_CACHE_HOME = createTmpDir("agentikit-search-cache-");
+  process.env.XDG_CACHE_HOME = createTmpDir("akm-search-cache-");
   delete process.env.AKM_REGISTRY_URL;
 });
 

--- a/tests/ripgrep-install.test.ts
+++ b/tests/ripgrep-install.test.ts
@@ -11,7 +11,7 @@ import path from "node:path";
 let tmpDirs: string[] = [];
 
 function makeTmpDir(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-rg-install-test-"));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-rg-install-test-"));
   tmpDirs.push(dir);
   return dir;
 }

--- a/tests/ripgrep.test.ts
+++ b/tests/ripgrep.test.ts
@@ -7,7 +7,7 @@ import { isRgAvailable, resolveRg } from "../src/ripgrep";
 const createdTmpDirs: string[] = [];
 
 function tmpDir(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-rg-"));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-rg-"));
   createdTmpDirs.push(dir);
   return dir;
 }

--- a/tests/stash-clone.test.ts
+++ b/tests/stash-clone.test.ts
@@ -27,10 +27,10 @@ function createStashDir(prefix: string): string {
 }
 
 beforeEach(() => {
-  testConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-clone-config-"));
-  testCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-clone-cache-"));
-  stashDir = createStashDir("agentikit-clone-working-");
-  searchPathDir = createStashDir("agentikit-clone-searchpath-");
+  testConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-clone-config-"));
+  testCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-clone-cache-"));
+  stashDir = createStashDir("akm-clone-working-");
+  searchPathDir = createStashDir("akm-clone-searchpath-");
   process.env.XDG_CONFIG_HOME = testConfigDir;
   process.env.XDG_CACHE_HOME = testCacheDir;
   process.env.AKM_STASH_DIR = stashDir;
@@ -147,7 +147,7 @@ describe("agentikitClone --dest", () => {
   let customDest: string;
 
   beforeEach(() => {
-    customDest = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-clone-dest-"));
+    customDest = fs.mkdtempSync(path.join(os.tmpdir(), "akm-clone-dest-"));
   });
 
   afterEach(() => {
@@ -220,7 +220,7 @@ describe("agentikitClone remote", () => {
 
   beforeEach(() => {
     // Create a fixture directory that simulates a remote package
-    remoteFixtureDir = createStashDir("agentikit-clone-remote-fixture-");
+    remoteFixtureDir = createStashDir("akm-clone-remote-fixture-");
     writeFile(path.join(remoteFixtureDir, "tools", "remote-tool.sh"), "#!/bin/bash\necho remote\n");
     writeFile(path.join(remoteFixtureDir, "skills", "remote-skill", "SKILL.md"), "# Remote Skill\n");
   });
@@ -258,7 +258,7 @@ describe("agentikitClone remote", () => {
   });
 
   test("clones from remote origin to custom destination", async () => {
-    const customDest = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-clone-remote-dest-"));
+    const customDest = fs.mkdtempSync(path.join(os.tmpdir(), "akm-clone-remote-dest-"));
     try {
       const result = await agentikitClone({
         sourceRef: `${remoteFixtureDir}//tool:remote-tool.sh`,

--- a/tests/stash-registry.test.ts
+++ b/tests/stash-registry.test.ts
@@ -7,7 +7,7 @@ import { agentikitList, agentikitRemove, agentikitUpdate } from "../src/stash-re
 
 const createdTmpDirs: string[] = [];
 
-function createTmpDir(prefix = "agentikit-registry-"): string {
+function createTmpDir(prefix = "akm-registry-"): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   createdTmpDirs.push(dir);
   return dir;
@@ -27,9 +27,9 @@ let testConfigDir = "";
 let stashDir = "";
 
 beforeEach(() => {
-  testCacheDir = createTmpDir("agentikit-registry-cache-");
-  testConfigDir = createTmpDir("agentikit-registry-config-");
-  stashDir = createTmpDir("agentikit-registry-stash-");
+  testCacheDir = createTmpDir("akm-registry-cache-");
+  testConfigDir = createTmpDir("akm-registry-config-");
+  stashDir = createTmpDir("akm-registry-stash-");
   for (const sub of ["tools", "skills", "commands", "agents", "knowledge", "scripts"]) {
     fs.mkdirSync(path.join(stashDir, sub), { recursive: true });
   }
@@ -78,8 +78,8 @@ describe("agentikitList", () => {
   });
 
   test("returns installed entries with status", async () => {
-    const cacheDir = createTmpDir("agentikit-registry-cache-entry-");
-    const stashRoot = createTmpDir("agentikit-registry-stashroot-");
+    const cacheDir = createTmpDir("akm-registry-cache-entry-");
+    const stashRoot = createTmpDir("akm-registry-stashroot-");
 
     saveConfig({
       semanticSearch: false,
@@ -111,8 +111,8 @@ describe("agentikitList", () => {
   });
 
   test("reports missing directories in status", async () => {
-    const nonExistentCache = path.join(os.tmpdir(), `agentikit-nonexistent-cache-${Date.now()}`);
-    const nonExistentStashRoot = path.join(os.tmpdir(), `agentikit-nonexistent-root-${Date.now()}`);
+    const nonExistentCache = path.join(os.tmpdir(), `akm-nonexistent-cache-${Date.now()}`);
+    const nonExistentStashRoot = path.join(os.tmpdir(), `akm-nonexistent-root-${Date.now()}`);
 
     saveConfig({
       semanticSearch: false,
@@ -164,8 +164,8 @@ describe("agentikitRemove", () => {
   });
 
   test("removes entry by id", async () => {
-    const cacheDir = createTmpDir("agentikit-registry-remove-cache-");
-    const stashRoot = createTmpDir("agentikit-registry-remove-root-");
+    const cacheDir = createTmpDir("akm-registry-remove-cache-");
+    const stashRoot = createTmpDir("akm-registry-remove-root-");
     for (const sub of ["tools", "skills", "commands", "agents", "knowledge", "scripts"]) {
       fs.mkdirSync(path.join(stashRoot, sub), { recursive: true });
     }
@@ -196,8 +196,8 @@ describe("agentikitRemove", () => {
   });
 
   test("removes entry by ref", async () => {
-    const cacheDir = createTmpDir("agentikit-registry-remove-cache-ref-");
-    const stashRoot = createTmpDir("agentikit-registry-remove-root-ref-");
+    const cacheDir = createTmpDir("akm-registry-remove-cache-ref-");
+    const stashRoot = createTmpDir("akm-registry-remove-root-ref-");
     for (const sub of ["tools", "skills", "commands", "agents", "knowledge", "scripts"]) {
       fs.mkdirSync(path.join(stashRoot, sub), { recursive: true });
     }
@@ -228,8 +228,8 @@ describe("agentikitRemove", () => {
   });
 
   test("cleans up cache directory", async () => {
-    const cacheDir = createTmpDir("agentikit-registry-remove-cache-cleanup-");
-    const stashRoot = createTmpDir("agentikit-registry-remove-root-cleanup-");
+    const cacheDir = createTmpDir("akm-registry-remove-cache-cleanup-");
+    const stashRoot = createTmpDir("akm-registry-remove-root-cleanup-");
     for (const sub of ["tools", "skills", "commands", "agents", "knowledge", "scripts"]) {
       fs.mkdirSync(path.join(stashRoot, sub), { recursive: true });
     }
@@ -274,7 +274,7 @@ describe("selectTargets via agentikitUpdate", () => {
   });
 
   test("--all selects all installed entries", async () => {
-    const stashRoot = createTmpDir("agentikit-registry-all-root-");
+    const stashRoot = createTmpDir("akm-registry-all-root-");
     for (const sub of ["tools", "skills", "commands", "agents", "knowledge", "scripts"]) {
       fs.mkdirSync(path.join(stashRoot, sub), { recursive: true });
     }

--- a/tests/stash-resolve.test.ts
+++ b/tests/stash-resolve.test.ts
@@ -6,7 +6,7 @@ import { resolveAssetPath } from "../src/stash-resolve";
 
 const createdTmpDirs: string[] = [];
 
-function createTmpDir(prefix = "agentikit-resolve-"): string {
+function createTmpDir(prefix = "akm-resolve-"): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   createdTmpDirs.push(dir);
   return dir;
@@ -69,7 +69,7 @@ describe("resolveAssetPath", () => {
     fs.mkdirSync(toolsDir, { recursive: true });
 
     // Create a file outside the stash entirely
-    const outsideDir = createTmpDir("agentikit-outside-");
+    const outsideDir = createTmpDir("akm-outside-");
     const outsideFile = path.join(outsideDir, "escaped.sh");
     writeFile(outsideFile, "#!/bin/sh\necho escaped");
 

--- a/tests/stash-search.test.ts
+++ b/tests/stash-search.test.ts
@@ -11,7 +11,7 @@ import type { LocalSearchHit } from "../src/stash-types";
 
 const createdTmpDirs: string[] = [];
 
-function createTmpDir(prefix = "agentikit-search-"): string {
+function createTmpDir(prefix = "akm-search-"): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   createdTmpDirs.push(dir);
   return dir;
@@ -34,7 +34,7 @@ function writeFile(filePath: string, content = "") {
  * Create a stash directory with all required subdirectories.
  */
 function tmpStash(): string {
-  const dir = createTmpDir("agentikit-search-stash-");
+  const dir = createTmpDir("akm-search-stash-");
   for (const sub of ["tools", "skills", "commands", "agents", "knowledge", "scripts"]) {
     fs.mkdirSync(path.join(dir, sub), { recursive: true });
   }
@@ -65,8 +65,8 @@ let testCacheDir = "";
 let testConfigDir = "";
 
 beforeEach(() => {
-  testCacheDir = createTmpDir("agentikit-search-cache-");
-  testConfigDir = createTmpDir("agentikit-search-config-");
+  testCacheDir = createTmpDir("akm-search-cache-");
+  testConfigDir = createTmpDir("akm-search-config-");
   process.env.XDG_CACHE_HOME = testCacheDir;
   process.env.XDG_CONFIG_HOME = testConfigDir;
 });

--- a/tests/stash-show.test.ts
+++ b/tests/stash-show.test.ts
@@ -7,7 +7,7 @@ import { agentikitShow } from "../src/stash-show";
 
 const createdTmpDirs: string[] = [];
 
-function createTmpDir(prefix = "agentikit-show-"): string {
+function createTmpDir(prefix = "akm-show-"): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   createdTmpDirs.push(dir);
   return dir;
@@ -32,9 +32,9 @@ let testConfigDir = "";
 let stashDir = "";
 
 beforeEach(() => {
-  testCacheDir = createTmpDir("agentikit-show-cache-");
-  testConfigDir = createTmpDir("agentikit-show-config-");
-  stashDir = createTmpDir("agentikit-show-stash-");
+  testCacheDir = createTmpDir("akm-show-cache-");
+  testConfigDir = createTmpDir("akm-show-config-");
+  stashDir = createTmpDir("akm-show-stash-");
   for (const sub of ["tools", "skills", "commands", "agents", "knowledge", "scripts"]) {
     fs.mkdirSync(path.join(stashDir, sub), { recursive: true });
   }
@@ -73,7 +73,7 @@ afterEach(() => {
 
 describe("agentikitShow installed ref", () => {
   test("throws with installCmd when registryId present and asset not found", async () => {
-    const installedStashRoot = createTmpDir("agentikit-show-installed-root-");
+    const installedStashRoot = createTmpDir("akm-show-installed-root-");
     // Create the type subdirectory so it is a valid stash root, but do NOT
     // create the actual asset file.
     fs.mkdirSync(path.join(installedStashRoot, "tools"), { recursive: true });
@@ -106,7 +106,7 @@ describe("agentikitShow installed ref", () => {
 
 describe("agentikitShow search path", () => {
   test("resolves from search path directories", async () => {
-    const searchPathDir = createTmpDir("agentikit-show-searchpath-");
+    const searchPathDir = createTmpDir("akm-show-searchpath-");
     writeFile(path.join(searchPathDir, "tools", "deploy.sh"), "#!/usr/bin/env bash\necho deploy\n");
 
     saveConfig({ semanticSearch: false, searchPaths: [searchPathDir] });
@@ -135,7 +135,7 @@ describe("agentikitShow editability", () => {
   });
 
   test("search path asset has editable true", async () => {
-    const searchPathDir = createTmpDir("agentikit-show-searchpath-editable-");
+    const searchPathDir = createTmpDir("akm-show-searchpath-editable-");
     writeFile(path.join(searchPathDir, "tools", "remote.sh"), "#!/usr/bin/env bash\necho remote\n");
 
     saveConfig({ semanticSearch: false, searchPaths: [searchPathDir] });
@@ -148,7 +148,7 @@ describe("agentikitShow editability", () => {
   });
 
   test("installed (cache-managed) asset has editable false with editHint", async () => {
-    const installedStashRoot = createTmpDir("agentikit-show-installed-resolve-");
+    const installedStashRoot = createTmpDir("akm-show-installed-resolve-");
     writeFile(path.join(installedStashRoot, "tools", "deploy.sh"), "#!/usr/bin/env bash\necho deploy\n");
 
     saveConfig({

--- a/tests/stash-source.test.ts
+++ b/tests/stash-source.test.ts
@@ -17,8 +17,8 @@ let testConfigDir = "";
 let stashDir = "";
 
 beforeEach(() => {
-  testConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-source-config-"));
-  stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-source-stash-"));
+  testConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-source-config-"));
+  stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-source-stash-"));
   for (const sub of ["tools", "skills", "commands", "agents", "knowledge", "scripts"]) {
     fs.mkdirSync(path.join(stashDir, sub), { recursive: true });
   }
@@ -47,7 +47,7 @@ describe("resolveStashSources", () => {
   });
 
   test("includes valid search paths", () => {
-    const extraDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-extra-"));
+    const extraDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-extra-"));
     try {
       saveConfig({ semanticSearch: false, searchPaths: [extraDir] });
       const sources = resolveStashSources();
@@ -66,7 +66,7 @@ describe("resolveStashSources", () => {
   });
 
   test("includes installed registry entries with registryId", () => {
-    const installedDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-installed-"));
+    const installedDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-installed-"));
     try {
       saveConfig({
         semanticSearch: false,
@@ -95,8 +95,8 @@ describe("resolveStashSources", () => {
   });
 
   test("preserves ordering: primary, search paths, installed", () => {
-    const extraDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-extra-"));
-    const installedDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-installed-"));
+    const extraDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-extra-"));
+    const installedDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-installed-"));
     try {
       saveConfig({
         semanticSearch: false,
@@ -129,7 +129,7 @@ describe("resolveStashSources", () => {
   });
 
   test("accepts overrideStashDir parameter", () => {
-    const overrideDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-override-"));
+    const overrideDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-override-"));
     try {
       saveConfig({ semanticSearch: false, searchPaths: [] });
       const sources = resolveStashSources(overrideDir);
@@ -171,7 +171,7 @@ describe("findSourceForPath", () => {
   });
 
   test("finds correct source for file inside search path", () => {
-    const extraDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-extra-"));
+    const extraDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-extra-"));
     try {
       const sources = [{ path: stashDir }, { path: extraDir }];
       const filePath = path.join(extraDir, "tools", "test.sh");
@@ -198,7 +198,7 @@ describe("isEditable", () => {
   });
 
   test("files in search paths are editable", () => {
-    const extraDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-extra-"));
+    const extraDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-extra-"));
     try {
       saveConfig({ semanticSearch: false, searchPaths: [extraDir] });
       const filePath = path.join(extraDir, "tools", "deploy.sh");
@@ -209,7 +209,7 @@ describe("isEditable", () => {
   });
 
   test("files in cache-managed dirs are NOT editable", () => {
-    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-cache-"));
+    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-cache-"));
     try {
       saveConfig({
         semanticSearch: false,

--- a/tests/stash.test.ts
+++ b/tests/stash.test.ts
@@ -11,7 +11,7 @@ import type { SearchHit } from "../src/stash-types";
 
 const createdTmpDirs: string[] = [];
 
-function createTmpDir(prefix = "agentikit-stash-"): string {
+function createTmpDir(prefix = "akm-stash-"): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   createdTmpDirs.push(dir);
   return dir;
@@ -44,8 +44,8 @@ let testCacheDir = "";
 let testConfigDir = "";
 
 beforeEach(() => {
-  testCacheDir = createTmpDir("agentikit-stash-cache-");
-  testConfigDir = createTmpDir("agentikit-stash-config-");
+  testCacheDir = createTmpDir("akm-stash-cache-");
+  testConfigDir = createTmpDir("akm-stash-config-");
   process.env.XDG_CACHE_HOME = testCacheDir;
   process.env.XDG_CONFIG_HOME = testConfigDir;
 });
@@ -72,7 +72,7 @@ afterEach(() => {
 });
 
 test("agentikitSearch only includes tool files with .sh/.ts/.js and returns run", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "tools", "deploy.sh"), "#!/usr/bin/env bash\necho deploy\n");
   writeFile(path.join(stashDir, "tools", "script.ts"), "console.log('x')\n");
   writeFile(path.join(stashDir, "tools", "README.md"), "ignore\n");
@@ -87,7 +87,7 @@ test("agentikitSearch only includes tool files with .sh/.ts/.js and returns run"
 });
 
 test("agentikitSearch creates bun run from nearest package.json up to tools root", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   const nestedTool = path.join(stashDir, "tools", "group", "nested", "job.js");
   writeFile(nestedTool, "console.log('job')\n");
   writeFile(path.join(stashDir, "tools", "group", "package.json"), '{"name":"group"}');
@@ -102,7 +102,7 @@ test("agentikitSearch creates bun run from nearest package.json up to tools root
 });
 
 test("agentikitSearch detects setup from package.json in nearby directory", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   const nestedTool = path.join(stashDir, "tools", "group", "nested", "job.js");
   writeFile(nestedTool, "console.log('job')\n");
   writeFile(path.join(stashDir, "tools", "group", "nested", "package.json"), '{"name":"group"}');
@@ -116,8 +116,8 @@ test("agentikitSearch detects setup from package.json in nearby directory", asyn
 });
 
 test("agentikitSearch resolves tool run correctly for search path directories", async () => {
-  const primaryStashDir = createTmpDir("agentikit-stash-primary-");
-  const searchPathDir = createTmpDir("agentikit-stash-searchpath-");
+  const primaryStashDir = createTmpDir("akm-stash-primary-");
+  const searchPathDir = createTmpDir("akm-stash-searchpath-");
 
   writeFile(path.join(primaryStashDir, "tools", "placeholder.sh"), "#!/usr/bin/env bash\necho primary\n");
   writeFile(path.join(searchPathDir, "tools", "group", "nested", "job.js"), "console.log('job')\n");
@@ -137,7 +137,7 @@ test("agentikitSearch resolves tool run correctly for search path directories", 
 });
 
 test("agentikitSearch includes explainability reasons for indexed hits", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "tools", "summarize-diff.ts"), "console.log('summarize')\n");
 
   saveConfig({ semanticSearch: true, searchPaths: [] });
@@ -158,7 +158,7 @@ test("agentikitSearch includes explainability reasons for indexed hits", async (
 });
 
 test("agentikitSearch usage mode both includes guide and per-hit metadata usage", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   const toolPath = path.join(stashDir, "tools", "deploy.sh");
   writeFile(toolPath, "#!/usr/bin/env bash\necho deploy\n");
   writeFile(
@@ -187,7 +187,7 @@ test("agentikitSearch usage mode both includes guide and per-hit metadata usage"
 });
 
 test("agentikitSearch usage mode guide omits per-hit usage", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "tools", "deploy.sh"), "#!/usr/bin/env bash\necho deploy\n");
   writeFile(
     path.join(stashDir, "tools", ".stash.json"),
@@ -214,7 +214,7 @@ test("agentikitSearch usage mode guide omits per-hit usage", async () => {
 });
 
 test("agentikitSearch usage mode item omits usage guide", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "tools", "deploy.sh"), "#!/usr/bin/env bash\necho deploy\n");
   writeFile(
     path.join(stashDir, "tools", ".stash.json"),
@@ -241,7 +241,7 @@ test("agentikitSearch usage mode item omits usage guide", async () => {
 });
 
 test("agentikitSearch usage mode none omits guide and per-hit usage", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "tools", "deploy.sh"), "#!/usr/bin/env bash\necho deploy\n");
   writeFile(
     path.join(stashDir, "tools", ".stash.json"),
@@ -268,7 +268,7 @@ test("agentikitSearch usage mode none omits guide and per-hit usage", async () =
 });
 
 test("agentikitSearch fallback includes usageGuide for guide mode", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "tools", "deploy.sh"), "#!/usr/bin/env bash\necho deploy\n");
 
   process.env.AKM_STASH_DIR = stashDir;
@@ -280,7 +280,7 @@ test("agentikitSearch fallback includes usageGuide for guide mode", async () => 
 });
 
 test("agentikitShow returns full payloads for skill/command/agent", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "skills", "ops", "SKILL.md"), "# Ops\n");
   writeFile(path.join(stashDir, "commands", "release.md"), '---\ndescription: "Release command"\n---\nrun release\n');
   writeFile(path.join(stashDir, "agents", "coach.md"), '---\ndescription: "Coach"\nmodel: "gpt-5"\n---\nGuide users\n');
@@ -302,7 +302,7 @@ test("agentikitShow returns full payloads for skill/command/agent", async () => 
 });
 
 test("agentikitShow returns clear error when stash type root is missing", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   try {
     process.env.AKM_STASH_DIR = stashDir;
     await expect(agentikitShow({ ref: "agent:missing.md" })).rejects.toThrow(
@@ -314,13 +314,13 @@ test("agentikitShow returns clear error when stash type root is missing", async 
 });
 
 test("agentikitShow rejects invalid asset type in ref", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   process.env.AKM_STASH_DIR = stashDir;
   await expect(agentikitShow({ ref: "widget:foo" })).rejects.toThrow(/Invalid asset type/);
 });
 
 test("agentikitShow rejects traversal and absolute path refs", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   process.env.AKM_STASH_DIR = stashDir;
 
   await expect(agentikitShow({ ref: "tool:../outside.sh" })).rejects.toThrow(/Path traversal/);
@@ -328,8 +328,8 @@ test("agentikitShow rejects traversal and absolute path refs", async () => {
 });
 
 test("agentikitShow blocks symlink escapes outside stash type root", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
-  const outsideDir = createTmpDir("agentikit-outside-");
+  const stashDir = createTmpDir("akm-stash-");
+  const outsideDir = createTmpDir("akm-outside-");
   const outsideFile = path.join(outsideDir, "outside.sh");
   const symlinkFile = path.join(stashDir, "tools", "link.sh");
   writeFile(outsideFile, "echo outside\n");
@@ -372,7 +372,7 @@ Creates a user.
 `;
 
 test("agentikitSearch finds knowledge assets", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "knowledge", "api-guide.md"), KNOWLEDGE_DOC);
 
   process.env.AKM_STASH_DIR = stashDir;
@@ -384,7 +384,7 @@ test("agentikitSearch finds knowledge assets", async () => {
 });
 
 test("agentikitShow returns full content for knowledge by default", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "knowledge", "api-guide.md"), KNOWLEDGE_DOC);
 
   process.env.AKM_STASH_DIR = stashDir;
@@ -396,7 +396,7 @@ test("agentikitShow returns full content for knowledge by default", async () => 
 });
 
 test("agentikitShow returns TOC for knowledge with view toc", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "knowledge", "api-guide.md"), KNOWLEDGE_DOC);
 
   process.env.AKM_STASH_DIR = stashDir;
@@ -410,7 +410,7 @@ test("agentikitShow returns TOC for knowledge with view toc", async () => {
 });
 
 test("agentikitShow extracts section for knowledge", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "knowledge", "api-guide.md"), KNOWLEDGE_DOC);
 
   process.env.AKM_STASH_DIR = stashDir;
@@ -425,7 +425,7 @@ test("agentikitShow extracts section for knowledge", async () => {
 });
 
 test("agentikitShow extracts line range for knowledge", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "knowledge", "api-guide.md"), KNOWLEDGE_DOC);
 
   process.env.AKM_STASH_DIR = stashDir;
@@ -436,7 +436,7 @@ test("agentikitShow extracts line range for knowledge", async () => {
 });
 
 test("agentikitShow extracts frontmatter for knowledge", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "knowledge", "api-guide.md"), KNOWLEDGE_DOC);
 
   process.env.AKM_STASH_DIR = stashDir;
@@ -448,7 +448,7 @@ test("agentikitShow extracts frontmatter for knowledge", async () => {
 });
 
 test("agentikitShow returns no-frontmatter message when missing", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "knowledge", "plain.md"), "# Just a heading\nSome text.\n");
 
   process.env.AKM_STASH_DIR = stashDir;
@@ -458,7 +458,7 @@ test("agentikitShow returns no-frontmatter message when missing", async () => {
 });
 
 test("agentikitShow returns helpful message for missing section in knowledge", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "knowledge", "api-guide.md"), KNOWLEDGE_DOC);
 
   process.env.AKM_STASH_DIR = stashDir;
@@ -474,7 +474,7 @@ test("agentikitShow returns helpful message for missing section in knowledge", a
 });
 
 test("agentikitShow for tool type returns run", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "tools", "deploy.sh"), "#!/usr/bin/env bash\necho deploy\n");
 
   process.env.AKM_STASH_DIR = stashDir;
@@ -489,9 +489,9 @@ test("agentikitShow for tool type returns run", async () => {
 test("agentikitInit returns created false when stash dir already exists", async () => {
   const origHome = process.env.HOME;
   const origStashDir = process.env.AKM_STASH_DIR;
-  const tmpHome = createTmpDir("agentikit-home-");
-  // Pre-create the agentikit directory at the new default location (~/agentikit)
-  const stashPath = path.join(tmpHome, "agentikit");
+  const tmpHome = createTmpDir("akm-home-");
+  // Pre-create the akm directory at the new default location (~/akm)
+  const stashPath = path.join(tmpHome, "akm");
   fs.mkdirSync(stashPath, { recursive: true });
 
   process.env.HOME = tmpHome;
@@ -512,7 +512,7 @@ test("agentikitInit returns created false when stash dir already exists", async 
 
 test("agentikitShow throws unsupported tool extension for .txt file", async () => {
   const origStashDir = process.env.AKM_STASH_DIR;
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "tools", "readme.txt"), "not a tool\n");
 
   process.env.AKM_STASH_DIR = stashDir;
@@ -530,7 +530,7 @@ test("agentikitShow throws unsupported tool extension for .txt file", async () =
 test("agentikitInit creates knowledge directory", async () => {
   const origHome = process.env.HOME;
   const origStashDir = process.env.AKM_STASH_DIR;
-  const tmpHome = createTmpDir("agentikit-home-");
+  const tmpHome = createTmpDir("akm-home-");
   process.env.HOME = tmpHome;
   delete process.env.AKM_STASH_DIR;
 
@@ -550,7 +550,7 @@ test("agentikitInit creates knowledge directory", async () => {
 
 test("agentikitSearch finds script assets with broad extensions", async () => {
   const origStashDir = process.env.AKM_STASH_DIR;
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "scripts", "cleanup.sh"), "#!/usr/bin/env bash\necho cleanup\n");
   writeFile(path.join(stashDir, "scripts", "process.py"), "print('hello')\n");
   writeFile(path.join(stashDir, "scripts", "README.md"), "ignore\n");
@@ -574,7 +574,7 @@ test("agentikitSearch finds script assets with broad extensions", async () => {
 
 test("agentikitSearch returns run for runnable script extensions", async () => {
   const origStashDir = process.env.AKM_STASH_DIR;
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "scripts", "deploy.sh"), "#!/usr/bin/env bash\necho deploy\n");
 
   try {
@@ -596,7 +596,7 @@ test("agentikitSearch returns run for runnable script extensions", async () => {
 
 test("agentikitShow returns run for python script (auto-detected interpreter)", async () => {
   const origStashDir = process.env.AKM_STASH_DIR;
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "scripts", "process.py"), "# A python script\nprint('hello')\n");
 
   try {
@@ -617,7 +617,7 @@ test("agentikitShow returns run for python script (auto-detected interpreter)", 
 });
 
 test("agentikitShow returns run for runnable script", async () => {
-  const stashDir = createTmpDir("agentikit-stash-");
+  const stashDir = createTmpDir("akm-stash-");
   writeFile(path.join(stashDir, "scripts", "deploy.sh"), "#!/usr/bin/env bash\necho deploy\n");
 
   process.env.AKM_STASH_DIR = stashDir;
@@ -631,7 +631,7 @@ test("agentikitShow returns run for runnable script", async () => {
 test("agentikitInit writes config outside the stash directory", async () => {
   const origHome = process.env.HOME;
   const origStashDir = process.env.AKM_STASH_DIR;
-  const tmpHome = createTmpDir("agentikit-home-");
+  const tmpHome = createTmpDir("akm-home-");
   process.env.HOME = tmpHome;
   delete process.env.AKM_STASH_DIR;
 

--- a/tests/walker.test.ts
+++ b/tests/walker.test.ts
@@ -7,7 +7,7 @@ import { walkStash, walkStashFlat } from "../src/walker";
 const createdTmpDirs: string[] = [];
 
 function tmpDir(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentikit-walker-"));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-walker-"));
   createdTmpDirs.push(dir);
   return dir;
 }


### PR DESCRIPTION
## Summary

- Renames npm package from `agentikit` to `akm-cli` (v0.1.0), binary stays `akm`
- Updates all filesystem paths: `~/agentikit` → `~/akm`, `~/.config/agentikit` → `~/.config/akm`, `~/.cache/agentikit` → `~/.cache/akm`
- Adds `AKM_CONFIG_DIR`, `AKM_CACHE_DIR`, `AKM_STASH_DIR` env overrides to `paths.ts`
- Updates registry references: `agentikit-registry` → `akm-registry` (URL + User-Agent)
- Updates install scripts: `AGENTIKIT_INSTALL_DIR` → `AKM_INSTALL_DIR`, default dirs
- Changes kit config field from `"agentikit"` to `"akm"` in package.json
- Updates self-update npm message to `akm-cli@latest`
- Updates plugin references: `agentikit-opencode` → `akm-opencode`
- Updates all docs, README, CHANGELOG (comprehensive 0.1.0 entry), and 51 files total
- Internal type/function renames (`AgentikitAssetType`, `agentikitSearch`, etc.) deferred to P2
- GitHub repo URLs unchanged (repo stays at `itlackey/agentikit`)

## Test plan

- [x] All 702 tests pass (0 failures)
- [x] Build succeeds
- [x] New env override tests added for `AKM_CONFIG_DIR`, `AKM_CACHE_DIR`, `AKM_STASH_DIR`
- [x] Verify `akm init` creates `~/akm` directory
- [x] Verify `akm config` reads from `~/.config/akm/config.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)