### PR TITLE
akm-bench Wave B: initial task corpus (17 tasks across 3 domains)

### DIFF
--- a/tests/bench/corpus.test.ts
+++ b/tests/bench/corpus.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { getTasksRoot, listTasks, loadTask, partitionSlice, type TaskMetadata } from "./corpus";
+import { effectiveSlice, getTasksRoot, listTasks, loadTask, partitionSlice, type TaskMetadata } from "./corpus";
 
 describe("listTasks", () => {
   test("the corpus root resolves under tests/fixtures/bench/tasks", () => {
@@ -141,5 +141,34 @@ describe("partitionSlice", () => {
     const b = partitionSlice(corpus);
     expect(a.train.map((t) => t.id)).toEqual(b.train.map((t) => t.id));
     expect(a.eval.map((t) => t.id)).toEqual(b.eval.map((t) => t.id));
+  });
+
+  test("a task without explicit slice is bucketed deterministically and goes to exactly one slice", () => {
+    // This guards against the regression where `listTasks({ slice })` would
+    // pass an unsliced task through *both* the train and eval filters because
+    // the early code only excluded tasks whose explicit slice differed.
+    const synthetic: TaskMetadata = {
+      id: "synthetic/no-slice-task",
+      title: "Synthetic task with no explicit slice",
+      domain: "synthetic",
+      difficulty: "easy",
+      stash: "minimal",
+      verifier: "regex",
+      budget: { tokens: 1000, wallMs: 1000 },
+      taskDir: "/tmp/none",
+    };
+    const slice = effectiveSlice(synthetic);
+    expect(["train", "eval"]).toContain(slice);
+    // Re-running must give the same bucket.
+    expect(effectiveSlice(synthetic)).toBe(slice);
+    // partitionSlice and effectiveSlice must agree.
+    const { train, eval: evalSlice } = partitionSlice([synthetic]);
+    if (slice === "train") {
+      expect(train.map((t) => t.id)).toEqual([synthetic.id]);
+      expect(evalSlice).toEqual([]);
+    } else {
+      expect(evalSlice.map((t) => t.id)).toEqual([synthetic.id]);
+      expect(train).toEqual([]);
+    }
   });
 });

--- a/tests/bench/corpus.test.ts
+++ b/tests/bench/corpus.test.ts
@@ -2,7 +2,10 @@
  * Unit tests for the bench corpus loader.
  *
  *   • `listTasks()` returns `[]` cleanly when the corpus dir is missing.
- *   • The shipped sample task at `_example/example-task` loads correctly.
+ *   • The shipped sample task at `_example/example-task` is excluded by
+ *     default but loadable via `{ includeExamples: true }`.
+ *   • The seeded corpus contains 17 tasks (issue #237) and every entry
+ *     validates against the §13.1 schema.
  *   • `partitionSlice` is deterministic — same input → same partitioning
  *     across calls.
  */
@@ -21,8 +24,13 @@ describe("listTasks", () => {
     expect(Array.isArray(tasks)).toBe(true);
   });
 
-  test("includes the shipped sample task", () => {
+  test("excludes `_example/` tasks by default", () => {
     const tasks = listTasks();
+    expect(tasks.find((t) => t.id.startsWith("_example/"))).toBeUndefined();
+  });
+
+  test("loads `_example/` when includeExamples is set", () => {
+    const tasks = listTasks({ includeExamples: true });
     const sample = tasks.find((t) => t.id === "_example/example-task");
     expect(sample).toBeDefined();
     expect(sample?.title).toContain("Example task");
@@ -32,20 +40,61 @@ describe("listTasks", () => {
     expect(sample?.budget.wallMs).toBe(30_000);
   });
 
+  test("seeds 17 hand-authored tasks across three domains (issue #237)", () => {
+    const tasks = listTasks();
+    expect(tasks).toHaveLength(17);
+    const byDomain = new Map<string, TaskMetadata[]>();
+    for (const task of tasks) {
+      const list = byDomain.get(task.domain) ?? [];
+      list.push(task);
+      byDomain.set(task.domain, list);
+    }
+    expect(new Set(byDomain.keys())).toEqual(new Set(["docker-homelab", "az-cli", "opencode"]));
+    expect(byDomain.get("docker-homelab")).toHaveLength(6);
+    expect(byDomain.get("az-cli")).toHaveLength(6);
+    expect(byDomain.get("opencode")).toHaveLength(5);
+  });
+
+  test("every task validates against the §13.1 schema", () => {
+    const ID_RE = /^[a-z0-9][a-z0-9-]*\/[a-z0-9][a-z0-9-]*$/;
+    for (const task of listTasks()) {
+      expect(task.id).toMatch(ID_RE);
+      expect(task.title.length).toBeGreaterThan(0);
+      expect(["easy", "medium", "hard"]).toContain(task.difficulty);
+      expect(["train", "eval"]).toContain(task.slice as string);
+      expect(["pytest", "script", "regex"]).toContain(task.verifier);
+      expect(typeof task.stash).toBe("string");
+      expect(task.budget.tokens).toBeGreaterThan(0);
+      expect(task.budget.wallMs).toBeGreaterThan(0);
+      if (task.verifier === "regex") {
+        expect(task.expectedMatch).toBeDefined();
+        expect((task.expectedMatch ?? "").length).toBeGreaterThan(0);
+      }
+    }
+  });
+
   test("filters by slice when requested", () => {
     const train = listTasks({ slice: "train" });
-    expect(train.every((t) => t.slice === "train" || t.slice === undefined)).toBe(true);
     const evalTasks = listTasks({ slice: "eval" });
-    // No eval-only task ships in #236, so this is allowed to be []. We just
-    // assert the call shape.
-    expect(Array.isArray(evalTasks)).toBe(true);
+    expect(train.every((t) => t.slice === "train")).toBe(true);
+    expect(evalTasks.every((t) => t.slice === "eval")).toBe(true);
+    // The seeded corpus is split 9 train / 8 eval.
+    expect(train).toHaveLength(9);
+    expect(evalTasks).toHaveLength(8);
   });
 });
 
 describe("loadTask", () => {
-  test("loads the sample task by id", () => {
-    const meta = loadTask("_example/example-task");
-    expect(meta.title).toContain("Example task");
+  test("loads a real corpus task by id", () => {
+    const meta = loadTask("docker-homelab/redis-healthcheck");
+    expect(meta.title).toContain("Redis healthcheck");
+    expect(meta.taskDir).toContain("docker-homelab/redis-healthcheck");
+    expect(meta.verifier).toBe("pytest");
+  });
+
+  test("loads the example task only with includeExamples", () => {
+    expect(() => loadTask("_example/example-task")).toThrow();
+    const meta = loadTask("_example/example-task", { includeExamples: true });
     expect(meta.taskDir).toContain("_example/example-task");
   });
 
@@ -84,5 +133,13 @@ describe("partitionSlice", () => {
     expect(a.eval.map((t) => t.id)).toEqual(b.eval.map((t) => t.id));
     // Sanity: every task ends up in exactly one slice.
     expect(a.train.length + a.eval.length).toBe(tasks.length);
+  });
+
+  test("partition of the real corpus is stable across calls", () => {
+    const corpus = listTasks();
+    const a = partitionSlice(corpus);
+    const b = partitionSlice(corpus);
+    expect(a.train.map((t) => t.id)).toEqual(b.train.map((t) => t.id));
+    expect(a.eval.map((t) => t.id)).toEqual(b.eval.map((t) => t.id));
   });
 });

--- a/tests/bench/corpus.ts
+++ b/tests/bench/corpus.ts
@@ -49,16 +49,30 @@ export function getTasksRoot(): string {
 }
 
 /**
+ * The `_example/` task tree is reserved for loader unit tests; real corpus
+ * statistics must exclude it. The path-prefix check matches both POSIX (`/`)
+ * and Windows (`\`) separators.
+ */
+const EXAMPLE_PREFIX = `${path.sep}_example${path.sep}`;
+
+function isExampleTaskDir(dir: string): boolean {
+  return dir.includes(EXAMPLE_PREFIX);
+}
+
+/**
  * Load a single task by id. Walks the tasks tree until a directory whose
- * `task.yaml` carries the requested `id` is found.
+ * `task.yaml` carries the requested `id` is found. By default the
+ * `_example/` tree is skipped; pass `{ includeExamples: true }` to load
+ * tasks under that prefix (used by loader-unit tests).
  *
  * Throws if the corpus directory is missing or no task matches.
  */
-export function loadTask(taskId: string): TaskMetadata {
+export function loadTask(taskId: string, options: { includeExamples?: boolean } = {}): TaskMetadata {
   if (!fs.existsSync(TASKS_ROOT)) {
     throw new Error(`bench corpus directory missing: ${TASKS_ROOT}`);
   }
   for (const candidate of walkTaskDirs(TASKS_ROOT)) {
+    if (!options.includeExamples && isExampleTaskDir(candidate)) continue;
     const meta = readTask(candidate);
     if (meta && meta.id === taskId) return meta;
   }
@@ -67,16 +81,25 @@ export function loadTask(taskId: string): TaskMetadata {
 
 export interface ListTasksOptions {
   slice?: TaskSlice;
+  /**
+   * Include tasks under the `_example/` tree. Defaults to `false` so corpus
+   * statistics match the real seeded corpus. Loader-unit tests set this to
+   * `true` to address the shipped sample task explicitly.
+   */
+  includeExamples?: boolean;
 }
 
 /**
  * Return every task in the corpus, optionally filtered by `slice`. When the
- * corpus directory is missing this returns `[]` (the corpus is built in #237).
+ * corpus directory is missing this returns `[]`. By default tasks under the
+ * `_example/` tree are excluded; pass `{ includeExamples: true }` to include
+ * them.
  */
 export function listTasks(options: ListTasksOptions = {}): TaskMetadata[] {
   if (!fs.existsSync(TASKS_ROOT)) return [];
   const out: TaskMetadata[] = [];
   for (const dir of walkTaskDirs(TASKS_ROOT)) {
+    if (!options.includeExamples && isExampleTaskDir(dir)) continue;
     const meta = readTask(dir);
     if (!meta) continue;
     if (options.slice && meta.slice && meta.slice !== options.slice) continue;

--- a/tests/bench/corpus.ts
+++ b/tests/bench/corpus.ts
@@ -102,7 +102,13 @@ export function listTasks(options: ListTasksOptions = {}): TaskMetadata[] {
     if (!options.includeExamples && isExampleTaskDir(dir)) continue;
     const meta = readTask(dir);
     if (!meta) continue;
-    if (options.slice && meta.slice && meta.slice !== options.slice) continue;
+    if (options.slice) {
+      // Tasks without an explicit `slice:` are partitioned by id-hash so the
+      // filter behaves consistently with `partitionSlice()`. Without this,
+      // an unsliced task would always pass through both `slice: "train"` and
+      // `slice: "eval"` filters, double-counting in evaluation reports.
+      if (effectiveSlice(meta) !== options.slice) continue;
+    }
     out.push(meta);
   }
   out.sort((a, b) => a.id.localeCompare(b.id));
@@ -118,7 +124,7 @@ export function partitionSlice(tasks: TaskMetadata[]): { train: TaskMetadata[]; 
   const train: TaskMetadata[] = [];
   const evalSlice: TaskMetadata[] = [];
   for (const task of tasks) {
-    const slice = task.slice ?? assignSliceByHash(task.id);
+    const slice = effectiveSlice(task);
     if (slice === "train") train.push(task);
     else evalSlice.push(task);
   }
@@ -130,6 +136,16 @@ function assignSliceByHash(id: string): TaskSlice {
   // for slice partitioning. We avoid `node:crypto.randomInt` (non-deterministic).
   const digest = createHash("sha1").update(id).digest();
   return digest[0] % 2 === 0 ? "train" : "eval";
+}
+
+/**
+ * Resolve a task's effective slice. If `task.yaml` declares `slice:` we honour
+ * it; otherwise the id-hash partition assigns one deterministically. Exported
+ * so that consumers (and tests) can ask "which slice would this task fall in?"
+ * without re-running `partitionSlice()`.
+ */
+export function effectiveSlice(task: Pick<TaskMetadata, "id" | "slice">): TaskSlice {
+  return task.slice ?? assignSliceByHash(task.id);
 }
 
 /** Walk the corpus tree depth-first, yielding every directory containing a `task.yaml`. */

--- a/tests/bench/leakage.test.ts
+++ b/tests/bench/leakage.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Leakage smoke test for the seeded bench corpus (spec §7.4).
+ *
+ * For every task that declares a `gold_ref` of the form `skill:<name>`,
+ * locate the SKILL.md inside the named fixture stash and assert that the
+ * verifier's *structural assertions* do not appear verbatim in the gold-ref
+ * content. The gold ref is allowed (and expected) to discuss the topic in
+ * general terms — what it must NOT do is hand the agent a copy-pasteable
+ * fragment that satisfies the verifier directly.
+ *
+ * The check extracts:
+ *   • for `regex` verifiers — the literal segments of `expected_match`
+ *     between regex meta-characters (these are the substrings the agent
+ *     must produce);
+ *   • for `pytest` verifiers — Python-style structural assertion paths and
+ *     dictionary lookups (e.g., `services.redis.healthcheck.test`,
+ *     `redis["healthcheck"]["test"]`);
+ *   • for `script` (shell) verifiers — single-quoted `grep` patterns and
+ *     `jq -e` expressions, which encode the exact assertion shape.
+ *
+ * Each fragment is checked individually. Lone tokens that legitimately
+ * appear in any reasonable description of the topic (e.g., `redis-cli`,
+ * `akm`, `bridge`, `feedback`) are filtered out by a minimum-length and
+ * minimum-token-count rule.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+import { getTasksRoot, listTasks, type TaskMetadata } from "./corpus";
+
+const STASHES_ROOT = path.resolve(getTasksRoot(), "..", "..", "stashes");
+
+/** Resolve `skill:<name>` against the named stash; returns SKILL.md path or `undefined`. */
+function resolveGoldRefPath(stashName: string, goldRef: string): string | undefined {
+  const match = /^skill:([a-z0-9][a-z0-9-]*)$/.exec(goldRef);
+  if (!match) return undefined;
+  const skillDir = path.join(STASHES_ROOT, stashName, "skills", match[1]);
+  const skillFile = path.join(skillDir, "SKILL.md");
+  return fs.existsSync(skillFile) ? skillFile : undefined;
+}
+
+/**
+ * Pull the literal segments out of a regex pattern. Splits on regex
+ * meta-characters and discards short fragments. The remaining strings are
+ * what the agent's stdout must contain — and therefore what the gold ref
+ * must NOT spell out verbatim.
+ */
+function regexLiterals(pattern: string): string[] {
+  return pattern
+    .split(/[.*+?^${}()|[\]\\]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length >= 6 && s.includes(" "));
+}
+
+/** Pull structural assertion fragments out of a pytest verifier file. */
+function pytestStructuralFragments(text: string): string[] {
+  const out = new Set<string>();
+  // Subscript chains like compose["services"]["redis"]["healthcheck"]["test"].
+  const subscriptRe = /(?:\["[a-z0-9_]+"\]){2,}/g;
+  for (const m of text.matchAll(subscriptRe)) out.add(m[0]);
+  // Dotted attribute paths used in error messages, e.g. services.redis.healthcheck.test.
+  const dottedRe = /[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*){2,}/g;
+  for (const m of text.matchAll(dottedRe)) out.add(m[0]);
+  return [...out];
+}
+
+/** Pull shell-verifier assertions: single-quoted greps and jq -e expressions. */
+function shellAssertionFragments(text: string): string[] {
+  const out = new Set<string>();
+  // grep -q '<pattern>' or grep -qi '<pattern>'.
+  const grepRe = /grep\s+-[a-zA-Z]+\s+'([^']{4,})'/g;
+  for (const m of text.matchAll(grepRe)) out.add(m[1]);
+  // jq -e '<expr>'.
+  const jqRe = /jq\s+-e\s+'([^']{4,})'/g;
+  for (const m of text.matchAll(jqRe)) out.add(m[1]);
+  return [...out];
+}
+
+function readVerifierFiles(task: TaskMetadata): string {
+  let combined = "";
+  if (task.verifier === "pytest") {
+    const testsDir = path.join(task.taskDir, "tests");
+    if (fs.existsSync(testsDir)) {
+      for (const entry of fs.readdirSync(testsDir)) {
+        if (entry.endsWith(".py")) combined += `${fs.readFileSync(path.join(testsDir, entry), "utf8")}\n`;
+      }
+    }
+  } else if (task.verifier === "script") {
+    const verify = path.join(task.taskDir, "verify.sh");
+    if (fs.existsSync(verify)) combined += fs.readFileSync(verify, "utf8");
+  }
+  return combined;
+}
+
+describe("gold-ref leakage check", () => {
+  const tasks = listTasks().filter((t) => t.goldRef);
+  test("at least one task ships with a gold_ref", () => {
+    expect(tasks.length).toBeGreaterThan(0);
+  });
+
+  for (const task of tasks) {
+    test(`${task.id}: verifier text does not appear in gold-ref content`, () => {
+      const goldRef = task.goldRef as string;
+      const goldPath = resolveGoldRefPath(task.stash, goldRef);
+      // If the gold ref points at a non-skill asset or a missing file, the
+      // task is responsible for documenting that in CORPUS.md; we skip the
+      // automated check rather than failing.
+      if (!goldPath) {
+        return;
+      }
+      const goldContent = fs.readFileSync(goldPath, "utf8");
+
+      const fragments: string[] = [];
+      if (task.verifier === "regex" && task.expectedMatch) {
+        fragments.push(...regexLiterals(task.expectedMatch));
+      } else {
+        const verifierText = readVerifierFiles(task);
+        fragments.push(...pytestStructuralFragments(verifierText));
+        fragments.push(...shellAssertionFragments(verifierText));
+      }
+
+      const leaked = fragments.filter((frag) => goldContent.includes(frag));
+      expect(leaked).toEqual([]);
+    });
+  }
+});

--- a/tests/bench/leakage.test.ts
+++ b/tests/bench/leakage.test.ts
@@ -104,11 +104,13 @@ describe("gold-ref leakage check", () => {
     test(`${task.id}: verifier text does not appear in gold-ref content`, () => {
       const goldRef = task.goldRef as string;
       const goldPath = resolveGoldRefPath(task.stash, goldRef);
-      // If the gold ref points at a non-skill asset or a missing file, the
-      // task is responsible for documenting that in CORPUS.md; we skip the
-      // automated check rather than failing.
+      // A declared gold_ref MUST resolve to an existing fixture asset. Silent
+      // skipping here previously masked typos and stash-name drift; we now
+      // fail loudly so the corpus author is forced to fix the reference.
       if (!goldPath) {
-        return;
+        throw new Error(
+          `${task.id}: gold_ref "${goldRef}" against stash "${task.stash}" did not resolve to a SKILL.md under tests/fixtures/stashes/. Fix the gold_ref, fix the stash name, or remove the gold_ref.`,
+        );
       }
       const goldContent = fs.readFileSync(goldPath, "utf8");
 

--- a/tests/fixtures/bench/tasks/CORPUS.md
+++ b/tests/fixtures/bench/tasks/CORPUS.md
@@ -1,0 +1,44 @@
+# akm-bench seeded corpus
+
+Seventeen hand-authored tasks across three domains. Each task references a
+fixture stash by name (`tests/fixtures/stashes/<name>/`). The `_example/`
+subtree exists for loader unit tests and is excluded by `listTasks()` by
+default — see `tests/bench/corpus.ts`.
+
+Train/eval split: 9 train, 8 eval (~50/50 per domain: docker 3+3, az 3+3,
+opencode 3+2).
+
+## Tasks
+
+| id | domain | slice | fixture | verifier | leakage check |
+|---|---|---|---|---|---|
+| docker-homelab/redis-healthcheck | docker-homelab | eval | docker-homelab | pytest | SKILL.md mentions `redis-cli ping` as one of several in-container probes; verifier asserts `services.redis.healthcheck.test` contains `redis-cli`. The literal `services.redis.healthcheck.test: redis-cli ping` does not appear in the gold ref. |
+| docker-homelab/restart-policy | docker-homelab | train | docker-homelab | pytest | SKILL.md does not contain the literal `restart: unless-stopped` or `services.web.restart`. |
+| docker-homelab/env-from-file | docker-homelab | train | docker-homelab | pytest | SKILL.md does not contain `env_file:` or `./app.env`. |
+| docker-homelab/named-volume | docker-homelab | eval | docker-homelab | pytest | SKILL.md mentions named volumes generally; the literal path `/var/lib/postgresql/data` and the volume name `pgdata` do not appear. |
+| docker-homelab/bridge-network | docker-homelab | eval | docker-homelab | pytest | SKILL.md describes bridge networking generally; the literal network name `internal` and the YAML structural fragments do not appear. |
+| docker-homelab/compose-version-upgrade | docker-homelab | train | docker-homelab | pytest | SKILL.md states "compose v3+" generally; the literal string `version: "3.8"` and the v2-only key list (`mem_limit`, `cpu_shares`) do not appear. |
+| az-cli/create-resource-group | az-cli | train | az-cli | regex | SKILL.md describes RG lifecycle generally; the literal `az group create --name myrg --location eastus` does not appear. |
+| az-cli/assign-managed-identity | az-cli | eval | az-cli | regex | SKILL.md does not contain `az vm identity assign` or the literal `-g myrg -n myvm`. |
+| az-cli/query-by-tag | az-cli | train | az-cli | regex | SKILL.md does not contain `az resource list --tag env=prod`. |
+| az-cli/keyvault-secret-set | az-cli | train | az-cli | regex | SKILL.md does not contain `az keyvault secret set --vault-name myvault --name dbpass`. |
+| az-cli/aks-get-credentials | az-cli | eval | az-cli | regex | SKILL.md does not contain `az aks get-credentials -g myrg -n mycluster`. |
+| az-cli/storage-account-create | az-cli | eval | az-cli | regex | SKILL.md does not contain `az storage account create --name mystorage --sku Standard_LRS`. |
+| opencode/agents-md-akm-snippet | opencode | eval | multi-domain | script | gold ref `skill:opencode` (multi-domain) describes opencode generally; does not contain the phrase `akm search` or an `AGENTS.md` snippet. |
+| opencode/opencode-config-model | opencode | train | multi-domain | script | gold ref mentions `opencode.json` for model config generally; does not pin `anthropic/claude-opus-4-7` verbatim. |
+| opencode/tool-allowlist | opencode | train | multi-domain | script | gold ref does not list `["bash","edit","read"]` or describe a tool allowlist. |
+| opencode/provider-akm-feedback | opencode | eval | multi-domain | script | gold ref does not mention `akm feedback` or `provider.sh`. |
+| opencode/system-prompt-snippet | opencode | train | multi-domain | script | gold ref does not contain a system-prompt snippet referencing `akm feedback`. |
+
+## Leakage discipline (spec §7.4)
+
+The `tests/bench/leakage.test.ts` suite enforces a substring check between
+each verifier's *structural* assertions (regex literals, Python subscript
+chains, shell `grep`/`jq` patterns) and the gold-ref SKILL.md content. The
+table above is the human-reviewed counterpart: each row records the manual
+check the corpus author performed against the shipped fixture stash content
+on `release/1.0.0`.
+
+If a fixture stash skill is later expanded to include a fragment that
+satisfies a verifier directly, both the table entry and the automated test
+will need to be revisited.

--- a/tests/fixtures/bench/tasks/CORPUS.md
+++ b/tests/fixtures/bench/tasks/CORPUS.md
@@ -18,12 +18,12 @@ opencode 3+2).
 | docker-homelab/named-volume | docker-homelab | eval | docker-homelab | pytest | SKILL.md mentions named volumes generally; the literal path `/var/lib/postgresql/data` and the volume name `pgdata` do not appear. |
 | docker-homelab/bridge-network | docker-homelab | eval | docker-homelab | pytest | SKILL.md describes bridge networking generally; the literal network name `internal` and the YAML structural fragments do not appear. |
 | docker-homelab/compose-version-upgrade | docker-homelab | train | docker-homelab | pytest | SKILL.md states "compose v3+" generally; the literal string `version: "3.8"` and the v2-only key list (`mem_limit`, `cpu_shares`) do not appear. |
-| az-cli/create-resource-group | az-cli | train | az-cli | regex | SKILL.md describes RG lifecycle generally; the literal `az group create --name myrg --location eastus` does not appear. |
-| az-cli/assign-managed-identity | az-cli | eval | az-cli | regex | SKILL.md does not contain `az vm identity assign` or the literal `-g myrg -n myvm`. |
-| az-cli/query-by-tag | az-cli | train | az-cli | regex | SKILL.md does not contain `az resource list --tag env=prod`. |
-| az-cli/keyvault-secret-set | az-cli | train | az-cli | regex | SKILL.md does not contain `az keyvault secret set --vault-name myvault --name dbpass`. |
-| az-cli/aks-get-credentials | az-cli | eval | az-cli | regex | SKILL.md does not contain `az aks get-credentials -g myrg -n mycluster`. |
-| az-cli/storage-account-create | az-cli | eval | az-cli | regex | SKILL.md does not contain `az storage account create --name mystorage --sku Standard_LRS`. |
+| az-cli/create-resource-group | az-cli | train | az-cli | script | verify.sh greps `commands.txt` for `az group create`, `-n/--name myrg`, `-l/--location eastus`. SKILL.md describes RG lifecycle generally; none of those grep clauses appear verbatim. |
+| az-cli/assign-managed-identity | az-cli | eval | az-cli | script | verify.sh greps for `az vm identity assign`, `-g/--resource-group myrg`, `-n/--name myvm`. SKILL.md does not contain any of these clauses. |
+| az-cli/query-by-tag | az-cli | train | az-cli | script | verify.sh greps for `az resource list` and `--tag env=prod`. SKILL.md does not contain either. |
+| az-cli/keyvault-secret-set | az-cli | train | az-cli | script | verify.sh greps for `az keyvault secret set`, `--vault-name myvault`, `-n/--name dbpass`. SKILL.md does not contain these. |
+| az-cli/aks-get-credentials | az-cli | eval | az-cli | script | verify.sh greps for `az aks get-credentials`, `-g/--resource-group myrg`, `-n/--name mycluster`. SKILL.md does not contain these. |
+| az-cli/storage-account-create | az-cli | eval | az-cli | script | verify.sh greps for `az storage account create`, `-n/--name mystorage`, `--sku Standard_LRS`, `-g/--resource-group myrg`. SKILL.md does not contain these. |
 | opencode/agents-md-akm-snippet | opencode | eval | multi-domain | script | gold ref `skill:opencode` (multi-domain) describes opencode generally; does not contain the phrase `akm search` or an `AGENTS.md` snippet. |
 | opencode/opencode-config-model | opencode | train | multi-domain | script | gold ref mentions `opencode.json` for model config generally; does not pin `anthropic/claude-opus-4-7` verbatim. |
 | opencode/tool-allowlist | opencode | train | multi-domain | script | gold ref does not list `["bash","edit","read"]` or describe a tool allowlist. |

--- a/tests/fixtures/bench/tasks/az-cli/aks-get-credentials/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/aks-get-credentials/task.yaml
@@ -1,0 +1,12 @@
+id: az-cli/aks-get-credentials
+title: "Produce the az command to fetch AKS kubeconfig for mycluster"
+domain: az-cli
+difficulty: easy
+slice: eval
+gold_ref: skill:az-cli
+stash: az-cli
+verifier: regex
+expected_match: "az aks get-credentials.*-g myrg.*-n mycluster"
+budget:
+  tokens: 25000
+  wallMs: 90000

--- a/tests/fixtures/bench/tasks/az-cli/aks-get-credentials/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/aks-get-credentials/task.yaml
@@ -5,8 +5,7 @@ difficulty: easy
 slice: eval
 gold_ref: skill:az-cli
 stash: az-cli
-verifier: regex
-expected_match: "az aks get-credentials.*-g myrg.*-n mycluster"
+verifier: script
 budget:
   tokens: 25000
   wallMs: 90000

--- a/tests/fixtures/bench/tasks/az-cli/aks-get-credentials/verify.sh
+++ b/tests/fixtures/bench/tasks/az-cli/aks-get-credentials/verify.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f commands.txt ]]; then
+  echo "commands.txt missing"
+  exit 1
+fi
+
+if ! grep -qE 'az aks get-credentials' commands.txt; then
+  echo "commands.txt missing 'az aks get-credentials'"
+  exit 1
+fi
+
+if ! grep -qE '(-g|--resource-group)[[:space:]]+myrg' commands.txt; then
+  echo "commands.txt missing resource group myrg"
+  exit 1
+fi
+
+if ! grep -qE '(-n|--name)[[:space:]]+mycluster' commands.txt; then
+  echo "commands.txt missing cluster name mycluster"
+  exit 1
+fi
+
+echo "ok"
+exit 0

--- a/tests/fixtures/bench/tasks/az-cli/aks-get-credentials/workspace/README.md
+++ b/tests/fixtures/bench/tasks/az-cli/aks-get-credentials/workspace/README.md
@@ -1,0 +1,5 @@
+# Task: get AKS credentials
+
+Append to `commands.txt` the `az` CLI command that fetches kubeconfig
+credentials for the AKS cluster `mycluster` in resource group `myrg`. Do not
+execute the command.

--- a/tests/fixtures/bench/tasks/az-cli/assign-managed-identity/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/assign-managed-identity/task.yaml
@@ -5,8 +5,7 @@ difficulty: medium
 slice: eval
 gold_ref: skill:az-cli
 stash: az-cli
-verifier: regex
-expected_match: "az vm identity assign.*-g myrg.*-n myvm"
+verifier: script
 budget:
   tokens: 25000
   wallMs: 90000

--- a/tests/fixtures/bench/tasks/az-cli/assign-managed-identity/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/assign-managed-identity/task.yaml
@@ -1,0 +1,12 @@
+id: az-cli/assign-managed-identity
+title: "Produce the az command to assign a system-managed identity to a VM"
+domain: az-cli
+difficulty: medium
+slice: eval
+gold_ref: skill:az-cli
+stash: az-cli
+verifier: regex
+expected_match: "az vm identity assign.*-g myrg.*-n myvm"
+budget:
+  tokens: 25000
+  wallMs: 90000

--- a/tests/fixtures/bench/tasks/az-cli/assign-managed-identity/verify.sh
+++ b/tests/fixtures/bench/tasks/az-cli/assign-managed-identity/verify.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f commands.txt ]]; then
+  echo "commands.txt missing"
+  exit 1
+fi
+
+if ! grep -qE 'az vm identity assign' commands.txt; then
+  echo "commands.txt missing 'az vm identity assign'"
+  exit 1
+fi
+
+if ! grep -qE '(-g|--resource-group)[[:space:]]+myrg' commands.txt; then
+  echo "commands.txt missing resource group myrg"
+  exit 1
+fi
+
+if ! grep -qE '(-n|--name)[[:space:]]+myvm' commands.txt; then
+  echo "commands.txt missing VM name myvm"
+  exit 1
+fi
+
+echo "ok"
+exit 0

--- a/tests/fixtures/bench/tasks/az-cli/assign-managed-identity/workspace/README.md
+++ b/tests/fixtures/bench/tasks/az-cli/assign-managed-identity/workspace/README.md
@@ -1,0 +1,5 @@
+# Task: assign system-managed identity
+
+Append to `commands.txt` the `az` CLI command that assigns a system-managed
+identity to the VM `myvm` in resource group `myrg`. Do not execute the
+command.

--- a/tests/fixtures/bench/tasks/az-cli/create-resource-group/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/create-resource-group/task.yaml
@@ -5,8 +5,7 @@ difficulty: easy
 slice: train
 gold_ref: skill:az-cli
 stash: az-cli
-verifier: regex
-expected_match: "az group create.*--name myrg.*--location eastus"
+verifier: script
 budget:
   tokens: 25000
   wallMs: 90000

--- a/tests/fixtures/bench/tasks/az-cli/create-resource-group/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/create-resource-group/task.yaml
@@ -1,0 +1,12 @@
+id: az-cli/create-resource-group
+title: "Produce the az command to create RG myrg in eastus"
+domain: az-cli
+difficulty: easy
+slice: train
+gold_ref: skill:az-cli
+stash: az-cli
+verifier: regex
+expected_match: "az group create.*--name myrg.*--location eastus"
+budget:
+  tokens: 25000
+  wallMs: 90000

--- a/tests/fixtures/bench/tasks/az-cli/create-resource-group/verify.sh
+++ b/tests/fixtures/bench/tasks/az-cli/create-resource-group/verify.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f commands.txt ]]; then
+  echo "commands.txt missing"
+  exit 1
+fi
+
+if ! grep -qE 'az group create' commands.txt; then
+  echo "commands.txt missing 'az group create'"
+  exit 1
+fi
+
+if ! grep -qE '(-n|--name)[[:space:]]+myrg' commands.txt; then
+  echo "commands.txt missing resource group name myrg"
+  exit 1
+fi
+
+if ! grep -qE '(-l|--location)[[:space:]]+eastus' commands.txt; then
+  echo "commands.txt missing location eastus"
+  exit 1
+fi
+
+echo "ok"
+exit 0

--- a/tests/fixtures/bench/tasks/az-cli/create-resource-group/workspace/README.md
+++ b/tests/fixtures/bench/tasks/az-cli/create-resource-group/workspace/README.md
@@ -1,0 +1,5 @@
+# Task: create resource group
+
+Append the exact `az` CLI command that creates a resource group named `myrg`
+in the `eastus` Azure region to `commands.txt`. Do not run the command — only
+write what you would run.

--- a/tests/fixtures/bench/tasks/az-cli/keyvault-secret-set/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/keyvault-secret-set/task.yaml
@@ -5,8 +5,7 @@ difficulty: easy
 slice: train
 gold_ref: skill:az-cli
 stash: az-cli
-verifier: regex
-expected_match: "az keyvault secret set.*--vault-name myvault.*--name dbpass"
+verifier: script
 budget:
   tokens: 25000
   wallMs: 90000

--- a/tests/fixtures/bench/tasks/az-cli/keyvault-secret-set/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/keyvault-secret-set/task.yaml
@@ -1,0 +1,12 @@
+id: az-cli/keyvault-secret-set
+title: "Produce the az command to set keyvault secret dbpass in myvault"
+domain: az-cli
+difficulty: easy
+slice: train
+gold_ref: skill:az-cli
+stash: az-cli
+verifier: regex
+expected_match: "az keyvault secret set.*--vault-name myvault.*--name dbpass"
+budget:
+  tokens: 25000
+  wallMs: 90000

--- a/tests/fixtures/bench/tasks/az-cli/keyvault-secret-set/verify.sh
+++ b/tests/fixtures/bench/tasks/az-cli/keyvault-secret-set/verify.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f commands.txt ]]; then
+  echo "commands.txt missing"
+  exit 1
+fi
+
+if ! grep -qE 'az keyvault secret set' commands.txt; then
+  echo "commands.txt missing 'az keyvault secret set'"
+  exit 1
+fi
+
+if ! grep -qE '\-\-vault-name[[:space:]]+myvault' commands.txt; then
+  echo "commands.txt missing --vault-name myvault"
+  exit 1
+fi
+
+if ! grep -qE '(-n|--name)[[:space:]]+dbpass' commands.txt; then
+  echo "commands.txt missing secret name dbpass"
+  exit 1
+fi
+
+echo "ok"
+exit 0

--- a/tests/fixtures/bench/tasks/az-cli/keyvault-secret-set/workspace/README.md
+++ b/tests/fixtures/bench/tasks/az-cli/keyvault-secret-set/workspace/README.md
@@ -1,0 +1,5 @@
+# Task: set a keyvault secret
+
+Append to `commands.txt` the `az` CLI command that sets a secret named
+`dbpass` (any value) in the keyvault named `myvault`. Do not execute the
+command.

--- a/tests/fixtures/bench/tasks/az-cli/query-by-tag/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/query-by-tag/task.yaml
@@ -1,0 +1,12 @@
+id: az-cli/query-by-tag
+title: "Produce the az command to list resources tagged env=prod"
+domain: az-cli
+difficulty: easy
+slice: train
+gold_ref: skill:az-cli
+stash: az-cli
+verifier: regex
+expected_match: "az resource list.*--tag env=prod"
+budget:
+  tokens: 25000
+  wallMs: 90000

--- a/tests/fixtures/bench/tasks/az-cli/query-by-tag/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/query-by-tag/task.yaml
@@ -5,8 +5,7 @@ difficulty: easy
 slice: train
 gold_ref: skill:az-cli
 stash: az-cli
-verifier: regex
-expected_match: "az resource list.*--tag env=prod"
+verifier: script
 budget:
   tokens: 25000
   wallMs: 90000

--- a/tests/fixtures/bench/tasks/az-cli/query-by-tag/verify.sh
+++ b/tests/fixtures/bench/tasks/az-cli/query-by-tag/verify.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f commands.txt ]]; then
+  echo "commands.txt missing"
+  exit 1
+fi
+
+if ! grep -qE 'az resource list' commands.txt; then
+  echo "commands.txt missing 'az resource list'"
+  exit 1
+fi
+
+if ! grep -qE '\-\-tag[[:space:]]+env=prod' commands.txt; then
+  echo "commands.txt missing --tag env=prod"
+  exit 1
+fi
+
+echo "ok"
+exit 0

--- a/tests/fixtures/bench/tasks/az-cli/query-by-tag/workspace/README.md
+++ b/tests/fixtures/bench/tasks/az-cli/query-by-tag/workspace/README.md
@@ -1,0 +1,4 @@
+# Task: list resources by tag
+
+Append to `commands.txt` the `az` CLI command that lists every Azure resource
+carrying the tag `env=prod`. Do not execute the command.

--- a/tests/fixtures/bench/tasks/az-cli/storage-account-create/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/storage-account-create/task.yaml
@@ -1,0 +1,12 @@
+id: az-cli/storage-account-create
+title: "Produce the az command to create a Standard_LRS storage account"
+domain: az-cli
+difficulty: medium
+slice: eval
+gold_ref: skill:az-cli
+stash: az-cli
+verifier: regex
+expected_match: "az storage account create.*--name mystorage.*--sku Standard_LRS.*-g myrg"
+budget:
+  tokens: 25000
+  wallMs: 90000

--- a/tests/fixtures/bench/tasks/az-cli/storage-account-create/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/storage-account-create/task.yaml
@@ -5,8 +5,7 @@ difficulty: medium
 slice: eval
 gold_ref: skill:az-cli
 stash: az-cli
-verifier: regex
-expected_match: "az storage account create.*--name mystorage.*--sku Standard_LRS.*-g myrg"
+verifier: script
 budget:
   tokens: 25000
   wallMs: 90000

--- a/tests/fixtures/bench/tasks/az-cli/storage-account-create/verify.sh
+++ b/tests/fixtures/bench/tasks/az-cli/storage-account-create/verify.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f commands.txt ]]; then
+  echo "commands.txt missing"
+  exit 1
+fi
+
+if ! grep -qE 'az storage account create' commands.txt; then
+  echo "commands.txt missing 'az storage account create'"
+  exit 1
+fi
+
+if ! grep -qE '(-n|--name)[[:space:]]+mystorage' commands.txt; then
+  echo "commands.txt missing storage account name mystorage"
+  exit 1
+fi
+
+if ! grep -qE '\-\-sku[[:space:]]+Standard_LRS' commands.txt; then
+  echo "commands.txt missing --sku Standard_LRS"
+  exit 1
+fi
+
+if ! grep -qE '(-g|--resource-group)[[:space:]]+myrg' commands.txt; then
+  echo "commands.txt missing resource group myrg"
+  exit 1
+fi
+
+echo "ok"
+exit 0

--- a/tests/fixtures/bench/tasks/az-cli/storage-account-create/workspace/README.md
+++ b/tests/fixtures/bench/tasks/az-cli/storage-account-create/workspace/README.md
@@ -1,0 +1,5 @@
+# Task: create a storage account
+
+Append to `commands.txt` the `az` CLI command that creates a storage account
+named `mystorage` with SKU `Standard_LRS` in resource group `myrg`. Do not
+execute the command.

--- a/tests/fixtures/bench/tasks/docker-homelab/bridge-network/task.yaml
+++ b/tests/fixtures/bench/tasks/docker-homelab/bridge-network/task.yaml
@@ -1,0 +1,11 @@
+id: docker-homelab/bridge-network
+title: "Attach two services to a custom internal bridge network"
+domain: docker-homelab
+difficulty: medium
+slice: eval
+gold_ref: skill:docker-homelab
+stash: docker-homelab
+verifier: pytest
+budget:
+  tokens: 25000
+  wallMs: 90000

--- a/tests/fixtures/bench/tasks/docker-homelab/bridge-network/tests/test_bridge_network.py
+++ b/tests/fixtures/bench/tasks/docker-homelab/bridge-network/tests/test_bridge_network.py
@@ -1,0 +1,27 @@
+import pathlib
+
+import yaml
+
+
+def _service_networks(svc: dict) -> set[str]:
+    raw = svc.get("networks") or []
+    if isinstance(raw, dict):
+        return set(raw.keys())
+    return {str(n) for n in raw}
+
+
+def test_internal_bridge_attaches_two_services() -> None:
+    compose = yaml.safe_load(pathlib.Path("docker-compose.yml").read_text())
+    networks = compose.get("networks") or {}
+    assert "internal" in networks, "expected top-level internal network"
+    cfg = networks["internal"] or {}
+    if isinstance(cfg, dict):
+        driver = cfg.get("driver", "bridge")
+        assert driver == "bridge", f"expected bridge driver, got {driver}"
+
+    attached = [
+        name
+        for name, svc in (compose.get("services") or {}).items()
+        if "internal" in _service_networks(svc)
+    ]
+    assert len(attached) >= 2, f"expected 2+ services on internal, got {attached}"

--- a/tests/fixtures/bench/tasks/docker-homelab/bridge-network/workspace/docker-compose.yml
+++ b/tests/fixtures/bench/tasks/docker-homelab/bridge-network/workspace/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  api:
+    image: ghcr.io/example/api:1.0.0
+    ports: ["8000:8000"]
+  worker:
+    image: ghcr.io/example/worker:1.0.0

--- a/tests/fixtures/bench/tasks/docker-homelab/compose-version-upgrade/task.yaml
+++ b/tests/fixtures/bench/tasks/docker-homelab/compose-version-upgrade/task.yaml
@@ -1,0 +1,11 @@
+id: docker-homelab/compose-version-upgrade
+title: "Upgrade compose version 2 syntax to 3.8"
+domain: docker-homelab
+difficulty: medium
+slice: train
+gold_ref: skill:docker-homelab
+stash: docker-homelab
+verifier: pytest
+budget:
+  tokens: 25000
+  wallMs: 90000

--- a/tests/fixtures/bench/tasks/docker-homelab/compose-version-upgrade/tests/test_compose_version_upgrade.py
+++ b/tests/fixtures/bench/tasks/docker-homelab/compose-version-upgrade/tests/test_compose_version_upgrade.py
@@ -1,0 +1,17 @@
+import pathlib
+
+import yaml
+
+
+# Keys that v2 supported at the service level but were removed/replaced in v3.
+V2_ONLY_SERVICE_KEYS = {"mem_limit", "cpu_shares", "volume_driver", "cpuset", "cpu_quota"}
+
+
+def test_compose_upgraded_to_v3_8() -> None:
+    raw = pathlib.Path("docker-compose.yml").read_text()
+    compose = yaml.safe_load(raw)
+    assert str(compose.get("version")) == "3.8", f"expected version 3.8, got {compose.get('version')!r}"
+
+    for name, svc in (compose.get("services") or {}).items():
+        leaked = V2_ONLY_SERVICE_KEYS & set(svc or {})
+        assert not leaked, f"service {name!r} still has v2-only keys: {leaked}"

--- a/tests/fixtures/bench/tasks/docker-homelab/compose-version-upgrade/workspace/docker-compose.yml
+++ b/tests/fixtures/bench/tasks/docker-homelab/compose-version-upgrade/workspace/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "2"
+services:
+  web:
+    image: nginx:1.27-alpine
+    ports: ["80:80"]
+    mem_limit: 256m
+    cpu_shares: 512
+    volume_driver: local

--- a/tests/fixtures/bench/tasks/docker-homelab/env-from-file/task.yaml
+++ b/tests/fixtures/bench/tasks/docker-homelab/env-from-file/task.yaml
@@ -1,0 +1,11 @@
+id: docker-homelab/env-from-file
+title: "Load environment for the app service from ./app.env"
+domain: docker-homelab
+difficulty: easy
+slice: train
+gold_ref: skill:docker-homelab
+stash: docker-homelab
+verifier: pytest
+budget:
+  tokens: 25000
+  wallMs: 90000

--- a/tests/fixtures/bench/tasks/docker-homelab/env-from-file/tests/test_env_from_file.py
+++ b/tests/fixtures/bench/tasks/docker-homelab/env-from-file/tests/test_env_from_file.py
@@ -1,0 +1,18 @@
+import pathlib
+
+import yaml
+
+
+def test_app_loads_env_from_file() -> None:
+    compose = yaml.safe_load(pathlib.Path("docker-compose.yml").read_text())
+    app = compose["services"]["app"]
+    env_file = app.get("env_file")
+    assert env_file is not None, "expected env_file on the app service"
+    if isinstance(env_file, str):
+        candidates = [env_file]
+    else:
+        candidates = [
+            entry if isinstance(entry, str) else (entry or {}).get("path", "")
+            for entry in env_file
+        ]
+    assert any("app.env" in str(c) for c in candidates)

--- a/tests/fixtures/bench/tasks/docker-homelab/env-from-file/workspace/app.env
+++ b/tests/fixtures/bench/tasks/docker-homelab/env-from-file/workspace/app.env
@@ -1,0 +1,2 @@
+APP_ENV=production
+APP_PORT=3000

--- a/tests/fixtures/bench/tasks/docker-homelab/env-from-file/workspace/docker-compose.yml
+++ b/tests/fixtures/bench/tasks/docker-homelab/env-from-file/workspace/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  app:
+    image: ghcr.io/example/app:1.0.0
+    ports: ["3000:3000"]

--- a/tests/fixtures/bench/tasks/docker-homelab/named-volume/task.yaml
+++ b/tests/fixtures/bench/tasks/docker-homelab/named-volume/task.yaml
@@ -1,0 +1,11 @@
+id: docker-homelab/named-volume
+title: "Mount a named pgdata volume on the postgres service"
+domain: docker-homelab
+difficulty: medium
+slice: eval
+gold_ref: skill:docker-homelab
+stash: docker-homelab
+verifier: pytest
+budget:
+  tokens: 25000
+  wallMs: 90000

--- a/tests/fixtures/bench/tasks/docker-homelab/named-volume/tests/test_named_volume.py
+++ b/tests/fixtures/bench/tasks/docker-homelab/named-volume/tests/test_named_volume.py
@@ -1,0 +1,26 @@
+import pathlib
+
+import yaml
+
+
+def _normalize_volume(entry: object) -> tuple[str, str]:
+    if isinstance(entry, str):
+        parts = entry.split(":")
+        return parts[0], parts[1] if len(parts) > 1 else ""
+    if isinstance(entry, dict):
+        return str(entry.get("source", "")), str(entry.get("target", ""))
+    return "", ""
+
+
+def test_pgdata_named_volume_mounted() -> None:
+    compose = yaml.safe_load(pathlib.Path("docker-compose.yml").read_text())
+    top_volumes = compose.get("volumes") or {}
+    assert "pgdata" in top_volumes, "expected top-level pgdata volume declaration"
+
+    postgres = compose["services"]["postgres"]
+    mounts = postgres.get("volumes") or []
+    targets = {_normalize_volume(m) for m in mounts}
+    assert any(
+        src == "pgdata" and tgt == "/var/lib/postgresql/data"
+        for src, tgt in targets
+    ), f"expected pgdata mounted at /var/lib/postgresql/data, got {targets}"

--- a/tests/fixtures/bench/tasks/docker-homelab/named-volume/workspace/docker-compose.yml
+++ b/tests/fixtures/bench/tasks/docker-homelab/named-volume/workspace/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_PASSWORD: example
+    ports: ["5432:5432"]

--- a/tests/fixtures/bench/tasks/docker-homelab/redis-healthcheck/task.yaml
+++ b/tests/fixtures/bench/tasks/docker-homelab/redis-healthcheck/task.yaml
@@ -1,0 +1,11 @@
+id: docker-homelab/redis-healthcheck
+title: "Add a Redis healthcheck to the homelab compose stack"
+domain: docker-homelab
+difficulty: easy
+slice: eval
+gold_ref: skill:docker-homelab
+stash: docker-homelab
+verifier: pytest
+budget:
+  tokens: 25000
+  wallMs: 90000

--- a/tests/fixtures/bench/tasks/docker-homelab/redis-healthcheck/tests/test_redis_health.py
+++ b/tests/fixtures/bench/tasks/docker-homelab/redis-healthcheck/tests/test_redis_health.py
@@ -1,0 +1,11 @@
+import pathlib
+
+import yaml
+
+
+def test_redis_has_healthcheck() -> None:
+    compose = yaml.safe_load(pathlib.Path("docker-compose.yml").read_text())
+    redis = compose["services"]["redis"]
+    assert "healthcheck" in redis
+    assert "test" in redis["healthcheck"]
+    assert "redis-cli" in str(redis["healthcheck"]["test"])

--- a/tests/fixtures/bench/tasks/docker-homelab/redis-healthcheck/workspace/docker-compose.yml
+++ b/tests/fixtures/bench/tasks/docker-homelab/redis-healthcheck/workspace/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  redis:
+    image: redis:7-alpine
+    ports: ["6379:6379"]

--- a/tests/fixtures/bench/tasks/docker-homelab/restart-policy/task.yaml
+++ b/tests/fixtures/bench/tasks/docker-homelab/restart-policy/task.yaml
@@ -1,0 +1,11 @@
+id: docker-homelab/restart-policy
+title: "Apply restart: unless-stopped to the web service"
+domain: docker-homelab
+difficulty: easy
+slice: train
+gold_ref: skill:docker-homelab
+stash: docker-homelab
+verifier: pytest
+budget:
+  tokens: 25000
+  wallMs: 90000

--- a/tests/fixtures/bench/tasks/docker-homelab/restart-policy/tests/test_restart_policy.py
+++ b/tests/fixtures/bench/tasks/docker-homelab/restart-policy/tests/test_restart_policy.py
@@ -1,0 +1,9 @@
+import pathlib
+
+import yaml
+
+
+def test_web_has_restart_policy() -> None:
+    compose = yaml.safe_load(pathlib.Path("docker-compose.yml").read_text())
+    web = compose["services"]["web"]
+    assert web.get("restart") == "unless-stopped"

--- a/tests/fixtures/bench/tasks/docker-homelab/restart-policy/workspace/docker-compose.yml
+++ b/tests/fixtures/bench/tasks/docker-homelab/restart-policy/workspace/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  web:
+    image: nginx:1.27-alpine
+    ports: ["8080:80"]

--- a/tests/fixtures/bench/tasks/opencode/agents-md-akm-snippet/task.yaml
+++ b/tests/fixtures/bench/tasks/opencode/agents-md-akm-snippet/task.yaml
@@ -1,0 +1,11 @@
+id: opencode/agents-md-akm-snippet
+title: "Write AGENTS.md telling the agent to akm search before coding"
+domain: opencode
+difficulty: easy
+slice: eval
+gold_ref: skill:opencode
+stash: multi-domain
+verifier: script
+budget:
+  tokens: 25000
+  wallMs: 90000

--- a/tests/fixtures/bench/tasks/opencode/agents-md-akm-snippet/verify.sh
+++ b/tests/fixtures/bench/tasks/opencode/agents-md-akm-snippet/verify.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f AGENTS.md ]]; then
+  echo "AGENTS.md missing"
+  exit 1
+fi
+
+if grep -q 'akm search' AGENTS.md; then
+  echo "ok"
+  exit 0
+fi
+
+echo "AGENTS.md did not mention 'akm search'"
+exit 1

--- a/tests/fixtures/bench/tasks/opencode/agents-md-akm-snippet/workspace/README.md
+++ b/tests/fixtures/bench/tasks/opencode/agents-md-akm-snippet/workspace/README.md
@@ -1,0 +1,6 @@
+# Task: AGENTS.md akm-first guidance
+
+Create an `AGENTS.md` file in this workspace that instructs the coding agent
+to call `akm search` for relevant skills/knowledge before writing code. The
+exact phrasing is up to you, but the file must contain the literal string
+`akm search`.

--- a/tests/fixtures/bench/tasks/opencode/opencode-config-model/task.yaml
+++ b/tests/fixtures/bench/tasks/opencode/opencode-config-model/task.yaml
@@ -1,0 +1,11 @@
+id: opencode/opencode-config-model
+title: "Pin opencode model to anthropic/claude-opus-4-7 via opencode.json"
+domain: opencode
+difficulty: easy
+slice: train
+gold_ref: skill:opencode
+stash: multi-domain
+verifier: script
+budget:
+  tokens: 25000
+  wallMs: 90000

--- a/tests/fixtures/bench/tasks/opencode/opencode-config-model/verify.sh
+++ b/tests/fixtures/bench/tasks/opencode/opencode-config-model/verify.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f opencode.json ]]; then
+  echo "opencode.json missing"
+  exit 1
+fi
+
+if jq -e '.model == "anthropic/claude-opus-4-7"' opencode.json >/dev/null; then
+  echo "ok"
+  exit 0
+fi
+
+echo "opencode.json did not pin model to anthropic/claude-opus-4-7"
+exit 1

--- a/tests/fixtures/bench/tasks/opencode/opencode-config-model/workspace/README.md
+++ b/tests/fixtures/bench/tasks/opencode/opencode-config-model/workspace/README.md
@@ -1,0 +1,5 @@
+# Task: pin the opencode model
+
+Write an `opencode.json` config file in this workspace that pins the model
+to `anthropic/claude-opus-4-7`. The file must be valid JSON and the top-level
+`model` key must equal that string.

--- a/tests/fixtures/bench/tasks/opencode/provider-akm-feedback/task.yaml
+++ b/tests/fixtures/bench/tasks/opencode/provider-akm-feedback/task.yaml
@@ -1,0 +1,11 @@
+id: opencode/provider-akm-feedback
+title: "Write a provider script that emits akm feedback after each task"
+domain: opencode
+difficulty: medium
+slice: eval
+gold_ref: skill:opencode
+stash: multi-domain
+verifier: script
+budget:
+  tokens: 25000
+  wallMs: 90000

--- a/tests/fixtures/bench/tasks/opencode/provider-akm-feedback/verify.sh
+++ b/tests/fixtures/bench/tasks/opencode/provider-akm-feedback/verify.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f provider.sh ]]; then
+  echo "provider.sh missing"
+  exit 1
+fi
+
+if grep -q 'akm feedback' provider.sh; then
+  echo "ok"
+  exit 0
+fi
+
+echo "provider.sh did not invoke akm feedback"
+exit 1

--- a/tests/fixtures/bench/tasks/opencode/provider-akm-feedback/workspace/README.md
+++ b/tests/fixtures/bench/tasks/opencode/provider-akm-feedback/workspace/README.md
@@ -1,0 +1,6 @@
+# Task: provider script that calls akm feedback
+
+Write a small shell script `provider.sh` in this workspace that runs after a
+coding task completes and records `akm feedback` against the asset(s) the
+agent used. The script body is up to you, but it must invoke `akm feedback`
+at least once.

--- a/tests/fixtures/bench/tasks/opencode/system-prompt-snippet/task.yaml
+++ b/tests/fixtures/bench/tasks/opencode/system-prompt-snippet/task.yaml
@@ -1,0 +1,11 @@
+id: opencode/system-prompt-snippet
+title: "Author a system.txt snippet that records akm feedback after asset use"
+domain: opencode
+difficulty: easy
+slice: train
+gold_ref: skill:opencode
+stash: multi-domain
+verifier: script
+budget:
+  tokens: 25000
+  wallMs: 90000

--- a/tests/fixtures/bench/tasks/opencode/system-prompt-snippet/verify.sh
+++ b/tests/fixtures/bench/tasks/opencode/system-prompt-snippet/verify.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f system.txt ]]; then
+  echo "system.txt missing"
+  exit 1
+fi
+
+if ! grep -qi 'akm feedback' system.txt; then
+  echo "system.txt did not mention 'akm feedback'"
+  exit 1
+fi
+
+if grep -qiE '(positive|negative|±)' system.txt; then
+  echo "ok"
+  exit 0
+fi
+
+echo "system.txt did not mention positive/negative/±"
+exit 1

--- a/tests/fixtures/bench/tasks/opencode/system-prompt-snippet/workspace/README.md
+++ b/tests/fixtures/bench/tasks/opencode/system-prompt-snippet/workspace/README.md
@@ -1,0 +1,6 @@
+# Task: system prompt snippet for akm feedback
+
+Create a file `system.txt` in this workspace containing a short system-prompt
+snippet. The snippet must instruct the agent to record `akm feedback`
+(positive or negative) after using a stash asset. The text must mention
+both `akm feedback` and at least one of `positive`, `negative`, or `±`.

--- a/tests/fixtures/bench/tasks/opencode/tool-allowlist/task.yaml
+++ b/tests/fixtures/bench/tasks/opencode/tool-allowlist/task.yaml
@@ -1,0 +1,11 @@
+id: opencode/tool-allowlist
+title: "Restrict opencode tools to bash, edit, read"
+domain: opencode
+difficulty: medium
+slice: train
+gold_ref: skill:opencode
+stash: multi-domain
+verifier: script
+budget:
+  tokens: 25000
+  wallMs: 90000

--- a/tests/fixtures/bench/tasks/opencode/tool-allowlist/verify.sh
+++ b/tests/fixtures/bench/tasks/opencode/tool-allowlist/verify.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f opencode.json ]]; then
+  echo "opencode.json missing"
+  exit 1
+fi
+
+if jq -e '(.tools | sort) == ["bash","edit","read"]' opencode.json >/dev/null; then
+  echo "ok"
+  exit 0
+fi
+
+echo "opencode.json tools did not equal [bash, edit, read]"
+exit 1

--- a/tests/fixtures/bench/tasks/opencode/tool-allowlist/workspace/README.md
+++ b/tests/fixtures/bench/tasks/opencode/tool-allowlist/workspace/README.md
@@ -1,0 +1,5 @@
+# Task: restrict the opencode tool allowlist
+
+Write an `opencode.json` config file in this workspace where the `tools`
+key is an array containing exactly `bash`, `edit`, and `read` (in any order).
+The file must be valid JSON.


### PR DESCRIPTION
## Summary

Wave B of the `akm-bench` evaluation framework rollout (umbrella tracker #234, milestone `akm-bench`, source plan `docs/technical/benchmark.md`). Lands the hand-authored task corpus that downstream metrics (#238–#242) and Track B (#243) will measure against. Builds on the merged Wave A foundation (#235 fixture stashes + #236 bench skeleton).

| Issue | Branch | Title |
|---|---|---|
| #237 | `issue-237-task-corpus` | test(bench): seed initial task corpus (15-20 tasks across 3 domains) |

Closes #237.

## What landed

### 17 tasks under `tests/fixtures/bench/tasks/`

**docker-homelab (6)** — `verifier: pytest` reading docker-compose.yml with `yaml.safe_load`:
- `redis-healthcheck` (eval, §13.2 sample), `restart-policy` (train), `env-from-file` (train), `named-volume` (eval), `bridge-network` (eval), `compose-version-upgrade` (train).

**az-cli (6)** — `verifier: script` (`verify.sh` reads `commands.txt` with multiple `grep -qE` clauses for flag-order-independent matching):
- `create-resource-group` (train), `assign-managed-identity` (eval), `query-by-tag` (train), `keyvault-secret-set` (train), `aks-get-credentials` (eval), `storage-account-create` (eval).

**opencode (5)** — `verifier: script` against expected output files (`opencode.json`, `AGENTS.md`, etc.):
- `agents-md-akm-snippet` (eval), `opencode-config-model` (train), `tool-allowlist` (train), `provider-akm-feedback` (eval), `system-prompt-snippet` (train).

Train/eval split: **9 train + 8 eval**, per-domain ~50/50.

### Loader changes (`tests/bench/corpus.ts`)
- Filters `_example/` by default; `{ includeExamples: true }` opt-in (so the sample fixture from #236 doesn't pollute aggregate stats).
- Slice filter now uses `effectiveSlice()` helper: tasks without explicit `slice:` are deterministically id-hash bucketed, so filtering by `train`/`eval` no longer leaks unsliced tasks through.

### Leakage discipline
- `tests/bench/leakage.test.ts` (new) — automated structural-fragment check against gold-ref content. Catches verbatim verifier text in SKILL.md and friends. **Hardened**: missing `gold_ref` paths now FAIL the test (catches typos and stash-name drift) instead of silently skipping.
- `tests/fixtures/bench/tasks/CORPUS.md` — 17-row table with per-task leakage notes (manual §7.4 review).

## Test plan

- `bunx tsc --noEmit` — clean.
- `bunx biome check src/ tests/` — 1 pre-existing info (`tests/architecture/agent-no-llm-sdk-guard.test.ts:86`), no new warnings/errors.
- `bun test` — **2250 pass / 9 skip / 0 fail / 6103 expects across 147 files**.
  - Wave A baseline at `release/1.0.0`@`b9b7442`: 2226 / 9 / 0.
  - Net: +24 tests (17 task-load assertions + 6 leakage assertions + 1 slice-filter regression test).

## Reviewer pass discipline

Three reviewer roles ran in parallel (senior-engineer, security, domain-expert).

- **senior-engineer** flagged 4 findings; all addressed in fixup `a48f771`:
  - **CRITICAL**: az-cli verifier-workspace mismatch — `task.yaml` had `verifier: regex` (matches stdout) but the workspace README told the agent to append to `commands.txt`. Tasks-as-shipped didn't actually work. Resolved by converting all 6 az-cli tasks to `verifier: script` with a `verify.sh` that reads the file.
  - Argument-order regex false-fails (e.g., `--name X.*--sku Y.*-g Z`). Resolved by per-clause `grep -qE` so flag ordering is irrelevant.
  - Slice filter latent bug (`if (options.slice && meta.slice && ...)` — undefined slice always passed through). Fixed via the `effectiveSlice()` helper.
  - Leakage test silent-skip on unresolvable `gold_ref`. Fixed: now an explicit failure with actionable message.
- **security** approved — `set -euo pipefail` everywhere, `yaml.safe_load` only, no nested-quantifier regexes, no secrets in workspaces, loader filter conservative.
- **domain-expert** approved — coverage exact (17/3-domain), gold_refs all resolve, manual leakage spot-check clean. Advisory note: 4 az-cli tasks and 2 opencode tasks have prompts that name every literal the verifier checks — likely won't discriminate akm signal in `delta_pass_rate`. Filed as future-hardening: add `hard`-tier tasks where SKILL.md is the only source of obscure flags.

## CLAUDE.md compliance

- No source-provider-kind branches outside `src/core/write-source.ts`.
- No new URI schemes for refs.
- No new top-level directory; corpus lives entirely under `tests/fixtures/bench/tasks/`.
- No new prod dependencies. `pyyaml` is a Python runtime dep for the bench operator (documented in `tests/bench/BENCH.md`), not a Node/Bun one.
- Verifier dispatch unchanged from #236; uses existing `script | pytest | regex` types only.

## Follow-ups (not blocking; queued for subsequent runs)

- **#238** — `bench utility` outcome+trajectory metrics + JSON/markdown report. Consumes this corpus. First end-to-end usable Track A run.
- **#239–#242** — Phase 1 diagnostics (parallelize cleanly within their wave).
- **#243–#244** — Track B longitudinal evolution + feedback-signal integrity.
- **Future hardening** (advisory, non-blocking from this wave):
  - Add `hard`-tier tasks where the SKILL.md is the only source of truth for the verifier's literals.
  - Tighten the 4 too-easy az-cli tasks and 2 too-easy opencode tasks (rephrase prompts to omit literals).
  - Note: az-cli pytest tasks need `pyyaml` available on the operator's host; if not present, the harness records `harness_error` (not silent fail), per the #236 driver.

## Run scratch directory

`.akm-run/26c553e1-cafb-43ba-bc47-f408ebe7b6b6/` (not pushed): intake/plan/prepare-worktrees/integrate notes, `plan.json`, `summaries/issue-237.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)