### PR TITLE
Replace tarball download with git clone; add writable stash support and akm save command

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "akm-cli",
       "dependencies": {
         "@clack/prompts": "^1.1.0",
-        "@huggingface/transformers": "^3.8.1",
         "citty": "^0.2.1",
         "yaml": "^2.8.2",
       },
@@ -16,6 +16,7 @@
         "typescript": "^5.9.3",
       },
       "optionalDependencies": {
+        "@huggingface/transformers": "^3.8.1",
         "sqlite-vec": "0.1.7-alpha.2",
       },
     },

--- a/docs/AGENTS.full.md
+++ b/docs/AGENTS.full.md
@@ -87,6 +87,28 @@ akm clone "npm:@scope/pkg//script:deploy.sh"  # Clone from remote package
 
 When `--dest` is provided, `akm init` is not required first.
 
+## Save
+
+Commit local changes in a git-backed stash. Behaviour adapts automatically:
+
+- **Not a git repo** — no-op (silent skip)
+- **Git repo, no remote** — stage and commit only (the default stash always falls here)
+- **Git repo, has remote, not writable** — stage and commit only
+- **Git repo, has remote, `writable: true`** — stage, commit, and push
+
+```sh
+akm save                                      # Save primary stash (timestamp message)
+akm save -m "Add deploy skill"               # Save with explicit message
+akm save my-skills                            # Save a named writable git stash
+akm save my-skills -m "Update patterns"      # Save named stash with message
+```
+
+The `--writable` flag on `akm add` opts a remote git stash into push-on-save:
+
+```sh
+akm add git@github.com:org/skills.git --provider git --name my-skills --writable
+```
+
 ## Registries
 
 ```sh

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -16,6 +16,8 @@ akm import ./notes/release-checklist.md       # Import a knowledge doc into your
 akm feedback <ref> --positive|--negative      # Record whether an asset helped
 akm add <ref>                                 # Add a source (npm, GitHub, git, local dir)
 akm clone <ref>                               # Copy an asset to the working stash (optional --dest arg to clone to specific location)
+akm save                                      # Commit (and push if writable) the primary git stash
+akm save my-skills -m "Update"               # Save a named writable git stash
 akm registry search "<query>"                 # Search all registries
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -397,13 +397,15 @@ akm save my-skills -m "Update"     # Save named stash with message
 
 | State | Result |
 | --- | --- |
-| Not a git repo | Silent no-op |
+| Not a git repo | Exit 0, `skipped: true` in JSON output — no error |
 | Git repo, no remote | Stage and commit only |
 | Git repo, has remote, not writable | Stage and commit only |
 | Git repo, has remote, `writable: true` | Stage, commit, and push |
 
-The default stash is always a local git repo without a remote (initialized by
-`akm init`), so `akm save` will always commit there safely without pushing.
+When `akm init` successfully initializes the default stash as a local git repo
+(requires `git` to be installed), `akm save` will commit there safely without
+pushing. If git is unavailable, the stash will not be a git repo and save will
+return a skipped result.
 
 To make a remote git stash writable, pass `--writable` when adding it:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -375,6 +375,41 @@ When `--dest` is provided, the working stash (`AKM_STASH_DIR`) is not
 required. This makes clone usable in CI or fresh environments without
 running `akm init` first.
 
+### save
+
+Stage and commit local changes in a git-backed stash. If the stash has a
+remote configured and is marked `writable: true`, the commit is also pushed.
+
+```sh
+akm save                            # Save primary stash (auto timestamp message)
+akm save -m "Add deploy skill"     # Save with custom message
+akm save my-skills                  # Save a named writable git stash
+akm save my-skills -m "Update"     # Save named stash with message
+```
+
+| Argument / Flag | Description |
+| --- | --- |
+| `[name]` | Optional stash name. Defaults to the primary stash |
+| `-m`, `--message` | Commit message. Defaults to `akm save <timestamp>` |
+
+**Behaviour by repo state:**
+
+| State | Result |
+| --- | --- |
+| Not a git repo | Silent no-op |
+| Git repo, no remote | Stage and commit only |
+| Git repo, has remote, not writable | Stage and commit only |
+| Git repo, has remote, `writable: true` | Stage, commit, and push |
+
+The default stash is always a local git repo without a remote (initialized by
+`akm init`), so `akm save` will always commit there safely without pushing.
+
+To make a remote git stash writable, pass `--writable` when adding it:
+
+```sh
+akm add git@github.com:org/skills.git --provider git --name my-skills --writable
+```
+
 ### remember
 
 Record a memory in the default stash. This writes a markdown file into

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -243,7 +243,8 @@ akm add https://docs.example.com --max-pages 100 --max-depth 5
 | Flag | Description |
 | --- | --- |
 | `--name` | Human-friendly name for the source |
-| `--provider` | Provider type (e.g. `openviking`). Required for remote provider sources |
+| `--provider` | Provider type (e.g. `git`, `openviking`). Required for remote provider sources |
+| `--writable` | Mark a git stash as writable so `akm save` also pushes (default: false) |
 | `--options` | Provider options as JSON (e.g. `'{"apiKey":"key"}'`) |
 | `--max-pages` | Maximum pages to crawl for website sources (default: 50) |
 | `--max-depth` | Maximum crawl depth for website sources (default: 3) |

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -374,7 +374,7 @@ akm add https://github.com/andrewyng/context-hub --provider git
 ```
 
 Key behaviors:
-- Downloads and securely mirrors the GitHub repo archive into akm's cache
+- Clones the repository using `git clone --depth 1` into akm's cache
 - Discovers `content/**/DOC.md` and `content/**/SKILL.md` entries
 - Maps Context Hub docs to `knowledge` hits and skills to `skill` hits
 - Returns direct `akm show ...` actions for matched entries

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1011,7 +1011,7 @@ const addCommand = defineCommand({
       if (ref === CONTEXT_HUB_ALIAS_REF) {
         const result = addStash({
           target: CONTEXT_HUB_ALIAS_URL,
-          providerType: "context-hub",
+          providerType: "git",
           name: "context-hub",
         });
         output("stash-add", result);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ import { searchRegistry } from "./registry-search";
 import { checkForUpdate, performUpgrade } from "./self-update";
 import { akmAdd } from "./stash-add";
 import { akmClone } from "./stash-clone";
+import { pushGitStash } from "./stash-providers/git";
 import { akmSearch, parseSearchSource } from "./stash-search";
 import { akmShowUnified } from "./stash-show";
 import { addStash } from "./stash-source-manage";
@@ -1301,6 +1302,31 @@ const configCommand = defineCommand({
   },
 });
 
+const pushCommand = defineCommand({
+  meta: {
+    name: "push",
+    description: "Commit and push local changes in a writable git stash back to the remote",
+  },
+  args: {
+    name: {
+      type: "positional",
+      description: "Name of the writable git stash to push",
+      required: true,
+    },
+    message: {
+      type: "string",
+      alias: "m",
+      description: 'Commit message (default: "Update stash assets")',
+    },
+  },
+  async run({ args }) {
+    await runWithJsonErrors(async () => {
+      const result = pushGitStash(args.name, args.message);
+      output("push", result);
+    });
+  },
+});
+
 const cloneCommand = defineCommand({
   meta: {
     name: "clone",
@@ -1913,6 +1939,7 @@ const main = defineCommand({
     remember: rememberCommand,
     import: importKnowledgeCommand,
     lint: lintCommand,
+    push: pushCommand,
     clone: cloneCommand,
     registry: registryCommand,
     config: configCommand,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -995,6 +995,11 @@ const addCommand = defineCommand({
     provider: { type: "string", description: "Provider type (e.g. openviking). Required for URL sources." },
     options: { type: "string", description: 'Provider options as JSON (e.g. \'{"apiKey":"key"}\').' },
     name: { type: "string", description: "Human-friendly name for the source" },
+    writable: {
+      type: "boolean",
+      description: "Mark a git stash as writable so changes can be pushed back",
+      default: false,
+    },
     "max-pages": { type: "string", description: "Maximum pages to crawl for website sources (default: 50)" },
     "max-depth": { type: "string", description: "Maximum crawl depth for website sources (default: 3)" },
   },
@@ -1038,6 +1043,7 @@ const addCommand = defineCommand({
           name: args.name,
           providerType: args.provider,
           options: parsedOptions,
+          writable: args.writable,
         });
         output("stash-add", result);
         return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,7 @@ import { searchRegistry } from "./registry-search";
 import { checkForUpdate, performUpgrade } from "./self-update";
 import { akmAdd } from "./stash-add";
 import { akmClone } from "./stash-clone";
-import { pushGitStash } from "./stash-providers/git";
+import { saveGitStash } from "./stash-providers/git";
 import { akmSearch, parseSearchSource } from "./stash-search";
 import { akmShowUnified } from "./stash-show";
 import { addStash } from "./stash-source-manage";
@@ -1308,27 +1308,28 @@ const configCommand = defineCommand({
   },
 });
 
-const pushCommand = defineCommand({
+const saveCommand = defineCommand({
   meta: {
-    name: "push",
-    description: "Commit and push local changes in a writable git stash back to the remote",
+    name: "save",
+    description:
+      "Save changes in a git-backed stash: commits (and pushes when writable + remote is configured). No-op for non-git stashes.",
   },
   args: {
     name: {
       type: "positional",
-      description: "Name of the writable git stash to push",
-      required: true,
+      description: "Name of the git stash to save (default: primary stash directory)",
+      required: false,
     },
     message: {
       type: "string",
       alias: "m",
-      description: 'Commit message (default: "Update stash assets")',
+      description: "Commit message (default: timestamp)",
     },
   },
   async run({ args }) {
     await runWithJsonErrors(async () => {
-      const result = pushGitStash(args.name, args.message);
-      output("push", result);
+      const result = saveGitStash(args.name, args.message);
+      output("save", result);
     });
   },
 });
@@ -1945,7 +1946,7 @@ const main = defineCommand({
     remember: rememberCommand,
     import: importKnowledgeCommand,
     lint: lintCommand,
-    push: pushCommand,
+    save: saveCommand,
     clone: cloneCommand,
     registry: registryCommand,
     config: configCommand,
@@ -2129,6 +2130,7 @@ akm import ./notes/release-checklist.md       # Import a knowledge doc into your
 akm feedback <ref> --positive|--negative      # Record whether an asset helped
 akm add <ref>                                 # Add a source (npm, GitHub, git, local dir)
 akm clone <ref>                               # Copy an asset to the working stash (optional --dest arg to clone to specific location)
+akm save                                      # Commit (and push if writable remote) changes in the primary stash
 akm registry search "<query>"                 # Search all registries
 \`\`\`
 
@@ -2222,24 +2224,6 @@ akm feedback agent:reviewer --negative         # Record that an asset missed the
 Use \`akm feedback\` whenever an asset materially helps or fails so future search
 ranking can learn from actual usage.
 
-## Add & Manage Sources
-
-\`\`\`sh
-akm add <ref>                                 # Add a source
-akm add @scope/kit                            # From npm (managed)
-akm add owner/repo                            # From GitHub (managed)
-akm add ./path/to/local/kit                   # Local directory
-akm enable skills.sh                          # Enable the skills.sh registry
-akm disable skills.sh                         # Disable the skills.sh registry
-akm enable context-hub                        # Add/enable the context-hub source
-akm disable context-hub                       # Disable the context-hub source
-akm list                                      # List all sources
-akm list --kind managed                       # List managed sources only
-akm remove <target>                           # Remove by id, ref, path, or name
-akm update --all                              # Update all managed sources
-akm update <target> --force                   # Force re-download
-\`\`\`
-
 ## Clone
 
 Copy an asset to the working stash or a custom destination for editing.
@@ -2253,6 +2237,47 @@ akm clone "npm:@scope/pkg//script:deploy.sh"  # Clone from remote package
 \`\`\`
 
 When \`--dest\` is provided, \`akm init\` is not required first.
+
+## Save
+
+Commit local changes in a git-backed stash. Behaviour adapts automatically:
+
+- **Not a git repo** — no-op (silent skip)
+- **Git repo, no remote** — stage and commit only (the default stash always falls here)
+- **Git repo, has remote, not writable** — stage and commit only
+- **Git repo, has remote, \`writable: true\`** — stage, commit, and push
+
+\`\`\`sh
+akm save                                      # Save primary stash (timestamp message)
+akm save -m "Add deploy skill"               # Save with explicit message
+akm save my-skills                            # Save a named writable git stash
+akm save my-skills -m "Update patterns"      # Save named stash with message
+\`\`\`
+
+The \`--writable\` flag on \`akm add\` opts a remote git stash into push-on-save:
+
+\`\`\`sh
+akm add git@github.com:org/skills.git --provider git --name my-skills --writable
+\`\`\`
+
+## Add & Manage Sources
+
+\`\`\`sh
+akm add <ref>                                 # Add a source
+akm add @scope/kit                            # From npm (managed)
+akm add owner/repo                            # From GitHub (managed)
+akm add ./path/to/local/kit                   # Local directory
+akm add git@github.com:org/repo.git --provider git --name my-skills --writable
+akm enable skills.sh                          # Enable the skills.sh registry
+akm disable skills.sh                         # Disable the skills.sh registry
+akm enable context-hub                        # Add/enable the context-hub source
+akm disable context-hub                       # Disable the context-hub source
+akm list                                      # List all sources
+akm list --kind managed                       # List managed sources only
+akm remove <target>                           # Remove by id, ref, path, or name
+akm update --all                              # Update all managed sources
+akm update <target> --force                   # Force re-download
+\`\`\`
 
 ## Registries
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,7 +73,7 @@ export interface RegistryConfigEntry {
 }
 
 export interface StashConfigEntry {
-  /** Provider type (e.g. "filesystem", "openviking", "context-hub") */
+  /** Provider type (e.g. "filesystem", "git", "openviking") */
   type: string;
   /** Filesystem path (for type: "filesystem") */
   path?: string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,6 +83,8 @@ export interface StashConfigEntry {
   name?: string;
   /** Whether this stash is active. Default: true */
   enabled?: boolean;
+  /** If true, the stash is a git repo the user can commit and push changes back to. */
+  writable?: boolean;
   /** Arbitrary provider-specific options */
   options?: Record<string, unknown>;
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -5,6 +5,7 @@
  * in config.json, and ensures ripgrep is available.
  */
 
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { TYPE_DIRS } from "./asset-spec";
@@ -39,6 +40,9 @@ export async function akmInit(options?: { dir?: string }): Promise<InitResponse>
     }
   }
 
+  // Ensure the default stash is a local git repo (no remote required)
+  ensureGitRepo(stashDir);
+
   // Persist stashDir in config.json
   const configPath = getConfigPath();
   const existing = loadUserConfig();
@@ -57,4 +61,12 @@ export async function akmInit(options?: { dir?: string }): Promise<InitResponse>
   }
 
   return { stashDir, created, configPath, ripgrep };
+}
+
+/** Initialise `dir` as a git repository if it is not already one. */
+function ensureGitRepo(dir: string): void {
+  const gitDir = path.join(dir, ".git");
+  if (fs.existsSync(gitDir)) return;
+  // Non-fatal: git may not be available in all environments
+  spawnSync("git", ["init", dir], { encoding: "utf8", timeout: 15_000 });
 }

--- a/src/search-source.ts
+++ b/src/search-source.ts
@@ -206,7 +206,7 @@ export async function ensureStashCaches(config?: AkmConfig): Promise<void> {
     try {
       const repo = parseGitRepoUrl(entry.url);
       const cachePaths = getCachePaths(repo.canonicalUrl);
-      await ensureGitMirror(repo, cachePaths, { requireRepoDir: true });
+      await ensureGitMirror(repo, cachePaths, { requireRepoDir: true, writable: entry.writable === true });
     } catch (err) {
       warn(
         `Warning: failed to refresh git mirror for "${entry.url}": ${err instanceof Error ? err.message : String(err)}`,

--- a/src/search-source.ts
+++ b/src/search-source.ts
@@ -53,7 +53,7 @@ export function resolveStashSources(overrideStashDir?: string, existingConfig?: 
   }
 
   // Git stash entries: resolve cache directory so the indexer can walk it.
-  // "context-hub", "github", and "git" provider types are handled.
+  // "git" provider type (and its legacy aliases "context-hub", "github") are handled.
   for (const entry of config.stashes ?? []) {
     if (GIT_STASH_TYPES.has(entry.type) && entry.url && entry.enabled !== false) {
       try {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -665,7 +665,7 @@ export async function stepStashSources(current: AkmConfig): Promise<StashConfigE
   for (const url of selectedRepos) {
     if (!existingUrls.has(url)) {
       const rec = RECOMMENDED_GITHUB_REPOS.find((r) => r.url === url);
-      stashes.push({ type: "github", url, name: rec?.name });
+      stashes.push({ type: "git", url, name: rec?.name });
       existingUrls.add(url);
     }
   }
@@ -762,7 +762,7 @@ export async function stepStashSources(current: AkmConfig): Promise<StashConfigE
       );
       if (name === null) continue;
 
-      const entry: StashConfigEntry = { type: "github", url: url.trim() };
+      const entry: StashConfigEntry = { type: "git", url: url.trim() };
       if (name.trim()) entry.name = name.trim();
       if (!stashes.some((s) => s.url === entry.url)) {
         stashes.push(entry);

--- a/src/stash-providers/git.ts
+++ b/src/stash-providers/git.ts
@@ -1,11 +1,11 @@
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { fetchWithRetry } from "../common";
 import type { StashConfigEntry } from "../config";
 import { ConfigError } from "../errors";
 import { getRegistryIndexCacheDir } from "../paths";
-import { extractTarGzSecure } from "../registry-install";
+import { validateGitUrl } from "../registry-resolve";
 import type { StashProvider, StashSearchOptions, StashSearchResult } from "../stash-provider";
 import { registerStashProvider } from "../stash-provider-factory";
 import type { KnowledgeView, ShowResponse } from "../stash-types";
@@ -18,9 +18,8 @@ const CACHE_TTL_MS = 12 * 60 * 60 * 1000;
 const CACHE_STALE_MS = 7 * 24 * 60 * 60 * 1000;
 
 interface ParsedRepoUrl {
-  owner: string;
-  repo: string;
-  ref: string;
+  cloneUrl: string;
+  ref: string | null;
   canonicalUrl: string;
 }
 
@@ -58,7 +57,6 @@ registerStashProvider("github", (config) => new GitStashProvider(config));
 
 function getCachePaths(repoUrl: string): {
   rootDir: string;
-  archivePath: string;
   repoDir: string;
   indexPath: string;
 } {
@@ -66,7 +64,6 @@ function getCachePaths(repoUrl: string): {
   const rootDir = path.join(getRegistryIndexCacheDir(), `context-hub-${key}`);
   return {
     rootDir,
-    archivePath: path.join(rootDir, "repo.tar.gz"),
     repoDir: path.join(rootDir, "repo"),
     indexPath: path.join(rootDir, "index.json"),
   };
@@ -93,8 +90,7 @@ async function ensureGitMirror(
 
   try {
     fs.mkdirSync(cachePaths.rootDir, { recursive: true });
-    await downloadArchive(buildTarballUrl(repo), cachePaths.archivePath);
-    extractTarGzSecure(cachePaths.archivePath, cachePaths.repoDir);
+    cloneRepo(repo.cloneUrl, repo.ref, cachePaths.repoDir);
     // Touch index file to track freshness
     fs.writeFileSync(cachePaths.indexPath, "[]", { encoding: "utf8", mode: 0o600 });
   } catch (err) {
@@ -105,6 +101,24 @@ async function ensureGitMirror(
   }
 }
 
+function cloneRepo(cloneUrl: string, ref: string | null, destDir: string): void {
+  if (fs.existsSync(destDir)) fs.rmSync(destDir, { recursive: true, force: true });
+
+  const args = ["clone", "--depth", "1"];
+  if (ref) args.push("--branch", ref);
+  args.push(cloneUrl, destDir);
+
+  const result = spawnSync("git", args, { encoding: "utf8", timeout: 120_000 });
+  if (result.status !== 0) {
+    const err = result.stderr?.trim() || result.error?.message || "unknown error";
+    throw new Error(`Failed to clone ${cloneUrl}: ${err}`);
+  }
+
+  // Remove .git directory — we only need the working tree
+  const gitDir = path.join(destDir, ".git");
+  if (fs.existsSync(gitDir)) fs.rmSync(gitDir, { recursive: true, force: true });
+}
+
 function hasExtractedRepo(repoDir: string): boolean {
   try {
     return fs.statSync(repoDir).isDirectory() && fs.statSync(path.join(repoDir, "content")).isDirectory();
@@ -113,32 +127,18 @@ function hasExtractedRepo(repoDir: string): boolean {
   }
 }
 
-async function downloadArchive(url: string, destination: string): Promise<void> {
-  const response = await fetchWithRetry(url, undefined, { timeout: 120_000, retries: 1 });
-  if (!response.ok) {
-    throw new Error(`Failed to download archive (${response.status}) from ${url}`);
-  }
-
-  const BunRuntime = (globalThis as Record<string, unknown>).Bun as {
-    write?: (path: string, body: Response) => Promise<number>;
-  };
-  if (BunRuntime?.write) {
-    await BunRuntime.write(destination, response);
-    return;
-  }
-
-  const arrayBuffer = await response.arrayBuffer();
-  fs.writeFileSync(destination, Buffer.from(arrayBuffer));
-}
-
-function buildTarballUrl(repo: ParsedRepoUrl): string {
-  return `https://github.com/${repo.owner}/${repo.repo}/archive/refs/heads/${repo.ref}.tar.gz`;
-}
-
 function parseGitRepoUrl(rawUrl: string): ParsedRepoUrl {
   if (!rawUrl) {
-    throw new ConfigError("Git provider requires a GitHub repository URL");
+    throw new ConfigError("Git provider requires a repository URL");
   }
+
+  // SSH shorthand: git@host:path — valid as-is, delegated to system git credentials
+  if (/^git@[^:]+:.+$/.test(rawUrl)) {
+    return { cloneUrl: rawUrl, ref: null, canonicalUrl: rawUrl };
+  }
+
+  // Validate URL scheme is safe before parsing
+  validateGitUrl(rawUrl);
 
   let parsed: URL;
   try {
@@ -147,38 +147,35 @@ function parseGitRepoUrl(rawUrl: string): ParsedRepoUrl {
     throw new ConfigError(`Git provider URL is not valid: "${rawUrl}"`);
   }
 
-  if (parsed.protocol !== "https:") {
-    throw new ConfigError(`Git provider URL must use https://, got "${parsed.protocol}"`);
-  }
-  if (parsed.hostname !== "github.com") {
-    throw new ConfigError(`Git provider only supports github.com URLs, got "${parsed.hostname}"`);
+  // GitHub web URLs: extract a clean clone URL and optional branch from /tree/<ref>
+  if (parsed.hostname === "github.com" && parsed.protocol === "https:") {
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (segments.length < 2) {
+      throw new ConfigError(`Git provider URL must point to a repository, got "${rawUrl}"`);
+    }
+
+    const owner = sanitizeString(segments[0]);
+    const repo = sanitizeString(segments[1].replace(/\.git$/i, ""));
+
+    if (!owner || !repo || !/^[A-Za-z0-9_.-]+$/.test(owner) || !/^[A-Za-z0-9_.-]+$/.test(repo)) {
+      throw new ConfigError(`Unsupported repository URL: "${rawUrl}"`);
+    }
+
+    let ref: string | null = null;
+    if (segments[2] === "tree" && segments.length >= 4) {
+      const rawRef = sanitizeString(segments.slice(3).join("/"), 255);
+      if (rawRef && !rawRef.includes("..") && /^[A-Za-z0-9._/-]+$/.test(rawRef)) {
+        ref = rawRef;
+      }
+    }
+
+    const cloneUrl = `https://github.com/${owner}/${repo}`;
+    const canonicalUrl = ref ? `${cloneUrl}/tree/${ref}` : cloneUrl;
+    return { cloneUrl, ref, canonicalUrl };
   }
 
-  const segments = parsed.pathname.split("/").filter(Boolean);
-  if (segments.length < 2) {
-    throw new ConfigError(`Git provider URL must point to a GitHub repository, got "${rawUrl}"`);
-  }
-
-  const owner = sanitizeString(segments[0]);
-  const repo = sanitizeString(segments[1].replace(/\.git$/i, ""));
-  let ref = "main";
-  if (segments[2] === "tree" && segments.length >= 4) {
-    ref = sanitizeString(segments.slice(3).join("/"), 255) || "main";
-  }
-
-  if (!owner || !repo || !/^[A-Za-z0-9_.-]+$/.test(owner) || !/^[A-Za-z0-9_.-]+$/.test(repo)) {
-    throw new ConfigError(`Unsupported repository URL: "${rawUrl}"`);
-  }
-  if (!ref || ref.includes("..") || !/^[A-Za-z0-9._/-]+$/.test(ref)) {
-    throw new ConfigError(`Unsupported branch/ref in URL: "${rawUrl}"`);
-  }
-
-  return {
-    owner,
-    repo,
-    ref,
-    canonicalUrl: `https://github.com/${owner}/${repo}/tree/${ref}`,
-  };
+  // Any other valid git URL: use as-is, rely on system git credentials
+  return { cloneUrl: rawUrl, ref: null, canonicalUrl: rawUrl };
 }
 
 // ── Exports ─────────────────────────────────────────────────────────────────

--- a/src/stash-providers/git.ts
+++ b/src/stash-providers/git.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { resolveStashDir } from "../common";
 import type { StashConfigEntry } from "../config";
 import { loadConfig } from "../config";
 import { ConfigError, UsageError } from "../errors";
@@ -24,12 +25,6 @@ interface ParsedRepoUrl {
   cloneUrl: string;
   ref: string | null;
   canonicalUrl: string;
-}
-
-export interface PushGitStashResult {
-  committed: boolean;
-  pushed: boolean;
-  output: string;
 }
 
 class GitStashProvider implements StashProvider {
@@ -206,56 +201,79 @@ function parseGitRepoUrl(rawUrl: string): ParsedRepoUrl {
   return { cloneUrl: rawUrl, ref: null, canonicalUrl: rawUrl };
 }
 
-// ── Push support ─────────────────────────────────────────────────────────────
+// ── Save support ─────────────────────────────────────────────────────────────
 
-export function pushGitStash(name: string, message = "Update stash assets"): PushGitStashResult {
-  const config = loadConfig();
-  const stash = config.stashes?.find((s) => s.name === name || s.url === name);
+export interface SaveGitStashResult {
+  committed: boolean;
+  pushed: boolean;
+  skipped: boolean;
+  reason?: string;
+  output: string;
+}
 
-  if (!stash) {
-    throw new UsageError(`No git stash found with name "${name}"`);
-  }
-  if (!GIT_STASH_TYPES.has(stash.type)) {
-    throw new UsageError(`Stash "${name}" is not a git stash (type: ${stash.type})`);
-  }
-  if (!stash.writable) {
-    throw new UsageError(
-      `Stash "${name}" is not marked as writable. Add writable: true to its config entry to enable push.`,
-    );
-  }
-  if (!stash.url) {
-    throw new UsageError(`Stash "${name}" has no URL configured`);
+/**
+ * Commit (and optionally push) local changes in a git-backed stash.
+ *
+ * Behaviour:
+ *   - Not a git repo → skipped (no-op)
+ *   - Git repo, no remote → commit only
+ *   - Git repo, has remote, but stash is not writable → commit only
+ *   - Git repo, has remote, stash is writable → commit + push
+ *
+ * When `name` is omitted the primary stash directory is used.
+ * When `message` is omitted a timestamp is used.
+ */
+export function saveGitStash(name?: string, message?: string): SaveGitStashResult {
+  const timestamp = new Date().toISOString().replace("T", " ").slice(0, 19);
+  const commitMessage = message?.trim() || `akm save ${timestamp}`;
+
+  let repoDir: string;
+  let writable = false;
+
+  if (name) {
+    const config = loadConfig();
+    const stash = config.stashes?.find((s) => s.name === name || s.url === name);
+    if (!stash) throw new UsageError(`No git stash found with name "${name}"`);
+    if (!GIT_STASH_TYPES.has(stash.type)) {
+      throw new UsageError(`Stash "${name}" is not a git stash (type: ${stash.type})`);
+    }
+    if (!stash.url) throw new UsageError(`Stash "${name}" has no URL configured`);
+    const repo = parseGitRepoUrl(stash.url);
+    repoDir = getCachePaths(repo.canonicalUrl).repoDir;
+    writable = stash.writable === true;
+  } else {
+    repoDir = resolveStashDir({ readOnly: true });
   }
 
-  const repo = parseGitRepoUrl(stash.url);
-  const cachePaths = getCachePaths(repo.canonicalUrl);
-  const repoDir = cachePaths.repoDir;
-
+  // No-op: not a git repo
   if (!fs.existsSync(path.join(repoDir, ".git"))) {
-    throw new UsageError(
-      `Stash "${name}" has not been initialised as a writable repo. Run "akm index" to clone it first.`,
-    );
+    return { committed: false, pushed: false, skipped: true, reason: "not a git repository", output: "" };
   }
 
-  // Check for changes
+  // Nothing to commit?
   const statusResult = spawnSync("git", ["-C", repoDir, "status", "--porcelain"], { encoding: "utf8" });
   if (!statusResult.stdout.trim()) {
-    return { committed: false, pushed: false, output: "Nothing to commit, working tree clean" };
+    return { committed: false, pushed: false, skipped: false, output: "nothing to commit, working tree clean" };
   }
 
-  // Stage all changes
+  // Stage and commit
   const addResult = spawnSync("git", ["-C", repoDir, "add", "-A"], { encoding: "utf8" });
   if (addResult.status !== 0) {
     throw new Error(`git add failed: ${addResult.stderr?.trim() || "unknown error"}`);
   }
-
-  // Commit
-  const commitResult = spawnSync("git", ["-C", repoDir, "commit", "-m", message], { encoding: "utf8" });
+  const commitResult = spawnSync("git", ["-C", repoDir, "commit", "-m", commitMessage], { encoding: "utf8" });
   if (commitResult.status !== 0) {
     throw new Error(`git commit failed: ${commitResult.stderr?.trim() || "unknown error"}`);
   }
 
-  // Push
+  // Push only when there is a remote AND the stash is marked writable
+  const remoteResult = spawnSync("git", ["-C", repoDir, "remote"], { encoding: "utf8" });
+  const hasRemote = remoteResult.stdout.trim().length > 0;
+
+  if (!hasRemote || !writable) {
+    return { committed: true, pushed: false, skipped: false, output: commitResult.stdout.trim() };
+  }
+
   const pushResult = spawnSync("git", ["-C", repoDir, "push"], { encoding: "utf8", timeout: 120_000 });
   if (pushResult.status !== 0) {
     throw new Error(`git push failed: ${pushResult.stderr?.trim() || "unknown error"}`);
@@ -264,7 +282,8 @@ export function pushGitStash(name: string, message = "Update stash assets"): Pus
   return {
     committed: true,
     pushed: true,
-    output: (commitResult.stdout + pushResult.stdout).trim() || "Changes committed and pushed",
+    skipped: false,
+    output: (commitResult.stdout + pushResult.stdout).trim() || "changes committed and pushed",
   };
 }
 

--- a/src/stash-providers/git.ts
+++ b/src/stash-providers/git.ts
@@ -161,7 +161,12 @@ function parseGitRepoUrl(rawUrl: string): ParsedRepoUrl {
   }
 
   // Validate URL scheme is safe before parsing
-  validateGitUrl(rawUrl);
+  try {
+    validateGitUrl(rawUrl);
+  } catch (err) {
+    if (err instanceof UsageError) throw new ConfigError(err.message);
+    throw err;
+  }
 
   let parsed: URL;
   try {
@@ -197,8 +202,20 @@ function parseGitRepoUrl(rawUrl: string): ParsedRepoUrl {
     return { cloneUrl, ref, canonicalUrl };
   }
 
-  // Any other valid git URL: use as-is, rely on system git credentials
-  return { cloneUrl: rawUrl, ref: null, canonicalUrl: rawUrl };
+  // Any other valid git URL: use as-is for cloning, but strip embedded credentials
+  // from canonicalUrl so secrets don't leak into cache keys or warning messages.
+  let canonicalUrl = rawUrl;
+  try {
+    const u = new URL(rawUrl);
+    u.username = "";
+    u.password = "";
+    u.search = "";
+    u.hash = "";
+    canonicalUrl = u.toString();
+  } catch {
+    // URL failed to parse — fall back to raw (validateGitUrl already accepted it)
+  }
+  return { cloneUrl: rawUrl, ref: null, canonicalUrl };
 }
 
 // ── Save support ─────────────────────────────────────────────────────────────
@@ -252,22 +269,35 @@ export function saveGitStash(name?: string, message?: string): SaveGitStashResul
 
   // Nothing to commit?
   const statusResult = spawnSync("git", ["-C", repoDir, "status", "--porcelain"], { encoding: "utf8" });
+  if (statusResult.error || statusResult.status !== 0) {
+    throw new Error(
+      `git status failed: ${statusResult.error?.message || statusResult.stderr?.trim() || "unknown error"}`,
+    );
+  }
   if (!statusResult.stdout.trim()) {
     return { committed: false, pushed: false, skipped: false, output: "nothing to commit, working tree clean" };
   }
 
-  // Stage and commit
+  // Stage and commit — supply fallback identity so fresh environments without
+  // user.name/user.email configured can always commit to the default stash.
   const addResult = spawnSync("git", ["-C", repoDir, "add", "-A"], { encoding: "utf8" });
   if (addResult.status !== 0) {
     throw new Error(`git add failed: ${addResult.stderr?.trim() || "unknown error"}`);
   }
-  const commitResult = spawnSync("git", ["-C", repoDir, "commit", "-m", commitMessage], { encoding: "utf8" });
+  const commitResult = spawnSync(
+    "git",
+    ["-C", repoDir, "-c", "user.name=akm", "-c", "user.email=akm@local", "commit", "-m", commitMessage],
+    { encoding: "utf8" },
+  );
   if (commitResult.status !== 0) {
     throw new Error(`git commit failed: ${commitResult.stderr?.trim() || "unknown error"}`);
   }
 
   // Push only when there is a remote AND the stash is marked writable
   const remoteResult = spawnSync("git", ["-C", repoDir, "remote"], { encoding: "utf8" });
+  if (remoteResult.status !== 0) {
+    throw new Error(`git remote failed: ${remoteResult.stderr?.trim() || "unknown error"}`);
+  }
   const hasRemote = remoteResult.stdout.trim().length > 0;
 
   if (!hasRemote || !writable) {

--- a/src/stash-providers/git.ts
+++ b/src/stash-providers/git.ts
@@ -3,7 +3,8 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { StashConfigEntry } from "../config";
-import { ConfigError } from "../errors";
+import { loadConfig } from "../config";
+import { ConfigError, UsageError } from "../errors";
 import { getRegistryIndexCacheDir } from "../paths";
 import { validateGitUrl } from "../registry-resolve";
 import type { StashProvider, StashSearchOptions, StashSearchResult } from "../stash-provider";
@@ -17,10 +18,18 @@ const CACHE_TTL_MS = 12 * 60 * 60 * 1000;
 /** Maximum stale age allowed when refresh fails (7 days). */
 const CACHE_STALE_MS = 7 * 24 * 60 * 60 * 1000;
 
+const GIT_STASH_TYPES = new Set(["git", "context-hub", "github"]);
+
 interface ParsedRepoUrl {
   cloneUrl: string;
   ref: string | null;
   canonicalUrl: string;
+}
+
+export interface PushGitStashResult {
+  committed: boolean;
+  pushed: boolean;
+  output: string;
 }
 
 class GitStashProvider implements StashProvider {
@@ -72,9 +81,10 @@ function getCachePaths(repoUrl: string): {
 async function ensureGitMirror(
   repo: ParsedRepoUrl,
   cachePaths: ReturnType<typeof getCachePaths>,
-  options?: { requireRepoDir?: boolean },
+  options?: { requireRepoDir?: boolean; writable?: boolean },
 ): Promise<void> {
   const requireRepoDir = options?.requireRepoDir === true;
+  const writable = options?.writable === true;
 
   // Check if cache is fresh
   let mtime = 0;
@@ -90,7 +100,12 @@ async function ensureGitMirror(
 
   try {
     fs.mkdirSync(cachePaths.rootDir, { recursive: true });
-    cloneRepo(repo.cloneUrl, repo.ref, cachePaths.repoDir);
+    if (writable && fs.existsSync(path.join(cachePaths.repoDir, ".git"))) {
+      // Writable repo already cloned — pull instead of re-clone to preserve local changes
+      pullRepo(cachePaths.repoDir);
+    } else {
+      cloneRepo(repo.cloneUrl, repo.ref, cachePaths.repoDir, writable);
+    }
     // Touch index file to track freshness
     fs.writeFileSync(cachePaths.indexPath, "[]", { encoding: "utf8", mode: 0o600 });
   } catch (err) {
@@ -101,7 +116,7 @@ async function ensureGitMirror(
   }
 }
 
-function cloneRepo(cloneUrl: string, ref: string | null, destDir: string): void {
+function cloneRepo(cloneUrl: string, ref: string | null, destDir: string, writable = false): void {
   if (fs.existsSync(destDir)) fs.rmSync(destDir, { recursive: true, force: true });
 
   const args = ["clone", "--depth", "1"];
@@ -114,9 +129,22 @@ function cloneRepo(cloneUrl: string, ref: string | null, destDir: string): void 
     throw new Error(`Failed to clone ${cloneUrl}: ${err}`);
   }
 
-  // Remove .git directory — we only need the working tree
-  const gitDir = path.join(destDir, ".git");
-  if (fs.existsSync(gitDir)) fs.rmSync(gitDir, { recursive: true, force: true });
+  if (!writable) {
+    // Remove .git directory — we only need the working tree for read-only stashes
+    const gitDir = path.join(destDir, ".git");
+    if (fs.existsSync(gitDir)) fs.rmSync(gitDir, { recursive: true, force: true });
+  }
+}
+
+function pullRepo(repoDir: string): void {
+  const result = spawnSync("git", ["-C", repoDir, "pull", "--ff-only"], {
+    encoding: "utf8",
+    timeout: 120_000,
+  });
+  if (result.status !== 0) {
+    const err = result.stderr?.trim() || result.error?.message || "unknown error";
+    throw new Error(`Failed to pull ${repoDir}: ${err}`);
+  }
 }
 
 function hasExtractedRepo(repoDir: string): boolean {
@@ -176,6 +204,68 @@ function parseGitRepoUrl(rawUrl: string): ParsedRepoUrl {
 
   // Any other valid git URL: use as-is, rely on system git credentials
   return { cloneUrl: rawUrl, ref: null, canonicalUrl: rawUrl };
+}
+
+// ── Push support ─────────────────────────────────────────────────────────────
+
+export function pushGitStash(name: string, message = "Update stash assets"): PushGitStashResult {
+  const config = loadConfig();
+  const stash = config.stashes?.find((s) => s.name === name || s.url === name);
+
+  if (!stash) {
+    throw new UsageError(`No git stash found with name "${name}"`);
+  }
+  if (!GIT_STASH_TYPES.has(stash.type)) {
+    throw new UsageError(`Stash "${name}" is not a git stash (type: ${stash.type})`);
+  }
+  if (!stash.writable) {
+    throw new UsageError(
+      `Stash "${name}" is not marked as writable. Add writable: true to its config entry to enable push.`,
+    );
+  }
+  if (!stash.url) {
+    throw new UsageError(`Stash "${name}" has no URL configured`);
+  }
+
+  const repo = parseGitRepoUrl(stash.url);
+  const cachePaths = getCachePaths(repo.canonicalUrl);
+  const repoDir = cachePaths.repoDir;
+
+  if (!fs.existsSync(path.join(repoDir, ".git"))) {
+    throw new UsageError(
+      `Stash "${name}" has not been initialised as a writable repo. Run "akm index" to clone it first.`,
+    );
+  }
+
+  // Check for changes
+  const statusResult = spawnSync("git", ["-C", repoDir, "status", "--porcelain"], { encoding: "utf8" });
+  if (!statusResult.stdout.trim()) {
+    return { committed: false, pushed: false, output: "Nothing to commit, working tree clean" };
+  }
+
+  // Stage all changes
+  const addResult = spawnSync("git", ["-C", repoDir, "add", "-A"], { encoding: "utf8" });
+  if (addResult.status !== 0) {
+    throw new Error(`git add failed: ${addResult.stderr?.trim() || "unknown error"}`);
+  }
+
+  // Commit
+  const commitResult = spawnSync("git", ["-C", repoDir, "commit", "-m", message], { encoding: "utf8" });
+  if (commitResult.status !== 0) {
+    throw new Error(`git commit failed: ${commitResult.stderr?.trim() || "unknown error"}`);
+  }
+
+  // Push
+  const pushResult = spawnSync("git", ["-C", repoDir, "push"], { encoding: "utf8", timeout: 120_000 });
+  if (pushResult.status !== 0) {
+    throw new Error(`git push failed: ${pushResult.stderr?.trim() || "unknown error"}`);
+  }
+
+  return {
+    committed: true,
+    pushed: true,
+    output: (commitResult.stdout + pushResult.stdout).trim() || "Changes committed and pushed",
+  };
 }
 
 // ── Exports ─────────────────────────────────────────────────────────────────

--- a/src/stash-source-manage.ts
+++ b/src/stash-source-manage.ts
@@ -39,15 +39,21 @@ export function addStash(opts: {
   name?: string;
   providerType?: string;
   options?: Record<string, unknown>;
+  writable?: boolean;
 }): SourceAddResult {
-  const { target, name, providerType, options: providerOptions } = opts;
+  const { target, name, providerType, options: providerOptions, writable } = opts;
   const config = loadUserConfig();
   const stashes = [...(config.stashes ?? [])];
-  const isUrl = target.startsWith("http://") || target.startsWith("https://");
+  const isRemoteUrl =
+    target.startsWith("http://") ||
+    target.startsWith("https://") ||
+    target.startsWith("git@") ||
+    target.startsWith("ssh://") ||
+    target.startsWith("git://");
 
   let entry: StashConfigEntry;
 
-  if (isUrl) {
+  if (isRemoteUrl) {
     if (!providerType) {
       throw new UsageError("--provider is required for URL sources (e.g. --provider openviking)");
     }
@@ -57,6 +63,7 @@ export function addStash(opts: {
     }
     entry = { type: providerType, url: target };
     if (name) entry.name = name;
+    if (writable) entry.writable = true;
     if (providerOptions) entry.options = providerOptions;
   } else {
     // Filesystem path

--- a/src/stash-source-manage.ts
+++ b/src/stash-source-manage.ts
@@ -88,7 +88,12 @@ export function addStash(opts: {
 export function removeStash(target: string): SourceRemoveResult {
   const config = loadUserConfig();
   const stashes = [...(config.stashes ?? [])];
-  const isUrl = target.startsWith("http://") || target.startsWith("https://");
+  const isUrl =
+    target.startsWith("http://") ||
+    target.startsWith("https://") ||
+    target.startsWith("git@") ||
+    target.startsWith("ssh://") ||
+    target.startsWith("git://");
   const resolvedPath = !isUrl ? path.resolve(target) : undefined;
 
   // Try URL match first, then path, then name (most specific → least specific)

--- a/tests/add-context-hub-alias.test.ts
+++ b/tests/add-context-hub-alias.test.ts
@@ -51,7 +51,7 @@ describe("akm add context-hub alias", () => {
     };
     expect(parsed.added).toBe(true);
     expect(parsed.entry).toEqual({
-      type: "context-hub",
+      type: "git",
       url: "https://github.com/andrewyng/context-hub",
       name: "context-hub",
     });
@@ -61,7 +61,7 @@ describe("akm add context-hub alias", () => {
       stashes?: Array<{ type?: string; url?: string; name?: string }>;
     };
     expect(config.stashes).toContainEqual({
-      type: "context-hub",
+      type: "git",
       url: "https://github.com/andrewyng/context-hub",
       name: "context-hub",
     });

--- a/tests/completions.test.ts
+++ b/tests/completions.test.ts
@@ -75,6 +75,7 @@ describe("completions command", () => {
       "remember",
       "import",
       "clone",
+      "save",
       "feedback",
       "registry",
       "config",

--- a/tests/save-command.test.ts
+++ b/tests/save-command.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const CLI = path.join(__dirname, "..", "src", "cli.ts");
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function runCli(args: string[], stashDir: string) {
+  const xdgCache = makeTempDir("akm-save-cache-");
+  const xdgConfig = makeTempDir("akm-save-cfg-");
+  return spawnSync("bun", [CLI, ...args], {
+    encoding: "utf8",
+    timeout: 30_000,
+    env: {
+      ...process.env,
+      AKM_STASH_DIR: stashDir,
+      XDG_CACHE_HOME: xdgCache,
+      XDG_CONFIG_HOME: xdgConfig,
+    },
+  });
+}
+
+function parseSaveOutput(stdout: string): Record<string, unknown> {
+  return JSON.parse(stdout.trim()) as Record<string, unknown>;
+}
+
+/** Initialise a bare git repo in `dir` so akm save can commit. */
+function initGitRepo(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  spawnSync("git", ["init", dir], { encoding: "utf8" });
+  spawnSync("git", ["-C", dir, "config", "commit.gpgsign", "false"], { encoding: "utf8" });
+}
+
+describe("akm save", () => {
+  test("returns skipped when stash is not a git repo", () => {
+    const stashDir = makeTempDir("akm-save-nongit-");
+    const result = runCli(["save"], stashDir);
+    expect(result.status).toBe(0);
+    const json = parseSaveOutput(result.stdout);
+    expect(json.skipped).toBe(true);
+    expect(json.committed).toBe(false);
+    expect(json.pushed).toBe(false);
+  });
+
+  test("reports nothing to commit on a clean git repo", () => {
+    const stashDir = makeTempDir("akm-save-clean-");
+    initGitRepo(stashDir);
+    // Create an initial commit so the repo is not bare
+    const f = path.join(stashDir, "README.md");
+    fs.writeFileSync(f, "hello");
+    spawnSync("git", ["-C", stashDir, "add", "-A"], { encoding: "utf8" });
+    spawnSync("git", ["-C", stashDir, "-c", "user.name=test", "-c", "user.email=t@t", "commit", "-m", "init"], {
+      encoding: "utf8",
+    });
+
+    const result = runCli(["save"], stashDir);
+    expect(result.status).toBe(0);
+    const json = parseSaveOutput(result.stdout);
+    expect(json.committed).toBe(false);
+    expect(json.skipped).toBe(false);
+    expect(json.output).toContain("nothing to commit");
+  });
+
+  test("commits changes in a git repo with no remote", () => {
+    const stashDir = makeTempDir("akm-save-commit-");
+    initGitRepo(stashDir);
+
+    // Write a file so there's something to commit
+    fs.writeFileSync(path.join(stashDir, "skill.md"), "# Test");
+
+    const result = runCli(["save", "-m", "test commit"], stashDir);
+    expect(result.status).toBe(0);
+    const json = parseSaveOutput(result.stdout);
+    expect(json.committed).toBe(true);
+    expect(json.pushed).toBe(false);
+    expect(json.skipped).toBe(false);
+
+    // Verify the commit actually landed
+    const log = spawnSync("git", ["-C", stashDir, "log", "--oneline"], { encoding: "utf8" });
+    expect(log.stdout).toContain("test commit");
+  });
+
+  test("uses timestamp message when -m is omitted", () => {
+    const stashDir = makeTempDir("akm-save-ts-");
+    initGitRepo(stashDir);
+    fs.writeFileSync(path.join(stashDir, "skill.md"), "# Test");
+
+    const result = runCli(["save"], stashDir);
+    expect(result.status).toBe(0);
+    const json = parseSaveOutput(result.stdout);
+    expect(json.committed).toBe(true);
+
+    const log = spawnSync("git", ["-C", stashDir, "log", "--oneline"], { encoding: "utf8" });
+    expect(log.stdout).toContain("akm save");
+  });
+});

--- a/tests/setup-wizard.test.ts
+++ b/tests/setup-wizard.test.ts
@@ -111,7 +111,7 @@ const CTX_HUB_URL = "https://github.com/andrewyng/context-hub";
 describe("stepStashSources – recommended GitHub repos", () => {
   beforeEach(reset);
 
-  test("selecting a recommended repo adds it with type 'github'", async () => {
+  test("selecting a recommended repo adds it with type 'git'", async () => {
     const { stepStashSources } = await import("../src/setup");
 
     // multiselect recommended repos → select context-hub
@@ -122,14 +122,14 @@ describe("stepStashSources – recommended GitHub repos", () => {
     const result = await stepStashSources({ stashes: [] } as never);
     const hub = result.find((s) => s.url === CTX_HUB_URL);
     expect(hub).toBeDefined();
-    expect(hub?.type).toBe("github");
+    expect(hub?.type).toBe("git");
     expect(hub?.name).toBe("context-hub");
   });
 
   test("deselecting a previously added recommended repo removes it", async () => {
     const { stepStashSources } = await import("../src/setup");
     const cfg = {
-      stashes: [{ type: "github", url: CTX_HUB_URL, name: "context-hub" }],
+      stashes: [{ type: "git", url: CTX_HUB_URL, name: "context-hub" }],
     };
 
     // multiselect recommended repos → deselect all (empty array)
@@ -145,7 +145,7 @@ describe("stepStashSources – recommended GitHub repos", () => {
   test("keeping a recommended repo that is already configured", async () => {
     const { stepStashSources } = await import("../src/setup");
     const cfg = {
-      stashes: [{ type: "github", url: CTX_HUB_URL, name: "context-hub" }],
+      stashes: [{ type: "git", url: CTX_HUB_URL, name: "context-hub" }],
     };
 
     // multiselect → keep it selected
@@ -204,7 +204,7 @@ describe("semantic search setup", () => {
 describe("stepStashSources – custom GitHub repo", () => {
   beforeEach(reset);
 
-  test("adds a custom GitHub repo with type 'github'", async () => {
+  test("adds a custom GitHub repo with type 'git'", async () => {
     const { stepStashSources } = await import("../src/setup");
 
     // multiselect recommended repos → none
@@ -221,7 +221,7 @@ describe("stepStashSources – custom GitHub repo", () => {
     const result = await stepStashSources({ stashes: [] } as never);
     const repo = result.find((s) => s.url === "https://github.com/owner/repo");
     expect(repo).toBeDefined();
-    expect(repo?.type).toBe("github");
+    expect(repo?.type).toBe("git");
     expect(repo?.name).toBe("my-repo");
   });
 });

--- a/tests/stash-providers/context-hub.test.ts
+++ b/tests/stash-providers/context-hub.test.ts
@@ -23,16 +23,9 @@ function writeFile(filePath: string, content: string): void {
   fs.writeFileSync(filePath, content, "utf8");
 }
 
-function createTarball(sourceDir: string, archivePath: string): void {
-  const result = spawnSync("tar", ["czf", archivePath, "-C", path.dirname(sourceDir), path.basename(sourceDir)], {
-    encoding: "utf8",
-    timeout: 30_000,
-  });
-  expect(result.status).toBe(0);
-}
-
-function buildContextHubArchive(): string {
-  const repoDir = path.join(createTmpDir("akm-git-repo-"), "context-hub-main");
+/** Create a local git repo with akm-style content for use as a clone source in tests. */
+function createLocalGitRepo(): string {
+  const repoDir = createTmpDir("akm-git-repo-");
 
   writeFile(
     path.join(repoDir, "content", "openai", "docs", "chat-api", "python", "DOC.md"),
@@ -66,27 +59,23 @@ Chain multiple prompts together.
 `,
   );
 
-  const archivePath = path.join(createTmpDir("akm-git-archive-"), "context-hub-main.tar.gz");
-  createTarball(repoDir, archivePath);
-  return archivePath;
-}
-
-function mockArchiveFetch(archivePath: string): () => void {
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = (async (input: RequestInfo | URL) => {
-    const url = String(input);
-    if (url === "https://github.com/andrewyng/context-hub/archive/refs/heads/main.tar.gz") {
-      return new Response(Bun.file(archivePath), {
-        status: 200,
-        headers: { "Content-Type": "application/gzip" },
-      });
+  // Initialise a real git repo so git clone works from local path
+  for (const args of [
+    ["init"],
+    ["checkout", "-b", "main"],
+    ["config", "user.email", "test@test.com"],
+    ["config", "user.name", "Test"],
+    ["config", "commit.gpgsign", "false"],
+    ["add", "."],
+    ["commit", "-m", "init"],
+  ] as string[][]) {
+    const result = spawnSync("git", args, { cwd: repoDir, encoding: "utf8", timeout: 30_000 });
+    if (result.status !== 0) {
+      throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
     }
-    return new Response("not found", { status: 404 });
-  }) as typeof fetch;
+  }
 
-  return () => {
-    globalThis.fetch = originalFetch;
-  };
+  return repoDir;
 }
 
 function createWorkingStash(): string {
@@ -157,48 +146,64 @@ describe("GitStashProvider", () => {
     expect(provider.canShow("skill:foo")).toBe(false);
   });
 
-  test("cache mirror extracts content to disk", async () => {
-    const archivePath = buildContextHubArchive();
-    const restoreFetch = mockArchiveFetch(archivePath);
+  test("cache mirror clones content to disk via git", async () => {
+    const localRepoPath = createLocalGitRepo();
+    // Construct ParsedRepoUrl directly to point at the local repo
+    const repo = { cloneUrl: localRepoPath, ref: null as string | null, canonicalUrl: localRepoPath };
+    const cachePaths = getCachePaths(repo.canonicalUrl);
 
-    try {
-      const repo = parseGitRepoUrl("https://github.com/andrewyng/context-hub");
-      const cachePaths = getCachePaths(repo.canonicalUrl);
-      await ensureGitMirror(repo, cachePaths, { requireRepoDir: true });
+    await ensureGitMirror(repo, cachePaths, { requireRepoDir: true });
 
-      // Verify extracted content exists
-      const docPath = path.join(cachePaths.repoDir, "content", "openai", "docs", "chat-api", "python", "DOC.md");
-      expect(fs.existsSync(docPath)).toBe(true);
-      const content = fs.readFileSync(docPath, "utf8");
-      expect(content).toContain("# Chat API");
-    } finally {
-      restoreFetch();
-    }
+    // Verify cloned content exists at the expected path
+    const docPath = path.join(cachePaths.repoDir, "content", "openai", "docs", "chat-api", "python", "DOC.md");
+    expect(fs.existsSync(docPath)).toBe(true);
+    const content = fs.readFileSync(docPath, "utf8");
+    expect(content).toContain("# Chat API");
+  });
+
+  test("cache mirror respects TTL and skips re-clone when fresh", async () => {
+    const localRepoPath = createLocalGitRepo();
+    const repo = { cloneUrl: localRepoPath, ref: null as string | null, canonicalUrl: localRepoPath };
+    const cachePaths = getCachePaths(repo.canonicalUrl);
+
+    // Prime the cache
+    await ensureGitMirror(repo, cachePaths, { requireRepoDir: true });
+
+    // Remove the content to verify it is NOT re-cloned (cache is still fresh)
+    const docPath = path.join(cachePaths.repoDir, "content", "openai", "docs", "chat-api", "python", "DOC.md");
+    fs.rmSync(docPath);
+
+    await ensureGitMirror(repo, cachePaths, { requireRepoDir: false });
+
+    // File should still be absent — clone was skipped due to fresh cache
+    expect(fs.existsSync(docPath)).toBe(false);
   });
 
   test("integrates with stash sources via ensureGitCaches", async () => {
-    const archivePath = buildContextHubArchive();
-    const restoreFetch = mockArchiveFetch(archivePath);
+    // Pre-populate the cache so ensureGitMirror returns early without cloning
+    const stashUrl = "https://github.com/andrewyng/context-hub";
+    const repo = parseGitRepoUrl(stashUrl);
+    const cachePaths = getCachePaths(repo.canonicalUrl);
 
-    try {
-      saveConfig({
-        semanticSearchMode: "off",
-        stashes: [{ type: "context-hub", url: "https://github.com/andrewyng/context-hub", name: "context-hub" }],
-      });
-      resetConfigCache();
+    fs.mkdirSync(cachePaths.rootDir, { recursive: true });
+    fs.mkdirSync(path.join(cachePaths.repoDir, "content"), { recursive: true });
+    fs.writeFileSync(cachePaths.indexPath, "[]", { encoding: "utf8", mode: 0o600 });
 
-      const { ensureGitCaches } = await import("../../src/search-source");
-      const { loadConfig } = await import("../../src/config");
-      const config = loadConfig();
-      await ensureGitCaches(config);
+    saveConfig({
+      semanticSearchMode: "off",
+      stashes: [{ type: "context-hub", url: stashUrl, name: "context-hub" }],
+    });
+    resetConfigCache();
 
-      // Verify context-hub content dir appears in stash sources
-      const { resolveStashSources } = await import("../../src/search-source");
-      const sources = resolveStashSources(undefined, config);
-      const gitSource = sources.find((s) => s.path.includes("context-hub-"));
-      expect(gitSource).toBeDefined();
-    } finally {
-      restoreFetch();
-    }
+    const { ensureGitCaches } = await import("../../src/search-source");
+    const { loadConfig } = await import("../../src/config");
+    const config = loadConfig();
+    await ensureGitCaches(config);
+
+    // Verify context-hub content dir appears in stash sources
+    const { resolveStashSources } = await import("../../src/search-source");
+    const sources = resolveStashSources(undefined, config);
+    const gitSource = sources.find((s) => s.path.includes("context-hub-"));
+    expect(gitSource).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

This PR overhauls git-backed stash handling with three related improvements: universal git authentication, writable stash round-trips, and a new `akm save` command.

### 1. Git authentication via `git clone` (replaces HTTP tarball)

The previous implementation downloaded GitHub repo archives over HTTP, which required managing tokens in config files and didn't support SSH. The new implementation delegates all authentication to the system git credential stack:

- Replace HTTP tarball download with `git clone --depth 1` via subprocess
- SSH (`git@host:path`), HTTPS + credential helpers (`osxkeychain`, `wincred`, `~/.netrc`), and SSH agent all work automatically
- `parseGitRepoUrl()` now accepts SSH shorthand, GitHub web URLs, and any valid git URL
- No tokens or credentials stored in config files

### 2. Writable stash support

- Add `writable?: boolean` to `StashConfigEntry` in config
- When `writable: true`, the `.git` directory is preserved after clone so the repo can be committed back to
- On refresh, writable stashes use `git pull --ff-only` instead of re-clone (preserving local edits)
- Pass `--writable` to `akm add` to opt a remote git stash into push-on-save

### 3. `akm save` command

Commit (and optionally push) local changes in a git-backed stash. Behaviour adapts automatically:

| State | Result |
|---|---|
| Not a git repo | Silent no-op |
| Git repo, no remote | Stage and commit only |
| Git repo, has remote, not writable | Stage and commit only |
| Git repo, has remote, `writable: true` | Stage, commit, and push |

- Message is optional; defaults to `akm save <timestamp>`
- Stash name is optional; defaults to the primary stash

### 4. Default stash auto-initialized as local git repo

`akm init` now calls `git init` on the default stash directory so `akm save` always works there (commit-only, no remote push).

### 5. Provider type cleanup

- `setup.ts`: new stash entries now use `type: "git"` instead of legacy `"github"` alias
- `cli.ts`: context-hub convenience alias maps to `providerType: "git"`
- `config.ts` JSDoc and comments updated to reflect canonical types: `filesystem`, `git`, `openviking`
- Legacy aliases (`context-hub`, `github`) remain registered for backward compatibility

## Usage

```sh
# Add a writable remote git stash
akm add git@github.com:org/skills.git --provider git --name my-skills --writable

# Edit assets, then save
akm save my-skills -m "Add deploy skill"

# Save the primary (local-only) stash
akm save
akm save -m "checkpoint before refactor"
```

## Test plan

- `bun test` — 1401 pass, 17 skip (2 pre-existing `install-script.test.ts` failures unrelated to this PR)
- `bunx tsc --noEmit` — clean
- `bunx biome check --write src/ tests/` — clean
- Git stash tests refactored to use local git repos instead of tarball mocks
- Completions test updated to include `save` in the expected command list

https://claude.ai/code/session_016fSCTHGbGMm6CGU3NqbW4v