### PR TITLE
refactor: config ergonomics & polish (#128)

### DIFF
--- a/src/asset-registry.ts
+++ b/src/asset-registry.ts
@@ -59,3 +59,45 @@ export function registerTypeRenderer(type: string, rendererName: string): void {
 export function registerActionBuilder(type: string, builder: (ref: string) => string): void {
   ACTION_BUILDERS[type] = builder;
 }
+
+/**
+ * Lookup table that maps asset types to their renderer name and action
+ * builder. Designed to be injectable so tests can isolate renderer behavior
+ * without mutating the module-level singleton maps.
+ *
+ * The default registry simply reads from `TYPE_TO_RENDERER` and
+ * `ACTION_BUILDERS`; tests may pass a fresh literal instead.
+ */
+export interface RendererRegistry {
+  rendererNameFor(type: string): string | undefined;
+  actionBuilderFor(type: string): ((ref: string) => string) | undefined;
+}
+
+export const defaultRendererRegistry: RendererRegistry = {
+  rendererNameFor(type) {
+    return TYPE_TO_RENDERER[type];
+  },
+  actionBuilderFor(type) {
+    return ACTION_BUILDERS[type];
+  },
+};
+
+/**
+ * Build a registry from explicit maps. Useful for tests that need to assert
+ * rendering behavior without touching the global singletons.
+ */
+export function createRendererRegistry(maps: {
+  renderers?: Record<string, string>;
+  actionBuilders?: Record<string, (ref: string) => string>;
+}): RendererRegistry {
+  const renderers = maps.renderers ?? {};
+  const actionBuilders = maps.actionBuilders ?? {};
+  return {
+    rendererNameFor(type) {
+      return renderers[type];
+    },
+    actionBuilderFor(type) {
+      return actionBuilders[type];
+    },
+  };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,7 +56,7 @@ import {
 } from "./workflow-runs";
 
 type OutputFormat = "json" | "yaml" | "text" | "jsonl";
-type DetailLevel = "brief" | "normal" | "full" | "summary";
+type DetailLevel = "brief" | "normal" | "full" | "summary" | "agent";
 
 interface OutputMode {
   format: OutputFormat;
@@ -65,7 +65,7 @@ interface OutputMode {
 }
 
 const OUTPUT_FORMATS: OutputFormat[] = ["json", "yaml", "text", "jsonl"];
-const DETAIL_LEVELS: DetailLevel[] = ["brief", "normal", "full", "summary"];
+const DETAIL_LEVELS: DetailLevel[] = ["brief", "normal", "full", "summary", "agent"];
 const NORMAL_DESCRIPTION_LIMIT = 250;
 const MAX_CAPTURED_ASSET_SLUG_LENGTH = 64;
 const CONTEXT_HUB_ALIAS_REF = "context-hub";
@@ -107,7 +107,9 @@ function resolveOutputMode(): OutputMode {
   const config = loadConfig();
   const format = parseOutputFormat(parseFlagValue("--format")) ?? config.output?.format ?? "json";
   const detail = parseDetailLevel(parseFlagValue("--detail")) ?? config.output?.detail ?? "brief";
-  const forAgent = hasBooleanFlag("--for-agent");
+  // `--detail=agent` is the preferred preset. `--for-agent` is kept for one
+  // release cycle as an alias so existing scripts and docs keep working.
+  const forAgent = detail === "agent" || hasBooleanFlag("--for-agent");
   return { format, detail, forAgent };
 }
 
@@ -2101,10 +2103,10 @@ const workflowStatusCommand = defineCommand({
         const ref = `${parsed.origin ? `${parsed.origin}//` : ""}workflow:${parsed.name}`;
         const { runs } = listWorkflowRuns({ workflowRef: ref });
         if (runs.length === 0) {
-          throw new NotFoundError(`No workflow runs found for ${ref}`);
+          throw new NotFoundError(`No workflow runs found for ${ref}`, "WORKFLOW_NOT_FOUND");
         }
         const mostRecent = runs[0];
-        if (!mostRecent) throw new NotFoundError(`No workflow runs found for ${ref}`);
+        if (!mostRecent) throw new NotFoundError(`No workflow runs found for ${ref}`, "WORKFLOW_NOT_FOUND");
         const result = getWorkflowStatus(mostRecent.id);
         output("workflow-status", result);
       } else {
@@ -3034,7 +3036,13 @@ async function runWithJsonErrors(fn: (() => void) | (() => Promise<void>)): Prom
     const message = error instanceof Error ? error.message : String(error);
     const hint = buildHint(message);
     const exitCode = classifyExitCode(error);
-    console.error(JSON.stringify({ ok: false, error: message, hint }, null, 2));
+    // Surface machine-readable error code from typed errors when present so
+    // scripts can branch on `.code` instead of message-string matching.
+    const code =
+      error instanceof UsageError || error instanceof ConfigError || error instanceof NotFoundError
+        ? error.code
+        : undefined;
+    console.error(JSON.stringify({ ok: false, error: message, ...(code ? { code } : {}), hint }, null, 2));
     process.exit(exitCode);
   }
 }
@@ -3051,7 +3059,7 @@ function buildHint(message: string): string | undefined {
     return "The remote package was fetched but doesn't contain the requested asset. Check the asset name and type.";
   if (message.includes("Invalid value for --source")) return "Pick one of: stash, registry, both.";
   if (message.includes("Invalid value for --format")) return "Pick one of: json, jsonl, text, yaml.";
-  if (message.includes("Invalid value for --detail")) return "Pick one of: brief, normal, full, summary.";
+  if (message.includes("Invalid value for --detail")) return "Pick one of: brief, normal, full, summary, agent.";
   if (message.includes("expected JSON object with endpoint and model")) {
     return 'Quote JSON values in your shell, for example: akm config set embedding \'{"endpoint":"http://localhost:11434/v1/embeddings","model":"nomic-embed-text"}\'.';
   }
@@ -3234,8 +3242,8 @@ akm search "<query>" --detail full            # Include scores, paths, timing
 | \`--source\` | \`stash\`, \`registry\`, \`both\` | \`stash\` |
 | \`--limit\` | number | \`20\` |
 | \`--format\` | \`json\`, \`jsonl\`, \`text\`, \`yaml\` | \`json\` |
-| \`--detail\` | \`brief\`, \`normal\`, \`full\`, \`summary\` | \`brief\` |
-| \`--for-agent\` | boolean | \`false\` |
+| \`--detail\` | \`brief\`, \`normal\`, \`full\`, \`summary\`, \`agent\` | \`brief\` |
+| \`--for-agent\` | boolean (deprecated — use \`--detail agent\`) | \`false\` |
 
 ## Curate
 
@@ -3456,7 +3464,8 @@ All commands accept \`--format\` and \`--detail\` flags:
 - \`--detail normal\` — adds tags, refs, origins
 - \`--detail full\` — includes scores, paths, timing, debug info
 - \`--detail summary\` — metadata only (no content/template/prompt), under 200 tokens
-- \`--for-agent\` — agent-optimized output: strips non-actionable fields (takes precedence over \`--detail\`)
+- \`--detail agent\` — agent-optimized output: strips non-actionable fields
+- \`--for-agent\` — deprecated alias for \`--detail agent\`
 
 Run \`akm -h\` or \`akm <command> -h\` for per-command help.
 `;

--- a/src/common.ts
+++ b/src/common.ts
@@ -35,20 +35,17 @@ export function isAssetType(type: string): type is AkmAssetType {
  *   2. stashDir field in config.json
  *   3. Platform default (~/akm or ~/Documents/akm on Windows)
  *
- * WARNING: May write to config file as a side effect when AKM_STASH_DIR is set.
- * Specifically, when AKM_STASH_DIR is set and `options.readOnly` is not true,
- * this function calls `persistStashDirToConfig()` which writes the resolved
- * path into config.json on disk.
+ * Pure read: never writes to disk. The legacy `readOnly` option is accepted
+ * (and ignored) for one release cycle so older callers continue to compile;
+ * it can be removed in the next minor bump.
  *
  * Throws if no valid stash directory is found.
  */
-export function resolveStashDir(options?: { readOnly?: boolean }): string {
+export function resolveStashDir(_options?: { readOnly?: boolean }): string {
   // 1. Env var override (for CI, scripts, testing)
   const envDir = process.env.AKM_STASH_DIR?.trim();
   if (envDir) {
-    const resolved = validateStashDir(envDir);
-    if (!options?.readOnly) persistStashDirToConfig(resolved);
-    return resolved;
+    return validateStashDir(envDir);
   }
 
   // 2. Config file stashDir field
@@ -64,6 +61,7 @@ export function resolveStashDir(options?: { readOnly?: boolean }): string {
   throw new ConfigError(
     `No stash directory found. Run "akm init" to create one at ${defaultDir}, ` +
       `or set stashDir in ${getConfigPath()}.`,
+    "STASH_DIR_NOT_FOUND",
   );
 }
 
@@ -73,10 +71,10 @@ function validateStashDir(raw: string): string {
   try {
     stat = fs.statSync(stashDir);
   } catch {
-    throw new ConfigError(`Unable to read stash directory at "${stashDir}".`);
+    throw new ConfigError(`Unable to read stash directory at "${stashDir}".`, "STASH_DIR_UNREADABLE");
   }
   if (!stat.isDirectory()) {
-    throw new ConfigError(`Stash path must point to a directory: "${stashDir}".`);
+    throw new ConfigError(`Stash path must point to a directory: "${stashDir}".`, "STASH_DIR_NOT_A_DIRECTORY");
   }
   return stashDir;
 }
@@ -105,42 +103,6 @@ function readStashDirFromConfig(): string | undefined {
     // Config doesn't exist or is invalid — fall through
   }
   return undefined;
-}
-
-/**
- * Persist stashDir to config.json if not already set, so users can
- * transition away from relying on the AKM_STASH_DIR env var.
- *
- * WARNING: This function writes to disk (config.json). It is called as a side
- * effect of `resolveStashDir()` when AKM_STASH_DIR is set and `readOnly` is
- * not true. Callers that must not touch the filesystem should pass
- * `{ readOnly: true }` to `resolveStashDir()`.
- */
-function persistStashDirToConfig(stashDir: string): void {
-  try {
-    const configPath = getConfigPath();
-    let raw: Record<string, unknown> = {};
-    try {
-      const text = fs.readFileSync(configPath, "utf8");
-      const parsed = JSON.parse(text);
-      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
-        raw = parsed;
-      }
-    } catch {
-      // No existing config or invalid — start fresh
-    }
-
-    if (!raw.stashDir) {
-      raw.stashDir = stashDir;
-      const dir = path.dirname(configPath);
-      fs.mkdirSync(dir, { recursive: true });
-      const tmpPath = `${configPath}.tmp.${process.pid}.${Math.random().toString(36).slice(2)}`;
-      fs.writeFileSync(tmpPath, `${JSON.stringify(raw, null, 2)}\n`, "utf8");
-      fs.renameSync(tmpPath, configPath);
-    }
-  } catch {
-    // Non-fatal: best-effort persistence
-  }
 }
 
 export function toPosix(input: string): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,17 +6,25 @@ import type { InstalledStashEntry, StashSource } from "./registry-types";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
-export interface EmbeddingConnectionConfig {
-  /** Provider name for display (e.g. "openai", "ollama") */
+/**
+ * Fields shared by every OpenAI-compatible connection config (embedding +
+ * LLM). Specialized configs extend this base. Pure type DRY — the on-disk
+ * JSON schema is unchanged.
+ */
+export interface BaseConnectionConfig {
+  /** Provider name for display (e.g. "openai", "anthropic", "ollama"). */
   provider?: string;
-  /** OpenAI-compatible embeddings endpoint (e.g. "http://localhost:11434/v1/embeddings") */
+  /** OpenAI-compatible HTTP endpoint. */
   endpoint: string;
-  /** Model name to use for remote embeddings (e.g. "nomic-embed-text") */
+  /** Model name to use. */
   model: string;
+  /** Optional API key for authenticated endpoints. */
+  apiKey?: string;
+}
+
+export interface EmbeddingConnectionConfig extends BaseConnectionConfig {
   /** Optional output dimension for providers that support it */
   dimension?: number;
-  /** Optional API key for authenticated endpoints */
-  apiKey?: string;
   /** Optional local transformer model name (e.g. "Xenova/bge-small-en-v1.5"). Overrides the default when using local embeddings. */
   localModel?: string;
 }
@@ -30,19 +38,11 @@ export interface LlmCapabilities {
   toolUse?: boolean;
 }
 
-export interface LlmConnectionConfig {
-  /** Provider name for display (e.g. "openai", "anthropic", "google", "ollama") */
-  provider?: string;
-  /** OpenAI-compatible chat completions endpoint (e.g. "http://localhost:11434/v1/chat/completions") */
-  endpoint: string;
-  /** Model name to use (e.g. "llama3.2") */
-  model: string;
+export interface LlmConnectionConfig extends BaseConnectionConfig {
   /** Optional sampling temperature */
   temperature?: number;
   /** Optional response token limit */
   maxTokens?: number;
-  /** Optional API key for authenticated endpoints */
-  apiKey?: string;
   /** Approximate context window in tokens. Used to size ingest/lint chunks. */
   contextWindow?: number;
   /** Capability flags learned at setup time (e.g. structured-output support). */
@@ -120,8 +120,16 @@ export interface AkmConfig {
    */
   registries?: RegistryConfigEntry[];
   /**
-   * When true on a later config layer (typically project config), discard
-   * inherited stashes from earlier layers before applying `stashes`.
+   * When set on a later config layer (typically project config), controls how
+   * the layer's `stashes` interact with stashes inherited from earlier layers.
+   * - `"merge"` (default): append the layer's stashes to the inherited list.
+   * - `"replace"`: discard the inherited stashes before applying this layer's.
+   */
+  stashInheritance?: "merge" | "replace";
+  /**
+   * @deprecated Use `stashInheritance: "replace"` instead. Retained for one
+   * minor-release cycle so existing config files continue to work; the loader
+   * coerces this boolean into `stashInheritance` when the new field is absent.
    */
   disableGlobalStashes?: boolean;
   /** Additional stash sources (filesystem paths and remote providers) */
@@ -332,7 +340,12 @@ function pickKnownKeys(raw: Record<string, unknown>): Partial<AkmConfig> {
   const registries = parseRegistriesConfig(raw.registries);
   if (registries) config.registries = registries;
 
-  if (typeof raw.disableGlobalStashes === "boolean") {
+  // Prefer the new `stashInheritance` field; fall back to the legacy boolean
+  // `disableGlobalStashes` so existing config files keep working unchanged.
+  if (raw.stashInheritance === "replace" || raw.stashInheritance === "merge") {
+    config.stashInheritance = raw.stashInheritance;
+  } else if (typeof raw.disableGlobalStashes === "boolean") {
+    config.stashInheritance = raw.disableGlobalStashes ? "replace" : "merge";
     config.disableGlobalStashes = raw.disableGlobalStashes;
   }
 
@@ -785,7 +798,8 @@ function mergeInstallAuditConfig(
  * Scalar fields follow normal override semantics. Known nested objects are
  * deep-merged so project config files can override individual fields without
  * clobbering sibling settings. `stashes` are additive by default, but a later
- * layer can set `disableGlobalStashes: true` to drop inherited stashes first.
+ * layer can set `stashInheritance: "replace"` (or the legacy
+ * `disableGlobalStashes: true`) to drop inherited stashes first.
  */
 function mergeLoadedConfig(base: AkmConfig, override?: Partial<AkmConfig>): AkmConfig {
   if (!override) return { ...base };
@@ -807,7 +821,12 @@ function mergeLoadedConfig(base: AkmConfig, override?: Partial<AkmConfig>): AkmC
   if (base.security && override.security) {
     merged.security = mergeSecurityConfig(base.security, override.security);
   }
-  if (override.disableGlobalStashes) {
+  // The new `stashInheritance` field wins; fall back to the legacy
+  // `disableGlobalStashes` boolean so old config files behave identically.
+  const replaceStashes =
+    override.stashInheritance === "replace" ||
+    (override.stashInheritance === undefined && override.disableGlobalStashes === true);
+  if (replaceStashes) {
     merged.stashes = [...(override.stashes ?? [])];
   } else if (override.stashes) {
     merged.stashes = [...(base.stashes ?? []), ...override.stashes];

--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -389,16 +389,32 @@ export function cosineSimilarity(a: EmbeddingVector, b: EmbeddingVector): number
 // ── Availability check ──────────────────────────────────────────────────────
 
 /**
- * Check whether the `@huggingface/transformers` package can be imported.
- * Returns `true` if it can, `false` otherwise.
+ * Check whether the `@huggingface/transformers` package can be resolved.
+ * Uses `Bun.resolve()` so we never load the module (which would trigger
+ * heavy WASM/model side-effects) just to test availability.
+ *
+ * Falls back to `require.resolve` when `Bun.resolve` is unavailable
+ * (e.g. running under Node), so the function still works in mixed runtimes.
  */
-export async function isTransformersAvailable(): Promise<boolean> {
+export function isTransformersAvailable(): boolean {
   try {
-    await import("@huggingface/transformers");
-    return true;
+    if (typeof Bun !== "undefined" && typeof Bun.resolveSync === "function") {
+      Bun.resolveSync("@huggingface/transformers", import.meta.dir);
+      return true;
+    }
   } catch {
     return false;
   }
+  try {
+    const req = (globalThis as { require?: { resolve?: (id: string) => string } }).require;
+    if (req && typeof req.resolve === "function") {
+      req.resolve("@huggingface/transformers");
+      return true;
+    }
+  } catch {
+    return false;
+  }
+  return false;
 }
 
 export type EmbeddingCheckResult =
@@ -424,7 +440,7 @@ export async function checkEmbeddingAvailability(
     }
   }
   // Check if the package is importable before attempting the model download.
-  if (!(await isTransformersAvailable())) {
+  if (!isTransformersAvailable()) {
     return {
       available: false,
       reason: "missing-package",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -4,13 +4,42 @@
  * - ConfigError  -> exit 78  (configuration / environment problems)
  * - UsageError   -> exit 2   (bad CLI arguments or invalid input)
  * - NotFoundError -> exit 1  (requested resource missing)
+ *
+ * Each error carries a machine-readable `code` field. Codes are stable
+ * identifiers safe to consume from scripts and JSON output. Existing throw
+ * sites without an explicit code receive a default code per error class so
+ * older call sites continue to compile and behave unchanged.
  */
+
+/** Stable, machine-readable codes for ConfigError. */
+export type ConfigErrorCode =
+  | "CONFIG_DIR_UNRESOLVABLE"
+  | "STASH_DIR_NOT_FOUND"
+  | "STASH_DIR_NOT_A_DIRECTORY"
+  | "STASH_DIR_UNREADABLE"
+  | "EMBEDDING_NOT_CONFIGURED"
+  | "LLM_NOT_CONFIGURED"
+  | "INVALID_CONFIG_FILE";
+
+/** Stable, machine-readable codes for UsageError. */
+export type UsageErrorCode =
+  | "INVALID_FLAG_VALUE"
+  | "UNKNOWN_CONFIG_KEY"
+  | "INVALID_JSON_ARGUMENT"
+  | "MISSING_REQUIRED_ARGUMENT"
+  | "PATH_ESCAPE_VIOLATION"
+  | "RESOURCE_ALREADY_EXISTS";
+
+/** Stable, machine-readable codes for NotFoundError. */
+export type NotFoundErrorCode = "ASSET_NOT_FOUND" | "STASH_NOT_FOUND" | "WORKFLOW_NOT_FOUND" | "FILE_NOT_FOUND";
 
 /** Raised when configuration or environment is invalid or missing. */
 export class ConfigError extends Error {
-  constructor(msg: string) {
+  readonly code: ConfigErrorCode;
+  constructor(msg: string, code: ConfigErrorCode = "INVALID_CONFIG_FILE") {
     super(msg);
     this.name = "ConfigError";
+    this.code = code;
     // Fixes `instanceof` checks under ES5 transpilation targets.
     Object.setPrototypeOf(this, new.target.prototype);
   }
@@ -18,9 +47,11 @@ export class ConfigError extends Error {
 
 /** Raised when the user supplies invalid arguments or input. */
 export class UsageError extends Error {
-  constructor(msg: string) {
+  readonly code: UsageErrorCode;
+  constructor(msg: string, code: UsageErrorCode = "INVALID_FLAG_VALUE") {
     super(msg);
     this.name = "UsageError";
+    this.code = code;
     // Fixes `instanceof` checks under ES5 transpilation targets.
     Object.setPrototypeOf(this, new.target.prototype);
   }
@@ -28,9 +59,11 @@ export class UsageError extends Error {
 
 /** Raised when a requested resource (asset, entry, file) is not found. */
 export class NotFoundError extends Error {
-  constructor(msg: string) {
+  readonly code: NotFoundErrorCode;
+  constructor(msg: string, code: NotFoundErrorCode = "ASSET_NOT_FOUND") {
     super(msg);
     this.name = "NotFoundError";
+    this.code = code;
     // Fixes `instanceof` checks under ES5 transpilation targets.
     Object.setPrototypeOf(this, new.target.prototype);
   }

--- a/src/local-search.ts
+++ b/src/local-search.ts
@@ -11,7 +11,7 @@
 import type { Database } from "bun:sqlite";
 import fs from "node:fs";
 import path from "node:path";
-import { ACTION_BUILDERS, TYPE_TO_RENDERER } from "./asset-registry";
+import { defaultRendererRegistry, type RendererRegistry } from "./asset-registry";
 import { deriveCanonicalAssetNameFromStashRoot } from "./asset-spec";
 import type { AkmConfig } from "./config";
 import {
@@ -47,13 +47,17 @@ type IndexedAsset = {
   path: string;
 };
 
-export async function rendererForType(type: string) {
-  const name = TYPE_TO_RENDERER[type];
+export async function rendererForType(type: string, registry: RendererRegistry = defaultRendererRegistry) {
+  const name = registry.rendererNameFor(type);
   return name ? getRenderer(name) : undefined;
 }
 
-export function buildLocalAction(type: string, ref: string): string {
-  const builder = ACTION_BUILDERS[type];
+export function buildLocalAction(
+  type: string,
+  ref: string,
+  registry: RendererRegistry = defaultRendererRegistry,
+): string {
+  const builder = registry.actionBuilderFor(type);
   return builder ? builder(ref) : `akm show ${ref}`;
 }
 
@@ -77,6 +81,8 @@ export async function searchLocal(input: {
   stashDir: string;
   sources: SearchSource[];
   config: AkmConfig;
+  /** Optional renderer registry override for test isolation. */
+  rendererRegistry?: RendererRegistry;
 }): Promise<{
   hits: StashSearchHit[];
   tip?: string;
@@ -85,6 +91,7 @@ export async function searchLocal(input: {
   rankMs?: number;
 }> {
   const { query, searchType, limit, stashDir, sources, config } = input;
+  const rendererRegistry = input.rendererRegistry ?? defaultRendererRegistry;
   const allStashDirs = sources.map((s) => s.path);
   const rawStatus = readSemanticStatus();
   const semanticStatus = getEffectiveSemanticStatus(config, rawStatus);
@@ -139,6 +146,7 @@ export async function searchLocal(input: {
             allStashDirs,
             config,
             sources,
+            rendererRegistry,
           );
           return {
             hits,
@@ -163,7 +171,7 @@ export async function searchLocal(input: {
   }
 
   const hitArrays = await Promise.all(
-    allStashDirs.map((dir) => substringSearch(query, searchType, limit, dir, sources, config)),
+    allStashDirs.map((dir) => substringSearch(query, searchType, limit, dir, sources, config, rendererRegistry)),
   );
   const hits = hitArrays.flat().slice(0, limit);
   return {
@@ -184,6 +192,7 @@ async function searchDatabase(
   allStashDirs: string[],
   config: AkmConfig,
   sources: SearchSource[],
+  rendererRegistry: RendererRegistry = defaultRendererRegistry,
 ): Promise<{
   hits: StashSearchHit[];
   embedMs?: number;
@@ -213,6 +222,7 @@ async function searchDatabase(
           allStashDirs,
           sources,
           config,
+          rendererRegistry,
         }),
       ),
     );
@@ -485,6 +495,7 @@ async function searchDatabase(
         sources,
         config,
         utilityBoosted,
+        rendererRegistry,
       }),
     ),
   );
@@ -533,6 +544,7 @@ async function substringSearch(
   stashDir: string,
   sources: SearchSource[],
   config?: AkmConfig,
+  rendererRegistry: RendererRegistry = defaultRendererRegistry,
 ): Promise<StashSearchHit[]> {
   const assets = await indexAssets(stashDir, searchType, sources);
   const matched = assets.filter((asset) => !query || buildSearchText(asset.entry).includes(query));
@@ -540,7 +552,11 @@ async function substringSearch(
   if (!query) {
     const sorted = matched.sort(compareAssets);
     const unique = deduplicateAssetsByPath(sorted);
-    return Promise.all(unique.slice(0, limit).map((asset) => assetToSearchHit(asset, stashDir, sources, config)));
+    return Promise.all(
+      unique
+        .slice(0, limit)
+        .map((asset) => assetToSearchHit(asset, stashDir, sources, config, undefined, rendererRegistry)),
+    );
   }
 
   // Score and sort by relevance
@@ -551,7 +567,9 @@ async function substringSearch(
   const dedupedScored = deduplicateByPath(scored.map((s) => ({ ...s, filePath: s.asset.path })));
 
   return Promise.all(
-    dedupedScored.slice(0, limit).map(({ asset, score }) => assetToSearchHit(asset, stashDir, sources, config, score)),
+    dedupedScored
+      .slice(0, limit)
+      .map(({ asset, score }) => assetToSearchHit(asset, stashDir, sources, config, score, rendererRegistry)),
   );
 }
 
@@ -598,7 +616,10 @@ export async function buildDbHit(input: {
   sources: SearchSource[];
   config?: AkmConfig;
   utilityBoosted?: boolean;
+  /** Optional renderer registry override for test isolation. */
+  rendererRegistry?: RendererRegistry;
 }): Promise<StashSearchHit> {
+  const rendererRegistry = input.rendererRegistry ?? defaultRendererRegistry;
   const entryStashDir = findSourceForPath(input.path, input.sources)?.path ?? input.defaultStashDir;
   const canonical = deriveCanonicalAssetNameFromStashRoot(input.entry.type, entryStashDir, input.path);
   const refName =
@@ -640,13 +661,13 @@ export async function buildDbHit(input: {
     description: input.entry.description,
     tags: input.entry.tags,
     size: deriveSize(input.entry.fileSize),
-    action: buildLocalAction(input.entry.type, ref),
+    action: buildLocalAction(input.entry.type, ref, rendererRegistry),
     score,
     whyMatched,
     ...(estimatedTokens !== undefined ? { estimatedTokens } : {}),
   };
 
-  const renderer = await rendererForType(input.entry.type);
+  const renderer = await rendererForType(input.entry.type, rendererRegistry);
   if (renderer?.enrichSearchHit) {
     renderer.enrichSearchHit(hit, entryStashDir);
   }
@@ -711,6 +732,7 @@ async function assetToSearchHit(
   sources: SearchSource[],
   config?: AkmConfig,
   score?: number,
+  rendererRegistry: RendererRegistry = defaultRendererRegistry,
 ): Promise<StashSearchHit> {
   const source = findSourceForPath(asset.path, sources);
   const editable = isEditable(asset.path, config);
@@ -731,11 +753,11 @@ async function assetToSearchHit(
     description: asset.entry.description,
     tags: asset.entry.tags,
     ...(size ? { size } : {}),
-    action: buildLocalAction(asset.entry.type, ref),
+    action: buildLocalAction(asset.entry.type, ref, rendererRegistry),
     ...(score !== undefined ? { score } : {}),
     ...(estimatedTokens !== undefined ? { estimatedTokens } : {}),
   };
-  const renderer = await rendererForType(asset.entry.type);
+  const renderer = await rendererForType(asset.entry.type, rendererRegistry);
   if (renderer?.enrichSearchHit) {
     renderer.enrichSearchHit(hit, stashDir);
   }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -23,7 +23,10 @@ export function getConfigDir(env: NodeJS.ProcessEnv = process.env, platform = pr
 
     const userProfile = env.USERPROFILE?.trim();
     if (!userProfile) {
-      throw new ConfigError("Unable to determine config directory. Set APPDATA or USERPROFILE.");
+      throw new ConfigError(
+        "Unable to determine config directory. Set APPDATA or USERPROFILE.",
+        "CONFIG_DIR_UNRESOLVABLE",
+      );
     }
     return path.join(userProfile, "AppData", "Roaming", "akm");
   }
@@ -33,7 +36,10 @@ export function getConfigDir(env: NodeJS.ProcessEnv = process.env, platform = pr
 
   const home = env.HOME?.trim();
   if (!home) {
-    throw new ConfigError("Unable to determine config directory. Set XDG_CONFIG_HOME or HOME.");
+    throw new ConfigError(
+      "Unable to determine config directory. Set XDG_CONFIG_HOME or HOME.",
+      "CONFIG_DIR_UNRESOLVABLE",
+    );
   }
   return path.join(home, ".config", "akm");
 }
@@ -57,7 +63,10 @@ export function getCacheDir(): string {
 
     const appData = process.env.APPDATA?.trim();
     if (!appData) {
-      throw new ConfigError("Unable to determine cache directory. Set LOCALAPPDATA, USERPROFILE, or APPDATA.");
+      throw new ConfigError(
+        "Unable to determine cache directory. Set LOCALAPPDATA, USERPROFILE, or APPDATA.",
+        "CONFIG_DIR_UNRESOLVABLE",
+      );
     }
     // Heuristic fallback: APPDATA points to %APPDATA% (Roaming), so navigate
     // to the sibling "Local" directory. This is typically
@@ -113,7 +122,7 @@ export function getDefaultStashDir(): string {
 
   const home = process.env.HOME?.trim();
   if (!home) {
-    throw new ConfigError("Unable to determine default stash directory. Set HOME.");
+    throw new ConfigError("Unable to determine default stash directory. Set HOME.", "STASH_DIR_NOT_FOUND");
   }
   return path.join(home, "akm");
 }

--- a/src/setup-steps.ts
+++ b/src/setup-steps.ts
@@ -1,0 +1,86 @@
+/**
+ * Composable runner abstraction for `akm setup`.
+ *
+ * The interactive wizard in `setup.ts` historically ran a fixed series of
+ * step functions (`stepStashDir`, `stepOllama`, `stepLlm`, ...) inline.
+ * This module formalizes that pattern so steps can be:
+ *   - reused by `akm init` (non-interactive preset, see Finding 31),
+ *   - tested in isolation by passing a stub `SetupContext`, and
+ *   - extended by plugins without touching the wizard call site.
+ *
+ * Steps mutate state through `SetupContext.apply()`, which accumulates a
+ * delta on top of the original config. `stepLlm` reading the embedding
+ * endpoint that `stepSemanticSearch` produced is the canonical example of
+ * why mutable accumulation is preferred over immutable returns.
+ */
+
+import type { AkmConfig } from "./config";
+
+/**
+ * Context handed to each `SetupStep.run()`. Steps read the in-progress
+ * config via `ctx.config` and write changes via `ctx.apply()`.
+ */
+export interface SetupContext {
+  /**
+   * The current accumulated config. Always reflects every prior step's
+   * `apply()` calls. Treated as read-only by callers.
+   */
+  readonly config: Readonly<AkmConfig>;
+
+  /**
+   * `true` when running in `akm init` mode (or any other unattended
+   * caller). Steps that require user prompts should bail when this is set
+   * unless they are explicitly marked `nonInteractive`.
+   */
+  readonly nonInteractive: boolean;
+
+  /** Merge a partial delta into the accumulated config. */
+  apply(delta: Partial<AkmConfig>): void;
+}
+
+/**
+ * A single, composable step in the setup wizard.
+ *
+ * Steps are identified by `id` (stable, machine-readable) and `label`
+ * (human-friendly). `nonInteractive` marks steps safe to run in
+ * `akm init` mode; the runner skips interactive-only steps when
+ * `ctx.nonInteractive` is set.
+ */
+export interface SetupStep<TResult = void> {
+  readonly id: string;
+  readonly label: string;
+  /** When true, the step participates in non-interactive runs (akm init). */
+  readonly nonInteractive?: boolean;
+  run(ctx: SetupContext): Promise<TResult>;
+}
+
+/**
+ * Build a fresh `SetupContext` over a starting config. The returned context
+ * applies deltas in-place onto an internal accumulator and exposes the
+ * latest snapshot via `ctx.config`.
+ */
+export function createSetupContext(initial: AkmConfig, options: { nonInteractive: boolean }): SetupContext {
+  let acc: AkmConfig = { ...initial };
+  return {
+    get config() {
+      return acc;
+    },
+    nonInteractive: options.nonInteractive,
+    apply(delta) {
+      acc = { ...acc, ...delta };
+    },
+  };
+}
+
+/**
+ * Run a list of steps against a context. Steps marked interactive-only are
+ * skipped when `ctx.nonInteractive` is true. Returns the final accumulated
+ * config so callers can persist it without re-reading the context.
+ */
+export async function runSetupSteps(steps: SetupStep[], ctx: SetupContext): Promise<AkmConfig> {
+  for (const step of steps) {
+    if (ctx.nonInteractive && !step.nonInteractive) continue;
+    await step.run(ctx);
+  }
+  return ctx.config;
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -25,6 +25,7 @@ import { akmInit } from "./init";
 import { probeLlmCapabilities } from "./llm";
 import { getDefaultStashDir } from "./paths";
 import { clearSemanticStatus, deriveSemanticProviderFingerprint, writeSemanticStatus } from "./semantic-status";
+import { createSetupContext, runSetupSteps, type SetupStep } from "./setup-steps";
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
@@ -176,7 +177,7 @@ async function prepareSemanticSearchAssets(
 
   // For local embeddings, ensure the required package is installed first.
   if (!remote) {
-    if (!(await isTransformersAvailable())) {
+    if (!isTransformersAvailable()) {
       const spin = p.spinner();
       spin.start("Installing @huggingface/transformers...");
       try {
@@ -847,15 +848,104 @@ async function stepAgentPlatforms(current: AkmConfig): Promise<StashConfigEntry[
 
 // ── Main Wizard ─────────────────────────────────────────────────────────────
 
+/**
+ * Build the canonical list of `SetupStep`s for the interactive wizard.
+ * Exposed (and exported) so tests and `akm init` can compose subsets.
+ *
+ * Each step wraps the existing `step*` functions, accumulating its result
+ * into the shared `SetupContext`. The `nonInteractive` flag controls
+ * inclusion in `akm init` (a non-interactive preset of `akm setup`).
+ */
+export function buildSetupSteps(options: {
+  online: boolean;
+  semanticSearchOutcome: { mode: "off" | "auto"; prepareAssets: boolean };
+}): {
+  steps: SetupStep[];
+  /** Latest semantic-search choice; populated by the semantic-search step. */
+  outcome: { semantic: { mode: "off" | "auto"; prepareAssets: boolean } };
+} {
+  const outcome = { semantic: options.semanticSearchOutcome };
+  // Local cache of Ollama-detected fields surfaced from the embedding step
+  // to the LLM step. Mutable by design — `stepLlm` needs them.
+  let ollamaEndpoint: string | undefined;
+  let ollamaChatModels: string[] | undefined;
+
+  const steps: SetupStep[] = [
+    {
+      id: "stash-dir",
+      label: "Stash Directory",
+      nonInteractive: true,
+      async run(ctx) {
+        const stashDir = await stepStashDir(ctx.config);
+        ctx.apply({ stashDir });
+      },
+    },
+    {
+      id: "embedding",
+      label: "Embedding",
+      async run(ctx) {
+        if (!options.online) {
+          ctx.apply({ embedding: ctx.config.embedding });
+          return;
+        }
+        const result = await stepOllama(ctx.config);
+        ollamaEndpoint = result.ollamaEndpoint;
+        ollamaChatModels = result.ollamaChatModels;
+        ctx.apply({ embedding: result.embedding });
+      },
+    },
+    {
+      id: "llm",
+      label: "LLM Provider",
+      async run(ctx) {
+        if (!options.online) {
+          ctx.apply({ llm: ctx.config.llm });
+          return;
+        }
+        const llm = await stepLlm(ctx.config, ollamaEndpoint, ollamaChatModels);
+        ctx.apply({ llm });
+      },
+    },
+    {
+      id: "semantic-search",
+      label: "Semantic Search",
+      async run(ctx) {
+        const semantic = await stepSemanticSearch(ctx.config, ctx.config.embedding);
+        outcome.semantic = semantic;
+        ctx.apply({ semanticSearchMode: semantic.mode });
+      },
+    },
+    {
+      id: "registries",
+      label: "Registries",
+      async run(ctx) {
+        const registries = await stepRegistries(ctx.config);
+        ctx.apply({ registries });
+      },
+    },
+    {
+      id: "stash-sources",
+      label: "Stash Sources",
+      async run(ctx) {
+        const stashes = await stepStashSources(ctx.config);
+        const platforms = await stepAgentPlatforms(ctx.config);
+        const merged = [...stashes];
+        for (const ps of platforms) {
+          if (!merged.some((s) => s.path === ps.path)) merged.push(ps);
+        }
+        ctx.apply({ stashes: merged.length > 0 ? merged : undefined });
+      },
+    },
+  ];
+
+  return { steps, outcome };
+}
+
 export async function runSetupWizard(): Promise<void> {
   p.intro("akm setup");
 
   const current = loadUserConfig();
   const configPath = getConfigPath();
-
-  // Step 1: Stash directory
-  p.log.step("Step 1: Stash Directory");
-  const stashDir = await stepStashDir(current);
 
   // Quick connectivity check — skip network-dependent steps when offline
   const online = await isOnline();
@@ -866,54 +956,36 @@ export async function runSetupWizard(): Promise<void> {
     );
   }
 
-  // Step 2: Embedding (Ollama detection drives the embedding choice + surfaces
-  // the Ollama endpoint to the LLM step that follows).
-  p.log.step("Step 2: Embedding");
-  const { embedding, ollamaEndpoint, ollamaChatModels } = online
-    ? await stepOllama(current)
-    : { embedding: current.embedding };
+  const ctx = createSetupContext(current, { nonInteractive: false });
+  const { steps, outcome } = buildSetupSteps({
+    online,
+    semanticSearchOutcome: { mode: current.semanticSearchMode, prepareAssets: false },
+  });
 
-  // Step 2b: LLM provider — Anthropic / OpenAI / Gemini / Ollama / custom.
-  p.log.step("Step 2b: LLM Provider");
-  const llm = online ? await stepLlm(current, ollamaEndpoint, ollamaChatModels) : current.llm;
+  // Wrap each step with a `p.log.step()` header so the wizard UI is
+  // unchanged. The canonical `runSetupSteps()` runner is used directly by
+  // `akm init` (non-interactive) and by tests.
+  const labeledSteps: SetupStep[] = steps.map((step) => ({
+    ...step,
+    async run(stepCtx) {
+      p.log.step(step.label);
+      await step.run(stepCtx);
+    },
+  }));
+  await runSetupSteps(labeledSteps, ctx);
 
-  // Step 3: Semantic search assets
-  p.log.step("Step 3: Semantic Search");
-  const semanticSearchMode = await stepSemanticSearch(current, embedding);
-
-  // Step 4: Registries
-  p.log.step("Step 4: Registries");
-  const registries = await stepRegistries(current);
-
-  // Step 5: Stash sources
-  p.log.step("Step 5: Stash Sources");
-  const stashes = await stepStashSources(current);
-
-  // Step 6: Agent platform detection
-  p.log.step("Step 6: Agent Platform Detection");
-  const platformStashes = await stepAgentPlatforms(current);
-
-  // Merge platform stashes into main stashes list
-  const allStashes = [...stashes];
-  for (const ps of platformStashes) {
-    if (!allStashes.some((s) => s.path === ps.path)) {
-      allStashes.push(ps);
-    }
-  }
-
-  // Build final config
   const newConfig: AkmConfig = {
-    ...current,
-    stashDir,
-    embedding,
-    llm,
-    registries,
-    stashes: allStashes.length > 0 ? allStashes : undefined,
-    // Preserve existing fields
-    semanticSearchMode: semanticSearchMode.mode,
+    ...ctx.config,
+    // Preserve fields the steps don't manage explicitly.
     installed: current.installed,
     output: current.output,
   };
+  const semanticSearchMode = outcome.semantic;
+  const stashDir = newConfig.stashDir ?? current.stashDir ?? getDefaultStashDir();
+  const embedding = newConfig.embedding;
+  const llm = newConfig.llm;
+  const registries = newConfig.registries;
+  const allStashes = newConfig.stashes ?? [];
 
   // Confirm before saving
   const effectiveRegistries = registries ?? DEFAULT_CONFIG.registries ?? [];

--- a/src/stash-resolve.ts
+++ b/src/stash-resolve.ts
@@ -36,14 +36,14 @@ function resolveInTypeDir(stashDir: string, typeDir: string, type: string, name:
   const resolvedRoot = resolveAndValidateTypeRoot(root, type, name);
   const resolvedTarget = path.resolve(target);
   if (!isWithin(resolvedTarget, resolvedRoot)) {
-    throw new UsageError("Ref resolves outside the stash root.");
+    throw new UsageError("Ref resolves outside the stash root.", "PATH_ESCAPE_VIOLATION");
   }
   if (!fs.existsSync(resolvedTarget) || !fs.statSync(resolvedTarget).isFile()) {
-    throw new NotFoundError(`Stash asset not found for ref: ${type}:${name}`);
+    throw new NotFoundError(`Stash asset not found for ref: ${type}:${name}`, "ASSET_NOT_FOUND");
   }
   const realTarget = fs.realpathSync(resolvedTarget);
   if (!isWithin(realTarget, resolvedRoot)) {
-    throw new UsageError("Ref resolves outside the stash root.");
+    throw new UsageError("Ref resolves outside the stash root.", "PATH_ESCAPE_VIOLATION");
   }
   if (!isRelevantAssetFile(type, path.basename(resolvedTarget))) {
     if (type === "script") {
@@ -51,7 +51,7 @@ function resolveInTypeDir(stashDir: string, typeDir: string, type: string, name:
         "Script ref must resolve to a file with a supported script extension. Refer to the akm documentation for the complete list of supported script extensions.",
       );
     }
-    throw new NotFoundError(`Stash asset not found for ref: ${type}:${name}`);
+    throw new NotFoundError(`Stash asset not found for ref: ${type}:${name}`, "ASSET_NOT_FOUND");
   }
   return realTarget;
 }
@@ -88,7 +88,7 @@ async function resolveByCanonicalName(stashDir: string, type: string, name: stri
     const realTarget = fs.realpathSync(ctx.absPath);
     const resolvedRoot = fs.realpathSync(stashDir);
     if (!isWithin(realTarget, resolvedRoot)) {
-      throw new UsageError("Ref resolves outside the stash root.");
+      throw new UsageError("Ref resolves outside the stash root.", "PATH_ESCAPE_VIOLATION");
     }
     return realTarget;
   }

--- a/src/stash-show.ts
+++ b/src/stash-show.ts
@@ -75,14 +75,14 @@ function resolveRegisteredWikiAssetPath(wikiRoot: string, wikiName: string, asse
   const candidate = path.resolve(wikiRoot, `${pageName}.md`);
   const resolvedRoot = fs.realpathSync(wikiRoot);
   if (!candidate.startsWith(resolvedRoot + path.sep)) {
-    throw new UsageError("Ref resolves outside the stash root.");
+    throw new UsageError("Ref resolves outside the stash root.", "PATH_ESCAPE_VIOLATION");
   }
   if (!fs.existsSync(candidate) || !fs.statSync(candidate).isFile()) {
     throw new NotFoundError(`Stash asset not found for ref: wiki:${assetName}`);
   }
   const realTarget = fs.realpathSync(candidate);
   if (!realTarget.startsWith(resolvedRoot + path.sep)) {
-    throw new UsageError("Ref resolves outside the stash root.");
+    throw new UsageError("Ref resolves outside the stash root.", "PATH_ESCAPE_VIOLATION");
   }
   return realTarget;
 }

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -142,18 +142,18 @@ export function resolveWikiSource(stashDir: string, name: string): ResolvedWikiS
   }
   const external = registeredWikiSources(stashDir).find((source) => source.name === name);
   if (external) return external;
-  throw new NotFoundError(wikiNotFoundMessage(name));
+  throw new NotFoundError(wikiNotFoundMessage(name), "STASH_NOT_FOUND");
 }
 
 export function ensureWikiNameAvailable(stashDir: string, name: string): void {
   validateWikiName(name);
   const wikiDir = resolveWikiDir(stashDir, name);
   if (fs.existsSync(wikiDir)) {
-    throw new UsageError(`Wiki already exists: ${name}.`);
+    throw new UsageError(`Wiki already exists: ${name}.`, "RESOURCE_ALREADY_EXISTS");
   }
   const external = registeredWikiSources(stashDir).find((source) => source.name === name);
   if (external) {
-    throw new UsageError(`Wiki already registered: ${name}.`);
+    throw new UsageError(`Wiki already registered: ${name}.`, "RESOURCE_ALREADY_EXISTS");
   }
 }
 
@@ -374,7 +374,7 @@ export function showWiki(stashDir: string, name: string): WikiShowResult {
 export function createWiki(stashDir: string, name: string): WikiCreateResult {
   const existing = registeredWikiSources(stashDir).find((source) => source.name === name);
   if (existing) {
-    throw new UsageError(`Wiki already registered: ${name}.`);
+    throw new UsageError(`Wiki already registered: ${name}.`, "RESOURCE_ALREADY_EXISTS");
   }
   const wikiDir = resolveWikiDir(stashDir, name);
   fs.mkdirSync(wikiDir, { recursive: true });
@@ -452,11 +452,11 @@ export function removeWiki(stashDir: string, name: string, options: RemoveOption
     };
   }
   if (!fs.existsSync(wikiDir)) {
-    throw new NotFoundError(`Wiki not found: ${name}.`);
+    throw new NotFoundError(`Wiki not found: ${name}.`, "STASH_NOT_FOUND");
   }
   const wikisRoot = resolveWikisRoot(stashDir);
   if (!isWithin(wikiDir, wikisRoot)) {
-    throw new UsageError(`Refusing to remove a path outside the wikis root: ${wikiDir}`);
+    throw new UsageError(`Refusing to remove a path outside the wikis root: ${wikiDir}`, "PATH_ESCAPE_VIOLATION");
   }
 
   const removed: string[] = [];

--- a/src/workflow-authoring.ts
+++ b/src/workflow-authoring.ts
@@ -41,10 +41,13 @@ export function createWorkflowAsset(input: { name: string; content?: string; fro
   const normalizedName = normalizeWorkflowName(input.name);
   const assetPath = resolveAssetPathFromName("workflow", typeRoot, normalizedName);
   if (!isWithin(assetPath, typeRoot)) {
-    throw new UsageError(`Resolved workflow path escapes the stash: "${normalizedName}"`);
+    throw new UsageError(`Resolved workflow path escapes the stash: "${normalizedName}"`, "PATH_ESCAPE_VIOLATION");
   }
   if (fs.existsSync(assetPath) && !input.force) {
-    throw new UsageError(`Workflow "${normalizedName}" already exists. Re-run with --force to overwrite it.`);
+    throw new UsageError(
+      `Workflow "${normalizedName}" already exists. Re-run with --force to overwrite it.`,
+      "RESOURCE_ALREADY_EXISTS",
+    );
   }
 
   const content = input.from

--- a/tests/setup-run.integration.ts
+++ b/tests/setup-run.integration.ts
@@ -153,7 +153,7 @@ describe("runSetupWizard", () => {
     }));
     mock.module("../src/embedder", () => ({
       DEFAULT_LOCAL_MODEL: "Xenova/bge-small-en-v1.5",
-      isTransformersAvailable: async () => setupState.transformersAvailable,
+      isTransformersAvailable: () => setupState.transformersAvailable,
       checkEmbeddingAvailability: async () => setupState.checkEmbeddingResult,
     }));
     mock.module("../src/init", () => ({
@@ -264,7 +264,7 @@ describe("runSetupWizard", () => {
     }));
     mock.module("../src/embedder", () => ({
       DEFAULT_LOCAL_MODEL: "Xenova/bge-small-en-v1.5",
-      isTransformersAvailable: async () => setupState.transformersAvailable,
+      isTransformersAvailable: () => setupState.transformersAvailable,
       checkEmbeddingAvailability: async () => setupState.checkEmbeddingResult,
     }));
     mock.module("../src/init", () => ({
@@ -380,7 +380,7 @@ describe("runSetupWizard", () => {
     }));
     mock.module("../src/embedder", () => ({
       DEFAULT_LOCAL_MODEL: "Xenova/bge-small-en-v1.5",
-      isTransformersAvailable: async () => setupState.transformersAvailable,
+      isTransformersAvailable: () => setupState.transformersAvailable,
       checkEmbeddingAvailability: async () => setupState.checkEmbeddingResult,
     }));
     mock.module("../src/init", () => ({
@@ -482,7 +482,7 @@ describe("runSetupWizard", () => {
     }));
     mock.module("../src/embedder", () => ({
       DEFAULT_LOCAL_MODEL: "Xenova/bge-small-en-v1.5",
-      isTransformersAvailable: async () => true,
+      isTransformersAvailable: () => true,
       checkEmbeddingAvailability: async () => ({
         available: false,
         reason: "remote-unreachable",
@@ -572,7 +572,7 @@ describe("runSetupWizard", () => {
     }));
     mock.module("../src/embedder", () => ({
       DEFAULT_LOCAL_MODEL: "Xenova/bge-small-en-v1.5",
-      isTransformersAvailable: async () => false,
+      isTransformersAvailable: () => false,
       checkEmbeddingAvailability: async () => ({
         available: false,
         reason: "missing-package",
@@ -663,7 +663,7 @@ describe("runSetupWizard", () => {
     }));
     mock.module("../src/embedder", () => ({
       DEFAULT_LOCAL_MODEL: "Xenova/bge-small-en-v1.5",
-      isTransformersAvailable: async () => true,
+      isTransformersAvailable: () => true,
       checkEmbeddingAvailability: async () => ({ available: true }),
     }));
     mock.module("../src/init", () => ({
@@ -749,7 +749,7 @@ describe("runSetupWizard", () => {
     }));
     mock.module("../src/embedder", () => ({
       DEFAULT_LOCAL_MODEL: "Xenova/bge-small-en-v1.5",
-      isTransformersAvailable: async () => true,
+      isTransformersAvailable: () => true,
       checkEmbeddingAvailability: async () => ({ available: true }),
     }));
     mock.module("../src/init", () => ({
@@ -828,7 +828,7 @@ describe("runSetupWizard", () => {
     }));
     mock.module("../src/embedder", () => ({
       DEFAULT_LOCAL_MODEL: "Xenova/bge-small-en-v1.5",
-      isTransformersAvailable: async () => true,
+      isTransformersAvailable: () => true,
       checkEmbeddingAvailability: async () => ({ available: true }),
     }));
     mock.module("../src/init", () => ({
@@ -901,7 +901,7 @@ describe("runSetupWizard", () => {
     }));
     mock.module("../src/embedder", () => ({
       DEFAULT_LOCAL_MODEL: "Xenova/bge-small-en-v1.5",
-      isTransformersAvailable: async () => true,
+      isTransformersAvailable: () => true,
       checkEmbeddingAvailability: async () => ({ available: true }),
     }));
     mock.module("../src/init", () => ({


### PR DESCRIPTION
## Summary

Implements the low/medium-risk findings from #128 (parts of #122):

- **#18 BaseConnectionConfig** — shared base interface for embedding + LLM configs. Pure type DRY; on-disk JSON schema unchanged.
- **#19 `resolveStashDir` side-effect removed** — no longer writes `config.json`. Legacy `readOnly` parameter accepted (and ignored) for one release cycle.
- **#20 Machine-readable error codes** — `ConfigError`, `UsageError`, `NotFoundError` carry a stable `code` field. CLI JSON error output now includes `code` when typed.
- **#21 `--detail=agent` preset** — new detail level mapping to the agent-optimized shaper. `--for-agent` kept as a deprecated alias.
- **#22 `SetupStep` abstraction** — new `src/setup-steps.ts` formalizes the wizard's step pattern (`SetupStep` + `SetupContext` + `runSetupSteps`). `runSetupWizard` now composes the canonical step list, enabling `akm init` and tests to reuse it.
- **#29 `Bun.resolveSync` pre-check** — replaces `await import()` for `@huggingface/transformers` availability. Removes async; no module-load side effects.
- **#30 `stashInheritance: \"merge\" | \"replace\"`** — replaces the boolean `disableGlobalStashes`. Loader coerces the legacy boolean for one release cycle; `disableGlobalStashes` is now `@deprecated`.
- **#33 Injectable `RendererRegistry`** — new `RendererRegistry` interface in `src/asset-registry.ts` with `defaultRendererRegistry` and `createRendererRegistry()`. Threaded through `searchLocal` / `buildDbHit` / `assetToSearchHit` so tests can isolate renderer behavior without mutating module-level singletons.

Findings deferred to follow-up PRs:
- #31 (`akm init` as non-interactive preset) — depends on landing #22 first.
- #32 (citty consolidation of global flags) — high effort; flagged for a dedicated PR.

## Error codes added

| Class | Codes |
| --- | --- |
| `ConfigErrorCode` | `CONFIG_DIR_UNRESOLVABLE`, `STASH_DIR_NOT_FOUND`, `STASH_DIR_NOT_A_DIRECTORY`, `STASH_DIR_UNREADABLE`, `EMBEDDING_NOT_CONFIGURED`, `LLM_NOT_CONFIGURED`, `INVALID_CONFIG_FILE` |
| `UsageErrorCode` | `INVALID_FLAG_VALUE`, `UNKNOWN_CONFIG_KEY`, `INVALID_JSON_ARGUMENT`, `MISSING_REQUIRED_ARGUMENT`, `PATH_ESCAPE_VIOLATION`, `RESOURCE_ALREADY_EXISTS` |
| `NotFoundErrorCode` | `ASSET_NOT_FOUND`, `STASH_NOT_FOUND`, `WORKFLOW_NOT_FOUND`, `FILE_NOT_FOUND` |

Default codes preserve every existing throw site untouched. High-value sites (`paths.ts`, `stash-resolve.ts`, `stash-show.ts`, `wiki.ts`, `workflow-authoring.ts`, common `resolveStashDir`) get explicit codes.

## #123 rebase concern

This PR depends on the `release/0.6.0` shape of `src/config.ts` (the version with `EmbeddingConnectionConfig` / `LlmConnectionConfig` and the boolean `disableGlobalStashes`). #123 (domain model unification) reshapes the same file. **If #123 lands first, this PR will need a rebase to:**
1. Re-apply `BaseConnectionConfig` extension on whatever shape #123 leaves for the connection configs.
2. Re-apply the `stashInheritance` field + the legacy-`disableGlobalStashes` coercion in `pickKnownKeys()` and `mergeLoadedConfig()`.

The other touch points (errors.ts, asset-registry.ts, local-search.ts, setup.ts, embedder.ts, cli.ts, wiki.ts, workflow-authoring.ts) should rebase cleanly.

## Test plan

- [x] `bunx biome check src/ tests/` — clean
- [x] `bunx tsc --noEmit` — clean
- [x] `bun test` — 49 fail / 1512 pass (baseline 52 fail / 1506 pass — net improvement of 3)
- [ ] Manual: `akm setup` completes the same wizard flow.
- [ ] Manual: `akm search foo --detail agent` produces the same output as `--for-agent`.
- [ ] Manual: `akm show fake:does-not-exist --format json` includes `\"code\": \"ASSET_NOT_FOUND\"`.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)