### PR TITLE
fix(security,robustness): bundle of 5 review-driven tightening changes

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -707,6 +707,11 @@ const registryCommand = defineCommand({
         name: { type: "string", description: "Human-friendly name for the registry" },
         provider: { type: "string", description: "Provider type (e.g. static-index, skills-sh)" },
         options: { type: "string", description: 'Provider options as JSON (e.g. \'{"apiKey":"key"}\').' },
+        "allow-insecure": {
+          type: "boolean",
+          description: "Allow a plain HTTP registry URL (otherwise rejected)",
+          default: false,
+        },
       },
       run({ args }) {
         return runWithJsonErrors(() => {
@@ -714,8 +719,15 @@ const registryCommand = defineCommand({
             throw new UsageError("Registry URL must start with http:// or https://");
           }
           if (args.url.startsWith("http://")) {
+            const allowInsecure = Boolean((args as Record<string, unknown>)["allow-insecure"]);
+            if (!allowInsecure) {
+              throw new UsageError(
+                "Registry URL uses plain HTTP (not HTTPS). An on-path attacker could substitute a malicious index. " +
+                  "Use https:// or pass --allow-insecure if you have explicitly accepted the risk.",
+              );
+            }
             warn(
-              "Warning: registry URL uses plain HTTP (not HTTPS). For security, prefer https:// to protect against eavesdropping and tampering.",
+              "Warning: registry URL uses plain HTTP (not HTTPS). --allow-insecure was set; an on-path attacker could substitute a malicious index.",
             );
           }
           const config = loadUserConfig();

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -506,12 +506,17 @@ async function enhanceDirsWithLlm(
 ): Promise<void> {
   if (!config.llm || dirsNeedingLlm.length === 0) return;
 
+  // Aggregate per-entry failures so a misconfigured LLM endpoint surfaces
+  // as a single visible warning instead of silently degrading every entry
+  // and leaving the user wondering why nothing got enhanced.
+  const summary: LlmEnhancementSummary = { attempted: 0, succeeded: 0, failureSamples: [] };
+
   for (const { dirPath, files, currentStashDir, stash: originalStash } of dirsNeedingLlm) {
     // Only enhance generated entries; user-provided overrides should not be overwritten
     const generatedEntries = originalStash.entries.filter((e) => e.quality === "generated");
     if (generatedEntries.length === 0) continue;
     const generatedStash: StashFile = { entries: generatedEntries };
-    const enhanced = await enhanceStashWithLlm(config.llm, generatedStash, files);
+    const enhanced = await enhanceStashWithLlm(config.llm, generatedStash, files, summary);
 
     // Re-upsert the enhanced entries in a single transaction so a crash
     // cannot leave half the entries updated and the rest stale.
@@ -523,6 +528,18 @@ async function enhanceDirsWithLlm(
         upsertEntry(db, entryKey, dirPath, entryPath, currentStashDir, attachFileSize(entry, entryPath), searchText);
       }
     })();
+  }
+
+  if (summary.attempted > 0 && summary.succeeded === 0) {
+    const sample = summary.failureSamples.length ? ` Example: ${summary.failureSamples[0]}` : "";
+    warn(
+      `LLM enhancement failed for all ${summary.attempted} attempted entries — index built without LLM enrichment.` +
+        ` Check llm.endpoint and llm.model in your config.${sample}`,
+    );
+  } else if (summary.attempted > 0 && summary.succeeded < summary.attempted) {
+    const failed = summary.attempted - summary.succeeded;
+    const sample = summary.failureSamples.length ? ` Examples: ${summary.failureSamples.join("; ")}` : "";
+    warn(`LLM enhancement failed for ${failed}/${summary.attempted} entries — they were left un-enhanced.${sample}`);
   }
 }
 
@@ -758,15 +775,25 @@ function isDirStale(
   return false;
 }
 
+interface LlmEnhancementSummary {
+  attempted: number;
+  succeeded: number;
+  /** Sample of error messages from failed entries (first 3, deduped). */
+  failureSamples: string[];
+}
+
 async function enhanceStashWithLlm(
   llmConfig: LlmConnectionConfig,
   stash: StashFile,
   files: string[],
+  summary: LlmEnhancementSummary,
 ): Promise<StashFile> {
   const { enhanceMetadata } = await import("./llm.js");
 
   const enhanced: StashEntry[] = [];
+  const seenSamples = new Set<string>();
   for (const entry of stash.entries) {
+    summary.attempted++;
     try {
       const entryFile = entry.filename
         ? (files.find((f) => path.basename(f) === entry.filename) ?? files[0])
@@ -786,8 +813,14 @@ async function enhanceStashWithLlm(
       if (improvements.searchHints?.length) updated.searchHints = improvements.searchHints;
       if (improvements.tags?.length) updated.tags = improvements.tags;
       enhanced.push(updated);
-    } catch {
+      summary.succeeded++;
+    } catch (err) {
       enhanced.push(entry);
+      const msg = err instanceof Error ? err.message : String(err);
+      if (summary.failureSamples.length < 3 && !seenSamples.has(msg)) {
+        summary.failureSamples.push(msg);
+        seenSamples.add(msg);
+      }
     }
   }
   return { entries: enhanced };

--- a/src/install-audit.ts
+++ b/src/install-audit.ts
@@ -450,12 +450,27 @@ function matchesAllowedFinding(
   ref: string,
   allowedFindings: InstallAuditAllowedFinding[],
 ): boolean {
+  // Normalize paths so a waiver written against `scripts/setup.sh` matches
+  // a finding emitted as `./scripts/setup.sh` or `scripts//setup.sh`. On
+  // Windows we also fold case, mirroring `isWithin`'s comparison rules.
+  const findingPathNormalized = normalizeWaiverPath(finding.file);
   return allowedFindings.some((allowed) => {
     if (allowed.id !== finding.id) return false;
     if (allowed.ref && allowed.ref !== ref) return false;
-    if (allowed.path && allowed.path !== finding.file) return false;
+    if (allowed.path && normalizeWaiverPath(allowed.path) !== findingPathNormalized) return false;
     return true;
   });
+}
+
+function normalizeWaiverPath(value: string | undefined): string | undefined {
+  if (!value) return value;
+  // Strip a leading `./`, collapse duplicate slashes via path.normalize, and
+  // POSIX-ify so Windows path separators don't trigger spurious mismatches.
+  const normalized = path
+    .normalize(value)
+    .replace(/\\/g, "/")
+    .replace(/^\.\/+/, "");
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
 }
 
 function addUrlLabels(labels: Set<string>, rawUrl: string | undefined): void {

--- a/src/stash-providers/website.ts
+++ b/src/stash-providers/website.ts
@@ -34,6 +34,14 @@ const MAX_DEPTH_DEFAULT = 3;
  */
 const WEBSITE_PAGE_BYTE_CAP = 5 * 1024 * 1024;
 
+/**
+ * Wall-clock cap for a full crawl (10 minutes). With per-request timeouts
+ * of 15s and a `maxPages` default of 50, an unresponsive site could
+ * otherwise stall `akm add` for 12.5 minutes with no feedback. Cap the
+ * whole crawl and return what we have when time runs out.
+ */
+const WEBSITE_CRAWL_WALL_CLOCK_MS = 10 * 60 * 1000;
+
 interface WebsitePage {
   url: string;
   title: string;
@@ -220,8 +228,14 @@ async function crawlWebsite(startUrl: string, options: { maxPages: number; maxDe
   const queue: Array<{ url: string; depth: number }> = [{ url: start.toString(), depth: 0 }];
   const visited = new Set<string>();
   const pages: WebsitePage[] = [];
+  const deadline = Date.now() + WEBSITE_CRAWL_WALL_CLOCK_MS;
+  let stoppedAtDeadline = false;
 
   while (queue.length > 0 && pages.length < options.maxPages) {
+    if (Date.now() > deadline) {
+      stoppedAtDeadline = true;
+      break;
+    }
     const next = queue.shift();
     if (!next) break;
     const normalized = normalizeCrawlUrl(next.url);
@@ -240,6 +254,12 @@ async function crawlWebsite(startUrl: string, options: { maxPages: number; maxDe
       if (!candidate || visited.has(candidate) || isAssetLikePath(link.pathname)) continue;
       queue.push({ url: candidate, depth: next.depth + 1 });
     }
+  }
+
+  if (stoppedAtDeadline) {
+    console.warn(
+      `[akm] website crawl stopped at the ${WEBSITE_CRAWL_WALL_CLOCK_MS / 1000}s wall-clock cap with ${pages.length}/${options.maxPages} pages collected from ${startUrl}.`,
+    );
   }
 
   return pages;

--- a/src/workflow-authoring.ts
+++ b/src/workflow-authoring.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { resolveAssetPathFromName } from "./asset-spec";
 import { isWithin, resolveStashDir } from "./common";
 import { UsageError } from "./errors";
+import { warn } from "./warn";
 import { parseWorkflowMarkdown, WorkflowValidationError } from "./workflow-markdown";
 
 const DEFAULT_WORKFLOW_TEMPLATE = renderWorkflowTemplate({
@@ -51,7 +52,7 @@ export function createWorkflowAsset(input: { name: string; content?: string; fro
   }
 
   const content = input.from
-    ? readWorkflowSource(input.from)
+    ? readWorkflowSource(input.from, stashDir)
     : (input.content ?? buildWorkflowTemplate(normalizedName));
   try {
     parseWorkflowMarkdown(content);
@@ -72,7 +73,7 @@ export function createWorkflowAsset(input: { name: string; content?: string; fro
   };
 }
 
-function readWorkflowSource(source: string): string {
+function readWorkflowSource(source: string, stashDir: string): string {
   const resolved = path.resolve(source);
   let stat: fs.Stats;
   try {
@@ -82,6 +83,15 @@ function readWorkflowSource(source: string): string {
   }
   if (!stat.isFile()) {
     throw new UsageError(`Workflow source must be a file: "${source}".`);
+  }
+  // The user is allowed to import any readable file as a workflow body, but
+  // an import from outside the stash is unusual enough to warn about. Anyone
+  // running `akm workflow create --from /etc/passwd` deserves a heads-up.
+  if (!isWithin(resolved, stashDir)) {
+    warn(
+      `Importing workflow content from outside the stash: ${resolved}\n  ` +
+        `If this was unintentional, abort and re-run with a --from path inside ${stashDir}.`,
+    );
   }
   return fs.readFileSync(resolved, "utf8");
 }

--- a/tests/workflow-cli.test.ts
+++ b/tests/workflow-cli.test.ts
@@ -32,6 +32,27 @@ function writeConfig(env: NodeJS.ProcessEnv, config: Record<string, unknown>) {
   fs.writeFileSync(path.join(configDir, "config.json"), `${JSON.stringify(config, null, 2)}\n`, "utf8");
 }
 
+/**
+ * Pull the JSON error envelope out of stderr. Stderr may contain
+ * preceding `warn(...)` lines (e.g. the "Importing workflow content
+ * from outside the stash" notice) before the (possibly multi-line) JSON
+ * envelope. We slice from the last `{` at column 0 to the end and parse
+ * that.
+ */
+function parseLastJsonLine(stderr: string): unknown {
+  const lines = stderr.split("\n");
+  let startIdx = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (lines[i].startsWith("{")) {
+      startIdx = i;
+      break;
+    }
+  }
+  if (startIdx === -1) throw new Error(`stderr did not contain a JSON envelope: ${stderr}`);
+  const tail = lines.slice(startIdx).join("\n").trim();
+  return JSON.parse(tail);
+}
+
 function runCli(args: string[], env: NodeJS.ProcessEnv) {
   return spawnSync("bun", [CLI, ...args], {
     encoding: "utf8",
@@ -113,7 +134,7 @@ describe("workflow CLI", () => {
     const result = runCli(["workflow", "create", "broken", "--from", sourcePath], env);
     expect(result.status).toBe(2);
 
-    const error = JSON.parse(result.stderr) as { error: string };
+    const error = parseLastJsonLine(result.stderr) as { error: string };
     expect(error.error).toContain('must contain a "### Instructions" section');
   });
 
@@ -126,7 +147,7 @@ describe("workflow CLI", () => {
     const result = runCli(["workflow", "create", "duplicate", "--from", sourcePath], env);
     expect(result.status).toBe(2);
 
-    const error = JSON.parse(result.stderr) as { error: string };
+    const error = parseLastJsonLine(result.stderr) as { error: string };
     expect(error.error).toContain('Duplicate Step ID: "validate"');
   });
 


### PR DESCRIPTION
Bundle for the 5 medium-severity security + robustness items from the 0.6.0 review (#177).

- workflow create --from outside-stash warning
- install-audit waiver path normalization (path.normalize + slash-folding + Windows lowercase)
- plain-HTTP registry URL → reject unless --allow-insecure
- LLM enhancement aggregated warning when entries fail
- website crawl 10-min wall-clock cap

bun test → 1650 / 0 / 7. tsc + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)