### PR TITLE
Phases 10-12: schemaVersion, OSS health, documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug Report
+about: Report a bug in akm
+labels: bug
+---
+
+**Describe the bug**
+A clear description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior:
+1. Run `akm ...`
+2. ...
+
+**Expected behavior**
+What you expected to happen.
+
+**Environment**
+- OS: [e.g. macOS 14, Ubuntu 24.04]
+- akm version: [e.g. 0.1.0]
+- Install method: [binary / bun global]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature Request
+about: Suggest a feature for akm
+labels: enhancement
+---
+
+**Problem**
+What problem does this feature solve?
+
+**Proposed solution**
+Describe the solution you'd like.
+
+**Alternatives considered**
+Any alternative solutions or workarounds you've considered.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- What does this PR do? -->
+
+## Test plan
+
+<!-- How was this tested? -->
+
+## Checklist
+
+- [ ] Tests pass (`bun test`)
+- [ ] Lint passes (`bun run lint`)
+- [ ] Docs updated (if applicable)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to akm
+
+Thanks for your interest in contributing! This guide will help you get started.
+
+## Prerequisites
+
+- [Bun](https://bun.sh/) >= 1.0
+
+## Setting Up the Dev Environment
+
+```bash
+git clone https://github.com/itlackey/agentikit.git
+cd agentikit
+bun install
+```
+
+## Development Workflow
+
+### Running Tests
+
+```bash
+bun test
+```
+
+### Linting
+
+```bash
+bun run lint
+```
+
+### Building
+
+```bash
+bun run build
+```
+
+## Submitting Changes
+
+1. Fork the repository and create a feature branch from `main`.
+2. Make your changes, keeping commits focused and well-described.
+3. Ensure all tests pass (`bun test`) and linting is clean (`bun run lint`).
+4. Open a pull request against `main` with a clear description of the change.
+
+## Code Style
+
+- **TypeScript** in strict mode, using ESM modules.
+- **Biome** for formatting and linting. Run `bun run lint` before submitting.
+- Keep functions small and well-named. Prefer explicit types over `any`.
+
+## Reporting Issues
+
+If you find a bug or have a feature idea, please open an issue on GitHub. For security vulnerabilities, see [SECURITY.md](SECURITY.md).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MPL-2.0](LICENSE) license.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.1.x   | Yes       |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it through [GitHub Security Advisories](https://github.com/itlackey/agentikit/security/advisories/new) rather than opening a public issue.
+
+We aim to acknowledge reports within 48 hours and provide an initial assessment within 7 days.
+
+## Execution Model
+
+akm runs scripts and tools from your stash directory. This is equivalent to running any code you download from an external source. Before executing scripts from installed kits, review them the same way you would review any third-party code.
+
+Installed kits are cached locally and never executed automatically. The `akm show` command displays script content so you can inspect it before running.

--- a/docs/classification.md
+++ b/docs/classification.md
@@ -1,0 +1,170 @@
+# Classification System
+
+akm uses a specificity-based classification system to determine what type
+each file is and how it should be rendered. This document describes the
+specificity ranges, built-in matchers, and the content signals that drive
+classification.
+
+## Overview
+
+When akm walks a stash directory, every file is passed through a set of
+**matchers**. Each matcher inspects the file and either returns a match
+(with a type, specificity score, and renderer name) or abstains. The match
+with the highest specificity wins. Ties are broken by registration order:
+later-registered matchers win.
+
+The winning match determines two things:
+
+1. **Type** -- What kind of asset this file is (`script`, `skill`,
+   `command`, `agent`, or `knowledge`).
+2. **Renderer** -- How the asset is presented in `akm show` and search
+   results.
+
+## Specificity Ranges
+
+Specificity scores are divided into defined ranges. Each range corresponds
+to a confidence level and detection strategy:
+
+| Range | Level | Strategy |
+| --- | --- | --- |
+| 1-5 | Fallback | Extension-based detection. Lowest confidence. Works in any directory. |
+| 6-15 | Structural | Directory-based detection. The file's directory matches a known type name (e.g. `scripts/`, `agents/`). |
+| 16-25 | Content-definitive | Frontmatter or body content analysis. Highest confidence for built-in matchers. |
+| 26+ | Reserved | Reserved for user-registered or plugin matchers. |
+
+Higher specificity always wins. A content-based match at 20 overrides a
+directory-based match at 15, which in turn overrides an extension-only
+match at 3.
+
+## Built-in Matchers
+
+Four matchers ship with akm. They are evaluated for every file during
+walking and indexing.
+
+### Extension Matcher (specificity: 3)
+
+Classifies files purely by file extension. This is the baseline: every file
+with a known extension gets a type, regardless of directory.
+
+- Files with script extensions (`.sh`, `.ts`, `.js`, `.py`, `.rb`, `.go`,
+  etc.) are classified as `script`.
+- `SKILL.md` files are classified as `skill`.
+- `.md` files are **not** handled here -- they are deferred to the smart
+  markdown matcher for richer analysis.
+
+### Directory Matcher (specificity: 10)
+
+Boosts specificity when the first ancestor directory segment from the stash
+root matches a known type name:
+
+- `scripts/` or `tools/` -- script (for files with known script extensions)
+- `skills/` -- skill (for `SKILL.md` files)
+- `commands/` -- command (for `.md` files)
+- `agents/` -- agent (for `.md` files)
+- `knowledge/` -- knowledge (for `.md` files)
+
+### Parent-Dir Hint Matcher (specificity: 15)
+
+Similar to the directory matcher but uses the **immediate parent directory**
+name rather than the first ancestor. This provides higher confidence for
+nested structures where the immediate parent carries a strong naming
+convention (e.g. `my-project/agents/planning.md`).
+
+Same directory-to-type mappings as the directory matcher.
+
+### Smart Markdown Matcher (specificity: 20 / 18 / 8 / 5)
+
+Inspects `.md` file frontmatter and body content for type-specific signals.
+Returns different specificity levels depending on the strength of the
+signal:
+
+| Specificity | Signal | Classified As |
+| --- | --- | --- |
+| 20 | `tools` or `toolPolicy` in frontmatter | agent |
+| 18 | `agent` in frontmatter, or `$ARGUMENTS`/`$1`-`$3` in body | command |
+| 8 | `model` alone in frontmatter | agent (weak) |
+| 5 | Any `.md` with no other signals | knowledge (fallback) |
+
+**Agent-exclusive signals** (`tools`, `toolPolicy`) at specificity 20
+override everything else. These keys unambiguously identify an agent
+definition.
+
+**Command signals** at specificity 18 override directory hints (10/15).
+The `agent` frontmatter key names an OpenCode dispatch target, and
+`$ARGUMENTS`/`$1`-`$3` placeholders are definitively command template
+patterns.
+
+**Weak agent signal** (`model` alone) at specificity 8 loses to directory
+hints. A `.md` file with only `model` in its frontmatter that lives in
+`commands/` stays classified as a command (directory matcher returns 10 or
+15, which beats 8).
+
+**Knowledge fallback** at specificity 5 catches any `.md` file that has no
+agent or command signals. This is slightly above the extension matcher (3)
+so that markdown always gets classified, but it yields to directory hints.
+
+## Frozen Frontmatter Vocabulary
+
+The following frontmatter keys are recognized by the classification system
+and are frozen as of schema version 1:
+
+| Key | Classification Signal |
+| --- | --- |
+| `tools` | Agent-exclusive (specificity 20) |
+| `toolPolicy` | Agent-exclusive (specificity 20) |
+| `agent` | Command signal (specificity 18) |
+| `model` | Weak agent signal (specificity 8) |
+
+Other frontmatter keys (e.g. `description`) are used by renderers but do
+not affect classification.
+
+## Template Placeholders
+
+Command templates use placeholders from the OpenCode convention:
+
+| Placeholder | Purpose |
+| --- | --- |
+| `$ARGUMENTS` | Full argument string passed to the command |
+| `$1`, `$2`, `$3` | Positional arguments |
+
+The presence of any of these placeholders in a `.md` file body triggers
+command classification at specificity 18.
+
+## Renderers
+
+Each asset type has a dedicated renderer that determines how the asset is
+presented in `akm show` and how search hits are enriched:
+
+| Renderer | Asset Type | Output |
+| --- | --- | --- |
+| `script-source` | script | `run` command for known extensions; raw source for others |
+| `skill-md` | skill | Full SKILL.md content |
+| `command-md` | command | Extracted template, description, model hint, dispatch target |
+| `agent-md` | agent | Prompt with dispatch prefix, model hint, tool policy |
+| `knowledge-md` | knowledge | Content with view modes (full, toc, section, lines, frontmatter) |
+
+## Extensibility
+
+Custom matchers and renderers can be registered in source to support new
+asset types or override built-in behavior. Key rules:
+
+- Register custom matchers at specificity 26 or higher to reliably override
+  all built-in matchers.
+- Later registrations win ties at the same specificity, so a custom matcher
+  at specificity 20 overrides the built-in smart markdown matcher at 20.
+- Custom renderers replace any existing renderer with the same name.
+
+See `src/matchers.ts` and `src/renderers.ts` for implementation examples.
+
+## Classification in Practice
+
+A few examples showing how specificity resolution works:
+
+| File | Extension | Directory | Frontmatter | Winning Matcher | Type |
+| --- | --- | --- | --- | --- | --- |
+| `scripts/deploy.sh` | .sh | scripts/ | -- | parentDirHint (15) | script |
+| `random/deploy.sh` | .sh | random/ | -- | extension (3) | script |
+| `agents/reviewer.md` | .md | agents/ | `tools: [Bash]` | smartMd (20) | agent |
+| `commands/release.md` | .md | commands/ | `agent: coder` | smartMd (18) | command |
+| `commands/hint.md` | .md | commands/ | `model: gpt-4` | parentDirHint (15) | command |
+| `docs/guide.md` | .md | docs/ | -- | smartMd (5) | knowledge |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,113 @@
+# Getting Started
+
+This guide walks you through installing akm, adding your first asset, and
+using search and show to discover capabilities.
+
+## Install
+
+Install from npm:
+
+```sh
+bun install -g akm-cli
+```
+
+Or download a standalone binary from the
+[GitHub releases](https://github.com/itlackey/agentikit/releases) page.
+
+## Initialize the Stash
+
+Run `akm init` to create the stash directory structure:
+
+```sh
+akm init
+```
+
+This creates `~/akm` with subdirectories for each asset type: `scripts/`,
+`skills/`, `commands/`, `agents/`, `knowledge/`, and `tools/`. See
+[filesystem.md](filesystem.md) for platform-specific paths and environment
+variable overrides.
+
+## Add Your First Asset
+
+Create a simple shell script in the `scripts/` directory:
+
+```sh
+cat > ~/akm/scripts/hello.sh << 'EOF'
+#!/usr/bin/env bash
+# A simple greeting script
+echo "Hello from akm!"
+EOF
+chmod +x ~/akm/scripts/hello.sh
+```
+
+Any file with a known extension (`.sh`, `.ts`, `.py`, etc.) placed in the
+stash is automatically recognized. The `scripts/` directory is not required
+-- it just increases classification confidence. See [concepts.md](concepts.md)
+for how classification works.
+
+## Index
+
+Build the search index so your assets are discoverable:
+
+```sh
+akm index
+```
+
+This scans all stash sources and generates metadata for each asset. Run
+`akm index --full` to force a complete rebuild instead of an incremental
+update.
+
+## Search
+
+Find assets by keyword:
+
+```sh
+akm search "hello"
+```
+
+Results include an `openRef` field (e.g. `script:hello.sh`) that you pass
+to `akm show`. Filter by type or limit results:
+
+```sh
+akm search "deploy" --type script --limit 5
+```
+
+See [cli.md](cli.md) for the full set of search flags.
+
+## Show
+
+Inspect an asset by its ref:
+
+```sh
+akm show script:hello.sh
+```
+
+The output is structured JSON containing everything an agent needs to use
+the asset. For scripts, this includes a `run` command and `cwd`. For agents,
+a `prompt` payload. For knowledge, navigable `content` with view modes.
+
+See [show-response.md](show-response.md) for the full per-type field
+reference.
+
+## Install a Kit
+
+Install a kit from npm, GitHub, or any git host:
+
+```sh
+akm add @scope/kit
+akm add github:owner/repo
+```
+
+Installed kits are cached locally and their assets become searchable
+immediately. Use `akm list` to see installed kits and `akm update --all`
+to keep them current.
+
+See [registry.md](registry.md) for the full install flow and supported
+ref formats.
+
+## Next Steps
+
+- [Concepts](concepts.md) -- Asset types, classification, and the stash
+- [CLI Reference](cli.md) -- All commands and flags
+- [openRef Format](openref.md) -- How asset references work
+- [Kit Maker's Guide](kit-makers.md) -- Build and share your own kits

--- a/docs/openref.md
+++ b/docs/openref.md
@@ -1,0 +1,115 @@
+# openRef Format
+
+An openRef is a compact string that uniquely identifies an asset. It is the
+primary way to reference assets in `akm show`, search results, and
+cross-asset links.
+
+## Format
+
+```
+[origin//]type:name
+```
+
+| Part | Required | Description |
+| --- | --- | --- |
+| `origin` | no | Identifies which installed kit the asset belongs to. Separated from the rest of the ref by `//`. |
+| `type` | yes | The asset type. One of: `script`, `skill`, `command`, `agent`, `knowledge`. |
+| `name` | yes | The asset filename or path relative to the type directory. |
+
+## Types
+
+The `type` segment must be one of the five primary asset types:
+
+| Type | Purpose |
+| --- | --- |
+| `script` | Executable scripts with generated run commands |
+| `skill` | Structured skill packages (SKILL.md) |
+| `command` | Prompt templates with dispatch targets |
+| `agent` | Agent definitions with model hints |
+| `knowledge` | Reference documents with section navigation |
+
+`tool` is accepted as a transparent alias for `script`. Both `tool:deploy.sh`
+and `script:deploy.sh` resolve to the same asset. All output normalizes
+`tool` to `script`.
+
+## Name
+
+The `name` is the asset's filename (or path relative to the type directory
+when the asset is nested). Extensions are included for file-based types:
+
+- `script:deploy.sh`
+- `knowledge:api-guide.md`
+- `agent:reviewer.md`
+
+For skills, the name is the skill directory name (the directory containing
+`SKILL.md`):
+
+- `skill:code-review`
+
+## Origin
+
+The `origin` prefix is optional. When present, it identifies the installed
+kit that owns the asset. This is useful when multiple kits provide assets
+with the same name.
+
+The origin is separated from the type:name portion by `//`:
+
+```
+mykit//agent:reviewer
+npm:@scope/pkg//script:deploy.sh
+github:owner/repo//knowledge:guide.md
+```
+
+When no origin is specified, assets are resolved from all stash sources in
+priority order (primary stash, search paths, installed kits). The first
+match wins.
+
+## Version
+
+There is no version qualifier in openRefs. Versions are resolved at the
+stash layer:
+
+- npm packages use semver resolution
+- Git sources use tags, branches, or commits
+- Local sources use whatever is on disk
+
+The installed version is tracked in config and updated via `akm update`.
+
+## Parsing Rules
+
+To parse an openRef:
+
+1. Split on `//`. If the split produces two parts, the left side is the
+   `origin` and the right side continues to step 2. If there is no `//`,
+   the entire string continues to step 2 with no origin.
+2. Split the remaining string on the first `:`. The left side is the `type`
+   and the right side is the `name`.
+3. Normalize `tool` to `script` if the type is `tool`.
+
+## Examples
+
+| Ref | Origin | Type | Name |
+| --- | --- | --- | --- |
+| `script:deploy.sh` | (none) | script | deploy.sh |
+| `skill:code-review` | (none) | skill | code-review |
+| `knowledge:api-guide.md` | (none) | knowledge | api-guide.md |
+| `agent:reviewer.md` | (none) | agent | reviewer.md |
+| `command:release.md` | (none) | command | release.md |
+| `tool:lint.sh` | (none) | script | lint.sh |
+| `mykit//agent:reviewer` | mykit | agent | reviewer |
+| `npm:@scope/pkg//script:deploy.sh` | npm:@scope/pkg | script | deploy.sh |
+
+## Usage
+
+openRefs appear in two main contexts:
+
+1. **Search results** -- Each local hit includes an `openRef` field. Pass it
+   directly to `akm show`:
+
+   ```sh
+   akm show script:deploy.sh
+   ```
+
+2. **Cross-asset references** -- Commands can reference agents by name
+   (via the `agent` frontmatter key), and agents can reference tools. These
+   are not full openRefs but follow the same type:name pattern.

--- a/docs/show-response.md
+++ b/docs/show-response.md
@@ -1,0 +1,144 @@
+# ShowResponse Field Reference
+
+`akm show` returns structured JSON describing an asset. Every response
+includes a set of common fields. Additional fields vary by asset type.
+
+## Common Fields
+
+These fields are present on every ShowResponse regardless of type:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `schemaVersion` | number | Response schema version (currently `1`) |
+| `type` | string | Asset type: `script`, `skill`, `command`, `agent`, or `knowledge` |
+| `name` | string | Asset display name (usually the filename without extension) |
+| `path` | string | Absolute path to the asset file on disk |
+
+## Optional Common Fields
+
+These fields may appear on any asset type depending on context:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `registryId` | string | Registry identifier for assets from installed kits |
+| `editable` | boolean | Whether the asset is safe to edit in place. `false` for cache-managed files from installed kits. Verbose-only. |
+| `editHint` | string | Actionable guidance when `editable` is false (e.g. "use `akm clone` to make an editable copy"). Verbose-only. |
+
+## Per-Type Fields
+
+### script
+
+Scripts with a known extension (`.sh`, `.ts`, `.py`, etc.) return execution
+hints. Scripts with unrecognized extensions fall back to raw content.
+
+**Known extensions:**
+
+| Field | Type | Guaranteed | Description |
+| --- | --- | --- | --- |
+| `run` | string | yes | Full run command (e.g. `"bash /path/to/deploy.sh"`) |
+| `cwd` | string | yes | Working directory for execution |
+| `setup` | string | no | Setup command when a dependency file is detected (e.g. `"bun install"`) |
+
+**Unrecognized extensions:**
+
+| Field | Type | Guaranteed | Description |
+| --- | --- | --- | --- |
+| `content` | string | yes | Full source code of the script |
+
+Execution hints are resolved in priority order: `.stash.json` fields,
+then `@run`/`@setup`/`@cwd` header comment tags, then auto-detection from
+the file extension and nearby dependency files. See
+[concepts.md](concepts.md) for details.
+
+### skill
+
+| Field | Type | Guaranteed | Description |
+| --- | --- | --- | --- |
+| `content` | string | yes | Full text of the SKILL.md file |
+
+### command
+
+| Field | Type | Guaranteed | Description |
+| --- | --- | --- | --- |
+| `template` | string | yes | The command template body (markdown content after frontmatter extraction) |
+| `description` | string | no | Summary from frontmatter `description` key |
+| `modelHint` | unknown | no | Preferred model from frontmatter `model` key |
+| `agent` | string | no | Dispatch target agent from frontmatter `agent` key (OpenCode convention) |
+
+Template bodies may contain `$ARGUMENTS` or `$1`-`$3` placeholders that
+should be filled before dispatch.
+
+### agent
+
+| Field | Type | Guaranteed | Description |
+| --- | --- | --- | --- |
+| `prompt` | string | yes | Full agent prompt content, prefixed with a dispatch compliance notice |
+| `description` | string | no | Summary from frontmatter `description` key |
+| `modelHint` | unknown | no | Preferred model from frontmatter `model` key |
+| `toolPolicy` | string, string[], or object | no | Tool access policy from frontmatter `tools` key |
+
+The `toolPolicy` field can take several forms: a single tool name
+(`"Bash"`), a list of tool names (`["Bash", "Read"]`), or a structured
+policy object (`{ "read": "allow", "write": "deny" }`).
+
+### knowledge
+
+Knowledge assets support multiple view modes, controlled by a positional
+argument after the ref. All modes return their result in the `content`
+field.
+
+| Field | Type | Guaranteed | Description |
+| --- | --- | --- | --- |
+| `content` | string | yes | Document content (format depends on the view mode) |
+
+**View modes:**
+
+| Mode | Command | Content |
+| --- | --- | --- |
+| `full` (default) | `akm show knowledge:guide.md` | Full document text |
+| `toc` | `akm show knowledge:guide.md toc` | Formatted table of contents |
+| `frontmatter` | `akm show knowledge:guide.md frontmatter` | Raw YAML frontmatter block |
+| `section` | `akm show knowledge:guide.md section "Auth"` | Content under the named heading |
+| `lines` | `akm show knowledge:guide.md lines 10 30` | Lines 10 through 30 |
+
+## Example Responses
+
+A script with known extension:
+
+```json
+{
+  "schemaVersion": 1,
+  "type": "script",
+  "name": "deploy",
+  "path": "/home/user/akm/scripts/deploy.sh",
+  "run": "bash /home/user/akm/scripts/deploy.sh",
+  "cwd": "/home/user/akm/scripts",
+  "setup": "bun install"
+}
+```
+
+An agent:
+
+```json
+{
+  "schemaVersion": 1,
+  "type": "agent",
+  "name": "reviewer",
+  "path": "/home/user/akm/agents/reviewer.md",
+  "prompt": "Dispatching prompt must include the agent's full prompt content verbatim; summaries are non-compliant. \n\nYou are a code reviewer...",
+  "modelHint": "claude-3-opus",
+  "toolPolicy": ["Bash", "Read"]
+}
+```
+
+A knowledge asset with `toc` view:
+
+```json
+{
+  "schemaVersion": 1,
+  "type": "knowledge",
+  "name": "api-guide",
+  "path": "/home/user/akm/knowledge/api-guide.md",
+  "content": "# Table of Contents\n- Authentication\n- Endpoints\n- Error Handling"
+}
+```

--- a/src/stash-add.ts
+++ b/src/stash-add.ts
@@ -46,6 +46,7 @@ export async function agentikitAdd(input: { ref: string }): Promise<AddResponse>
   const index = await agentikitIndex({ stashDir });
 
   return {
+    schemaVersion: 1,
     stashDir,
     ref,
     installed: {

--- a/src/stash-registry.ts
+++ b/src/stash-registry.ts
@@ -15,6 +15,7 @@ export async function agentikitList(input?: { stashDir?: string }): Promise<List
   const installed = config.registry?.installed ?? [];
 
   return {
+    schemaVersion: 1,
     stashDir,
     installed: installed.map((entry) => ({
       ...entry,
@@ -42,6 +43,7 @@ export async function agentikitRemove(input: { target: string; stashDir?: string
   const index = await agentikitIndex({ stashDir });
 
   return {
+    schemaVersion: 1,
     stashDir,
     target,
     removed: {
@@ -121,6 +123,7 @@ export async function agentikitUpdate(input?: {
   const config = loadConfig();
 
   return {
+    schemaVersion: 1,
     stashDir,
     target,
     all,

--- a/src/stash-search.ts
+++ b/src/stash-search.ts
@@ -58,6 +58,7 @@ export async function agentikitSearch(input: {
   const sources = resolveStashSources(undefined, config);
   if (sources.length === 0) {
     return {
+      schemaVersion: 1,
       stashDir: "",
       source: source ?? "all",
       hits: [],
@@ -84,6 +85,7 @@ export async function agentikitSearch(input: {
 
   if (source === "local") {
     return {
+      schemaVersion: 1,
       stashDir,
       source,
       hits: localResult?.hits ?? [],
@@ -117,6 +119,7 @@ export async function agentikitSearch(input: {
   if (source === "registry") {
     const hits = registryHits.slice(0, limit);
     return {
+      schemaVersion: 1,
       stashDir,
       source,
       hits,
@@ -130,6 +133,7 @@ export async function agentikitSearch(input: {
   const warnings = [...(localResult?.warnings ?? []), ...(registryResult?.warnings ?? [])];
 
   return {
+    schemaVersion: 1,
     stashDir,
     source,
     hits: mergedHits,

--- a/src/stash-show.ts
+++ b/src/stash-show.ts
@@ -65,6 +65,7 @@ export async function agentikitShow(input: { ref: string; view?: KnowledgeView }
   const response = renderer.buildShowResponse(renderCtx);
   const editable = isEditable(assetPath, config);
   return {
+    schemaVersion: 1,
     ...response,
     registryId: source?.registryId,
     editable,

--- a/src/stash-types.ts
+++ b/src/stash-types.ts
@@ -51,6 +51,7 @@ export interface RegistrySearchResultHit {
 export type SearchHit = LocalSearchHit | RegistrySearchResultHit;
 
 export interface SearchResponse {
+  schemaVersion: number;
   stashDir: string;
   source: SearchSource;
   hits: SearchHit[];
@@ -62,6 +63,7 @@ export interface SearchResponse {
 }
 
 export interface AddResponse {
+  schemaVersion: number;
   stashDir: string;
   ref: string;
   installed: {
@@ -118,12 +120,14 @@ export interface RegistryListEntry {
 }
 
 export interface ListResponse {
+  schemaVersion: number;
   stashDir: string;
   installed: RegistryListEntry[];
   totalInstalled: number;
 }
 
 export interface RemoveResponse {
+  schemaVersion: number;
   stashDir: string;
   target: string;
   removed: {
@@ -163,6 +167,7 @@ export interface UpdateResultItem {
 }
 
 export interface UpdateResponse {
+  schemaVersion: number;
   stashDir: string;
   target?: string;
   all: boolean;
@@ -180,6 +185,7 @@ export interface UpdateResponse {
 }
 
 export interface ShowResponse {
+  schemaVersion?: number;
   type: AgentikitAssetType | string;
   name: string;
   path: string;

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -218,6 +218,7 @@ describe("Scenario: Full lifecycle (index → search → show)", () => {
   test("search with index returns scored results with descriptions", async () => {
     const result = await agentikitSearch({ query: "docker build image", type: "any" });
 
+    expect(result.schemaVersion).toBe(1);
     expect(result.hits.length).toBeGreaterThan(0);
     // Docker-build should be ranked first
     const topHit = result.hits[0];
@@ -263,6 +264,7 @@ describe("Scenario: Full lifecycle (index → search → show)", () => {
     expect(deployHit).toBeDefined();
 
     const openResult = await agentikitShow({ ref: deployHit!.openRef });
+    expect(openResult.schemaVersion).toBe(1);
     expect(openResult.type).toBe("script");
     expect(openResult.run).toBeTruthy();
     expect(openResult.run).toContain("bash");


### PR DESCRIPTION
## Summary

- **Phase 10**: Added `schemaVersion: 1` to all JSON response types (SearchResponse, ShowResponse, AddResponse, ListResponse, RemoveResponse, UpdateResponse)
- **Phase 11**: Added CONTRIBUTING.md, SECURITY.md, GitHub issue templates (bug report, feature request), and PR template
- **Phase 12**: Added 4 new documentation files:
  - `docs/getting-started.md` — Getting Started tutorial
  - `docs/openref.md` — openRef format specification
  - `docs/show-response.md` — Per-type ShowResponse field guarantees
  - `docs/classification.md` — Matcher specificity ranges and classification system

## Test plan

- [x] All 702 tests pass (1628 assertions)
- [x] Build succeeds
- [x] schemaVersion assertions added to e2e tests (search + show)

🤖 Generated with [Claude Code](https://claude.com/claude-code)