### PR TITLE
fix: address Copilot review comments on PR #168

### DIFF
--- a/docs/technical/search-updated.md
+++ b/docs/technical/search-updated.md
@@ -36,7 +36,7 @@ The local indexed path includes more than the primary working stash:
 
 - primary stash
 - configured filesystem stashes
-- installed stash stash roots
+- installed stash roots
 - cache-backed git mirrors
 - cache-backed website mirrors
 

--- a/docs/technical/search.md
+++ b/docs/technical/search.md
@@ -197,9 +197,9 @@ places provider noise below 0.28.
 
 ## Substring Fallback
 
-When no index is available, search falls back to scanning stash and stash
-directories and filtering by substring match. This ensures search always works,
-even before `akm index` has been run.
+When no index is available, search falls back to scanning the primary stash
+plus any installed/cache-backed stash roots and filtering by substring match.
+This ensures search always works, even before `akm index` has been run.
 
 ## Output Modes
 

--- a/src/registry-search.ts
+++ b/src/registry-search.ts
@@ -166,12 +166,22 @@ function isCompleteHit(hit: RegistrySearchHit | undefined | null): hit is Regist
 
 function isCompleteAssetHit(hit: RegistryAssetSearchHit | undefined | null): hit is RegistryAssetSearchHit {
   if (!hit || typeof hit !== "object") return false;
-  return (
-    hit.type === "registry-asset" &&
-    typeof hit.assetType === "string" &&
-    hit.assetType.length > 0 &&
-    typeof hit.assetName === "string" &&
-    hit.assetName.length > 0 &&
-    typeof hit.action === "string"
-  );
+  if (
+    hit.type !== "registry-asset" ||
+    typeof hit.assetType !== "string" ||
+    hit.assetType.length === 0 ||
+    typeof hit.assetName !== "string" ||
+    hit.assetName.length === 0 ||
+    typeof hit.action !== "string"
+  ) {
+    return false;
+  }
+  // `stash` is required by the consumer (output shaping + asset-action display);
+  // rejecting incomplete stashes here keeps malformed objects out of the JSON
+  // output. Flagged in PR #168 review (#9).
+  const stash = hit.stash as { id?: unknown; name?: unknown } | undefined;
+  if (!stash || typeof stash !== "object") return false;
+  if (typeof stash.id !== "string" || stash.id.length === 0) return false;
+  if (typeof stash.name !== "string" || stash.name.length === 0) return false;
+  return true;
 }

--- a/src/stash-providers/tar-utils.ts
+++ b/src/stash-providers/tar-utils.ts
@@ -110,16 +110,25 @@ function scanExtractedFiles(dir: string, root: string): void {
   }
   for (const entry of entries) {
     const fullPath = path.join(dir, entry.name);
-    // Check for ".." segments in names (e.g. symlink tricks or crafted filenames)
-    if (entry.name.includes("..")) {
+    // Reject only entries whose name is exactly the parent-traversal segment
+    // (or `.`). Substring matches (`foo..bar`, `archive..2024.tar`) are
+    // legitimate filenames that the previous `entry.name.includes("..")`
+    // check rejected as false positives — flagged in PR #168 review.
+    if (entry.name === ".." || entry.name === ".") {
       throw new Error(`Post-extraction scan: suspicious entry name: ${fullPath}`);
     }
-    // Resolve symlinks to detect escapes outside the destination directory
+    // Symlinks: resolve and confirm the target stays inside the destination.
     if (entry.isSymbolicLink()) {
       const target = fs.realpathSync(fullPath);
       if (!isWithin(target, root)) {
         throw new Error(`Post-extraction scan: symlink escapes destination directory: ${fullPath} -> ${target}`);
       }
+    }
+    // Belt-and-suspenders: any regular entry whose resolved path lands outside
+    // the destination root is rejected, regardless of how its name looks. This
+    // catches anything the tar pre-validation missed.
+    if (!entry.isSymbolicLink() && !isWithin(fullPath, root)) {
+      throw new Error(`Post-extraction scan: entry escapes destination directory: ${fullPath}`);
     }
     if (entry.isDirectory()) {
       scanExtractedFiles(fullPath, root);

--- a/tests/registry-search.test.ts
+++ b/tests/registry-search.test.ts
@@ -710,4 +710,58 @@ describe("incomplete hits filter (#159)", () => {
     expect(result.assetHits?.length).toBe(1);
     expect(result.assetHits?.[0].assetName).toBe("deploy");
   });
+
+  // PR #168 review #9: asset hits with missing/empty `stash.id` or `stash.name`
+  // are also incomplete and must not propagate to JSON output.
+  test("asset hits with missing or empty stash fields are dropped", async () => {
+    const { registerProvider } = await import("../src/registry-factory");
+    registerProvider("incomplete-stash-test", () => ({
+      type: "incomplete-stash-test",
+      async search() {
+        return {
+          hits: [],
+          assetHits: [
+            // stash entirely missing
+            {
+              type: "registry-asset",
+              assetType: "skill",
+              assetName: "no-stash",
+              action: "akm show skill:no-stash",
+            } as never,
+            // stash present but id is empty
+            {
+              type: "registry-asset",
+              assetType: "skill",
+              assetName: "empty-id",
+              action: "akm show skill:empty-id",
+              stash: { id: "", name: "x" },
+            } as never,
+            // stash present but name is missing
+            {
+              type: "registry-asset",
+              assetType: "skill",
+              assetName: "no-name",
+              action: "akm show skill:no-name",
+              stash: { id: "x" },
+            } as never,
+            // valid — only this one should survive
+            {
+              type: "registry-asset" as const,
+              assetType: "skill",
+              assetName: "good",
+              action: "akm show skill:good",
+              stash: { id: "x", name: "x" },
+            },
+          ],
+        };
+      },
+    }));
+
+    const result = await searchRegistry("anything", {
+      registries: [{ url: "http://unused", provider: "incomplete-stash-test" }],
+    });
+
+    expect(result.assetHits?.length).toBe(1);
+    expect(result.assetHits?.[0].assetName).toBe("good");
+  });
 });

--- a/tests/tar-utils-scan.test.ts
+++ b/tests/tar-utils-scan.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { extractTarGzSecure } from "../src/stash-providers/tar-utils";
+
+/**
+ * Regression tests for the post-extraction scanner in `tar-utils.ts`.
+ *
+ * PR #168 review flagged that the previous `entry.name.includes("..")`
+ * check rejected legitimate filenames like `archive..2024.tar` or
+ * `foo..bar.md`. The scanner now only rejects exact "." / ".." segments
+ * and instead enforces containment via `isWithin`.
+ *
+ * These tests construct real tarballs in a temp directory and run them
+ * through the actual extraction path so the post-scan logic is exercised
+ * end-to-end.
+ */
+
+const tmpDirs: string[] = [];
+
+function tmpDir(prefix = "akm-tar-scan-"): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/**
+ * Build a tarball where the inner directory wraps two files. Returns the
+ * tarball path and the destination dir for `extractTarGzSecure`.
+ */
+function buildTarball(rootName: string, entries: Array<{ name: string; body: string }>): string {
+  const work = tmpDir("akm-tar-build-");
+  const root = path.join(work, rootName);
+  fs.mkdirSync(root, { recursive: true });
+  for (const entry of entries) {
+    const file = path.join(root, entry.name);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, entry.body, "utf8");
+  }
+  const tarPath = path.join(work, `${rootName}.tar.gz`);
+  // Use system tar — present on macOS, Linux. The scanner is what we care
+  // about; building the archive itself is incidental.
+  const proc = Bun.spawnSync(["tar", "-czf", tarPath, "-C", work, rootName]);
+  if (proc.exitCode !== 0) {
+    throw new Error(`tar build failed: ${new TextDecoder().decode(proc.stderr)}`);
+  }
+  return tarPath;
+}
+
+describe("scanExtractedFiles — filename .. substring guard (PR #168 review #8)", () => {
+  test("accepts filenames containing `..` substrings (no false positive)", () => {
+    const tarPath = buildTarball("pkg", [
+      { name: "archive..2024.tar", body: "tar body bytes" },
+      { name: "notes/foo..bar.md", body: "# notes" },
+    ]);
+    const dest = tmpDir("akm-tar-extract-");
+    // Should NOT throw — these names previously failed the substring check.
+    expect(() => extractTarGzSecure(tarPath, dest)).not.toThrow();
+    expect(fs.existsSync(path.join(dest, "archive..2024.tar"))).toBe(true);
+    expect(fs.existsSync(path.join(dest, "notes/foo..bar.md"))).toBe(true);
+  });
+
+  test("accepts ordinary filenames", () => {
+    const tarPath = buildTarball("pkg", [
+      { name: "README.md", body: "# README" },
+      { name: "src/main.ts", body: "export const x = 1;" },
+    ]);
+    const dest = tmpDir("akm-tar-extract-ok-");
+    expect(() => extractTarGzSecure(tarPath, dest)).not.toThrow();
+    expect(fs.existsSync(path.join(dest, "README.md"))).toBe(true);
+    expect(fs.existsSync(path.join(dest, "src/main.ts"))).toBe(true);
+  });
+});


### PR DESCRIPTION
Addresses the 4 substantive Copilot review comments on PR #168 (release/0.6.0 → main). The other 7 were about `.dev/workspace/` files already untracked in #176.

## Changes
- **`tar-utils.ts`** (#8): `scanExtractedFiles` no longer rejects filenames containing `..` substrings. Now only rejects exact `.` / `..` segments + adds `isWithin` containment check on every entry.
- **`registry-search.ts`** (#9): `isCompleteAssetHit` validates the required `stash` field (object with non-empty `id` + `name`).
- **`docs/technical/search.md`** (#10): "stash and stash directories" → "the primary stash plus any installed/cache-backed stash roots".
- **`docs/technical/search-updated.md`** (#11): "installed stash stash roots" → "installed stash roots".

## Tests
- New `tests/tar-utils-scan.test.ts` (2 cases): filenames with `..` substrings extract; ordinary filenames extract.
- `tests/registry-search.test.ts` (+1 case): asset hits with missing/empty `stash.id` or `stash.name` are dropped.

`bun test` → **1716 pass / 0 fail / 7 skip**. tsc + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)