### PR TITLE
fix(workflow): allow resuming blocked steps for reclassification

### DIFF
--- a/src/workflow-runs.ts
+++ b/src/workflow-runs.ts
@@ -201,9 +201,21 @@ export function resumeWorkflowRun(runId: string): WorkflowRunDetail {
       const steps = readWorkflowRunSteps(workflowDb, run.id);
       return buildWorkflowRunDetail(run, steps);
     }
-    // blocked or failed → flip back to active
+    // blocked or failed → flip back to active and re-open the current step so
+    // it can be reclassified (completed, failed, skipped) after resuming.
     const now = new Date().toISOString();
-    workflowDb.prepare("UPDATE workflow_runs SET status = 'active', updated_at = ? WHERE id = ?").run(now, run.id);
+    workflowDb.transaction(() => {
+      if (run.current_step_id) {
+        workflowDb
+          .prepare(
+            `UPDATE workflow_run_steps
+             SET status = 'pending', notes = NULL, evidence_json = NULL, completed_at = NULL
+             WHERE run_id = ? AND step_id = ? AND status IN ('blocked', 'failed')`,
+          )
+          .run(run.id, run.current_step_id);
+      }
+      workflowDb.prepare("UPDATE workflow_runs SET status = 'active', updated_at = ? WHERE id = ?").run(now, run.id);
+    })();
     const updated: WorkflowRunRow = { ...run, status: "active", updated_at: now };
     const steps = readWorkflowRunSteps(workflowDb, run.id);
     return buildWorkflowRunDetail(updated, steps);

--- a/tests/workflow-qa-fixes.test.ts
+++ b/tests/workflow-qa-fixes.test.ts
@@ -131,6 +131,56 @@ describe("workflow resume command", () => {
     const { run: resumedRun } = JSON.parse(resumed.stdout) as { run: { status: string } };
     expect(resumedRun.status).toBe("active");
   });
+
+  // Issue #156: after resuming a blocked run, the previously-blocked step must be
+  // re-actionable so it can be reclassified to completed/failed/skipped.
+  for (const newState of ["completed", "failed", "skipped"] as const) {
+    test(`resume re-opens a blocked step so it can be reclassified to ${newState}`, () => {
+      const env = createWorkflowEnv();
+      setupWorkflow(env);
+
+      const started = runCli(["workflow", "start", "workflow:test-flow"], env);
+      expect(started.status).toBe(0);
+      const { run: startRun } = JSON.parse(started.stdout) as { run: { id: string } };
+
+      expect(runCli(["workflow", "complete", startRun.id, "--step", "first", "--state", "blocked"], env).status).toBe(
+        0,
+      );
+      expect(runCli(["workflow", "resume", startRun.id], env).status).toBe(0);
+
+      const reclassified = runCli(
+        ["workflow", "complete", startRun.id, "--step", "first", "--state", newState, "--notes", "resolved"],
+        env,
+      );
+      expect(reclassified.status).toBe(0);
+      const parsed = JSON.parse(reclassified.stdout) as {
+        workflow: { steps: Array<{ id: string; status: string }> };
+      };
+      const firstStep = parsed.workflow.steps.find((s) => s.id === "first");
+      expect(firstStep?.status).toBe(newState);
+    });
+  }
+
+  test("resume does not disturb already-completed earlier steps", () => {
+    const env = createWorkflowEnv();
+    setupWorkflow(env);
+
+    const started = runCli(["workflow", "start", "workflow:test-flow"], env);
+    expect(started.status).toBe(0);
+    const { run: startRun } = JSON.parse(started.stdout) as { run: { id: string } };
+
+    expect(runCli(["workflow", "complete", startRun.id, "--step", "first"], env).status).toBe(0);
+    expect(runCli(["workflow", "complete", startRun.id, "--step", "second", "--state", "blocked"], env).status).toBe(0);
+    expect(runCli(["workflow", "resume", startRun.id], env).status).toBe(0);
+
+    const status = runCli(["workflow", "status", startRun.id], env);
+    expect(status.status).toBe(0);
+    const detail = JSON.parse(status.stdout) as {
+      workflow: { steps: Array<{ id: string; status: string }> };
+    };
+    expect(detail.workflow.steps.find((s) => s.id === "first")?.status).toBe("completed");
+    expect(detail.workflow.steps.find((s) => s.id === "second")?.status).toBe("pending");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #156

## Summary
When a workflow step was marked `blocked` and the run was later resumed, only the `workflow_runs` row flipped from `blocked` → `active`; the step row stayed at `blocked`, so `completeWorkflowStep` rejected any follow-up transition. Wrap the resume in a transaction that also resets the current blocked/failed step back to `pending`, clearing notes/evidence/completed_at so the step is genuinely re-actionable.

## Acceptance
- [x] After `akm workflow resume <id>`, marking the previously-blocked step `completed`/`failed`/`skipped` works (3 parametrized tests).
- [x] Run state and step state stay in sync (guard test confirms earlier completed steps are untouched).
- [x] Existing resume semantics (blocked → active, failed → active, completed run rejected) preserved.

## Checks
- `bunx tsc --noEmit` clean
- `bunx biome check src/ tests/` clean (2 pre-existing warnings only)
- `bun test tests/workflow-qa-fixes.test.ts` → 26 pass / 0 fail
- Full suite on integration branch containing all five 0.6.0 fixes: 1581 / 0 / 7 skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)