### PR TITLE
docs(reviews): add 0.6.0 end-to-end review

### DIFF
--- a/docs/reviews/0.6.0-e2e-review.md
+++ b/docs/reviews/0.6.0-e2e-review.md
@@ -1,0 +1,251 @@
+# akm 0.6.0 — End-to-End Code Review
+
+**Branch:** `release/0.6.0` at HEAD `bae45e7`
+**Review date:** 2026-04-24
+**Scope:** CLI ergonomics · architecture & complexity · security · performance · maintainability
+**Method:** three parallel read-only reviewer agents (sonnet), findings consolidated below.
+
+---
+
+## Executive summary
+
+akm 0.6.0 is structurally healthy for a pre-v1 CLI. The terminology cleanup landed cleanly, the test suite outweighs the source by line count, the error envelope is rock-solid, and the core abstractions (asset spec ↔ matcher ↔ renderer, the `LiveStashProvider` / `SyncableStashProvider` split, the provider-registry generic, the embedder facade) are at the right level. The defensive code — path containment, tar-extraction safety, vault stdout discipline, git subprocess hygiene, migration-help path guard — is notably solid.
+
+Three themes emerge across the three reviews:
+
+1. **`src/cli.ts` is carrying too much.** 2,687 lines with 39 imports, and it still holds domain logic (memory frontmatter assembly, LLM enrichment, heuristics, 250 lines of inline hints) that belongs in dedicated modules. This is the single highest-leverage pre-v1 extraction.
+2. **Output-shape documentation has drifted from output-shape code.** `--detail agent` is invisible in every `--help` screen, `docs/cli.md` describes `--detail normal` fields that the code does not emit, and two commands break the output-key naming convention. These are small bugs with large blast radius for agent consumers.
+3. **Untrusted-network surface has no byte-cap.** Website scraping, registry JSON fetches, and the remote embedder all buffer full responses into memory with no size gate. Local-only attacks are well-defended; network-reachable endpoints need a shared streaming byte cap.
+
+Nothing in the review is a release blocker for 0.6.0. The findings are grouped below as **H** (high — fix before v1), **M** (medium — fix within 0.6.x), and **L** (low / nit).
+
+---
+
+## Cross-cutting priorities
+
+| # | Finding | Severity | Category | Effort |
+|---|---------|----------|----------|--------|
+| 1 | Extract `remember` domain logic + inline hints from `cli.ts` | H | architecture | ~1d |
+| 2 | Response-body size caps on all fetch paths | H | security | ~0.5d |
+| 3 | `--detail agent` invisible in every `--help` | H | ergonomics | ~15m |
+| 4 | `docs/cli.md` output-shape tables vs actual output | H | ergonomics | ~30m |
+| 5 | `buildMemoryFrontmatter` interpolates raw strings into YAML | H | security | ~30m |
+| 6 | `rebuildFts` full table scan on every incremental index | H | performance | ~1d |
+| 7 | `workflow resume` + `stash-add` output-key naming | M | ergonomics | ~5m each |
+| 8 | CamelCase flags (`--skipChecksum`, `--npmRegistry`, `--githubApi`) | M | ergonomics | ~15m |
+| 9 | `db.ts` `__usageBackup` side-channel → typed migration boundary | M | architecture | ~1d |
+| 10 | Indexer re-export of `buildSearchText` pulls heavy deps into `db-search.ts` | M | architecture | ~15m |
+| 11 | `cosineSimilarity` misplaced in `embedder.ts` | M | architecture | ~15m |
+| 12 | No dedicated tests for `renderers.ts`, `output-shapes.ts`, `matchers.ts`, `workflow-runs.ts`, `search-source.ts` | M | testing | ~2d total |
+| 13 | `hints --detail brief` silently falls back to `normal` | M | ergonomics | ~15m |
+| 14 | `workflow-authoring` `--from` accepts paths outside stash | M | security | ~30m |
+| 15 | `install-audit` `allowedFindings` path matching is case-sensitive + unnormalized | M | security | ~30m |
+| 16 | Internal `--akmView/Heading/Start/End` flags exposed in help | L | ergonomics | ~15m |
+| 17 | `deleteRelatedRows` `IN (?)` dynamic placeholders — structurally distinct | L | security note | — |
+| 18 | HTTP plain-text registry URL only warns, doesn't block | L | security | ~15m |
+
+---
+
+## 1. CLI ergonomics
+
+Full report: `/tmp/akm-review/cli-ergonomics.md`
+
+### Strengths
+
+- Error envelope (`{ok, error, hint, code}`) and exit codes (0 / 1 / 2 / 78) are consistent across every failing command — scripts can branch on exit code alone.
+- `--for-agent` → `--detail=agent` deprecation is handled gracefully (alias retained, migration note in docs).
+- Repeatable `--tag` via `parseAllFlagValues` is the right workaround for citty's last-value-wins behavior.
+- Workflow subcommand set (`start / next / complete / status / list / create / template / resume`) covers the lifecycle without overlap.
+- `vault load` security model (shell snippet, never values in structured output) is clearly documented inline.
+- `akm search ""` list-all behavior is explicit and honored.
+
+### High-severity findings
+
+**`--detail=agent` is invisible in every help screen.**
+Root `--help`, `search --help`, and `show --help` all render `brief|normal|full|summary` — `agent` is absent. `docs/cli.md` and `akm hints --detail full` document it, but the CLI itself does not. This is the primary agent-friendliness mechanism, so invisibility undermines its purpose.
+- Fix: add `agent` to the description string at `src/cli.ts:2161`, `:178`, `:435`. No logic change.
+
+**`docs/cli.md:171–174` drift vs actual output shapes.**
+Docs claim `--detail brief` includes `description` (it does not), and `--detail normal` includes `ref`, `origin`, `size`, `tags` (actual: `type, name, description, action, score, estimatedTokens`). An agent following the docs will query for a `ref` handle at normal and get none.
+- Fix: either update the docs to match `src/output-shapes.ts:117–124`, or add `ref` and `origin` to the normal pick list.
+
+### Medium-severity findings
+
+- **Output key drift.** `workflow resume` emits `"workflow-run"` (`src/cli.ts:1140`), every other workflow subcommand emits `workflow-<sub>`. `akm add --provider ...` emits `"stash-add"` (`src/cli.ts:284`) while other `add` paths emit `"add"`. Agents branching on output keys need a special case for both.
+- **CamelCase flags.** `--skipChecksum` (`src/cli.ts:406`), `--npmRegistry`, `--githubApi` (`src/cli.ts:784–785`) break the CLI-wide kebab-case convention. citty auto-maps kebab → camelCase, so the fix is description-only.
+- **`akm hints --detail brief` silently falls back.** `hints` has its own local `--detail` accepting only `normal|full`; any other value returns normal with no error. Inconsistent with the global `--detail` parser's strict validation.
+
+### Low / nits
+
+- Internal show-positional flags (`--akmView`, `--akmHeading`, `--akmStart`, `--akmEnd`) surface in `akm show --help`. Removing their descriptions would quiet the help output.
+- `akm workflow` with no subcommand silently emits active runs (same as `workflow list --active`). Undocumented.
+- `akm config --list` and `akm config list` are duplicate surfaces; flag form is undocumented.
+- `wiki stash --as <slug>` breaks the `--name` convention used elsewhere.
+
+### Consistency gaps worth calling out
+
+- Output-key convention is `<command>` / `<command>-<subcommand>` — two exceptions as above.
+- `--detail` values differ between global flag (`brief|normal|full|summary|agent`) and `hints` (`normal|full`). Three surfaces (args table, `docs/cli.md`, `hints`) disagree.
+- `search --source` help says `stash|registry|both`; `local` is also silently accepted (`src/stash-search.ts:267–268`).
+
+### Discoverability
+
+- `akm hints` is listed after `help` — for agent onboarding it is the highest-value command and should be more prominent.
+- `akm curate` is conceptually the preferred agent entry point (search + action hint) but is positioned after `search` with a description that understates its usefulness.
+- `akm search "" --source stash` list-all works but the help text makes it hard to discover.
+
+---
+
+## 2. Architecture & complexity
+
+Full report: `/tmp/akm-review/architecture.md`
+
+### Shape
+
+**~26K source lines across 80+ modules. ~30K test lines across 88 test files (>1.0 test-to-source ratio).** The decomposition is generally healthy; the two primary risks are concentrated.
+
+### What is working
+
+- `src/asset-spec.ts` — clean extension point; `AssetSpec` + `registerAssetType` is a good surface.
+- `src/stash-provider.ts` — `LiveStashProvider` / `SyncableStashProvider` split is the right cut.
+- `src/embedder.ts` + `src/embedders/*` — facade-over-submodules with clean 4-way split (cache / local / remote / types).
+- `src/create-provider-registry.ts` — 19 lines of reusable generic, two consumers built on it without duplication.
+- `src/file-context.ts` — lazy-caching `FileContext` is a good design.
+- `src/workflow-db.ts`, `src/workflow-authoring.ts`, `src/workflow-cli.ts` — workflow subsystem appropriately decomposed.
+
+### Complexity hotspots
+
+**`src/cli.ts` — 2,687 lines, 39 imports.**
+Three overlapping roles never fully separated: argument parsing, output routing, domain logic. `rememberCommand` alone contains `buildMemoryFrontmatter`, `runAutoHeuristics`, `runLlmEnrich`, `parseDuration`, `writeMarkdownAsset` (lines ~1174–1477). Two inline hint strings (`EMBEDDED_HINTS`, `EMBEDDED_HINTS_FULL`, lines 2397/2441) add ~250 lines of content-not-code. Direct import of `saveGitStash` from `./stash-providers/git` (line 28) breaks the layering rest of the codebase respects.
+- **Suggested cut:** extract `src/remember.ts` (memory-frontmatter logic) and `src/cli-hints.ts` (hint content, or a build-time embed from `docs/`). Promote `saveGitStash` to the public stash-operation surface.
+
+**`src/db.ts` — 862 lines.**
+Schema DDL, version migration, vec-extension loading, vec-dimension reconciliation, usage-event backup/restore, and JS-fallback warning heuristic all co-habit. The `__usageBackup` pattern at line 154 casts `Database` to `Record<string, unknown>` to thread migration state through a side channel.
+- **Suggested cut:** extract `src/db-migrate.ts` (version detection + backup/restore cycle with typed params) and `src/db-vec.ts` (extension loading + availability, already has its own `WeakMap`/`WeakSet` state).
+
+**`src/indexer.ts` — 924 lines.**
+Re-exports `buildSearchFields` / `buildSearchText` from `search-fields.ts`, causing `db-search.ts` to import `buildSearchText` from `indexer` and transitively pulling in the entire indexer dependency chain (LLM, embedder).
+- **Suggested cut:** remove the re-export; change `db-search.ts` to import directly from `search-fields.ts`. One-line change, outsized graph impact.
+
+**`src/config.ts` — 1,176 lines.**
+Type hierarchy (8 interfaces including deprecated `StashConfigEntry`), FNV-1a cache-key hasher, three-layer config loading, env-key injection, migration helpers, all in one file. `StashConfigEntry` / `StashEntry` deprecation shim adds bulk.
+- **Suggested cut:** `src/config-loader.ts` (loading/merging/env injection); leave `config.ts` as pure types + defaults. Drop `StashConfigEntry` in v1 cycle.
+
+### Seams that are right
+
+- `LiveStashProvider` / `SyncableStashProvider` discriminator + `isSyncable()` type guard.
+- Asset spec ↔ matcher ↔ renderer triangle, glued by `FileContext`.
+- Provider-registry generic.
+- Embedder facade (except `cosineSimilarity` is misplaced — it is a math utility with no embedder dependency; belongs in `embedders/types.ts`).
+
+### Test gaps (structural, high-value)
+
+No dedicated test files for:
+
+- `src/renderers.ts` (724 lines)
+- `src/output-shapes.ts` (final gate before CLI output)
+- `src/workflow-runs.ts` (517 lines)
+- `src/search-source.ts` (critical path for every search/show)
+- `src/matchers.ts` (specificity cascade has subtle edges)
+
+Coverage is integration-heavy (many tests spawn the CLI via `spawnSync`), which is a strong regression fence but provides weak signal on internal boundary regressions.
+
+### Dependencies
+
+Runtime deps are lean (4 required + 2 optional):
+
+- `citty` · `yaml` · `dotenv` · `@clack/prompts` required.
+- `@huggingface/transformers` · `sqlite-vec` optional (correctly gated).
+- `sqlite-vec 0.1.7-alpha.2` — alpha tag is a stability signal to watch.
+- `@clack/prompts` is load-bearing for a single command (`setup`). Acceptable but could be replaced with a readline-based flow if the setup surface stabilizes.
+
+### Pre-v1 trajectory
+
+1. Extract `remember` + hints from `cli.ts`.
+2. Fix the `buildSearchText` re-export and move `cosineSimilarity` to `embedders/types.ts`.
+3. Formalize the `db.ts` migration boundary with typed parameters.
+
+---
+
+## 3. Security · performance · maintainability
+
+Full report: `/tmp/akm-review/security.md`
+
+### Security
+
+**High (network-reachable DoS surface):**
+
+1. **No response-body size limit on website scraping.** `src/stash-providers/website.ts:259` — `response.text()` with no byte cap. A malicious site can OOM the process. Mitigation: read `Content-Length`; stream with byte-cap if absent.
+2. **No response-body size limit on registry JSON fetches.** `src/providers/static-index.ts`, `src/registry-build-index.ts:4`, `src/registry-resolve.ts` all `.json()` / `.text()` without a gate. Same OOM surface on a compromised registry.
+3. **`buildMemoryFrontmatter` interpolates raw strings into YAML.** `src/cli.ts:1192–1208` — `description: ${fields.description}` allows a value containing `\n` + `tags: [injected]` to add arbitrary frontmatter fields. Local write-path, but corrupted indexer state and downstream-agent prompt-injection exposure. Fix: serialize via the already-imported `yaml` library, or single-quote-escape + reject embedded newlines.
+
+**Medium:**
+
+- `install-audit` `allowedFindings` path comparison is raw string equality (`src/install-audit.ts:448–458`); diverging normalization between disk and finding path can mis-match waivers, either blocking intended installs or failing to flag rejected ones.
+- `workflow-authoring.readWorkflowSource` (`src/workflow-authoring.ts:75–87`) accepts any `--from` path. `akm workflow create --from /etc/passwd ...` reads the file; parse fails, but contents sit in memory briefly. Document or warn when path is outside stash.
+- Plain-HTTP registry URLs emit a `warn()` and continue (`src/cli.ts:713–716`); an attacker on-path can MITM. Consider making it an error unless `--allow-insecure` is set.
+- `walker.isInsideGitRepo` walks to filesystem root with no depth cap (`src/walker.ts:130–146`) — hundreds of `statSync` calls on deep path hierarchies.
+
+**Low / notes:**
+
+- `deleteRelatedRows` builds `IN (?)` with `chunk.map(() => "?")` — safe (placeholders only, no user data), but structurally distinct from the rest of the code; future maintainers could miscopy the pattern.
+- `githubHeaders()` calls `gh auth token` via `spawnSync` on every uncached header build (`src/github.ts:12–21`). Low security impact; domain check at line 41 is good mitigation.
+- `isSafeVersionComponent` + `escapeRegexString` in `migration-help.ts` are correct.
+
+### Performance
+
+**User-visible hotspots:**
+
+1. `rebuildFts` full table scan on every `akm index` run (`src/db.ts:408–443`). Reads all `entry_json` into memory, rebuilds FTS row-by-row, even when only one entry changed. Incremental `akmIndex` skips unchanged directories but still calls `rebuildFts` unconditionally. At 10k+ entries this is a noticeable pause.
+2. `recomputeUtilityScores` loads all `utility_scores` into a `Map` on every index run (`src/indexer.ts:900–907`), even when the aggregate already limits to entries with events.
+3. Website scraper wall-clock: `src/stash-providers/website.ts:242` uses 15s per-request timeout; with `maxPages=50` default, a slow site can stall `akm add` for up to 12.5 minutes. Add a per-crawl wall-clock ceiling or a progress indicator.
+
+**Startup cost:**
+
+`src/cli.ts:1–51` top-level imports pull `bun:sqlite`, `yaml`, the indexer, embedder, and LLM machinery for every command including `--help`. The `setup` command already uses `await import("./setup")`; extend this pattern to the heavy imports that are only needed for specific subcommands.
+
+**Hidden O(n²):**
+
+- `buildFileBasenameMap` rebuilt once per entry instead of once per directory (`src/indexer.ts:462–474`). `O(files × entries)` per directory — unlikely to bite in practice but trivially fixable.
+
+### Maintainability
+
+- Several `catch { /* ignore */ }` blocks in `deleteRelatedRows` (`src/db.ts:376–405`) — understandable for missing-table cases, but unexpected errors would be silent. Distinguishing `no such table` from other errors + a single `warn()` would help debug partial-state issues.
+- `parseJsonObject` / `parseJsonArray` in `workflow-runs.ts:482–506` silently return `undefined` on corrupt DB data; a corrupt `params_json` loses the run's parameters with no warning.
+- `enhanceDirsWithLlm` swallows all errors per-entry (`src/indexer.ts:789`). If the LLM endpoint is misconfigured, every entry silently falls back — no aggregated warning to the user. Track whether any call succeeded; warn once if all failed.
+- `warn.ts` `quiet` module-singleton could leak across test files; `resetQuiet()` exists but isn't enforced by a shared teardown.
+- Per-entry `"[db] rebuildFts: skipping entry id=... — invalid entry_json"` on stderr has no rollup/dedup for corrupt-JSON scans.
+
+### What is already solid
+
+- **Migration-help path guard** (`src/migration-help.ts:56–59`) — allowlist regex + `.includes("..")` rejection. Shipped in #174, works as designed.
+- **Vault stdout discipline** (`src/vault.ts`) — `listKeys()` never returns values; `buildShellExportScript` writes to mode-0600 temp files; `quoteValue` rejects multi-line and mixed-quote values.
+- **Tar extraction** (`src/stash-providers/tar-utils.ts`) — pre-listing + post-extraction symlink scan, per-entry validation before `--strip-components=1`. Defense-in-depth against TOCTOU.
+- **Git subprocess safety** (`src/stash-providers/git.ts`, `src/registry-resolve.ts`) — all `spawnSync("git", [...])` use array args; `validateGitUrl` / `validateGitRef` gate before invocation (blocks `ext::` helpers, unusual ref chars).
+- **`fetchWithTimeout`** (`src/common.ts:168`) — 30s default, consistent usage across LLM + registry calls.
+- **GitHub token domain-scoping** (`src/github.ts:40–48`) — `Authorization` header suppressed on non-GitHub domains; prevents token leak on unexpected redirects.
+- **`isWithin` / `safeRealpath`** (`src/common.ts:117–158`) — symlink-aware path comparison, handles non-existent child paths. The right implementation.
+
+---
+
+## Appendix: agent attribution
+
+| Scope | Subagent | Runtime |
+|-------|----------|---------|
+| CLI ergonomics | `bunjs-ts-code-reviewer` (sonnet) | ~9 min |
+| Architecture + complexity | `bun-node-architect` (sonnet) | ~5.5 min |
+| Security + performance + maintainability | `code-reviewer` (sonnet) | ~4 min |
+
+Individual agent reports preserved at `/tmp/akm-review/{cli-ergonomics,architecture,security}.md` during the review run. This consolidated document is the canonical output; individual reports can be regenerated at any time by dispatching the same agents.
+
+---
+
+## What to do next (author's pick)
+
+If forced to pick **three cuts** before v1, do these in order:
+
+1. **Extract `remember` + hints out of `cli.ts`** (architecture #1). Earns testability on the LLM enrichment path and shaves ~450 lines off `cli.ts`.
+2. **Align output shapes with `docs/cli.md`** + make `--detail=agent` visible in every help screen (ergonomics H#1, H#2, H#3). All together these are <2h and close the biggest agent-footgun in the current surface.
+3. **Add a shared size-guarded `fetchWithByteCap` helper** and route every `.json()` / `.text()` on an untrusted response through it (security H#1, H#2). Closes the DoS surface for both website scraping and compromised-registry scenarios in one change.
+
+The remaining items are either `0.6.x` grooming or `v1` hygiene — none block the 0.6.0 release.


### PR DESCRIPTION
## Summary
Consolidated end-to-end review of akm 0.6.0 at \`bae45e7\` from three parallel read-only reviewer agents (sonnet):

- **CLI ergonomics** (bunjs-ts-code-reviewer) — user-facing surfaces, flag consistency, output shapes, discoverability.
- **Architecture + complexity** (bun-node-architect) — decomposition, coupling, hotspots, dependency hygiene.
- **Security + performance + maintainability** (code-reviewer) — defensive posture, hot paths, error-handling idioms.

## Headline findings

- **Three themes emerge**: \`cli.ts\` is carrying too much domain logic (2,687 lines), \`docs/cli.md\` output-shape tables have drifted from actual output (\`--detail agent\` invisible, \`--detail normal\` misdocumented), and untrusted-network responses have no byte cap.
- **18 prioritized findings** with severity, category, and effort estimates in a single cross-cutting table.
- **Author's pick — 3 cuts before v1**: (1) extract \`remember\` + inline hints from cli.ts, (2) align output-shape docs with code + make \`--detail=agent\` visible, (3) add a shared size-guarded \`fetchWithByteCap\` for all untrusted network reads.
- **Nothing is a 0.6.0 release blocker** — findings are grooming material for 0.6.x and structural work for v1.

## Artefacts
- \`docs/reviews/0.6.0-e2e-review.md\` — consolidated report (~10k words).

🤖 Generated with [Claude Code](https://claude.com/claude-code)