### PR TITLE
ci: dedupe release/* triggers and add concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,19 @@
 name: CI
 
+# `release/*` is intentionally listed only under `pull_request`. Every change
+# to a release branch goes through a PR, and the pre-merge pull_request run
+# already validates the merged state (pull_request CI runs against the
+# `refs/pull/N/merge` ref, which is the PR head merged into its base). Adding
+# `release/*` to `push` duplicated every merge with a second redundant run.
+# Direct pushes to `release/*` are not an expected flow; if one is ever needed,
+# re-add the pattern and trust the human operator to read the resulting run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
-    branches: [main, "fix/*", "release/*"]
+    branches: [main, "fix/*"]
     paths-ignore:
       - "docs/**"
       - "README.md"


### PR DESCRIPTION
## Summary
Every merge to a release branch produced two redundant CI runs — one from `push` and one from `pull_request`, both firing on the same commit. This PR removes `release/*` from `push.branches` (the pre-merge `pull_request` run already validates the merged state against `refs/pull/N/merge`) and adds a top-level `concurrency` group so in-flight runs on the same PR collapse when a new commit arrives.

## Why this works
- A PR to `release/0.6.0` triggers `pull_request` CI. That run tests `refs/pull/N/merge`, which *is* the PR head merged into the release branch. If it's green, the merge commit is (barring a race) also green.
- The post-merge `push` event previously re-ran the same checks on an equivalent commit. Pure redundancy.
- `fix/*` stays in `push.branches` for direct-push CI on fix branches that skip the PR flow.
- `concurrency: cancel-in-progress: true` prevents rapid-fire PR pushes from piling up overlapping runs.

## Tradeoff
A direct push to `release/*` (no PR — e.g. a hotfix bypassing review) now produces no CI run. If that becomes a real flow, add `release/*` back to `push.branches`.

## Checks
- Config-only change. Validated the two-run pattern by inspecting #173 and #174 merges (each produced runs `24905475595` + `24905476771` on the same commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)