### PR TITLE
test: add direct unit tests for output-shapes + matchers

### DIFF
--- a/tests/matchers-unit.test.ts
+++ b/tests/matchers-unit.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, test } from "bun:test";
+import type { FileContext } from "../src/file-context";
+import { directoryMatcher, extensionMatcher, parentDirHintMatcher, smartMdMatcher, wikiMatcher } from "../src/matchers";
+
+/**
+ * Build a synthetic FileContext for matcher unit tests. The matchers
+ * (except smartMdMatcher) are pure functions of path-derived fields, so
+ * the lazy `content`/`frontmatter`/`stat` getters can return canned data
+ * — no real filesystem access needed.
+ */
+function ctx(opts: { relPath: string; content?: string; frontmatter?: Record<string, unknown> | null }): FileContext {
+  const segments = opts.relPath.split("/");
+  const fileName = segments[segments.length - 1];
+  const ext = (() => {
+    const dot = fileName.lastIndexOf(".");
+    return dot > 0 ? fileName.slice(dot).toLowerCase() : "";
+  })();
+  const dirSegments = segments.slice(0, -1);
+  const parentDir = dirSegments.length > 0 ? dirSegments[dirSegments.length - 1] : "";
+  const parentDirAbs = `/stash/${dirSegments.join("/")}`.replace(/\/+$/, "");
+  return {
+    absPath: `/stash/${opts.relPath}`,
+    relPath: opts.relPath,
+    ext,
+    fileName,
+    parentDir,
+    parentDirAbs,
+    ancestorDirs: dirSegments,
+    stashRoot: "/stash",
+    content: () => opts.content ?? "",
+    frontmatter: () => opts.frontmatter ?? null,
+    stat: () => {
+      throw new Error("stat() should not be called by these matchers");
+    },
+  };
+}
+
+// ── extensionMatcher ────────────────────────────────────────────────────────
+
+describe("extensionMatcher", () => {
+  test("classifies SKILL.md anywhere as skill at high specificity", () => {
+    const result = extensionMatcher(ctx({ relPath: "anywhere/deep/SKILL.md" }));
+    expect(result).toEqual({ type: "skill", specificity: 25, renderer: "skill-md" });
+  });
+
+  test("does NOT classify SKILL.md under wikis/ as skill", () => {
+    const result = extensionMatcher(ctx({ relPath: "wikis/research/SKILL.md" }));
+    expect(result).toBeNull();
+  });
+
+  test("classifies known script extensions as script at low specificity", () => {
+    expect(extensionMatcher(ctx({ relPath: "stuff/deploy.sh" }))?.type).toBe("script");
+    expect(extensionMatcher(ctx({ relPath: "stuff/lint.ts" }))?.type).toBe("script");
+    expect(extensionMatcher(ctx({ relPath: "stuff/lint.ts" }))?.specificity).toBe(3);
+  });
+
+  test("does not handle .md files (smartMdMatcher's job)", () => {
+    expect(extensionMatcher(ctx({ relPath: "stuff/notes.md" }))).toBeNull();
+  });
+
+  test("returns null for unknown extensions", () => {
+    expect(extensionMatcher(ctx({ relPath: "stuff/data.bin" }))).toBeNull();
+  });
+});
+
+// ── directoryMatcher ────────────────────────────────────────────────────────
+
+describe("directoryMatcher", () => {
+  test("scripts/ ancestor classifies a script", () => {
+    const result = directoryMatcher(ctx({ relPath: "scripts/azure/deploy.sh" }));
+    expect(result).toEqual({ type: "script", specificity: 10, renderer: "script-source" });
+  });
+
+  test("first matching ancestor wins (commands/ before agents/ in path)", () => {
+    const result = directoryMatcher(ctx({ relPath: "commands/agents/foo.md" }));
+    expect(result?.type).toBe("command");
+  });
+
+  test("agents/foo.md classifies as agent", () => {
+    expect(directoryMatcher(ctx({ relPath: "agents/foo.md" }))?.type).toBe("agent");
+  });
+
+  test("knowledge/foo.md classifies as knowledge", () => {
+    expect(directoryMatcher(ctx({ relPath: "knowledge/foo.md" }))?.type).toBe("knowledge");
+  });
+
+  test("workflows/foo.md classifies as workflow", () => {
+    expect(directoryMatcher(ctx({ relPath: "workflows/foo.md" }))?.type).toBe("workflow");
+  });
+
+  test("memories/foo.md classifies as memory", () => {
+    expect(directoryMatcher(ctx({ relPath: "memories/foo.md" }))?.type).toBe("memory");
+  });
+
+  test("vaults/.env classifies as vault", () => {
+    expect(directoryMatcher(ctx({ relPath: "vaults/.env" }))?.type).toBe("vault");
+    expect(directoryMatcher(ctx({ relPath: "vaults/staging.env" }))?.type).toBe("vault");
+  });
+
+  test("unmatched directories return null", () => {
+    expect(directoryMatcher(ctx({ relPath: "random/file.md" }))).toBeNull();
+  });
+});
+
+// ── parentDirHintMatcher ────────────────────────────────────────────────────
+
+describe("parentDirHintMatcher", () => {
+  test("immediate parent named scripts/ classifies a script at higher specificity", () => {
+    const result = parentDirHintMatcher(ctx({ relPath: "my-project/scripts/run.sh" }));
+    expect(result).toEqual({ type: "script", specificity: 15, renderer: "script-source" });
+  });
+
+  test("agents parent dir classifies an .md as agent", () => {
+    expect(parentDirHintMatcher(ctx({ relPath: "anything/agents/foo.md" }))?.type).toBe("agent");
+  });
+
+  test("returns null when parent doesn't match a type", () => {
+    expect(parentDirHintMatcher(ctx({ relPath: "random/blah.md" }))).toBeNull();
+  });
+});
+
+// ── smartMdMatcher ─────────────────────────────────────────────────────────
+
+describe("smartMdMatcher", () => {
+  test("returns null for non-.md files", () => {
+    expect(smartMdMatcher(ctx({ relPath: "stuff/run.sh", content: "" }))).toBeNull();
+  });
+
+  test("workflow signals classify as workflow at specificity 19", () => {
+    const body = `# Workflow: Deploy
+## Step: Validate
+Step ID: validate
+
+### Instructions
+Do the thing.
+`;
+    const result = smartMdMatcher(ctx({ relPath: "anywhere.md", content: body }));
+    expect(result).toEqual({ type: "workflow", specificity: 19, renderer: "workflow-md" });
+  });
+
+  test("toolPolicy frontmatter classifies as agent at 20 (highest)", () => {
+    const result = smartMdMatcher(
+      ctx({
+        relPath: "blah.md",
+        content: "body",
+        frontmatter: { toolPolicy: "strict" },
+      }),
+    );
+    expect(result).toEqual({ type: "agent", specificity: 20, renderer: "agent-md" });
+  });
+
+  test("tools frontmatter classifies as agent at 20", () => {
+    const result = smartMdMatcher(
+      ctx({
+        relPath: "blah.md",
+        content: "body",
+        frontmatter: { tools: ["read"] },
+      }),
+    );
+    expect(result?.type).toBe("agent");
+    expect(result?.specificity).toBe(20);
+  });
+
+  test("agent-named frontmatter (OpenCode command) classifies as command at 18", () => {
+    const result = smartMdMatcher(
+      ctx({
+        relPath: "blah.md",
+        content: "body",
+        frontmatter: { agent: "review" },
+      }),
+    );
+    expect(result).toEqual({ type: "command", specificity: 18, renderer: "command-md" });
+  });
+
+  test("$ARGUMENTS placeholder classifies as command at 18", () => {
+    const result = smartMdMatcher(
+      ctx({
+        relPath: "blah.md",
+        content: "Run with $ARGUMENTS",
+      }),
+    );
+    expect(result).toEqual({ type: "command", specificity: 18, renderer: "command-md" });
+  });
+
+  test("$1 placeholder classifies as command at 18", () => {
+    const result = smartMdMatcher(
+      ctx({
+        relPath: "blah.md",
+        content: "First arg is $1",
+      }),
+    );
+    expect(result?.type).toBe("command");
+  });
+
+  test("model frontmatter alone is a weak agent signal (specificity 8)", () => {
+    const result = smartMdMatcher(
+      ctx({
+        relPath: "blah.md",
+        content: "body",
+        frontmatter: { model: "gpt-4o" },
+      }),
+    );
+    expect(result).toEqual({ type: "agent", specificity: 8, renderer: "agent-md" });
+  });
+
+  test("plain .md falls back to knowledge at specificity 5", () => {
+    const result = smartMdMatcher(
+      ctx({
+        relPath: "blah.md",
+        content: "Just some prose with no signals.",
+      }),
+    );
+    expect(result).toEqual({ type: "knowledge", specificity: 5, renderer: "knowledge-md" });
+  });
+});
+
+// ── wikiMatcher ─────────────────────────────────────────────────────────────
+
+describe("wikiMatcher", () => {
+  test("any .md under wikis/<name>/ classifies as wiki at specificity 20", () => {
+    const result = wikiMatcher(ctx({ relPath: "wikis/research/page.md" }));
+    expect(result).toEqual({ type: "wiki", specificity: 20, renderer: "wiki-md" });
+  });
+
+  test("nested wiki pages also classify as wiki", () => {
+    expect(wikiMatcher(ctx({ relPath: "wikis/research/sub/deep/page.md" }))?.type).toBe("wiki");
+  });
+
+  test("non-.md files are ignored", () => {
+    expect(wikiMatcher(ctx({ relPath: "wikis/research/page.txt" }))).toBeNull();
+  });
+
+  test("a stray .md at bare wikis/ root is NOT a wiki page", () => {
+    expect(wikiMatcher(ctx({ relPath: "wikis/orphan.md" }))).toBeNull();
+  });
+
+  test("paths without wikis/ are ignored", () => {
+    expect(wikiMatcher(ctx({ relPath: "knowledge/page.md" }))).toBeNull();
+  });
+});

--- a/tests/output-shapes-unit.test.ts
+++ b/tests/output-shapes-unit.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, test } from "bun:test";
+import {
+  capDescription,
+  pickFields,
+  shapeAssetHit,
+  shapeForCommand,
+  shapeRegistrySearchOutput,
+  shapeSearchHit,
+  shapeSearchHitForAgent,
+  shapeSearchOutput,
+  shapeShowOutput,
+  truncateDescription,
+} from "../src/output-shapes";
+
+describe("pickFields", () => {
+  test("returns only requested fields, in the requested order", () => {
+    const source = { a: 1, b: 2, c: 3, d: 4 };
+    expect(pickFields(source, ["b", "d"])).toEqual({ b: 2, d: 4 });
+  });
+
+  test("omits fields that are absent", () => {
+    expect(pickFields({ a: 1 }, ["a", "b"])).toEqual({ a: 1 });
+  });
+
+  test("omits fields whose value is undefined", () => {
+    expect(pickFields({ a: 1, b: undefined }, ["a", "b"])).toEqual({ a: 1 });
+  });
+
+  test("preserves null values explicitly", () => {
+    expect(pickFields({ a: 1, b: null }, ["a", "b"])).toEqual({ a: 1, b: null });
+  });
+});
+
+describe("truncateDescription", () => {
+  test("returns short descriptions unchanged", () => {
+    expect(truncateDescription("hello", 100)).toBe("hello");
+  });
+
+  test("collapses whitespace", () => {
+    expect(truncateDescription("hello   world\n\nagain", 100)).toBe("hello world again");
+  });
+
+  test("truncates to a word boundary when possible", () => {
+    const long = "the quick brown fox jumps over the lazy dog repeatedly";
+    const result = truncateDescription(long, 25);
+    // Body is up to limit-1 chars; `...` is appended → realistic max = limit+2.
+    expect(result.length).toBeLessThanOrEqual(25 + 2);
+    expect(result.endsWith("...")).toBe(true);
+    // Should not split on a word
+    const beforeEllipsis = result.slice(0, -3).trimEnd();
+    expect(long).toContain(beforeEllipsis);
+  });
+
+  test("falls back to hard truncation when no word boundary is reasonable", () => {
+    const noSpaces = "x".repeat(40);
+    const result = truncateDescription(noSpaces, 10);
+    expect(result.length).toBeLessThanOrEqual(10 + 2);
+    expect(result.endsWith("...")).toBe(true);
+  });
+});
+
+describe("capDescription", () => {
+  test("caps a long description", () => {
+    const hit = { name: "x", description: "a".repeat(500) };
+    const capped = capDescription(hit, 100);
+    // truncateDescription appends `...`, so the resulting body is up to limit+2.
+    expect((capped.description as string).length).toBeLessThanOrEqual(100 + 2);
+    expect(capped.name).toBe("x");
+  });
+
+  test("leaves a short description alone", () => {
+    const hit = { name: "x", description: "short" };
+    expect(capDescription(hit, 100)).toEqual({ name: "x", description: "short" });
+  });
+
+  test("ignores hits without a string description", () => {
+    const hit = { name: "x", description: 42 as unknown };
+    expect(capDescription(hit, 100)).toEqual(hit);
+  });
+});
+
+describe("shapeSearchHit — local stash hits", () => {
+  const fullHit = {
+    type: "skill",
+    name: "deploy",
+    description: "Deploy the app",
+    ref: "skill:deploy",
+    action: "akm show skill:deploy",
+    score: 0.42,
+    estimatedTokens: 120,
+    origin: "local:.",
+    tags: ["ops"],
+    whyMatched: "name match",
+  };
+
+  test("brief keeps only type/name/action/estimatedTokens", () => {
+    expect(shapeSearchHit(fullHit, "brief")).toEqual({
+      type: "skill",
+      name: "deploy",
+      action: "akm show skill:deploy",
+      estimatedTokens: 120,
+    });
+  });
+
+  test("normal adds description and score (and caps description)", () => {
+    const out = shapeSearchHit(fullHit, "normal");
+    expect(out).toMatchObject({
+      type: "skill",
+      name: "deploy",
+      description: "Deploy the app",
+      action: "akm show skill:deploy",
+      score: 0.42,
+      estimatedTokens: 120,
+    });
+    expect(out).not.toHaveProperty("ref");
+    expect(out).not.toHaveProperty("origin");
+    expect(out).not.toHaveProperty("tags");
+  });
+
+  test("full passes the hit through verbatim", () => {
+    expect(shapeSearchHit(fullHit, "full")).toEqual(fullHit);
+  });
+});
+
+describe("shapeSearchHit — registry hits", () => {
+  const registryHit = {
+    type: "registry",
+    name: "azure-ops",
+    description: "Azure ops kit",
+    action: "akm add npm:azure-ops",
+    curated: true,
+    id: "npm:azure-ops",
+    score: 0.7,
+  };
+
+  test("brief keeps only name/action", () => {
+    expect(shapeSearchHit(registryHit, "brief")).toEqual({
+      name: "azure-ops",
+      action: "akm add npm:azure-ops",
+    });
+  });
+
+  test("normal adds description and curated", () => {
+    expect(shapeSearchHit(registryHit, "normal")).toMatchObject({
+      name: "azure-ops",
+      description: "Azure ops kit",
+      action: "akm add npm:azure-ops",
+      curated: true,
+    });
+  });
+
+  test("full passes through", () => {
+    expect(shapeSearchHit(registryHit, "full")).toEqual(registryHit);
+  });
+});
+
+describe("shapeSearchHitForAgent", () => {
+  test("includes ref + caps description", () => {
+    const hit = {
+      type: "skill",
+      name: "deploy",
+      ref: "skill:deploy",
+      description: "long ".repeat(100),
+      action: "akm show skill:deploy",
+      score: 0.5,
+      estimatedTokens: 100,
+      tags: ["ops"],
+      origin: "local:.",
+    };
+    const out = shapeSearchHitForAgent(hit);
+    expect(out).toMatchObject({
+      name: "deploy",
+      ref: "skill:deploy",
+      type: "skill",
+      action: "akm show skill:deploy",
+      score: 0.5,
+      estimatedTokens: 100,
+    });
+    expect(out).not.toHaveProperty("tags");
+    expect(out).not.toHaveProperty("origin");
+    expect(typeof out.description).toBe("string");
+  });
+});
+
+describe("shapeAssetHit", () => {
+  const asset = {
+    assetName: "deploy",
+    assetType: "skill",
+    description: "Deploy the app",
+    stash: { id: "x", name: "x" },
+    action: "akm show skill:deploy",
+    estimatedTokens: 120,
+  };
+
+  test("brief drops description", () => {
+    expect(shapeAssetHit(asset, "brief")).toEqual({
+      assetName: "deploy",
+      assetType: "skill",
+      action: "akm show skill:deploy",
+      estimatedTokens: 120,
+    });
+  });
+
+  test("normal includes description + stash", () => {
+    expect(shapeAssetHit(asset, "normal")).toMatchObject({
+      assetName: "deploy",
+      assetType: "skill",
+      description: "Deploy the app",
+      stash: { id: "x", name: "x" },
+    });
+  });
+});
+
+describe("shapeShowOutput", () => {
+  const fullShow = {
+    type: "skill",
+    name: "deploy",
+    description: "Deploy",
+    action: "akm show skill:deploy",
+    content: "long body...",
+    template: "tpl",
+    cwd: "/tmp",
+    extra: "should-not-appear-in-agent-mode",
+  };
+
+  test("forAgent picks the agent-action field set", () => {
+    const out = shapeShowOutput(fullShow, "full", true);
+    expect(out).toMatchObject({
+      type: "skill",
+      name: "deploy",
+      description: "Deploy",
+      content: "long body...",
+    });
+    expect(out).not.toHaveProperty("extra");
+  });
+
+  test("forAgent=false at full picks the show field set + adds schemaVersion", () => {
+    const out = shapeShowOutput(fullShow, "full", false);
+    expect(out.schemaVersion).toBe(1);
+    expect(out).toMatchObject({
+      type: "skill",
+      name: "deploy",
+      description: "Deploy",
+      content: "long body...",
+      template: "tpl",
+      cwd: "/tmp",
+    });
+    // `extra` was not in the picked field set, even at full.
+    expect(out).not.toHaveProperty("extra");
+  });
+
+  test("forAgent=false at brief omits schemaVersion (only added at full)", () => {
+    const out = shapeShowOutput(fullShow, "brief", false);
+    expect(out).not.toHaveProperty("schemaVersion");
+    expect(out.name).toBe("deploy");
+  });
+});
+
+describe("shapeForCommand", () => {
+  test("routes search results through shapeSearchOutput", () => {
+    const out = shapeForCommand(
+      "search",
+      { hits: [{ type: "skill", name: "x", action: "a", estimatedTokens: 1 }], registryHits: [] },
+      "brief",
+      false,
+    ) as Record<string, unknown>;
+    expect(Array.isArray(out.hits)).toBe(true);
+    expect((out.hits as unknown[])[0]).toEqual({
+      type: "skill",
+      name: "x",
+      action: "a",
+      estimatedTokens: 1,
+    });
+  });
+
+  test("routes show results through shapeShowOutput at full + forAgent=true", () => {
+    const out = shapeForCommand(
+      "show",
+      { type: "skill", name: "deploy", action: "a", extra: "drop me" },
+      "full",
+      true,
+    ) as Record<string, unknown>;
+    expect(out).not.toHaveProperty("extra");
+  });
+
+  test("non-search/show commands pass through unmodified", () => {
+    const result = { something: "untouched" };
+    expect(shapeForCommand("info", result, "full", false)).toEqual(result);
+  });
+});
+
+describe("shapeSearchOutput", () => {
+  test("respects detail level for hits", () => {
+    const result = {
+      hits: [{ type: "skill", name: "x", action: "a", estimatedTokens: 1, description: "desc" }],
+      registryHits: [],
+    };
+    const brief = shapeSearchOutput(result, "brief", false);
+    const normal = shapeSearchOutput(result, "normal", false);
+    expect((brief.hits[0] as Record<string, unknown>).description).toBeUndefined();
+    expect((normal.hits[0] as Record<string, unknown>).description).toBe("desc");
+  });
+
+  test("forAgent overrides detail and uses the agent shape", () => {
+    const result = {
+      hits: [
+        {
+          type: "skill",
+          name: "x",
+          action: "a",
+          ref: "skill:x",
+          description: "d",
+          score: 0.1,
+          estimatedTokens: 1,
+        },
+      ],
+      registryHits: [],
+    };
+    const out = shapeSearchOutput(result, "brief", true);
+    expect((out.hits[0] as Record<string, unknown>).ref).toBe("skill:x");
+  });
+});
+
+describe("shapeRegistrySearchOutput", () => {
+  test("shapes registry hits at the requested detail level", () => {
+    const result = {
+      hits: [
+        {
+          name: "azure-ops",
+          description: "Azure ops kit",
+          action: "akm add npm:azure-ops",
+          curated: true,
+          score: 0.5,
+          id: "npm:azure-ops",
+        },
+      ],
+      registryHits: [],
+    };
+    const brief = shapeRegistrySearchOutput(result, "brief");
+    expect(brief.hits[0]).toEqual({ name: "azure-ops", action: "akm add npm:azure-ops" });
+  });
+});


### PR DESCRIPTION
Closes 2 of 3 high-blast-radius test gaps from #177. +59 unit tests covering output-shapes (final gate before CLI response) and matchers (classification cascade with subtle edges). renderers.ts deferred to a follow-up; it's ~724 lines and deserves a focused PR. 1709/0/7.