### PR TITLE
feat: add GitHub Actions workflow for publishing to dev.to

### DIFF
--- a/.github/workflows/publish-devto.yml
+++ b/.github/workflows/publish-devto.yml
@@ -1,0 +1,22 @@
+name: Publish to dev.to
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "posts/**/*.md"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish articles to dev.to
+        uses: sinedied/publish-devto@v2
+        with:
+          devto_key: ${{ secrets.DEVTO_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: "posts/**/*.md"
+          branch: main
+          conventional_commits: true

--- a/posts/intro-part-01.md
+++ b/posts/intro-part-01.md
@@ -1,0 +1,57 @@
+---
+title: Your AI Agent's Skill List Is Getting Out of Hand
+series: akm
+description: A quick introduction to the Agent-i-Kit CLI for managing AI agent extensions
+tags: [ai, agents, cli, skills]
+published: true
+---
+
+If you've been building with Claude Code or OpenCode for any length of time, you've probably hit the same wall. You start with a handful of skills and commands. They work great. So you add more. Then a few more for that new project. Then a teammate shares theirs and you copy those in too.
+
+Before long you've got dozens of files scattered across directories, no good way to find the one you need, and an agent that's either missing context it should have or drowning in context it doesn't need.
+
+That's the problem [Agent-i-Kit](https://github.com/itlackey/agentikit) is built to solve.
+
+## The Real Issue Isn't Storage, It's Discovery
+
+Claude Code and OpenCode are great at *using* skills and tools. They're not great at helping you *manage* them. There's no built-in search. No way to share a curated set of skills with your team without copying files around. No versioning. No registry.
+
+So most people end up with one of two bad situations:
+
+**Option A:** You stuff everything into context at startup. Your agent sees every skill, every tool, every command — whether it needs them or not. This sounds fine until you realize that loading irrelevant context doesn't just waste tokens, it actively degrades the quality of your agent's decisions. More isn't better. It's just noise.
+
+**Option B:** You keep your stash small and tightly curated. The agent stays sharp, but you're constantly maintaining it by hand, rediscovering skills you forgot you had, and starting from scratch every time you spin up a new project.
+
+Neither of these scales.
+
+## Progressive Disclosure: Only Load What You Actually Need
+
+The idea behind Agent-i-Kit is straightforward: your agent shouldn't have to know about every skill upfront. It should be able to *search* for what it needs, then load only that.
+
+This is called progressive disclosure — a pattern from UX design that's finding a second life in agent architecture. Instead of front-loading everything, you expose a lightweight index. The agent scans it, decides what's relevant to the current task, and fetches only those resources. Everything else stays out of context.
+
+The difference in practice is significant. An agent working from a bloated context window will drop steps, misfire on tool selection, and hallucinate connections between things that have nothing to do with each other. An agent that fetches only what it needs stays focused.
+
+Agent-i-Kit gives you this through two commands your agent can call: `akm search` to find relevant skills by intent, and `akm show` to load the full content of only the ones it actually needs. Semantic search means you're not matching on exact keywords — the agent can describe what it's trying to do in plain language and get back relevant results.
+
+## Skills Should Be Shareable
+
+The other problem Agent-i-Kit tackles is distribution. Right now, if you build a great skill for managing Docker containers or generating print-ready PDFs, sharing it with someone else means sending files. There's no package lifecycle, no versioning, no clean way to pull updates.
+
+Agent-i-Kit adds a registry layer on top of your stash. You can install a kit from GitHub or npm in one command. Your team can maintain an internal repository of shared skills that everyone pulls from. Community-maintained kits can be versioned and updated the same way you'd update any other dependency.
+
+This matters because the value of a good skill compounds when it's shared. A skill that took you an afternoon to get right shouldn't have to be reinvented by every person on your team — or by strangers on the internet who ran into the same problem you did.
+
+## It's Not Replacing Anything
+
+Agent-i-Kit isn't trying to replace MCP, or the skill systems built into Claude Code and OpenCode. It sits alongside them as a management and discovery layer. You still define your skills the same way. You still use them the same way. You just also have a way to find them, share them, and keep them organized as the collection grows.
+
+Think of it like the difference between having a folder full of scripts and having a package manager. The scripts are still scripts. You just don't have to remember where you put them.
+
+## Beta Testers and Agents Wanted
+
+The project is young — v0.0.9 as of this writing — but the problem it's solving is real and it's only going to get worse as agent workflows get more capable and more complex. A community-maintained registry of high-quality, searchable, versioned skills is genuinely useful infrastructure.
+
+Give it a look at [github.com/itlackey/agentikit](https://github.com/itlackey/agentikit). And if you've built skills worth sharing, this is a good time to think about how to package them so others can benefit.
+
+Feel free to drop links in the comments to skills or kits you've built that you think others should know about.

--- a/posts/intro-part-02.md
+++ b/posts/intro-part-02.md
@@ -1,0 +1,198 @@
+---
+title: You Already Have Dozens of Agent Skills. You Just Can't Find Them.
+series: akm
+description: A quick introduction to managing stashes
+tags: [ai, agents, cli, skills]
+published: false
+---
+
+In the [last post](https://dev.to/itlackey/your-ai-agents-skill-list-is-getting-out-of-hand-32ck), I talked about the problem: your agent's skill collection is growing faster than your ability to manage it. Skills scattered across directories, no search, no sharing, no sanity. I introduced [Agentikit](https://github.com/itlackey/agentikit) as the fix — a CLI called `akm` that gives your agent a searchable, indexed stash of assets.
+
+But here's what I glossed over: most of you aren't starting from zero. You've already got skills, commands, agents, and rules spread across multiple platforms. Claude Code has `~/.claude/skills/`. OpenCode has `.opencode/`. Cursor has `.cursor/rules/`. Codex has its `agents.md`. You might be using two or three of these tools in the same week, building up assets in each one, and none of them can see each other.
+
+That's the real unlock with `akm`. It doesn't care where your assets came from. Point it at a directory, and it indexes everything inside. Point it at five directories, and now you've got semantic search across all of them. One command, every platform, every model.
+
+Let me show you how fast this actually works.
+
+## Install
+
+Pick your poison:
+
+```bash
+# Standalone binary (no runtime needed)
+curl -fsSL https://raw.githubusercontent.com/itlackey/agentikit/main/install.sh | bash
+
+# Or via Bun
+bun install -g akm-cli
+```
+
+That's it. You now have the `akm` binary on your PATH. And when a new version drops, `akm upgrade` handles it in place.
+
+## Initialize Your Stash
+
+```bash
+akm init
+```
+
+This creates `~/akm` with subdirectories for each asset type: `scripts/`, `skills/`, `commands/`, `agents/`, `knowledge/`, and `memories/`. If you want to put it somewhere else, set `AKM_STASH_DIR` before you init.
+
+But the real power move isn't putting everything in one folder. It's telling `akm` where your stuff already lives.
+
+## Add Your Existing Platform Directories
+
+Here's what most people's machines actually look like. You've got Claude Code skills in one place, OpenCode assets in another, maybe some Cursor rules in a third. Instead of copying files around or choosing a winner, just add them as stash sources.
+
+```bash
+akm stash add ~/.claude/skills
+akm stash add ./my-project/.opencode/skills
+akm stash add ./.cursor/rules
+```
+
+One command per directory. Each `akm stash add` registers the path, and the search index picks it up on the next build. No JSON editing, no manual config files. Your files stay exactly where they are — `akm` just knows about them now.
+
+You can name sources to keep track of what's what:
+
+```bash
+akm stash add ~/.claude/skills --name "claude-skills"
+akm stash add ./team-shared --name "team"
+```
+
+And see everything at a glance:
+
+```bash
+akm stash list
+```
+
+That shows your primary stash, all the directories you've added, and any installed kits — in priority order. Need to remove one? `akm stash remove` takes a path or a name.
+
+For assets that live in a git repo or an npm package, `akm add` handles installation and makes them searchable immediately:
+
+```bash
+# A team repo full of shared skills
+akm add github:your-org/team-agent-toolkit
+
+# An npm kit
+akm add @scope/deploy-skills
+
+# A local git directory
+akm add ./path/to/my-opencode-skills
+```
+
+Every `akm add` registers the kit, caches the assets, and triggers an incremental index build.
+
+## Build the Index
+
+```bash
+akm index
+```
+
+First run builds the full index. After that, it runs incrementally — only rescanning directories that changed. If you've configured an embedding endpoint (local Ollama, OpenAI, whatever), you get vector-based semantic search. If not, you still get solid keyword matching out of the box with the built-in local model.
+
+Want the enhanced experience? If you're running Ollama:
+
+```bash
+ollama pull nomic-embed-text
+akm config set embedding '{"endpoint":"http://localhost:11434/v1/embeddings","model":"nomic-embed-text","dimension":384}'
+akm index --full
+```
+
+## Search Across Everything
+
+Now here's where it pays off. Say you're working in Claude Code and you vaguely remember writing a skill for Docker container management a few months ago. Was it in your OpenCode stash? Your Claude Code skills? That shared repo your teammate set up?
+
+Doesn't matter.
+
+```bash
+akm search "docker container management"
+```
+
+That searches across every source you've registered — your primary stash, every directory you added with `akm stash add`, and all installed kits. Semantic search means you don't need to remember the exact filename. Describe what you're looking for and `akm` finds it.
+
+Results come back with a `ref` you can pass straight to `akm show`:
+
+```bash
+akm show skill:docker-homelab
+```
+
+Your agent gets the full SKILL.md content, ready to use. For scripts, it gets a `run` command it can execute directly. For commands, the full markdown template with placeholders. For knowledge, navigable content with TOC and section views. No manual file hunting.
+
+Want to search the community registries too? `akm` ships with [skills.sh](https://skills.sh) built in:
+
+```bash
+akm search "code review" --source both
+```
+
+Now you're searching your local stash and community registries in one shot. Found something useful? Install it:
+
+```bash
+akm add github:someone/great-kit
+```
+
+Or if you just want one asset from a kit without installing the whole thing:
+
+```bash
+akm clone "github:someone/great-kit//skill:code-review" --dest ./.claude
+```
+
+That clones just the skill directly into your project's Claude Code skills directory. The type subdirectory (`skills/`, `scripts/`, etc.) gets appended automatically.
+
+## Tell Your Agent About It
+
+Here's the part that ties it all together. Drop this into your `AGENTS.md`, `CLAUDE.md`, or system prompt:
+
+~~~markdown
+## Resources & Capabilities
+
+You have access to a searchable library of scripts, skills, commands, agents,
+knowledge, and memories via the `akm` CLI. Use `akm -h` for details.
+~~~
+
+That's the entire integration. No plugins, no SDKs, no integration code. Any model that can run shell commands can use `akm`. Claude Code, OpenCode, Codex, Cursor — if it has a terminal, it works.
+
+The agent runs `akm search` to find what it needs, `akm show` to load the content, and gets to work. Everything else stays out of context.
+
+## What This Looks Like in Practice
+
+Let's say your setup looks something like this:
+
+- **Claude Code**: `~/.claude/skills/` has skills for PDF generation, CMYK conversion, and print layout QA
+- **OpenCode**: `.opencode/skills/` in a project has custom Azure deployment scripts and a LiteLLM manager
+- **Shared team repo**: A git repo with Docker, CI/CD, and code review assets
+- **Cursor**: `.cursor/rules/` has coding conventions and architecture patterns
+
+After setup:
+
+```bash
+akm init
+akm stash add ~/.claude/skills
+akm stash add .opencode/skills
+akm stash add .cursor/rules
+akm add github:your-org/team-agent-toolkit
+akm index
+```
+
+Now when your agent runs `akm search "deploy container to azure"`, it finds your Azure deployment script from the OpenCode directory, the Docker skill from your team repo, and maybe a relevant knowledge doc from Cursor's rules. All in one search. All ranked by relevance.
+
+The agent picks what it needs, loads only that, and gets to work. Progressive disclosure means your agent's context stays clean — no drowning in irrelevant skills, no missing the one it actually needs.
+
+## Why This Matters More Than It Sounds
+
+The fragmentation problem in agent tooling is only getting worse. Every platform is building its own skill format, its own directory conventions, its own discovery mechanism. None of them talk to each other. If you're serious about building agent workflows, you're going to end up with assets in three or four of these systems within the year.
+
+You can either manage that by hand — maintaining parallel copies, forgetting where things are, rebuilding from scratch when you switch tools — or you can index once and search everywhere.
+
+`akm` isn't trying to replace any of these platforms. Your Claude Code skills stay Claude Code skills. Your OpenCode scripts stay OpenCode scripts. `akm` just makes them all findable from one place, regardless of which agent is asking.
+
+## Get Started
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/itlackey/agentikit/main/install.sh | bash
+akm init
+akm stash add ~/.claude/skills
+akm index
+akm search "whatever you need"
+```
+
+Five commands. Every skill you've ever written, searchable in seconds.
+
+The repo is at [github.com/itlackey/agentikit](https://github.com/itlackey/agentikit). If you've got agent assets scattered across platforms, give it a shot and let me know what breaks.

--- a/posts/intro-part-03.md
+++ b/posts/intro-part-03.md
@@ -1,0 +1,181 @@
+---
+title: Your Agent's Memory Shouldn't Disappear When the Session Ends
+series: akm
+description: A quick introduction to using OpenViking with akm
+tags: [ai, agents, cli, skills]
+published: false
+---
+
+This is part three in a series about managing the growing pile of skills, scripts, and context that AI coding agents depend on. In [part one](https://dev.to/itlackey/your-ai-agents-skill-list-is-getting-out-of-hand-32ck), I talked about why progressive disclosure beats loading everything into context. In [part two](https://dev.to/itlackey/you-already-have-dozens-of-agent-skills-you-just-cant-find-them), I showed how `akm` unifies your existing Claude Code, OpenCode, and Cursor assets into one searchable stash.
+
+Both of those were about files on disk. Local skills, local scripts, local knowledge documents. That covers most people's immediate pain, but it leaves a bigger problem on the table: what happens when the context your agent needs isn't local?
+
+Think about project architecture docs that live in a shared knowledge base. Team decisions captured during previous sessions. Coding standards that evolve over time and shouldn't be copy-pasted into every developer's stash. Agent memories that accumulate across conversations and need to persist somewhere more durable than a markdown file in a git repo.
+
+That's where [OpenViking](https://github.com/volcengine/OpenViking) comes in, and why `akm` now supports it as a first-class stash provider.
+
+## What Is OpenViking?
+
+OpenViking is an open-source context database built by ByteDance's Volcano Engine team. Instead of treating agent context as flat vectors in a RAG pipeline, it organizes everything — memories, resources, skills — into a hierarchical virtual filesystem under the `viking://` protocol.
+
+The mental model is deliberate: agent context should be as navigable as a file tree. You can `ls` a directory, read a specific document by URI, and search semantically across the entire tree. Everything gets a unique address like `viking://resources/project-context` or `viking://memories/sprint-decisions`.
+
+The part that matters for `akm` is the API. OpenViking exposes REST endpoints for search (semantic and text), content read, and file stat. That's exactly what a stash provider needs: the ability to find things and retrieve them. So we built one.
+
+## Adding OpenViking as a Stash Source
+
+If you already have `akm` installed and an OpenViking server running, the setup is one command:
+
+```bash
+akm stash add http://localhost:1933 --provider openviking
+```
+
+That registers the server as a stash source. From that point on, `akm search` queries your local stash and the OpenViking server in parallel. Results from both show up in the same `hits[]` array, ranked together.
+
+If your server requires authentication:
+
+```bash
+akm stash add http://localhost:1933 \
+  --provider openviking \
+  --options '{"apiKey":"your-api-key"}'
+```
+
+Give it a name to keep things tidy:
+
+```bash
+akm stash add http://localhost:1933 \
+  --provider openviking \
+  --name "team-context" \
+  --options '{"apiKey":"your-api-key"}'
+```
+
+Verify it's registered:
+
+```bash
+akm stash list
+```
+
+That's the full setup. No config files to hand-edit, no environment variables to set. The provider handles caching, retries, and graceful degradation — if the server goes down, your local stash still works fine and the provider falls back to cached results for up to an hour.
+
+## Searching Remote and Local Together
+
+Here's what changes in practice. Before OpenViking, an `akm search` hit your local stash — your primary directory, search paths, and installed kits. Now it also hits any OpenViking servers you've registered.
+
+```bash
+akm search "project architecture"
+```
+
+This might return a local skill from your Claude Code directory *and* a resource document from OpenViking. The results are unified: same format, same scoring, same `ref` handles. The only difference is that OpenViking hits use `viking://` URIs instead of local `type:name` refs.
+
+```bash
+akm show viking://resources/project-context/project-context.md
+```
+
+That fetches the full content directly from the OpenViking server. No local copy needed. The response comes back in the same format as any other `akm show` — with a `content` field, an `action` field, and type metadata. Your agent doesn't need to know or care whether the asset was local or remote.
+
+By default, OpenViking search uses semantic matching (via `POST /api/v1/search/find`). If you prefer text search for exact matching, configure the provider with:
+
+```bash
+akm stash add http://localhost:1933 \
+  --provider openviking \
+  --options '{"apiKey":"your-key","searchType":"text"}'
+```
+
+Text search uses OpenViking's grep endpoint, which deduplicates results by URI and ranks them by match frequency.
+
+## Standing Up a Test Server
+
+If you want to try this locally before pointing at a shared server, the akm repo includes a ready-made Docker Compose setup:
+
+```bash
+git clone https://github.com/itlackey/agentikit.git
+cd agentikit/tests/fixtures/openviking
+
+# Start the server
+docker compose up -d
+
+# Wait a few seconds, then seed sample content
+./seed.sh
+```
+
+The seed script loads a handful of test documents — project architecture notes, coding standards, an API reference, and a project memory — into the OpenViking server. These map to `viking://resources/` and `viking://memories/` URIs.
+
+Now register it:
+
+```bash
+akm stash add http://localhost:1933 \
+  --provider openviking \
+  --name openviking \
+  --options '{"apiKey":"akm-test-key"}'
+```
+
+And test:
+
+```bash
+akm show viking://resources/project-context/project-context.md
+```
+
+You should get back the full markdown content of the project architecture document. Search works too:
+
+```bash
+akm search "coding standards"
+```
+
+And if you have Ollama running locally, you can enable semantic search by updating the `ov.conf` to point the embedding endpoint at your Ollama instance (`http://host.docker.internal:11434/v1`). Without embeddings, text search and direct content access still work fine.
+
+Tear it down when you're done:
+
+```bash
+docker compose down
+```
+
+## Why This Matters for Teams
+
+The OpenViking integration solves a class of problems that local-only stash management can't.
+
+**Shared context without shared files.** Your team can maintain a single OpenViking instance with project documentation, architectural decisions, and coding standards. Every developer's agent can search and retrieve that context without syncing files, mounting network drives, or maintaining parallel copies. Update a document in OpenViking and every agent sees the change immediately.
+
+**Persistent memory across sessions.** OpenViking's memory system stores recalled context fragments that survive across conversations. When your agent starts a new session, it can search for memories from previous work — `akm search "sprint planning decisions" --type memory` — and get back what it learned last week. That's a fundamentally different capability than loading the same static skills every time.
+
+**Unified search across everything.** This is the compounding effect of the whole series. Part one gave you progressive disclosure for local skills. Part two unified your multi-platform assets into one searchable stash. Now part three adds remote context to the same search surface. One `akm search` query, one result set, one `akm show` command — regardless of whether the asset is a Claude Code skill in `~/.claude/skills/`, a script from an npm kit, or a knowledge document on an OpenViking server across the network.
+
+## The Full Picture
+
+After three posts, here's what a fully-wired setup looks like:
+
+```bash
+# Install
+curl -fsSL https://raw.githubusercontent.com/itlackey/agentikit/main/install.sh | bash
+akm init
+
+# Local platform assets
+akm stash add ~/.claude/skills
+akm stash add .opencode/skills
+akm stash add .cursor/rules
+
+# Community and team kits
+akm add github:your-org/team-agent-toolkit
+akm add @scope/deploy-skills
+
+# Remote context server
+akm stash add https://your-viking.internal:1933 \
+  --provider openviking \
+  --name team-context \
+  --options '{"apiKey":"..."}'
+
+# Build the index
+akm index
+```
+
+Now drop the `AGENTS.md` snippet into every project and your agent has access to all of it:
+
+~~~markdown
+## Resources & Capabilities
+
+You have access to a searchable library of scripts, skills, commands, agents,
+knowledge, and memories via the `akm` CLI. Use `akm -h` for details.
+~~~
+
+Local skills, remote knowledge, team kits, community registries, persistent memories. One search, one interface, every agent.
+
+The repo is at [github.com/itlackey/agentikit](https://github.com/itlackey/agentikit). OpenViking is at [github.com/volcengine/OpenViking](https://github.com/volcengine/OpenViking). Both are open source, both are moving fast, and the combination is genuinely useful infrastructure for anyone running agents in production.


### PR DESCRIPTION
This pull request introduces a new publishing workflow and adds the first three posts in a technical series about managing AI agent skills and context using Agent-i-Kit (`akm`). The posts cover progressive disclosure for agent skills, unifying multiple skill sources, and integrating remote context with OpenViking. The workflow automates publishing markdown posts to dev.to.

The most important changes are:

**Dev.to Publishing Automation:**
- Added a new GitHub Actions workflow (`.github/workflows/publish-devto.yml`) to automatically publish markdown articles in the `posts/` directory to dev.to when changes are pushed to `main`. This uses the `sinedied/publish-devto` action and supports conventional commits.

**New Technical Blog Posts:**
- Added `posts/intro-part-01.md`: Introduces the problem of managing growing agent skill lists and presents Agent-i-Kit as a solution for progressive disclosure and skill sharing.
- Added `posts/intro-part-02.md`: Explains how to unify and search skills, commands, and rules across multiple platforms (Claude Code, OpenCode, Cursor, etc.) using `akm`, including setup and indexing instructions.
- Added `posts/intro-part-03.md`: Details integrating remote, persistent context with OpenViking as a stash provider for `akm`, enabling unified search across local and remote resources and persistent agent memory.