### PR TITLE
docs(getting-started): add isolated sandbox workflow section

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -133,6 +133,33 @@ akm add https://www.agentic-patterns.com/ --name agent-patterns --max-pages 100
 See [registry.md](registry.md) for the full install flow and supported
 ref formats.
 
+## Isolated Sandbox Workflow
+
+When testing agent behavior, authoring new assets, or reproducing an issue,
+you often want a clean stash that does not touch your real one. Every akm
+command honours the standard XDG env vars plus `AKM_STASH_DIR`, so you can
+spin up a disposable environment in a single terminal:
+
+```bash
+SANDBOX=$(mktemp -d)
+export HOME="$SANDBOX"
+export XDG_CONFIG_HOME="$SANDBOX/config"
+export XDG_DATA_HOME="$SANDBOX/data"
+export XDG_CACHE_HOME="$SANDBOX/cache"
+export AKM_STASH_DIR="$SANDBOX/stash"
+
+akm init                        # initialize the sandbox stash
+akm index --full                # empty but valid index
+akm workflow create demo        # create a template-backed workflow asset
+akm workflow start workflow:demo
+# ... exercise the flow ...
+
+rm -rf "$SANDBOX"               # tear down when done
+```
+
+Nothing written to `$SANDBOX` ever reaches your default stash, so this
+pattern is safe to script into CI or agent test harnesses.
+
 ## Next Steps
 
 - [Concepts](concepts.md) -- Asset types, classification, and the stash


### PR DESCRIPTION
Fixes #160

## Summary
Clean-stash agentic experimentation is supported end-to-end once #157 (path resolution) and #158 (parser intro) land, but the recipe was undocumented. Add a short, self-contained section to `getting-started.md` that spins up a throwaway `HOME` + `XDG_*` + `AKM_STASH_DIR` sandbox so agents and CI can reproduce issues or test assets without touching the user's real stash.

Verified by reproducing the original issue's repro steps end-to-end against a sandbox: `akm init` → `akm index --full` → `akm workflow create <name>` → `akm workflow create <name> --from <file>` → `akm workflow start` all succeed cleanly once #157 and #158 are applied.

## Acceptance
- [x] `akm init` + workflow create/import/start works in a fresh isolated sandbox.
- [x] Docs contain a short sandbox recipe.
- [x] Errors surfaced during the repro now point to the next corrective action (covered by #157 + #158 messaging).

## Dependencies
- Depends on #157 (path escape) and #158 (intro prose). Safe to merge in any order since this PR is docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)