### PR TITLE
fix(workflow): allow intro paragraph before first step

### DIFF
--- a/src/workflow-markdown.ts
+++ b/src/workflow-markdown.ts
@@ -121,6 +121,18 @@ function extractWorkflowSteps(body: string): WorkflowStepDefinition[] {
   const steps: WorkflowStepDefinition[] = [];
   let index = titleLineIndex + 1;
 
+  // Skip optional intro prose before the first ## Step: section.
+  while (index < lines.length && !/^##\s+Step:\s+/.test((lines[index] ?? "").trim())) {
+    const line = lines[index] ?? "";
+    const trimmed = line.trim();
+
+    if (trimmed.startsWith("# ") && !/^#\s+Workflow:\s+/.test(trimmed)) {
+      throw new WorkflowValidationError(`Unexpected top-level heading after workflow title: "${trimmed}".`);
+    }
+
+    index++;
+  }
+
   while (index < lines.length) {
     const line = lines[index] ?? "";
     const trimmed = line.trim();

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -937,16 +937,14 @@ describe("Scenario: Registry lifecycle CLI (no network)", () => {
       ].join("\n"),
       "utf8",
     );
+    // Truly malformed: no `# Workflow:` heading. Intro prose between the
+    // title and the first step is now permitted (#158).
     fs.writeFileSync(
       path.join(stashDir, "workflows", "bad.md"),
       [
         "---",
         "description: Bad workflow",
         "---",
-        "",
-        "# Workflow: Bad",
-        "",
-        "This prose breaks the parser.",
         "",
         "## Step: First",
         "Step ID: first",

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -247,16 +247,14 @@ test("akmIndex skips malformed workflow assets and reports warnings", async () =
       "",
     ].join("\n"),
   );
+  // Truly malformed: no `# Workflow:` heading at all. (Intro prose between
+  // the title and the first step is now permitted — see #158.)
   writeFile(
     path.join(stashDir, "workflows", "bad.md"),
     [
       "---",
       "description: Bad workflow",
       "---",
-      "",
-      "# Workflow: Bad",
-      "",
-      "This prose breaks the parser.",
       "",
       "## Step: First",
       "Step ID: first",

--- a/tests/workflow-markdown.test.ts
+++ b/tests/workflow-markdown.test.ts
@@ -80,3 +80,40 @@ describe("parseWorkflowMarkdown", () => {
     expect(() => parseWorkflowMarkdown(invalid)).toThrow(/Unsupported key\(s\): model/);
   });
 });
+
+describe("parseWorkflowMarkdown — intro paragraph (issue #158)", () => {
+  const WORKFLOW_WITH_INTRO = `# Workflow: Example
+
+This workflow is advisory and should only prepare commands.
+
+## Step: First Step
+Step ID: first-step
+
+### Instructions
+Do the thing.
+`;
+
+  test("parses cleanly when intro paragraph precedes first step", () => {
+    const workflow = parseWorkflowMarkdown(WORKFLOW_WITH_INTRO);
+    expect(workflow.title).toBe("Example");
+    expect(workflow.steps).toHaveLength(1);
+    expect(workflow.steps[0]?.id).toBe("first-step");
+    expect(workflow.steps[0]?.title).toBe("First Step");
+  });
+
+  test("existing valid workflows without intro paragraph parse identically", () => {
+    const workflow = parseWorkflowMarkdown(VALID_WORKFLOW);
+    expect(workflow.title).toBe("Ship Release");
+    expect(workflow.steps).toHaveLength(2);
+    expect(workflow.steps[0]?.id).toBe("validate");
+    expect(workflow.steps[1]?.id).toBe("deploy");
+  });
+
+  test("rejects workflow with intro paragraph but no steps", () => {
+    const noSteps = `# Workflow: No Steps
+
+This workflow has an intro but no steps at all.
+`;
+    expect(() => parseWorkflowMarkdown(noSteps)).toThrow(/must contain at least one "## Step: <title>" section/);
+  });
+});


### PR DESCRIPTION
Fixes #158

## Summary
The workflow markdown parser rejected any non-blank content between `# Workflow: <title>` and the first `## Step:`, even short advisory paragraphs. Add a pre-loop that advances past non-step content before the existing step parser takes over. The \"at least one step\" guard stays in place, and unexpected top-level `#` headings are still rejected.

## Acceptance
- [x] Intro paragraph + step parses cleanly.
- [x] Existing valid workflows parse identically (no fixture regressions).
- [x] Intro-only workflow (no `## Step:`) still rejected with clear error.

## Checks
- `bunx tsc --noEmit` clean
- `bunx biome check` clean
- 3 new parser tests; also updates `tests/indexer.test.ts` and `tests/e2e.test.ts` fixtures that used \"intro paragraph\" as a malformed-workflow example (now valid) — switched those fixtures to omit the `# Workflow:` heading entirely.
- Full suite on integration: 1581 / 0 / 7 skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)