### PR TITLE
fix: flaky config-persistence tests

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1912,18 +1912,33 @@ const WIKI_SUBCOMMAND_SET = new Set([
 ]);
 const SHOW_VIEW_MODES = new Set(["toc", "frontmatter", "full", "section", "lines"]);
 
+// ── Exit codes ──────────────────────────────────────────────────────────────
+const EXIT_GENERAL = 1;
+const EXIT_USAGE = 2;
+const EXIT_CONFIG = 78;
+
 // citty reads process.argv directly and does not accept a custom argv array,
 // so we must replace process.argv with the normalized version before runMain.
 process.argv = normalizeShowArgv(process.argv);
 // Resolve output mode once at startup from the (normalized) argv and persisted
 // config. All subsequent output() calls read from this in-memory singleton.
-initOutputMode(process.argv, loadConfig().output ?? {});
+// `initOutputMode` can throw a UsageError when --format/--detail values are
+// invalid; surface it through the same JSON-error path the rest of the CLI uses
+// rather than letting the raw exception escape with a stack trace.
+try {
+  initOutputMode(process.argv, loadConfig().output ?? {});
+} catch (error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  const hint = buildHint(message);
+  const exitCode = classifyExitCode(error);
+  const code =
+    error instanceof UsageError || error instanceof ConfigError || error instanceof NotFoundError
+      ? error.code
+      : undefined;
+  console.error(JSON.stringify({ ok: false, error: message, ...(code ? { code } : {}), hint }, null, 2));
+  process.exit(exitCode);
+}
 runMain(main);
-
-// ── Exit codes ──────────────────────────────────────────────────────────────
-const EXIT_GENERAL = 1;
-const EXIT_USAGE = 2;
-const EXIT_CONFIG = 78;
 
 function classifyExitCode(error: unknown): number {
   if (error instanceof UsageError) return EXIT_USAGE;

--- a/src/config.ts
+++ b/src/config.ts
@@ -239,11 +239,23 @@ export function getConfigPath(): string {
 const PROJECT_CONFIG_RELATIVE_PATH = path.join(".akm", "config.json");
 
 let cachedConfig: { config: AkmConfig; signature: string } | undefined;
-let cachedUserConfig: { config: AkmConfig; path: string; mtime: number } | undefined;
+let cachedUserConfig: { config: AkmConfig; path: string; mtime: number; size: number; contentHash: string } | undefined;
 
 export function resetConfigCache(): void {
   cachedConfig = undefined;
   cachedUserConfig = undefined;
+}
+
+function hashString(text: string): string {
+  // Simple, fast non-cryptographic hash (FNV-1a 32-bit) — sufficient to detect
+  // content changes between config writes when filesystem mtime resolution is
+  // too coarse to reflect rapid back-to-back writes (common in tests).
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16);
 }
 
 export function loadUserConfig(): AkmConfig {
@@ -252,17 +264,43 @@ export function loadUserConfig(): AkmConfig {
   let stat: fs.Stats;
   try {
     stat = fs.statSync(configPath);
-    if (cachedUserConfig && cachedUserConfig.path === configPath && cachedUserConfig.mtime === stat.mtimeMs) {
-      return cachedUserConfig.config;
-    }
   } catch {
     cachedUserConfig = undefined;
     return applyRuntimeEnvApiKeys({ ...DEFAULT_CONFIG });
   }
 
-  const config = mergeLoadedConfig(DEFAULT_CONFIG, readNormalizedConfig(configPath));
+  // Cache key combines mtimeMs + size + content hash. mtimeMs alone is unreliable
+  // when tests write multiple times within the filesystem mtime resolution
+  // window (often 1ms+). Reading + hashing on cache miss is cheap and ensures
+  // we never serve stale config.
+  let text: string;
+  try {
+    text = fs.readFileSync(configPath, "utf8");
+  } catch {
+    cachedUserConfig = undefined;
+    return applyRuntimeEnvApiKeys({ ...DEFAULT_CONFIG });
+  }
+  const contentHash = hashString(text);
+
+  if (
+    cachedUserConfig &&
+    cachedUserConfig.path === configPath &&
+    cachedUserConfig.mtime === stat.mtimeMs &&
+    cachedUserConfig.size === stat.size &&
+    cachedUserConfig.contentHash === contentHash
+  ) {
+    return cachedUserConfig.config;
+  }
+
+  const config = mergeLoadedConfig(DEFAULT_CONFIG, readNormalizedConfigFromText(configPath, text));
   const finalConfig = applyRuntimeEnvApiKeys(config);
-  cachedUserConfig = { config: finalConfig, path: configPath, mtime: stat.mtimeMs };
+  cachedUserConfig = {
+    config: finalConfig,
+    path: configPath,
+    mtime: stat.mtimeMs,
+    size: stat.size,
+    contentHash,
+  };
   return finalConfig;
 }
 
@@ -287,6 +325,7 @@ export function loadConfig(): AkmConfig {
 
 export function saveConfig(config: AkmConfig): void {
   cachedConfig = undefined;
+  cachedUserConfig = undefined;
   const configPath = getConfigPath();
   const dir = path.dirname(configPath);
   fs.mkdirSync(dir, { recursive: true });
@@ -429,6 +468,18 @@ function readNormalizedConfig(configPath: string): Partial<AkmConfig> | undefine
   const raw = readConfigObject(configPath);
   const expanded = raw ? expandEnvVars(raw) : undefined;
   return expanded ? pickKnownKeys(expanded) : undefined;
+}
+
+function readNormalizedConfigFromText(_configPath: string, text: string): Partial<AkmConfig> | undefined {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(stripJsonComments(text));
+  } catch {
+    return undefined;
+  }
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return undefined;
+  const expanded = expandEnvVars(raw as Record<string, unknown>);
+  return pickKnownKeys(expanded);
 }
 
 function parseOutputConfig(value: unknown): OutputConfig | undefined {
@@ -1107,7 +1158,18 @@ function isFile(filePath: string): boolean {
 
 function getFileSignatureToken(filePath: string): string {
   try {
-    return String(fs.statSync(filePath).mtimeMs);
+    const stat = fs.statSync(filePath);
+    // mtimeMs alone is unreliable on filesystems with low-resolution mtime
+    // (HFS+, some network FS, or very fast back-to-back writes in tests).
+    // Combine mtime + size + content hash so the signature actually changes
+    // when content does.
+    let contentHash = "";
+    try {
+      contentHash = hashString(fs.readFileSync(filePath, "utf8"));
+    } catch {
+      // ignore — fall back to stat-only signature
+    }
+    return `${stat.mtimeMs}:${stat.size}:${contentHash}`;
   } catch {
     return "missing";
   }


### PR DESCRIPTION
## Root cause

Two distinct bugs surfaced as flaky tests in the full `bun test` run (all passed in isolation):

### 1. `cachedUserConfig` not invalidated on save (the big one — 27 tests)

`src/config.ts` keeps two module-level caches:

- `cachedConfig` — keyed by file signature (was just `mtimeMs`).
- `cachedUserConfig` — keyed by `{ path, mtimeMs }`.

`saveConfig()` cleared `cachedConfig` but **not** `cachedUserConfig`. Tests that fresh-mint an `XDG_CONFIG_HOME`, write a config, and immediately call `loadConfig()`/`loadUserConfig()` saw stale data because:

- `mtimeMs` resolution on most filesystems is ~1ms, and back-to-back writes in fast tests can leave it unchanged.
- Even when `loadConfig` invalidated, `loadUserConfig` (called inside it) returned the cached stale layer.

### 2. `initOutputMode` throw escaped the JSON-error envelope (1 test)

`src/cli.ts` calls `initOutputMode(process.argv, …)` at top level. When `--detail invalid` is passed, `parseDetailLevel` throws `UsageError`. This throw bypassed `runWithJsonErrors`, so the user got a raw stack trace instead of the JSON envelope with `hint`. The test asserted on the `hint` field and failed.

## Source-code fixes

**`src/config.ts`**
- `saveConfig()` now clears `cachedUserConfig` symmetrically with `cachedConfig`.
- `cachedUserConfig` cache key is now `{ path, mtime, size, contentHash }` — defense-in-depth so even a `saveConfig` we forgot to invalidate would still detect a change.
- `loadConfig`'s file signature token now includes size + content hash too.
- Content hash is FNV-1a 32-bit (cheap, non-cryptographic, fine for change-detection).

**`src/cli.ts`**
- Wrapped `initOutputMode(...)` in a try/catch that mirrors `runWithJsonErrors`: classifies exit code, builds hint, prints JSON envelope, exits.
- Hoisted `EXIT_GENERAL` / `EXIT_USAGE` / `EXIT_CONFIG` consts above the try/catch (TDZ).

## Tests deleted

None. Both bugs were real and now have proper fixes.

## Before / after

| | fails |
|---|---|
| before (release/0.6.0) | 1 |
| before (worktree base, includes 2 unrelated commits from main) | 28 |
| after | **0** |

(The 28 vs 1 delta is because the worktree happened to be branched from `main`, where the config-cache bug surfaced in many more tests than on `release/0.6.0`. All 28 fails on the worktree base, and the 1 fail on `release/0.6.0`, are fixed by this PR.)

## Verification

- `bunx biome check src/ tests/` — clean (2 pre-existing warnings in `stash-providers/{git,website}.ts`, unrelated)
- `bunx tsc --noEmit` — clean
- `bun test` — 1564 pass, 7 skip, **0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)