### PR TITLE
ci: include release/* branches in push and pull_request triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, "fix/*"]
+    branches: [main, "fix/*", "release/*"]
     paths-ignore:
       - "docs/**"
       - "README.md"
@@ -11,7 +11,7 @@ on:
       - "CLAUDE.md"
       - "LICENSE"
   pull_request:
-    branches: [main]
+    branches: [main, "release/*"]
     paths-ignore:
       - "docs/**"
       - "README.md"


### PR DESCRIPTION
## Summary
PRs targeting `release/0.6.0` produced no CI runs — the `pull_request.branches` filter was scoped to `[main]` only. This PR expands both `push.branches` and `pull_request.branches` to include `release/*` so release-line PRs get the same check matrix (`check`, `semantic-search`, `docker-install`) as main-targeted PRs.

Motivated by the 0.6.0 batch (#163-#167) landing against `release/0.6.0` with no CI coverage. Future PRs on release lines will be covered automatically.

## Checks
- Config-only change. YAML lints clean via biome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)