### PR TITLE
fix: purge orphaned index entries on kit removal and improve search

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -163,6 +163,11 @@ export async function fetchWithTimeout(url: string, opts?: RequestInit, timeoutM
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     return await fetch(url, { ...opts, signal: controller.signal });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      throw new Error(`Request timed out after ${timeoutMs}ms: ${url}`);
+    }
+    throw err;
   } finally {
     clearTimeout(timer);
   }

--- a/src/db.ts
+++ b/src/db.ts
@@ -244,6 +244,17 @@ export function upsertEntry(
 
 export function deleteEntriesByDir(db: Database, dirPath: string): void {
   const ids = db.prepare("SELECT id FROM entries WHERE dir_path = ?").all(dirPath) as Array<{ id: number }>;
+  deleteRelatedRows(db, ids);
+  db.prepare("DELETE FROM entries WHERE dir_path = ?").run(dirPath);
+}
+
+export function deleteEntriesByStashDir(db: Database, stashDir: string): void {
+  const ids = db.prepare("SELECT id FROM entries WHERE stash_dir = ?").all(stashDir) as Array<{ id: number }>;
+  deleteRelatedRows(db, ids);
+  db.prepare("DELETE FROM entries WHERE stash_dir = ?").run(stashDir);
+}
+
+function deleteRelatedRows(db: Database, ids: Array<{ id: number }>): void {
   for (const { id } of ids) {
     try {
       db.prepare("DELETE FROM embeddings WHERE id = ?").run(id);
@@ -258,7 +269,6 @@ export function deleteEntriesByDir(db: Database, dirPath: string): void {
       }
     }
   }
-  db.prepare("DELETE FROM entries WHERE dir_path = ?").run(dirPath);
 }
 
 export function rebuildFts(db: Database): void {

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -7,6 +7,7 @@ import {
   DB_VERSION,
   type DbIndexedEntry,
   deleteEntriesByDir,
+  deleteEntriesByStashDir,
   getEntriesByDir,
   getEntryCount,
   getMeta,
@@ -79,6 +80,19 @@ export async function agentikitIndex(options?: { stashDir?: string; full?: boole
       }
       db.exec("DELETE FROM entries_fts");
       db.exec("DELETE FROM entries");
+    } else {
+      // Incremental: purge entries from stash dirs that have been removed
+      // (e.g. after `akm remove`) so orphaned entries don't linger.
+      const prevStashDirsJson = getMeta(db, "stashDirs");
+      if (prevStashDirsJson) {
+        const prevStashDirs: string[] = JSON.parse(prevStashDirsJson);
+        const currentSet = new Set(allStashDirs);
+        for (const dir of prevStashDirs) {
+          if (!currentSet.has(dir)) {
+            deleteEntriesByStashDir(db, dir);
+          }
+        }
+      }
     }
 
     const tWalkStart = Date.now();

--- a/src/providers/skills-sh.ts
+++ b/src/providers/skills-sh.ts
@@ -100,6 +100,7 @@ class SkillsShProvider implements RegistryProvider {
         id: `skills-sh:${entry.id}`,
         title: entry.name,
         ref: entry.source,
+        installRef: `github:${entry.source}`,
         homepage: `${baseUrl}/${entry.id}`,
         score,
         metadata: {

--- a/src/providers/static-index.ts
+++ b/src/providers/static-index.ts
@@ -279,6 +279,7 @@ function toSearchHit(kit: RegistryKitEntry, score: number, registryName?: string
     title: kit.name,
     description: kit.description,
     ref: kit.ref,
+    installRef: buildInstallRef(kit.source, kit.ref),
     homepage: kit.homepage,
     score: Math.round(score * 1000) / 1000,
     metadata,
@@ -329,14 +330,7 @@ function scoreAssets(
   for (const { kit, registryName } of kits) {
     if (!kit.assets || kit.assets.length === 0) continue;
 
-    const installRef =
-      kit.source === "npm"
-        ? `npm:${kit.ref}`
-        : kit.source === "git"
-          ? `git+${kit.ref}`
-          : kit.source === "local"
-            ? kit.ref
-            : `github:${kit.ref}`;
+    const installRef = buildInstallRef(kit.source, kit.ref);
 
     for (const asset of kit.assets) {
       const score = scoreAsset(asset, tokens);
@@ -411,6 +405,19 @@ function asStringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const filtered = value.filter((v): v is string => typeof v === "string");
   return filtered.length > 0 ? filtered : undefined;
+}
+
+function buildInstallRef(source: string, ref: string): string {
+  switch (source) {
+    case "npm":
+      return `npm:${ref}`;
+    case "git":
+      return `git+${ref}`;
+    case "local":
+      return ref;
+    default:
+      return `github:${ref}`;
+  }
 }
 
 function toErrorMessage(error: unknown): string {

--- a/src/registry-resolve.ts
+++ b/src/registry-resolve.ts
@@ -18,6 +18,13 @@ export function parseRegistryRef(rawRef: string): ParsedRegistryRef {
   const ref = rawRef.trim();
   if (!ref) throw new Error("Registry ref is required.");
 
+  // Detect registry search result IDs (e.g. "skills-sh:org/skills/name")
+  // that are not installable refs. Known installable prefixes are handled below.
+  const registryIdHint = detectRegistrySearchId(ref);
+  if (registryIdHint) {
+    throw new Error(registryIdHint);
+  }
+
   if (ref.startsWith("npm:")) {
     return parseNpmRef(ref.slice(4), ref);
   }
@@ -43,6 +50,39 @@ export function parseRegistryRef(rawRef: string): ParsedRegistryRef {
   }
 
   return parseGithubShorthand(ref, ref);
+}
+
+/**
+ * Known prefixes that `parseRegistryRef` handles as installable sources.
+ * Anything with a colon that doesn't start with one of these is likely a
+ * registry search result ID (e.g. `skills-sh:org/skills/name`).
+ */
+const KNOWN_PREFIXES = ["npm:", "github:", "git+", "file:", "http://", "https://"];
+
+function detectRegistrySearchId(ref: string): string | undefined {
+  const colonIdx = ref.indexOf(":");
+  if (colonIdx < 1) return undefined;
+
+  // Skip known installable prefixes
+  for (const prefix of KNOWN_PREFIXES) {
+    if (ref.startsWith(prefix)) return undefined;
+  }
+
+  const prefix = ref.slice(0, colonIdx);
+  // Registry IDs use lowercase-with-hyphens prefixes (e.g. skills-sh, static-index)
+  if (!/^[a-z][a-z0-9-]*$/.test(prefix)) return undefined;
+
+  const rest = ref.slice(colonIdx + 1);
+  return [
+    `"${ref}" looks like a registry search result ID, not an installable ref.`,
+    `The "${prefix}:" prefix is a registry identifier and cannot be passed to \`akm add\`.`,
+    "",
+    "Use the installRef or ref field from the search result instead. For example:",
+    `  akm registry search "${rest}" --format json`,
+    "Then install using the installRef value from the result:",
+    "  akm add github:owner/repo",
+    "  akm add npm:package-name",
+  ].join("\n");
 }
 
 export async function resolveRegistryArtifact(parsed: ParsedRegistryRef): Promise<ResolvedRegistryArtifact> {

--- a/src/registry-types.ts
+++ b/src/registry-types.ts
@@ -72,6 +72,8 @@ export interface RegistrySearchHit {
   title: string;
   description?: string;
   ref: string;
+  /** Ready-to-use ref for `akm add`. Always prefixed with the source type. */
+  installRef: string;
   homepage?: string;
   score?: number;
   metadata?: Record<string, string>;

--- a/tests/registry-install.test.ts
+++ b/tests/registry-install.test.ts
@@ -336,6 +336,26 @@ describe("local directory installs", () => {
     }
   });
 
+  test("parseRegistryRef rejects registry search IDs like skills-sh:...", () => {
+    expect(() => parseRegistryRef("skills-sh:anthropics/skills/frontend-design")).toThrow(
+      "looks like a registry search result ID",
+    );
+  });
+
+  test("parseRegistryRef rejects static-index registry IDs", () => {
+    expect(() => parseRegistryRef("static-index:npm:some-kit")).toThrow("looks like a registry search result ID");
+  });
+
+  test("parseRegistryRef still allows npm: prefix", () => {
+    const parsed = parseRegistryRef("npm:some-kit");
+    expect(parsed.source).toBe("npm");
+  });
+
+  test("parseRegistryRef still allows github: prefix", () => {
+    const parsed = parseRegistryRef("github:owner/repo");
+    expect(parsed.source).toBe("github");
+  });
+
   test("applies include from nearest package.json for nested kit roots", async () => {
     const cacheHome = makeTempDir("akm-nested-include-cache-");
     const packageDir = makeTempDir("akm-nested-include-package-");

--- a/tests/registry-search.test.ts
+++ b/tests/registry-search.test.ts
@@ -426,11 +426,24 @@ describe("hit shape", () => {
       expect(hit?.source).toBe("npm");
       expect(hit?.title).toBe("@itlackey/openkit");
       expect(hit?.ref).toBe("@itlackey/openkit");
+      expect(hit?.installRef).toBe("npm:@itlackey/openkit");
       expect(hit?.metadata?.version).toBe("1.2.0");
       expect(hit?.metadata?.author).toBe("itlackey");
       expect(hit?.metadata?.license).toBe("MIT");
       expect(hit?.metadata?.assetTypes).toBe("skill, script, command");
       expect(typeof hit?.score).toBe("number");
+    } finally {
+      srv.close();
+    }
+  });
+
+  test("installRef is prefixed with source type for github kits", async () => {
+    const srv = serveIndex(FIXTURE_INDEX);
+    try {
+      const result = await searchRegistry("azure", { registries: [{ url: srv.url }] });
+      const hit = result.hits.find((h) => h.id === "github:someone/azure-ops-kit");
+      expect(hit).toBeDefined();
+      expect(hit?.installRef).toBe("github:someone/azure-ops-kit");
     } finally {
       srv.close();
     }
@@ -576,6 +589,13 @@ describe("provider routing", () => {
       const ids = result.hits.map((h) => h.id);
       expect(ids).toContain("npm:deploy-kit");
       expect(ids).toContain("skills-sh:org/skills/deploy-vercel");
+
+      // installRef should be directly usable with `akm add`
+      const npmHit = result.hits.find((h) => h.id === "npm:deploy-kit");
+      expect(npmHit?.installRef).toBe("npm:deploy-kit");
+      const skillsHit = result.hits.find((h) => h.id === "skills-sh:org/skills/deploy-vercel");
+      expect(skillsHit?.installRef).toBe("github:org/skills");
+
       expect(result.warnings).toEqual([]);
     } finally {
       staticSrv.close();


### PR DESCRIPTION
- Add deleteEntriesByStashDir() to clean up index entries when a kit is removed, fixing orphaned entries persisting in incremental rebuilds
- Add installRef field to RegistrySearchHit so search results are directly actionable with `akm add`
- Detect registry search result IDs (e.g. skills-sh:...) passed to `akm add` and show a helpful error instead of falling through to invalid npm parsing
- Wrap AbortError in fetchWithTimeout with URL and timeout context so registry timeout warnings are actionable


