### PR TITLE
fix: address 0.5.0 QA findings (wiki, workflow, vault, save/trust)

### DIFF
--- a/docs/agents/AGENTS.full.md
+++ b/docs/agents/AGENTS.full.md
@@ -36,6 +36,7 @@ akm show knowledge:guide toc                  # Table of contents
 akm show knowledge:guide section "Auth"       # Specific section
 akm show knowledge:guide lines 10 30          # Line range
 akm show knowledge:my-doc                    # Show a knowledge asset
+akm show wiki:research                        # Wiki summary (same as akm wiki show research)
 ```
 
 | Type | Key fields returned |
@@ -49,6 +50,10 @@ akm show knowledge:my-doc                    # Show a knowledge asset
 | memory | `content` (recalled context) |
 | vault | `keys`, `comments` (values are never returned) |
 | wiki | `content` (same view modes as knowledge). For any wiki task, run `akm wiki list` then `akm wiki ingest <name>` for the workflow. |
+
+`akm show wiki:<name>` returns the same summary as `akm wiki show <name>`: path,
+description from `schema.md`, page and raw counts, and the last 3 `log.md`
+entries.
 
 ## Capture Knowledge While You Work
 
@@ -81,7 +86,7 @@ akm wiki pages research                        # Page refs + descriptions (exclu
 akm wiki search research "attention"           # Scoped search (equivalent to --type wiki --wiki research)
 akm wiki stash research ./paper.md             # Copy source into raw/<slug>.md (never overwrites)
 echo "..." | akm wiki stash research -         # stdin form
-akm wiki lint research                         # Structural checks: orphans, broken xrefs, uncited raws, stale index
+akm wiki lint research                         # Structural checks: orphans, broken xrefs, uncited raws, stale index, broken sources
 akm wiki ingest research                       # Print the ingest workflow for this wiki (no action)
 akm wiki remove research --force               # Delete pages/schema/index/log; preserves raw/
 akm wiki remove research --force --with-sources # Full nuke, including raw/
@@ -91,6 +96,10 @@ akm wiki remove research --force --with-sources # Full nuke, including raw/
 to get the step-by-step workflow.** Wiki pages are also addressable as
 `wiki:<name>/<page-path>` and show up in stash-wide `akm search` as
 `type: wiki`. No `--llm` anywhere — akm never reasons about page content.
+
+`akm wiki lint` exits 1 when findings exist and 0 when the wiki is clean.
+The `broken-source` finding kind flags pages whose `sources:` frontmatter
+entries point to raw files that no longer exist.
 
 See [wikis.md](wikis.md) for the full guide.
 
@@ -144,6 +153,16 @@ The `--writable` flag on `akm add` opts a remote git stash into push-on-save:
 akm add git@github.com:org/skills.git --provider git --name my-skills --writable
 ```
 
+To make the primary stash push on save, set `writable: true` in your config
+(`~/.config/akm/config.json`):
+
+```json
+{
+  "stashDir": "~/akm",
+  "writable": true
+}
+```
+
 ## Registries
 
 ```sh
@@ -194,3 +213,33 @@ All commands accept `--format` and `--detail` flags:
 - `--detail summary` — metadata only (no content/template/prompt), under 200 tokens
 
 Run `akm -h` or `akm <command> -h` for per-command help.
+
+## Error Shapes and Exit Codes
+
+Every command returns JSON by default. On success, the shape is command-specific.
+On failure, every command emits:
+
+```json
+{"ok": false, "error": "<message>", "hint": "<optional remediation hint>"}
+```
+
+The `hint` field is present only when there is an actionable next step (e.g.
+`"Run akm add <source> --trust to bypass the audit for this source."`).
+
+Exit codes:
+
+| Code | Meaning | Error class |
+| --- | --- | --- |
+| 0 | Success | — |
+| 1 | Not found or general error | `NotFoundError`, other |
+| 2 | Usage / bad input | `UsageError` |
+| 78 | Configuration error | `ConfigError` |
+
+To detect failure reliably, check either:
+
+- `ok === false` in the parsed JSON response, or
+- a non-zero exit code (`$?` in shell, process exit code in SDK calls)
+
+Both signals are always set consistently. The JSON envelope is the preferred
+signal for agents parsing output programmatically; the exit code is the
+preferred signal for shell scripts.

--- a/docs/agents/AGENTS.md
+++ b/docs/agents/AGENTS.md
@@ -41,4 +41,24 @@ akm registry search "<query>"                 # Search all registries
 When an asset meaningfully helps or fails, record that with `akm feedback` so
 future search ranking can learn from real usage.
 
+## Error Shapes and Exit Codes
+
+Every command returns JSON by default. On failure, the shape is always:
+
+```json
+{"ok": false, "error": "<message>", "hint": "<optional remediation hint>"}
+```
+
+Exit codes:
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | Not found or general error |
+| 2 | Usage / bad input |
+| 78 | Configuration error |
+
+Check `ok === false` or a non-zero exit code to detect failure. The `hint`
+field, when present, describes a corrective action.
+
 Run `akm -h` for the full command reference.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -50,7 +50,9 @@ Every command exits with one of the following codes:
 | 2 | Usage / bad input | `UsageError` |
 | 78 | Configuration error | `ConfigError` |
 
-On failure, every command emits a JSON error envelope on stdout before exiting:
+On failure, every command emits a JSON error envelope on **stderr** before
+exiting; stdout is left empty (or contains only command-specific side-effect
+output such as shell snippets from `vault load`):
 
 ```json
 {"ok": false, "error": "<message>", "hint": "<optional hint>"}
@@ -58,8 +60,8 @@ On failure, every command emits a JSON error envelope on stdout before exiting:
 
 The `hint` field is present only when actionable remediation is available (e.g.
 `"Run akm add <source> --trust to bypass the audit for this source."`). Agents
-should check `ok === false` or a non-zero exit code to detect failure. Scripts
-can rely on the exit code alone.
+should check `ok === false` on the parsed stderr envelope or a non-zero exit
+code to detect failure. Scripts can rely on the exit code alone.
 
 ## Commands
 
@@ -284,9 +286,10 @@ akm workflow create ship-release --force --reset
 `--reset` (explicitly acknowledge you are overwriting in place). Without one of
 these, `--force` is rejected to prevent silent template overwrites.
 
-Workflow names must match `^[a-z0-9][a-z0-9._-]*$` — lowercase letters and
-digits, hyphens, dots, and underscores allowed; must start with a lowercase
-letter or digit.
+Workflow names must match `^[a-z0-9][a-z0-9._/-]*$` — lowercase letters and
+digits, hyphens, dots, underscores, and forward slashes allowed; must start
+with a lowercase letter or digit. Forward slashes are supported for
+hierarchical names (e.g. `release/ship`).
 
 #### workflow next
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,6 +39,28 @@ capability discovery:
 - **show**: `type`, `name`, `description`, `tags`, `parameters`, `workflowTitle`, `action`, `run`, `origin`
 - **search**: metadata-only view (no full content), under 200 tokens
 
+## Exit Codes and Error Envelope
+
+Every command exits with one of the following codes:
+
+| Exit code | Meaning | Error class |
+| --- | --- | --- |
+| 0 | Success | — |
+| 1 | Not found or general error | `NotFoundError`, other |
+| 2 | Usage / bad input | `UsageError` |
+| 78 | Configuration error | `ConfigError` |
+
+On failure, every command emits a JSON error envelope on stdout before exiting:
+
+```json
+{"ok": false, "error": "<message>", "hint": "<optional hint>"}
+```
+
+The `hint` field is present only when actionable remediation is available (e.g.
+`"Run akm add <source> --trust to bypass the audit for this source."`). Agents
+should check `ok === false` or a non-zero exit code to detect failure. Scripts
+can rely on the exit code alone.
+
 ## Commands
 
 ### init
@@ -214,6 +236,10 @@ everything else, and always return `editable: false`.
 If the ref points to a package origin that is not installed, `akm show`
 returns guidance to run `akm add <origin>` first.
 
+`akm show wiki:<name>` returns the same summary as `akm wiki show <name>` —
+path, description from `schema.md`, page and raw counts, and the last 3
+`log.md` entries.
+
 ### workflow
 
 Author, inspect, and execute structured workflow assets.
@@ -224,8 +250,11 @@ akm workflow create ship-release
 akm workflow create ship-release --from ./ship-release.md
 akm workflow start workflow:ship-release --params '{"version":"1.2.3"}'
 akm workflow next workflow:ship-release
+akm workflow next workflow:ship-release --params '{"version":"1.2.3"}'
 akm workflow complete <run-id> --step validate --state completed --notes "Inputs verified"
 akm workflow status <run-id>
+akm workflow status workflow:ship-release
+akm workflow resume <run-id>
 akm workflow list --active
 ```
 
@@ -238,8 +267,88 @@ Subcommands:
 | `start <ref>` | Create a new persisted workflow run |
 | `next <run-id\|ref>` | Return the current actionable step; resumes active runs and starts a new run when the ref has no active run |
 | `complete <run-id> --step <step-id>` | Update the current pending step on an active run and persist status, notes, and evidence |
-| `status <run-id>` | Show the full run state, including all step statuses |
+| `status <run-id\|ref>` | Show the full run state, including all step statuses |
 | `list` | List workflow runs (optionally filtered by `--ref` and `--active`) |
+| `resume <run-id>` | Flip a `blocked` or `failed` run back to `active`. Completed runs cannot be resumed |
+
+#### workflow create
+
+```sh
+akm workflow create ship-release
+akm workflow create ship-release --from ./ship-release.md
+akm workflow create ship-release --from ./ship-release.md --force
+akm workflow create ship-release --force --reset
+```
+
+`--force` requires either `--from <file>` (replace from a source file) or
+`--reset` (explicitly acknowledge you are overwriting in place). Without one of
+these, `--force` is rejected to prevent silent template overwrites.
+
+Workflow names must match `^[a-z0-9][a-z0-9._-]*$` — lowercase letters and
+digits, hyphens, dots, and underscores allowed; must start with a lowercase
+letter or digit.
+
+#### workflow next
+
+```sh
+akm workflow next workflow:ship-release
+akm workflow next <run-id>
+akm workflow next workflow:ship-release --params '{"version":"1.2.3"}'
+```
+
+When multiple active runs exist for the same workflow ref, `next` selects the
+**most-recently-updated** run.
+
+When no active run exists, `next` auto-starts a new run for the workflow ref.
+Pass `--params` to supply parameters for the auto-started run. If an active run
+already exists, `--params` is rejected with a usage error.
+
+Response shape:
+
+| Field | When present |
+| --- | --- |
+| `step` | The current actionable step object, or `null` when the run is complete |
+| `done` | `true` when the resolved run is already complete |
+| `autoStarted` | `true` when `next` auto-started a new run (no active run existed) |
+| `run` | The run object |
+
+When `done: true` is present, `step` is `null` and no further action is needed
+for this run. Start a new run with `akm workflow start` if required.
+
+**Snapshot isolation:** workflow runs snapshot their step list when started.
+Edits to the source workflow file after a run has started do not affect
+in-flight runs. The run always follows the steps that were defined at start
+time.
+
+#### workflow complete
+
+```sh
+akm workflow complete <run-id> --step <step-id>
+akm workflow complete <run-id> --step <step-id> --state completed --notes "Done"
+akm workflow complete <run-id> --step <step-id> --state skipped
+```
+
+`--state` defaults to `completed` when omitted. Accepted values: `completed`,
+`skipped`, `failed`.
+
+#### workflow status
+
+```sh
+akm workflow status <run-id>
+akm workflow status workflow:ship-release
+```
+
+Accepts either a run-id or a workflow ref. When given a workflow ref, resolves
+to the most-recently-updated run for that ref.
+
+#### workflow resume
+
+```sh
+akm workflow resume <run-id>
+```
+
+Flips a `blocked` or `failed` run back to `active`. Completed runs cannot be
+resumed. Use `workflow list` to find runs by status.
 
 Workflow markdown contract:
 
@@ -273,7 +382,8 @@ akm add github:owner/private-kit --trust
 ```
 
 Use `--trust` only for one-off installs you have manually reviewed. It does not
-persist trust in config.
+persist trust in config. Note: `--trust` has no effect on local directory
+sources — the audit is not run for local paths.
 
 HTTP(S) URLs pointing to known git hosts (GitHub, GitLab, Bitbucket, Codeberg,
 SourceHut) or ending in `.git` are treated as git sources. All other HTTP(S)
@@ -440,6 +550,7 @@ remote configured and is marked `writable: true`, the commit is also pushed.
 ```sh
 akm save                            # Save primary stash (auto timestamp message)
 akm save -m "Add deploy skill"     # Save with custom message
+akm save --format json             # Explicit format (both --format json and --format=json work)
 akm save my-skills                  # Save a named writable git stash
 akm save my-skills -m "Update"     # Save named stash with message
 ```
@@ -448,6 +559,7 @@ akm save my-skills -m "Update"     # Save named stash with message
 | --- | --- |
 | `[name]` | Optional stash name. Defaults to the primary stash |
 | `-m`, `--message` | Commit message. Defaults to `akm save <timestamp>` |
+| `--format` | Output format (`json`, `text`, `yaml`). Both `--format json` and `--format=json` are accepted |
 
 **Behaviour by repo state:**
 
@@ -458,12 +570,28 @@ akm save my-skills -m "Update"     # Save named stash with message
 | Git repo, has remote, not writable | Stage and commit only |
 | Git repo, has remote, `writable: true` | Stage, commit, and push |
 
+**Primary stash writable config:**
+
+To make the primary stash push on save, set `writable: true` at the root of
+your config file (`~/.config/akm/config.json` or the path shown by
+`akm config path`):
+
+```json
+{
+  "stashDir": "~/akm",
+  "writable": true
+}
+```
+
+When `writable: true` is set and the primary stash has a git remote configured,
+`akm save` will stage, commit, and push.
+
 When `akm init` successfully initializes the default stash as a local git repo
 (requires `git` to be installed), `akm save` will commit there safely without
 pushing. If git is unavailable, the stash will not be a git repo and save will
 return a skipped result.
 
-To make a remote git stash writable, pass `--writable` when adding it:
+To make a named remote git stash writable, pass `--writable` when adding it:
 
 ```sh
 akm add git@github.com:org/skills.git --provider git --name my-skills --writable
@@ -628,6 +756,110 @@ the CLI.
 akm hints
 ```
 
+### vault
+
+Manage `.env`-backed secret vaults. Each vault is a mode-0600 file stored
+under `vaults/` in your stash. The key security property: **vault values never
+appear in structured output**. `list` and `show` return key names and comments
+only.
+
+```sh
+akm vault list
+akm vault list vault:prod
+akm vault show vault:prod
+akm vault create prod
+akm vault set vault:prod DATABASE_URL https://db.example.com
+akm vault set vault:prod DATABASE_URL=https://db.example.com
+akm vault set vault:prod API_KEY=abc123 --comment "Rotate every 90 days"
+akm vault unset vault:prod DATABASE_URL
+eval "$(akm vault load vault:prod)"
+```
+
+Subcommands:
+
+| Subcommand | Description |
+| --- | --- |
+| `list` | List all vaults with key counts |
+| `list <ref>` | List keys and comments in one vault (no values) |
+| `show <ref>` | Alias for `list <ref>` — same output |
+| `create <name>` | Create an empty `.env` vault (mode 0600). No-op if it already exists |
+| `set <ref> <KEY> <VALUE>` | Set a key in the vault |
+| `unset <ref> <KEY>` | Remove a key from the vault |
+| `load <ref>` | Emit a shell snippet that loads vault values into the current shell |
+
+#### vault list
+
+```sh
+akm vault list                      # All vaults: name + keyCount
+akm vault list vault:prod           # Keys + comments for vault:prod (no values)
+```
+
+The top-level `list` returns one entry per vault with `name` and `keyCount`.
+The per-vault `list <ref>` returns an array of `{key, comment}` objects —
+values are never included.
+
+#### vault show
+
+```sh
+akm vault show vault:prod
+```
+
+An alias for `vault list <ref>`. Returns the same `{key, comment}` array as
+`vault list vault:prod`.
+
+#### vault create
+
+```sh
+akm vault create prod
+```
+
+Creates `vaults/prod.env` with mode 0600. If the vault already exists, the
+command exits 0 and reports `created: false` — it never overwrites.
+
+#### vault set
+
+```sh
+akm vault set vault:prod DATABASE_URL https://db.example.com
+akm vault set vault:prod DATABASE_URL=https://db.example.com
+akm vault set vault:prod API_KEY=abc123 --comment "Rotate every 90 days"
+```
+
+Both the three-positional form (`<ref> <KEY> <VALUE>`) and the combined
+`KEY=VALUE` form are accepted. The `=` split happens on the first `=` so
+values may themselves contain `=`.
+
+`--comment "<text>"` attaches a `# <text>` comment line immediately above the
+key in the `.env` file. If the key already exists and is being updated, the
+preceding comment is also updated. Existing unrelated comments are preserved.
+
+| Flag | Description |
+| --- | --- |
+| `--comment` | Attach a comment line above the key |
+
+#### vault unset
+
+```sh
+akm vault unset vault:prod DATABASE_URL
+```
+
+Removes the key and its associated comment from the vault. Exits 0 whether or
+not the key existed.
+
+#### vault load
+
+```sh
+eval "$(akm vault load vault:prod)"
+```
+
+Emits a shell snippet that loads vault values into the current shell session.
+The implementation writes a mode-0600 temp file, sources it, then immediately
+removes it. **Values never appear on akm's stdout** — the snippet is the only
+output, and the values are loaded directly into the shell environment.
+
+Use `eval "$(akm vault load vault:<name>)"` in shell scripts or agent tool
+calls to hydrate the environment before running commands that need those
+secrets.
+
 ### wiki
 
 Manage multiple markdown wikis following the Karpathy LLM-wiki pattern.
@@ -666,12 +898,11 @@ Subcommands:
 | `pages <name>` | List page refs + frontmatter descriptions (excludes `schema.md`, `index.md`, `log.md`, `raw/`) |
 | `search <name> <query>` | Scope-filtered search — equivalent to `akm search <query> --type wiki` filtered to one wiki |
 | `stash <name> <source>` | Copy `source` into `wikis/<name>/raw/<slug>.md`. Source is a file path or `-` for stdin. `--as <slug>` overrides the derived slug. Never overwrites |
-| `lint <name>` | Deterministic structural checks (no LLM): orphans, broken xrefs, missing descriptions, uncited raws, stale index |
+| `lint <name>` | Deterministic structural checks (no LLM): orphans, broken xrefs, missing descriptions, uncited raws, stale index, broken sources |
 | `ingest <name>` | Print the step-by-step ingest workflow for the named wiki. Does not perform any ingest |
 
-Wiki names must match `^[a-z0-9][a-z0-9-]*$`. Wiki pages are also
-first-class in stash-wide `akm search` (`--type wiki`), so consumers who
-don't care about scoping never need to use `akm wiki search` at all.
+Wiki names must match `^[a-z0-9][a-z0-9-]*$` — lowercase letters and digits
+only; must start with a lowercase letter or digit.
 
 **Side effect:** `akm index` regenerates each wiki's `index.md` as part of
 its normal stash walk — there is no separate `reindex` verb.
@@ -679,6 +910,42 @@ its normal stash walk — there is no separate `reindex` verb.
 **Not provided:** no `page-create`, `page-append`, `xref`, `log-append`,
 `reindex`, or `migrate` verb. Those are the agent's job using its native
 file tools against paths surfaced by `show` and `pages`.
+
+#### wiki lint
+
+```sh
+akm wiki lint research
+```
+
+Runs deterministic structural checks and exits 1 when findings exist, 0 when
+the wiki is clean. Output is always JSON with a `findings` array.
+
+Finding kinds:
+
+| Kind | Description |
+| --- | --- |
+| `orphan` | A page not linked from `index.md` |
+| `broken-xref` | An internal link that points to a non-existent page |
+| `missing-description` | A page without a frontmatter `description` field |
+| `uncited-raw` | A file in `raw/` not referenced by any page |
+| `stale-index` | `index.md` is out of date and needs to be regenerated |
+| `broken-source` | A `sources:` entry in a page's frontmatter points to a raw file that does not exist |
+
+#### wiki stash
+
+```sh
+akm wiki stash research ./paper.md
+akm wiki stash research ./paper.md --as my-paper
+echo "..." | akm wiki stash research -
+```
+
+Copies a file (or stdin) into `wikis/<name>/raw/<slug>.md`. Never overwrites
+an existing raw file.
+
+When `--as <slug>` is passed and the slug already exists, the command errors
+with a `UsageError` — it does not silently rename the slug. Without `--as`,
+auto-increment applies: if `paper` exists, the next attempt uses `paper-1`,
+then `paper-2`, and so on.
 
 ### completions
 

--- a/docs/posts/release-0.5.0.md
+++ b/docs/posts/release-0.5.0.md
@@ -17,8 +17,8 @@ akm 0.5.0 is out. This release adds four new asset types — wikis, workflows, a
 ## TL;DR
 
 - `akm wiki create|list|show|remove|pages|search|stash|lint|ingest` — multi-wiki support, no LLM required
-- `akm workflow create|start|next|complete|status|list` — multi-step agent procedures in the stash
-- `akm vault list|show|load` — `.env`-backed secrets that never appear in structured output
+- `akm workflow create|start|next|complete|status|list|resume` — multi-step agent procedures in the stash
+- `akm vault list|show|create|set|unset|load` — `.env`-backed secrets that never appear in structured output
 - `akm add <source> --writable` + `akm save` — push your stash changes back to a remote git repo
 - `akm add <source> --trust` — bypass the install audit for a single install
 - **Breaking**: the single-wiki LLM POC is removed; migrate to `akm wiki …`
@@ -97,14 +97,23 @@ Vaults store secrets and environment configuration. Each vault is a `.env` file 
 akm vault list
 
 # Show keys in a vault (no values)
-akm vault show prod-secrets
+akm vault show vault:prod-secrets
+
+# Create a new empty vault
+akm vault create prod-secrets
+
+# Set a key (three-positional form or combined KEY=VALUE form)
+akm vault set vault:prod-secrets API_KEY abc123
+akm vault set vault:prod-secrets API_KEY=abc123 --comment "Rotate every 90 days"
+
+# Remove a key
+akm vault unset vault:prod-secrets API_KEY
 
 # Emit a source snippet for the current shell — the only way to get values out
-akm vault load prod-secrets
-# outputs: source /path/to/.stash/vaults/prod-secrets.env
+eval "$(akm vault load vault:prod-secrets)"
 ```
 
-`akm vault load` emits a `source` command for the current shell rather than printing values to stdout. An agent can run `eval $(akm vault load prod-secrets)` to load the environment without the values passing through any logged output.
+`akm vault load` emits a shell snippet that sources vault values into the current shell via a temporary mode-0600 file. Values never appear on akm's stdout. An agent can run `eval "$(akm vault load vault:prod-secrets)"` to load the environment without the values passing through any logged output.
 
 This is a deliberate tradeoff: vaults are not a full secrets manager. They are a thin, auditable layer that keeps your `.env` files alongside your other agent assets and prevents accidental leakage through `akm show` or `akm search` results.
 
@@ -142,6 +151,8 @@ akm add github:your-org/internal-kit --trust
 ```
 
 `--trust` is a one-off bypass — it does not add the source to any persistent allowlist. Use it when you control the source and do not want to step through the audit prompt in a non-interactive context (a CI script, an automated agent workflow, a container build).
+
+When a blocked install error occurs, the error message includes a `hint` field referencing `--trust` as a remediation option.
 
 ---
 

--- a/docs/posts/workflows-vaults-09.md
+++ b/docs/posts/workflows-vaults-09.md
@@ -89,6 +89,8 @@ When the agent completes a step, it marks it done with notes:
 akm workflow complete run-abc123 --step validate --state completed --notes "Version 1.2.3, branch release/1.2.3 confirmed"
 ```
 
+`--state` defaults to `completed` when omitted, so the `--state completed` above is redundant but explicit.
+
 And the next call to `akm workflow next` returns the following step. The run persists independently of the conversation. If the session ends, a new agent picks up exactly where the previous one left off:
 
 ```sh
@@ -102,6 +104,12 @@ Want to see the full state of a run?
 akm workflow status run-abc123
 ```
 
+`workflow status` also accepts a workflow ref directly, resolving to the most-recently-updated run:
+
+```sh
+akm workflow status workflow:ship-release
+```
+
 That shows each step with its status and any notes the agent recorded. You can list all active runs:
 
 ```sh
@@ -111,6 +119,16 @@ akm workflow list --active
 The procedure is now auditable. You know which step failed, when, and what the agent noted. You can hand the run off to a different agent or a different developer. The state is outside the context window where it's durable.
 
 If you need a starting point, `akm workflow template` prints a starter workflow doc you can adapt.
+
+### Resuming blocked or failed runs
+
+Sometimes a run gets blocked — a step requires human input, an external dependency is unavailable, or a tool call fails. When that happens, the run transitions to `blocked` or `failed`. Use `workflow resume` to flip it back to `active` without discarding progress:
+
+```sh
+akm workflow resume run-abc123
+```
+
+Completed runs cannot be resumed. Use `workflow list` to find runs by status.
 
 ## Vault Assets: The Agent Knows What It Needs, Not What the Values Are
 
@@ -202,7 +220,7 @@ akm vault show vault:production
 # → { keys: ["DATABASE_URL", "API_KEY", "DEPLOY_TARGET"] }
 
 # Marks the step complete
-akm workflow complete run-xyz --step validate --state completed --notes "All keys present"
+akm workflow complete run-xyz --step validate --notes "All keys present"
 
 # Gets the next step
 akm workflow next workflow:ship-release

--- a/docs/technical/search-updated.md
+++ b/docs/technical/search-updated.md
@@ -1,0 +1,307 @@
+# Search
+
+Search in `akm` is built to degrade gracefully.
+
+That matters because there are a few moving parts involved:
+
+- stash sources
+- the local SQLite index
+- FTS search
+- embeddings
+- the vector search backend
+- optional remote or local embedding providers
+
+If one of those pieces is unavailable, `akm` usually keeps going instead of falling over. The quality of the results may drop, and performance may drop, but search is intentionally layered so the user still gets something useful back.
+
+This doc explains the current implementation in plain English.
+
+## The Big Idea
+
+There are really three search tiers in the local stash path:
+
+1. **Indexed hybrid search** — best case
+2. **Indexed keyword search** — semantic/vector layer degraded
+3. **Filesystem substring search** — index degraded or unavailable
+
+And above that, there is one more routing layer:
+
+- search the local stash
+- search the registry
+- search both and merge the results
+
+So when people ask whether search is "down," the answer is usually "which layer?"
+
+## Top-Level Search Flow
+
+When you run `akm search`, the implementation first decides where to search:
+
+- `stash`
+- `registry`
+- `both`
+
+From there:
+
+- `stash` searches the local stash and configured stash providers
+- `registry` skips local stash search entirely
+- `both` runs both paths and merges the results
+
+If there are no configured stashes, `akm` does not hard fail. It returns an empty response and tells the user to run `akm init`.
+
+## Local Search Path
+
+The local stash search path prefers the SQLite index when it can trust it.
+
+That indexed path is used only if the implementation can confirm all of the following:
+
+- the database file exists
+- the database opens successfully
+- it contains indexed entries
+- the stored stash metadata matches the active stash path
+
+If any of that fails, `akm` falls back to filesystem substring search.
+
+That is the broad fallback. It is not a semantic-search fallback. It is the fallback for when the index itself is unavailable or untrusted.
+
+## Search Tiers
+
+| Tier | Path | What you get | What you lose |
+|---|---|---|---|
+| 1 | Indexed hybrid search | FTS + semantic/vector scoring + reranking | Nothing important |
+| 2 | Indexed keyword search | FTS + reranking | Semantic relevance |
+| 3 | Filesystem substring search | Basic search that still returns useful matches | FTS ranking, semantic ranking, and most of the smarter ordering |
+| 4 | No stash configured | Empty result with guidance | All local search |
+
+This is the most important thing to understand about the current implementation: missing semantic search is not the same thing as missing search.
+
+## Indexed Search
+
+Inside the indexed path, `akm` does a couple of things:
+
+- runs FTS keyword search
+- tries semantic/vector scoring
+- combines scores when both are available
+- applies reranking boosts afterward
+
+The current implementation uses a weighted blend when both FTS and vector scores are present:
+
+- `0.7` FTS
+- `0.3` vector
+
+After that, additional boosts can influence the final order. That includes things like exact-ish matches, aliases, hints, and utility metadata.
+
+So even in the best case, the final ranking is not just raw BM25 and not just raw cosine similarity.
+
+## Ranking Modes
+
+| Mode | When it happens | Inputs used |
+|---|---|---|
+| `hybrid` | The item has both FTS and vector scores | FTS + vector |
+| `fts` | The item has FTS but no vector score | FTS only |
+| `semantic` | The item has a vector score but was not surfaced by FTS | Vector only |
+
+That last one matters. It means semantic search can rescue results that keyword search missed.
+
+## Semantic Search
+
+Here is the part that tends to confuse people:
+
+**semantic search is not the same thing as `sqlite-vec`.**
+
+`sqlite-vec` is only one vector backend.
+
+If `sqlite-vec` is installed and loads correctly, `akm` uses the `entries_vec` virtual table for vector lookup.
+
+If `sqlite-vec` is missing or fails to load, `akm` falls back to JavaScript cosine similarity over embeddings stored as blobs in SQLite.
+
+That means:
+
+- missing `sqlite-vec` does **not** disable semantic search
+- it does **not** force a fallback to keyword search
+- it does **not** break correctness
+- it **does** reduce performance, especially as the embedding count grows
+
+For small and moderate indexes, that tradeoff is usually acceptable. For larger indexes, it becomes more painful.
+
+## When `sqlite-vec` Is Missing
+
+| Condition | Result |
+|---|---|
+| `sqlite-vec` loads successfully | Native vector search is used |
+| `sqlite-vec` is unavailable | JS vector fallback is used |
+| `sqlite-vec` is unavailable and embedding count is large | JS fallback still works, but `akm` warns that performance may suffer |
+
+The current implementation starts warning around 10,000 indexed embeddings.
+
+So the right mental model is:
+
+- **No vector extension** = semantic search still works, slower
+- **No embeddings / semantic unavailable** = semantic scoring is skipped
+- **No index** = fall back to substring search
+
+Those are different failure modes.
+
+## Semantic Status
+
+`akm` tracks semantic readiness with a semantic status file.
+
+That status controls whether semantic search is attempted.
+
+| Status | Meaning | Effective behavior |
+|---|---|---|
+| `disabled` | Semantic mode is turned off | Semantic search is not attempted |
+| `pending` | Semantic is expected but not verified yet | Search continues with keyword/indexed search |
+| `blocked` | Semantic setup or indexing failed recently | Search continues with keyword/indexed search |
+| `ready-vec` | Semantic is ready with native vector support | Full hybrid search available |
+| `ready-js` | Semantic is ready using JS fallback | Full hybrid search available, slower vector backend |
+
+There is also a TTL behavior on `blocked`. After about 24 hours, it is treated more like `pending` so the system can retry semantic setup on a later rebuild.
+
+## When Semantic Search Is Skipped or Unavailable
+
+Semantic search is skipped, unavailable, or effectively empty under these conditions:
+
+| Condition | What happens |
+|---|---|
+| `semanticSearchMode` is `off` | Semantic search is disabled |
+| No semantic status file exists yet | Semantic is treated as pending |
+| Embedding provider fingerprint changed | Semantic is treated as pending until rebuilt |
+| Semantic status is `blocked` | Semantic scoring is skipped for now |
+| Query embedding generation fails | Vector scoring is skipped for that query |
+| Stored embeddings were cleared due to dimension change | Semantic search has nothing useful to search until reindexing |
+| No embeddings were generated yet | Semantic results come back empty |
+| Vector lookup fails at runtime | Vector scores are skipped and keyword search continues |
+
+This is where the implementation is doing the right thing: semantic failures usually do **not** break search as a whole.
+
+They just knock the search path down one tier.
+
+## What Happens When Semantic Search Is Degraded
+
+When semantic search is pending or blocked, `akm` continues with indexed keyword search if the SQLite index is otherwise healthy.
+
+That means the user still gets:
+
+- FTS matching
+- reranking boosts
+- a sensible result list
+
+What they lose is the semantic contribution.
+
+So the real downgrade is usually:
+
+- from **hybrid search**
+- to **keyword/indexed search**
+
+Not:
+
+- from **search**
+- to **nothing**
+
+## What Happens When the Index Is Degraded
+
+If the SQLite index cannot be opened, trusted, or matched to the active stash, `akm` falls all the way back to filesystem substring search.
+
+That is the bigger downgrade.
+
+At that point you lose:
+
+- FTS relevance
+- semantic/vector scoring
+- most of the better ranking behavior
+- some of the nicer metadata-driven ordering
+
+But you still usually get useful results.
+
+That is exactly what you want from a CLI tool like this. Keep working. Get worse gracefully.
+
+## Empty Query Behavior
+
+If the query string is empty, `akm` does not behave like a normal search.
+
+Instead, it returns indexed entries directly, deduped by file path and limited to the requested slice.
+
+This is more of a browse/list operation than a relevance-ranked search.
+
+## Error Handling
+
+The current implementation avoids turning partial failures into total failures.
+
+### Provider failures
+
+If an additional stash provider fails, `akm` records a warning and keeps the local results.
+
+### Vector failures
+
+If vector search fails during a query, `akm` logs a warning and skips vector scores for that search.
+
+### Index failures
+
+If the index is unavailable or untrusted, `akm` falls back to filesystem substring search.
+
+### No stash configured
+
+If no stash exists, `akm` returns an empty result and guidance instead of blowing up.
+
+## Operator Matrix
+
+| Condition | Effective path | Does search still return results? | What degrades | Likely fix |
+|---|---|---|---|---|
+| No stash configured | No local search | No | Everything local | `akm init` |
+| Search source is `registry` | Registry only | Yes | No local results | Use `stash` or `both` if needed |
+| Additional stash provider fails | Local results continue | Yes | That provider only | Fix provider config/runtime |
+| Semantic mode is off | Indexed keyword search | Yes | Semantic scoring | Re-enable semantic mode |
+| Semantic pending | Indexed keyword search | Yes | Semantic scoring | `akm setup` or `akm index --full` |
+| Semantic blocked | Indexed keyword search | Yes | Semantic scoring | Fix backend issue and rebuild |
+| Embedding config changed | Indexed keyword search | Yes | Semantic scoring until rebuild | `akm index --full` |
+| Query embedding generation fails | Indexed keyword search | Yes | Semantic scoring for that query | Fix embedder/backend/auth/model |
+| `sqlite-vec` missing | Indexed hybrid search with JS vector backend | Yes | Performance | Install `sqlite-vec` if needed |
+| `sqlite-vec` missing with large index | Indexed hybrid search with warning | Yes | Performance, more noticeably | Install `sqlite-vec` |
+| Index unavailable or untrusted | Filesystem substring search | Yes | Relevance quality and semantic ranking | `akm index` |
+| Embeddings missing or cleared | Indexed keyword search | Yes | Semantic results | Reindex to regenerate embeddings |
+
+## Practical Reading of the Current Implementation
+
+If you want the short version, it is this:
+
+- missing `sqlite-vec` is a **performance problem**, not a semantic-search outage
+- missing embeddings or blocked semantic status is a **semantic-quality problem**, not a search outage
+- missing or invalid index is the point where `akm` drops to **substring search**
+- no stash configured is the when local search is actually unavailable
+
+That is a solid design.
+
+It means `akm search` is not fragile. It just gets less smart as more pieces go missing.
+
+## Commands That Usually Fix Things
+
+Rebuild the index:
+
+```bash
+akm index
+```
+
+Force a full rebuild when semantic state, embeddings, or provider configuration changed:
+
+```bash
+akm index --full
+```
+
+Initialize the stash if none exists yet:
+
+```bash
+akm init
+```
+
+Run setup if semantic search is pending or not fully configured:
+
+```bash
+akm setup
+```
+
+## Final Note
+
+The current implementation gets the important part right.
+
+It does not confuse "semantic search degraded" with "search broken." It does not confuse "vector extension missing" with "semantic unavailable." And it does not force a hard failure when a softer fallback will still get the user where they need to go.
+
+That is exactly the kind of behavior you want in a tool that is supposed to help you find things instead of becoming one more thing you have to troubleshoot.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1277,6 +1277,10 @@ const addCommand = defineCommand({
       description: "Bypass install-audit blocking for this add invocation only",
       default: false,
     },
+    type: {
+      type: "string",
+      description: "Override asset type for all files in this stash (currently supports: wiki)",
+    },
     "max-pages": { type: "string", description: "Maximum pages to crawl for website sources (default: 50)" },
     "max-depth": { type: "string", description: "Maximum crawl depth for website sources (default: 3)" },
   },
@@ -1338,6 +1342,7 @@ const addCommand = defineCommand({
       const result = await akmAdd({
         ref,
         name: args.name,
+        overrideType: args.type,
         options: Object.keys(websiteOptions).length > 0 ? websiteOptions : undefined,
         trustThisInstall: args.trust,
         writable: args.writable,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1614,11 +1614,19 @@ const saveCommand = defineCommand({
     await runWithJsonErrors(async () => {
       // Fix: citty can consume `--format json` (space-separated) as the
       // positional `name` argument (e.g. `akm save --format json` parses
-      // name="json"). Detect this by checking whether the positional value
-      // equals the value of the --format flag as seen in process.argv.
+      // name="json"). Detect the mis-parse by checking argv order — only
+      // treat the positional as consumed by --format when --format appears
+      // before any standalone occurrence of the same value in the save
+      // subcommand's argv slice. This preserves legitimate invocations
+      // like `akm save json --format json`.
       const parsedFormat = parseFlagValue("--format");
       const effectiveName =
-        args.name !== undefined && parsedFormat !== undefined && args.name === parsedFormat ? undefined : args.name;
+        args.name !== undefined &&
+        parsedFormat !== undefined &&
+        args.name === parsedFormat &&
+        wasFormatValueConsumedAsName(args.name, parsedFormat)
+          ? undefined
+          : args.name;
 
       let writable: boolean | undefined;
       if (!effectiveName) {
@@ -1632,6 +1640,50 @@ const saveCommand = defineCommand({
     });
   },
 });
+
+/**
+ * Detect whether `--format <value>` was consumed by citty as the optional
+ * `name` positional of `akm save`. Returns true only when `--format` appears
+ * in the save subcommand's argv slice AND the candidate name does NOT
+ * appear as a standalone positional elsewhere (before or after the flag).
+ *
+ * This keeps `akm save json --format json` routing `json` as the stash name,
+ * while `akm save --format json` (no separate positional) is treated as a
+ * primary-stash save.
+ */
+function wasFormatValueConsumedAsName(name: string, formatValue: string): boolean {
+  const argv = process.argv.slice(2);
+  const saveIndex = argv.indexOf("save");
+  const tokens = saveIndex >= 0 ? argv.slice(saveIndex + 1) : argv;
+
+  let formatIndex = -1;
+  let formatConsumesNextToken = false;
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token === "--format") {
+      formatIndex = i;
+      formatConsumesNextToken = true;
+      break;
+    }
+    if (token === `--format=${formatValue}`) {
+      formatIndex = i;
+      break;
+    }
+  }
+
+  if (formatIndex === -1) return false;
+
+  // If the name appears as a standalone token before --format, it's the
+  // real positional and --format did not consume it.
+  if (tokens.slice(0, formatIndex).includes(name)) return false;
+
+  // If --format has a space-separated value, skip past the value token
+  // when scanning after the flag; otherwise start right after the flag.
+  const firstTokenAfterFormat = formatIndex + (formatConsumesNextToken ? 2 : 1);
+  if (tokens.slice(firstTokenAfterFormat).includes(name)) return false;
+
+  return true;
+}
 
 const cloneCommand = defineCommand({
   meta: {
@@ -2071,7 +2123,7 @@ const workflowCreateCommand = defineCommand({
       const namePattern = /^[a-z0-9][a-z0-9._/-]*$/;
       if (!namePattern.test(args.name)) {
         throw new UsageError(
-          "Workflow name must start with a lowercase letter or digit and contain only lowercase letters, digits, hyphens, dots, and underscores.",
+          "Workflow name must start with a lowercase letter or digit and contain only lowercase letters, digits, hyphens, dots, underscores, and slashes.",
         );
       }
       if (args.force && !args.from && !args.reset) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1607,7 +1607,22 @@ const saveCommand = defineCommand({
   },
   async run({ args }) {
     await runWithJsonErrors(async () => {
-      const result = saveGitStash(args.name, args.message);
+      // Fix: citty can consume `--format json` (space-separated) as the
+      // positional `name` argument (e.g. `akm save --format json` parses
+      // name="json"). Detect this by checking whether the positional value
+      // equals the value of the --format flag as seen in process.argv.
+      const parsedFormat = parseFlagValue("--format");
+      const effectiveName =
+        args.name !== undefined && parsedFormat !== undefined && args.name === parsedFormat ? undefined : args.name;
+
+      let writable: boolean | undefined;
+      if (!effectiveName) {
+        // Primary stash — honour the root-level writable flag from config.
+        const cfg = loadConfig();
+        writable = cfg.writable === true ? true : undefined;
+      }
+
+      const result = saveGitStash(effectiveName, args.message, writable);
       output("save", result);
     });
   },
@@ -3132,6 +3147,36 @@ akm wiki remove research --force --with-sources # Full nuke, including raw/
 to get the step-by-step workflow.** Wiki pages are also addressable as
 \`wiki:<name>/<page-path>\` and show up in stash-wide \`akm search\` as
 \`type: wiki\`. No \`--llm\` anywhere — akm never reasons about page content.
+
+## Vaults
+
+Encrypted-at-rest key/value stores for secrets. Each vault is a \`.env\`-format
+file at \`<stashDir>/vaults/<name>.env\`.
+
+\`\`\`sh
+akm vault create prod                         # Create a new vault
+akm vault set prod DB_URL postgres://...      # Set a key (or KEY=VALUE combined form)
+akm vault set prod DB_URL=postgres://...      # Combined KEY=VALUE form also works
+akm vault unset prod DB_URL                   # Remove a key
+akm vault list vault:prod                     # List key names (no values)
+akm vault show vault:prod                     # Same as list (alias)
+akm vault load vault:prod                     # Print export statements to source
+\`\`\`
+
+## Workflows
+
+Step-based workflows stored as \`<stashDir>/workflows/<name>.md\`.
+
+\`\`\`sh
+akm workflow template                         # Print a starter workflow template
+akm workflow create ship-release             # Scaffold a new workflow asset
+akm workflow start workflow:ship-release     # Start a new run
+akm workflow next workflow:ship-release      # Advance to the next step (or auto-start)
+akm workflow complete <run-id>               # Mark a step complete and advance
+akm workflow status <run-id>                 # Show current run status
+akm workflow resume <run-id>                 # Resume a blocked or failed run
+akm workflow list                            # List all workflow runs
+\`\`\`
 
 ## Clone
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2564,6 +2564,10 @@ const wikiSearchCommand = defineCommand({
     return runWithJsonErrors(async () => {
       const { searchInWiki } = await import("./wiki.js");
       const stashDir = resolveStashDir();
+      const wikiDir = path.join(stashDir, "wikis", args.name);
+      if (!fs.existsSync(wikiDir)) {
+        throw new NotFoundError(`Wiki not found: ${args.name}`);
+      }
       const parsedLimit = args.limit ? Number(args.limit) : undefined;
       const limit =
         typeof parsedLimit === "number" && Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : undefined;
@@ -2594,6 +2598,7 @@ const wikiStashCommand = defineCommand({
         wikiName: args.name,
         content,
         preferredName: args.as ?? preferredName,
+        explicitSlug: args.as !== undefined,
       });
       output("wiki-stash", { ok: true, wiki: args.name, source: args.source, ...result });
     });
@@ -2608,13 +2613,16 @@ const wikiLintCommand = defineCommand({
   args: {
     name: { type: "positional", description: "Wiki name", required: true },
   },
-  run({ args }) {
-    return runWithJsonErrors(async () => {
+  async run({ args }) {
+    let findingCount = 0;
+    await runWithJsonErrors(async () => {
       const { lintWiki } = await import("./wiki.js");
       const stashDir = resolveStashDir();
       const report = lintWiki(stashDir, args.name);
       output("wiki-lint", report);
+      findingCount = report.findings.length;
     });
+    if (findingCount > 0) process.exit(1); // EXIT_GENERAL
   },
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2401,36 +2401,38 @@ const vaultLoadCommand = defineCommand({
     ref: { type: "positional", description: "Vault ref", required: true },
   },
   async run({ args }) {
-    // This command deliberately bypasses output()/JSON shaping. Its stdout
-    // is a shell snippet intended for `eval`, not structured output.
-    const { name, absPath } = resolveVaultPath(args.ref);
-    if (!fs.existsSync(absPath)) {
-      throw new NotFoundError(`Vault not found: vault:${name}`);
-    }
+    return runWithJsonErrors(async () => {
+      // This command deliberately bypasses output()/JSON shaping. Its stdout
+      // is a shell snippet intended for `eval`, not structured output.
+      const { name, absPath } = resolveVaultPath(args.ref);
+      if (!fs.existsSync(absPath)) {
+        throw new NotFoundError(`Vault not found: vault:${name}`);
+      }
 
-    const { buildShellExportScript } = await import("./vault.js");
-    const crypto = await import("node:crypto");
-    const os = await import("node:os");
+      const { buildShellExportScript } = await import("./vault.js");
+      const crypto = await import("node:crypto");
+      const os = await import("node:os");
 
-    // Parse via dotenv (no expansion, no code execution) and build a
-    // script of literal `export KEY='value'` lines with `'\''` escaping.
-    // Sourcing this is safe even if the raw vault file contained shell
-    // metacharacters like $, backticks, or $(...).
-    const script = buildShellExportScript(absPath);
+      // Parse via dotenv (no expansion, no code execution) and build a
+      // script of literal `export KEY='value'` lines with `'\''` escaping.
+      // Sourcing this is safe even if the raw vault file contained shell
+      // metacharacters like $, backticks, or $(...).
+      const script = buildShellExportScript(absPath);
 
-    // Write to a mode-0600 temp file the shell can source.
-    const tmpPath = path.join(os.tmpdir(), `akm-vault-${crypto.randomBytes(12).toString("hex")}.sh`);
-    fs.writeFileSync(tmpPath, script, { mode: 0o600, encoding: "utf8" });
-    try {
-      fs.chmodSync(tmpPath, 0o600);
-    } catch {
-      /* best-effort on platforms without chmod */
-    }
+      // Write to a mode-0600 temp file the shell can source.
+      const tmpPath = path.join(os.tmpdir(), `akm-vault-${crypto.randomBytes(12).toString("hex")}.sh`);
+      fs.writeFileSync(tmpPath, script, { mode: 0o600, encoding: "utf8" });
+      try {
+        fs.chmodSync(tmpPath, 0o600);
+      } catch {
+        /* best-effort on platforms without chmod */
+      }
 
-    const quotedTmp = `'${tmpPath.replace(/'/g, "'\\''")}'`;
-    // Emit: source the temp file, then remove it — values reach bash only
-    // via the temp file (mode 0600), never via akm's stdout.
-    process.stdout.write(`. ${quotedTmp}; rm -f ${quotedTmp}\n`);
+      const quotedTmp = `'${tmpPath.replace(/'/g, "'\\''")}'`;
+      // Emit: source the temp file, then remove it — values reach bash only
+      // via the temp file (mode 0600), never via akm's stdout.
+      process.stdout.write(`. ${quotedTmp}; rm -f ${quotedTmp}\n`);
+    });
   },
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2420,18 +2420,40 @@ const vaultCreateCommand = defineCommand({
 });
 
 const vaultSetCommand = defineCommand({
-  meta: { name: "set", description: "Set a key in a vault. Value is written to disk and never echoed back." },
+  meta: {
+    name: "set",
+    description:
+      'Set a key in a vault. Value is written to disk and never echoed back. Accepts KEY=VALUE combined form or separate KEY VALUE args. Optionally attach a comment with --comment "description".',
+  },
   args: {
     ref: { type: "positional", description: "Vault ref (e.g. vault:prod or just prod)", required: true },
-    key: { type: "positional", description: "Key name (e.g. DB_URL)", required: true },
-    value: { type: "positional", description: "Value to store", required: true },
+    key: { type: "positional", description: "Key name (e.g. DB_URL) or KEY=VALUE combined form", required: true },
+    value: {
+      type: "positional",
+      description: "Value to store (omit when using KEY=VALUE combined form)",
+      required: false,
+    },
+    comment: { type: "string", description: "Optional comment written above the key line", required: false },
   },
   run({ args }) {
     return runWithJsonErrors(async () => {
       const { setKey } = await import("./vault.js");
       const { name, absPath } = resolveVaultPath(args.ref);
-      setKey(absPath, args.key, args.value);
-      output("vault-set", { ref: `vault:${name}`, key: args.key, path: absPath });
+
+      let realKey: string;
+      let realValue: string;
+
+      if ((args.value === undefined || args.value === "") && args.key.includes("=")) {
+        const eqIdx = args.key.indexOf("=");
+        realKey = args.key.slice(0, eqIdx);
+        realValue = args.key.slice(eqIdx + 1);
+      } else {
+        realKey = args.key;
+        realValue = args.value ?? "";
+      }
+
+      setKey(absPath, realKey, realValue, args.comment);
+      output("vault-set", { ref: `vault:${name}`, key: realKey, path: absPath });
     });
   },
 });
@@ -2500,6 +2522,24 @@ const vaultLoadCommand = defineCommand({
   },
 });
 
+const vaultShowCommand = defineCommand({
+  meta: { name: "show", description: "Show keys (no values) inside a vault — alias for `vault list <ref>`" },
+  args: {
+    ref: { type: "positional", description: "Vault ref (e.g. vault:prod or just prod)", required: true },
+  },
+  run({ args }) {
+    return runWithJsonErrors(async () => {
+      const { listKeys } = await import("./vault.js");
+      const { name, absPath } = resolveVaultPath(args.ref);
+      if (!fs.existsSync(absPath)) {
+        throw new NotFoundError(`Vault not found: vault:${name}`);
+      }
+      const { keys, comments } = listKeys(absPath);
+      output("vault-list", { ref: `vault:${name}`, path: absPath, keys, comments });
+    });
+  },
+});
+
 const vaultCommand = defineCommand({
   meta: {
     name: "vault",
@@ -2508,6 +2548,7 @@ const vaultCommand = defineCommand({
   },
   subCommands: {
     list: vaultListCommand,
+    show: vaultShowCommand,
     create: vaultCreateCommand,
     set: vaultSetCommand,
     unset: vaultUnsetCommand,
@@ -2777,7 +2818,7 @@ const main = defineCommand({
 });
 
 const CONFIG_SUBCOMMAND_SET = new Set(["path", "list", "get", "set", "unset"]);
-const VAULT_SUBCOMMAND_SET = new Set(["list", "create", "set", "unset", "load"]);
+const VAULT_SUBCOMMAND_SET = new Set(["list", "show", "create", "set", "unset", "load"]);
 const WIKI_SUBCOMMAND_SET = new Set(["create", "list", "show", "remove", "pages", "search", "stash", "lint", "ingest"]);
 const SHOW_VIEW_MODES = new Set(["toc", "frontmatter", "full", "section", "lines"]);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,6 +50,7 @@ import {
   getNextWorkflowStep,
   getWorkflowStatus,
   listWorkflowRuns,
+  resumeWorkflowRun,
   startWorkflowRun,
 } from "./workflow-runs";
 
@@ -1932,10 +1933,12 @@ const workflowNextCommand = defineCommand({
   },
   args: {
     target: { type: "positional", description: "Workflow run id or workflow ref", required: true },
+    params: { type: "string", description: "Workflow parameters as a JSON object (only for auto-started runs)" },
   },
   async run({ args }) {
     await runWithJsonErrors(async () => {
-      const result = await getNextWorkflowStep(args.target);
+      const parsedParams = args.params ? parseWorkflowJsonObject(args.params, "--params") : undefined;
+      const result = await getNextWorkflowStep(args.target, parsedParams);
       output("workflow-next", result);
     });
   },
@@ -1949,7 +1952,10 @@ const workflowCompleteCommand = defineCommand({
   args: {
     runId: { type: "positional", description: "Workflow run id", required: true },
     step: { type: "string", description: "Workflow step id", required: true },
-    state: { type: "string", description: `Step state (${WORKFLOW_STEP_STATES.join("|")})` },
+    state: {
+      type: "string",
+      description: `Step state (default: completed). One of: ${WORKFLOW_STEP_STATES.join(", ")}.`,
+    },
     notes: { type: "string", description: "Notes for the completed step" },
     evidence: { type: "string", description: "Evidence JSON object for the step" },
   },
@@ -1973,12 +1979,33 @@ const workflowStatusCommand = defineCommand({
     description: "Show full workflow run state for review or resume",
   },
   args: {
-    runId: { type: "positional", description: "Workflow run id", required: true },
+    target: { type: "positional", description: "Workflow run id or workflow ref (workflow:<name>)", required: true },
   },
   run({ args }) {
     return runWithJsonErrors(() => {
-      const result = getWorkflowStatus(args.runId);
-      output("workflow-status", result);
+      const target = args.target;
+      // Check if target looks like a workflow ref
+      const parsed = (() => {
+        try {
+          return parseAssetRef(target);
+        } catch {
+          return null;
+        }
+      })();
+      if (parsed?.type === "workflow") {
+        const ref = `${parsed.origin ? `${parsed.origin}//` : ""}workflow:${parsed.name}`;
+        const { runs } = listWorkflowRuns({ workflowRef: ref });
+        if (runs.length === 0) {
+          throw new NotFoundError(`No workflow runs found for ${ref}`);
+        }
+        const mostRecent = runs[0];
+        if (!mostRecent) throw new NotFoundError(`No workflow runs found for ${ref}`);
+        const result = getWorkflowStatus(mostRecent.id);
+        output("workflow-status", result);
+      } else {
+        const result = getWorkflowStatus(target);
+        output("workflow-status", result);
+      }
     });
   },
 });
@@ -2008,10 +2035,30 @@ const workflowCreateCommand = defineCommand({
   args: {
     name: { type: "positional", description: "Workflow name", required: true },
     from: { type: "string", description: "Import and validate markdown from an existing file" },
-    force: { type: "boolean", description: "Overwrite an existing workflow", default: false },
+    force: {
+      type: "boolean",
+      description: "Overwrite an existing workflow (requires --from or --reset)",
+      default: false,
+    },
+    reset: {
+      type: "boolean",
+      description: "Explicitly replace an existing workflow with a fresh template (use with --force)",
+      default: false,
+    },
   },
   run({ args }) {
     return runWithJsonErrors(() => {
+      const namePattern = /^[a-z0-9][a-z0-9._/-]*$/;
+      if (!namePattern.test(args.name)) {
+        throw new UsageError(
+          "Workflow name must start with a lowercase letter or digit and contain only lowercase letters, digits, hyphens, dots, and underscores.",
+        );
+      }
+      if (args.force && !args.from && !args.reset) {
+        throw new UsageError(
+          "Refusing to overwrite with template: pass --from <file> to replace content, or --reset to explicitly replace with a fresh template.",
+        );
+      }
       const result = createWorkflowAsset({
         name: args.name,
         from: args.from,
@@ -2032,6 +2079,22 @@ const workflowTemplateCommand = defineCommand({
   },
 });
 
+const workflowResumeCommand = defineCommand({
+  meta: {
+    name: "resume",
+    description: "Resume a blocked or failed workflow run, flipping it back to active",
+  },
+  args: {
+    runId: { type: "positional", description: "Workflow run id", required: true },
+  },
+  run({ args }) {
+    return runWithJsonErrors(() => {
+      const result = resumeWorkflowRun(args.runId);
+      output("workflow-run", result);
+    });
+  },
+});
+
 const workflowCommand = defineCommand({
   meta: {
     name: "workflow",
@@ -2045,6 +2108,7 @@ const workflowCommand = defineCommand({
     list: workflowListCommand,
     create: workflowCreateCommand,
     template: workflowTemplateCommand,
+    resume: workflowResumeCommand,
   },
   run({ args }) {
     return runWithJsonErrors(() => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -77,6 +77,8 @@ export interface StashConfigEntry {
   writable?: boolean;
   /** Arbitrary provider-specific options */
   options?: Record<string, unknown>;
+  /** If set, all .md files in this stash are indexed as wiki pages under this wiki name */
+  wikiName?: string;
 }
 
 export interface InstallAuditConfig {
@@ -631,6 +633,8 @@ function parseInstalledKitEntry(value: unknown): InstalledKitEntry | undefined {
   if (resolvedVersion) entry.resolvedVersion = resolvedVersion;
   const resolvedRevision = asNonEmptyString(obj.resolvedRevision);
   if (resolvedRevision) entry.resolvedRevision = resolvedRevision;
+  const wikiName = asNonEmptyString(obj.wikiName);
+  if (wikiName) entry.wikiName = wikiName;
   return entry;
 }
 
@@ -733,6 +737,8 @@ function parseStashConfigEntry(value: unknown): StashConfigEntry | undefined {
   if (typeof obj.options === "object" && obj.options !== null && !Array.isArray(obj.options)) {
     entry.options = obj.options as Record<string, unknown>;
   }
+  const wikiName = asNonEmptyString(obj.wikiName);
+  if (wikiName) entry.wikiName = wikiName;
   return entry;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -128,6 +128,11 @@ export interface AkmConfig {
   security?: SecurityConfig;
   /** Output defaults for CLI rendering */
   output?: OutputConfig;
+  /**
+   * When true, the primary stash is treated as a writable git repo and
+   * `akm save` will push after committing (if a remote is configured).
+   */
+  writable?: boolean;
 }
 
 export interface OutputConfig {
@@ -337,6 +342,10 @@ function pickKnownKeys(raw: Record<string, unknown>): Partial<AkmConfig> {
 
   const output = parseOutputConfig(raw.output);
   if (output) config.output = output;
+
+  if (typeof raw.writable === "boolean") {
+    config.writable = raw.writable;
+  }
 
   return config;
 }

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -24,6 +24,7 @@ import {
 import { generateMetadataFlat, loadStashFile, type StashEntry, type StashFile } from "./metadata";
 import { getDbPath } from "./paths";
 import { buildSearchText } from "./search-fields";
+import type { SearchSource } from "./search-source";
 import {
   classifySemanticFailure,
   clearSemanticStatus,
@@ -86,9 +87,10 @@ export async function akmIndex(options?: IndexOptions): Promise<IndexResponse> {
 
   // Ensure git stash caches are extracted before resolving stash dirs,
   // so their content directories exist on disk for the walker to discover.
-  const { ensureStashCaches, resolveAllStashDirs } = await import("./search-source.js");
+  const { ensureStashCaches, resolveStashSources } = await import("./search-source.js");
   await ensureStashCaches(config);
-  const allStashDirs = resolveAllStashDirs(stashDir);
+  const allStashSources = resolveStashSources(stashDir, config);
+  const allStashDirs = allStashSources.map((s) => s.path);
 
   const t0 = Date.now();
 
@@ -152,7 +154,7 @@ export async function akmIndex(options?: IndexOptions): Promise<IndexResponse> {
     const doFullDelete = options?.full || !isIncremental;
     const { scannedDirs, skippedDirs, generatedCount, dirsNeedingLlm } = await indexEntries(
       db,
-      allStashDirs,
+      allStashSources,
       isIncremental,
       builtAtMs,
       doFullDelete,
@@ -271,7 +273,7 @@ export async function akmIndex(options?: IndexOptions): Promise<IndexResponse> {
 
 async function indexEntries(
   db: Database,
-  allStashDirs: string[],
+  allStashSources: SearchSource[],
   isIncremental: boolean,
   builtAtMs: number,
   doFullDelete = false,
@@ -310,8 +312,44 @@ async function indexEntries(
 
   const dirRecords: DirRecord[] = [];
 
-  for (const currentStashDir of allStashDirs) {
+  for (const stashSource of allStashSources) {
+    const currentStashDir = stashSource.path;
     const fileContexts = walkStashFlat(currentStashDir);
+
+    // Wiki-root stashes: all .md files are indexed as wiki pages under wikiName
+    if (stashSource.wikiName) {
+      const wikiName = stashSource.wikiName;
+      const wikiDirGroups = new Map<string, { files: string[]; entries: StashEntry[] }>();
+      for (const ctx of fileContexts) {
+        if (ctx.ext !== ".md") continue;
+        const relNoExt = ctx.relPath.replace(/\.md$/, "");
+        const entry: StashEntry = {
+          name: `${wikiName}/${relNoExt}`,
+          type: "wiki",
+          filename: ctx.fileName,
+          description: ctx.frontmatter()?.description as string | undefined,
+          source: "frontmatter",
+        };
+        const dir = ctx.parentDirAbs;
+        const group = wikiDirGroups.get(dir);
+        if (group) {
+          group.files.push(ctx.absPath);
+          group.entries.push(entry);
+        } else {
+          wikiDirGroups.set(dir, { files: [ctx.absPath], entries: [entry] });
+        }
+      }
+      for (const [dirPath, { files, entries }] of wikiDirGroups) {
+        if (seenPaths.has(path.resolve(dirPath))) {
+          dirRecords.push({ dirPath, currentStashDir, files, stash: null, skip: true });
+          continue;
+        }
+        seenPaths.add(path.resolve(dirPath));
+        scannedDirs++;
+        dirRecords.push({ dirPath, currentStashDir, files, stash: { entries }, skip: false });
+      }
+      continue;
+    }
 
     const dirGroups = new Map<string, string[]>();
     for (const ctx of fileContexts) {

--- a/src/install-audit.ts
+++ b/src/install-audit.ts
@@ -239,7 +239,8 @@ export function formatInstallAuditFailure(ref: string, report: InstallAuditRepor
     lines.push(`- ${report.findings.length - 5} more finding(s) omitted`);
   }
   lines.push(
-    "Disable blocking with `security.installAudit.blockOnCritical = false`, or disable audits with `security.installAudit.enabled = false`.",
+    "Disable blocking with `security.installAudit.blockOnCritical = false`, or disable audits with `security.installAudit.enabled = false`." +
+      " Or pass --trust on a one-off 'akm add' to bypass this audit for this install only.",
   );
   return lines.join("\n");
 }

--- a/src/registry-types.ts
+++ b/src/registry-types.ts
@@ -55,6 +55,8 @@ export interface InstalledKitEntry {
   cacheDir: string;
   installedAt: string;
   writable?: boolean;
+  /** If set, all .md files in this kit are indexed as wiki pages under this wiki name */
+  wikiName?: string;
 }
 
 export interface KitInstallResult extends InstalledKitEntry {

--- a/src/search-source.ts
+++ b/src/search-source.ts
@@ -13,6 +13,8 @@ export interface SearchSource {
   path: string;
   /** For installed sources, the installed kit id */
   registryId?: string;
+  /** If set, all .md files in this source are indexed as wiki pages under this wiki name */
+  wikiName?: string;
 }
 
 // ── Resolution ──────────────────────────────────────────────────────────────
@@ -33,7 +35,7 @@ export function resolveStashSources(overrideStashDir?: string, existingConfig?: 
   const sources: SearchSource[] = [{ path: stashDir }];
   const seen = new Set<string>([path.resolve(stashDir)]);
 
-  const addSource = (dir: string, registryId?: string) => {
+  const addSource = (dir: string, registryId?: string, wikiName?: string) => {
     const resolved = path.resolve(dir);
     if (seen.has(resolved)) return;
     seen.add(resolved);
@@ -41,14 +43,18 @@ export function resolveStashSources(overrideStashDir?: string, existingConfig?: 
       warn(`Warning: stash root "${dir}" appears to be a system directory. This may be unintentional.`);
     }
     if (isValidDirectory(dir)) {
-      sources.push({ path: resolved, ...(registryId ? { registryId } : {}) });
+      sources.push({
+        path: resolved,
+        ...(registryId ? { registryId } : {}),
+        ...(wikiName ? { wikiName } : {}),
+      });
     }
   };
 
   // Filesystem entries from stashes[]
   for (const entry of config.stashes ?? []) {
     if (entry.type === "filesystem" && entry.path && entry.enabled !== false) {
-      addSource(entry.path, entry.name);
+      addSource(entry.path, entry.name, entry.wikiName);
     }
   }
 
@@ -62,7 +68,7 @@ export function resolveStashSources(overrideStashDir?: string, existingConfig?: 
         // The content/ subdirectory inside the extracted repo is the actual
         // stash root containing DOC.md / SKILL.md files that the walker indexes.
         const contentDir = path.join(cachePaths.repoDir, "content");
-        addSource(contentDir, entry.name);
+        addSource(contentDir, entry.name, entry.wikiName);
       } catch (err) {
         warn(
           `Warning: failed to resolve git stash cache for "${entry.url}": ${err instanceof Error ? err.message : String(err)}`,
@@ -77,7 +83,7 @@ export function resolveStashSources(overrideStashDir?: string, existingConfig?: 
     if (entry.type === "website" && entry.url && entry.enabled !== false) {
       try {
         const cachePaths = getWebsiteCachePaths(entry.url);
-        addSource(cachePaths.stashDir, entry.name ?? entry.url);
+        addSource(cachePaths.stashDir, entry.name ?? entry.url, entry.wikiName);
       } catch (err) {
         warn(
           `Warning: failed to resolve website stash cache for "${entry.url}": ${err instanceof Error ? err.message : String(err)}`,
@@ -88,7 +94,7 @@ export function resolveStashSources(overrideStashDir?: string, existingConfig?: 
 
   // Installed kits (registry and local)
   for (const entry of config.installed ?? []) {
-    addSource(entry.stashRoot, entry.id);
+    addSource(entry.stashRoot, entry.id, entry.wikiName);
   }
 
   return sources;

--- a/src/stash-add.ts
+++ b/src/stash-add.ts
@@ -10,6 +10,7 @@ import { detectStashRoot, installRegistryRef, upsertInstalledRegistryEntry } fro
 import { parseRegistryRef } from "./registry-resolve";
 import { ensureWebsiteMirror, validateWebsiteInputUrl } from "./stash-providers/website";
 import type { AddResponse } from "./stash-types";
+import { warn } from "./warn";
 
 export async function akmAdd(input: {
   ref: string;
@@ -35,6 +36,9 @@ export async function akmAdd(input: {
   try {
     const parsed = parseRegistryRef(ref);
     if (parsed.source === "local") {
+      if (input.trustThisInstall) {
+        warn("--trust has no effect on local directory sources; the install audit is not run for local paths.");
+      }
       return addLocalStashSource(ref, parsed.sourcePath, stashDir);
     }
   } catch {

--- a/src/stash-add.ts
+++ b/src/stash-add.ts
@@ -11,10 +11,14 @@ import { parseRegistryRef } from "./registry-resolve";
 import { ensureWebsiteMirror, validateWebsiteInputUrl } from "./stash-providers/website";
 import type { AddResponse } from "./stash-types";
 import { warn } from "./warn";
+import { validateWikiName } from "./wiki";
+
+const VALID_OVERRIDE_TYPES = new Set(["wiki"]);
 
 export async function akmAdd(input: {
   ref: string;
   name?: string;
+  overrideType?: string;
   options?: Record<string, unknown>;
   trustThisInstall?: boolean;
   writable?: boolean;
@@ -26,10 +30,25 @@ export async function akmAdd(input: {
         "Examples: `akm add @scope/kit`, `akm add github:owner/repo`, `akm add ./local/path`",
     );
 
+  // Validate and resolve wiki name when --type wiki is used
+  let wikiName: string | undefined;
+  if (input.overrideType) {
+    if (!VALID_OVERRIDE_TYPES.has(input.overrideType)) {
+      throw new UsageError(
+        `Invalid --type value: "${input.overrideType}". Supported types: ${[...VALID_OVERRIDE_TYPES].join(", ")}`,
+      );
+    }
+    if (input.overrideType === "wiki") {
+      const derived = input.name ?? deriveWikiNameFromRef(ref);
+      validateWikiName(derived);
+      wikiName = derived;
+    }
+  }
+
   const stashDir = resolveStashDir();
 
   if (shouldAddAsWebsiteUrl(ref)) {
-    return addWebsiteStashSource(ref, stashDir, input.name, input.options);
+    return addWebsiteStashSource(ref, stashDir, input.name ?? wikiName, input.options, wikiName);
   }
 
   // Detect local directory refs and route them to stashes[] instead of installed[]
@@ -39,20 +58,25 @@ export async function akmAdd(input: {
       if (input.trustThisInstall) {
         warn("--trust has no effect on local directory sources; the install audit is not run for local paths.");
       }
-      return addLocalStashSource(ref, parsed.sourcePath, stashDir);
+      return addLocalStashSource(ref, parsed.sourcePath, stashDir, wikiName);
     }
   } catch {
     // Not a local ref — fall through to registry install
   }
 
-  return addRegistryKit(ref, stashDir, input.trustThisInstall, input.writable);
+  return addRegistryKit(ref, stashDir, input.trustThisInstall, input.writable, wikiName);
 }
 
 /**
  * Add a local directory as a filesystem stash source.
  * Creates a stashes[] entry instead of an installed[] entry.
  */
-async function addLocalStashSource(ref: string, sourcePath: string, stashDir: string): Promise<AddResponse> {
+async function addLocalStashSource(
+  ref: string,
+  sourcePath: string,
+  stashDir: string,
+  wikiName?: string,
+): Promise<AddResponse> {
   const stashRoot = detectStashRoot(sourcePath);
   const resolvedPath = path.resolve(stashRoot);
   const config = loadUserConfig();
@@ -64,9 +88,13 @@ async function addLocalStashSource(ref: string, sourcePath: string, stashDir: st
     const entry: StashConfigEntry = {
       type: "filesystem",
       path: resolvedPath,
-      name: toReadableId(resolvedPath),
+      name: wikiName ?? toReadableId(resolvedPath),
+      ...(wikiName ? { wikiName } : {}),
     };
     stashes.push(entry);
+    saveConfig({ ...config, stashes });
+  } else if (wikiName && existing.wikiName !== wikiName) {
+    existing.wikiName = wikiName;
     saveConfig({ ...config, stashes });
   }
 
@@ -101,6 +129,7 @@ async function addWebsiteStashSource(
   stashDir: string,
   name?: string,
   options?: Record<string, unknown>,
+  wikiName?: string,
 ): Promise<AddResponse> {
   const normalizedUrl = validateWebsiteInputUrl(ref);
   const config = loadUserConfig();
@@ -115,12 +144,21 @@ async function addWebsiteStashSource(
       url: normalizedUrl,
       name: name ?? toWebsiteName(normalizedUrl),
       ...(options && Object.keys(options).length > 0 ? { options } : {}),
+      ...(wikiName ? { wikiName } : {}),
     };
     stashes.push(entry);
     saveConfig({ ...config, stashes });
-  } else if (options && Object.keys(options).length > 0) {
-    entry.options = { ...entry.options, ...options };
-    saveConfig({ ...config, stashes });
+  } else {
+    let changed = false;
+    if (options && Object.keys(options).length > 0) {
+      entry.options = { ...entry.options, ...options };
+      changed = true;
+    }
+    if (wikiName && entry.wikiName !== wikiName) {
+      entry.wikiName = wikiName;
+      changed = true;
+    }
+    if (changed) saveConfig({ ...config, stashes });
   }
 
   const cachePaths = await ensureWebsiteMirror(entry, { requireStashDir: true });
@@ -158,6 +196,7 @@ async function addRegistryKit(
   stashDir: string,
   trustThisInstall?: boolean,
   writable?: boolean,
+  wikiName?: string,
 ): Promise<AddResponse> {
   const installed = await installRegistryRef(ref, { trustThisInstall, writable });
   const replaced = (loadConfig().installed ?? []).find((entry) => entry.id === installed.id);
@@ -172,6 +211,7 @@ async function addRegistryKit(
     cacheDir: installed.cacheDir,
     installedAt: installed.installedAt,
     writable: installed.writable,
+    ...(wikiName ? { wikiName } : {}),
   });
 
   await upsertLockEntry({
@@ -255,4 +295,44 @@ function toWebsiteName(siteUrl: string): string {
   } catch {
     return siteUrl;
   }
+}
+
+/**
+ * Derive a wiki name from a ref string when --name is not provided.
+ * Lowercases and slugifies the most meaningful identifier segment.
+ */
+export function deriveWikiNameFromRef(ref: string): string {
+  let candidate = ref;
+
+  // github:owner/repo or github:owner/repo@ref
+  if (/^github:/i.test(ref)) {
+    const repoPath = ref.replace(/^github:/i, "").split("@")[0];
+    candidate = repoPath.split("/").pop() ?? repoPath;
+  }
+  // npm:pkg or @scope/pkg
+  else if (/^npm:/i.test(ref) || ref.startsWith("@")) {
+    candidate = ref
+      .replace(/^npm:/i, "")
+      .replace(/^@[^/]+\//, "")
+      .split("@")[0];
+  }
+  // git URLs or HTTPS git URLs
+  else if (/^(git:|https?:\/\/)/.test(ref)) {
+    try {
+      candidate = new URL(ref).pathname.split("/").pop() ?? candidate;
+    } catch {
+      candidate = ref.split("/").pop() ?? ref;
+    }
+    candidate = candidate.replace(/\.git$/, "");
+  }
+  // Local paths
+  else {
+    candidate = path.basename(ref.replace(/\/+$/, ""));
+  }
+
+  return candidate
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
 }

--- a/src/stash-providers/git.ts
+++ b/src/stash-providers/git.ts
@@ -255,7 +255,7 @@ export interface SaveGitStashResult {
  * When `name` is omitted the primary stash directory is used.
  * When `message` is omitted a timestamp is used.
  */
-export function saveGitStash(name?: string, message?: string): SaveGitStashResult {
+export function saveGitStash(name?: string, message?: string, writableOverride?: boolean): SaveGitStashResult {
   const timestamp = new Date().toISOString().replace("T", " ").slice(0, 19);
   const commitMessage = message?.trim() || `akm save ${timestamp}`;
 
@@ -275,6 +275,10 @@ export function saveGitStash(name?: string, message?: string): SaveGitStashResul
     writable = stash.writable === true;
   } else {
     repoDir = resolveStashDir({ readOnly: true });
+    // Allow caller to override writable for the primary stash (e.g. from root config.writable)
+    if (writableOverride !== undefined) {
+      writable = writableOverride;
+    }
   }
 
   // No-op: not a git repo

--- a/src/stash-providers/git.ts
+++ b/src/stash-providers/git.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { resolveStashDir } from "../common";
@@ -111,23 +111,38 @@ async function ensureGitMirror(
   }
 }
 
-function cloneRepo(cloneUrl: string, ref: string | null, destDir: string, writable = false): void {
-  if (fs.existsSync(destDir)) fs.rmSync(destDir, { recursive: true, force: true });
+export function cloneRepo(cloneUrl: string, ref: string | null, destDir: string, writable = false): void {
+  // Stage the clone into a sibling temp dir so that a failed clone never
+  // destroys a previously-valid destDir (e.g. when the remote is temporarily
+  // unreachable and we have a valid cached copy).
+  const tmpDir = `${destDir}.tmp-${randomBytes(4).toString("hex")}`;
 
   const args = ["clone", "--depth", "1"];
   if (ref) args.push("--branch", ref);
-  args.push(cloneUrl, destDir);
+  args.push(cloneUrl, tmpDir);
 
   const result = spawnSync("git", args, { encoding: "utf8", timeout: 120_000 });
   if (result.status !== 0) {
+    // Clean up the (possibly partial) temp dir but leave destDir untouched.
+    fs.rmSync(tmpDir, { recursive: true, force: true });
     const err = result.stderr?.trim() || result.error?.message || "unknown error";
     throw new Error(`Failed to clone ${cloneUrl}: ${err}`);
   }
 
-  if (!writable) {
-    // Remove .git directory — we only need the working tree for read-only stashes
-    const gitDir = path.join(destDir, ".git");
-    if (fs.existsSync(gitDir)) fs.rmSync(gitDir, { recursive: true, force: true });
+  try {
+    if (!writable) {
+      // Remove .git directory — we only need the working tree for read-only stashes
+      const gitDir = path.join(tmpDir, ".git");
+      if (fs.existsSync(gitDir)) fs.rmSync(gitDir, { recursive: true, force: true });
+    }
+
+    // Swap: remove the old destDir (if any) then atomically rename tmpDir into place.
+    if (fs.existsSync(destDir)) fs.rmSync(destDir, { recursive: true, force: true });
+    fs.renameSync(tmpDir, destDir);
+  } catch (err) {
+    // Post-clone steps failed — clean up the temp dir to avoid orphaned dirs.
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    throw err;
   }
 }
 

--- a/src/stash-show.ts
+++ b/src/stash-show.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { loadConfig } from "./config";
 import { closeDatabase, openDatabase } from "./db";
@@ -17,6 +18,36 @@ import { insertUsageEvent } from "./usage-events";
 import "./stash-providers/index";
 
 /**
+ * Show a wiki root (no page path) — returns the same payload as
+ * `akm wiki show <name>`.
+ *
+ * Called when `parseAssetRef` yields `type === "wiki"` and the name has no
+ * `/`, e.g. `wiki:research`.
+ */
+async function showWikiRoot(stashDir: string, wikiName: string): Promise<ShowResponse> {
+  const { showWiki, resolveWikiDir } = await import("./wiki.js");
+  const wikiDir = resolveWikiDir(stashDir, wikiName);
+  if (!fs.existsSync(wikiDir)) {
+    throw new NotFoundError(`Wiki not found: ${wikiName}. Run \`akm wiki create ${wikiName}\` to create it.`);
+  }
+  const result = showWiki(stashDir, wikiName);
+  // Shape the WikiShowResult into a ShowResponse-compatible object.
+  // The payload mirrors what `akm wiki show <name>` returns.
+  return {
+    type: "wiki",
+    name: result.ref,
+    path: result.path,
+    ...(result.description ? { description: result.description } : {}),
+    origin: null,
+    editable: false,
+    pages: result.pages,
+    raws: result.raws,
+    ...(result.lastModified ? { lastModified: result.lastModified } : {}),
+    recentLog: result.recentLog,
+  } as unknown as ShowResponse;
+}
+
+/**
  * Unified show: tries local FTS5 index first, then remote providers.
  *
  * When `detail` is `"summary"`, the response omits content/template/prompt and
@@ -28,6 +59,17 @@ export async function akmShowUnified(input: {
   detail?: ShowDetailLevel;
 }): Promise<ShowResponse> {
   const ref = input.ref.trim();
+
+  // 0. Wiki-root shortcut: `wiki:<name>` with no page path routes to the
+  //    wiki summary (same payload as `akm wiki show <name>`).
+  {
+    const parsed = parseAssetRef(ref);
+    if (parsed.type === "wiki" && !parsed.name.includes("/")) {
+      const { resolveStashDir } = await import("./common.js");
+      const stashDir = resolveStashDir({ readOnly: true });
+      return showWikiRoot(stashDir, parsed.name);
+    }
+  }
 
   // 1. Try local filesystem first (FTS5 index lookup)
   let localError: Error | undefined;

--- a/src/stash-show.ts
+++ b/src/stash-show.ts
@@ -61,13 +61,27 @@ export async function akmShowUnified(input: {
   const ref = input.ref.trim();
 
   // 0. Wiki-root shortcut: `wiki:<name>` with no page path routes to the
-  //    wiki summary (same payload as `akm wiki show <name>`).
+  //    wiki summary (same payload as `akm wiki show <name>`). Honour
+  //    `parsed.origin` by resolving against the matching stash source(s),
+  //    falling back to the primary stash when no origin is given.
   {
     const parsed = parseAssetRef(ref);
     if (parsed.type === "wiki" && !parsed.name.includes("/")) {
-      const { resolveStashDir } = await import("./common.js");
-      const stashDir = resolveStashDir({ readOnly: true });
-      return showWikiRoot(stashDir, parsed.name);
+      const allSources = resolveStashSources();
+      const searchSources = resolveSourcesForOrigin(parsed.origin, allSources);
+      let lastError: NotFoundError | undefined;
+      for (const source of searchSources) {
+        try {
+          return await showWikiRoot(source.path, parsed.name);
+        } catch (err) {
+          if (!(err instanceof NotFoundError)) throw err;
+          lastError = err;
+        }
+      }
+      throw (
+        lastError ??
+        new NotFoundError(`Wiki not found: ${parsed.name}. Run \`akm wiki create ${parsed.name}\` to create it.`)
+      );
     }
   }
 

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -134,8 +134,15 @@ export function buildShellExportScript(vaultPath: string): string {
  * values that contain no characters requiring escaping (see quoteValue for
  * the full rule set). Values containing newlines or both quote types are
  * rejected outright. Round-trip safety is enforced by the test suite.
+ *
+ * When `comment` is provided it is written as a `# <comment>` line
+ * immediately before the `KEY=value` line:
+ *  - New key: the comment line is inserted just before the appended key.
+ *  - Existing key: if the preceding line is already a comment it is replaced
+ *    with the new comment; otherwise a new comment line is inserted.
+ * When `comment` is absent the surrounding comment lines are left unchanged.
  */
-export function setKey(vaultPath: string, key: string, value: string): void {
+export function setKey(vaultPath: string, key: string, value: string, comment?: string): void {
   validateKeyName(key);
   ensureParentDir(vaultPath);
   const existing = fs.existsSync(vaultPath) ? fs.readFileSync(vaultPath, "utf8") : "";
@@ -148,12 +155,31 @@ export function setKey(vaultPath: string, key: string, value: string): void {
     if (m && m[1] === key) {
       lines[i] = formatted;
       replaced = true;
+      if (comment !== undefined) {
+        const commentLine = `# ${comment}`;
+        const prevIsComment = i > 0 && lines[i - 1].trimStart().startsWith("#");
+        if (prevIsComment) {
+          lines[i - 1] = commentLine;
+        } else {
+          lines.splice(i, 0, commentLine);
+        }
+      }
       break;
     }
   }
 
   if (!replaced) {
-    if (lines.length > 0 && lines[lines.length - 1] === "") {
+    if (comment !== undefined) {
+      const commentLine = `# ${comment}`;
+      if (lines.length > 0 && lines[lines.length - 1] === "") {
+        lines[lines.length - 1] = commentLine;
+        lines.push(formatted);
+        lines.push("");
+      } else {
+        lines.push(commentLine);
+        lines.push(formatted);
+      }
+    } else if (lines.length > 0 && lines[lines.length - 1] === "") {
       lines[lines.length - 1] = formatted;
       lines.push("");
     } else {

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -80,7 +80,7 @@ export function validateWikiName(name: string): void {
   if (!name) throw new UsageError("Wiki name cannot be empty.");
   if (!WIKI_NAME_RE.test(name)) {
     throw new UsageError(
-      `Invalid wiki name "${name}". Use lowercase letters, digits, and hyphens (must start with a letter or digit).`,
+      `Invalid wiki name "${name}". Use lowercase letters, digits, and hyphens (must start with a lowercase letter or digit).`,
     );
   }
 }
@@ -543,6 +543,7 @@ export async function searchInWiki(input: WikiSearchInput): Promise<SearchRespon
     limit: input.limit,
     source: "stash",
   });
+  const rawDir = path.join(wikiDir, RAW_SUBDIR);
   const filtered: StashSearchHit[] = [];
   for (const hit of response.hits) {
     // hits can be StashSearchHit or RegistrySearchResultHit (union); filter
@@ -551,6 +552,11 @@ export async function searchInWiki(input: WikiSearchInput): Promise<SearchRespon
     const stashHit = hit as StashSearchHit;
     if (!stashHit.path) continue;
     if (!isWithin(stashHit.path, wikiDir)) continue;
+    // Exclude infrastructure files: schema.md, index.md, log.md at wiki root
+    const basename = path.basename(stashHit.path);
+    if (WIKI_SPECIAL_FILES.has(basename) && path.dirname(stashHit.path) === wikiDir) continue;
+    // Exclude anything under raw/
+    if (isWithin(stashHit.path, rawDir)) continue;
     filtered.push(stashHit);
   }
   return { ...response, hits: filtered, registryHits: undefined };
@@ -645,6 +651,13 @@ export interface StashRawInput {
    * derived from the content's first non-empty line.
    */
   preferredName?: string;
+  /**
+   * When `true`, the caller explicitly supplied a slug via `--as`. If the
+   * derived slug already exists, throw a `UsageError` rather than
+   * auto-incrementing. When `false` or `undefined`, the legacy auto-increment
+   * behaviour is preserved.
+   */
+  explicitSlug?: boolean;
 }
 
 export interface StashRawResult {
@@ -674,6 +687,11 @@ export function stashRaw(input: StashRawInput): StashRawResult {
   fs.mkdirSync(rawDir, { recursive: true });
 
   const baseSlug = slugifyForWiki(input.preferredName ?? deriveQueryFromSource(input.content) ?? "source");
+  if (input.explicitSlug === true && fs.existsSync(path.join(rawDir, `${baseSlug}.md`))) {
+    throw new UsageError(
+      `Raw slug "${baseSlug}" already exists in wiki:${input.wikiName}. Pass a different --as or omit --as to auto-increment.`,
+    );
+  }
   const slug = pickUniqueRawSlug(rawDir, baseSlug);
   const absPath = path.join(rawDir, `${slug}.md`);
   if (!isWithin(absPath, rawDir)) {
@@ -690,7 +708,13 @@ export function stashRaw(input: StashRawInput): StashRawResult {
 
 // ── Lint ────────────────────────────────────────────────────────────────────
 
-export type WikiLintKind = "orphan" | "broken-xref" | "missing-description" | "uncited-raw" | "stale-index";
+export type WikiLintKind =
+  | "orphan"
+  | "broken-xref"
+  | "missing-description"
+  | "uncited-raw"
+  | "stale-index"
+  | "broken-source";
 
 export interface WikiLintFinding {
   kind: WikiLintKind;
@@ -784,6 +808,23 @@ export function lintWiki(stashDir: string, name: string): WikiLintReport {
         refs: [`wiki:${name}/raw/${base}`],
         message: `Raw source raw/${base}.md is not cited by any page's sources: frontmatter.`,
       });
+    }
+  }
+
+  // broken-source: each page's sources: entries must resolve to an existing raw file.
+  for (const page of pages) {
+    for (const src of page.sources ?? []) {
+      const match = src.match(/^raw\/([^/\s]+?)(?:\.md)?$/);
+      if (!match) continue; // non-raw source entries are out of scope
+      const slug = match[1];
+      const rawFilePath = path.join(wikiDir, RAW_SUBDIR, `${slug}.md`);
+      if (!fs.existsSync(rawFilePath)) {
+        findings.push({
+          kind: "broken-source",
+          refs: [page.ref],
+          message: `Page "${page.ref}" references missing raw source "raw/${slug}".`,
+        });
+      }
     }
   }
 

--- a/src/workflow-cli.ts
+++ b/src/workflow-cli.ts
@@ -8,7 +8,16 @@ export const WORKFLOW_STEP_STATES: Array<Exclude<WorkflowRunStepStatus, "pending
   "skipped",
 ];
 
-export const WORKFLOW_SUBCOMMANDS = new Set(["start", "next", "complete", "status", "list", "create", "template"]);
+export const WORKFLOW_SUBCOMMANDS = new Set([
+  "start",
+  "next",
+  "complete",
+  "status",
+  "list",
+  "create",
+  "template",
+  "resume",
+]);
 
 export function parseWorkflowJsonObject(
   raw: string | undefined,

--- a/src/workflow-runs.ts
+++ b/src/workflow-runs.ts
@@ -70,7 +70,9 @@ export interface WorkflowNextResult {
     title: string;
     steps: WorkflowRunStepState[];
   };
-  step?: WorkflowRunStepState;
+  step: WorkflowRunStepState | null;
+  done?: true;
+  autoStarted?: true;
 }
 
 export interface CompleteWorkflowStepInput {
@@ -150,7 +152,7 @@ export function listWorkflowRuns(input?: { workflowRef?: string; activeOnly?: bo
       params.push(`${parsed.origin ? `${parsed.origin}//` : ""}workflow:${parsed.name}`);
     }
     if (input?.activeOnly) {
-      filters.push("status = 'active'");
+      filters.push("status IN ('active', 'blocked')");
     }
     const where = filters.length > 0 ? `WHERE ${filters.join(" AND ")}` : "";
     const rows = workflowDb
@@ -162,12 +164,16 @@ export function listWorkflowRuns(input?: { workflowRef?: string; activeOnly?: bo
   }
 }
 
-export async function getNextWorkflowStep(specifier: string): Promise<WorkflowNextResult> {
+export async function getNextWorkflowStep(
+  specifier: string,
+  params?: Record<string, unknown>,
+): Promise<WorkflowNextResult> {
   const workflowDb = openWorkflowDatabase();
   try {
-    const run = await resolveRunSpecifier(workflowDb, specifier);
+    const { run, autoStarted } = await resolveRunSpecifier(workflowDb, specifier, params);
     const steps = readWorkflowRunSteps(workflowDb, run.id);
     const currentStep = resolveCurrentStep(run, steps);
+    const done = run.status === "completed" ? (true as const) : undefined;
     return {
       run: toWorkflowRunSummary(run),
       workflow: {
@@ -175,8 +181,32 @@ export async function getNextWorkflowStep(specifier: string): Promise<WorkflowNe
         title: run.workflow_title,
         steps: steps.map(toWorkflowRunStepState),
       },
-      ...(currentStep ? { step: toWorkflowRunStepState(currentStep) } : {}),
+      step: currentStep ? toWorkflowRunStepState(currentStep) : null,
+      ...(done ? { done } : {}),
+      ...(autoStarted ? { autoStarted } : {}),
     };
+  } finally {
+    closeWorkflowDatabase(workflowDb);
+  }
+}
+
+export function resumeWorkflowRun(runId: string): WorkflowRunDetail {
+  const workflowDb = openWorkflowDatabase();
+  try {
+    const run = readWorkflowRun(workflowDb, runId);
+    if (run.status === "completed") {
+      throw new UsageError(`Workflow run ${run.id} is already completed and cannot be resumed.`);
+    }
+    if (run.status === "active") {
+      const steps = readWorkflowRunSteps(workflowDb, run.id);
+      return buildWorkflowRunDetail(run, steps);
+    }
+    // blocked or failed → flip back to active
+    const now = new Date().toISOString();
+    workflowDb.prepare("UPDATE workflow_runs SET status = 'active', updated_at = ? WHERE id = ?").run(now, run.id);
+    const updated: WorkflowRunRow = { ...run, status: "active", updated_at: now };
+    const steps = readWorkflowRunSteps(workflowDb, run.id);
+    return buildWorkflowRunDetail(updated, steps);
   } finally {
     closeWorkflowDatabase(workflowDb);
   }
@@ -249,11 +279,22 @@ export function completeWorkflowStep(input: CompleteWorkflowStepInput): Workflow
   }
 }
 
-async function resolveRunSpecifier(db: import("bun:sqlite").Database, specifier: string): Promise<WorkflowRunRow> {
+async function resolveRunSpecifier(
+  db: import("bun:sqlite").Database,
+  specifier: string,
+  params?: Record<string, unknown>,
+): Promise<{ run: WorkflowRunRow; autoStarted: boolean }> {
   const explicitRun = db.prepare("SELECT * FROM workflow_runs WHERE id = ?").get(specifier) as
     | WorkflowRunRow
     | undefined;
-  if (explicitRun) return explicitRun;
+  if (explicitRun) {
+    if (params && Object.keys(params).length > 0) {
+      throw new UsageError(
+        `--params can only be set on a new run; ${explicitRun.workflow_ref} already has an active run`,
+      );
+    }
+    return { run: explicitRun, autoStarted: false };
+  }
 
   const parsed = parseAssetRef(specifier);
   if (parsed.type !== "workflow") {
@@ -265,10 +306,15 @@ async function resolveRunSpecifier(db: import("bun:sqlite").Database, specifier:
       "SELECT * FROM workflow_runs WHERE workflow_ref = ? AND status = 'active' ORDER BY updated_at DESC LIMIT 1",
     )
     .get(ref) as WorkflowRunRow | undefined;
-  if (active) return active;
+  if (active) {
+    if (params && Object.keys(params).length > 0) {
+      throw new UsageError(`--params can only be set on a new run; ${ref} already has an active run`);
+    }
+    return { run: active, autoStarted: false };
+  }
 
-  const started = await startWorkflowRun(ref);
-  return readWorkflowRun(db, started.run.id);
+  const started = await startWorkflowRun(ref, params ?? {});
+  return { run: readWorkflowRun(db, started.run.id), autoStarted: true };
 }
 
 async function loadWorkflowAsset(ref: string): Promise<WorkflowAsset> {

--- a/src/workflow-runs.ts
+++ b/src/workflow-runs.ts
@@ -290,7 +290,7 @@ async function resolveRunSpecifier(
   if (explicitRun) {
     if (params && Object.keys(params).length > 0) {
       throw new UsageError(
-        `--params can only be set on a new run; ${explicitRun.workflow_ref} already has an active run`,
+        `--params can only be used when starting a new run from a workflow ref, not with an existing run id ("${specifier}")`,
       );
     }
     return { run: explicitRun, autoStarted: false };

--- a/tests/git-provider-clone.test.ts
+++ b/tests/git-provider-clone.test.ts
@@ -1,0 +1,59 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { cloneRepo } from "../src/stash-providers/git";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const createdTmpDirs: string[] = [];
+
+function makeTempDir(prefix = "akm-clone-test-"): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  createdTmpDirs.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of createdTmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("cloneRepo: safe staging on failure", () => {
+  test("leaves an existing destDir untouched when the remote is unreachable", () => {
+    const destDir = makeTempDir("akm-clone-dest-");
+
+    // Seed destDir with a sentinel file that proves the directory was already
+    // populated before the failed clone attempt.
+    const sentinelPath = path.join(destDir, "sentinel.txt");
+    fs.writeFileSync(sentinelPath, "cached-content", "utf8");
+
+    // A bogus git URL that will never succeed (no service listening on port 1).
+    const bogusUrl = "git://127.0.0.1:1/nothing.git";
+
+    // The clone must throw — network is down.
+    expect(() => cloneRepo(bogusUrl, null, destDir)).toThrow();
+
+    // Critical assertion: the previously-valid destDir must still be intact.
+    expect(fs.existsSync(sentinelPath)).toBe(true);
+    expect(fs.readFileSync(sentinelPath, "utf8")).toBe("cached-content");
+  });
+
+  test("does not leave orphaned temp dirs after a failed clone", () => {
+    const parentDir = makeTempDir("akm-clone-parent-");
+    const destDir = path.join(parentDir, "repo");
+    // destDir does not pre-exist — fresh clone scenario.
+
+    const bogusUrl = "git://127.0.0.1:1/nothing.git";
+
+    expect(() => cloneRepo(bogusUrl, null, destDir)).toThrow();
+
+    // Ensure no .tmp-* sibling was left behind.
+    const siblings = fs.readdirSync(parentDir);
+    const tmpSiblings = siblings.filter((f) => f.includes(".tmp-"));
+    expect(tmpSiblings).toHaveLength(0);
+  });
+});

--- a/tests/save-trust-qa-fixes.test.ts
+++ b/tests/save-trust-qa-fixes.test.ts
@@ -1,0 +1,302 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix = "akm-sqafix-"): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const xdgCache = makeTempDir("akm-sqafix-cache-");
+const xdgConfig = makeTempDir("akm-sqafix-config-");
+const isolatedHome = makeTempDir("akm-sqafix-home-");
+
+const repoRoot = path.resolve(import.meta.dir, "..");
+const cliPath = path.join(repoRoot, "src", "cli.ts");
+
+function runCli(
+  args: string[],
+  extraEnv: Record<string, string | undefined> = {},
+): { stdout: string; stderr: string; status: number } {
+  const result = spawnSync("bun", [cliPath, ...args], {
+    encoding: "utf8",
+    timeout: 30_000,
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: isolatedHome,
+      XDG_CACHE_HOME: xdgCache,
+      XDG_CONFIG_HOME: xdgConfig,
+      AKM_STASH_DIR: undefined,
+      ...extraEnv,
+    },
+  });
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    status: result.status ?? 1,
+  };
+}
+
+// ── Test 1 & 2: akm save --format json (space-separated and = form) ──────────
+
+describe("save command: --format flag not consumed as positional name", () => {
+  test("1. akm save --format json returns JSON, not stash-name error", () => {
+    const stashDir = makeTempDir("akm-sqafix-stash-");
+    // Initialize a git repo in stashDir so save has something to work with
+    spawnSync("git", ["init", stashDir], { encoding: "utf8" });
+
+    const { stdout, stderr, status } = runCli(["save", "--format", "json"], {
+      AKM_STASH_DIR: stashDir,
+    });
+
+    // Should NOT produce the "No git stash found with name 'json'" error
+    expect(stderr).not.toContain('No git stash found with name "json"');
+    expect(stderr).not.toContain("No git stash found");
+    // Exit 0 (nothing to commit or committed) or the output is valid JSON
+    if (status === 0) {
+      const parsed = JSON.parse(stdout.trim());
+      expect(parsed).toHaveProperty("committed");
+    } else {
+      // May fail if stash dir env not found, but should NOT be a stash-name error
+      expect(stderr).not.toContain('"json"');
+    }
+  });
+
+  test("2. akm save --format=json still works (eq form)", () => {
+    const stashDir = makeTempDir("akm-sqafix-stash2-");
+    spawnSync("git", ["init", stashDir], { encoding: "utf8" });
+
+    const { stdout, stderr, status } = runCli(["save", "--format=json"], {
+      AKM_STASH_DIR: stashDir,
+    });
+
+    expect(stderr).not.toContain('No git stash found with name "json"');
+    if (status === 0) {
+      const parsed = JSON.parse(stdout.trim());
+      expect(parsed).toHaveProperty("committed");
+    }
+  });
+
+  test("3. akm save my-stash --format json routes correctly (name = my-stash)", () => {
+    // We don't have a real stash named my-stash, so we expect an error about
+    // "my-stash" not found — NOT about "json" not found.
+    const stashDir = makeTempDir("akm-sqafix-stash3-");
+    const { stderr } = runCli(["save", "my-stash", "--format", "json"], {
+      AKM_STASH_DIR: stashDir,
+    });
+
+    // Error should mention "my-stash", not "json"
+    if (stderr.includes("No git stash found")) {
+      expect(stderr).toContain("my-stash");
+      expect(stderr).not.toContain('"json"');
+    }
+  });
+});
+
+// ── Test 4: Primary stash with writable:true pushes on save ──────────────────
+
+describe("save command: primary stash respects root-level writable config", () => {
+  test(
+    "4. primary stash with writable:true in config pushes when remote is configured",
+    () => {
+      // Create a bare remote repo
+      const bareDir = makeTempDir("akm-sqafix-bare-");
+      spawnSync("git", ["init", "--bare", bareDir], { encoding: "utf8" });
+
+      // Create the primary stash as a git repo with the bare remote
+      const stashDir = makeTempDir("akm-sqafix-primary-");
+      spawnSync("git", ["init", stashDir], { encoding: "utf8" });
+      spawnSync("git", ["-C", stashDir, "remote", "add", "origin", bareDir], { encoding: "utf8" });
+      // Create an initial file so the repo is non-empty
+      fs.writeFileSync(path.join(stashDir, "skill.md"), "# skill\n");
+      spawnSync("git", ["-C", stashDir, "-c", "user.name=test", "-c", "user.email=test@local", "add", "-A"], {
+        encoding: "utf8",
+      });
+      spawnSync(
+        "git",
+        ["-C", stashDir, "-c", "user.name=test", "-c", "user.email=test@local", "commit", "-m", "init"],
+        { encoding: "utf8" },
+      );
+      spawnSync("git", ["-C", stashDir, "push", "--set-upstream", "origin", "master"], { encoding: "utf8" });
+      spawnSync("git", ["-C", stashDir, "push", "--set-upstream", "origin", "main"], { encoding: "utf8" });
+
+      // Write a config with writable:true and stashDir pointing to our git repo
+      const configDir = makeTempDir("akm-sqafix-cfg-");
+      const configPath = path.join(configDir, "config.json");
+      fs.writeFileSync(configPath, JSON.stringify({ semanticSearchMode: "off", writable: true }));
+
+      // Write a new file to commit and push
+      fs.writeFileSync(path.join(stashDir, "new-skill.md"), "# new skill\n");
+
+      const { stdout, status } = runCli(["save", "-m", "test push"], {
+        AKM_STASH_DIR: stashDir,
+        AKM_CONFIG_DIR: configDir,
+        HOME: makeTempDir("akm-sqafix-home2-"),
+        XDG_CONFIG_HOME: configDir,
+      });
+
+      // Should have committed and pushed
+      if (status === 0) {
+        const parsed = JSON.parse(stdout.trim());
+        expect(parsed.committed).toBe(true);
+        expect(parsed.pushed).toBe(true);
+      }
+      // Verify the remote received the push by checking it has commits
+      const logResult = spawnSync("git", ["--git-dir", bareDir, "log", "--oneline"], { encoding: "utf8" });
+      // If push succeeded, log should have at least the push commit
+      expect(logResult.stdout.trim().length).toBeGreaterThan(0);
+    },
+    { timeout: 30_000 },
+  );
+});
+
+// ── Test 5 & 6 & 7: akm add --trust warnings and audit ───────────────────────
+
+describe("stash-add: --trust warning for local paths", () => {
+  test("6. akm add <local-dir> --trust emits warning about no effect", () => {
+    const localDir = makeTempDir("akm-sqafix-local-");
+    // Create a minimal skill so the dir is a valid stash root
+    const skillsDir = path.join(localDir, "skills");
+    fs.mkdirSync(skillsDir, { recursive: true });
+    fs.writeFileSync(path.join(skillsDir, "test.md"), "# test skill\n");
+
+    const stashDir = makeTempDir("akm-sqafix-add-stash-");
+
+    const { stderr, status } = runCli(["add", localDir, "--trust"], {
+      AKM_STASH_DIR: stashDir,
+    });
+
+    // Should emit the clarifying warning on stderr
+    expect(stderr).toContain("--trust has no effect on local directory sources");
+    // Should still succeed
+    expect(status).toBe(0);
+  });
+
+  test("7. akm add <blocked-source> without --trust includes --trust in error message", () => {
+    // Use a local dir with a "malicious" content to trigger the audit block.
+    // We simulate by checking the install-audit error message text directly
+    // via formatInstallAuditFailure (unit-level check).
+    const { formatInstallAuditFailure } = require("../src/install-audit");
+    const fakeReport = {
+      enabled: true,
+      passed: false,
+      blocked: true,
+      trusted: false,
+      registryLabels: [],
+      findings: [
+        {
+          id: "remote-shell-pipe",
+          severity: "critical",
+          category: "malicious-code",
+          message: "Downloads remote content and pipes it directly into a shell.",
+        },
+      ],
+      scannedFiles: 1,
+      scannedBytes: 100,
+      summary: { low: 0, moderate: 0, high: 0, critical: 1, total: 1 },
+    };
+    const msg = formatInstallAuditFailure("test:pkg", fakeReport);
+    expect(msg).toContain("--trust");
+  });
+});
+
+// ── Test: install-audit formatInstallAuditFailure mentions --trust ────────────
+
+describe("install-audit: block error mentions --trust", () => {
+  test("block error message includes --trust as remediation", async () => {
+    const { formatInstallAuditFailure } = await import("../src/install-audit");
+    const fakeReport = {
+      enabled: true,
+      passed: false,
+      blocked: true,
+      trusted: false,
+      registryLabels: [],
+      findings: [
+        {
+          id: "remote-shell-pipe",
+          severity: "critical" as const,
+          category: "malicious-code" as const,
+          message: "Downloads remote content and pipes it directly into a shell.",
+        },
+      ],
+      scannedFiles: 1,
+      scannedBytes: 100,
+      summary: { low: 0, moderate: 0, high: 0, critical: 1, total: 1 },
+    };
+    const msg = formatInstallAuditFailure("test:pkg", fakeReport);
+    expect(msg).toContain("--trust");
+    expect(msg).toContain("bypass this audit");
+  });
+});
+
+// ── Test: config.ts root-level writable field is parsed ──────────────────────
+
+describe("config: root-level writable field", () => {
+  test("writable:true in config.json is loaded correctly", async () => {
+    const { loadConfig, resetConfigCache } = await import("../src/config");
+
+    // XDG_CONFIG_HOME -> akm subdir -> config.json
+    const xdgDir = makeTempDir("akm-sqafix-cfgtest-");
+    const akmConfigDir = path.join(xdgDir, "akm");
+    fs.mkdirSync(akmConfigDir, { recursive: true });
+    const configPath = path.join(akmConfigDir, "config.json");
+    fs.writeFileSync(configPath, JSON.stringify({ semanticSearchMode: "off", writable: true }));
+
+    // Use AKM_CONFIG_DIR env override (most direct override)
+    const origEnv = { AKM_CONFIG_DIR: process.env.AKM_CONFIG_DIR };
+    process.env.AKM_CONFIG_DIR = akmConfigDir;
+    resetConfigCache();
+
+    try {
+      const cfg = loadConfig();
+      expect(cfg.writable).toBe(true);
+    } finally {
+      if (origEnv.AKM_CONFIG_DIR === undefined) {
+        delete process.env.AKM_CONFIG_DIR;
+      } else {
+        process.env.AKM_CONFIG_DIR = origEnv.AKM_CONFIG_DIR;
+      }
+      resetConfigCache();
+    }
+  });
+
+  test("writable not set defaults to undefined (falsy)", async () => {
+    const { loadConfig, resetConfigCache } = await import("../src/config");
+
+    const xdgDir2 = makeTempDir("akm-sqafix-cfgtest2-");
+    const akmConfigDir2 = path.join(xdgDir2, "akm");
+    fs.mkdirSync(akmConfigDir2, { recursive: true });
+    const configPath = path.join(akmConfigDir2, "config.json");
+    fs.writeFileSync(configPath, JSON.stringify({ semanticSearchMode: "off" }));
+
+    const origEnv = { AKM_CONFIG_DIR: process.env.AKM_CONFIG_DIR };
+    process.env.AKM_CONFIG_DIR = akmConfigDir2;
+    resetConfigCache();
+
+    try {
+      const cfg = loadConfig();
+      expect(cfg.writable).toBeUndefined();
+    } finally {
+      if (origEnv.AKM_CONFIG_DIR === undefined) {
+        delete process.env.AKM_CONFIG_DIR;
+      } else {
+        process.env.AKM_CONFIG_DIR = origEnv.AKM_CONFIG_DIR;
+      }
+      resetConfigCache();
+    }
+  });
+});

--- a/tests/save-trust-qa-fixes.test.ts
+++ b/tests/save-trust-qa-fixes.test.ts
@@ -105,6 +105,22 @@ describe("save command: --format flag not consumed as positional name", () => {
       expect(stderr).not.toContain('"json"');
     }
   });
+
+  test("3b. akm save json --format json keeps 'json' as the positional stash name", () => {
+    // Edge case: the legitimate stash name happens to equal the --format value.
+    // argv-order check should detect this isn't a mis-parse (positional appears
+    // BEFORE --format) and route "json" as the stash name, not the primary.
+    const stashDir = makeTempDir("akm-sqafix-stash3b-");
+    const { stderr } = runCli(["save", "json", "--format", "json"], {
+      AKM_STASH_DIR: stashDir,
+    });
+
+    // The real stash named "json" doesn't exist, so we expect "No git stash found"
+    // referencing "json" by name — not a primary-stash success.
+    if (stderr.includes("No git stash found")) {
+      expect(stderr).toContain("json");
+    }
+  });
 });
 
 // ── Test 4: Primary stash with writable:true pushes on save ──────────────────

--- a/tests/vault-load-error.test.ts
+++ b/tests/vault-load-error.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix = "akm-vault-load-"): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const xdgCache = makeTempDir("akm-vle-cache-");
+const xdgConfig = makeTempDir("akm-vle-config-");
+const isolatedHome = makeTempDir("akm-vle-home-");
+
+const repoRoot = path.resolve(import.meta.dir, "..");
+const cliPath = path.join(repoRoot, "src", "cli.ts");
+
+function runCli(
+  args: string[],
+  extraEnv: Record<string, string | undefined> = {},
+): { stdout: string; stderr: string; status: number } {
+  const result = spawnSync("bun", [cliPath, ...args], {
+    encoding: "utf8",
+    timeout: 15_000,
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: isolatedHome,
+      XDG_CACHE_HOME: xdgCache,
+      XDG_CONFIG_HOME: xdgConfig,
+      AKM_STASH_DIR: undefined,
+      ...extraEnv,
+    },
+  });
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    status: result.status ?? 1,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("vault load: error envelope", () => {
+  test("returns {ok:false, error} JSON on stderr and exits 1 when vault does not exist", () => {
+    const stashDir = makeTempDir("akm-vle-stash-");
+    // Create the vaults sub-directory so akm resolves paths but the specific
+    // vault file is absent.
+    fs.mkdirSync(path.join(stashDir, "vaults"), { recursive: true });
+
+    const { stdout, stderr, status } = runCli(["vault", "load", "vault:does-not-exist"], {
+      AKM_STASH_DIR: stashDir,
+    });
+
+    // Must exit with code 1 (NotFoundError → EXIT_GENERAL).
+    expect(status).toBe(1);
+
+    // The JSON error envelope must appear on stderr (runWithJsonErrors writes
+    // to console.error).
+    const parsed = JSON.parse(stderr.trim());
+    expect(parsed.ok).toBe(false);
+    expect(typeof parsed.error).toBe("string");
+    expect(parsed.error).toContain("Vault not found");
+
+    // stdout must be empty — no shell snippet should leak on error.
+    expect(stdout.trim()).toBe("");
+  });
+
+  test("emits a shell snippet on stdout (not JSON) when the vault exists", () => {
+    const stashDir = makeTempDir("akm-vle-stash-ok-");
+    fs.mkdirSync(path.join(stashDir, "vaults"), { recursive: true });
+    fs.writeFileSync(path.join(stashDir, "vaults", "myvault.env"), "FOO=bar\n", "utf8");
+
+    const { stdout, stderr, status } = runCli(["vault", "load", "vault:myvault"], {
+      AKM_STASH_DIR: stashDir,
+    });
+
+    // Success path: exit 0 and a sourcing shell snippet on stdout.
+    expect(status).toBe(0);
+    expect(stdout).toContain(". ");
+    expect(stdout).toContain("rm -f");
+    // No error envelope on stderr.
+    expect(stderr.trim()).toBe("");
+  });
+});

--- a/tests/vault-qa-fixes.test.ts
+++ b/tests/vault-qa-fixes.test.ts
@@ -1,0 +1,202 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadEnv, setKey } from "../src/vault";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix = "akm-vqa-"): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const xdgCache = makeTempDir("akm-vqa-cache-");
+const xdgConfig = makeTempDir("akm-vqa-config-");
+const isolatedHome = makeTempDir("akm-vqa-home-");
+
+const repoRoot = path.resolve(import.meta.dir, "..");
+const cliPath = path.join(repoRoot, "src", "cli.ts");
+
+function runCli(
+  args: string[],
+  extraEnv: Record<string, string | undefined> = {},
+): { stdout: string; stderr: string; status: number } {
+  const result = spawnSync("bun", [cliPath, ...args], {
+    encoding: "utf8",
+    timeout: 30_000,
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: isolatedHome,
+      XDG_CACHE_HOME: xdgCache,
+      XDG_CONFIG_HOME: xdgConfig,
+      AKM_STASH_DIR: undefined,
+      ...extraEnv,
+    },
+  });
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    status: result.status ?? 1,
+  };
+}
+
+// ── setKey comment parameter (unit tests) ────────────────────────────────────
+
+describe("setKey: comment parameter", () => {
+  test("1. writes a new key with a leading comment line when comment provided", () => {
+    const dir = makeTempDir();
+    const fp = path.join(dir, "v.env");
+    setKey(fp, "DB_URL", "postgres://localhost/mydb", "database connection string");
+    const text = fs.readFileSync(fp, "utf8");
+    const lines = text.split("\n").filter((l) => l.length > 0);
+    const commentIdx = lines.indexOf("# database connection string");
+    const keyIdx = lines.findIndex((l) => l.startsWith("DB_URL="));
+    expect(commentIdx).toBeGreaterThanOrEqual(0);
+    expect(keyIdx).toBe(commentIdx + 1);
+    expect(loadEnv(fp).DB_URL).toBe("postgres://localhost/mydb");
+  });
+
+  test("2. updates an existing comment line in-place when the key is overwritten with a new comment", () => {
+    const dir = makeTempDir();
+    const fp = path.join(dir, "v.env");
+    fs.writeFileSync(fp, "# old comment\nDB_URL=postgres://old\n");
+    setKey(fp, "DB_URL", "postgres://new", "new comment");
+    const text = fs.readFileSync(fp, "utf8");
+    expect(text).toContain("# new comment");
+    expect(text).not.toContain("# old comment");
+    expect(loadEnv(fp).DB_URL).toBe("postgres://new");
+    // Comment line should immediately precede the key line
+    const lines = text.split("\n").filter((l) => l.length > 0);
+    const commentIdx = lines.indexOf("# new comment");
+    const keyIdx = lines.findIndex((l) => l.startsWith("DB_URL="));
+    expect(keyIdx).toBe(commentIdx + 1);
+  });
+
+  test("3. inserts a new comment before an existing key that lacks one", () => {
+    const dir = makeTempDir();
+    const fp = path.join(dir, "v.env");
+    fs.writeFileSync(fp, "FOO=bar\nDB_URL=postgres://old\nBAZ=qux\n");
+    setKey(fp, "DB_URL", "postgres://new", "injected comment");
+    const text = fs.readFileSync(fp, "utf8");
+    expect(text).toContain("# injected comment");
+    const lines = text.split("\n").filter((l) => l.length > 0);
+    const commentIdx = lines.indexOf("# injected comment");
+    const keyIdx = lines.findIndex((l) => l.startsWith("DB_URL="));
+    expect(keyIdx).toBe(commentIdx + 1);
+    // Other keys preserved
+    expect(loadEnv(fp).FOO).toBe("bar");
+    expect(loadEnv(fp).BAZ).toBe("qux");
+  });
+
+  test("4. without comment does not modify surrounding comments", () => {
+    const dir = makeTempDir();
+    const fp = path.join(dir, "v.env");
+    fs.writeFileSync(fp, "# original comment\nDB_URL=old\n");
+    setKey(fp, "DB_URL", "new");
+    const text = fs.readFileSync(fp, "utf8");
+    expect(text).toContain("# original comment");
+    expect(loadEnv(fp).DB_URL).toBe("new");
+  });
+});
+
+// ── vault show alias (CLI tests) ─────────────────────────────────────────────
+
+describe("vault show: alias for vault list <ref>", () => {
+  test("5. vault show vault:prod matches vault list vault:prod output", () => {
+    const stashDir = makeTempDir("akm-vqa-stash-");
+    fs.mkdirSync(path.join(stashDir, "vaults"), { recursive: true });
+    fs.writeFileSync(
+      path.join(stashDir, "vaults", "prod.env"),
+      "# production keys\nAPI_KEY=secret\nDB_PASS=hidden\n",
+      "utf8",
+    );
+
+    const listResult = runCli(["vault", "list", "vault:prod"], { AKM_STASH_DIR: stashDir });
+    const showResult = runCli(["vault", "show", "vault:prod"], { AKM_STASH_DIR: stashDir });
+
+    expect(listResult.status).toBe(0);
+    expect(showResult.status).toBe(0);
+
+    const listParsed = JSON.parse(listResult.stdout.trim());
+    const showParsed = JSON.parse(showResult.stdout.trim());
+
+    expect(showParsed).toEqual(listParsed);
+  });
+});
+
+// ── vault set combined KEY=VALUE form (CLI tests) ────────────────────────────
+
+describe("vault set: KEY=VALUE combined form", () => {
+  test("6. vault set prod KEY=value succeeds and writes KEY=value", () => {
+    const stashDir = makeTempDir("akm-vqa-stash-");
+    fs.mkdirSync(path.join(stashDir, "vaults"), { recursive: true });
+    fs.writeFileSync(path.join(stashDir, "vaults", "prod.env"), "", "utf8");
+
+    const result = runCli(["vault", "set", "prod", "MY_KEY=myvalue"], { AKM_STASH_DIR: stashDir });
+    expect(result.status).toBe(0);
+
+    const vaultPath = path.join(stashDir, "vaults", "prod.env");
+    expect(loadEnv(vaultPath).MY_KEY).toBe("myvalue");
+  });
+
+  test("7. vault set prod KEY value (3-arg form) still works", () => {
+    const stashDir = makeTempDir("akm-vqa-stash-");
+    fs.mkdirSync(path.join(stashDir, "vaults"), { recursive: true });
+    fs.writeFileSync(path.join(stashDir, "vaults", "prod.env"), "", "utf8");
+
+    const result = runCli(["vault", "set", "prod", "ANOTHER_KEY", "anothervalue"], { AKM_STASH_DIR: stashDir });
+    expect(result.status).toBe(0);
+
+    const vaultPath = path.join(stashDir, "vaults", "prod.env");
+    expect(loadEnv(vaultPath).ANOTHER_KEY).toBe("anothervalue");
+  });
+
+  test("8. vault set prod KEY=val1=val2 writes KEY with value val1=val2 (split on first =)", () => {
+    const stashDir = makeTempDir("akm-vqa-stash-");
+    fs.mkdirSync(path.join(stashDir, "vaults"), { recursive: true });
+    fs.writeFileSync(path.join(stashDir, "vaults", "prod.env"), "", "utf8");
+
+    const result = runCli(["vault", "set", "prod", "COMPLEX_KEY=val1=val2"], { AKM_STASH_DIR: stashDir });
+    expect(result.status).toBe(0);
+
+    const vaultPath = path.join(stashDir, "vaults", "prod.env");
+    expect(loadEnv(vaultPath).COMPLEX_KEY).toBe("val1=val2");
+  });
+});
+
+// ── vault set --comment flag (CLI tests) ─────────────────────────────────────
+
+describe("vault set: --comment flag", () => {
+  test("9. vault set prod KEY val --comment writes a comment line above the key", () => {
+    const stashDir = makeTempDir("akm-vqa-stash-");
+    fs.mkdirSync(path.join(stashDir, "vaults"), { recursive: true });
+    fs.writeFileSync(path.join(stashDir, "vaults", "prod.env"), "", "utf8");
+
+    const result = runCli(["vault", "set", "prod", "AUTH_TOKEN", "tok123", "--comment", "auth secret"], {
+      AKM_STASH_DIR: stashDir,
+    });
+    expect(result.status).toBe(0);
+
+    const vaultPath = path.join(stashDir, "vaults", "prod.env");
+    const text = fs.readFileSync(vaultPath, "utf8");
+    expect(text).toContain("# auth secret");
+    const lines = text.split("\n").filter((l) => l.length > 0);
+    const commentIdx = lines.indexOf("# auth secret");
+    const keyIdx = lines.findIndex((l) => l.startsWith("AUTH_TOKEN="));
+    expect(commentIdx).toBeGreaterThanOrEqual(0);
+    expect(keyIdx).toBe(commentIdx + 1);
+    expect(loadEnv(vaultPath).AUTH_TOKEN).toBe("tok123");
+  });
+});

--- a/tests/wiki-qa-fixes.test.ts
+++ b/tests/wiki-qa-fixes.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Regression tests for the 0.5.0 QA wiki fixes.
+ *
+ * Covers:
+ *   1. searchInWiki excludes schema.md, index.md, log.md, and raw/ files.
+ *   2. stashRaw with explicitSlug: true throws UsageError on collision;
+ *      with explicitSlug: false auto-increments.
+ *   3. lintWiki emits broken-source findings for dangling sources: refs.
+ *   4. validateWikiName error message includes "lowercase".
+ *   5. wiki search on a nonexistent wiki throws NotFoundError.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { UsageError } from "../src/errors";
+import {
+  createWiki,
+  INDEX_MD,
+  LOG_MD,
+  lintWiki,
+  RAW_SUBDIR,
+  SCHEMA_MD,
+  searchInWiki,
+  stashRaw,
+  validateWikiName,
+  WIKIS_SUBDIR,
+} from "../src/wiki";
+
+const tempDirs: string[] = [];
+
+function makeStash(prefix = "akm-wiki-qa-"): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writePage(wikiDir: string, relPath: string, body: string): string {
+  const abs = path.join(wikiDir, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, body, "utf8");
+  return abs;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/**
+ * Set up an isolated stash env for searchInWiki tests.
+ * Returns the stash dir and a cleanup function.
+ */
+function withIsolatedStash(): { stash: string; cleanup: () => void } {
+  const stash = makeStash();
+  const origStash = process.env.AKM_STASH_DIR;
+  const origHome = process.env.XDG_CONFIG_HOME;
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "akm-wiki-qa-home-"));
+  tempDirs.push(tmpHome);
+  process.env.AKM_STASH_DIR = stash;
+  process.env.XDG_CONFIG_HOME = tmpHome;
+  return {
+    stash,
+    cleanup() {
+      if (origStash === undefined) delete process.env.AKM_STASH_DIR;
+      else process.env.AKM_STASH_DIR = origStash;
+      if (origHome === undefined) delete process.env.XDG_CONFIG_HOME;
+      else process.env.XDG_CONFIG_HOME = origHome;
+    },
+  };
+}
+
+// ── 1. searchInWiki excludes infrastructure files ───────────────────────────
+
+describe("searchInWiki — infrastructure file exclusion", () => {
+  test("excludes schema.md, index.md, log.md from results", async () => {
+    const { stash, cleanup } = withIsolatedStash();
+    try {
+      createWiki(stash, "research");
+      const wikiDir = path.join(stash, WIKIS_SUBDIR, "research");
+      writePage(wikiDir, "ml-basics.md", "---\ndescription: Machine learning basics\n---\n# ML Basics\nContent.\n");
+
+      const response = await searchInWiki({
+        stashDir: stash,
+        wikiName: "research",
+        query: "machine learning",
+      });
+      // All returned hits must not be special infrastructure files
+      for (const hit of response.hits) {
+        if (hit.type === "registry") continue;
+        const stashHit = hit as { path?: string };
+        if (!stashHit.path) continue;
+        const basename = path.basename(stashHit.path);
+        expect([SCHEMA_MD, INDEX_MD, LOG_MD]).not.toContain(basename);
+        // Must not be under raw/
+        expect(stashHit.path).not.toContain(`${path.sep}${RAW_SUBDIR}${path.sep}`);
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("does not exclude real page files", async () => {
+    const { stash, cleanup } = withIsolatedStash();
+    try {
+      createWiki(stash, "research");
+      const wikiDir = path.join(stash, WIKIS_SUBDIR, "research");
+      writePage(wikiDir, "valid-page.md", "---\ndescription: A real page\n---\n# Valid\n");
+      // No assertion about hit presence (index may be absent); just no throw.
+      const response = await searchInWiki({
+        stashDir: stash,
+        wikiName: "research",
+        query: "real page",
+      });
+      expect(response).toBeDefined();
+      expect(Array.isArray(response.hits)).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// ── 2. stashRaw explicitSlug collision behaviour ─────────────────────────────
+
+describe("stashRaw — explicitSlug", () => {
+  test("explicitSlug: true throws UsageError on collision", () => {
+    const stash = makeStash();
+    createWiki(stash, "research");
+    // First write succeeds
+    stashRaw({
+      stashDir: stash,
+      wikiName: "research",
+      content: "first",
+      preferredName: "mysource",
+      explicitSlug: true,
+    });
+    // Second write with same slug and explicitSlug: true must throw
+    expect(() =>
+      stashRaw({
+        stashDir: stash,
+        wikiName: "research",
+        content: "second",
+        preferredName: "mysource",
+        explicitSlug: true,
+      }),
+    ).toThrow(UsageError);
+  });
+
+  test("UsageError message mentions the slug, 'already exists', and '--as'", () => {
+    const stash = makeStash();
+    createWiki(stash, "research");
+    stashRaw({ stashDir: stash, wikiName: "research", content: "first", preferredName: "myslug", explicitSlug: true });
+    let caught: Error | undefined;
+    try {
+      stashRaw({
+        stashDir: stash,
+        wikiName: "research",
+        content: "second",
+        preferredName: "myslug",
+        explicitSlug: true,
+      });
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).toBeInstanceOf(UsageError);
+    expect(caught?.message).toContain("myslug");
+    expect(caught?.message).toContain("already exists");
+    expect(caught?.message).toContain("--as");
+  });
+
+  test("explicitSlug: false auto-increments on collision (existing behaviour)", () => {
+    const stash = makeStash();
+    createWiki(stash, "research");
+    const r1 = stashRaw({
+      stashDir: stash,
+      wikiName: "research",
+      content: "a",
+      preferredName: "dup",
+      explicitSlug: false,
+    });
+    const r2 = stashRaw({
+      stashDir: stash,
+      wikiName: "research",
+      content: "b",
+      preferredName: "dup",
+      explicitSlug: false,
+    });
+    expect(r1.slug).toBe("dup");
+    expect(r2.slug).toBe("dup-1");
+  });
+
+  test("explicitSlug: undefined auto-increments (backward-compat)", () => {
+    const stash = makeStash();
+    createWiki(stash, "research");
+    const r1 = stashRaw({ stashDir: stash, wikiName: "research", content: "a", preferredName: "nodups" });
+    const r2 = stashRaw({ stashDir: stash, wikiName: "research", content: "b", preferredName: "nodups" });
+    expect(r1.slug).toBe("nodups");
+    expect(r2.slug).toBe("nodups-1");
+  });
+
+  test("explicitSlug: true on a new slug does NOT throw", () => {
+    const stash = makeStash();
+    createWiki(stash, "research");
+    expect(() =>
+      stashRaw({ stashDir: stash, wikiName: "research", content: "x", preferredName: "brand-new", explicitSlug: true }),
+    ).not.toThrow();
+  });
+});
+
+// ── 3. lintWiki broken-source findings ──────────────────────────────────────
+
+describe("lintWiki — broken-source", () => {
+  test("emits broken-source finding when sources: references a missing raw file", () => {
+    const stash = makeStash();
+    createWiki(stash, "research");
+    const wikiDir = path.join(stash, WIKIS_SUBDIR, "research");
+
+    // Page that references a raw file that doesn't exist
+    writePage(
+      wikiDir,
+      "orphaned-page.md",
+      "---\ndescription: Page with dangling source ref\nxrefs:\n  - wiki:research/orphaned-page\nsources:\n  - raw/ghost-paper\n---\n# Orphaned\n",
+    );
+
+    const report = lintWiki(stash, "research");
+    const brokenSrc = report.findings.filter((f) => f.kind === "broken-source");
+    expect(brokenSrc.length).toBeGreaterThanOrEqual(1);
+    expect(brokenSrc[0].refs[0]).toBe("wiki:research/orphaned-page");
+    expect(brokenSrc[0].message).toContain("ghost-paper");
+  });
+
+  test("does NOT emit broken-source when raw file exists", () => {
+    const stash = makeStash();
+    createWiki(stash, "research");
+    const wikiDir = path.join(stash, WIKIS_SUBDIR, "research");
+
+    // Stash the raw file first
+    stashRaw({ stashDir: stash, wikiName: "research", content: "raw content", preferredName: "real-paper" });
+
+    // Page citing the existing raw file — must NOT trigger broken-source
+    writePage(
+      wikiDir,
+      "good-page.md",
+      "---\ndescription: Page with valid source ref\nxrefs:\n  - wiki:research/good-page\nsources:\n  - raw/real-paper\n---\n# Good\n",
+    );
+
+    const report = lintWiki(stash, "research");
+    const brokenSrc = report.findings.filter((f) => f.kind === "broken-source");
+    expect(brokenSrc.length).toBe(0);
+  });
+
+  test("accepts both 'raw/slug' and 'raw/slug.md' source forms", () => {
+    const stash = makeStash();
+    createWiki(stash, "research");
+    const wikiDir = path.join(stash, WIKIS_SUBDIR, "research");
+
+    stashRaw({ stashDir: stash, wikiName: "research", content: "raw", preferredName: "existing-slug" });
+
+    // Cite with .md extension — should not break
+    writePage(
+      wikiDir,
+      "page-with-ext.md",
+      "---\ndescription: Cites with .md extension\nxrefs:\n  - wiki:research/page-with-ext\nsources:\n  - raw/existing-slug.md\n---\n# Ext\n",
+    );
+
+    const report = lintWiki(stash, "research");
+    const brokenSrc = report.findings.filter((f) => f.kind === "broken-source");
+    expect(brokenSrc.length).toBe(0);
+  });
+});
+
+// ── 4. validateWikiName error message includes "lowercase" ───────────────────
+
+describe("validateWikiName — error message", () => {
+  test("error message says 'lowercase' when name has uppercase letters", () => {
+    let caught: Error | undefined;
+    try {
+      validateWikiName("MyWiki");
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).toBeInstanceOf(UsageError);
+    expect(caught?.message.toLowerCase()).toContain("lowercase");
+  });
+
+  test("error message says 'lowercase' for leading-hyphen names", () => {
+    let caught: Error | undefined;
+    try {
+      validateWikiName("-bad");
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).toBeInstanceOf(UsageError);
+    expect(caught?.message.toLowerCase()).toContain("lowercase");
+  });
+});
+
+// ── 5. searchInWiki on nonexistent wiki throws NotFoundError ─────────────────
+
+describe("searchInWiki — nonexistent wiki", () => {
+  test("throws (via validateWikiName) for invalid wiki names", () => {
+    const stash = makeStash();
+    // An uppercase name fails validateWikiName, which is called by searchInWiki
+    expect(() => searchInWiki({ stashDir: stash, wikiName: "BadName", query: "test" })).toThrow();
+  });
+
+  test("valid-but-missing wiki name returns zero hits (path-filter drops everything)", async () => {
+    // searchInWiki itself does not throw for a valid-but-absent wiki dir — it
+    // just returns zero hits because the path-filter drops all non-wiki-dir
+    // paths. The CLI layer adds the explicit existence check.
+    const { stash, cleanup } = withIsolatedStash();
+    try {
+      const response = await searchInWiki({ stashDir: stash, wikiName: "nonexistent", query: "test" });
+      expect(response.hits).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/tests/workflow-qa-fixes.test.ts
+++ b/tests/workflow-qa-fixes.test.ts
@@ -1,0 +1,398 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const CLI = path.join(__dirname, "..", "src", "cli.ts");
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function createWorkflowEnv(): NodeJS.ProcessEnv {
+  const stashDir = makeTempDir("akm-wfqa-stash-");
+  const xdgCache = makeTempDir("akm-wfqa-cache-");
+  const xdgConfig = makeTempDir("akm-wfqa-config-");
+  return {
+    ...process.env,
+    AKM_STASH_DIR: stashDir,
+    XDG_CACHE_HOME: xdgCache,
+    XDG_CONFIG_HOME: xdgConfig,
+  };
+}
+
+function runCli(args: string[], env: NodeJS.ProcessEnv) {
+  return spawnSync("bun", [CLI, ...args], {
+    encoding: "utf8",
+    timeout: 30_000,
+    env,
+  });
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const TWO_STEP_WORKFLOW = `---
+description: Test workflow
+---
+
+# Workflow: Test Flow
+
+## Step: First Step
+Step ID: first
+
+### Instructions
+Do the first thing.
+
+### Completion Criteria
+- First thing done
+
+## Step: Second Step
+Step ID: second
+
+### Instructions
+Do the second thing.
+`;
+
+function setupWorkflow(env: NodeJS.ProcessEnv, name = "test-flow"): void {
+  const sourceDir = makeTempDir("akm-wfqa-src-");
+  const sourcePath = path.join(sourceDir, "wf.md");
+  fs.writeFileSync(sourcePath, TWO_STEP_WORKFLOW, "utf8");
+  const result = runCli(["workflow", "create", name, "--from", sourcePath], env);
+  if (result.status !== 0) {
+    throw new Error(`Failed to create workflow: ${result.stderr}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. resumeWorkflowRun — blocked → active; fails on completed
+// ---------------------------------------------------------------------------
+describe("workflow resume command", () => {
+  test("resume flips a blocked run back to active", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    const started = runCli(["workflow", "start", "workflow:test-flow"], env);
+    expect(started.status).toBe(0);
+    const { run: startRun } = JSON.parse(started.stdout) as { run: { id: string } };
+
+    // Complete first step as blocked
+    expect(runCli(["workflow", "complete", startRun.id, "--step", "first", "--state", "blocked"], env).status).toBe(0);
+
+    // Verify it's blocked
+    const statusBlocked = runCli(["workflow", "status", startRun.id], env);
+    expect(statusBlocked.status).toBe(0);
+    const { run: blockedRun } = JSON.parse(statusBlocked.stdout) as { run: { status: string } };
+    expect(blockedRun.status).toBe("blocked");
+
+    // Resume it
+    const resumed = runCli(["workflow", "resume", startRun.id], env);
+    expect(resumed.status).toBe(0);
+    const { run: resumedRun } = JSON.parse(resumed.stdout) as { run: { status: string } };
+    expect(resumedRun.status).toBe("active");
+  });
+
+  test("resume on a completed run returns an error", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    const started = runCli(["workflow", "start", "workflow:test-flow"], env);
+    expect(started.status).toBe(0);
+    const { run: startRun } = JSON.parse(started.stdout) as { run: { id: string } };
+
+    expect(runCli(["workflow", "complete", startRun.id, "--step", "first"], env).status).toBe(0);
+    expect(runCli(["workflow", "complete", startRun.id, "--step", "second"], env).status).toBe(0);
+
+    const resumed = runCli(["workflow", "resume", startRun.id], env);
+    expect(resumed.status).toBe(2);
+    const err = JSON.parse(resumed.stderr) as { error: string };
+    expect(err.error).toContain("already completed");
+  });
+
+  test("resume on a failed run flips it to active", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    const started = runCli(["workflow", "start", "workflow:test-flow"], env);
+    expect(started.status).toBe(0);
+    const { run: startRun } = JSON.parse(started.stdout) as { run: { id: string } };
+
+    expect(runCli(["workflow", "complete", startRun.id, "--step", "first", "--state", "failed"], env).status).toBe(0);
+
+    const resumed = runCli(["workflow", "resume", startRun.id], env);
+    expect(resumed.status).toBe(0);
+    const { run: resumedRun } = JSON.parse(resumed.stdout) as { run: { status: string } };
+    expect(resumedRun.status).toBe("active");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. listWorkflowRuns --active includes blocked runs
+// ---------------------------------------------------------------------------
+describe("workflow list --active includes blocked", () => {
+  test("blocked run appears in --active list", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    const started = runCli(["workflow", "start", "workflow:test-flow"], env);
+    expect(started.status).toBe(0);
+    const { run: startRun } = JSON.parse(started.stdout) as { run: { id: string } };
+
+    expect(runCli(["workflow", "complete", startRun.id, "--step", "first", "--state", "blocked"], env).status).toBe(0);
+
+    const listed = runCli(["workflow", "list", "--ref", "workflow:test-flow", "--active"], env);
+    expect(listed.status).toBe(0);
+    const { runs } = JSON.parse(listed.stdout) as { runs: Array<{ id: string; status: string }> };
+    expect(runs.some((r) => r.id === startRun.id && r.status === "blocked")).toBe(true);
+  });
+
+  test("completed run does NOT appear in --active list", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    const started = runCli(["workflow", "start", "workflow:test-flow"], env);
+    expect(started.status).toBe(0);
+    const { run: startRun } = JSON.parse(started.stdout) as { run: { id: string } };
+
+    expect(runCli(["workflow", "complete", startRun.id, "--step", "first"], env).status).toBe(0);
+    expect(runCli(["workflow", "complete", startRun.id, "--step", "second"], env).status).toBe(0);
+
+    const listed = runCli(["workflow", "list", "--active"], env);
+    expect(listed.status).toBe(0);
+    const { runs } = JSON.parse(listed.stdout) as { runs: Array<{ id: string }> };
+    expect(runs.some((r) => r.id === startRun.id)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. workflow next on a completed run: done:true, step:null
+// ---------------------------------------------------------------------------
+describe("workflow next — completed run signals done", () => {
+  test("next on a completed run-id returns done:true and step:null", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    const started = runCli(["workflow", "start", "workflow:test-flow"], env);
+    expect(started.status).toBe(0);
+    const { run: startRun } = JSON.parse(started.stdout) as { run: { id: string } };
+
+    expect(runCli(["workflow", "complete", startRun.id, "--step", "first"], env).status).toBe(0);
+    expect(runCli(["workflow", "complete", startRun.id, "--step", "second"], env).status).toBe(0);
+
+    const next = runCli(["workflow", "next", startRun.id], env);
+    expect(next.status).toBe(0);
+    const nextJson = JSON.parse(next.stdout) as { done?: boolean; step: unknown };
+    expect(nextJson.done).toBe(true);
+    expect(nextJson.step).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. workflow next <ref> auto-start: autoStarted:true
+// ---------------------------------------------------------------------------
+describe("workflow next — auto-start flags autoStarted", () => {
+  test("next on a ref with no existing run returns autoStarted:true", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    const next = runCli(["workflow", "next", "workflow:test-flow"], env);
+    expect(next.status).toBe(0);
+    const nextJson = JSON.parse(next.stdout) as {
+      autoStarted?: boolean;
+      run: { status: string };
+      step: { id: string };
+    };
+    expect(nextJson.autoStarted).toBe(true);
+    expect(nextJson.run.status).toBe("active");
+    expect(nextJson.step.id).toBe("first");
+  });
+
+  test("next on a ref with existing active run does NOT set autoStarted", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    // First call auto-starts
+    const first = runCli(["workflow", "next", "workflow:test-flow"], env);
+    expect(first.status).toBe(0);
+
+    // Second call resumes existing — no autoStarted
+    const second = runCli(["workflow", "next", "workflow:test-flow"], env);
+    expect(second.status).toBe(0);
+    const secondJson = JSON.parse(second.stdout) as { autoStarted?: boolean };
+    expect(secondJson.autoStarted).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. workflow next --params: sets params on auto-start; fails on existing run
+// ---------------------------------------------------------------------------
+describe("workflow next --params", () => {
+  test("--params is accepted when auto-starting a new run", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    const next = runCli(["workflow", "next", "workflow:test-flow", "--params", '{"x":1}'], env);
+    expect(next.status).toBe(0);
+    const nextJson = JSON.parse(next.stdout) as { run: { params?: Record<string, unknown> }; autoStarted?: boolean };
+    expect(nextJson.autoStarted).toBe(true);
+    expect(nextJson.run.params?.x).toBe(1);
+  });
+
+  test("--params fails when an active run already exists (ref specifier)", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    // Start a run first
+    expect(runCli(["workflow", "start", "workflow:test-flow"], env).status).toBe(0);
+
+    const next = runCli(["workflow", "next", "workflow:test-flow", "--params", '{"x":1}'], env);
+    expect(next.status).toBe(2);
+    const err = JSON.parse(next.stderr) as { error: string };
+    expect(err.error).toContain("--params can only be set on a new run");
+  });
+
+  test("--params fails when given a direct run-id (existing run)", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    const started = runCli(["workflow", "start", "workflow:test-flow"], env);
+    expect(started.status).toBe(0);
+    const { run: startRun } = JSON.parse(started.stdout) as { run: { id: string } };
+
+    const next = runCli(["workflow", "next", startRun.id, "--params", '{"x":1}'], env);
+    expect(next.status).toBe(2);
+    const err = JSON.parse(next.stderr) as { error: string };
+    expect(err.error).toContain("--params can only be set on a new run");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. workflow status workflow:<name> resolves to most-recent run
+// ---------------------------------------------------------------------------
+describe("workflow status with workflow ref", () => {
+  test("status workflow:<name> resolves to the most-recently-updated run", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    const started = runCli(["workflow", "start", "workflow:test-flow"], env);
+    expect(started.status).toBe(0);
+    const { run: startRun } = JSON.parse(started.stdout) as { run: { id: string } };
+
+    const status = runCli(["workflow", "status", "workflow:test-flow"], env);
+    expect(status.status).toBe(0);
+    const statusJson = JSON.parse(status.stdout) as { run: { id: string; status: string } };
+    expect(statusJson.run.id).toBe(startRun.id);
+    expect(statusJson.run.status).toBe("active");
+  });
+
+  test("status workflow:<name> returns NotFoundError when no runs exist", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    const status = runCli(["workflow", "status", "workflow:test-flow"], env);
+    // No runs created yet — should fail with not-found (exit 1)
+    expect(status.status).toBe(1);
+    const err = JSON.parse(status.stderr) as { error: string };
+    expect(err.error).toContain("No workflow runs found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. workflow create name validation
+// ---------------------------------------------------------------------------
+describe("workflow create — name validation", () => {
+  test("name with spaces is rejected", () => {
+    const env = createWorkflowEnv();
+
+    const result = runCli(["workflow", "create", "name with spaces"], env);
+    expect(result.status).toBe(2);
+    const err = JSON.parse(result.stderr) as { error: string };
+    expect(err.error).toContain("Workflow name must start with a lowercase letter");
+  });
+
+  test("name with uppercase is rejected", () => {
+    const env = createWorkflowEnv();
+
+    const result = runCli(["workflow", "create", "MyWorkflow"], env);
+    expect(result.status).toBe(2);
+    const err = JSON.parse(result.stderr) as { error: string };
+    expect(err.error).toContain("Workflow name must start with a lowercase letter");
+  });
+
+  test("valid lowercase name is accepted", () => {
+    const env = createWorkflowEnv();
+
+    const result = runCli(["workflow", "create", "my-workflow"], env);
+    expect(result.status).toBe(0);
+    const json = JSON.parse(result.stdout) as { ref: string };
+    expect(json.ref).toBe("workflow:my-workflow");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. workflow create --force without --from/--reset is rejected
+// ---------------------------------------------------------------------------
+describe("workflow create --force guard", () => {
+  test("--force without --from or --reset is rejected", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    const result = runCli(["workflow", "create", "test-flow", "--force"], env);
+    expect(result.status).toBe(2);
+    const err = JSON.parse(result.stderr) as { error: string };
+    expect(err.error).toContain("Refusing to overwrite with template");
+  });
+
+  test("--force --reset succeeds and overwrites with template", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    const result = runCli(["workflow", "create", "test-flow", "--force", "--reset"], env);
+    expect(result.status).toBe(0);
+    const json = JSON.parse(result.stdout) as { ok: boolean; ref: string };
+    expect(json.ok).toBe(true);
+    expect(json.ref).toBe("workflow:test-flow");
+  });
+
+  test("--force --from <file> succeeds and overwrites with file content", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    const sourceDir = makeTempDir("akm-wfqa-src2-");
+    const sourcePath = path.join(sourceDir, "new.md");
+    fs.writeFileSync(sourcePath, TWO_STEP_WORKFLOW, "utf8");
+
+    const result = runCli(["workflow", "create", "test-flow", "--force", "--from", sourcePath], env);
+    expect(result.status).toBe(0);
+    const json = JSON.parse(result.stdout) as { ok: boolean };
+    expect(json.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. complete --state help text documents default (just ensure it runs)
+// ---------------------------------------------------------------------------
+describe("workflow complete --state default", () => {
+  test("complete without --state defaults to completed", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    const started = runCli(["workflow", "start", "workflow:test-flow"], env);
+    expect(started.status).toBe(0);
+    const { run: startRun } = JSON.parse(started.stdout) as { run: { id: string } };
+
+    // No --state flag → should default to 'completed'
+    const completed = runCli(["workflow", "complete", startRun.id, "--step", "first"], env);
+    expect(completed.status).toBe(0);
+    const json = JSON.parse(completed.stdout) as { workflow: { steps: Array<{ id: string; status: string }> } };
+    const step = json.workflow.steps.find((s) => s.id === "first");
+    expect(step?.status).toBe("completed");
+  });
+});

--- a/tests/workflow-qa-fixes.test.ts
+++ b/tests/workflow-qa-fixes.test.ts
@@ -269,7 +269,8 @@ describe("workflow next --params", () => {
     const next = runCli(["workflow", "next", startRun.id, "--params", '{"x":1}'], env);
     expect(next.status).toBe(2);
     const err = JSON.parse(next.stderr) as { error: string };
-    expect(err.error).toContain("--params can only be set on a new run");
+    expect(err.error).toContain("--params can only be used when starting a new run from a workflow ref");
+    expect(err.error).toContain("existing run id");
   });
 });
 
@@ -333,6 +334,25 @@ describe("workflow create — name validation", () => {
     expect(result.status).toBe(0);
     const json = JSON.parse(result.stdout) as { ref: string };
     expect(json.ref).toBe("workflow:my-workflow");
+  });
+
+  test("hierarchical name with forward slash is accepted", () => {
+    // Slashes are allowed for hierarchical naming (e.g. release/ship)
+    const env = createWorkflowEnv();
+
+    const result = runCli(["workflow", "create", "release/ship"], env);
+    expect(result.status).toBe(0);
+    const json = JSON.parse(result.stdout) as { ref: string };
+    expect(json.ref).toBe("workflow:release/ship");
+  });
+
+  test("name validation error message mentions slashes", () => {
+    const env = createWorkflowEnv();
+
+    const result = runCli(["workflow", "create", "BAD NAME"], env);
+    expect(result.status).toBe(2);
+    const err = JSON.parse(result.stderr) as { error: string };
+    expect(err.error).toContain("slashes");
   });
 });
 


### PR DESCRIPTION
## Summary

Addresses 25 issues surfaced during QA testing of 0.5.0 across the four new feature surfaces (wiki, workflow, vault, writable-stash/save) plus one destructive bug in the git stash provider that pre-dates 0.5.0.

## Critical fixes

- **`cloneRepo` data loss** — previously `fs.rmSync(destDir)` ran unconditionally before the clone; a temporarily unreachable remote would wipe the cached repo. Now stages into a sibling temp dir and only swaps on success.
- **`vault load` raw stack trace** — the handler wasn't wrapped in `runWithJsonErrors`, so `NotFoundError` escaped as an uncaught Bun exception. Now returns the standard `{ok:false,error,hint}` envelope and exits 1.

## Per-feature fixes

**Wiki** — `akm show wiki:<name>` routes to wiki summary; `wiki lint` exits 1 on findings; `wiki search` filters out `schema.md`/`index.md`/`log.md`/`raw/` and errors on nonexistent wikis; `wiki stash --as` throws on slug collision instead of silently renaming; new `broken-source` lint finding flags dangling `sources:` refs; name-validation error clarifies "lowercase".

**Workflow** — `next` signals completion with `done:true,step:null`; flags auto-started runs with `autoStarted:true`; accepts `--params` for auto-started runs; `status` accepts workflow refs; new `resume` subcommand flips blocked/failed runs back to active; `--active` filter now includes blocked runs; `create` validates names and requires `--from` or new `--reset` flag alongside `--force`; `complete --state` help text documents default.

**Vault** — new `show` subcommand aliases `list <ref>`; `set` accepts `KEY=VALUE` combined form; new `--comment` flag attaches a preserved inline comment; `setKey` gains optional `comment` parameter.

**Save/Trust/Config** — `save` no longer consumes `--format <value>` as the positional name; new root-level `writable` config flag makes the primary stash push-capable; `akm add --trust` on a local path now warns that trust is a no-op; install-audit block error mentions `--trust` as a remediation; `akm hints --detail full` enumerates vault and workflow subcommands.

**Docs** — new vault section in `docs/cli.md`; exit-code and error-envelope reference for agent consumers; workflow/wiki clarifications; updated release post and `AGENTS.md` files.

## Test plan

- [x] `bun run build` — clean
- [x] `bunx tsc --noEmit` — clean  
- [x] `bunx biome check src/ tests/` — clean
- [x] `bun test` — 1504 pass / 29 fail (vs main: 1447 pass / 30 fail). 57 new passing tests, zero regressions. All 29 remaining failures pre-exist on main and are unrelated (config merging, stash-source-manage state isolation).
- [x] 10/10 manual smoke tests from the plan verification section pass end-to-end against a freshly-built `dist/cli.js`:
  1. `akm show wiki:research` returns summary
  2. `akm wiki lint <dirty>` exits 1
  3. `akm vault load vault:nope` returns JSON envelope, exits 1
  4. `akm vault show vault:prod` matches `akm vault list vault:prod`
  5. `akm vault set prod KEY=val` combined form works
  6. `akm save --format json` (space-separated) returns JSON
  7. `akm workflow next <completed-run>` returns `done:true, step:null`
  8. Install-audit error mentions `--trust`
  9. `akm wiki stash research file --as mysrc` twice → second call errors
  10. `akm workflow resume <blocked-run>` flips back to active

## Commits

- `86848cd` fix: critical 0.5.0 QA bugs (safe git clone, vault load error envelope)
- `549c1a0` fix(wiki): address 0.5.0 QA findings
- `02ae911` fix(workflow): address 0.5.0 QA findings
- `f9a4d2f` fix(vault): address 0.5.0 QA findings
- `3522da8` fix(save,trust): address 0.5.0 QA findings
- `1110ce6` docs: align 0.5.0 docs with QA-fix behavior

## Out of scope (deferred)

- `workflow list` pagination
- `workflow next` disclosing when multiple active runs exist
- `vault list` deterministic sort order
- `workflowEntryId` null-until-indexed UX
- Version bump from 0.4.1 → 0.5.0 (release-prep, separate concern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)