### PR TITLE
fix(cli): make --detail=agent visible, normalize output keys, fix doc drift

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -168,12 +168,19 @@ search results:
 - **`origin`** -- The source stash (e.g. `npm:@scope/pkg`), present only for managed source assets
 - **`id`** -- Registry-level stash identifier (registry hits only)
 
-The default brief shape is intentionally small: local hits expose `type`,
-`name`, `description`, and `action`; registry hits expose `type`, `name`,
-`id`, `description`, `action`, and `curated`. `--detail normal` adds commonly
-useful fields like `ref`, `origin`, `size`, and `tags`. `--detail full`
-includes debug-oriented fields such as scores, match explanations, timings,
-and stash metadata.
+The default brief shape is intentionally small. The exact field set per
+detail level matches `src/output-shapes.ts`:
+
+| Level | Local stash hits | Registry hits |
+| --- | --- | --- |
+| `brief` (default) | `type`, `name`, `action`, `estimatedTokens` | `type`, `name`, `id`, `description`, `action`, `curated` |
+| `normal` | adds `description` and `score` | adds `score` |
+| `full` | full hit object (includes `ref`, `origin`, `tags`, `whyMatched`, timings, stash metadata) | full hit object |
+| `summary` | metadata-only view (no content), under 200 tokens | — |
+| `agent` (preferred since 0.6.0; `--for-agent` is the deprecated alias) | `name`, `ref`, `type`, `description`, `action`, `score`, `estimatedTokens` | — |
+
+If you want a `ref` handle without the rest of the `full` payload, use
+`--detail=agent`.
 
 ### curate
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -175,7 +175,7 @@ const searchCommand = defineCommand({
     limit: { type: "string", description: "Maximum number of results" },
     source: { type: "string", description: "Search source (stash|registry|both)", default: "stash" },
     format: { type: "string", description: "Output format (json|jsonl|text|yaml)" },
-    detail: { type: "string", description: "Detail level (brief|normal|full|summary)" },
+    detail: { type: "string", description: "Detail level (brief|normal|full|summary|agent)" },
   },
   async run({ args }) {
     await runWithJsonErrors(async () => {
@@ -281,7 +281,7 @@ const addCommand = defineCommand({
           options: parsedOptions,
           writable: args.writable,
         });
-        output("stash-add", result);
+        output("add", result);
         return;
       }
 
@@ -404,7 +404,7 @@ const upgradeCommand = defineCommand({
   args: {
     check: { type: "boolean", description: "Check for updates without installing", default: false },
     force: { type: "boolean", description: "Force upgrade even if on latest", default: false },
-    skipChecksum: {
+    "skip-checksum": {
       type: "boolean",
       description: "Skip checksum verification (not recommended)",
       default: false,
@@ -417,7 +417,8 @@ const upgradeCommand = defineCommand({
         output("upgrade", check);
         return;
       }
-      const result = await performUpgrade(check, { force: args.force, skipChecksum: args.skipChecksum });
+      const skipChecksum = Boolean((args as Record<string, unknown>)["skip-checksum"]);
+      const result = await performUpgrade(check, { force: args.force, skipChecksum });
       output("upgrade", result);
     });
   },
@@ -432,7 +433,7 @@ const showCommand = defineCommand({
   args: {
     ref: { type: "positional", description: "Asset ref (type:name)", required: true },
     format: { type: "string", description: "Output format (json|jsonl|text|yaml)" },
-    detail: { type: "string", description: "Detail level (brief|normal|full|summary)" },
+    detail: { type: "string", description: "Detail level (brief|normal|full|summary|agent)" },
     akmView: { type: "string", description: "Internal positional knowledge view mode parser" },
     akmHeading: { type: "string", description: "Internal positional section heading parser" },
     akmStart: { type: "string", description: "Internal positional start-line parser" },
@@ -781,15 +782,16 @@ const registryCommand = defineCommand({
       args: {
         out: { type: "string", description: "Output path for the generated index", default: "index.json" },
         manual: { type: "string", description: "Manual entries JSON file", default: "manual-entries.json" },
-        npmRegistry: { type: "string", description: "Override npm registry base URL" },
-        githubApi: { type: "string", description: "Override GitHub API base URL" },
+        "npm-registry": { type: "string", description: "Override npm registry base URL" },
+        "github-api": { type: "string", description: "Override GitHub API base URL" },
       },
       async run({ args }) {
         await runWithJsonErrors(async () => {
+          const argsRecord = args as Record<string, unknown>;
           const result = await buildRegistryIndex({
             manualEntriesPath: args.manual,
-            npmRegistryBase: args.npmRegistry,
-            githubApiBase: args.githubApi,
+            npmRegistryBase: typeof argsRecord["npm-registry"] === "string" ? argsRecord["npm-registry"] : undefined,
+            githubApiBase: typeof argsRecord["github-api"] === "string" ? argsRecord["github-api"] : undefined,
           });
           const outPath = writeRegistryIndex(result.index, args.out);
           output("registry-build-index", {
@@ -1137,7 +1139,7 @@ const workflowResumeCommand = defineCommand({
   run({ args }) {
     return runWithJsonErrors(() => {
       const result = resumeWorkflowRun(args.runId);
-      output("workflow-run", result);
+      output("workflow-resume", result);
     });
   },
 });
@@ -1522,8 +1524,10 @@ const hintsCommand = defineCommand({
     detail: { type: "string", description: "Detail level (normal|full)", default: "normal" },
   },
   run({ args }) {
-    const detail = args.detail === "full" ? "full" : "normal";
-    process.stdout.write(loadHints(detail));
+    if (args.detail !== "normal" && args.detail !== "full") {
+      throw new UsageError(`Invalid value for --detail: ${args.detail}. Expected one of: normal|full.`);
+    }
+    process.stdout.write(loadHints(args.detail));
   },
 });
 
@@ -2158,7 +2162,7 @@ const main = defineCommand({
   },
   args: {
     format: { type: "string", description: "Output format (json|jsonl|text|yaml)" },
-    detail: { type: "string", description: "Detail level (brief|normal|full|summary)" },
+    detail: { type: "string", description: "Detail level (brief|normal|full|summary|agent)" },
     quiet: { type: "boolean", alias: "q", description: "Suppress stderr warnings", default: false },
   },
   subCommands: {


### PR DESCRIPTION
Implements the third "top 3 before v1" pick from #177 — small ergonomics adjustments with high blast radius for agent consumers.

## Changes
- **\`--detail=agent\` now visible** in every \`--help\` (root, search, show). Was silently absent from the rendered description string.
- **Output keys**: \`workflow resume\` → \`workflow-resume\` (was \`workflow-run\`); \`akm add --provider ...\` → \`add\` (was \`stash-add\`). Agents asserting on output keys no longer need special cases.
- **Kebab-case flag parity**: \`--skipChecksum\` → \`--skip-checksum\`; \`--npmRegistry\` → \`--npm-registry\`; \`--githubApi\` → \`--github-api\`. Matches the project convention used by \`--max-pages\`, \`--with-sources\`, etc.
- **\`hints --detail\` validation**: now throws \`UsageError\` for invalid values instead of silently falling back to \`normal\`.
- **\`docs/cli.md\` output-shape table** rewritten to match \`src/output-shapes.ts\` exactly. The prose previously claimed \`--detail brief\` includes \`description\` (it doesn't) and \`--detail normal\` includes \`ref\`/\`origin\`/\`size\`/\`tags\` (also doesn't — those appear at \`full\`).

## Checks
- \`bunx tsc --noEmit\` clean. \`bunx biome check\` clean.
- \`bun test\` → **1622 pass / 0 fail / 7 skip** (no regressions from the output-key renames).

🤖 Generated with [Claude Code](https://claude.com/claude-code)