### PR TITLE
Publish 0.5.0 release notes and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- **Multi-wiki support** (#119, #121): new `wiki` asset type with nine CLI verbs under `akm wiki …` (`create`, `list`, `show`, `remove`, `pages`, `search`, `stash`, `lint`, `ingest`). Each wiki lives at `<stashDir>/wikis/<name>/` with `schema.md`, `index.md`, `log.md`, `raw/`, and agent-authored pages. Wiki pages are first-class in stash-wide `akm search`. `akm index` regenerates each wiki's `index.md` as a side effect. See `docs/wikis.md` for the full guide. Design principle: **akm surfaces, the agent writes** — no LLM calls, no network access; akm owns only operations with invariants an agent can't reliably enforce (lifecycle, raw-slug uniqueness, structural lint, index regeneration, workflow discovery).
-- **Workflow asset type** (#118): new `workflow` type with `akm workflow create <name>` and `akm workflow next <ref>` for authoring and stepping through multi-step workflows stored in the stash
-- **Vault asset type** (#117): new `vault` type backed by `.env` files; `akm vault` subcommand with `list`, `show`, `load` (emits a `source` snippet for the current shell); values never appear in structured output
-- **`--trust` flag for installs**: `akm add <source> --trust` performs a one-off trusted install, bypassing the install audit for that source
-- **Writable git stash + `akm save`** (#114): `akm add … --writable` opts a remote git-backed stash into push-on-save; `akm save [name] [-m message]` commits (and pushes when writable + remote is set); default stash is auto-initialized as a git repo; git stash provider now uses `git clone` instead of HTTP tarball download
+- **Multi-wiki support** (#119, #121, #136, #139, #144): new `wiki` asset type with ten CLI verbs under `akm wiki …` (`create`, `register`, `list`, `show`, `remove`, `pages`, `search`, `stash`, `lint`, `ingest`). Each wiki lives at `<stashDir>/wikis/<name>/` with `schema.md`, `index.md`, `log.md`, `raw/`, and agent-authored pages. Wiki pages are first-class in stash-wide `akm search`. `akm index` regenerates each wiki's `index.md` as a side effect and is resilient to malformed workflow assets. Raw sources under `raw/` and the `schema.md` / `index.md` / `log.md` infrastructure files are intentionally excluded from the search index. See `docs/wikis.md` for the full guide. Design principle: **akm surfaces, the agent writes** — no LLM calls, no network access; akm owns only operations with invariants an agent can't reliably enforce (lifecycle, raw-slug uniqueness, structural lint, index regeneration, workflow discovery).
+- **External wiki registration** (#139, #144): `akm wiki register <name> <path-or-repo>` and `akm add --type wiki --name <name> <source>` register an existing directory or git/website repo as a first-class wiki without copying or mutating it; source and wiki search state are refreshed immediately and refs/state are normalized on subsequent indexing.
+- **Workflow asset type** (#118): new `workflow` type with `akm workflow` subcommands `template`, `create`, `start`, `next`, `complete`, `status`, `list`, and `resume` for authoring and stepping through multi-step workflows stored in the stash. Runs snapshot their step list at start so edits to the source workflow do not affect an in-flight run.
+- **Vault asset type** (#117): new `vault` type backed by `.env` files; `akm vault` subcommand with `list`, `show`, `create`, `set`, `unset`, and `load` (emits a `source` snippet for the current shell via a mode-0600 temp file); values never appear in structured output.
+- **`--trust` flag for installs**: `akm add <source> --trust` performs a one-off trusted install, bypassing the install audit for that source. Blocked install errors now include a `hint` pointing to `--trust` as a remediation option.
+- **Writable git stash + `akm save`** (#114): `akm add … --writable` opts a remote git-backed stash into push-on-save; `akm save [name] [-m message]` commits (and pushes when writable + remote is set); default stash is auto-initialized as a git repo; git stash provider now uses `git clone` instead of HTTP tarball download.
+- **`akm help migrate <version>`** (#132): prints the release notes and migration guidance for a given version (accepts `0.5.0`, `v0.5.0`, or `latest`). Pulls the matching section from `CHANGELOG.md` when available and supplements it with embedded migration notes for major releases.
+- **Broader `akm upgrade` coverage** (#132, #134): self-update now detects and upgrades npm, bun, pnpm, and standalone-binary installs (previously binary-only). Runtime assets covered by the upgrade flow were also expanded so newly shipped asset types stay current.
+
+### Fixed
+
+- **0.5.0 QA follow-ups** (#130): fixes across the new wiki, workflow, vault, and save/trust surfaces surfaced during release-candidate QA.
 
 ### Removed (breaking)
 
 - The unreleased single-wiki LLM POC: removes `akm lint` command, `akm import --llm` / `--dry-run` flags, `knowledge.pageKinds` config, and the `ingestKnowledgeSource` / `lintKnowledge` LLM prompts. Users of the POC should migrate to the new `akm wiki …` surface; raw content can be manually moved to `wikis/<name>/raw/`.
+
+### Documentation
+
+- **Technical docs refresh** (#138): stash and search architecture docs updated to match the current implementation.
+- **Wiki configuration guide** (#115): new docs page covering wiki configuration and ingest flow.
 
 ## [0.4.1] - 2026-04-21
 

--- a/docs/posts/release-0.5.0.md
+++ b/docs/posts/release-0.5.0.md
@@ -8,20 +8,23 @@ tags:
   - agents
   - cli
   - release
-published: false
+published: true
 date: '2026-04-22T00:00:00Z'
 id: 3539588
 ---
 
-akm 0.5.0 is out. This release adds four new asset types — wikis, workflows, and vaults are now first-class citizens — plus writable git stash support so your stash can sync back to a remote. There is one breaking change for anyone who was using the single-wiki LLM POC from 0.4.x.
+akm 0.5.0 is out. This release adds three new asset types — wikis, workflows, and vaults are now first-class citizens — plus writable git stash support so your stash can sync back to a remote. It also upgrades the self-update path to cover npm, bun, pnpm, and binary installs, and ships a new `akm help migrate` command for release-to-release guidance. There is one breaking change for anyone who was using the single-wiki LLM POC from 0.4.x.
 
 ## TL;DR
 
-- `akm wiki create|list|show|remove|pages|search|stash|lint|ingest` — multi-wiki support, no LLM required
-- `akm workflow create|start|next|complete|status|list|resume` — multi-step agent procedures in the stash
+- `akm wiki create|register|list|show|remove|pages|search|stash|lint|ingest` — multi-wiki support, no LLM required
+- `akm workflow template|create|start|next|complete|status|list|resume` — multi-step agent procedures in the stash
 - `akm vault list|show|create|set|unset|load` — `.env`-backed secrets that never appear in structured output
 - `akm add <source> --writable` + `akm save` — push your stash changes back to a remote git repo
 - `akm add <source> --trust` — bypass the install audit for a single install
+- `akm add --type wiki --name <name> <source>` / `akm wiki register` — register an existing directory or repo as a first-class wiki
+- `akm upgrade` now covers npm, bun, pnpm, and standalone-binary installs
+- `akm help migrate <version>` prints release notes and migration guidance for any shipped release
 - **Breaking**: the single-wiki LLM POC is removed; migrate to `akm wiki …`
 
 ---
@@ -57,7 +60,21 @@ Wiki pages are indexed by `akm index` and show up in stash-wide `akm search`, so
 
 The design principle is **akm surfaces, the agent writes**. akm makes no LLM calls. It owns only the operations where correctness is structural and deterministic: lifecycle management, raw-slug uniqueness, lint checks, index regeneration. The agent owns page content. This keeps the CLI fast and predictable — a wiki command always completes in milliseconds, and you can run it in any environment without model configuration.
 
-The 9-verb surface (`create`, `list`, `show`, `remove`, `pages`, `search`, `stash`, `lint`, `ingest`) covers the full lifecycle from creation to indexing to removal.
+The 10-verb surface (`create`, `register`, `list`, `show`, `remove`, `pages`, `search`, `stash`, `lint`, `ingest`) covers the full lifecycle from creation to indexing to removal.
+
+If you already have a wiki-shaped directory or repo you want to adopt without copying it, use `akm wiki register`:
+
+```sh
+# Register a local directory as a first-class wiki
+akm wiki register notes ~/team/notes
+
+# Or via the unified add command
+akm add --type wiki --name notes ~/team/notes
+
+# Registered external wikis show up in both `akm list` and `akm wiki list`
+```
+
+Registration refreshes source state and wiki search hits immediately, and the indexer normalizes external wiki refs on subsequent runs.
 
 ---
 
@@ -78,11 +95,14 @@ akm workflow next workflow:release-checklist
 # Check where you are
 akm workflow status workflow:release-checklist
 
-# Mark it done
-akm workflow complete workflow:release-checklist
+# Mark a specific step done (defaults to --state completed)
+akm workflow complete <run-id> --step validate --notes "Inputs verified"
 
-# List all workflows
+# List all workflow runs
 akm workflow list
+
+# Print a starter workflow you can adapt
+akm workflow template
 ```
 
 Workflows live in the stash like any other asset, so `akm search workflow:…` finds them and `akm show workflow:release-checklist` renders the current step. They can be shared in a kit and versioned in a git stash.
@@ -173,7 +193,31 @@ If you were using the wiki functionality introduced in 0.4.1, you will need to m
 3. Have your agent author wiki pages from the raw content
 4. Run `akm index` to regenerate the wiki index
 
-The new surface is more capable — 9 verbs vs the old 2, proper multi-wiki support, structural lint, and page search — and it does not require an LLM to be configured for any of the CLI operations.
+The new surface is more capable — 10 verbs vs the old 2, proper multi-wiki support, structural lint, and page search — and it does not require an LLM to be configured for any of the CLI operations.
+
+---
+
+## Broader `akm upgrade` coverage
+
+`akm upgrade` used to assume a standalone-binary install. 0.5.0 detects how akm was installed (npm, bun, pnpm, or binary) and runs the right self-update path for each. The same command now works whether you bootstrapped from the install script or from a package manager, and the internal runtime-asset coverage was expanded so newly shipped asset types stay up to date after an upgrade.
+
+```sh
+akm upgrade              # Works for binary, npm, bun, and pnpm installs
+akm upgrade --check      # Report whether an update is available, without installing
+```
+
+---
+
+## `akm help migrate <version>` — release notes at the CLI
+
+Release notes belong where you're actually working. `akm help migrate` prints the relevant CHANGELOG section plus embedded migration guidance for a given version, so you can review what changed (and what to do about it) without leaving the terminal.
+
+```sh
+akm help migrate 0.5.0     # or v0.5.0
+akm help migrate latest    # resolve against the most recent CHANGELOG entry
+```
+
+It favors the bundled CHANGELOG section when it exists and falls back to an embedded summary and a link to the full changelog otherwise.
 
 ---
 


### PR DESCRIPTION
## Summary

Publishes the 0.5.0 release notes and updates the CHANGELOG to reflect the final feature set for this release. Changes include:

- Sets `published: true` on the 0.5.0 release post
- Corrects feature count from "four" to "three" new asset types in the intro
- Adds details on new features: `akm wiki register` for external wiki registration, expanded `akm workflow` verbs, `akm help migrate` command, and broader `akm upgrade` coverage across npm/bun/pnpm/binary installs
- Expands the TL;DR section with concrete examples of new commands and workflows
- Updates wiki verb count from 9 to 10 (adding `register`)
- Updates workflow verbs to include `template` and clarifies `complete` behavior
- Adds new sections documenting external wiki registration, broader upgrade coverage, and the `akm help migrate` command
- Updates CHANGELOG with comprehensive feature descriptions, including PR references and design rationale
- Adds "Fixed" section for 0.5.0 QA follow-ups
- Adds "Documentation" section noting technical docs refresh and new wiki configuration guide

## Test plan

N/A — documentation and release notes only.

## Checklist

- [x] Docs updated (release notes and CHANGELOG)

https://claude.ai/code/session_01Ks2kqvas7mvgdbLGKXcdmX