### PR TITLE
Claude/update readme features 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ Key behaviors:
 
 ### skills.sh Integration
 
-`akm` integrates with [skills.sh](https://skills.sh), a public skills
-marketplace. Add it as a registry to search and install community skills:
+`akm` includes [skills.sh](https://skills.sh) as a built-in registry. Community
+skills from skills.sh are searchable out of the box alongside the official
+registry -- no setup required:
 
 ```sh
-akm registry add https://skills.sh --name skills.sh --provider skills-sh
-akm registry search "code review"    # Searches skills.sh alongside other registries
+akm search "code review"             # Searches skills.sh and official registry
+akm registry search "code review"    # Search registries directly
 ```
 
 Results include install counts and link back to skills.sh for details. The

--- a/src/config.ts
+++ b/src/config.ts
@@ -75,7 +75,10 @@ export interface OutputConfig {
 export const DEFAULT_CONFIG: AgentikitConfig = {
   semanticSearch: true,
   searchPaths: [],
-  registries: [{ url: "https://raw.githubusercontent.com/itlackey/akm-registry/main/index.json", name: "official" }],
+  registries: [
+    { url: "https://raw.githubusercontent.com/itlackey/akm-registry/main/index.json", name: "official" },
+    { url: "https://skills.sh", name: "skills.sh", provider: "skills-sh" },
+  ],
   output: {
     format: "json",
     detail: "brief",

--- a/tests/registry-cli.test.ts
+++ b/tests/registry-cli.test.ts
@@ -78,9 +78,11 @@ describe("registry add/remove/list via config", () => {
   test("list returns default registries when none configured", () => {
     const config = loadConfig();
     const registries = config.registries ?? [];
-    expect(registries.length).toBe(1);
+    expect(registries.length).toBe(2);
     expect(registries[0].name).toBe("official");
     expect(registries[0].url).toContain("akm-registry");
+    expect(registries[1].name).toBe("skills.sh");
+    expect(registries[1].provider).toBe("skills-sh");
   });
 
   test("add appends a registry entry", () => {
@@ -91,9 +93,9 @@ describe("registry add/remove/list via config", () => {
     saveConfig({ ...config, registries });
 
     const updated = loadConfig();
-    expect(updated.registries?.length).toBe(2);
-    expect(updated.registries?.[1].url).toBe("https://example.com/index.json");
-    expect(updated.registries?.[1].name).toBe("custom");
+    expect(updated.registries?.length).toBe(3);
+    expect(updated.registries?.[2].url).toBe("https://example.com/index.json");
+    expect(updated.registries?.[2].name).toBe("custom");
   });
 
   test("add deduplicates by URL", () => {


### PR DESCRIPTION
This pull request makes several improvements to the `akm` package manager for AI agent capabilities, focusing on expanding registry support, updating documentation for clarity and completeness, and ensuring tests reflect the new defaults. The most important changes are grouped below by theme.

Expanded registry support:

* Added the `skills.sh` registry as a built-in default alongside the official registry in the `DEFAULT_CONFIG` (`src/config.ts`). This enables out-of-the-box access to community skills from skills.sh.
* Updated tests to expect two default registries (`official` and `skills.sh`), and adjusted registry addition logic to reflect the new default configuration (`tests/registry-cli.test.ts`). [[1]](diffhunk://#diff-1d8286f7b64105fce6e0e7d365032397d30b5fbcfceb3f8ee07268383880e55aL81-R85) [[2]](diffhunk://#diff-1d8286f7b64105fce6e0e7d365032397d30b5fbcfceb3f8ee07268383880e55aL94-R98)

Documentation updates:

* Reorganized and clarified the `README.md` to highlight installation options, registry and asset management, skills.sh integration, and private registry support. The documentation now clearly explains how to install, search, clone, and publish kits, and details the features and behaviors of the package manager. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R103) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L182-R132)
* Improved the documentation table to reflect updated guides and concepts, and removed redundant installation instructions in favor of a consolidated install section.

These changes collectively make the package manager easier to use, expand its available capabilities, and ensure the documentation and tests are aligned with the latest features.