### PR TITLE
refactor: address /simplify findings on PRs #178-#186

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,14 @@ import { assembleInfo } from "./info";
 import { akmInit } from "./init";
 import { akmListSources, akmRemove, akmUpdate } from "./installed-stashes";
 import { renderMigrationHelp } from "./migration-help";
-import { getOutputMode, initOutputMode, type OutputMode, parseFlagValue } from "./output-context";
+import {
+  getHyphenatedArg,
+  getHyphenatedBoolean,
+  getOutputMode,
+  initOutputMode,
+  type OutputMode,
+  parseFlagValue,
+} from "./output-context";
 import { shapeForCommand } from "./output-shapes";
 import { formatPlain, outputJsonl } from "./output-text";
 import { getCacheDir, getDbPath, getDefaultStashDir } from "./paths";
@@ -419,7 +426,7 @@ const upgradeCommand = defineCommand({
         output("upgrade", check);
         return;
       }
-      const skipChecksum = Boolean((args as Record<string, unknown>)["skip-checksum"]);
+      const skipChecksum = getHyphenatedBoolean(args, "skip-checksum");
       const result = await performUpgrade(check, { force: args.force, skipChecksum });
       output("upgrade", result);
     });
@@ -470,7 +477,6 @@ const showCommand = defineCommand({
             throw new UsageError(`Unknown view mode: ${akmView}. Expected one of: full|toc|frontmatter|section|lines`);
         }
       }
-      // Map CLI detail level to ShowDetailLevel for the show function
       const cliDetail = getOutputMode().detail;
       const showDetail: ShowDetailLevel | undefined = cliDetail === "summary" ? "summary" : undefined;
       const result = await akmShowUnified({ ref: args.ref, view, detail: showDetail });
@@ -722,7 +728,7 @@ const registryCommand = defineCommand({
             throw new UsageError("Registry URL must start with http:// or https://");
           }
           if (args.url.startsWith("http://")) {
-            const allowInsecure = Boolean((args as Record<string, unknown>)["allow-insecure"]);
+            const allowInsecure = getHyphenatedBoolean(args, "allow-insecure");
             if (!allowInsecure) {
               throw new UsageError(
                 "Registry URL uses plain HTTP (not HTTPS). An on-path attacker could substitute a malicious index. " +
@@ -804,11 +810,10 @@ const registryCommand = defineCommand({
       },
       async run({ args }) {
         await runWithJsonErrors(async () => {
-          const argsRecord = args as Record<string, unknown>;
           const result = await buildRegistryIndex({
             manualEntriesPath: args.manual,
-            npmRegistryBase: typeof argsRecord["npm-registry"] === "string" ? argsRecord["npm-registry"] : undefined,
-            githubApiBase: typeof argsRecord["github-api"] === "string" ? argsRecord["github-api"] : undefined,
+            npmRegistryBase: getHyphenatedArg<string>(args, "npm-registry"),
+            githubApiBase: getHyphenatedArg<string>(args, "github-api"),
           });
           const outPath = writeRegistryIndex(result.index, args.out);
           output("registry-build-index", {
@@ -1224,7 +1229,6 @@ const rememberCommand = defineCommand({
 
       const hasStructuredArgs = rawTags.length > 0 || !!args.expires || !!args.source || args.auto || args.enrich;
 
-      // Zero-flag path: write bare memory (no frontmatter). Preserve existing behaviour.
       if (!hasStructuredArgs) {
         const result = writeMarkdownAsset({
           type: "memory",
@@ -1837,7 +1841,7 @@ const wikiRemoveCommand = defineCommand({
       if (!args.force) {
         throw new UsageError("Refusing to remove without --force. Pass `--force` to confirm.");
       }
-      const withSources = Boolean((args as Record<string, unknown>)["with-sources"]);
+      const withSources = getHyphenatedBoolean(args, "with-sources");
       const { removeWiki } = await import("./wiki.js");
       const { akmIndex } = await import("./indexer");
       const stashDir = resolveStashDir();

--- a/src/db.ts
+++ b/src/db.ts
@@ -202,6 +202,16 @@ function ensureSchema(db: Database, embeddingDim: number): void {
     );
   `);
 
+  // FTS-dirty queue. Created here (not lazily on first upsert) so the
+  // per-entry write path doesn't issue a CREATE TABLE IF NOT EXISTS on
+  // every call — that DDL would fire thousands of times during a full
+  // index. See `markFtsDirty` and `rebuildFts({ incremental: true })`.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS entries_fts_dirty (
+      entry_id INTEGER PRIMARY KEY
+    );
+  `);
+
   // sqlite-vec table
   if (isVecAvailable(db)) {
     // Check if stored embedding dimension differs from configured one
@@ -348,47 +358,59 @@ export function upsertEntry(
   entry: StashEntry,
   searchText: string,
 ): number {
-  const stmt = db.prepare(`
-    INSERT INTO entries (entry_key, dir_path, file_path, stash_dir, entry_json, search_text, entry_type)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
-    ON CONFLICT(entry_key) DO UPDATE SET
-      dir_path = excluded.dir_path,
-      file_path = excluded.file_path,
-      stash_dir = excluded.stash_dir,
-      entry_json = excluded.entry_json,
-      search_text = excluded.search_text,
-      entry_type = excluded.entry_type
-  `);
-  stmt.run(entryKey, dirPath, filePath, stashDir, JSON.stringify(entry), searchText, entry.type);
-  // Fetch the row id explicitly since last_insert_rowid() is unreliable for ON CONFLICT DO UPDATE
-  const row = db.prepare("SELECT id FROM entries WHERE entry_key = ?").get(entryKey) as { id: number } | undefined;
-  if (!row) throw new Error("upsertEntry: entry_key not found after upsert");
+  // Hot path during indexing — cache the two prepared statements per
+  // database connection so we don't pay the SQL parse/compile cost on
+  // every call. The dirty-mark INSERT and the upsert-with-RETURNING
+  // share the same WeakMap so they live and die with the connection.
+  const stmts = getUpsertStmts(db);
+  const result = stmts.upsert.get(
+    entryKey,
+    dirPath,
+    filePath,
+    stashDir,
+    JSON.stringify(entry),
+    searchText,
+    entry.type,
+  ) as { id: number } | undefined;
+  if (!result) throw new Error("upsertEntry: entry_key not found after upsert");
 
-  // Mark this entry as FTS-dirty so an incremental rebuild only revisits the
-  // entries that actually changed. Without this, every `akm index` run had to
-  // re-scan and re-insert every FTS row, even if only one entry was touched.
-  markFtsDirty(db, row.id);
-  return row.id;
+  // Mark this entry as FTS-dirty so `rebuildFts({ incremental: true })`
+  // only revisits entries that actually changed. INSERT OR IGNORE is
+  // idempotent across multiple upserts of the same row.
+  stmts.markDirty.run(result.id);
+  return result.id;
 }
 
-/**
- * Mark an entry as needing FTS re-indexing on the next `rebuildFts` call.
- *
- * The list lives in a small `entries_fts_dirty` table — a per-entry-id queue
- * of work items. `rebuildFts({ incremental: true })` drains this list rather
- * than scanning the entire `entries` table.
- */
-function markFtsDirty(db: Database, entryId: number): void {
-  ensureFtsDirtyTable(db);
-  db.prepare("INSERT OR IGNORE INTO entries_fts_dirty (entry_id) VALUES (?)").run(entryId);
+interface UpsertStmts {
+  upsert: ReturnType<Database["prepare"]>;
+  markDirty: ReturnType<Database["prepare"]>;
 }
 
-function ensureFtsDirtyTable(db: Database): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS entries_fts_dirty (
-      entry_id INTEGER PRIMARY KEY
-    );
-  `);
+const upsertStmtsByDb = new WeakMap<Database, UpsertStmts>();
+
+function getUpsertStmts(db: Database): UpsertStmts {
+  const existing = upsertStmtsByDb.get(db);
+  if (existing) return existing;
+  const stmts: UpsertStmts = {
+    // RETURNING id handles ON CONFLICT DO UPDATE correctly — no second
+    // SELECT round-trip needed (last_insert_rowid() is unreliable for
+    // ON CONFLICT). Use `.get()` so a single row comes back.
+    upsert: db.prepare(`
+      INSERT INTO entries (entry_key, dir_path, file_path, stash_dir, entry_json, search_text, entry_type)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(entry_key) DO UPDATE SET
+        dir_path = excluded.dir_path,
+        file_path = excluded.file_path,
+        stash_dir = excluded.stash_dir,
+        entry_json = excluded.entry_json,
+        search_text = excluded.search_text,
+        entry_type = excluded.entry_type
+      RETURNING id
+    `),
+    markDirty: db.prepare("INSERT OR IGNORE INTO entries_fts_dirty (entry_id) VALUES (?)"),
+  };
+  upsertStmtsByDb.set(db, stmts);
+  return stmts;
 }
 
 export function deleteEntriesByDir(db: Database, dirPath: string): void {
@@ -489,7 +511,6 @@ export function rebuildFts(db: Database, options?: { incremental?: boolean }): v
   db.transaction(() => {
     let rows: Array<{ id: number; entry_json: string }>;
     if (incremental) {
-      ensureFtsDirtyTable(db);
       // Read the dirty queue and join against entries to get the JSON.
       // Then drop the matching rows from entries_fts so the INSERT below
       // doesn't double-up. The dirty list is drained at the end.
@@ -543,10 +564,8 @@ export function rebuildFts(db: Database, options?: { incremental?: boolean }): v
     if (incremental) {
       db.exec("DELETE FROM entries_fts_dirty");
     } else {
-      // Full path: only drop the dirty table if it exists. Use
-      // `CREATE IF NOT EXISTS` then DELETE so we don't error on databases
-      // that haven't run any upserts yet (e.g. fresh schema).
-      ensureFtsDirtyTable(db);
+      // Full path: drain the dirty queue too. The table is created by
+      // ensureSchema(), so it always exists at this point.
       db.exec("DELETE FROM entries_fts_dirty");
     }
   })();

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -1,7 +1,7 @@
 import type { Database } from "bun:sqlite";
 import fs from "node:fs";
 import path from "node:path";
-import { isHttpUrl, resolveStashDir } from "./common";
+import { isHttpUrl, resolveStashDir, toErrorMessage } from "./common";
 import type { AkmConfig, LlmConnectionConfig } from "./config";
 import {
   closeDatabase,
@@ -797,7 +797,6 @@ async function enhanceStashWithLlm(
   const { enhanceMetadata } = await import("./llm.js");
 
   const enhanced: StashEntry[] = [];
-  const seenSamples = new Set<string>();
   for (const entry of stash.entries) {
     summary.attempted++;
     try {
@@ -822,10 +821,11 @@ async function enhanceStashWithLlm(
       summary.succeeded++;
     } catch (err) {
       enhanced.push(entry);
-      const msg = err instanceof Error ? err.message : String(err);
-      if (summary.failureSamples.length < 3 && !seenSamples.has(msg)) {
+      const msg = toErrorMessage(err);
+      // failureSamples is bounded to 3 items, so a linear scan is cheaper
+      // than maintaining a parallel Set for membership checks (#177 review).
+      if (summary.failureSamples.length < 3 && !summary.failureSamples.includes(msg)) {
         summary.failureSamples.push(msg);
-        seenSamples.add(msg);
       }
     }
   }

--- a/src/install-audit.ts
+++ b/src/install-audit.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { filterNonEmptyStrings } from "./common";
+import { filterNonEmptyStrings, toPosix } from "./common";
 import type { AkmConfig, InstallAuditAllowedFinding } from "./config";
 import type { KitSource } from "./registry-types";
 
@@ -464,12 +464,9 @@ function matchesAllowedFinding(
 
 function normalizeWaiverPath(value: string | undefined): string | undefined {
   if (!value) return value;
-  // Strip a leading `./`, collapse duplicate slashes via path.normalize, and
-  // POSIX-ify so Windows path separators don't trigger spurious mismatches.
-  const normalized = path
-    .normalize(value)
-    .replace(/\\/g, "/")
-    .replace(/^\.\/+/, "");
+  // Strip a leading `./` and POSIX-ify after path.normalize so Windows path
+  // separators don't trigger spurious mismatches.
+  const normalized = toPosix(path.normalize(value)).replace(/^\.\/+/, "");
   return process.platform === "win32" ? normalized.toLowerCase() : normalized;
 }
 

--- a/src/output-context.ts
+++ b/src/output-context.ts
@@ -54,6 +54,25 @@ export function hasBooleanFlag(argv: string[], flag: string): boolean {
 }
 
 /**
+ * Read a hyphenated arg out of citty's parsed `args` object.
+ *
+ * citty does not auto-camelise hyphenated arg keys (see `--max-pages`,
+ * `--with-sources` for the existing convention), so command handlers end up
+ * casting `args` to a string-indexed record at every read site. This helper
+ * encapsulates the cast.
+ */
+export function getHyphenatedArg<T = string>(args: unknown, key: string): T | undefined {
+  if (typeof args !== "object" || args === null) return undefined;
+  const value = (args as Record<string, unknown>)[key];
+  return value === undefined ? undefined : (value as T);
+}
+
+/** Boolean variant of {@link getHyphenatedArg} for `--<flag>` switches. */
+export function getHyphenatedBoolean(args: unknown, key: string): boolean {
+  return Boolean(getHyphenatedArg(args, key));
+}
+
+/**
  * Resolve output mode from a synthetic argv array and config defaults.
  * Pure function — no IO. Suitable for unit tests.
  */

--- a/src/remember.ts
+++ b/src/remember.ts
@@ -7,7 +7,7 @@
  */
 
 import { stringify as yamlStringify } from "yaml";
-import { tryReadStdinText } from "./common";
+import { toErrorMessage, tryReadStdinText } from "./common";
 import { loadConfig } from "./config";
 import { UsageError } from "./errors";
 import { warn } from "./warn";
@@ -113,34 +113,34 @@ export function runAutoHeuristics(body: string): HeuristicResult {
   const source = urlMatch ? urlMatch[0] : undefined;
 
   // ISO date token or obvious relative date phrase → observed_at
-  let observed_at: string | undefined;
-  const isoMatch = body.match(/\b(\d{4}-\d{2}-\d{2})\b/);
-  if (isoMatch) {
-    observed_at = isoMatch[1];
-  } else {
-    const relMatch = body.match(/\b(today|yesterday|last\s+week|last\s+month)\b/i);
-    if (relMatch) {
-      const phrase = relMatch[1].toLowerCase();
-      const now = new Date();
-      if (phrase === "today") {
-        observed_at = now.toISOString().slice(0, 10);
-      } else if (phrase === "yesterday") {
-        const d = new Date(now);
-        d.setDate(d.getDate() - 1);
-        observed_at = d.toISOString().slice(0, 10);
-      } else if (phrase.startsWith("last week")) {
-        const d = new Date(now);
-        d.setDate(d.getDate() - 7);
-        observed_at = d.toISOString().slice(0, 10);
-      } else if (phrase.startsWith("last month")) {
-        const d = new Date(now);
-        d.setMonth(d.getMonth() - 1);
-        observed_at = d.toISOString().slice(0, 10);
-      }
-    }
-  }
+  const observed_at = detectObservedAt(body);
 
   return { tags, source, observed_at, subjective };
+}
+
+const RELATIVE_DATE_OFFSETS: Record<string, (d: Date) => void> = {
+  today: () => {},
+  yesterday: (d) => d.setDate(d.getDate() - 1),
+  "last week": (d) => d.setDate(d.getDate() - 7),
+  "last month": (d) => d.setMonth(d.getMonth() - 1),
+};
+
+function detectObservedAt(body: string): string | undefined {
+  const isoMatch = body.match(/\b(\d{4}-\d{2}-\d{2})\b/);
+  if (isoMatch) return isoMatch[1];
+
+  const relMatch = body.match(/\b(today|yesterday|last\s+week|last\s+month)\b/i);
+  if (!relMatch) return undefined;
+
+  // Normalise the matched phrase: lowercase, collapse internal whitespace,
+  // so "last  week" matches the lookup table key.
+  const phrase = relMatch[1].toLowerCase().replace(/\s+/g, " ");
+  const offset = RELATIVE_DATE_OFFSETS[phrase];
+  if (!offset) return undefined;
+
+  const d = new Date();
+  offset(d);
+  return d.toISOString().slice(0, 10);
 }
 
 /**
@@ -220,8 +220,7 @@ Return ONLY the JSON object, no prose, no markdown fences.`;
 
     return { tags, description, observed_at };
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    warn(`Warning: --enrich failed (${msg}). Writing memory without enrichment.`);
+    warn(`Warning: --enrich failed (${toErrorMessage(err)}). Writing memory without enrichment.`);
     return { tags: [] };
   }
 }

--- a/src/stash-providers/website.ts
+++ b/src/stash-providers/website.ts
@@ -14,6 +14,7 @@ import type {
 } from "../stash-provider";
 import { registerStashProvider } from "../stash-provider-factory";
 import type { KnowledgeView, ShowResponse } from "../stash-types";
+import { warn } from "../warn";
 import { isDirectory, isExpired, sanitizeString } from "./provider-utils";
 
 /** Refresh website snapshots every 12 hours to balance freshness with scraping load. */
@@ -229,13 +230,9 @@ async function crawlWebsite(startUrl: string, options: { maxPages: number; maxDe
   const visited = new Set<string>();
   const pages: WebsitePage[] = [];
   const deadline = Date.now() + WEBSITE_CRAWL_WALL_CLOCK_MS;
-  let stoppedAtDeadline = false;
 
   while (queue.length > 0 && pages.length < options.maxPages) {
-    if (Date.now() > deadline) {
-      stoppedAtDeadline = true;
-      break;
-    }
+    if (Date.now() > deadline) break;
     const next = queue.shift();
     if (!next) break;
     const normalized = normalizeCrawlUrl(next.url);
@@ -256,9 +253,13 @@ async function crawlWebsite(startUrl: string, options: { maxPages: number; maxDe
     }
   }
 
-  if (stoppedAtDeadline) {
-    console.warn(
-      `[akm] website crawl stopped at the ${WEBSITE_CRAWL_WALL_CLOCK_MS / 1000}s wall-clock cap with ${pages.length}/${options.maxPages} pages collected from ${startUrl}.`,
+  if (Date.now() > deadline) {
+    warn(
+      "[akm] website crawl stopped at the %ds wall-clock cap with %d/%d pages collected from %s.",
+      WEBSITE_CRAWL_WALL_CLOCK_MS / 1000,
+      pages.length,
+      options.maxPages,
+      startUrl,
     );
   }
 


### PR DESCRIPTION
Three review agents (reuse / quality / efficiency) ran over the post-#177 src/ diff and converged on a small list of fixes. None change behaviour; all are local hygiene + hot-path wins.

## Hot-path wins
- `upsertEntry` (per-entry indexer hot path) now (a) uses `INSERT ... RETURNING id` instead of a separate SELECT, (b) caches its prepared statements in a `WeakMap<Database>`, and (c) no longer fires `CREATE TABLE IF NOT EXISTS` on every call (table created in `ensureSchema`).

## Hygiene
- `normalizeWaiverPath` uses `toPosix`; `runLlmEnrich` + `enhanceStashWithLlm` use `toErrorMessage`.
- New `getHyphenatedArg` / `getHyphenatedBoolean` helpers in `output-context.ts` replace the `(args as Record<string, unknown>)[…]` cast at 4 call sites.
- Drop redundant state: `stoppedAtDeadline` boolean (website crawl), `seenSamples` Set (LLM aggregation).
- Relative-date detection becomes a lookup table + `detectObservedAt` helper.
- Crawl wall-clock warning now goes through `warn()` so `--quiet` honours it.
- Drop two narrating comments.

`bun test` → **1716 / 0 / 7**. tsc + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)