### PR TITLE
feat(agent): config, profiles, spawn wrapper, setup detection (#221)

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,11 +1,14 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { type AgentConfig, parseAgentConfig } from "../integrations/agent/config";
 import type { InstalledStashEntry, KitSource } from "../registry/types";
 import { filterNonEmptyStrings } from "./common";
 import { ConfigError } from "./errors";
 import { getConfigDir as _getConfigDir, getConfigPath as _getConfigPath } from "./paths";
 import { warn } from "./warn";
+
+export type { AgentConfig } from "../integrations/agent/config";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -219,6 +222,14 @@ export interface AkmConfig {
    * source-array order" fallback.
    */
   defaultWriteTarget?: string;
+  /**
+   * Optional agent CLI integration block (v1 spec §12). Configures
+   * external agent CLIs that akm can shell out to. Missing block disables
+   * agent commands; unknown nested keys are warn-and-ignored. Built-in
+   * profiles ship for opencode, claude, codex, gemini, aider — users can
+   * override or add profiles via `agent.profiles[<name>]`.
+   */
+  agent?: AgentConfig;
   /**
    * Search-specific tuning parameters.
    */
@@ -490,6 +501,11 @@ function pickKnownKeys(raw: Record<string, unknown>): Partial<AkmConfig> {
 
   if (typeof raw.defaultWriteTarget === "string" && raw.defaultWriteTarget.trim()) {
     config.defaultWriteTarget = raw.defaultWriteTarget.trim();
+  }
+
+  if ("agent" in raw) {
+    const agent = parseAgentConfig(raw.agent);
+    if (agent) config.agent = agent;
   }
 
   if (typeof raw.search === "object" && raw.search !== null && !Array.isArray(raw.search)) {
@@ -1141,6 +1157,21 @@ function parseRegistryConfigEntry(value: unknown): RegistryConfigEntry | undefin
   return entry;
 }
 
+function mergeAgentConfig(base: AgentConfig, override: AgentConfig): AgentConfig {
+  const merged: AgentConfig = { ...base, ...override };
+  const baseProfiles = base.profiles;
+  const overrideProfiles = override.profiles;
+  if (baseProfiles && overrideProfiles) {
+    const profiles: NonNullable<AgentConfig["profiles"]> = { ...baseProfiles };
+    for (const [name, entry] of Object.entries(overrideProfiles)) {
+      const existing = baseProfiles[name];
+      profiles[name] = existing ? { ...existing, ...entry } : entry;
+    }
+    merged.profiles = profiles;
+  }
+  return merged;
+}
+
 function mergeSecurityConfig(base?: SecurityConfig, override?: SecurityConfig): SecurityConfig | undefined {
   if (!base && !override) return undefined;
   const installAudit = mergeInstallAuditConfig(base?.installAudit, override?.installAudit);
@@ -1187,6 +1218,9 @@ function mergeLoadedConfig(base: AkmConfig, override?: Partial<AkmConfig>): AkmC
   }
   if (base.security && override.security) {
     merged.security = mergeSecurityConfig(base.security, override.security);
+  }
+  if (base.agent && override.agent) {
+    merged.agent = mergeAgentConfig(base.agent, override.agent);
   }
   // The new `stashInheritance` field wins; fall back to the legacy
   // `disableGlobalStashes` boolean so old config files behave identically.

--- a/src/integrations/agent/config.ts
+++ b/src/integrations/agent/config.ts
@@ -1,0 +1,347 @@
+/**
+ * Parser + resolver for the optional `agent` config block (v1 spec §12).
+ *
+ * The on-disk shape is:
+ *
+ * ```jsonc
+ * {
+ *   "agent": {
+ *     "default": "opencode",
+ *     "timeoutMs": 60000,
+ *     "profiles": {
+ *       "opencode": { "bin": "opencode", "args": ["--non-interactive"], ... }
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * Unknown keys at any level under `agent` are warn-and-ignored — this is the
+ * v1 §9.2 contract. Missing `agent` block disables agent commands; callers
+ * should reach for {@link requireAgentConfig} to surface a stable
+ * `ConfigError` with a hint pointing at setup.
+ *
+ * No LLM SDK is imported here. The runtime path is shell-out only (see
+ * `./spawn.ts`).
+ */
+import { ConfigError } from "../../core/errors";
+import { warn } from "../../core/warn";
+import {
+  type AgentParseMode,
+  type AgentProfile,
+  type AgentStdioMode,
+  BUILTIN_AGENT_PROFILE_NAMES,
+  getBuiltinAgentProfile,
+  listBuiltinAgentProfiles,
+} from "./profiles";
+
+/** Keys recognised at the top level of an `agent` config block. */
+const KNOWN_AGENT_KEYS = new Set(["default", "timeoutMs", "profiles"]);
+
+/** Keys recognised on a profile entry. */
+const KNOWN_PROFILE_KEYS = new Set(["bin", "args", "stdio", "env", "envPassthrough", "timeoutMs", "parseOutput"]);
+
+/**
+ * Default hard timeout for an agent CLI. Spec §12.2 calls for a hard
+ * timeout; 60s matches the example value in `docs/configuration.md`.
+ */
+export const DEFAULT_AGENT_TIMEOUT_MS = 60_000;
+
+/**
+ * Persisted form of `agent.profiles[<name>]`. Every field is optional so
+ * users can override one piece of a built-in without re-stating the rest.
+ */
+export interface AgentProfileConfig {
+  bin?: string;
+  args?: string[];
+  stdio?: AgentStdioMode;
+  env?: Record<string, string>;
+  envPassthrough?: string[];
+  timeoutMs?: number;
+  parseOutput?: AgentParseMode;
+}
+
+/** Persisted form of the `agent` block. */
+export interface AgentConfig {
+  default?: string;
+  timeoutMs?: number;
+  profiles?: Record<string, AgentProfileConfig>;
+}
+
+/**
+ * Parse a raw value (typically `rawConfig.agent` from `JSON.parse`) into a
+ * normalised {@link AgentConfig}. Returns `undefined` when the value is not
+ * an object (i.e. the block is absent or malformed at the root level — for
+ * malformed roots we emit a warning).
+ *
+ * Unknown keys (top-level and per-profile) are warn-and-ignore. Type errors
+ * on individual fields are warn-and-ignore so a bad `timeoutMs` does not
+ * break the rest of the block.
+ */
+export function parseAgentConfig(value: unknown): AgentConfig | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    warn('[akm] Ignoring "agent" config: expected an object.');
+    return undefined;
+  }
+
+  const raw = value as Record<string, unknown>;
+  const out: AgentConfig = {};
+
+  for (const key of Object.keys(raw)) {
+    if (!KNOWN_AGENT_KEYS.has(key)) {
+      warn(`[akm] Ignoring unknown agent config key: "${key}"`);
+    }
+  }
+
+  if ("default" in raw) {
+    if (typeof raw.default === "string" && raw.default.trim()) {
+      out.default = raw.default.trim();
+    } else if (raw.default !== undefined) {
+      warn("[akm] Ignoring agent.default: expected a non-empty string.");
+    }
+  }
+
+  if ("timeoutMs" in raw) {
+    if (
+      typeof raw.timeoutMs === "number" &&
+      Number.isFinite(raw.timeoutMs) &&
+      Number.isInteger(raw.timeoutMs) &&
+      raw.timeoutMs > 0
+    ) {
+      out.timeoutMs = raw.timeoutMs;
+    } else {
+      warn("[akm] Ignoring agent.timeoutMs: expected a positive integer (milliseconds).");
+    }
+  }
+
+  if ("profiles" in raw) {
+    const profiles = parseAgentProfilesMap(raw.profiles);
+    if (profiles) out.profiles = profiles;
+  }
+
+  return out;
+}
+
+function parseAgentProfilesMap(value: unknown): Record<string, AgentProfileConfig> | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    warn("[akm] Ignoring agent.profiles: expected an object.");
+    return undefined;
+  }
+  const out: Record<string, AgentProfileConfig> = {};
+  for (const [name, raw] of Object.entries(value as Record<string, unknown>)) {
+    const parsed = parseAgentProfileConfig(name, raw);
+    if (parsed) out[name] = parsed;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function parseAgentProfileConfig(name: string, value: unknown): AgentProfileConfig | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    warn(`[akm] Ignoring agent.profiles."${name}": expected an object.`);
+    return undefined;
+  }
+  const raw = value as Record<string, unknown>;
+  const out: AgentProfileConfig = {};
+
+  for (const key of Object.keys(raw)) {
+    if (!KNOWN_PROFILE_KEYS.has(key)) {
+      warn(`[akm] Ignoring unknown agent.profiles."${name}" key: "${key}"`);
+    }
+  }
+
+  if (typeof raw.bin === "string" && raw.bin.trim()) {
+    out.bin = raw.bin.trim();
+  } else if (raw.bin !== undefined) {
+    warn(`[akm] Ignoring agent.profiles."${name}".bin: expected a non-empty string.`);
+  }
+
+  if (Array.isArray(raw.args)) {
+    const args = raw.args.filter((a): a is string => typeof a === "string");
+    if (args.length === raw.args.length) {
+      out.args = args;
+    } else {
+      warn(`[akm] Ignoring non-string entries in agent.profiles."${name}".args.`);
+      if (args.length > 0) out.args = args;
+    }
+  } else if (raw.args !== undefined) {
+    warn(`[akm] Ignoring agent.profiles."${name}".args: expected an array of strings.`);
+  }
+
+  if (raw.stdio === "captured" || raw.stdio === "interactive") {
+    out.stdio = raw.stdio;
+  } else if (raw.stdio !== undefined) {
+    warn(`[akm] Ignoring agent.profiles."${name}".stdio: expected "captured" or "interactive".`);
+  }
+
+  if (typeof raw.env === "object" && raw.env !== null && !Array.isArray(raw.env)) {
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(raw.env)) {
+      if (typeof v === "string") env[k] = v;
+    }
+    if (Object.keys(env).length > 0) out.env = env;
+  } else if (raw.env !== undefined) {
+    warn(`[akm] Ignoring agent.profiles."${name}".env: expected a string-valued object.`);
+  }
+
+  if (Array.isArray(raw.envPassthrough)) {
+    const list = raw.envPassthrough.filter((s): s is string => typeof s === "string" && s.length > 0);
+    if (list.length > 0) out.envPassthrough = list;
+  } else if (raw.envPassthrough !== undefined) {
+    warn(`[akm] Ignoring agent.profiles."${name}".envPassthrough: expected an array of strings.`);
+  }
+
+  if (
+    typeof raw.timeoutMs === "number" &&
+    Number.isFinite(raw.timeoutMs) &&
+    Number.isInteger(raw.timeoutMs) &&
+    raw.timeoutMs > 0
+  ) {
+    out.timeoutMs = raw.timeoutMs;
+  } else if (raw.timeoutMs !== undefined) {
+    warn(`[akm] Ignoring agent.profiles."${name}".timeoutMs: expected a positive integer.`);
+  }
+
+  if (raw.parseOutput === "text" || raw.parseOutput === "json") {
+    out.parseOutput = raw.parseOutput;
+  } else if (raw.parseOutput !== undefined) {
+    warn(`[akm] Ignoring agent.profiles."${name}".parseOutput: expected "text" or "json".`);
+  }
+
+  return out;
+}
+
+/**
+ * Merge a user override (from `agent.profiles[<name>]`) on top of the
+ * built-in profile (if any) and return the resolved profile. If `name`
+ * matches no built-in and the user override has no `bin`, returns
+ * `undefined` — the profile is unusable.
+ *
+ * Used at the spawn site, never at config-load time. Keeping merge logic
+ * here means the parser stays a pure shape-checker.
+ */
+export function resolveAgentProfile(name: string, overrides?: AgentProfileConfig): AgentProfile | undefined {
+  const builtin = getBuiltinAgentProfile(name);
+  if (!builtin && !overrides?.bin) return undefined;
+
+  const base: AgentProfile =
+    builtin ??
+    ({
+      name,
+      bin: overrides?.bin ?? name,
+      args: [],
+      stdio: "captured",
+      envPassthrough: [],
+      parseOutput: "text",
+    } as AgentProfile);
+
+  if (!overrides) return base;
+
+  const merged: AgentProfile = {
+    name,
+    bin: overrides.bin ?? base.bin,
+    args: overrides.args ?? base.args,
+    stdio: overrides.stdio ?? base.stdio,
+    env: overrides.env ?? base.env,
+    envPassthrough: overrides.envPassthrough
+      ? mergePassthrough(base.envPassthrough, overrides.envPassthrough)
+      : base.envPassthrough,
+    timeoutMs: overrides.timeoutMs ?? base.timeoutMs,
+    parseOutput: overrides.parseOutput ?? base.parseOutput,
+  };
+  return merged;
+}
+
+function mergePassthrough(base: readonly string[], extra: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const k of [...base, ...extra]) {
+    if (!seen.has(k)) {
+      seen.add(k);
+      out.push(k);
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve the runnable profile for `name`, or `undefined` if none is
+ * available (no built-in and no user override with a `bin`).
+ */
+export function resolveProfileFromConfig(name: string, agent?: AgentConfig): AgentProfile | undefined {
+  return resolveAgentProfile(name, agent?.profiles?.[name]);
+}
+
+/**
+ * Return the names of every profile available in `agent` config (built-in
+ * names plus any user-defined ones). Sorted, deduplicated.
+ */
+export function listAgentProfileNames(agent?: AgentConfig): string[] {
+  const seen = new Set<string>(BUILTIN_AGENT_PROFILE_NAMES);
+  for (const name of Object.keys(agent?.profiles ?? {})) seen.add(name);
+  return [...seen].sort();
+}
+
+/**
+ * Resolve the default profile name. Order: explicit `name` arg → config
+ * `agent.default` → undefined.
+ */
+export function resolveDefaultProfileName(agent: AgentConfig | undefined, requested?: string): string | undefined {
+  if (requested?.trim()) return requested.trim();
+  if (agent?.default?.trim()) return agent.default.trim();
+  return undefined;
+}
+
+/**
+ * Throw a {@link ConfigError} with a stable hint when the caller needs
+ * `agent` config but it is missing or unresolvable.
+ *
+ * Covers two cases per acceptance criteria:
+ *
+ * 1. The `agent` block is absent — agent commands are disabled.
+ * 2. The block exists but no usable profile (no `default`, no requested
+ *    name, or the named profile cannot be resolved).
+ *
+ * Use as `const profile = requireAgentProfile(config.agent, requestedName)`.
+ */
+export function requireAgentProfile(agent: AgentConfig | undefined, requested?: string): AgentProfile {
+  if (!agent) {
+    throw new ConfigError(
+      "agent commands are disabled: no `agent` block in config.json.",
+      "INVALID_CONFIG_FILE",
+      'Run `akm setup` to detect and configure an agent CLI, or add an `agent` block manually (see docs/configuration.md "agent.*").',
+    );
+  }
+
+  const name = resolveDefaultProfileName(agent, requested);
+  if (!name) {
+    throw new ConfigError(
+      "agent commands require a profile: pass --profile or set `agent.default` in config.json.",
+      "INVALID_CONFIG_FILE",
+      `Available profiles: ${listAgentProfileNames(agent).join(", ")}.`,
+    );
+  }
+
+  const profile = resolveProfileFromConfig(name, agent);
+  if (!profile) {
+    throw new ConfigError(
+      `agent profile "${name}" is not built-in and has no \`bin\` override.`,
+      "INVALID_CONFIG_FILE",
+      `Define agent.profiles."${name}".bin in config.json, or pick one of: ${listAgentProfileNames(agent).join(", ")}.`,
+    );
+  }
+  return profile;
+}
+
+/**
+ * Convenience: list every fully-resolved profile (built-ins merged with
+ * any user overrides). Used by setup detection to enumerate candidates.
+ */
+export function listResolvedAgentProfiles(agent?: AgentConfig): AgentProfile[] {
+  const resolved: AgentProfile[] = [];
+  const builtins = listBuiltinAgentProfiles();
+  for (const name of listAgentProfileNames(agent)) {
+    const profile = resolveProfileFromConfig(name, agent) ?? builtins[name];
+    if (profile) resolved.push(profile);
+  }
+  return resolved;
+}

--- a/src/integrations/agent/detect.ts
+++ b/src/integrations/agent/detect.ts
@@ -1,0 +1,109 @@
+/**
+ * Setup-time agent CLI detection (v1 spec §12.3).
+ *
+ * Probes every known/configured agent profile by checking `which <bin>` on
+ * PATH. We do **not** call `<bin> --version` — that would execute the
+ * binary at setup time, which is unnecessarily side-effectful for
+ * detection. The presence of the binary on PATH is sufficient signal; the
+ * spawn wrapper handles failures at run-time.
+ *
+ * Tests inject a fake `whichFn` so detection branches can be exercised
+ * without poking at the real PATH.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import type { AgentConfig } from "./config";
+import { listResolvedAgentProfiles } from "./config";
+import type { AgentProfile } from "./profiles";
+
+/** Function signature for a binary lookup probe. */
+export type WhichFn = (bin: string) => string | undefined;
+
+/**
+ * Default PATH lookup. Walks `process.env.PATH` and returns the first
+ * existing executable file. Returns `undefined` when the bin is not on
+ * PATH or the env is empty.
+ *
+ * `process.env.PATH` is split on the platform-correct delimiter; on
+ * Windows the binary may have an executable extension, but for v1 we
+ * keep this Unix-flavoured (Bun's primary target) and look for an exact
+ * match.
+ */
+export function defaultWhich(bin: string, envSource: NodeJS.ProcessEnv = process.env): string | undefined {
+  if (!bin || bin.includes("/") || bin.includes("\\")) {
+    // Absolute / relative paths: caller already specified location.
+    try {
+      return fs.statSync(bin).isFile() ? bin : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  const pathVar = envSource.PATH ?? envSource.Path ?? envSource.path ?? "";
+  if (!pathVar) return undefined;
+  const sep = pathVar.includes(";") && !pathVar.includes(":") ? ";" : path.delimiter;
+  for (const dir of pathVar.split(sep)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, bin);
+    try {
+      const st = fs.statSync(candidate);
+      if (st.isFile()) return candidate;
+    } catch {
+      /* keep walking */
+    }
+  }
+  return undefined;
+}
+
+/** Result of probing one profile during setup. */
+export interface AgentDetectionResult {
+  /** Profile name. */
+  name: string;
+  /** Bin checked on PATH. */
+  bin: string;
+  /** Resolved path on PATH, or `undefined` when not found. */
+  resolvedPath?: string;
+  /** True iff the binary was found. */
+  available: boolean;
+}
+
+/**
+ * Probe every resolvable agent profile (built-ins plus user overrides)
+ * for an installed CLI.
+ *
+ * @param agent  Optional `agent` config block. When omitted we probe the
+ *               built-ins.
+ * @param whichFn  Binary lookup. Tests should inject a stub.
+ */
+export function detectAgentCliProfiles(agent?: AgentConfig, whichFn: WhichFn = defaultWhich): AgentDetectionResult[] {
+  const profiles = listResolvedAgentProfiles(agent);
+  return profiles.map((profile) => probeProfile(profile, whichFn));
+}
+
+function probeProfile(profile: AgentProfile, whichFn: WhichFn): AgentDetectionResult {
+  const resolved = whichFn(profile.bin);
+  return {
+    name: profile.name,
+    bin: profile.bin,
+    available: Boolean(resolved),
+    ...(resolved ? { resolvedPath: resolved } : {}),
+  };
+}
+
+/**
+ * Pick the default profile to persist after a setup-time detection run.
+ *
+ * Strategy:
+ *   1. If the user already set `agent.default` and that profile is
+ *      available, keep it (round-trip stability).
+ *   2. Otherwise, pick the first available result in detection order.
+ *   3. If nothing is available, return `undefined` and the caller skips
+ *      writing `agent.default`.
+ */
+export function pickDefaultAgentProfile(results: AgentDetectionResult[], existingDefault?: string): string | undefined {
+  if (existingDefault) {
+    const match = results.find((r) => r.name === existingDefault && r.available);
+    if (match) return match.name;
+  }
+  const first = results.find((r) => r.available);
+  return first?.name;
+}

--- a/src/integrations/agent/index.ts
+++ b/src/integrations/agent/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Internal entry point for the `agent` integration. CLI-only project — no
+ * public exports map. Other akm modules import from this barrel for the
+ * sake of grouping imports.
+ *
+ * Surface:
+ *   • Types: AgentProfile, AgentConfig, AgentRunResult, AgentFailureReason.
+ *   • Profiles: getBuiltinAgentProfile, listBuiltinAgentProfiles, BUILTIN_AGENT_PROFILE_NAMES.
+ *   • Config: parseAgentConfig, resolveProfileFromConfig, requireAgentProfile, listResolvedAgentProfiles, listAgentProfileNames.
+ *   • Spawn: runAgent.
+ *   • Detection: detectAgentCliProfiles, pickDefaultAgentProfile, defaultWhich.
+ */
+
+export type {
+  AgentConfig,
+  AgentProfileConfig,
+} from "./config";
+export {
+  DEFAULT_AGENT_TIMEOUT_MS,
+  listAgentProfileNames,
+  listResolvedAgentProfiles,
+  parseAgentConfig,
+  requireAgentProfile,
+  resolveAgentProfile,
+  resolveDefaultProfileName,
+  resolveProfileFromConfig,
+} from "./config";
+export type {
+  AgentDetectionResult,
+  WhichFn,
+} from "./detect";
+export { defaultWhich, detectAgentCliProfiles, pickDefaultAgentProfile } from "./detect";
+export type {
+  AgentParseMode,
+  AgentProfile,
+  AgentStdioMode,
+} from "./profiles";
+export {
+  BUILTIN_AGENT_PROFILE_NAMES,
+  getBuiltinAgentProfile,
+  listBuiltinAgentProfiles,
+} from "./profiles";
+export type {
+  AgentFailureReason,
+  AgentRunResult,
+  RunAgentOptions,
+  SpawnedSubprocess,
+  SpawnFn,
+} from "./spawn";
+export { runAgent } from "./spawn";

--- a/src/integrations/agent/profiles.ts
+++ b/src/integrations/agent/profiles.ts
@@ -1,0 +1,112 @@
+/**
+ * Built-in profile registry for external agent CLIs (v1 spec §12.1).
+ *
+ * A `AgentProfile` is the minimum metadata required to shell-out to a
+ * coding-agent CLI. The profile is intentionally tiny — there is no
+ * vendor SDK in scope. Users can override or extend any field via
+ * `agent.profiles[<name>]` in `config.json`.
+ *
+ * The wrapper that uses these profiles is in `./spawn.ts`. The config
+ * parser that merges user overrides on top of the built-ins is in
+ * `./config.ts`.
+ */
+export type AgentStdioMode = "captured" | "interactive";
+export type AgentParseMode = "text" | "json";
+
+/**
+ * Concrete profile used by the spawn wrapper. Built-ins are immutable;
+ * resolved profiles (after merging user overrides) are also `Readonly`.
+ */
+export interface AgentProfile {
+  /** Profile name (key in `agent.profiles`). */
+  readonly name: string;
+  /** Command to spawn (looked up on PATH). */
+  readonly bin: string;
+  /** Base args prepended to caller args. */
+  readonly args: readonly string[];
+  /** Default stdio mode. Callers may override per-call. */
+  readonly stdio: AgentStdioMode;
+  /** Extra env vars merged on top of process.env at spawn time. */
+  readonly env?: Readonly<Record<string, string>>;
+  /**
+   * Names of environment variables that should be passed through to the
+   * child even if the caller scrubs the env (e.g. for credential vars
+   * the agent CLI needs). Always-passed for built-in profiles; user
+   * overrides may extend the list.
+   */
+  readonly envPassthrough: readonly string[];
+  /** Per-profile timeout override (ms). Falls back to `agent.timeoutMs`. */
+  readonly timeoutMs?: number;
+  /** How the wrapper should attempt to parse stdout. */
+  readonly parseOutput: AgentParseMode;
+}
+
+const COMMON_PASSTHROUGH = ["HOME", "PATH", "USER", "LANG", "LC_ALL", "TERM", "TMPDIR"] as const;
+
+/**
+ * Built-in profiles for the five agent CLIs the v1 spec calls out
+ * explicitly. The fields here are conservative defaults — every value is
+ * overridable from user config.
+ */
+const BUILTINS: Record<string, AgentProfile> = {
+  opencode: {
+    name: "opencode",
+    bin: "opencode",
+    args: [],
+    stdio: "interactive",
+    envPassthrough: [...COMMON_PASSTHROUGH, "OPENCODE_API_KEY", "OPENCODE_CONFIG"],
+    parseOutput: "text",
+  },
+  claude: {
+    name: "claude",
+    bin: "claude",
+    args: [],
+    stdio: "interactive",
+    envPassthrough: [...COMMON_PASSTHROUGH, "ANTHROPIC_API_KEY", "CLAUDE_CONFIG"],
+    parseOutput: "text",
+  },
+  codex: {
+    name: "codex",
+    bin: "codex",
+    args: [],
+    stdio: "interactive",
+    envPassthrough: [...COMMON_PASSTHROUGH, "OPENAI_API_KEY", "CODEX_CONFIG"],
+    parseOutput: "text",
+  },
+  gemini: {
+    name: "gemini",
+    bin: "gemini",
+    args: [],
+    stdio: "interactive",
+    envPassthrough: [...COMMON_PASSTHROUGH, "GEMINI_API_KEY", "GOOGLE_API_KEY"],
+    parseOutput: "text",
+  },
+  aider: {
+    name: "aider",
+    bin: "aider",
+    args: ["--no-auto-commits"],
+    stdio: "interactive",
+    envPassthrough: [...COMMON_PASSTHROUGH, "OPENAI_API_KEY", "ANTHROPIC_API_KEY"],
+    parseOutput: "text",
+  },
+};
+
+/** Names of every built-in profile. Stable, sorted. */
+export const BUILTIN_AGENT_PROFILE_NAMES: readonly string[] = Object.freeze(Object.keys(BUILTINS).sort());
+
+/** Returns the built-in profile by name, or `undefined` if not built-in. */
+export function getBuiltinAgentProfile(name: string): AgentProfile | undefined {
+  return BUILTINS[name];
+}
+
+/**
+ * Return a deep copy of every built-in profile keyed by name. Callers
+ * should not assume reference equality with subsequent calls.
+ */
+export function listBuiltinAgentProfiles(): Record<string, AgentProfile> {
+  const out: Record<string, AgentProfile> = {};
+  for (const [name, profile] of Object.entries(BUILTINS)) {
+    out[name] = { ...profile };
+  }
+  return out;
+}

--- a/src/integrations/agent/spawn.ts
+++ b/src/integrations/agent/spawn.ts
@@ -1,0 +1,284 @@
+/**
+ * Agent CLI spawn wrapper (v1 spec §12.2).
+ *
+ * Single helper that owns:
+ *   • Process spawn (Bun's subprocess API).
+ *   • Captured vs interactive stdio.
+ *   • Hard timeout (per-call override or profile default).
+ *   • Structured failure reasons — `timeout`, `spawn_failed`,
+ *     `non_zero_exit`, `parse_error`.
+ *
+ * NEVER imports an LLM SDK. Agents are reachable only via shell-out;
+ * this is a pre-emptive guarantee against the #222 invariant.
+ */
+import { DEFAULT_AGENT_TIMEOUT_MS } from "./config";
+import type { AgentParseMode, AgentProfile, AgentStdioMode } from "./profiles";
+
+/** Stable failure-reason vocabulary. Wider strings are not allowed. */
+export type AgentFailureReason = "timeout" | "spawn_failed" | "non_zero_exit" | "parse_error";
+
+/** Minimum subprocess surface we need. Bun.spawn returns this shape. */
+export interface SpawnedSubprocess {
+  exitCode: number | null;
+  exited: Promise<number>;
+  stdout?: ReadableStream<Uint8Array> | null;
+  stderr?: ReadableStream<Uint8Array> | null;
+  stdin?: WritableStream<Uint8Array> | null;
+  kill(signal?: number | string): void;
+}
+
+/**
+ * Function signature compatible with `Bun.spawn`. Tests inject a fake
+ * implementation so the spawn wrapper can be exercised deterministically
+ * without poking at real binaries.
+ */
+export type SpawnFn = (
+  cmd: string[],
+  options: {
+    stdin?: "inherit" | "pipe" | "ignore";
+    stdout?: "inherit" | "pipe" | "ignore";
+    stderr?: "inherit" | "pipe" | "ignore";
+    env?: Record<string, string>;
+    cwd?: string;
+  },
+) => SpawnedSubprocess;
+
+/**
+ * Per-call options for {@link runAgent}. All fields are optional. Caller
+ * may override the profile's `stdio`, `timeoutMs`, and `parseOutput`.
+ */
+export interface RunAgentOptions {
+  /** Override `profile.stdio`. Captured = pipe stdout/stderr; interactive = inherit. */
+  stdio?: AgentStdioMode;
+  /** Override the profile/global timeout (ms). */
+  timeoutMs?: number;
+  /** Override `profile.parseOutput`. */
+  parseOutput?: AgentParseMode;
+  /** Extra env vars merged on top of the profile-derived env. */
+  env?: Record<string, string>;
+  /** Working directory for the child. */
+  cwd?: string;
+  /** Extra args appended after `profile.args`. */
+  args?: readonly string[];
+  /** Optional stdin payload (only honoured in `captured` mode). */
+  stdin?: string;
+  /** Process env source. Defaults to `process.env`. Tests inject a fake. */
+  envSource?: NodeJS.ProcessEnv;
+  /** Spawn function. Defaults to `Bun.spawn`. Tests inject a fake. */
+  spawn?: SpawnFn;
+  /**
+   * `setTimeout` shim. Defaults to the global. Tests pass a synchronous
+   * timer driver so timeout assertions are deterministic.
+   */
+  setTimeoutFn?: typeof setTimeout;
+  /** `clearTimeout` shim. Defaults to the global. */
+  clearTimeoutFn?: typeof clearTimeout;
+}
+
+/** Result envelope. `ok=false` always carries a `reason`. */
+export interface AgentRunResult {
+  ok: boolean;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+  /** Parsed JSON when `parseOutput === "json"` and parsing succeeded. */
+  parsed?: unknown;
+  reason?: AgentFailureReason;
+  /** Human-readable error message paired with `reason`. */
+  error?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = DEFAULT_AGENT_TIMEOUT_MS;
+
+function resolveSpawnFn(options: RunAgentOptions): SpawnFn {
+  if (options.spawn) return options.spawn;
+  // Pull from globalThis so tests that swap it out at module level are honoured.
+  const bun = (globalThis as { Bun?: { spawn: SpawnFn } }).Bun;
+  if (!bun?.spawn) {
+    throw new Error("Bun.spawn is unavailable; pass options.spawn for non-Bun environments.");
+  }
+  return bun.spawn.bind(bun);
+}
+
+/**
+ * Build the child env. Starts empty and copies through:
+ *   • Every name in `profile.envPassthrough`.
+ *   • Every entry in `profile.env`.
+ *   • Every entry in `options.env` (highest precedence).
+ */
+function buildChildEnv(profile: AgentProfile, options: RunAgentOptions): Record<string, string> {
+  const source = options.envSource ?? process.env;
+  const env: Record<string, string> = {};
+  for (const name of profile.envPassthrough) {
+    const value = source[name];
+    if (value !== undefined) env[name] = value;
+  }
+  if (profile.env) {
+    for (const [k, v] of Object.entries(profile.env)) env[k] = v;
+  }
+  if (options.env) {
+    for (const [k, v] of Object.entries(options.env)) env[k] = v;
+  }
+  return env;
+}
+
+async function readStream(stream: ReadableStream<Uint8Array> | null | undefined): Promise<string> {
+  if (!stream) return "";
+  try {
+    return await new Response(stream).text();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Spawn the agent CLI described by `profile` with `prompt` (forwarded as
+ * the last positional arg by default) and return a structured result.
+ *
+ * The `prompt` argument is appended to `profile.args` (and `options.args`)
+ * unless it is `undefined`. Pass `prompt = ""` to forward an explicit
+ * empty positional, or pass extra args via `options.args`.
+ *
+ * Failure modes (see {@link AgentFailureReason}):
+ *
+ *   • `spawn_failed`  — `Bun.spawn` threw synchronously.
+ *   • `timeout`       — exceeded the resolved timeout.
+ *   • `non_zero_exit` — child exited with a non-zero code.
+ *   • `parse_error`   — `parseOutput === "json"` and stdout was not JSON.
+ *
+ * `ok === true` requires exit code 0 and (if `parseOutput === "json"`)
+ * a successful `JSON.parse`.
+ */
+export async function runAgent(
+  profile: AgentProfile,
+  prompt: string | undefined,
+  options: RunAgentOptions = {},
+): Promise<AgentRunResult> {
+  const stdioMode = options.stdio ?? profile.stdio;
+  const timeoutMs = options.timeoutMs ?? profile.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const parseOutput = options.parseOutput ?? profile.parseOutput;
+  const setTimeoutImpl = options.setTimeoutFn ?? setTimeout;
+  const clearTimeoutImpl = options.clearTimeoutFn ?? clearTimeout;
+
+  const args: string[] = [...profile.args, ...(options.args ?? [])];
+  if (prompt !== undefined) args.push(prompt);
+
+  const env = buildChildEnv(profile, options);
+  const start = Date.now();
+
+  let proc: SpawnedSubprocess;
+  try {
+    const spawnFn = resolveSpawnFn(options);
+    proc = spawnFn([profile.bin, ...args], {
+      stdin: stdioMode === "captured" ? "pipe" : "inherit",
+      stdout: stdioMode === "captured" ? "pipe" : "inherit",
+      stderr: stdioMode === "captured" ? "pipe" : "inherit",
+      env,
+      ...(options.cwd ? { cwd: options.cwd } : {}),
+    });
+  } catch (err) {
+    const durationMs = Date.now() - start;
+    return {
+      ok: false,
+      exitCode: null,
+      stdout: "",
+      stderr: "",
+      durationMs,
+      reason: "spawn_failed",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  // Optional stdin payload (captured mode only).
+  if (options.stdin !== undefined && stdioMode === "captured" && proc.stdin) {
+    try {
+      const writer = proc.stdin.getWriter();
+      const bytes = new TextEncoder().encode(options.stdin);
+      await writer.write(bytes);
+      await writer.close();
+    } catch {
+      // Best-effort: ignore stdin write failures, the child will get EOF.
+    }
+  }
+
+  // Hard timeout. We prefer SIGTERM, then SIGKILL if SIGTERM is ignored,
+  // but Bun.spawn only exposes a single .kill() — one signal is enough
+  // for the structured-failure contract.
+  let timedOut = false;
+  const timer = setTimeoutImpl(() => {
+    timedOut = true;
+    try {
+      proc.kill("SIGTERM");
+    } catch {
+      /* ignore */
+    }
+  }, timeoutMs);
+
+  const stdoutPromise = stdioMode === "captured" ? readStream(proc.stdout ?? null) : Promise.resolve("");
+  const stderrPromise = stdioMode === "captured" ? readStream(proc.stderr ?? null) : Promise.resolve("");
+
+  let exitCode: number | null = null;
+  try {
+    exitCode = await proc.exited;
+  } catch (err) {
+    clearTimeoutImpl(timer);
+    const durationMs = Date.now() - start;
+    return {
+      ok: false,
+      exitCode: null,
+      stdout: "",
+      stderr: "",
+      durationMs,
+      reason: "spawn_failed",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+  clearTimeoutImpl(timer);
+
+  const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
+  const durationMs = Date.now() - start;
+
+  if (timedOut) {
+    return {
+      ok: false,
+      exitCode,
+      stdout,
+      stderr,
+      durationMs,
+      reason: "timeout",
+      error: `agent CLI "${profile.name}" timed out after ${timeoutMs}ms`,
+    };
+  }
+
+  if (exitCode !== 0) {
+    return {
+      ok: false,
+      exitCode,
+      stdout,
+      stderr,
+      durationMs,
+      reason: "non_zero_exit",
+      error: `agent CLI "${profile.name}" exited with code ${exitCode}`,
+    };
+  }
+
+  if (parseOutput === "json" && stdioMode === "captured") {
+    try {
+      const parsed = JSON.parse(stdout);
+      return { ok: true, exitCode, stdout, stderr, durationMs, parsed };
+    } catch (err) {
+      return {
+        ok: false,
+        exitCode,
+        stdout,
+        stderr,
+        durationMs,
+        reason: "parse_error",
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  return { ok: true, exitCode, stdout, stderr, durationMs };
+}

--- a/src/setup/setup.ts
+++ b/src/setup/setup.ts
@@ -26,6 +26,12 @@ import {
   deriveSemanticProviderFingerprint,
   writeSemanticStatus,
 } from "../indexer/semantic-status";
+import {
+  type AgentConfig,
+  type AgentDetectionResult,
+  detectAgentCliProfiles,
+  pickDefaultAgentProfile,
+} from "../integrations/agent";
 import { probeLlmCapabilities } from "../llm/client";
 import { checkEmbeddingAvailability, DEFAULT_LOCAL_MODEL, isTransformersAvailable } from "../llm/embedder";
 import { detectAgentPlatforms, detectOllama } from "./detect";
@@ -813,6 +819,51 @@ async function stepAgentPlatforms(current: AkmConfig): Promise<SourceConfigEntry
   return entries;
 }
 
+// ── Agent CLI detection step (v1 spec §12.3) ────────────────────────────────
+
+/**
+ * Result of the agent CLI detection step. The wizard surfaces this to the
+ * caller so the consolidated config write at the end of setup can persist
+ * the new `agent` block.
+ *
+ * @internal Exported for testing only.
+ */
+export interface AgentSetupResult {
+  /** Updated agent config block, or `undefined` if the user has nothing installed and no existing block. */
+  agent?: AgentConfig;
+  /** Per-profile detection results, available to the UI for display. */
+  detections: AgentDetectionResult[];
+}
+
+/**
+ * Detect installed agent CLIs and produce an updated `agent` config block
+ * with a sensible `default` (the first detected profile that the user has
+ * not already overridden).
+ *
+ * Pure-ish: file system / PATH probes are routed through `detectFn` so
+ * tests can drive the branches without touching the real PATH.
+ *
+ * @internal Exported for testing only.
+ */
+export function stepAgentCliDetection(
+  current: AkmConfig,
+  detectFn: (agent?: AgentConfig) => AgentDetectionResult[] = detectAgentCliProfiles,
+): AgentSetupResult {
+  const detections = detectFn(current.agent);
+  const defaultName = pickDefaultAgentProfile(detections, current.agent?.default);
+
+  // No installed agents found and no existing config → leave block absent.
+  if (!defaultName && !current.agent) {
+    return { detections };
+  }
+
+  const agent: AgentConfig = {
+    ...(current.agent ?? {}),
+    ...(defaultName ? { default: defaultName } : {}),
+  };
+  return { agent, detections };
+}
+
 // ── Main Wizard ─────────────────────────────────────────────────────────────
 
 /**
@@ -901,6 +952,26 @@ export function buildSetupSteps(options: {
           if (!merged.some((s) => s.path === ps.path)) merged.push(ps);
         }
         ctx.apply({ sources: merged.length > 0 ? merged : undefined });
+      },
+    },
+    {
+      id: "agent-cli",
+      label: "Agent CLI",
+      nonInteractive: true,
+      async run(ctx) {
+        const result = stepAgentCliDetection(ctx.config);
+        const detected = result.detections.filter((d) => d.available);
+        if (detected.length > 0) {
+          p.log.info(
+            `Detected agent CLIs: ${detected.map((d) => d.name).join(", ")}.` +
+              (result.agent?.default ? ` Default profile: ${result.agent.default}.` : ""),
+          );
+        } else {
+          p.log.info(
+            "No agent CLIs detected on PATH. Agent commands will be disabled until one is installed and `akm setup` is re-run.",
+          );
+        }
+        ctx.apply({ agent: result.agent });
       },
     },
   ];

--- a/tests/agent/agent-config-loader.test.ts
+++ b/tests/agent/agent-config-loader.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Integration test: the AkmConfig loader propagates the `agent` block
+ * through `loadConfig()` (and through the on-disk JSONC parser, exercising
+ * the `pickKnownKeys` path).
+ *
+ * The acceptance criterion "config schema accepts an optional agent block"
+ * lives at the loader boundary, not just the parser; this test pins the
+ * end-to-end shape.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+let tmpHome: string;
+let originalHome: string | undefined;
+let originalXdg: string | undefined;
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "akm-agent-cfg-"));
+  originalHome = process.env.HOME;
+  originalXdg = process.env.XDG_CONFIG_HOME;
+  process.env.HOME = tmpHome;
+  process.env.XDG_CONFIG_HOME = path.join(tmpHome, ".config");
+});
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = originalXdg;
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("AkmConfig loader — agent block", () => {
+  test("loads agent.default + agent.profiles from disk", async () => {
+    const { getConfigPath, loadUserConfig, resetConfigCache } = await import("../../src/core/config");
+    const cfgPath = getConfigPath();
+    fs.mkdirSync(path.dirname(cfgPath), { recursive: true });
+    fs.writeFileSync(
+      cfgPath,
+      JSON.stringify(
+        {
+          semanticSearchMode: "auto",
+          agent: {
+            default: "claude",
+            timeoutMs: 45000,
+            profiles: {
+              claude: { args: ["--print"] },
+              rover: { bin: "rover-cli", parseOutput: "json" },
+            },
+            // Unknown key — must not throw at load.
+            mystery: 1,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    resetConfigCache();
+    const cfg = loadUserConfig();
+    expect(cfg.agent?.default).toBe("claude");
+    expect(cfg.agent?.timeoutMs).toBe(45000);
+    expect(cfg.agent?.profiles?.claude?.args).toEqual(["--print"]);
+    expect(cfg.agent?.profiles?.rover?.bin).toBe("rover-cli");
+    expect(cfg.agent?.profiles?.rover?.parseOutput).toBe("json");
+  });
+
+  test("agent block absent → cfg.agent is undefined → requireAgentProfile throws", async () => {
+    const { loadUserConfig, resetConfigCache } = await import("../../src/core/config");
+    const { requireAgentProfile } = await import("../../src/integrations/agent/config");
+    const { ConfigError } = await import("../../src/core/errors");
+    resetConfigCache();
+    const cfg = loadUserConfig();
+    expect(cfg.agent).toBeUndefined();
+    expect(() => requireAgentProfile(cfg.agent)).toThrow(ConfigError);
+  });
+});

--- a/tests/agent/agent-config.test.ts
+++ b/tests/agent/agent-config.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for the `agent.*` config block parser and profile resolver.
+ *
+ * Acceptance coverage:
+ *   • Parser accepts the documented shape.
+ *   • Unknown keys are warn-and-ignored (no throw).
+ *   • Built-in profiles resolve for opencode, claude, codex, gemini, aider.
+ *   • Missing block surfaces a stable ConfigError via requireAgentProfile.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const warnings: string[] = [];
+
+mock.module("../../src/core/warn", () => ({
+  warn: (...args: unknown[]) => {
+    warnings.push(args.join(" "));
+  },
+  setQuiet: () => {},
+  resetQuiet: () => {},
+  isQuiet: () => false,
+}));
+
+beforeEach(() => {
+  warnings.length = 0;
+});
+
+afterEach(() => {
+  warnings.length = 0;
+});
+
+describe("parseAgentConfig", () => {
+  test("returns undefined when block is absent", async () => {
+    const { parseAgentConfig } = await import("../../src/integrations/agent/config");
+    expect(parseAgentConfig(undefined)).toBeUndefined();
+    expect(warnings).toHaveLength(0);
+  });
+
+  test("warns and returns undefined for non-object root", async () => {
+    const { parseAgentConfig } = await import("../../src/integrations/agent/config");
+    expect(parseAgentConfig("oops")).toBeUndefined();
+    expect(warnings.some((w) => w.includes('"agent"'))).toBe(true);
+  });
+
+  test("accepts the documented shape", async () => {
+    const { parseAgentConfig } = await import("../../src/integrations/agent/config");
+    const parsed = parseAgentConfig({
+      default: "opencode",
+      timeoutMs: 30000,
+      profiles: {
+        opencode: { bin: "opencode", args: ["--non-interactive"], stdio: "captured" },
+      },
+    });
+    expect(parsed?.default).toBe("opencode");
+    expect(parsed?.timeoutMs).toBe(30000);
+    expect(parsed?.profiles?.opencode).toEqual({
+      bin: "opencode",
+      args: ["--non-interactive"],
+      stdio: "captured",
+    });
+  });
+
+  test("warn-and-ignore unknown top-level keys (no throw)", async () => {
+    const { parseAgentConfig } = await import("../../src/integrations/agent/config");
+    const parsed = parseAgentConfig({
+      default: "claude",
+      moonRoutingTable: { foo: "bar" }, // unknown
+    });
+    expect(parsed?.default).toBe("claude");
+    expect(warnings.some((w) => w.includes("moonRoutingTable"))).toBe(true);
+  });
+
+  test("warn-and-ignore unknown per-profile keys", async () => {
+    const { parseAgentConfig } = await import("../../src/integrations/agent/config");
+    const parsed = parseAgentConfig({
+      profiles: {
+        custom: { bin: "ok", quirks: "nope" },
+      },
+    });
+    expect(parsed?.profiles?.custom?.bin).toBe("ok");
+    expect(warnings.some((w) => w.includes("quirks"))).toBe(true);
+  });
+
+  test("warn-and-ignore malformed timeoutMs", async () => {
+    const { parseAgentConfig } = await import("../../src/integrations/agent/config");
+    const parsed = parseAgentConfig({ timeoutMs: "60s" });
+    expect(parsed?.timeoutMs).toBeUndefined();
+    expect(warnings.some((w) => w.includes("timeoutMs"))).toBe(true);
+  });
+
+  test("rejects non-string args entries", async () => {
+    const { parseAgentConfig } = await import("../../src/integrations/agent/config");
+    const parsed = parseAgentConfig({
+      profiles: { opencode: { args: ["--ok", 5, "--also-ok"] } },
+    });
+    expect(parsed?.profiles?.opencode?.args).toEqual(["--ok", "--also-ok"]);
+    expect(warnings.some((w) => w.includes("args"))).toBe(true);
+  });
+
+  test("rejects bad stdio mode", async () => {
+    const { parseAgentConfig } = await import("../../src/integrations/agent/config");
+    const parsed = parseAgentConfig({
+      profiles: { opencode: { stdio: "weird" } },
+    });
+    expect(parsed?.profiles?.opencode?.stdio).toBeUndefined();
+    expect(warnings.some((w) => w.includes("stdio"))).toBe(true);
+  });
+});
+
+describe("built-in profile resolution", () => {
+  test("resolves opencode, claude, codex, gemini, aider out of the box", async () => {
+    const { BUILTIN_AGENT_PROFILE_NAMES, getBuiltinAgentProfile } = await import(
+      "../../src/integrations/agent/profiles"
+    );
+    expect(BUILTIN_AGENT_PROFILE_NAMES).toEqual(["aider", "claude", "codex", "gemini", "opencode"]);
+    for (const name of ["opencode", "claude", "codex", "gemini", "aider"]) {
+      const profile = getBuiltinAgentProfile(name);
+      expect(profile).toBeDefined();
+      expect(profile?.bin).toBeTruthy();
+      expect(profile?.envPassthrough).toContain("PATH");
+    }
+  });
+
+  test("user override merges on top of built-in", async () => {
+    const { resolveAgentProfile } = await import("../../src/integrations/agent/config");
+    const merged = resolveAgentProfile("opencode", { args: ["--scripted"], stdio: "captured" });
+    expect(merged?.bin).toBe("opencode"); // built-in default
+    expect(merged?.args).toEqual(["--scripted"]); // override
+    expect(merged?.stdio).toBe("captured"); // override
+    expect(merged?.envPassthrough).toContain("PATH"); // built-in retained
+  });
+
+  test("user-defined profile (no built-in) requires bin", async () => {
+    const { resolveAgentProfile } = await import("../../src/integrations/agent/config");
+    expect(resolveAgentProfile("rover", undefined)).toBeUndefined();
+    expect(resolveAgentProfile("rover", {})).toBeUndefined();
+    const ok = resolveAgentProfile("rover", { bin: "rover-cli", args: ["--silent"] });
+    expect(ok?.bin).toBe("rover-cli");
+    expect(ok?.args).toEqual(["--silent"]);
+    expect(ok?.stdio).toBe("captured");
+  });
+
+  test("envPassthrough merges base + override", async () => {
+    const { resolveAgentProfile } = await import("../../src/integrations/agent/config");
+    const merged = resolveAgentProfile("opencode", { envPassthrough: ["MY_TOKEN"] });
+    expect(merged?.envPassthrough).toContain("PATH"); // from built-in
+    expect(merged?.envPassthrough).toContain("MY_TOKEN"); // from override
+  });
+
+  test("listAgentProfileNames includes built-ins plus user-defined", async () => {
+    const { listAgentProfileNames } = await import("../../src/integrations/agent/config");
+    const names = listAgentProfileNames({ profiles: { rover: { bin: "rover" } } });
+    expect(names).toContain("rover");
+    expect(names).toContain("opencode");
+    expect(names).toContain("claude");
+  });
+});
+
+describe("requireAgentProfile", () => {
+  test("throws ConfigError when the agent block is missing", async () => {
+    const { requireAgentProfile } = await import("../../src/integrations/agent/config");
+    const { ConfigError } = await import("../../src/core/errors");
+    let caught: unknown;
+    try {
+      requireAgentProfile(undefined);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ConfigError);
+    expect((caught as Error).message).toContain("agent commands are disabled");
+    const hint = (caught as { hint: () => string | undefined }).hint();
+    expect(hint).toBeTruthy();
+    expect(hint).toContain("akm setup");
+  });
+
+  test("throws when no default and no requested name", async () => {
+    const { requireAgentProfile } = await import("../../src/integrations/agent/config");
+    const { ConfigError } = await import("../../src/core/errors");
+    let caught: unknown;
+    try {
+      requireAgentProfile({});
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ConfigError);
+    expect((caught as Error).message).toContain("require a profile");
+  });
+
+  test("resolves the requested profile when valid", async () => {
+    const { requireAgentProfile } = await import("../../src/integrations/agent/config");
+    const profile = requireAgentProfile({ default: "claude" });
+    expect(profile.name).toBe("claude");
+    expect(profile.bin).toBe("claude");
+  });
+
+  test("explicit requested name beats config default", async () => {
+    const { requireAgentProfile } = await import("../../src/integrations/agent/config");
+    const profile = requireAgentProfile({ default: "claude" }, "codex");
+    expect(profile.name).toBe("codex");
+  });
+});

--- a/tests/agent/agent-detect.test.ts
+++ b/tests/agent/agent-detect.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for setup-time agent CLI detection.
+ *
+ * Acceptance coverage:
+ *   • Detects every built-in profile bin via the injected `which` probe.
+ *   • Picks the first available profile as the default.
+ *   • Honours an existing `agent.default` when that profile is still
+ *     available (round-trip stability).
+ *   • Returns `undefined` when nothing is installed.
+ *   • `stepAgentCliDetection` produces a config-shaped result the wizard
+ *     can `apply()`.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { detectAgentCliProfiles, pickDefaultAgentProfile, type WhichFn } from "../../src/integrations/agent/detect";
+
+function whichOnly(installed: string[]): WhichFn {
+  const set = new Set(installed);
+  return (bin: string) => (set.has(bin) ? `/usr/local/bin/${bin}` : undefined);
+}
+
+describe("detectAgentCliProfiles", () => {
+  test("reports every built-in profile, available iff bin found", () => {
+    const results = detectAgentCliProfiles(undefined, whichOnly(["claude", "codex"]));
+    const names = results.map((r) => r.name).sort();
+    expect(names).toEqual(["aider", "claude", "codex", "gemini", "opencode"]);
+    expect(results.find((r) => r.name === "claude")?.available).toBe(true);
+    expect(results.find((r) => r.name === "codex")?.available).toBe(true);
+    expect(results.find((r) => r.name === "gemini")?.available).toBe(false);
+  });
+
+  test("includes user-defined profiles via the resolver", () => {
+    const results = detectAgentCliProfiles({ profiles: { rover: { bin: "rover-cli" } } }, whichOnly(["rover-cli"]));
+    const rover = results.find((r) => r.name === "rover");
+    expect(rover?.available).toBe(true);
+    expect(rover?.resolvedPath).toContain("rover-cli");
+  });
+
+  test("returns nothing-installed when the probe always says no", () => {
+    const results = detectAgentCliProfiles(undefined, whichOnly([]));
+    expect(results.every((r) => !r.available)).toBe(true);
+  });
+});
+
+describe("pickDefaultAgentProfile", () => {
+  test("picks the first available result when no existing default", () => {
+    const picked = pickDefaultAgentProfile([
+      { name: "aider", bin: "aider", available: false },
+      { name: "claude", bin: "claude", available: true },
+      { name: "codex", bin: "codex", available: true },
+    ]);
+    expect(picked).toBe("claude");
+  });
+
+  test("keeps an existing available default", () => {
+    const picked = pickDefaultAgentProfile(
+      [
+        { name: "claude", bin: "claude", available: true },
+        { name: "codex", bin: "codex", available: true },
+      ],
+      "codex",
+    );
+    expect(picked).toBe("codex");
+  });
+
+  test("falls back when the existing default is no longer available", () => {
+    const picked = pickDefaultAgentProfile(
+      [
+        { name: "claude", bin: "claude", available: true },
+        { name: "codex", bin: "codex", available: false },
+      ],
+      "codex",
+    );
+    expect(picked).toBe("claude");
+  });
+
+  test("returns undefined when nothing is available", () => {
+    const picked = pickDefaultAgentProfile([
+      { name: "claude", bin: "claude", available: false },
+      { name: "codex", bin: "codex", available: false },
+    ]);
+    expect(picked).toBeUndefined();
+  });
+});
+
+describe("stepAgentCliDetection (setup wizard)", () => {
+  test("persists default + leaves block absent when nothing detected & no prior config", async () => {
+    const { stepAgentCliDetection } = await import("../../src/setup/setup");
+    const result = stepAgentCliDetection({ semanticSearchMode: "auto" }, () => [
+      { name: "claude", bin: "claude", available: false },
+      { name: "codex", bin: "codex", available: false },
+    ]);
+    expect(result.agent).toBeUndefined();
+    expect(result.detections).toHaveLength(2);
+  });
+
+  test("writes agent.default to the first detected profile", async () => {
+    const { stepAgentCliDetection } = await import("../../src/setup/setup");
+    const result = stepAgentCliDetection({ semanticSearchMode: "auto" }, () => [
+      { name: "claude", bin: "claude", available: false },
+      { name: "codex", bin: "codex", available: true },
+    ]);
+    expect(result.agent?.default).toBe("codex");
+  });
+
+  test("preserves user-overridden default when still available", async () => {
+    const { stepAgentCliDetection } = await import("../../src/setup/setup");
+    const result = stepAgentCliDetection(
+      {
+        semanticSearchMode: "auto",
+        agent: { default: "aider", profiles: { aider: { args: ["--no-auto-commits"] } } },
+      },
+      () => [
+        { name: "claude", bin: "claude", available: true },
+        { name: "aider", bin: "aider", available: true },
+      ],
+    );
+    expect(result.agent?.default).toBe("aider");
+    expect(result.agent?.profiles?.aider?.args).toEqual(["--no-auto-commits"]);
+  });
+});

--- a/tests/agent/agent-spawn.test.ts
+++ b/tests/agent/agent-spawn.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for the agent CLI spawn wrapper (`runAgent`).
+ *
+ * Acceptance coverage:
+ *   • Captured stdio collects stdout/stderr.
+ *   • Hard timeout maps to `reason: "timeout"`.
+ *   • Non-zero exit maps to `reason: "non_zero_exit"`.
+ *   • Synchronous spawn failure maps to `reason: "spawn_failed"`.
+ *   • Malformed JSON output (when `parseOutput: "json"`) maps to
+ *     `reason: "parse_error"`.
+ *   • Successful run returns `ok: true`, captured `stdout`, parsed JSON.
+ *
+ * The wrapper takes a `spawn` injection point so we never touch real
+ * binaries here. Where we do touch a real subprocess (one fast `bun -e`
+ * timeout test) we keep the timeout small and deterministic.
+ */
+import { describe, expect, test } from "bun:test";
+
+import type { AgentProfile } from "../../src/integrations/agent/profiles";
+import type { SpawnedSubprocess, SpawnFn } from "../../src/integrations/agent/spawn";
+import { runAgent } from "../../src/integrations/agent/spawn";
+
+function makeProfile(overrides: Partial<AgentProfile> = {}): AgentProfile {
+  return {
+    name: "test-agent",
+    bin: "test-agent",
+    args: [],
+    stdio: "captured",
+    envPassthrough: ["PATH"],
+    parseOutput: "text",
+    ...overrides,
+  };
+}
+
+function asReadableStream(text: string): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(text);
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+interface FakeSubprocessConfig {
+  exitCode: number;
+  stdout?: string;
+  stderr?: string;
+  /** When set, `proc.exited` only resolves once `kill()` is called. */
+  hangsUntilKilled?: boolean;
+  /** When set, throw synchronously from the spawn fn. */
+  throwSync?: Error;
+  /** When set, reject `proc.exited`. */
+  rejectExit?: Error;
+}
+
+function fakeSpawnFn(config: FakeSubprocessConfig): { spawn: SpawnFn; kills: number } {
+  const state = { kills: 0 };
+  const spawn: SpawnFn = () => {
+    if (config.throwSync) throw config.throwSync;
+    let resolveExit: (code: number) => void = () => {};
+    const exited = new Promise<number>((resolve, reject) => {
+      resolveExit = resolve;
+      if (config.rejectExit) {
+        reject(config.rejectExit);
+      } else if (!config.hangsUntilKilled) {
+        resolve(config.exitCode);
+      }
+    });
+    const proc: SpawnedSubprocess = {
+      exitCode: config.hangsUntilKilled ? null : config.exitCode,
+      exited,
+      stdout: asReadableStream(config.stdout ?? ""),
+      stderr: asReadableStream(config.stderr ?? ""),
+      stdin: null,
+      kill() {
+        state.kills += 1;
+        // Simulate process exit on signal.
+        resolveExit(143);
+      },
+    };
+    return proc;
+  };
+  return { spawn, kills: 0 } as { spawn: SpawnFn; kills: number };
+}
+
+describe("runAgent — captured stdio", () => {
+  test("returns ok:true with stdout/stderr on exit 0", async () => {
+    const { spawn } = fakeSpawnFn({ exitCode: 0, stdout: "hello\n", stderr: "" });
+    const result = await runAgent(makeProfile(), "go", { spawn });
+    expect(result.ok).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("hello\n");
+    expect(result.reason).toBeUndefined();
+    expect(typeof result.durationMs).toBe("number");
+  });
+
+  test("non-zero exit yields structured `non_zero_exit`", async () => {
+    const { spawn } = fakeSpawnFn({ exitCode: 7, stderr: "boom" });
+    const result = await runAgent(makeProfile(), "go", { spawn });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("non_zero_exit");
+    expect(result.exitCode).toBe(7);
+    expect(result.stderr).toBe("boom");
+    expect(result.error).toContain("exited with code 7");
+  });
+
+  test("synchronous spawn failure yields `spawn_failed`", async () => {
+    const { spawn } = fakeSpawnFn({ exitCode: 0, throwSync: new Error("ENOENT: command not found") });
+    const result = await runAgent(makeProfile(), "go", { spawn });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("spawn_failed");
+    expect(result.error).toContain("ENOENT");
+    expect(result.exitCode).toBeNull();
+  });
+
+  test("rejected proc.exited yields `spawn_failed`", async () => {
+    const { spawn } = fakeSpawnFn({ exitCode: 0, rejectExit: new Error("kernel ate it") });
+    const result = await runAgent(makeProfile(), "go", { spawn });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("spawn_failed");
+  });
+});
+
+describe("runAgent — timeout", () => {
+  test("kills the subprocess and reports `timeout`", async () => {
+    // Drive the timer manually so the assertion is deterministic.
+    let timerCallback: (() => void) | undefined;
+    const fakeSet = ((cb: () => void) => {
+      timerCallback = cb;
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    }) as unknown as typeof setTimeout;
+    const fakeClear = (() => {}) as unknown as typeof clearTimeout;
+
+    const { spawn } = fakeSpawnFn({ exitCode: 0, hangsUntilKilled: true });
+    const promise = runAgent(makeProfile(), "go", {
+      spawn,
+      setTimeoutFn: fakeSet,
+      clearTimeoutFn: fakeClear,
+      timeoutMs: 100,
+    });
+    // Kick the deadline.
+    expect(timerCallback).toBeDefined();
+    timerCallback?.();
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("timeout");
+    expect(result.error).toContain("100ms");
+  });
+
+  test("real timeout against `bun -e` sleeping past the deadline (deterministic & fast)", async () => {
+    const profile = makeProfile({ bin: "bun", args: ["-e", "await new Promise(r => setTimeout(r, 5000))"] });
+    const start = Date.now();
+    const result = await runAgent(profile, undefined, { timeoutMs: 250 });
+    const elapsed = Date.now() - start;
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("timeout");
+    // Should bail well before the 5-second sleep would complete.
+    expect(elapsed).toBeLessThan(2000);
+  });
+});
+
+describe("runAgent — JSON parse mode", () => {
+  test("parses JSON stdout and surfaces it via `parsed`", async () => {
+    const { spawn } = fakeSpawnFn({ exitCode: 0, stdout: '{"role":"agent"}' });
+    const result = await runAgent(makeProfile({ parseOutput: "json" }), "go", { spawn });
+    expect(result.ok).toBe(true);
+    expect(result.parsed).toEqual({ role: "agent" });
+  });
+
+  test("malformed JSON yields `parse_error`", async () => {
+    const { spawn } = fakeSpawnFn({ exitCode: 0, stdout: "not json {" });
+    const result = await runAgent(makeProfile({ parseOutput: "json" }), "go", { spawn });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("parse_error");
+    expect(result.error).toBeTruthy();
+  });
+});
+
+describe("runAgent — argument and env construction", () => {
+  test("appends prompt after profile.args and options.args", async () => {
+    let capturedCmd: string[] | undefined;
+    const spawn: SpawnFn = (cmd) => {
+      capturedCmd = cmd;
+      return {
+        exitCode: 0,
+        exited: Promise.resolve(0),
+        stdout: asReadableStream(""),
+        stderr: asReadableStream(""),
+        stdin: null,
+        kill() {},
+      };
+    };
+    await runAgent(makeProfile({ args: ["--profile-arg"] }), "the-prompt", { spawn, args: ["--call-arg"] });
+    expect(capturedCmd).toEqual(["test-agent", "--profile-arg", "--call-arg", "the-prompt"]);
+  });
+
+  test("env is filtered by envPassthrough plus profile/options env", async () => {
+    let capturedEnv: Record<string, string> | undefined;
+    const spawn: SpawnFn = (_cmd, opts) => {
+      capturedEnv = opts.env;
+      return {
+        exitCode: 0,
+        exited: Promise.resolve(0),
+        stdout: asReadableStream(""),
+        stderr: asReadableStream(""),
+        stdin: null,
+        kill() {},
+      };
+    };
+    await runAgent(makeProfile({ envPassthrough: ["KEEP_ME"], env: { PROFILE_VAR: "1" } }), undefined, {
+      spawn,
+      env: { CALL_VAR: "2" },
+      envSource: { KEEP_ME: "yes", DROP_ME: "no" } as NodeJS.ProcessEnv,
+    });
+    expect(capturedEnv).toEqual({ KEEP_ME: "yes", PROFILE_VAR: "1", CALL_VAR: "2" });
+  });
+});


### PR DESCRIPTION
## Summary

- Optional `agent` config block; built-in profiles for opencode, claude, codex, gemini, aider.
- `runAgent()` spawn wrapper: captured + interactive stdio, hard timeout, discriminated-union failure reason.
- Setup detects installed agent CLIs via injectable `WhichFn`; persists default profile.
- 39 new tests in `tests/agent/`. Spawn wrapper imports no LLM SDK.

## Wave

Wave 1 — depends on #220 (and the workflow plan added #222 as dependent on #221). Already integrated into `release/0.7.0`.

## Deferred (intentionally)

CLI verb registrations for `akm agent` / `akm reflect` / `akm propose` not added in this PR. Runtime + library APIs are ready for follow-up.

## Known limitation

Spawn wrapper sends a single SIGTERM; Bun's `proc.kill()` exposes only one signal. All five targeted agent CLIs respond to SIGTERM.

## Test plan

- [x] `bunx biome check src/ tests/`
- [x] `bunx tsc --noEmit`
- [x] `bun test` (1962 pass / 7 skip / 0 fail; agent-only subset 39/0)

Fixes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)