### PR TITLE
docs(reviews): add critical architecture review of release/0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- **Multi-wiki support** (#119, #121): new `wiki` asset type with nine CLI verbs under `akm wiki …` (`create`, `list`, `show`, `remove`, `pages`, `search`, `stash`, `lint`, `ingest`). Each wiki lives at `<stashDir>/wikis/<name>/` with `schema.md`, `index.md`, `log.md`, `raw/`, and agent-authored pages. Wiki pages are first-class in stash-wide `akm search`. `akm index` regenerates each wiki's `index.md` as a side effect. See `docs/wikis.md` for the full guide. Design principle: **akm surfaces, the agent writes** — no LLM calls, no network access; akm owns only operations with invariants an agent can't reliably enforce (lifecycle, raw-slug uniqueness, structural lint, index regeneration, workflow discovery).
-- **Workflow asset type** (#118): new `workflow` type with `akm workflow create <name>` and `akm workflow next <ref>` for authoring and stepping through multi-step workflows stored in the stash
-- **Vault asset type** (#117): new `vault` type backed by `.env` files; `akm vault` subcommand with `list`, `show`, `load` (emits a `source` snippet for the current shell); values never appear in structured output
-- **`--trust` flag for installs**: `akm add <source> --trust` performs a one-off trusted install, bypassing the install audit for that source
-- **Writable git stash + `akm save`** (#114): `akm add … --writable` opts a remote git-backed stash into push-on-save; `akm save [name] [-m message]` commits (and pushes when writable + remote is set); default stash is auto-initialized as a git repo; git stash provider now uses `git clone` instead of HTTP tarball download
+- **Multi-wiki support** (#119, #121, #136, #139, #144): new `wiki` asset type with ten CLI verbs under `akm wiki …` (`create`, `register`, `list`, `show`, `remove`, `pages`, `search`, `stash`, `lint`, `ingest`). Each wiki lives at `<stashDir>/wikis/<name>/` with `schema.md`, `index.md`, `log.md`, `raw/`, and agent-authored pages. Wiki pages are first-class in stash-wide `akm search`. `akm index` regenerates each wiki's `index.md` as a side effect and is resilient to malformed workflow assets. Raw sources under `raw/` and the `schema.md` / `index.md` / `log.md` infrastructure files are intentionally excluded from the search index. See `docs/wikis.md` for the full guide. Design principle: **akm surfaces, the agent writes** — no LLM calls, no network access; akm owns only operations with invariants an agent can't reliably enforce (lifecycle, raw-slug uniqueness, structural lint, index regeneration, workflow discovery).
+- **External wiki registration** (#139, #144): `akm wiki register <name> <path-or-repo>` and `akm add --type wiki --name <name> <source>` register an existing directory or git/website repo as a first-class wiki without copying or mutating it; source and wiki search state are refreshed immediately and refs/state are normalized on subsequent indexing.
+- **Workflow asset type** (#118): new `workflow` type with `akm workflow` subcommands `template`, `create`, `start`, `next`, `complete`, `status`, `list`, and `resume` for authoring and stepping through multi-step workflows stored in the stash. Runs snapshot their step list at start so edits to the source workflow do not affect an in-flight run.
+- **Vault asset type** (#117): new `vault` type backed by `.env` files; `akm vault` subcommand with `list`, `show`, `create`, `set`, `unset`, and `load` (emits a `source` snippet for the current shell via a mode-0600 temp file); values never appear in structured output.
+- **`--trust` flag for installs**: `akm add <source> --trust` performs a one-off trusted install, bypassing the install audit for that source. Blocked install errors now include a `hint` pointing to `--trust` as a remediation option.
+- **Writable git stash + `akm save`** (#114): `akm add … --writable` opts a remote git-backed stash into push-on-save; `akm save [name] [-m message]` commits (and pushes when writable + remote is set); default stash is auto-initialized as a git repo; git stash provider now uses `git clone` instead of HTTP tarball download.
+- **`akm help migrate <version>`** (#132): prints the release notes and migration guidance for a given version (accepts `0.5.0`, `v0.5.0`, or `latest`). Pulls the matching section from `CHANGELOG.md` when available and supplements it with embedded migration notes for major releases.
+- **Broader `akm upgrade` coverage** (#132, #134): self-update now detects and upgrades npm, bun, pnpm, and standalone-binary installs (previously binary-only). Runtime assets covered by the upgrade flow were also expanded so newly shipped asset types stay current.
+
+### Fixed
+
+- **0.5.0 QA follow-ups** (#130): fixes across the new wiki, workflow, vault, and save/trust surfaces surfaced during release-candidate QA.
 
 ### Removed (breaking)
 
 - The unreleased single-wiki LLM POC: removes `akm lint` command, `akm import --llm` / `--dry-run` flags, `knowledge.pageKinds` config, and the `ingestKnowledgeSource` / `lintKnowledge` LLM prompts. Users of the POC should migrate to the new `akm wiki …` surface; raw content can be manually moved to `wikis/<name>/raw/`.
+
+### Documentation
+
+- **Technical docs refresh** (#138): stash and search architecture docs updated to match the current implementation.
+- **Wiki configuration guide** (#115): new docs page covering wiki configuration and ingest flow.
 
 ## [0.4.1] - 2026-04-21
 

--- a/docs/posts/release-0.5.0.md
+++ b/docs/posts/release-0.5.0.md
@@ -8,20 +8,23 @@ tags:
   - agents
   - cli
   - release
-published: false
+published: true
 date: '2026-04-22T00:00:00Z'
 id: 3539588
 ---
 
-akm 0.5.0 is out. This release adds four new asset types — wikis, workflows, and vaults are now first-class citizens — plus writable git stash support so your stash can sync back to a remote. There is one breaking change for anyone who was using the single-wiki LLM POC from 0.4.x.
+akm 0.5.0 is out. This release adds three new asset types — wikis, workflows, and vaults are now first-class citizens — plus writable git stash support so your stash can sync back to a remote. It also upgrades the self-update path to cover npm, bun, pnpm, and binary installs, and ships a new `akm help migrate` command for release-to-release guidance. There is one breaking change for anyone who was using the single-wiki LLM POC from 0.4.x.
 
 ## TL;DR
 
-- `akm wiki create|list|show|remove|pages|search|stash|lint|ingest` — multi-wiki support, no LLM required
-- `akm workflow create|start|next|complete|status|list|resume` — multi-step agent procedures in the stash
+- `akm wiki create|register|list|show|remove|pages|search|stash|lint|ingest` — multi-wiki support, no LLM required
+- `akm workflow template|create|start|next|complete|status|list|resume` — multi-step agent procedures in the stash
 - `akm vault list|show|create|set|unset|load` — `.env`-backed secrets that never appear in structured output
 - `akm add <source> --writable` + `akm save` — push your stash changes back to a remote git repo
 - `akm add <source> --trust` — bypass the install audit for a single install
+- `akm add --type wiki --name <name> <source>` / `akm wiki register` — register an existing directory or repo as a first-class wiki
+- `akm upgrade` now covers npm, bun, pnpm, and standalone-binary installs
+- `akm help migrate <version>` prints release notes and migration guidance for any shipped release
 - **Breaking**: the single-wiki LLM POC is removed; migrate to `akm wiki …`
 
 ---
@@ -57,7 +60,21 @@ Wiki pages are indexed by `akm index` and show up in stash-wide `akm search`, so
 
 The design principle is **akm surfaces, the agent writes**. akm makes no LLM calls. It owns only the operations where correctness is structural and deterministic: lifecycle management, raw-slug uniqueness, lint checks, index regeneration. The agent owns page content. This keeps the CLI fast and predictable — a wiki command always completes in milliseconds, and you can run it in any environment without model configuration.
 
-The 9-verb surface (`create`, `list`, `show`, `remove`, `pages`, `search`, `stash`, `lint`, `ingest`) covers the full lifecycle from creation to indexing to removal.
+The 10-verb surface (`create`, `register`, `list`, `show`, `remove`, `pages`, `search`, `stash`, `lint`, `ingest`) covers the full lifecycle from creation to indexing to removal.
+
+If you already have a wiki-shaped directory or repo you want to adopt without copying it, use `akm wiki register`:
+
+```sh
+# Register a local directory as a first-class wiki
+akm wiki register notes ~/team/notes
+
+# Or via the unified add command
+akm add --type wiki --name notes ~/team/notes
+
+# Registered external wikis show up in both `akm list` and `akm wiki list`
+```
+
+Registration refreshes source state and wiki search hits immediately, and the indexer normalizes external wiki refs on subsequent runs.
 
 ---
 
@@ -78,11 +95,14 @@ akm workflow next workflow:release-checklist
 # Check where you are
 akm workflow status workflow:release-checklist
 
-# Mark it done
-akm workflow complete workflow:release-checklist
+# Mark a specific step done (defaults to --state completed)
+akm workflow complete <run-id> --step validate --notes "Inputs verified"
 
-# List all workflows
+# List all workflow runs
 akm workflow list
+
+# Print a starter workflow you can adapt
+akm workflow template
 ```
 
 Workflows live in the stash like any other asset, so `akm search workflow:…` finds them and `akm show workflow:release-checklist` renders the current step. They can be shared in a kit and versioned in a git stash.
@@ -173,7 +193,31 @@ If you were using the wiki functionality introduced in 0.4.1, you will need to m
 3. Have your agent author wiki pages from the raw content
 4. Run `akm index` to regenerate the wiki index
 
-The new surface is more capable — 9 verbs vs the old 2, proper multi-wiki support, structural lint, and page search — and it does not require an LLM to be configured for any of the CLI operations.
+The new surface is more capable — 10 verbs vs the old 2, proper multi-wiki support, structural lint, and page search — and it does not require an LLM to be configured for any of the CLI operations.
+
+---
+
+## Broader `akm upgrade` coverage
+
+`akm upgrade` used to assume a standalone-binary install. 0.5.0 detects how akm was installed (npm, bun, pnpm, or binary) and runs the right self-update path for each. The same command now works whether you bootstrapped from the install script or from a package manager, and the internal runtime-asset coverage was expanded so newly shipped asset types stay up to date after an upgrade.
+
+```sh
+akm upgrade              # Works for binary, npm, bun, and pnpm installs
+akm upgrade --check      # Report whether an update is available, without installing
+```
+
+---
+
+## `akm help migrate <version>` — release notes at the CLI
+
+Release notes belong where you're actually working. `akm help migrate` prints the relevant CHANGELOG section plus embedded migration guidance for a given version, so you can review what changed (and what to do about it) without leaving the terminal.
+
+```sh
+akm help migrate 0.5.0     # or v0.5.0
+akm help migrate latest    # resolve against the most recent CHANGELOG entry
+```
+
+It favors the bundled CHANGELOG section when it exists and falls back to an embedded summary and a link to the full changelog otherwise.
 
 ---
 

--- a/docs/reviews/0.6.0-architecture-critique.md
+++ b/docs/reviews/0.6.0-architecture-critique.md
@@ -1,0 +1,135 @@
+# akm 0.6.0 — Critical architecture & clean-code review
+
+**Branch reviewed:** `release/0.6.0` at `563542e` (version `0.6.0-rc1`)
+**Review angle:** architecture, clean code, maintainability, extendability
+**Method:** independent read-through of `src/` and `docs/technical/architecture.md`, cross-checked against the rules in `CLAUDE.md`. This is a second opinion; it deliberately does **not** duplicate `docs/reviews/0.6.0-e2e-review.md` (CLI ergonomics, security, performance hotspots). Read this alongside that document.
+
+---
+
+## Verdict
+
+`release/0.6.0` is a competent pre-v1 codebase. The test suite outsizes production code, the error envelope is consistent, extraction work (`remember.ts`, `cli-hints.ts`, `curate.ts`, `workflow-*`) has visibly moved domain logic out of `cli.ts`, and schema migrations now pass a typed `UsageEventRow[]` instead of the old `__usageBackup` side channel (`src/db.ts:122`, `:139`). The recently merged incremental FTS rebuild (`src/db.ts:486–516`) closes the single biggest perf complaint from the previous review.
+
+What remains is consistent with a 0.x product still defining its seams: **the abstractions that `CLAUDE.md` and `docs/technical/architecture.md` promise are not the abstractions the code actually enforces.** The gap is small enough to close before v1, but every month it stays open makes it more expensive.
+
+The five themes below are ordered by leverage, not severity. None of them is a release blocker for 0.6.0.
+
+---
+
+## 1. The provider abstraction is aspirational, not load-bearing
+
+`src/stash-provider.ts:33,105` defines `LiveStashProvider` / `SyncableStashProvider` with a clean discriminator. In practice the orchestration layer does not use that discriminator — it hand-codes the list of "real" provider types at every junction:
+
+- `src/stash-search.ts:58–60` — additional providers are filtered by string equality: `p.type !== "filesystem" && p.type !== "git"`. Any new syncable provider (e.g. the orphaned `src/stash-providers/npm.ts` present in `src/stash-providers/index.ts` but never referenced elsewhere) must be added here by name or it will be silently double-searched.
+- `src/stash-show.ts:142` — same pattern: `p.type !== "filesystem" && p.canShow(ref)`.
+- `src/search-source.ts:13` — `GIT_STASH_TYPES = new Set(["git"])`, used at `:104` and `:238` to branch on provider type.
+- `src/search-source.ts:100–130` — `resolveEntryContentDir` is an `if (type === "filesystem") ... else if (git) ... else if (website) ... else undefined` ladder that imports provider internals (`parseGitRepoUrl`, `getCachePaths`, `getWebsiteCachePaths`). The orchestrator is reaching into provider cache-layout implementation details, which is exactly what the provider abstraction exists to prevent.
+
+The Liskov side is also weak. `git` and `website` declare themselves `SyncableStashProvider` but do not honor the `search()` / `show()` contract — they return empty hits and throw (`src/stash-providers/git.ts:62–69`, `src/stash-providers/website.ts:69–80`). Their real "operation" is `sync()` into a cache dir that the indexer then walks through the filesystem path. Functionally correct, but the `search` / `show` methods are dead weight that also misleads anyone reading the interface.
+
+**Suggested cut.** Lift content-dir resolution into the provider interface itself (`getIndexableRoots(): string[] | undefined`) so `search-source.ts:100–130` collapses to a single polymorphic call. At the same time split `SyncableStashProvider` between providers that *serve* queries (`openviking`) and providers that *materialize* content on disk (`git`, `website`, `filesystem`). Two small interfaces are easier to reason about than one large one with two flavors of compliance.
+
+## 2. "One scoring pipeline" is half-true; the merge assumes comparability that the scores do not have
+
+`CLAUDE.md` and `docs/technical/architecture.md:74–98` both assert one scoring pipeline that merges local and remote hits fairly. In practice there are three incompatible score sources that meet in `mergeStashHits` and are sorted by a shared numeric field:
+
+- **Local FTS5 + boosts** — BM25 normalized into a range that varies per query (`src/db-search.ts:256`). Weight constants (0.7 FTS / 0.3 vec; 0.5 utility) are hard-coded in `db-search.ts` with no config surface.
+- **OpenViking** — normalized by dividing by `maxScore` and scaling to 1000 (`src/stash-providers/openviking.ts:197–220`). This is per-response normalization; two OpenViking queries return scores on the same axis but they are *not* on the same axis as local FTS5 scores.
+- **Registries** — raw provider scores passed through unchanged (`src/registry-search.ts:84`).
+
+The three are then merged by `score` in `stash-search.ts:99,255` on the assumption that higher is better across sources. That assumption is never stated and never validated; if OpenViking starts returning 0–1 floats instead of 0–1000 integers, local hits silently dominate every query and nothing fails.
+
+**Suggested cut.** Pick a canonical score range (0–1 is the usual one), force every `StashSearchHit` through a normalization step before it enters `mergeStashHits`, and write the contract on the `LiveStashProvider` interface so providers cannot forget it. If different sources cannot be made comparable, stop merging and render them as separate sections — an honest UX is better than a plausible one.
+
+## 3. Ref handling has two dialects and user-facing refs narrowly escape the URI layer
+
+`CLAUDE.md` states: "Asset refs are `type:name` (e.g., `skill:deploy`). Nothing else" and "MUST NOT use URI schemes in user-facing refs."
+
+The user-facing surface is in fact clean — `stash-ref.ts:48–78` only emits `[origin//]type:name`. But the OpenViking provider maintains an internal URI dialect (`viking://skills/deploy`), converts on every call (`src/stash-providers/openviking.ts:94,276–283`), and accepts either form in `show()` so it is impossible to tell from the type signature which the caller is supposed to pass. Two parallel type-name maps (`OV_TYPE_MAP` at `:38–52` and `AKM_TO_OV_DIR` at `:286–293`) must stay synchronized by hand; nothing enforces that.
+
+Origin scoping is the weaker half. `parseAssetRef` will accept any string as origin, including things like `npm:@scope/pkg` that look like install refs (`stash-ref.ts:77`). `stash-show.ts:110–111` then feeds that origin into `resolveSourcesForOrigin`, which does source-list lookups, but never validates that the user's origin actually corresponds to an installed source. If no source matches, the result is an empty hit list and a message that is easy to misread as "asset does not exist."
+
+**Suggested cut.** Make OpenViking's `show()` take the canonical `type:name` only and delete the URI-accepting branch at `:91–94`. Derive `AKM_TO_OV_DIR` from `OV_TYPE_MAP` at module load. Have `parseAssetRef` reject origins that do not match either a known stash name or a registered install-ref grammar — the earlier an invalid origin fails, the less surface there is for subtle "no results" bugs.
+
+## 4. The output pipeline is advertised as a single gate; most commands bypass it
+
+`src/cli.ts:81–103` routes every command through `shapeForCommand` (`src/output-shapes.ts`). `shapeForCommand` itself handles exactly three commands: `search`, `registry-search`, `show` (`output-shapes.ts:13–24`). The remaining 40-plus `output(...)` call sites (counted by `grep -oE 'output\("[^"]+"' src/cli.ts | sort -u`) hit the `default: return result` branch unshaped.
+
+The consequence is that `formatPlain` in `src/output-text.ts` carries command-specific field knowledge for every unshaped command, and every shape change needs to be made in two places (the function that builds the result, and the formatter that consumes it). There is no enforcement that a new command register either a shaper or a formatter — quietly adding neither will produce `JSON.stringify(result, null, 2)` when the user asked for `--format=text`, as the fallback at `cli.ts:99` shows.
+
+**Suggested cut.** Either (a) make `shapeForCommand` exhaustive and let `formatPlain` take only the shaped subset, or (b) turn `output()` into a registry where each command contributes its own `{ shape, text }` pair at module load. (a) is less code, (b) scales better if command ownership ever splits across files.
+
+## 5. The CLI/domain boundary is still permeable; `buildHint` is the most visible symptom
+
+`src/cli.ts` is down to ~2,230 lines from wherever it started, and the extractions listed in the intro are real. But several boundary violations remain:
+
+- **Direct provider import.** `cli.ts:30` imports `saveGitStash` from `./stash-providers/git` for the `save` subcommand. This is the only place in the codebase where upper-layer code reaches into `stash-providers/*` for anything other than a shared utility. Every other command hops through an orchestration module. Promote `saveGitStash` into a public surface (e.g. `stash-save.ts`) so the dependency graph stops having a direct `cli → stash-providers/*` edge.
+- **`buildHint` duplicates the job of typed errors.** `cli.ts:2104–2121` is a 17-line `if (message.includes(...))` chain that re-derives hint strings from the human-readable error message. The code already has `UsageError`, `ConfigError`, and `NotFoundError` (`src/errors.ts`) with machine-readable `.code` values — and `cli.ts:2066–2098` already extracts `.code` from them. Either attach hints to the error class (`UsageError.hint()`) or move hint resolution into a lookup on `code`. The current regex chain means every new error message has to be discovered by failing in production before the hint appears, and renaming a message string breaks the hint silently.
+- **Large "command-handler" bodies still contain logic.** `addCommand`, `workflow resume`, `wiki ingest` are command definitions that each hold enough inline control flow that unit-testing the non-CLI parts requires spawning the binary. `remember.ts` is the template for how these should look; apply it consistently.
+
+---
+
+## Secondary observations (smaller, still worth fixing before v1)
+
+### `db.ts` treats the DB_VERSION upgrade as "drop everything, let indexer refill"
+
+`src/db.ts:270–293` is the only migration path and it wipes `entries`, `entries_fts`, `embeddings`, `entries_vec`, `utility_scores`, `index_meta`. `usage_events` is preserved; nothing else is. For a tool whose index rebuild touches the filesystem, calls an LLM, and talks to an embedding endpoint, "run `akm index` again" is a much heavier cost than the message at `:291` implies. There is no migration DSL and no per-version branch — future schema evolution has the same wipe cost as today.
+
+This is fine for a pre-v1 tool whose users treat the index as ephemeral cache, but it should be documented explicitly (e.g. in `architecture.md`) so users know the index can be rebuilt at any time and there is no expectation of stability across versions. After v1, non-destructive migrations become table stakes.
+
+### Silent error swallowing is pervasive and hides correctness bugs
+
+Every one of these returns empty/zero and continues:
+
+- Corrupt `entry_json` during FTS rebuild (`db.ts:544–552` aggregated warning — good) and every other entry-read path (unaggregated).
+- `cosineSimilarity` dimension mismatch returns 0, not `null`/throw (`src/embedders/types.ts:37–54`) — mixes "dissimilar" with "cannot compare."
+- `upsertEmbedding` writes BLOB and `entries_vec` in two steps; if the second fails, state is inconsistent (`db.ts:557–572`).
+- `enhanceDirsWithLlm` does aggregate a single warning if all calls fail (`indexer.ts:539–549`) — the correct pattern — but the per-embedding failures at `indexer.ts:598–620` do not.
+- `deleteRelatedRows` has six `catch { /* ignore */ }` blocks around table-delete statements (`db.ts:423–468`) for cases where the table "may not exist yet." The cost of this is that a real SQL error during delete is indistinguishable from a normal cold-start.
+
+The pattern suggests a principle was applied uniformly — "indexing must never hard-fail" — but its cost is that correctness regressions are detected only by test suite, never by user reports.
+
+**Suggested cut.** Distinguish "expected cold-start conditions" (table does not exist yet) from actual errors by checking the error class/message once at the boundary; re-throw anything else. If reporting is a concern, add a `warnings` channel to the DB layer so the CLI can surface a rollup.
+
+### Modules that are noticeably too large for their job
+
+- `src/cli.ts` (2,231 lines) — the existing review already flagged this; the residual work is item 5 above.
+- `src/wiki.ts` (1,114 lines) — bundles wiki CRUD, index building, linting, ingestion, and lookup. Splitting to `wiki-crud.ts`, `wiki-index.ts`, `wiki-lint.ts`, `wiki-ingest.ts` mirrors the pattern used for workflows and stops the file from being the only place to read wiki behavior.
+- `src/setup.ts` (1,106 lines) — already has a step-registration pattern. The steps should live in their own files and the wizard should compose them.
+- `src/config.ts` (1,176 lines) — pure types + defaults separated from loading/merging/env-injection would bring this under 500 lines; the `StashConfigEntry` deprecation shim (`:119–142`) can be dropped after one release cycle.
+- `src/renderers.ts` (724 lines) — per-asset logic justifies a `renderers/<type>.ts` split.
+
+### Orphaned / unreferenced modules
+
+`src/stash-providers/npm.ts` (195 lines) is imported by `src/stash-providers/index.ts:1` so it can self-register, but `stash-search.ts:58–60` and `stash-show.ts:142` filter by hard-coded names and the search-source resolver has no branch for `npm` (`search-source.ts:100–130`). Either wire it into the orchestrator or delete it — dead code that looks live is worse than either alternative.
+
+### Tests that are not there
+
+Still missing dedicated unit coverage for `src/renderers.ts`, `src/search-source.ts` (critical path), `src/workflow-runs.ts`, `src/matchers.ts`. The test-to-source ratio is >1.0, but the weight is on integration paths (`spawnSync` against the binary), which is a strong regression fence and a weak internal-boundary signal. The fastest fix is to exercise `matchers.ts` directly — its specificity cascade (`matchers.ts:226`) has subtle tiebreaker rules that integration tests observe only indirectly.
+
+---
+
+## What I would fix before v1, in priority order
+
+1. **Collapse the provider-type `if`-ladders** at `stash-search.ts:58–60`, `stash-show.ts:142`, `search-source.ts:100–130` into polymorphic calls on the provider interface. Deletes code, makes `npm`-style providers pluggable, stops "new provider" from being a cross-cutting refactor.
+2. **Normalize scores at the provider boundary, not the merge.** Replace the current `mergeStashHits` sort by a single normalized score range written into `LiveStashProvider`.
+3. **Make `shapeForCommand` exhaustive** (item 4). The win isn't shape correctness — it's that formatPlain stops being a second source of truth.
+4. **Move `buildHint` onto the error class or an error-code lookup.** Delete the regex chain at `cli.ts:2104–2121`.
+5. **Document the "wipe to migrate" schema strategy**, then plan a non-destructive migration DSL for the v1 cycle. This is the only item here that is mostly a doc task today but becomes a much bigger task the longer it waits.
+
+None of these change user-visible behavior. All of them compound: every month they stay open, the surface that depends on the current shape grows.
+
+---
+
+## What I explicitly want to call out as *well done*
+
+- `src/create-provider-registry.ts` (20 lines of generic, two consumers) is the kind of small, correct abstraction most projects never write.
+- `src/file-context.ts` lazy caching is the right shape for a walker that may or may not need file content.
+- `src/asset-spec.ts` registration API — adding a new asset type is one file change, not N.
+- `src/errors.ts` + consistent exit codes (`EXIT_USAGE=2`, `EXIT_CONFIG=78`, `EXIT_GENERAL=1`) give scripts a real contract.
+- Schema upgrade now threads `UsageEventRow[]` as an explicit parameter (`db.ts:122,139`) instead of pinning it to the `Database` as an untyped property. Small cleanup; large improvement in "how would I add the next migration."
+- `src/stash-ref.ts:82–92` strict validation (no null bytes, no traversal, no Windows drives) is the model for input sanitization in the rest of the code.
+
+---
+
+*Review authored on branch `claude/review-0.6.0-architecture-Hh1kz`. Reading order: this document, then `docs/reviews/0.6.0-e2e-review.md` for the ergonomics/security/perf companion.*


### PR DESCRIPTION
Independent second-opinion review of the 0.6.0 branch focused on
architecture, clean code, maintainability, and extendability. Intended
to be read alongside the existing docs/reviews/0.6.0-e2e-review.md.

Main themes:
- Provider abstraction is aspirational; orchestrators still hand-code
  provider-type ladders in stash-search, stash-show, and search-source.
- "One scoring pipeline" merges OpenViking, registry, and FTS5 scores
  that are not actually on the same axis.
- Ref handling has two dialects (OpenViking URIs vs canonical
  type:name); origin validation is weak.
- Output pipeline advertises a single gate but only three of forty
  commands route through shapeForCommand.
- CLI/domain boundary leaks: direct stash-providers/git import,
  regex-based buildHint duplicates typed errors.
- DB version upgrade wipes everything and rebuilds.

https://claude.ai/code/session_018vTM9THitaPynisHoVQNs9