### PR TITLE
docs: complete 0.6.0 migration guide + broader docs audit

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,8 +12,8 @@ These flags are accepted by all commands:
 | Flag | Values | Default | Description |
 | --- | --- | --- | --- |
 | `--format` | `json`, `text`, `yaml`, `jsonl` | `json` | Output format |
-| `--detail` | `brief`, `normal`, `full`, `summary` | `brief` | Output detail level |
-| `--for-agent` | boolean | `false` | Agent-optimized output: strips non-actionable fields, overrides `--detail` |
+| `--detail` | `brief`, `normal`, `full`, `summary`, `agent` | `brief` | Output detail level |
+| `--for-agent` | boolean | `false` | **Deprecated alias** for `--detail=agent`; kept for one release cycle. Prefer `--detail=agent` |
 | `--quiet` / `-q` | boolean | `false` | Suppress stderr warnings |
 
 ### `--format jsonl`
@@ -22,14 +22,16 @@ Outputs one JSON object per line. For `search` and `registry search`, each hit
 is a separate line. For other commands, the entire result is a single line.
 Useful for streaming consumption by scripts or agents.
 
-### `--for-agent`
+### `--detail=agent` (was `--for-agent`)
 
 Strips output to only action-relevant fields:
 
 - **search**: keeps `name`, `ref`, `type`, `description`, `action`, `score`, `estimatedTokens`
 - **show**: keeps `type`, `name`, `description`, `action`, `content`, `template`, `prompt`, `run`, `setup`, `cwd`, `toolPolicy`, `modelHint`, `agent`, `parameters`, `workflowTitle`, `workflowParameters`, `steps`
 
-Takes precedence over `--detail`.
+Prefer `--detail=agent` going forward. The `--for-agent` boolean is kept as
+a deprecated alias for one release cycle and will be removed in a future
+minor release — see the [v0.5 → v0.6 migration guide](migration/v0.5-to-v0.6.md).
 
 ### `--detail summary`
 
@@ -406,7 +408,7 @@ akm add github:owner/repo#v1.2.3     # GitHub with tag
 akm add https://github.com/owner/repo
 akm add git+https://gitlab.com/org/stash
 akm add ./path/to/local/stash
-akm add context-hub
+akm add github:andrewyng/context-hub --name context-hub  # context-hub as a git stash
 akm add https://docs.example.com --name docs              # Website
 akm add https://docs.example.com --max-pages 100 --max-depth 5
 ```
@@ -441,8 +443,12 @@ config so subsequent re-indexes use the same limits.
 
 See [registry.md](registry.md) for the full install flow for managed sources.
 
-`akm add context-hub` is a convenience alias that adds the context-hub
-GitHub repo as a git provider source.
+> **0.6.0 note:** the pre-0.6.0 `akm add context-hub` convenience alias and
+> the `akm enable context-hub` / `akm disable context-hub` commands were
+> removed. Add it explicitly as a git stash:
+> `akm add github:andrewyng/context-hub --name context-hub`. The legacy
+> stash *type* string `"context-hub"` in existing configs still normalizes
+> to `"git"` at load time, so you don't need to edit your config files.
 
 ### list
 
@@ -611,15 +617,38 @@ Record a memory in the default stash. This writes a markdown file into
 akm remember "Deployment needs VPN access"
 akm remember --name release-retro < notes.md
 akm remember "Pair with ops before rotating prod secrets" --name ops/prod-secrets
+
+# With structured frontmatter (0.6.0+):
+akm remember "VPN required for staging deploys" \
+  --tag ops --tag networking \
+  --expires 90d \
+  --source "skill:deploy"
+
+# Opt-in heuristic tagging — derives `code`, `source`, `observed_at`, `subjective`:
+akm remember "Found this snippet: \`curl -fsSL ... | bash\`" --tag ops --auto
+
+# Opt-in LLM enrichment (requires configured LLM endpoint; fails soft):
+akm remember "Long meeting notes..." --enrich
 ```
 
 | Flag | Description |
 | --- | --- |
 | `--name` | Optional memory name. Defaults to a slug derived from the content |
 | `--force` | Overwrite an existing memory with the same name |
+| `--tag <v>` | Tag to attach to the memory. Repeatable: `--tag foo --tag bar` |
+| `--expires <dur>` | Expiry shorthand (`30d`, `12h`, `6m`). Resolved to an ISO date |
+| `--source <s>` | Free-form source reference — URL, asset ref, file path, or any string |
+| `--auto` | Apply heuristic tagging from the body (opt-in, zero-latency, pure TS) |
+| `--enrich` | Call the configured LLM for tag/description proposals (opt-in, 10s timeout, fails soft) |
 
 Pass the content as a quoted positional argument for short notes, or pipe
 markdown into stdin for longer memories.
+
+**Zero-flag form** (`akm remember "body"`) writes a bare memory with no
+frontmatter — existing agent scripts keep working unchanged. Any use of
+`--tag` / `--expires` / `--source` / `--auto` / `--enrich` triggers a
+required-field check: if `tags` cannot be derived, the command rejects
+*before* writing the file, so you never end up with an orphan.
 
 ### import
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -116,6 +116,13 @@ akm add http://host:1933 --provider openviking --options '{"apiKey":"key"}'
 Memory assets appear in search results with the `memory` type, giving agents
 access to recalled context from previous sessions or external knowledge bases.
 
+Memories captured with `akm remember` can carry optional YAML frontmatter
+(`tags`, `source`, `observed_at`, `expires`, `subjective`, `description`) that
+the indexer uses for ranking. Supply those fields explicitly with
+`--tag`/`--expires`/`--source`, derive them from the body heuristically with
+`--auto`, or have the configured LLM propose them with `--enrich`. See
+[`akm remember`](cli.md#remember) for the full flag list.
+
 ## Refs
 
 Assets are identified by a **ref** -- a compact handle returned by

--- a/docs/migration/v0.5-to-v0.6.md
+++ b/docs/migration/v0.5-to-v0.6.md
@@ -16,16 +16,48 @@ from `CHANGELOG.md` and the release notes embedded in this document.
 
 ## Table of contents
 
+- [Installing 0.6.0](#installing-060)
 - [What changed in 0.6.0](#what-changed-in-060)
 - [Automatic migrations (no action required)](#automatic-migrations-no-action-required)
 - [Manual actions required](#manual-actions-required)
 - [Wire format change: `kits[]` → `stashes[]`](#wire-format-change-kits--stashes)
 - [Registry index schema v3](#registry-index-schema-v3)
 - [Publisher / kit-maker changes](#publisher--kit-maker-changes)
+- [Sibling repositories](#sibling-repositories)
+- [New in 0.6.0 (bonus features)](#new-in-060-bonus-features)
 - [Internal types and file renames (developers only)](#internal-types-and-file-renames-developers-only)
 - [Removed without replacement](#removed-without-replacement)
 - [Verifying the upgrade](#verifying-the-upgrade)
+- [Troubleshooting](#troubleshooting)
 - [Rolling back](#rolling-back)
+
+## Installing 0.6.0
+
+Pick whichever install method you used for 0.5.x:
+
+```sh
+# npm
+npm install -g akm-cli@0.6.0
+
+# bun
+bun install -g akm-cli@0.6.0
+
+# From source (contributors)
+git fetch origin && git checkout v0.6.0 && bun install
+```
+
+If you installed via `akm upgrade` on 0.5.x, you can use it again on
+0.6.0 — the command re-runs the same underlying package install:
+
+```sh
+akm upgrade
+```
+
+The upgrade itself does **not** touch your stash files, your
+`config.json`, or your registry index. Automatic migrations run the
+first time a 0.6.0 command reads them. See
+[Automatic migrations](#automatic-migrations-no-action-required) for the
+exact list.
 
 ## What changed in 0.6.0
 
@@ -407,6 +439,59 @@ The `akm.include` array and other publish-time `package.json` fields are
 unchanged in 0.6.0. Existing kits do not need to be re-published unless
 you also want to drop the `akm-kit` keyword.
 
+## Sibling repositories
+
+akm ships as three coordinated repositories. All three shipped the 0.6.0
+terminology cut together:
+
+- **`itlackey/akm`** (this repo) — the CLI. Ship as `akm-cli@0.6.0`.
+- **`itlackey/akm-stash`** — the reference stash of official agent assets.
+  Its `package.json` `keywords` and repo topic both moved from `akm-kit`
+  to `akm-stash`. If you depend on the published npm package, pin the
+  0.6.0-compatible release.
+- **`itlackey/akm-registry`** — the build pipeline that generates the
+  public registry index. It now emits schema v3 (`stashes[]`). If you
+  self-host a registry built from this pipeline, pull the 0.6.0 tag and
+  regenerate your index — older clients (`akm-cli` 0.5.x) will not parse
+  v3, so you may want to keep two index URLs during your transition
+  window.
+
+If you consume only the official hosted registry, no action is needed —
+the registry already serves a v3 index from every 0.6.0+ CLI build.
+
+## New in 0.6.0 (bonus features)
+
+These are additive — none of them require action to upgrade — but they
+are worth a scan because they unlock new workflows once you're on 0.6.0.
+
+- **Memory frontmatter on `akm remember` (#169).** `--tag`, `--expires`,
+  `--source`, plus opt-in `--auto` (heuristics) and `--enrich` (LLM)
+  attach structured metadata to memories so the indexer can rank them.
+  Bare `akm remember "body"` still writes a flat memory, so existing
+  agent scripts keep working. See [`akm remember`](../cli.md#remember).
+- **Workflow parser accepts intro prose (#158).** You can now put a
+  short advisory paragraph between `# Workflow:` and the first
+  `## Step:` without tripping a validation error.
+- **Workflow resume reclassifies blocked steps (#156).** After
+  `akm workflow resume <id>`, the previously-blocked step becomes
+  actionable again so you can mark it `completed`, `failed`, or
+  `skipped`.
+- **Workflow create works in clean stashes (#157).** `akm workflow
+  create <name>` and `--from <file>` no longer false-positive on a path
+  escape when any ancestor of your stash is a symlink (macOS `/tmp` →
+  `/private/tmp`, symlinked `HOME`, etc.).
+- **Registry search filters incomplete hits (#159).** Providers that
+  return partial records no longer surface as empty `{}` objects in
+  JSON output; dropped counts appear in `warnings`.
+- **Isolated sandbox recipe (#160).** [`docs/getting-started.md`
+  §Isolated Sandbox Workflow](../getting-started.md#isolated-sandbox-workflow)
+  spells out the one-terminal recipe for a throwaway `HOME + XDG_* +
+  AKM_STASH_DIR` environment — handy for agent testing, CI, and issue
+  reproduction.
+- **CI coverage for release branches (#170).** If you fork the repo or
+  run downstream CI off it, the shipped `.github/workflows/ci.yml` now
+  fires on PRs targeting `release/*` in addition to `main`.
+
 ## Internal types and file renames (developers only)
 
 These changes only affect contributors to akm itself or to projects that
@@ -585,6 +670,57 @@ also changed your embedding model or want to pick up new asset types:
 ```sh
 akm index --full
 ```
+
+### Post-upgrade checklist
+
+Five-step confirmation that nothing regressed:
+
+```sh
+akm info --format text                                # 1. version 0.6.x, no context-hub provider
+akm config list --format json | head -40              # 2. stashes[] populated; no `installed[]`
+akm list                                              # 3. your sources resolve; `origin`/`access` columns
+akm workflow list --format json | head -20            # 4. any active workflow runs still show
+akm search "<a query you know works>" --format json   # 5. indexed content still matches
+```
+
+If any step returns an error or missing data, see Troubleshooting below.
+
+## Troubleshooting
+
+**"Unknown stash type 'context-hub'" after upgrade.**
+Legacy aliases normalize at config load, but a truly corrupt entry can
+still slip through. Run `akm config show` to see how your entry is
+parsed. If it still rejects, edit `config.json` to set
+`"type": "git"` and restore the URL from your backup.
+
+**`registry search` returns `warnings: ["schema version 2 unsupported"]`.**
+Your registry is still serving v2. Pull the latest `akm-registry` and
+regenerate, or swap your registry URL to the official hosted one. See
+[Migrating a self-hosted registry](#migrating-a-self-hosted-registry).
+
+**`akm list` shows empty `stashes[]` but your 0.5.x config had entries.**
+The migration copies `installed[]` into `stashes[]` only on the first
+0.6.0 command that **writes** config (e.g. `akm add`, `akm config set`).
+If you've only run read-only commands, the new array may not yet be
+populated. Run `akm add <any-stash>` or force a rewrite with
+`akm config set stashes "$(akm config get stashes)"`.
+
+**`akm workflow create <name>` in a fresh stash still errors `path
+escapes the stash`.**
+That was fixed in 0.6.0 (#157) — confirm you're on the 0.6.0 CLI with
+`akm info | grep version`. If you are and still see it, the symlink
+resolution is likely hitting an edge case; file an issue with the
+output of `realpath "$AKM_STASH_DIR"`.
+
+**`akm.lock` was not created.**
+akm only creates the lockfile when it first writes to the stash
+directory. Run any write command (`akm add`, `akm remember`,
+`akm import`, `akm workflow create`) to generate it.
+
+**`--for-agent` still works, but I want to migrate my scripts.**
+Replace it with `--detail=agent` — same behaviour, preferred spelling.
+The old flag is retained as a deprecated alias through at least the
+0.6.x series.
 
 ## Rolling back
 

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -142,9 +142,12 @@ relevant, the registry enforces tag-based filtering:
 - **npm** -- Only packages whose `keywords` array includes `"akm-stash"` appear in search results.
 - **GitHub** -- Only repositories with the topic `akm-stash` appear in search results.
 
-> Legacy keywords/topics `akm-stash` and `agentikit` are still honored by the
-> official registry's discovery merge, but new publishers should prefer
-> `akm-stash`.
+> **0.6.0 breaking change:** `akm-cli >= 0.6.0` indexes only the
+> `akm-stash` keyword / topic. The pre-0.6.0 `akm-kit` and `agentikit`
+> keywords/topics are **not** honored as fallbacks. Publishers migrating
+> from 0.5.x must add the new tag — see the
+> [migration guide](migration/v0.5-to-v0.6.md) for the step-by-step
+> publisher checklist.
 
 If you are publishing a stash, add these tags so it can be discovered:
 

--- a/docs/stash-makers.md
+++ b/docs/stash-makers.md
@@ -234,9 +234,13 @@ akm show script:deploy.sh
    gh repo edit --add-topic akm-stash
    ```
 
-   Or add it from the repository settings page under "Topics". The legacy
-   `akm-stash` and `agentikit` topics are still honored by the official
-   registry, but `akm-stash` is preferred for new publishers.
+   Or add it from the repository settings page under "Topics". `akm-cli`
+   0.6.0 indexes only the `akm-stash` topic; the pre-0.6.0 `akm-kit` and
+   `agentikit` topics are **not** honored as fallbacks. If you are migrating
+   a 0.5.x stash, add the new topic (and remove the old ones once your
+   audience has moved). See the
+   [v0.5 → v0.6 migration guide](migration/v0.5-to-v0.6.md) for the full
+   publisher checklist.
 
 3. Others can now install it:
 

--- a/docs/technical/akm-core-principles.md
+++ b/docs/technical/akm-core-principles.md
@@ -28,7 +28,7 @@ current CLI that usually means:
 
 - `brief`: `type`, `name`, `action`, `estimatedTokens`
 - `normal`: adds `description` and `score`
-- `for-agent`: includes `ref`
+- `agent` (0.6.0+; `--for-agent` is the deprecated alias): includes `ref`
 
 Richer provenance/debug fields belong behind fuller detail modes.
 

--- a/docs/technical/search-updated.md
+++ b/docs/technical/search-updated.md
@@ -61,7 +61,7 @@ Search output is shaped in `src/cli.ts`:
 - `brief` stash hits: `type`, `name`, `action`, `estimatedTokens`
 - `normal` stash hits: adds `description` and `score`
 - `full` stash hits: full hit object
-- `for-agent`: keeps `name`, `ref`, `type`, `description`, `action`, `score`, `estimatedTokens`
+- `agent` (preferred since 0.6.0; `--for-agent` is the deprecated alias): keeps `name`, `ref`, `type`, `description`, `action`, `score`, `estimatedTokens`
 
 Registry hits use a smaller shape and still stay under `registryHits`.
 

--- a/docs/technical/search.md
+++ b/docs/technical/search.md
@@ -214,8 +214,9 @@ By default (`--format json`, `--detail brief`), search emits minimal fields:
 
 ### Agent-optimized output
 
-`--for-agent` strips non-actionable fields, keeping only: `name`, `ref`,
-`type`, `description`, `action`, `score`. Takes precedence over `--detail`.
+`--detail=agent` strips non-actionable fields, keeping only: `name`, `ref`,
+`type`, `description`, `action`, `score`. (The pre-0.6.0 `--for-agent`
+boolean is kept as a deprecated alias for one release cycle.)
 
 `--format jsonl` outputs one JSON object per line for streaming consumption.
 


### PR DESCRIPTION
## Summary
Final docs pass for 0.6.0. Two parallel agents were dispatched to do this audit; both landed on the wrong base branch (`main` not `release/0.6.0`) and correctly bailed without doing any work — so this PR is a direct edit.

## Migration guide additions (`docs/migration/v0.5-to-v0.6.md`, +136 lines)
- **Installing 0.6.0** — npm / bun / source / `akm upgrade`. States explicitly that the upgrade itself doesn't touch stash or config.
- **Sibling repositories** — akm-stash and akm-registry coordination; keyword/topic bump + schema v3 rollout.
- **New in 0.6.0 (bonus features)** — the additive wins from the 0.6.0 batch (#156, #157, #158, #159, #160, #169, #170) so upgraders know what they unlock.
- **Post-upgrade checklist** — 5-command verification recipe.
- **Troubleshooting** — common pitfalls (context-hub parsing, v2 registry leftover, empty `stashes[]` after read-only upgrade path, `--for-agent` migration note).

## Broader docs fixes
- `docs/cli.md`: documents the new `akm remember` flags (`--tag`, `--expires`, `--source`, `--auto`, `--enrich`) with examples. Marks `--for-agent` as a deprecated alias. Fixes a misleading `akm add context-hub` example (not a 0.6.0 command) — replaces with the correct `akm add github:andrewyng/context-hub --name context-hub`.
- `docs/concepts.md`: memory section cross-links to the new frontmatter flags.
- `docs/stash-makers.md` + `docs/registry.md`: fix an incorrect claim that pre-0.6.0 `akm-kit`/`agentikit` keywords/topics are still honored — they are not; `akm-cli >= 0.6.0` indexes only `akm-stash`. Link publishers to the migration guide.
- `docs/technical/{search.md,search-updated.md,akm-core-principles.md}`: annotate `--for-agent` as the deprecated alias of `--detail=agent`.

## Not touched
- `docs/posts/*.md` — historical record; footers were already updated by the 0.6.0 terminology sweep.
- `docs/migration/v0.5-to-v0.6.md` existing sections — kept verbatim; additions only.

## Checks
- Docs-only change; no code touched.
- No residual legacy `kit`/`kits` references in actionable docs (only in `docs/technical/registry-index.schema.json` as accurate historical context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)