### PR TITLE
fix(registry): drop incomplete hit objects from search response

### DIFF
--- a/src/registry-search.ts
+++ b/src/registry-search.ts
@@ -57,8 +57,26 @@ export async function searchRegistry(query: string, options?: RegistrySearchOpti
     const value = result.value;
     if (!value) continue;
 
-    allHits.push(...value.hits);
-    if (value.assetHits) allAssetHits.push(...value.assetHits);
+    let dropped = 0;
+    for (const hit of value.hits) {
+      if (isCompleteHit(hit)) {
+        allHits.push(hit);
+      } else {
+        dropped++;
+      }
+    }
+    if (value.assetHits) {
+      for (const hit of value.assetHits) {
+        if (isCompleteAssetHit(hit)) {
+          allAssetHits.push(hit);
+        } else {
+          dropped++;
+        }
+      }
+    }
+    if (dropped > 0) {
+      warnings.push(`Registry returned ${dropped} incomplete hit(s); dropped from response.`);
+    }
     if (value.warnings) warnings.push(...value.warnings);
   }
 
@@ -126,4 +144,34 @@ function createProvider(entry: RegistryConfigEntry, warnings: string[]) {
 function clampLimit(limit: number | undefined): number {
   if (!limit || !Number.isFinite(limit)) return 20;
   return Math.min(100, Math.max(1, Math.trunc(limit)));
+}
+
+// A complete hit must have the fields downstream consumers (CLI rendering,
+// `akm add`) rely on. Providers that return partial records would otherwise
+// surface as `{}` in the JSON output.
+function isCompleteHit(hit: RegistrySearchHit | undefined | null): hit is RegistrySearchHit {
+  if (!hit || typeof hit !== "object") return false;
+  return (
+    typeof hit.source === "string" &&
+    typeof hit.id === "string" &&
+    hit.id.length > 0 &&
+    typeof hit.title === "string" &&
+    hit.title.length > 0 &&
+    typeof hit.ref === "string" &&
+    hit.ref.length > 0 &&
+    typeof hit.installRef === "string" &&
+    hit.installRef.length > 0
+  );
+}
+
+function isCompleteAssetHit(hit: RegistryAssetSearchHit | undefined | null): hit is RegistryAssetSearchHit {
+  if (!hit || typeof hit !== "object") return false;
+  return (
+    hit.type === "registry-asset" &&
+    typeof hit.assetType === "string" &&
+    hit.assetType.length > 0 &&
+    typeof hit.assetName === "string" &&
+    hit.assetName.length > 0 &&
+    typeof hit.action === "string"
+  );
 }

--- a/tests/registry-search.test.ts
+++ b/tests/registry-search.test.ts
@@ -648,3 +648,66 @@ describe("provider routing", () => {
     }
   });
 });
+
+// ── Issue #159: incomplete hits must never appear in JSON output ────────────
+
+describe("incomplete hits filter (#159)", () => {
+  test("hits missing required fields are dropped from response", async () => {
+    const { registerProvider } = await import("../src/registry-factory");
+    const goodHit = {
+      source: "github" as const,
+      id: "github:owner/good",
+      title: "Good Hit",
+      ref: "github:owner/good",
+      installRef: "github:owner/good",
+    };
+    registerProvider("incomplete-hits-test", () => ({
+      type: "incomplete-hits-test",
+      async search() {
+        return {
+          // {} = empty placeholder; missing-id = partial; goodHit = valid
+          hits: [{} as never, { source: "github", title: "x" } as never, goodHit],
+        };
+      },
+    }));
+
+    const result = await searchRegistry("anything", {
+      registries: [{ url: "http://unused", provider: "incomplete-hits-test" }],
+    });
+
+    expect(result.hits).toEqual([goodHit]);
+    expect(result.hits.every((h) => h && typeof h === "object" && Object.keys(h).length > 0)).toBe(true);
+    expect(result.warnings.some((w) => /incomplete hit/i.test(w))).toBe(true);
+  });
+
+  test("incomplete asset hits are dropped from assetHits", async () => {
+    const { registerProvider } = await import("../src/registry-factory");
+    registerProvider("incomplete-assets-test", () => ({
+      type: "incomplete-assets-test",
+      async search() {
+        return {
+          hits: [],
+          assetHits: [
+            {} as never,
+            { type: "registry-asset", assetType: "skill" } as never,
+            {
+              type: "registry-asset" as const,
+              assetType: "skill",
+              assetName: "deploy",
+              action: "akm show skill:deploy",
+              stash: { id: "x", name: "x" },
+            },
+          ],
+        };
+      },
+    }));
+
+    const result = await searchRegistry("anything", {
+      registries: [{ url: "http://unused", provider: "incomplete-assets-test" }],
+    });
+
+    expect(result.assetHits).toBeDefined();
+    expect(result.assetHits?.length).toBe(1);
+    expect(result.assetHits?.[0].assetName).toBe("deploy");
+  });
+});


### PR DESCRIPTION
Fixes #159

## Summary
Providers returning partial records surfaced as empty `{}` hits in `akm registry search --format json`, breaking schema-dependent consumers. Filter at the merge point with predicate guards on both stash hits and asset hits, and emit a warning naming the dropped count so the upstream provider bug stays visible instead of being silently hidden.

## Acceptance
- [x] Hits missing required fields (`id`, `title`, `ref`, `installRef`) are dropped.
- [x] Asset hits missing required fields (`assetType`, `assetName`, `action`) are dropped.
- [x] A warning names the dropped count so the provider bug remains visible.
- [x] Well-formed hits flow through untouched.

## Checks
- `bunx tsc --noEmit` clean
- `bunx biome check` clean
- 2 new tests in `tests/registry-search.test.ts` using in-test provider registration
- Full suite on integration: 1581 / 0 / 7 skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)