### PR TITLE
akm-bench Wave C: bench utility — outcome & trajectory metrics + JSON/markdown report

### DIFF
--- a/tests/bench/BENCH.md
+++ b/tests/bench/BENCH.md
@@ -54,12 +54,12 @@ metrics. It defines two booleans that the v1 utility report emits today:
 - `feedback_recorded` — did the agent emit any `feedback` event?
 
 The §13.3 sample envelope shows two additional illustrative fields
-(`replan_count` and `tool_call_overhead_ms`). Those were aspirational
-sketches, not part of the v1 commitment, and computing them well requires
-tool-call tracing and replan detection that #238 deliberately deferred. The
-JSON `trajectory.akm` object therefore carries **only** the two §6.2 fields
-in v1; if a future PR wants to land replan/overhead metrics, it can extend
-the shape additively without breaking the v1 contract.
+(`searched_before_acting` and `irrelevant_assets_loaded`). Those were
+aspirational sketches, not part of the v1 commitment, and computing them
+well requires tool-call tracing that #238 deliberately deferred. The JSON
+`trajectory.akm` object therefore carries **only** the two §6.2 fields in
+v1; if a future PR wants to land them, it can extend the shape additively
+without breaking the v1 contract.
 
 Per-run inputs (events.jsonl bytes-read and verifierStdout substring scan)
 are capped at 16 MiB each. A runaway agent that produces more than that does

--- a/tests/bench/BENCH.md
+++ b/tests/bench/BENCH.md
@@ -36,9 +36,35 @@ Subcommands:
 - `compare` — diff two report JSON files. Stub in #236; lands in #240.
 - `attribute` — per-asset marginal contribution. Stub in #236; lands in #243.
 
-`--tasks` accepts `train | eval | all`. `--json` emits the JSON envelope on
-stdout and the markdown summary on stderr; without `--json`, only the markdown
-summary goes to stdout.
+`--tasks` accepts `train | eval | all`; any other value exits 2 with a clear
+error rather than silently coercing. The JSON envelope is **always** written
+to stdout — that is the bench's machine-readable contract and matches
+`tests/benchmark-suite.ts`. The `--json` flag means "machine-readable only":
+it suppresses the human-friendly markdown summary that is otherwise written to
+stderr alongside the JSON. Without `--json`, both stdout (JSON) and stderr
+(markdown summary) get content; with `--json`, stderr only carries minor trace
+lines (e.g. the `tasks discovered: …` line).
+
+## Trajectory metrics — what the v1 contract emits
+
+`docs/technical/benchmark.md` §6.2 is the normative list of trajectory
+metrics. It defines two booleans that the v1 utility report emits today:
+
+- `correct_asset_loaded` — did the agent invoke `akm show <goldRef>`?
+- `feedback_recorded` — did the agent emit any `feedback` event?
+
+The §13.3 sample envelope shows two additional illustrative fields
+(`replan_count` and `tool_call_overhead_ms`). Those were aspirational
+sketches, not part of the v1 commitment, and computing them well requires
+tool-call tracing and replan detection that #238 deliberately deferred. The
+JSON `trajectory.akm` object therefore carries **only** the two §6.2 fields
+in v1; if a future PR wants to land replan/overhead metrics, it can extend
+the shape additively without breaking the v1 contract.
+
+Per-run inputs (events.jsonl bytes-read and verifierStdout substring scan)
+are capped at 16 MiB each. A runaway agent that produces more than that does
+not OOM the bench; trajectory is computed from the prefix and a warning is
+appended to the report's top-level `warnings[]`.
 
 ## Per-run isolation
 

--- a/tests/bench/cli.test.ts
+++ b/tests/bench/cli.test.ts
@@ -114,4 +114,48 @@ describe("bench CLI", () => {
     expect(r.exitCode).toBe(2);
     expect(r.stderr).toContain("unknown subcommand");
   });
+
+  test("unknown --tasks value exits 2 with a clear error (no silent coerce to all)", () => {
+    const r = run(["utility", "--tasks", "bogus"], { BENCH_OPENCODE_MODEL: "test-model" });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain("invalid --tasks");
+    expect(r.stderr).toContain("bogus");
+    expect(r.stderr).toContain("all");
+    expect(r.stderr).toContain("train");
+    expect(r.stderr).toContain("eval");
+  });
+
+  test("without --json: JSON still goes to stdout, markdown summary goes to stderr", () => {
+    const r = run(
+      ["utility", "--tasks", "train", "--seeds", "1", "--budget-tokens", "1000", "--budget-wall-ms", "1000"],
+      { BENCH_OPENCODE_MODEL: "anthropic/claude-opus-4-7" },
+    );
+    expect(r.exitCode).toBe(0);
+    // stdout MUST be valid JSON (the bench's machine-readable contract).
+    let parsed: Record<string, unknown> | undefined;
+    expect(() => {
+      parsed = JSON.parse(r.stdout) as Record<string, unknown>;
+    }).not.toThrow();
+    expect(parsed?.schemaVersion).toBe(1);
+    expect(parsed?.track).toBe("utility");
+    // stderr MUST contain the human-friendly markdown summary.
+    expect(r.stderr).toContain("# akm-bench utility");
+    expect(r.stderr).toContain("## Aggregate");
+    expect(r.stderr).toContain("tasks discovered:");
+  }, 60_000);
+
+  test("with --json: stderr carries no markdown summary", () => {
+    const r = run(
+      ["utility", "--tasks", "train", "--seeds", "1", "--budget-tokens", "1000", "--budget-wall-ms", "1000", "--json"],
+      { BENCH_OPENCODE_MODEL: "anthropic/claude-opus-4-7" },
+    );
+    expect(r.exitCode).toBe(0);
+    // stdout is still JSON.
+    expect(() => JSON.parse(r.stdout)).not.toThrow();
+    // stderr MUST NOT contain the markdown summary headings.
+    expect(r.stderr).not.toContain("# akm-bench utility");
+    expect(r.stderr).not.toContain("## Aggregate");
+    // The minor trace line is fine.
+    expect(r.stderr).toContain("tasks discovered:");
+  }, 60_000);
 });

--- a/tests/bench/cli.test.ts
+++ b/tests/bench/cli.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for the bench CLI dispatcher.
+ *
+ * We exercise the binary by spawning it with various argv permutations.
+ * Real opencode is never invoked — the corpus tasks each fail at the
+ * agent-spawn step (no `opencode` on PATH in CI), and that is exactly the
+ * failure mode we want to verify produces a valid §13.3 envelope.
+ */
+
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const CLI = path.join(REPO_ROOT, "tests", "bench", "cli.ts");
+
+interface SpawnResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+function run(args: string[], env: Record<string, string> = {}): SpawnResult {
+  const result = Bun.spawnSync({
+    cmd: ["bun", "run", CLI, ...args],
+    cwd: REPO_ROOT,
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    exitCode: result.exitCode ?? -1,
+    stdout: new TextDecoder().decode(result.stdout ?? new Uint8Array()),
+    stderr: new TextDecoder().decode(result.stderr ?? new Uint8Array()),
+  };
+}
+
+describe("bench CLI", () => {
+  test("`help` subcommand exits 0 and lists the four subcommands", () => {
+    const r = run(["help"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("utility");
+    expect(r.stdout).toContain("evolve");
+    expect(r.stdout).toContain("compare");
+    expect(r.stdout).toContain("attribute");
+  });
+
+  test("utility without BENCH_OPENCODE_MODEL exits 2", () => {
+    // Strip out any inherited model env so the missing-model branch fires.
+    const r = run(["utility", "--tasks", "train"], { BENCH_OPENCODE_MODEL: "" });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain("BENCH_OPENCODE_MODEL");
+  });
+
+  test("evolve / compare / attribute remain not-implemented", () => {
+    for (const sub of ["evolve", "compare", "attribute"]) {
+      const r = run([sub]);
+      expect(r.exitCode).toBe(2);
+      expect(r.stderr).toContain("not yet implemented");
+    }
+  });
+
+  test("utility --tasks train --seeds 1 --json produces a §13.3 envelope", () => {
+    const r = run(
+      ["utility", "--tasks", "train", "--seeds", "1", "--budget-tokens", "1000", "--budget-wall-ms", "1000", "--json"],
+      { BENCH_OPENCODE_MODEL: "anthropic/claude-opus-4-7" },
+    );
+    expect(r.exitCode).toBe(0);
+    // Stdout should be valid JSON.
+    let parsed: Record<string, unknown>;
+    expect(() => {
+      parsed = JSON.parse(r.stdout) as Record<string, unknown>;
+    }).not.toThrow();
+    parsed = JSON.parse(r.stdout) as Record<string, unknown>;
+    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.track).toBe("utility");
+    expect((parsed.agent as { model: string }).model).toBe("anthropic/claude-opus-4-7");
+    const corpus = parsed.corpus as Record<string, unknown>;
+    expect(corpus.slice).toBe("train");
+    expect(corpus.seedsPerArm).toBe(1);
+    expect(typeof corpus.tasks).toBe("number");
+    expect((corpus.tasks as number) > 0).toBe(true);
+    expect(Array.isArray(parsed.tasks)).toBe(true);
+    expect(Array.isArray(parsed.warnings)).toBe(true);
+    // Aggregate must have all three sections.
+    const aggregate = parsed.aggregate as Record<string, unknown>;
+    expect(aggregate.noakm).toBeDefined();
+    expect(aggregate.akm).toBeDefined();
+    expect(aggregate.delta).toBeDefined();
+    // Trajectory.akm must have both fields.
+    const trajectory = (parsed.trajectory as Record<string, Record<string, unknown>>).akm;
+    expect("correct_asset_loaded" in trajectory).toBe(true);
+    expect("feedback_recorded" in trajectory).toBe(true);
+  }, 60_000);
+
+  test("utility --tasks eval filters to eval slice", () => {
+    const trainR = run(
+      ["utility", "--tasks", "train", "--seeds", "1", "--budget-tokens", "100", "--budget-wall-ms", "100", "--json"],
+      { BENCH_OPENCODE_MODEL: "test-model" },
+    );
+    const evalR = run(
+      ["utility", "--tasks", "eval", "--seeds", "1", "--budget-tokens", "100", "--budget-wall-ms", "100", "--json"],
+      { BENCH_OPENCODE_MODEL: "test-model" },
+    );
+    expect(trainR.exitCode).toBe(0);
+    expect(evalR.exitCode).toBe(0);
+    const trainCorpus = (JSON.parse(trainR.stdout) as { corpus: { tasks: number } }).corpus;
+    const evalCorpus = (JSON.parse(evalR.stdout) as { corpus: { tasks: number } }).corpus;
+    // The two slices partition the corpus; together they should account for every non-_example task.
+    expect(trainCorpus.tasks + evalCorpus.tasks).toBeGreaterThanOrEqual(1);
+  }, 60_000);
+
+  test("unknown subcommand exits 2 and prints help", () => {
+    const r = run(["bogus"]);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain("unknown subcommand");
+  });
+});

--- a/tests/bench/cli.ts
+++ b/tests/bench/cli.ts
@@ -38,7 +38,9 @@ utility flags:
   --seeds <N>              seeds per arm  (default: 5)
   --budget-tokens <N>      per-run token cap (default: 30000)
   --budget-wall-ms <N>     per-run wallclock cap in ms (default: 120000)
-  --json                   emit JSON to stdout; markdown summary to stderr.
+  --json                   suppress the markdown summary on stderr (machine-readable only).
+                           Without --json, JSON still goes to stdout and the markdown
+                           summary is also written to stderr for human-friendly reads.
   -h, --help               show this message.
 
 Environment:
@@ -140,15 +142,14 @@ export async function runUtilityCli(options: UtilityCliOptions): Promise<Utility
   const jsonText = `${JSON.stringify(json, null, 2)}\n`;
   const markdownText = `${markdown}\n`;
 
-  let stdout: string;
-  let stderr: string;
-  if (options.json) {
-    stdout = jsonText;
-    stderr = markdownText;
-  } else {
-    stdout = markdownText;
-    stderr = "";
-  }
+  // JSON ALWAYS goes to stdout. This is the bench's machine-readable
+  // contract (matches `tests/benchmark-suite.ts` and the future `bench
+  // compare`/`attribute` subcommands). The `--json` flag means
+  // "suppress the human-friendly markdown summary on stderr"; without it,
+  // both the JSON envelope (stdout) and the markdown summary (stderr) are
+  // emitted so an operator running it interactively gets both views.
+  const stdout = jsonText;
+  let stderr = options.json ? "" : markdownText;
   stderr += `tasks discovered: ${tasks.length} (slice=${options.slice})\n`;
   if (tasks.length === 0) {
     stderr += "no tasks found — corpus is empty or the slice filter excluded all tasks\n";
@@ -180,10 +181,13 @@ async function main(argv: string[]): Promise<number> {
   switch (parsed.subcommand) {
     case "utility": {
       const sliceRaw = parsed.flags.get("tasks") ?? "all";
-      const slice =
-        sliceRaw === "train" || sliceRaw === "eval" || sliceRaw === "all"
-          ? (sliceRaw as "train" | "eval" | "all")
-          : "all";
+      if (sliceRaw !== "train" && sliceRaw !== "eval" && sliceRaw !== "all") {
+        process.stderr.write(
+          `bench utility: invalid --tasks value "${sliceRaw}"; expected one of: all, train, eval.\n`,
+        );
+        return 2;
+      }
+      const slice = sliceRaw as "train" | "eval" | "all";
       const model = getEnv("BENCH_OPENCODE_MODEL");
       if (!model) {
         process.stderr.write("bench utility: BENCH_OPENCODE_MODEL environment variable is required.\n");

--- a/tests/bench/cli.ts
+++ b/tests/bench/cli.ts
@@ -4,25 +4,23 @@
  *
  * Subcommands:
  *   • `utility`    — paired noakm vs akm utility benchmark (Track A).
- *   • `evolve`     — longitudinal evolution loop (Track B). Stub in #236.
- *   • `compare`    — diff two report JSON files. Stub in #236.
- *   • `attribute`  — per-asset marginal contribution. Stub in #236.
+ *   • `evolve`     — longitudinal evolution loop (Track B). Stub.
+ *   • `compare`    — diff two report JSON files. Stub.
+ *   • `attribute`  — per-asset marginal contribution. Stub.
  *
- * #236 implements `--help` and a thin `utility` skeleton that walks the
- * corpus and produces an empty report. The other three subcommands print a
- * pointer to their tracking issue and exit 2.
+ * #238 wires `utility` to the K-seed runner and §13.3 report renderer. The
+ * other three subcommands stay as "not yet implemented" pointers.
  *
- * NOTE: This file is intentionally argv-light. citty is the project's CLI
- * framework but the bench binary is not part of the public CLI surface, so
- * a hand-rolled parser keeps the dependency graph tight.
+ * NOTE: The bench binary is intentionally argv-light. citty is the project's
+ * CLI framework but the bench is not part of the public CLI surface, so a
+ * hand-rolled parser keeps the dependency graph tight.
  */
 
 import process from "node:process";
 
 import { listTasks } from "./corpus";
-import type { RunResult } from "./driver";
-import { computeOutcomeAggregate, type OutcomeAggregate } from "./metrics";
-import { renderJsonReport, renderMarkdownSummary } from "./report";
+import { renderUtilityReport } from "./report";
+import { runUtility } from "./runner";
 
 const HELP = `akm-bench — agent-plus-akm evaluation framework
 
@@ -35,13 +33,16 @@ Subcommands:
   compare       Diff two report JSON files (refuses cross-model diffs).
   attribute     Per-asset marginal pass-rate contribution.
 
-Common flags:
-  --tasks <slice>     train | eval | all  (default: eval)
-  --json              Emit JSON to stdout; markdown summary to stderr.
-  -h, --help          Show this message.
+utility flags:
+  --tasks <slice>          train | eval | all  (default: all)
+  --seeds <N>              seeds per arm  (default: 5)
+  --budget-tokens <N>      per-run token cap (default: 30000)
+  --budget-wall-ms <N>     per-run wallclock cap in ms (default: 120000)
+  --json                   emit JSON to stdout; markdown summary to stderr.
+  -h, --help               show this message.
 
 Environment:
-  BENCH_OPENCODE_MODEL   model id stamped into every RunResult.
+  BENCH_OPENCODE_MODEL   model id stamped into every RunResult. REQUIRED for utility.
 
 See tests/bench/BENCH.md for the operator guide.
 `;
@@ -89,65 +90,86 @@ function parseArgs(argv: string[]): ParsedArgs {
 }
 
 function notImplemented(name: string, issueRef: string): never {
-  process.stderr.write(`bench ${name}: not yet implemented in #236; see ${issueRef}.\n`);
+  process.stderr.write(`bench ${name}: not yet implemented; see ${issueRef}.\n`);
   process.exit(2);
 }
 
-interface UtilityOptions {
+export interface UtilityCliOptions {
   slice: "train" | "eval" | "all";
   json: boolean;
+  seedsPerArm: number;
+  budgetTokens: number;
+  budgetWallMs: number;
   model: string;
-  branch: string;
-  commit: string;
-  timestamp: string;
+  branch?: string;
+  commit?: string;
+  timestamp?: string;
+}
+
+export interface UtilityCliResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
 }
 
 /**
- * `utility` subcommand skeleton. #236 walks the corpus and emits an empty
- * report. Real run execution lands in #238 once the corpus has tasks.
+ * `utility` subcommand. Walks the corpus, runs K seeds per arm per task,
+ * and produces the §13.3 report.
+ *
+ * Returns rather than mutates process to keep this unit-testable. The
+ * `main()` driver below maps the result onto the actual stdout/stderr/exit.
  */
-export function runUtility(options: UtilityOptions): { exitCode: number; stdout: string; stderr: string } {
+export async function runUtilityCli(options: UtilityCliOptions): Promise<UtilityCliResult> {
   const sliceFilter = options.slice === "all" ? undefined : options.slice;
   const tasks = listTasks(sliceFilter ? { slice: sliceFilter } : {});
 
-  const empty: RunResult[] = [];
-  const arms: Record<string, OutcomeAggregate> = {
-    noakm: computeOutcomeAggregate(empty),
-    akm: computeOutcomeAggregate(empty),
-  };
-
-  const reportInput = {
-    timestamp: options.timestamp,
-    branch: options.branch,
-    commit: options.commit,
+  const report = await runUtility({
+    tasks,
+    arms: ["noakm", "akm"],
     model: options.model,
-    track: "utility" as const,
-    arms,
-  };
-  const json = renderJsonReport(reportInput);
-  const md = renderMarkdownSummary(reportInput);
+    seedsPerArm: options.seedsPerArm,
+    budgetTokens: options.budgetTokens,
+    budgetWallMs: options.budgetWallMs,
+    slice: options.slice,
+    ...(options.branch !== undefined ? { branch: options.branch } : {}),
+    ...(options.commit !== undefined ? { commit: options.commit } : {}),
+    ...(options.timestamp !== undefined ? { timestamp: options.timestamp } : {}),
+  });
 
-  let stdout = "";
-  let stderr = "";
+  const { json, markdown } = renderUtilityReport(report);
+  const jsonText = `${JSON.stringify(json, null, 2)}\n`;
+  const markdownText = `${markdown}\n`;
+
+  let stdout: string;
+  let stderr: string;
   if (options.json) {
-    stdout = `${json}\n`;
-    stderr = `${md}\n`;
+    stdout = jsonText;
+    stderr = markdownText;
   } else {
-    stdout = `${md}\n`;
+    stdout = markdownText;
+    stderr = "";
   }
   stderr += `tasks discovered: ${tasks.length} (slice=${options.slice})\n`;
   if (tasks.length === 0) {
-    stderr += "no tasks found — corpus is built in #237\n";
+    stderr += "no tasks found — corpus is empty or the slice filter excluded all tasks\n";
   }
+
   return { exitCode: 0, stdout, stderr };
 }
 
-function getEnv(name: string, fallback: string): string {
+function getEnv(name: string): string | undefined {
   const value = process.env[name];
-  return value && value.length > 0 ? value : fallback;
+  return value && value.length > 0 ? value : undefined;
 }
 
-function main(argv: string[]): number {
+function parseInt32(text: string | undefined, fallback: number): number {
+  if (text === undefined) return fallback;
+  const n = Number.parseInt(text, 10);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return n;
+}
+
+async function main(argv: string[]): Promise<number> {
   const parsed = parseArgs(argv);
 
   if (parsed.bool.has("help") || parsed.subcommand === "" || parsed.subcommand === "help") {
@@ -157,18 +179,23 @@ function main(argv: string[]): number {
 
   switch (parsed.subcommand) {
     case "utility": {
-      const sliceRaw = parsed.flags.get("tasks") ?? "eval";
+      const sliceRaw = parsed.flags.get("tasks") ?? "all";
       const slice =
         sliceRaw === "train" || sliceRaw === "eval" || sliceRaw === "all"
           ? (sliceRaw as "train" | "eval" | "all")
-          : "eval";
-      const result = runUtility({
+          : "all";
+      const model = getEnv("BENCH_OPENCODE_MODEL");
+      if (!model) {
+        process.stderr.write("bench utility: BENCH_OPENCODE_MODEL environment variable is required.\n");
+        return 2;
+      }
+      const result = await runUtilityCli({
         slice,
         json: parsed.bool.has("json"),
-        model: getEnv("BENCH_OPENCODE_MODEL", "unset"),
-        branch: getEnv("BENCH_BRANCH", "unknown"),
-        commit: getEnv("BENCH_COMMIT", "unknown"),
-        timestamp: new Date().toISOString(),
+        seedsPerArm: parseInt32(parsed.flags.get("seeds"), 5),
+        budgetTokens: parseInt32(parsed.flags.get("budget-tokens"), 30000),
+        budgetWallMs: parseInt32(parsed.flags.get("budget-wall-ms"), 120000),
+        model,
       });
       if (result.stdout) process.stdout.write(result.stdout);
       if (result.stderr) process.stderr.write(result.stderr);
@@ -187,9 +214,9 @@ function main(argv: string[]): number {
   }
 }
 
-// Only execute when invoked directly. The exported `runUtility` is callable
+// Only execute when invoked directly. The exported `runUtilityCli` is callable
 // from tests without triggering process.exit.
 if (import.meta.main) {
-  const code = main(process.argv.slice(2));
+  const code = await main(process.argv.slice(2));
   process.exit(code);
 }

--- a/tests/bench/driver.test.ts
+++ b/tests/bench/driver.test.ts
@@ -14,6 +14,7 @@ import {
   _ISOLATED_ENV_NAMES,
   buildIsolatedEnv,
   createIsolationDirs,
+  EVENTS_READ_CAP_BYTES,
   parseTokenUsage,
   type RunOptions,
   readRunEvents,
@@ -243,6 +244,50 @@ describe("driver helpers", () => {
       const events = readRunEvents(tmp);
       expect(events.length).toBe(1);
       expect(events[0]?.eventType).toBe("feedback");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("readRunEvents caps reads at EVENTS_READ_CAP_BYTES and records a warning when exceeded", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bench-events-cap-"));
+    try {
+      const akm = path.join(tmp, "akm");
+      fs.mkdirSync(akm, { recursive: true });
+      const eventsPath = path.join(akm, "events.jsonl");
+      // Write a leading parseable record, then a giant filler line that
+      // pushes total size past the cap.
+      const firstLine = `${JSON.stringify({ schemaVersion: 1, ts: "2026-04-27T00:00:00Z", eventType: "feedback" })}\n`;
+      const fd = fs.openSync(eventsPath, "w");
+      try {
+        fs.writeSync(fd, firstLine);
+        // Filler line: a single very long line that — combined with the
+        // first — exceeds the cap. We cap at 16MiB so write 17MiB of 'x'.
+        const fillerSize = EVENTS_READ_CAP_BYTES + 1024 * 1024;
+        const chunk = Buffer.alloc(64 * 1024, "x".charCodeAt(0));
+        let written = 0;
+        while (written < fillerSize) {
+          const remaining = fillerSize - written;
+          const toWrite = remaining < chunk.length ? chunk.subarray(0, remaining) : chunk;
+          fs.writeSync(fd, toWrite);
+          written += toWrite.length;
+        }
+        fs.writeSync(fd, "\n");
+      } finally {
+        fs.closeSync(fd);
+      }
+      const totalSize = fs.statSync(eventsPath).size;
+      expect(totalSize).toBeGreaterThan(EVENTS_READ_CAP_BYTES);
+
+      const warnings: string[] = [];
+      const events = readRunEvents(tmp, { warnings });
+      // The first parseable record should still be returned from the prefix.
+      expect(events.length).toBe(1);
+      expect(events[0]?.eventType).toBe("feedback");
+      // A warning was appended that mentions the cap and the actual size.
+      expect(warnings.length).toBe(1);
+      expect(warnings[0]).toContain("events.jsonl truncated");
+      expect(warnings[0]).toContain(String(EVENTS_READ_CAP_BYTES));
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/tests/bench/driver.ts
+++ b/tests/bench/driver.ts
@@ -61,6 +61,12 @@ export interface RunOptions {
    * this `undefined` so each phase uses `Bun.spawn` directly.
    */
   spawn?: SpawnFn;
+  /**
+   * Optional collector for run-scoped warnings (e.g. events.jsonl truncated
+   * because it exceeded the read cap). The runner threads this in so the
+   * top-level report's `warnings[]` aggregates every cap hit.
+   */
+  warnings?: string[];
 }
 
 /**
@@ -146,13 +152,58 @@ export function parseTokenUsage(stdout: string): { input: number; output: number
 }
 
 /**
+ * Maximum bytes read from events.jsonl per run. A runaway agent producing
+ * GBs of structured-log output would otherwise OOM the bench. Trajectory
+ * parsing operates on the prefix; a warning is appended when the cap is
+ * hit so the report surfaces the truncation.
+ */
+export const EVENTS_READ_CAP_BYTES = 16 * 1024 * 1024;
+
+/**
  * Read the events.jsonl file produced by this run, if any. The path is
  * `<XDG_CACHE_HOME>/akm/events.jsonl` per `src/core/events.ts`.
+ *
+ * Caps the number of bytes read at `EVENTS_READ_CAP_BYTES` (16 MiB). When the
+ * file is larger, the prefix is parsed and a warning is appended to
+ * `opts.warnings` (when supplied). The trailing partial line after a
+ * truncation is dropped, since `JSON.parse` would reject it anyway.
  */
-export function readRunEvents(cacheHome: string): EventEnvelope[] {
+export function readRunEvents(cacheHome: string, opts?: { warnings?: string[] }): EventEnvelope[] {
   const eventsPath = path.join(cacheHome, "akm", "events.jsonl");
   if (!fs.existsSync(eventsPath)) return [];
-  const text = fs.readFileSync(eventsPath, "utf8");
+
+  // Read up to the cap. We open the file rather than `readFileSync` so we
+  // don't allocate an arbitrarily large buffer just to throw most of it away.
+  let totalSize = 0;
+  try {
+    totalSize = fs.statSync(eventsPath).size;
+  } catch {
+    return [];
+  }
+  const cap = EVENTS_READ_CAP_BYTES;
+  const truncated = totalSize > cap;
+  let text: string;
+  if (truncated) {
+    const buf = Buffer.alloc(cap);
+    const fd = fs.openSync(eventsPath, "r");
+    try {
+      fs.readSync(fd, buf, 0, cap, 0);
+    } finally {
+      fs.closeSync(fd);
+    }
+    text = buf.toString("utf8");
+    // Drop the partial trailing line so we don't try to parse half a record.
+    const lastNl = text.lastIndexOf("\n");
+    if (lastNl !== -1) text = text.slice(0, lastNl);
+    if (opts?.warnings) {
+      opts.warnings.push(
+        `events.jsonl truncated: ${totalSize} bytes exceeds ${cap}-byte cap; trajectory computed from the prefix.`,
+      );
+    }
+  } else {
+    text = fs.readFileSync(eventsPath, "utf8");
+  }
+
   const out: EventEnvelope[] = [];
   let id = 0;
   for (const line of text.split("\n")) {
@@ -236,7 +287,7 @@ export async function runOne(options: RunOptions): Promise<RunResult> {
 
     result.wallclockMs = agentResult.durationMs;
     result.tokens = parseTokenUsage(agentResult.stdout);
-    result.events = readRunEvents(dirs.cacheHome);
+    result.events = readRunEvents(dirs.cacheHome, { warnings: options.warnings });
 
     if (!agentResult.ok) {
       if (agentResult.reason === "timeout") {

--- a/tests/bench/metrics.test.ts
+++ b/tests/bench/metrics.test.ts
@@ -1,11 +1,19 @@
 /**
- * Unit tests for `computeOutcomeAggregate`.
+ * Unit tests for outcome / per-task / corpus / trajectory aggregation.
  */
 
 import { describe, expect, test } from "bun:test";
 
 import type { RunResult } from "./driver";
-import { computeOutcomeAggregate } from "./metrics";
+import {
+  aggregateCorpus,
+  aggregatePerTask,
+  aggregateTrajectory,
+  computeCorpusDelta,
+  computeOutcomeAggregate,
+  computePerTaskDelta,
+  type PerTaskMetrics,
+} from "./metrics";
 
 function fakeResult(overrides: Partial<RunResult>): RunResult {
   return {
@@ -54,5 +62,191 @@ describe("computeOutcomeAggregate", () => {
     const agg = computeOutcomeAggregate(results);
     expect(agg.passRate).toBe(0);
     expect(agg.tokensPerPass).toBe(0);
+  });
+});
+
+describe("aggregatePerTask", () => {
+  test("0 of K passes — tokensPerPass is null, passRate is 0", () => {
+    const runs = [
+      fakeResult({ seed: 0, outcome: "fail", wallclockMs: 1000 }),
+      fakeResult({ seed: 1, outcome: "fail", wallclockMs: 2000 }),
+      fakeResult({ seed: 2, outcome: "harness_error", wallclockMs: 3000 }),
+    ];
+    const m = aggregatePerTask(runs);
+    expect(m.passRate).toBe(0);
+    expect(m.passAt1).toBe(0);
+    expect(m.tokensPerPass).toBeNull();
+    expect(m.wallclockMs).toBe(2000);
+    expect(m.harnessErrorCount).toBe(1);
+    expect(m.budgetExceededCount).toBe(0);
+    expect(m.count).toBe(3);
+  });
+
+  test("K of K passes — passRate is 1, stdev is 0", () => {
+    const runs = Array.from({ length: 5 }, (_, i) =>
+      fakeResult({ seed: i, outcome: "pass", tokens: { input: 1000, output: 0 }, wallclockMs: 1000 }),
+    );
+    const m = aggregatePerTask(runs);
+    expect(m.passRate).toBe(1);
+    expect(m.passAt1).toBe(1);
+    expect(m.tokensPerPass).toBe(1000);
+    expect(m.passRateStdev).toBe(0);
+  });
+
+  test("partial passes — passRate, stdev, and budget_exceeded count are computed", () => {
+    const runs = [
+      fakeResult({ seed: 0, outcome: "pass", tokens: { input: 800, output: 200 }, wallclockMs: 1000 }),
+      fakeResult({ seed: 1, outcome: "pass", tokens: { input: 1200, output: 300 }, wallclockMs: 1500 }),
+      fakeResult({ seed: 2, outcome: "fail", wallclockMs: 2000 }),
+      fakeResult({ seed: 3, outcome: "budget_exceeded", wallclockMs: 3000 }),
+    ];
+    const m = aggregatePerTask(runs);
+    expect(m.passRate).toBeCloseTo(0.5);
+    expect(m.passAt1).toBe(1);
+    expect(m.tokensPerPass).toBeCloseTo((1000 + 1500) / 2);
+    expect(m.budgetExceededCount).toBe(1);
+    // Sample stdev of [1, 1, 0, 0] over 4 samples = sqrt(4/3 * 0.25) — non-zero.
+    expect(m.passRateStdev).toBeGreaterThan(0);
+  });
+
+  test("passAt1 honours seed=0 specifically when present", () => {
+    const runs = [
+      fakeResult({ seed: 1, outcome: "pass" }),
+      fakeResult({ seed: 0, outcome: "fail" }),
+      fakeResult({ seed: 2, outcome: "pass" }),
+    ];
+    const m = aggregatePerTask(runs);
+    expect(m.passAt1).toBe(0);
+  });
+
+  test("empty input returns a zeroed envelope", () => {
+    const m = aggregatePerTask([]);
+    expect(m.count).toBe(0);
+    expect(m.passRate).toBe(0);
+    expect(m.tokensPerPass).toBeNull();
+  });
+});
+
+describe("aggregateCorpus", () => {
+  test("weights every task equally regardless of seed count", () => {
+    const perTask: Record<string, PerTaskMetrics> = {
+      a: {
+        passRate: 1,
+        passAt1: 1,
+        tokensPerPass: 1000,
+        wallclockMs: 1000,
+        passRateStdev: 0,
+        budgetExceededCount: 0,
+        harnessErrorCount: 0,
+        count: 5,
+      },
+      b: {
+        passRate: 0,
+        passAt1: 0,
+        tokensPerPass: null,
+        wallclockMs: 2000,
+        passRateStdev: 0,
+        budgetExceededCount: 0,
+        harnessErrorCount: 0,
+        count: 1,
+      },
+    };
+    const corpus = aggregateCorpus(perTask);
+    expect(corpus.passRate).toBeCloseTo(0.5);
+    expect(corpus.wallclockMs).toBeCloseTo(1500);
+    expect(corpus.tokensPerPass).toBeCloseTo(1000); // null is dropped
+  });
+
+  test("tokensPerPass is null when every task has null tokensPerPass", () => {
+    const perTask: Record<string, PerTaskMetrics> = {
+      a: {
+        passRate: 0,
+        passAt1: 0,
+        tokensPerPass: null,
+        wallclockMs: 1000,
+        passRateStdev: 0,
+        budgetExceededCount: 0,
+        harnessErrorCount: 0,
+        count: 1,
+      },
+    };
+    const corpus = aggregateCorpus(perTask);
+    expect(corpus.tokensPerPass).toBeNull();
+  });
+
+  test("empty input returns zeros + null tokens", () => {
+    const corpus = aggregateCorpus({});
+    expect(corpus.passRate).toBe(0);
+    expect(corpus.tokensPerPass).toBeNull();
+  });
+});
+
+describe("delta helpers", () => {
+  test("computeCorpusDelta — akm − noakm", () => {
+    const noakm = { passRate: 0.3, tokensPerPass: 18000, wallclockMs: 4000 };
+    const akm = { passRate: 0.7, tokensPerPass: 14000, wallclockMs: 3000 };
+    const d = computeCorpusDelta(noakm, akm);
+    expect(d.passRate).toBeCloseTo(0.4);
+    expect(d.tokensPerPass).toBeCloseTo(-4000);
+    expect(d.wallclockMs).toBeCloseTo(-1000);
+  });
+
+  test("computeCorpusDelta — null tokensPerPass propagates", () => {
+    const noakm = { passRate: 0, tokensPerPass: null, wallclockMs: 1 };
+    const akm = { passRate: 1, tokensPerPass: 5, wallclockMs: 2 };
+    expect(computeCorpusDelta(noakm, akm).tokensPerPass).toBeNull();
+  });
+
+  test("computePerTaskDelta — same null-safety rule", () => {
+    const noakm: PerTaskMetrics = {
+      passRate: 0,
+      passAt1: 0,
+      tokensPerPass: null,
+      wallclockMs: 0,
+      passRateStdev: 0,
+      budgetExceededCount: 0,
+      harnessErrorCount: 0,
+      count: 1,
+    };
+    const akm: PerTaskMetrics = {
+      passRate: 1,
+      passAt1: 1,
+      tokensPerPass: 1000,
+      wallclockMs: 100,
+      passRateStdev: 0,
+      budgetExceededCount: 0,
+      harnessErrorCount: 0,
+      count: 1,
+    };
+    expect(computePerTaskDelta(noakm, akm).tokensPerPass).toBeNull();
+  });
+});
+
+describe("aggregateTrajectory", () => {
+  test("returns null/0 on empty input", () => {
+    const t = aggregateTrajectory([]);
+    expect(t.correctAssetLoaded).toBeNull();
+    expect(t.feedbackRecorded).toBe(0);
+  });
+
+  test("correctAssetLoaded is null when no run had a known goldRef", () => {
+    const runs = [
+      fakeResult({ trajectory: { correctAssetLoaded: null, feedbackRecorded: false } }),
+      fakeResult({ trajectory: { correctAssetLoaded: null, feedbackRecorded: true } }),
+    ];
+    const t = aggregateTrajectory(runs);
+    expect(t.correctAssetLoaded).toBeNull();
+    expect(t.feedbackRecorded).toBeCloseTo(0.5);
+  });
+
+  test("correctAssetLoaded is fraction over runs with goldRef", () => {
+    const runs = [
+      fakeResult({ trajectory: { correctAssetLoaded: true, feedbackRecorded: false } }),
+      fakeResult({ trajectory: { correctAssetLoaded: false, feedbackRecorded: false } }),
+      fakeResult({ trajectory: { correctAssetLoaded: null, feedbackRecorded: false } }),
+    ];
+    const t = aggregateTrajectory(runs);
+    expect(t.correctAssetLoaded).toBeCloseTo(0.5);
+    expect(t.feedbackRecorded).toBe(0);
   });
 });

--- a/tests/bench/metrics.ts
+++ b/tests/bench/metrics.ts
@@ -1,14 +1,15 @@
 /**
  * akm-bench metrics (spec §6).
  *
- * #236 ships only `computeOutcomeAggregate`; the §6.1-6.8 catalog (trajectory,
- * proposal-quality, longitudinal, attribution, failure-mode taxonomy, search-
- * pipeline bridge, feedback-signal integrity) lands in #238 and beyond. The
- * single function here is what `bench utility`'s unit test exercises so the
- * CLI dispatcher has something concrete to call.
+ * Outcome metrics (§6.1) and trajectory metrics (§6.2). Both are pure
+ * functions over `RunResult[]` slices so the runner can compose them
+ * however it likes. The §6.3+ catalog (proposal-quality, longitudinal,
+ * attribution, failure-mode taxonomy) lands in #239/#240/#243.
  */
 
 import type { RunResult } from "./driver";
+
+// ── Outcome (§6.1) ─────────────────────────────────────────────────────────
 
 export interface OutcomeAggregate {
   /** Fraction of runs whose outcome is `pass`. Zero when results is empty. */
@@ -28,9 +29,8 @@ export interface OutcomeAggregate {
  * Aggregate outcome metrics over a flat list of RunResults.
  *
  * Aggregations across multiple arms are the caller's responsibility — pass
- * each arm's slice in separately. This helper deliberately stays a single
- * pure function so the v1 contract is "what does a single bag of runs look
- * like in summary." Anything richer is post-#236.
+ * each arm's slice in separately. Backward-compatible v1 contract; the
+ * richer per-task / corpus shapes below subsume this.
  */
 export function computeOutcomeAggregate(results: RunResult[]): OutcomeAggregate {
   if (results.length === 0) {
@@ -54,5 +54,191 @@ export function computeOutcomeAggregate(results: RunResult[]): OutcomeAggregate 
     tokensPerPass: passes === 0 ? 0 : totalTokensInPasses / passes,
     wallclockMs: totalWallclock / results.length,
     budgetExceeded,
+  };
+}
+
+// ── Per-task aggregation (§6.1, K seeds per arm) ───────────────────────────
+
+/**
+ * Per-(task, arm) aggregate produced by collapsing K seed runs.
+ *
+ * `tokensPerPass` is `null` when no run in the bag passed (NaN-safety —
+ * downstream report renderers turn `null` into a sentinel rather than
+ * `Infinity` polluting the JSON envelope).
+ */
+export interface PerTaskMetrics {
+  /** Fraction of K runs that passed. */
+  passRate: number;
+  /** Pass-or-fail of seed 0 (or first run when seed 0 is absent). */
+  passAt1: 0 | 1;
+  /** Mean total tokens in passing runs. `null` when 0 passes. */
+  tokensPerPass: number | null;
+  /** Mean wallclock ms across all K runs. */
+  wallclockMs: number;
+  /** Sample standard deviation of pass (1) / fail (0) across the K seeds. */
+  passRateStdev: number;
+  /** Count of `budget_exceeded` outcomes across the K seeds. */
+  budgetExceededCount: number;
+  /** Count of `harness_error` outcomes across the K seeds. */
+  harnessErrorCount: number;
+  /** Number of runs aggregated. Useful when K varies (last seed dropped, etc.). */
+  count: number;
+}
+
+/**
+ * Aggregate K seed runs of one (task, arm) pair into PerTaskMetrics. Returns
+ * a zeroed envelope on empty input — callers decide whether to skip or render.
+ */
+export function aggregatePerTask(results: RunResult[]): PerTaskMetrics {
+  if (results.length === 0) {
+    return {
+      passRate: 0,
+      passAt1: 0,
+      tokensPerPass: null,
+      wallclockMs: 0,
+      passRateStdev: 0,
+      budgetExceededCount: 0,
+      harnessErrorCount: 0,
+      count: 0,
+    };
+  }
+
+  let passes = 0;
+  let totalTokensInPasses = 0;
+  let totalWallclock = 0;
+  let budgetExceeded = 0;
+  let harnessError = 0;
+  // For the standard deviation we need a fixed-iteration buffer of pass/fail.
+  const passSamples: number[] = [];
+  for (const r of results) {
+    totalWallclock += r.wallclockMs;
+    const isPass = r.outcome === "pass" ? 1 : 0;
+    passSamples.push(isPass);
+    if (isPass === 1) {
+      passes += 1;
+      totalTokensInPasses += r.tokens.input + r.tokens.output;
+    } else if (r.outcome === "budget_exceeded") {
+      budgetExceeded += 1;
+    } else if (r.outcome === "harness_error") {
+      harnessError += 1;
+    }
+  }
+
+  const seed0 = results.find((r) => r.seed === 0) ?? results[0];
+  const passAt1: 0 | 1 = seed0 && seed0.outcome === "pass" ? 1 : 0;
+
+  return {
+    passRate: passes / results.length,
+    passAt1,
+    tokensPerPass: passes === 0 ? null : totalTokensInPasses / passes,
+    wallclockMs: totalWallclock / results.length,
+    passRateStdev: stdev(passSamples),
+    budgetExceededCount: budgetExceeded,
+    harnessErrorCount: harnessError,
+    count: results.length,
+  };
+}
+
+/** Sample standard deviation. Returns 0 for length ≤ 1 (no spread to measure). */
+function stdev(values: number[]): number {
+  if (values.length <= 1) return 0;
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const sumSq = values.reduce((acc, v) => acc + (v - mean) * (v - mean), 0);
+  // Sample stdev (Bessel's correction) — n-1 denominator.
+  return Math.sqrt(sumSq / (values.length - 1));
+}
+
+// ── Corpus aggregation (§6.1 corpus-wide row) ──────────────────────────────
+
+/** Corpus aggregate is a mean over per-task metrics, weighting each task equally. */
+export interface CorpusMetrics {
+  passRate: number;
+  /** Mean over per-task tokensPerPass, treating `null` as missing. `null` if all missing. */
+  tokensPerPass: number | null;
+  wallclockMs: number;
+}
+
+/**
+ * Mean across per-task metrics. Each task contributes once, regardless of
+ * how many seeds it ran (K is already collapsed in `aggregatePerTask`).
+ *
+ * `tokensPerPass`: tasks where `tokensPerPass` is `null` (no passes) are
+ * dropped from that mean. The result is `null` if every task failed.
+ */
+export function aggregateCorpus(perTask: Record<string, PerTaskMetrics>): CorpusMetrics {
+  const tasks = Object.values(perTask);
+  if (tasks.length === 0) {
+    return { passRate: 0, tokensPerPass: null, wallclockMs: 0 };
+  }
+  const passRate = tasks.reduce((a, t) => a + t.passRate, 0) / tasks.length;
+  const wallclockMs = tasks.reduce((a, t) => a + t.wallclockMs, 0) / tasks.length;
+  const tppValues = tasks.map((t) => t.tokensPerPass).filter((v): v is number => v !== null);
+  const tokensPerPass = tppValues.length === 0 ? null : tppValues.reduce((a, b) => a + b, 0) / tppValues.length;
+  return { passRate, tokensPerPass, wallclockMs };
+}
+
+// ── Delta (§6.1 corpus row, akm vs noakm) ──────────────────────────────────
+
+export interface CorpusDelta {
+  passRate: number;
+  /** akm − noakm. `null` if either side is `null`. */
+  tokensPerPass: number | null;
+  wallclockMs: number;
+}
+
+/**
+ * Compute the akm − noakm delta. Negative `tokensPerPass`/`wallclockMs` mean
+ * akm was cheaper / faster; positive means it cost more. Pass-rate uses the
+ * opposite convention (positive = akm wins).
+ */
+export function computeCorpusDelta(noakm: CorpusMetrics, akm: CorpusMetrics): CorpusDelta {
+  return {
+    passRate: akm.passRate - noakm.passRate,
+    tokensPerPass:
+      akm.tokensPerPass === null || noakm.tokensPerPass === null ? null : akm.tokensPerPass - noakm.tokensPerPass,
+    wallclockMs: akm.wallclockMs - noakm.wallclockMs,
+  };
+}
+
+/** Per-task delta with the same null-safety as the corpus delta. */
+export function computePerTaskDelta(noakm: PerTaskMetrics, akm: PerTaskMetrics): CorpusDelta {
+  return {
+    passRate: akm.passRate - noakm.passRate,
+    tokensPerPass:
+      akm.tokensPerPass === null || noakm.tokensPerPass === null ? null : akm.tokensPerPass - noakm.tokensPerPass,
+    wallclockMs: akm.wallclockMs - noakm.wallclockMs,
+  };
+}
+
+// ── Trajectory (§6.2) ──────────────────────────────────────────────────────
+
+export interface TrajectoryAggregate {
+  /**
+   * Fraction of runs (with a known goldRef) where the agent loaded the
+   * correct asset. `null` when no run had a goldRef.
+   */
+  correctAssetLoaded: number | null;
+  /** Fraction of runs that emitted a `feedback` event. `0..1`. */
+  feedbackRecorded: number;
+}
+
+/** Aggregate trajectory booleans across a bag of runs. */
+export function aggregateTrajectory(results: RunResult[]): TrajectoryAggregate {
+  if (results.length === 0) {
+    return { correctAssetLoaded: null, feedbackRecorded: 0 };
+  }
+  let knownAsset = 0;
+  let assetLoaded = 0;
+  let feedback = 0;
+  for (const r of results) {
+    if (r.trajectory.correctAssetLoaded !== null) {
+      knownAsset += 1;
+      if (r.trajectory.correctAssetLoaded) assetLoaded += 1;
+    }
+    if (r.trajectory.feedbackRecorded === true) feedback += 1;
+  }
+  return {
+    correctAssetLoaded: knownAsset === 0 ? null : assetLoaded / knownAsset,
+    feedbackRecorded: feedback / results.length,
   };
 }

--- a/tests/bench/report.test.ts
+++ b/tests/bench/report.test.ts
@@ -3,8 +3,19 @@
  */
 
 import { describe, expect, test } from "bun:test";
-
-import { type ReportInput, renderJsonReport, renderMarkdownSummary } from "./report";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { PerTaskMetrics } from "./metrics";
+import {
+  type ReportInput,
+  renderJsonReport,
+  renderMarkdownSummary,
+  renderUtilityReport,
+  resolveGitBranch,
+  resolveGitCommit,
+  type UtilityRunReport,
+} from "./report";
 
 const sample: ReportInput = {
   timestamp: "2026-04-27T12:00:00Z",
@@ -49,5 +60,145 @@ describe("renderMarkdownSummary", () => {
     expect(md).toContain("noakm");
     expect(md).toContain("akm");
     expect(md).toContain("pass_rate=");
+  });
+});
+
+// ── Utility-track report (§13.3) ───────────────────────────────────────────
+
+function pt(passRate: number, tokens: number | null, wall: number, count = 5): PerTaskMetrics {
+  const passes = Math.round(passRate * count);
+  return {
+    passRate,
+    passAt1: passes > 0 ? 1 : 0,
+    tokensPerPass: tokens,
+    wallclockMs: wall,
+    passRateStdev: 0,
+    budgetExceededCount: 0,
+    harnessErrorCount: 0,
+    count,
+  };
+}
+
+const utilSample: UtilityRunReport = {
+  timestamp: "2026-04-27T12:00:00Z",
+  branch: "release/1.0.0",
+  commit: "deadbee",
+  model: "anthropic/claude-opus-4-7",
+  corpus: { domains: 3, tasks: 2, slice: "all", seedsPerArm: 5 },
+  aggregateNoakm: { passRate: 0.4, tokensPerPass: 18000, wallclockMs: 41000 },
+  aggregateAkm: { passRate: 0.7, tokensPerPass: 14000, wallclockMs: 36000 },
+  aggregateDelta: { passRate: 0.3, tokensPerPass: -4000, wallclockMs: -5000 },
+  trajectoryAkm: { correctAssetLoaded: 0.78, feedbackRecorded: 0.65 },
+  tasks: [
+    {
+      id: "domain-a/task-1",
+      noakm: pt(0.4, 20000, 40000),
+      akm: pt(0.8, 13000, 35000),
+      delta: { passRate: 0.4, tokensPerPass: -7000, wallclockMs: -5000 },
+    },
+    {
+      id: "domain-b/task-2",
+      noakm: pt(0.4, null, 42000),
+      akm: pt(0.6, 15000, 37000),
+      delta: { passRate: 0.2, tokensPerPass: null, wallclockMs: -5000 },
+    },
+  ],
+  warnings: [],
+};
+
+describe("renderUtilityReport JSON", () => {
+  test("conforms to the §13.3 shape", () => {
+    const { json } = renderUtilityReport(utilSample);
+    const obj = json as Record<string, unknown>;
+    expect(obj.schemaVersion).toBe(1);
+    expect(obj.track).toBe("utility");
+    expect(obj.branch).toBe("release/1.0.0");
+    expect(obj.commit).toBe("deadbee");
+    expect(obj.timestamp).toBe("2026-04-27T12:00:00Z");
+    expect((obj.agent as Record<string, unknown>).harness).toBe("opencode");
+    expect((obj.agent as Record<string, unknown>).model).toBe("anthropic/claude-opus-4-7");
+
+    const corpus = obj.corpus as Record<string, unknown>;
+    expect(corpus.domains).toBe(3);
+    expect(corpus.tasks).toBe(2);
+    expect(corpus.slice).toBe("all");
+    expect(corpus.seedsPerArm).toBe(5);
+
+    const aggregate = obj.aggregate as Record<string, Record<string, unknown>>;
+    expect(aggregate.noakm.pass_rate).toBeCloseTo(0.4);
+    expect(aggregate.akm.tokens_per_pass).toBe(14000);
+    expect(aggregate.delta.pass_rate).toBeCloseTo(0.3);
+    expect(aggregate.delta.wallclock_ms).toBeCloseTo(-5000);
+
+    const trajectory = obj.trajectory as Record<string, Record<string, unknown>>;
+    expect(trajectory.akm.correct_asset_loaded).toBeCloseTo(0.78);
+    expect(trajectory.akm.feedback_recorded).toBeCloseTo(0.65);
+
+    const tasks = obj.tasks as Array<Record<string, unknown>>;
+    expect(tasks.length).toBe(2);
+    expect(tasks[0]?.id).toBe("domain-a/task-1");
+    expect((tasks[0]?.akm as Record<string, unknown>).pass_rate).toBeCloseTo(0.8);
+    expect((tasks[1]?.delta as Record<string, unknown>).tokens_per_pass).toBeNull();
+
+    expect(obj.warnings).toEqual([]);
+  });
+});
+
+describe("renderUtilityReport markdown", () => {
+  test("contains the expected sections", () => {
+    const { markdown } = renderUtilityReport(utilSample);
+    expect(markdown).toContain("# akm-bench utility");
+    expect(markdown).toContain("anthropic/claude-opus-4-7");
+    expect(markdown).toContain("release/1.0.0");
+    expect(markdown).toContain("## Aggregate");
+    expect(markdown).toContain("## Trajectory (akm)");
+    expect(markdown).toContain("## Per-task pass rates");
+    expect(markdown).toContain("domain-a/task-1");
+    expect(markdown).toContain("domain-b/task-2");
+    expect(markdown).toContain("correct_asset_loaded: 78.0%");
+    expect(markdown).toContain("feedback_recorded: 65.0%");
+  });
+
+  test("delta row shows signed values", () => {
+    const { markdown } = renderUtilityReport(utilSample);
+    expect(markdown).toContain("**delta**");
+    expect(markdown).toContain("+0.30");
+    expect(markdown).toContain("-4000");
+    expect(markdown).toContain("-5000");
+  });
+
+  test("is byte-stable across reruns with identical input", () => {
+    const a = renderUtilityReport(utilSample).markdown;
+    const b = renderUtilityReport(utilSample).markdown;
+    expect(a).toBe(b);
+  });
+
+  test("renders warnings section when warnings are present", () => {
+    const withWarn: UtilityRunReport = { ...utilSample, warnings: ["stash xyz failed to load"] };
+    const { markdown } = renderUtilityReport(withWarn);
+    expect(markdown).toContain("## Warnings");
+    expect(markdown).toContain("stash xyz failed to load");
+  });
+});
+
+describe("git resolvers", () => {
+  test("resolveGitBranch + resolveGitCommit return non-empty strings in this repo", () => {
+    // The bench worktree IS a git repo; these MUST succeed.
+    const branch = resolveGitBranch();
+    const commit = resolveGitCommit();
+    expect(typeof branch).toBe("string");
+    expect(branch.length).toBeGreaterThan(0);
+    expect(typeof commit).toBe("string");
+    expect(commit.length).toBeGreaterThan(0);
+  });
+
+  test("falls back to 'unknown' outside a git repo", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bench-nogit-"));
+    try {
+      expect(resolveGitBranch(tmp)).toBe("unknown");
+      expect(resolveGitCommit(tmp)).toBe("unknown");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -1,12 +1,22 @@
 /**
  * akm-bench report rendering (spec §13.3).
  *
- * #236 ships a minimal stamped-JSON envelope plus a 5-line markdown summary.
- * The full §13.3 report shape — per-task breakdown, trajectory metrics,
- * delta arrays, warnings — lands in #238.
+ * Two report flavours coexist:
+ *
+ *   • `renderJsonReport` / `renderMarkdownSummary` — the simple v1 envelope
+ *     introduced in #236. Kept for backward-compat with the empty-corpus
+ *     skeleton path; not used by the populated `utility` flow.
+ *
+ *   • `renderUtilityReport` — the §13.3 shape, including per-task breakdown,
+ *     per-arm and corpus-wide aggregates, akm−noakm deltas, and the
+ *     trajectory subsection. This is what `bench utility` writes when the
+ *     corpus has tasks.
  */
 
-import type { OutcomeAggregate } from "./metrics";
+import { execSync } from "node:child_process";
+import type { CorpusDelta, CorpusMetrics, OutcomeAggregate, PerTaskMetrics, TrajectoryAggregate } from "./metrics";
+
+// ── Legacy envelope (#236) ─────────────────────────────────────────────────
 
 export interface ReportInput {
   /** ISO-8601 timestamp; caller is free to inject a fixed value in tests. */
@@ -42,8 +52,8 @@ export function renderJsonReport(input: ReportInput): string {
 }
 
 /**
- * 5-ish-line markdown summary for stderr / PR descriptions. The full diff
- * table lands with #238.
+ * 5-ish-line markdown summary for stderr / PR descriptions. Used by the
+ * empty-corpus skeleton path.
  */
 export function renderMarkdownSummary(input: ReportInput): string {
   const lines: string[] = [];
@@ -55,4 +65,225 @@ export function renderMarkdownSummary(input: ReportInput): string {
     );
   }
   return lines.join("\n");
+}
+
+// ── Utility-track report (§13.3) ───────────────────────────────────────────
+
+/**
+ * Per-task envelope inside `tasks[]`. Mirrors the §13.3 layout: `noakm` and
+ * `akm` are PerTaskMetrics, `delta` is the akm − noakm difference.
+ */
+export interface UtilityReportTaskEntry {
+  id: string;
+  noakm: PerTaskMetrics;
+  akm: PerTaskMetrics;
+  delta: CorpusDelta;
+}
+
+/**
+ * Top-level §13.3 input. The runner produces this; `renderUtilityReport`
+ * stamps it into the canonical shape (snake-case keys, percentages, etc.).
+ */
+export interface UtilityRunReport {
+  timestamp: string;
+  branch: string;
+  commit: string;
+  model: string;
+  corpus: {
+    domains: number;
+    tasks: number;
+    slice: "all" | "train" | "eval";
+    seedsPerArm: number;
+  };
+  aggregateNoakm: CorpusMetrics;
+  aggregateAkm: CorpusMetrics;
+  aggregateDelta: CorpusDelta;
+  trajectoryAkm: TrajectoryAggregate;
+  tasks: UtilityReportTaskEntry[];
+  warnings: string[];
+}
+
+/**
+ * Stamp a utility run into both the §13.3 JSON envelope and a markdown
+ * summary. Callers wire stdout/stderr separately.
+ *
+ * Determinism: given identical input the function is byte-stable. Markdown
+ * does not embed `timestamp` in the body table (only in the header), so
+ * snapshot tests are stable across reruns.
+ */
+export function renderUtilityReport(input: UtilityRunReport): { json: object; markdown: string } {
+  const json = buildUtilityJson(input);
+  const markdown = buildUtilityMarkdown(input);
+  return { json, markdown };
+}
+
+function buildUtilityJson(input: UtilityRunReport): object {
+  const tasks = input.tasks.map((t) => ({
+    id: t.id,
+    noakm: serialisePerTaskMetrics(t.noakm),
+    akm: serialisePerTaskMetrics(t.akm),
+    delta: serialiseDelta(t.delta),
+  }));
+
+  return {
+    schemaVersion: 1,
+    track: "utility",
+    branch: input.branch,
+    commit: input.commit,
+    timestamp: input.timestamp,
+    agent: { harness: "opencode", model: input.model },
+    corpus: input.corpus,
+    aggregate: {
+      noakm: serialiseCorpus(input.aggregateNoakm),
+      akm: serialiseCorpus(input.aggregateAkm),
+      delta: serialiseDelta(input.aggregateDelta),
+    },
+    trajectory: {
+      akm: {
+        correct_asset_loaded: input.trajectoryAkm.correctAssetLoaded,
+        feedback_recorded: input.trajectoryAkm.feedbackRecorded,
+      },
+    },
+    tasks,
+    warnings: input.warnings,
+  };
+}
+
+function serialiseCorpus(c: CorpusMetrics): {
+  pass_rate: number;
+  tokens_per_pass: number | null;
+  wallclock_ms: number;
+} {
+  return {
+    pass_rate: c.passRate,
+    tokens_per_pass: c.tokensPerPass,
+    wallclock_ms: c.wallclockMs,
+  };
+}
+
+function serialiseDelta(d: CorpusDelta): { pass_rate: number; tokens_per_pass: number | null; wallclock_ms: number } {
+  return {
+    pass_rate: d.passRate,
+    tokens_per_pass: d.tokensPerPass,
+    wallclock_ms: d.wallclockMs,
+  };
+}
+
+function serialisePerTaskMetrics(m: PerTaskMetrics): {
+  pass_rate: number;
+  pass_at_1: 0 | 1;
+  tokens_per_pass: number | null;
+  wallclock_ms: number;
+  pass_rate_stdev: number;
+  budget_exceeded_count: number;
+  harness_error_count: number;
+  count: number;
+} {
+  return {
+    pass_rate: m.passRate,
+    pass_at_1: m.passAt1,
+    tokens_per_pass: m.tokensPerPass,
+    wallclock_ms: m.wallclockMs,
+    pass_rate_stdev: m.passRateStdev,
+    budget_exceeded_count: m.budgetExceededCount,
+    harness_error_count: m.harnessErrorCount,
+    count: m.count,
+  };
+}
+
+function buildUtilityMarkdown(input: UtilityRunReport): string {
+  const lines: string[] = [];
+  lines.push(`# akm-bench utility — ${input.model}`);
+  lines.push("");
+  lines.push(`branch \`${input.branch}\` @ \`${input.commit}\` — ${input.timestamp}`);
+  lines.push(
+    `corpus: ${input.corpus.tasks} tasks across ${input.corpus.domains} domains (slice=${input.corpus.slice}, seedsPerArm=${input.corpus.seedsPerArm})`,
+  );
+  lines.push("");
+  lines.push("## Aggregate");
+  lines.push("");
+  lines.push("| arm | pass_rate | tokens_per_pass | wallclock_ms |");
+  lines.push("|-----|-----------|-----------------|--------------|");
+  lines.push(corpusRow("noakm", input.aggregateNoakm));
+  lines.push(corpusRow("akm", input.aggregateAkm));
+  lines.push(deltaRow(input.aggregateDelta));
+  lines.push("");
+  lines.push("## Trajectory (akm)");
+  lines.push("");
+  lines.push(`- correct_asset_loaded: ${formatPercent(input.trajectoryAkm.correctAssetLoaded)}`);
+  lines.push(`- feedback_recorded: ${formatPercent(input.trajectoryAkm.feedbackRecorded)}`);
+  lines.push("");
+  lines.push("## Per-task pass rates");
+  lines.push("");
+  lines.push("| task | noakm | akm | delta |");
+  lines.push("|------|-------|-----|-------|");
+  // Sort tasks alphabetically for byte-stable markdown output.
+  const sorted = [...input.tasks].sort((a, b) => a.id.localeCompare(b.id));
+  for (const t of sorted) {
+    lines.push(taskRow(t));
+  }
+  if (input.warnings.length > 0) {
+    lines.push("");
+    lines.push("## Warnings");
+    lines.push("");
+    for (const w of input.warnings) lines.push(`- ${w}`);
+  }
+  return lines.join("\n");
+}
+
+function corpusRow(arm: string, c: CorpusMetrics): string {
+  const tpp = c.tokensPerPass === null ? "n/a" : c.tokensPerPass.toFixed(0);
+  return `| ${arm} | ${c.passRate.toFixed(2)} | ${tpp} | ${c.wallclockMs.toFixed(0)} |`;
+}
+
+function deltaRow(d: CorpusDelta): string {
+  const tpp = d.tokensPerPass === null ? "n/a" : signed(d.tokensPerPass.toFixed(0));
+  return `| **delta** | ${signed(d.passRate.toFixed(2))} | ${tpp} | ${signed(d.wallclockMs.toFixed(0))} |`;
+}
+
+function taskRow(t: UtilityReportTaskEntry): string {
+  return `| ${t.id} | ${t.noakm.passRate.toFixed(2)} | ${t.akm.passRate.toFixed(2)} | ${signed(t.delta.passRate.toFixed(2))} |`;
+}
+
+function signed(text: string): string {
+  if (text.startsWith("-")) return text;
+  if (text === "0" || text === "0.00" || text === "0.0") return text;
+  return `+${text}`;
+}
+
+function formatPercent(value: number | null): string {
+  if (value === null) return "n/a";
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+// ── Git helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Resolve `git rev-parse --abbrev-ref HEAD`. Falls back to `"unknown"` if
+ * git is unavailable or the cwd is not a repo. Tests inject `cwd` to point
+ * at a tmp non-repo to exercise the fallback.
+ */
+export function resolveGitBranch(cwd?: string): string {
+  return tryGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+}
+
+/**
+ * Resolve `git rev-parse --short HEAD`. Same fallback rules as
+ * `resolveGitBranch`.
+ */
+export function resolveGitCommit(cwd?: string): string {
+  return tryGit(["rev-parse", "--short", "HEAD"], cwd);
+}
+
+function tryGit(args: string[], cwd?: string): string {
+  try {
+    const out = execSync(`git ${args.join(" ")}`, {
+      cwd: cwd ?? process.cwd(),
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+    });
+    return out.trim() || "unknown";
+  } catch {
+    return "unknown";
+  }
 }

--- a/tests/bench/runner.test.ts
+++ b/tests/bench/runner.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Unit tests for the K-seed runner.
+ *
+ * The runner is exercised end-to-end with an injected fake spawn so no real
+ * opencode binary is required. We assert:
+ *   • Cardinality: tasks × arms × seeds RunResults are produced.
+ *   • Workspace isolation: each (arm, seed) sees a fresh cwd.
+ *   • Cleanup: tmp dirs are torn down on success and failure.
+ *   • Trajectory splice: goldRef + tool-call output produces the right boolean.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { SpawnedSubprocess, SpawnFn } from "../../src/integrations/agent/spawn";
+import type { TaskMetadata } from "./corpus";
+import { runUtility } from "./runner";
+
+function asReadableStream(text: string): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(text);
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+function fakeSpawnFactory(
+  agentStdoutByArm: { noakm?: string; akm?: string } = {},
+  options: { agentExitCode?: number; verifierExitCode?: number; verifierStdout?: string } = {},
+): { spawn: SpawnFn; observed: { cmd: string[]; cwd?: string; armSeen: ("noakm" | "akm")[] } } {
+  const observed = { cmd: [] as string[], cwd: undefined as string | undefined, armSeen: [] as ("noakm" | "akm")[] };
+  let lastArmCacheHome: string | undefined;
+  const spawn: SpawnFn = (cmd, opts) => {
+    observed.cmd = cmd;
+    observed.cwd = opts.cwd;
+    const isAgent = cmd[0] === "opencode";
+    let arm: "noakm" | "akm" = "noakm";
+    if (isAgent) {
+      arm = opts.env?.AKM_STASH_DIR ? "akm" : "noakm";
+      observed.armSeen.push(arm);
+      lastArmCacheHome = opts.env?.XDG_CACHE_HOME;
+    }
+    const stdout = isAgent
+      ? ((arm === "akm" ? agentStdoutByArm.akm : agentStdoutByArm.noakm) ?? "")
+      : (options.verifierStdout ?? "");
+    const exitCode = isAgent ? (options.agentExitCode ?? 0) : (options.verifierExitCode ?? 0);
+
+    const proc: SpawnedSubprocess = {
+      exitCode,
+      exited: Promise.resolve(exitCode),
+      stdout: asReadableStream(stdout),
+      stderr: asReadableStream(""),
+      stdin: null,
+      kill() {},
+    };
+
+    // For akm-arm runs, drop a synthetic events.jsonl into the cache home so
+    // the trajectory parser sees a feedback event when the test wants one.
+    if (isAgent && arm === "akm" && lastArmCacheHome && agentStdoutByArm.akm?.includes("FEEDBACK")) {
+      const akmDir = path.join(lastArmCacheHome, "akm");
+      fs.mkdirSync(akmDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(akmDir, "events.jsonl"),
+        `${JSON.stringify({ schemaVersion: 1, ts: "2026-04-27T00:00:00Z", eventType: "feedback", ref: "skill:foo" })}\n`,
+      );
+    }
+
+    return proc;
+  };
+  return { spawn, observed };
+}
+
+function fakeTask(taskDir: string, overrides: Partial<TaskMetadata> = {}): TaskMetadata {
+  return {
+    id: "fake/task-a",
+    title: "Fake task",
+    domain: "fake",
+    difficulty: "easy",
+    stash: "minimal",
+    verifier: "regex",
+    expectedMatch: "ok",
+    budget: { tokens: 1000, wallMs: 5000 },
+    taskDir,
+    ...overrides,
+  };
+}
+
+describe("runUtility", () => {
+  let workspaceRoot: string;
+  let taskDir: string;
+
+  beforeAll(() => {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bench-runner-test-"));
+    taskDir = path.join(workspaceRoot, "task-a");
+    fs.mkdirSync(taskDir, { recursive: true });
+    // No workspace template — runs start with empty cwd, which is valid.
+  });
+
+  afterAll(() => {
+    fs.rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  test("produces tasks × arms × seeds run records (cardinality)", async () => {
+    const { spawn, observed } = fakeSpawnFactory({ noakm: "ok", akm: "ok" });
+    const report = await runUtility({
+      tasks: [fakeTask(taskDir)],
+      arms: ["noakm", "akm"],
+      model: "test-model",
+      seedsPerArm: 3,
+      spawn,
+      materialiseStash: false,
+      branch: "test-branch",
+      commit: "abc123",
+      timestamp: "2026-04-27T00:00:00Z",
+    });
+    expect(report.tasks.length).toBe(1);
+    // 3 seeds × 2 arms = 6 agent invocations.
+    expect(observed.armSeen.length).toBe(6);
+    expect(observed.armSeen.filter((a) => a === "akm").length).toBe(3);
+    expect(observed.armSeen.filter((a) => a === "noakm").length).toBe(3);
+
+    // Per-task aggregates were filled.
+    const t = report.tasks[0];
+    expect(t).toBeDefined();
+    expect(t?.noakm.count).toBe(3);
+    expect(t?.akm.count).toBe(3);
+    expect(t?.noakm.passRate).toBe(1); // verifier exitCode 0 → pass
+    expect(t?.akm.passRate).toBe(1);
+  });
+
+  test("workspace isolation: each run gets a fresh cwd", async () => {
+    const cwds = new Set<string>();
+    const spawn: SpawnFn = (cmd, opts) => {
+      if (cmd[0] === "opencode" && opts.cwd) cwds.add(opts.cwd);
+      return {
+        exitCode: 0,
+        exited: Promise.resolve(0),
+        stdout: asReadableStream("ok"),
+        stderr: asReadableStream(""),
+        stdin: null,
+        kill() {},
+      };
+    };
+    const report = await runUtility({
+      tasks: [fakeTask(taskDir)],
+      arms: ["noakm", "akm"],
+      model: "test",
+      seedsPerArm: 2,
+      spawn,
+      materialiseStash: false,
+    });
+    expect(report.tasks.length).toBe(1);
+    // 2 seeds × 2 arms = 4 unique cwds.
+    expect(cwds.size).toBe(4);
+  });
+
+  test("cleanup: workspace tmp dirs are removed after each run", async () => {
+    const cwdsObserved = new Set<string>();
+    const spawn: SpawnFn = (cmd, opts) => {
+      if (cmd[0] === "opencode" && opts.cwd) cwdsObserved.add(opts.cwd);
+      return {
+        exitCode: 0,
+        exited: Promise.resolve(0),
+        stdout: asReadableStream("ok"),
+        stderr: asReadableStream(""),
+        stdin: null,
+        kill() {},
+      };
+    };
+    await runUtility({
+      tasks: [fakeTask(taskDir)],
+      arms: ["noakm"],
+      model: "test",
+      seedsPerArm: 2,
+      spawn,
+      materialiseStash: false,
+    });
+    expect(cwdsObserved.size).toBe(2);
+    for (const cwd of cwdsObserved) {
+      expect(fs.existsSync(cwd)).toBe(false);
+    }
+  });
+
+  test("cleanup happens even when verifier reports failure (workspace still removed)", async () => {
+    const cwdsObserved = new Set<string>();
+    const spawn: SpawnFn = (cmd, opts) => {
+      if (cmd[0] === "opencode" && opts.cwd) cwdsObserved.add(opts.cwd);
+      const isAgent = cmd[0] === "opencode";
+      const exitCode = isAgent ? 0 : 1;
+      return {
+        exitCode,
+        exited: Promise.resolve(exitCode),
+        stdout: asReadableStream(isAgent ? "nope" : ""),
+        stderr: asReadableStream(""),
+        stdin: null,
+        kill() {},
+      };
+    };
+    const report = await runUtility({
+      tasks: [fakeTask(taskDir)],
+      arms: ["noakm"],
+      model: "test",
+      seedsPerArm: 2,
+      spawn,
+      materialiseStash: false,
+    });
+    expect(report.tasks[0]?.noakm.passRate).toBe(0);
+    for (const cwd of cwdsObserved) {
+      expect(fs.existsSync(cwd)).toBe(false);
+    }
+  });
+
+  test("trajectory splice: correctAssetLoaded + feedbackRecorded fill from akm-arm runs", async () => {
+    const akmStdout = "tool: akm show skill:foo\nFEEDBACK emitted\n";
+    const { spawn } = fakeSpawnFactory({ noakm: "ok", akm: akmStdout });
+    const report = await runUtility({
+      tasks: [fakeTask(taskDir, { goldRef: "skill:foo" })],
+      arms: ["noakm", "akm"],
+      model: "test",
+      seedsPerArm: 2,
+      spawn,
+      materialiseStash: false,
+    });
+    expect(report.trajectoryAkm.correctAssetLoaded).toBe(1);
+    expect(report.trajectoryAkm.feedbackRecorded).toBe(1);
+  });
+
+  test("workspace template files are copied into per-run cwd", async () => {
+    // Drop a sentinel file into the task's workspace/ template.
+    const wsTemplate = path.join(taskDir, "workspace");
+    fs.mkdirSync(wsTemplate, { recursive: true });
+    fs.writeFileSync(path.join(wsTemplate, "marker.txt"), "hello");
+    const seenContents: string[] = [];
+    const spawn: SpawnFn = (cmd, opts) => {
+      if (cmd[0] === "opencode" && opts.cwd) {
+        const p = path.join(opts.cwd, "marker.txt");
+        if (fs.existsSync(p)) seenContents.push(fs.readFileSync(p, "utf8"));
+      }
+      return {
+        exitCode: 0,
+        exited: Promise.resolve(0),
+        stdout: asReadableStream("ok"),
+        stderr: asReadableStream(""),
+        stdin: null,
+        kill() {},
+      };
+    };
+    try {
+      await runUtility({
+        tasks: [fakeTask(taskDir)],
+        arms: ["noakm"],
+        model: "test",
+        seedsPerArm: 1,
+        spawn,
+        materialiseStash: false,
+      });
+      expect(seenContents).toEqual(["hello"]);
+    } finally {
+      fs.rmSync(wsTemplate, { recursive: true, force: true });
+    }
+  });
+
+  test("default seedsPerArm is 5", async () => {
+    const { spawn, observed } = fakeSpawnFactory({ noakm: "ok", akm: "ok" });
+    await runUtility({
+      tasks: [fakeTask(taskDir)],
+      arms: ["noakm"],
+      model: "test",
+      spawn,
+      materialiseStash: false,
+    });
+    expect(observed.armSeen.length).toBe(5);
+  });
+
+  test("multi-task: each task lands in tasks[] in input order", async () => {
+    const { spawn } = fakeSpawnFactory({ noakm: "ok", akm: "ok" });
+    const taskA = fakeTask(taskDir, { id: "alpha/x", domain: "alpha" });
+    const taskB = fakeTask(taskDir, { id: "beta/y", domain: "beta" });
+    const report = await runUtility({
+      tasks: [taskA, taskB],
+      arms: ["noakm"],
+      model: "test",
+      seedsPerArm: 1,
+      spawn,
+      materialiseStash: false,
+    });
+    expect(report.tasks.map((t) => t.id)).toEqual(["alpha/x", "beta/y"]);
+    expect(report.corpus.domains).toBe(2);
+    expect(report.corpus.tasks).toBe(2);
+  });
+});

--- a/tests/bench/runner.ts
+++ b/tests/bench/runner.ts
@@ -1,0 +1,280 @@
+/**
+ * akm-bench K-seed runner (spec §5 + §6).
+ *
+ * `runUtility(options)` is the single entry point used by both the CLI
+ * dispatcher (`tests/bench/cli.ts utility`) and unit tests. It expands the
+ * caller's `(tasks × arms × seeds)` cartesian product, calls `runOne` for
+ * each triple, splices the trajectory record back in, and returns a
+ * `UtilityRunReport` that `renderUtilityReport` can stamp into JSON +
+ * markdown.
+ *
+ * Per-(arm, seed) isolation:
+ *   • Workspace: each (task, arm, seed) gets a fresh tmp dir seeded from the
+ *     task's `workspace/` template so runs cannot pollute each other.
+ *   • Stash: only the `akm` arm materialises a stash via `loadFixtureStash`.
+ *     We materialise once per task (the stash content is identical across
+ *     the K seeds) and reuse it.
+ *
+ * Cleanup: every tmp resource is wrapped in `try/finally`. We never leak
+ * tmp dirs even on harness exceptions.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { SpawnFn } from "../../src/integrations/agent/spawn";
+import { type LoadedFixtureStash, loadFixtureStash } from "../fixtures/stashes/load";
+import type { TaskMetadata, TaskSlice } from "./corpus";
+import { type RunOptions, type RunResult, runOne } from "./driver";
+import {
+  aggregateCorpus,
+  aggregatePerTask,
+  aggregateTrajectory,
+  computeCorpusDelta,
+  computePerTaskDelta,
+  type PerTaskMetrics,
+} from "./metrics";
+import { resolveGitBranch, resolveGitCommit, type UtilityReportTaskEntry, type UtilityRunReport } from "./report";
+import { computeTrajectory } from "./trajectory";
+
+export type Arm = "noakm" | "akm";
+
+/** Caller-facing options for `runUtility`. */
+export interface RunUtilityOptions {
+  tasks: TaskMetadata[];
+  arms: Arm[];
+  model: string;
+  /** K seeds per arm. Defaults to 5. */
+  seedsPerArm?: number;
+  /** Token budget per run. Defaults to 30000 (spec §7.1). */
+  budgetTokens?: number;
+  /** Wallclock budget per run in ms. Defaults to 120000. */
+  budgetWallMs?: number;
+  /** Slice label stamped into the report's `corpus.slice` field. */
+  slice?: TaskSlice | "all";
+  /** Override timestamp (tests). Defaults to `new Date().toISOString()`. */
+  timestamp?: string;
+  /** Override branch (tests). Defaults to `git rev-parse --abbrev-ref HEAD`. */
+  branch?: string;
+  /** Override commit sha (tests). Defaults to `git rev-parse --short HEAD`. */
+  commit?: string;
+  /** Injected spawn for unit tests. Forwarded to `runOne` for every triple. */
+  spawn?: SpawnFn;
+  /**
+   * Whether to materialise the akm stash via `loadFixtureStash`. Tests pass
+   * `false` so the runner never spawns `akm index` against a real fixture.
+   * Defaults to `true`.
+   */
+  materialiseStash?: boolean;
+}
+
+/** Internal: raw run records grouped by (taskId, arm). */
+type GroupedRuns = Map<string, Map<Arm, RunResult[]>>;
+
+/**
+ * Run K seeds × len(arms) × len(tasks) and return the §13.3 report.
+ *
+ * The function is robust to per-run failures — `runOne` already captures
+ * every failure path into a RunResult, so the runner only has to worry
+ * about its own infrastructure (stash materialisation, workspace copy).
+ * Those failures are recorded as `harness_error` runs.
+ */
+export async function runUtility(options: RunUtilityOptions): Promise<UtilityRunReport> {
+  const seedsPerArm = options.seedsPerArm ?? 5;
+  const budgetTokens = options.budgetTokens ?? 30000;
+  const budgetWallMs = options.budgetWallMs ?? 120000;
+  const slice = options.slice ?? "all";
+  const materialiseStash = options.materialiseStash ?? true;
+
+  const grouped: GroupedRuns = new Map();
+  const warnings: string[] = [];
+
+  for (const task of options.tasks) {
+    const taskRuns = new Map<Arm, RunResult[]>();
+    grouped.set(task.id, taskRuns);
+
+    // Materialise the akm-arm stash once per task. We share it across the K
+    // seeds because the stash content is identical and re-running `akm
+    // index` for every seed is wasted work.
+    let stash: LoadedFixtureStash | undefined;
+    let stashError: string | undefined;
+    if (options.arms.includes("akm") && materialiseStash) {
+      try {
+        stash = loadFixtureStash(task.stash, { skipIndex: true });
+      } catch (err) {
+        stashError = err instanceof Error ? err.message : String(err);
+        warnings.push(`task ${task.id}: stash "${task.stash}" failed to load: ${stashError}`);
+      }
+    }
+
+    try {
+      for (const arm of options.arms) {
+        const armRuns: RunResult[] = [];
+        taskRuns.set(arm, armRuns);
+        for (let seed = 0; seed < seedsPerArm; seed += 1) {
+          // Resolve the stashDir we'll forward to the agent. The akm arm
+          // always carries a stashDir so AKM_STASH_DIR is set in the child
+          // env — this is how downstream tooling (and the trajectory parser
+          // event-stream lookup) distinguishes arms. When the operator opted
+          // out of fixture materialisation (tests, dry-run), we still pass a
+          // stable placeholder so the env keys are wired correctly.
+          let stashDir: string | undefined;
+          if (arm === "akm") {
+            if (stash) stashDir = stash.stashDir;
+            else if (!materialiseStash) stashDir = path.join(task.taskDir, "__no-stash__");
+          }
+          const run = await runOneIsolated({
+            task,
+            arm,
+            seed,
+            model: options.model,
+            stashDir,
+            budgetTokens,
+            budgetWallMs,
+            spawn: options.spawn,
+          });
+          armRuns.push(run);
+        }
+      }
+    } finally {
+      stash?.cleanup();
+    }
+  }
+
+  return buildReport({
+    grouped,
+    options,
+    seedsPerArm,
+    slice,
+    warnings,
+  });
+}
+
+/**
+ * Set up a fresh workspace for one (task, arm, seed) triple, run `runOne`
+ * against it, splice in the trajectory record, then tear everything down.
+ */
+async function runOneIsolated(args: {
+  task: TaskMetadata;
+  arm: Arm;
+  seed: number;
+  model: string;
+  stashDir: string | undefined;
+  budgetTokens: number;
+  budgetWallMs: number;
+  spawn?: SpawnFn;
+}): Promise<RunResult> {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), `akm-bench-ws-${args.task.domain}-`));
+  try {
+    seedWorkspace(args.task.taskDir, workspace);
+
+    const runOptions: RunOptions = {
+      track: "utility",
+      arm: args.arm,
+      taskId: args.task.id,
+      workspace,
+      model: args.model,
+      seed: args.seed,
+      budgetTokens: args.budgetTokens,
+      budgetWallMs: args.budgetWallMs,
+      verifier: args.task.verifier,
+      taskDir: args.task.taskDir,
+      ...(args.task.expectedMatch ? { expectedMatch: args.task.expectedMatch } : {}),
+      ...(args.stashDir ? { stashDir: args.stashDir } : {}),
+      ...(args.spawn ? { spawn: args.spawn } : {}),
+    };
+
+    const result = await runOne(runOptions);
+
+    // Splice in the trajectory metric. The driver always returns
+    // `{ null, null }` — this is where the real values get filled.
+    const trajectory = computeTrajectory({ goldRef: args.task.goldRef }, result);
+    return { ...result, trajectory };
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Copy the task's `workspace/` template into the per-run tmp dir. If the
+ * task has no `workspace/` (loader-test fixtures), the run starts with an
+ * empty cwd — that is also valid for verifier-only tasks.
+ */
+function seedWorkspace(taskDir: string, dest: string): void {
+  const src = path.join(taskDir, "workspace");
+  if (!fs.existsSync(src)) return;
+  copyDirRecursive(src, dest);
+}
+
+function copyDirRecursive(src: string, dest: string): void {
+  fs.mkdirSync(dest, { recursive: true });
+  const entries = fs.readdirSync(src, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name === ".gitkeep") continue;
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) copyDirRecursive(s, d);
+    else if (entry.isFile()) fs.copyFileSync(s, d);
+  }
+}
+
+interface BuildReportArgs {
+  grouped: GroupedRuns;
+  options: RunUtilityOptions;
+  seedsPerArm: number;
+  slice: "all" | TaskSlice;
+  warnings: string[];
+}
+
+function buildReport(args: BuildReportArgs): UtilityRunReport {
+  const tasks: UtilityReportTaskEntry[] = [];
+  const noakmPerTask: Record<string, PerTaskMetrics> = {};
+  const akmPerTask: Record<string, PerTaskMetrics> = {};
+  const akmRunsAll: RunResult[] = [];
+
+  for (const task of args.options.tasks) {
+    const taskRuns = args.grouped.get(task.id);
+    const noakmRuns = taskRuns?.get("noakm") ?? [];
+    const akmRuns = taskRuns?.get("akm") ?? [];
+
+    const noakmMetrics = aggregatePerTask(noakmRuns);
+    const akmMetrics = aggregatePerTask(akmRuns);
+    const delta = computePerTaskDelta(noakmMetrics, akmMetrics);
+
+    noakmPerTask[task.id] = noakmMetrics;
+    akmPerTask[task.id] = akmMetrics;
+    akmRunsAll.push(...akmRuns);
+
+    tasks.push({ id: task.id, noakm: noakmMetrics, akm: akmMetrics, delta });
+  }
+
+  const aggregateNoakm = aggregateCorpus(noakmPerTask);
+  const aggregateAkm = aggregateCorpus(akmPerTask);
+  const aggregateDelta = computeCorpusDelta(aggregateNoakm, aggregateAkm);
+  const trajectoryAkm = aggregateTrajectory(akmRunsAll);
+
+  const domains = new Set(args.options.tasks.map((t) => t.domain)).size;
+  const branch = args.options.branch ?? resolveGitBranch();
+  const commit = args.options.commit ?? resolveGitCommit();
+  const timestamp = args.options.timestamp ?? new Date().toISOString();
+
+  return {
+    timestamp,
+    branch,
+    commit,
+    model: args.options.model,
+    corpus: {
+      domains,
+      tasks: args.options.tasks.length,
+      slice: args.slice,
+      seedsPerArm: args.seedsPerArm,
+    },
+    aggregateNoakm,
+    aggregateAkm,
+    aggregateDelta,
+    trajectoryAkm,
+    tasks,
+    warnings: args.warnings,
+  };
+}

--- a/tests/bench/runner.ts
+++ b/tests/bench/runner.ts
@@ -133,6 +133,7 @@ export async function runUtility(options: RunUtilityOptions): Promise<UtilityRun
             budgetTokens,
             budgetWallMs,
             spawn: options.spawn,
+            warnings,
           });
           armRuns.push(run);
         }
@@ -164,6 +165,7 @@ async function runOneIsolated(args: {
   budgetTokens: number;
   budgetWallMs: number;
   spawn?: SpawnFn;
+  warnings: string[];
 }): Promise<RunResult> {
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), `akm-bench-ws-${args.task.domain}-`));
   try {
@@ -183,13 +185,16 @@ async function runOneIsolated(args: {
       ...(args.task.expectedMatch ? { expectedMatch: args.task.expectedMatch } : {}),
       ...(args.stashDir ? { stashDir: args.stashDir } : {}),
       ...(args.spawn ? { spawn: args.spawn } : {}),
+      warnings: args.warnings,
     };
 
     const result = await runOne(runOptions);
 
     // Splice in the trajectory metric. The driver always returns
     // `{ null, null }` — this is where the real values get filled.
-    const trajectory = computeTrajectory({ goldRef: args.task.goldRef }, result);
+    const trajectory = computeTrajectory({ goldRef: args.task.goldRef }, result, {
+      warnings: args.warnings,
+    });
     return { ...result, trajectory };
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });

--- a/tests/bench/trajectory.test.ts
+++ b/tests/bench/trajectory.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for the trajectory parser.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { EventEnvelope } from "../../src/core/events";
+import type { RunResult } from "./driver";
+import { computeTrajectory } from "./trajectory";
+
+function fakeRun(overrides: Partial<RunResult> = {}): RunResult {
+  return {
+    schemaVersion: 1,
+    taskId: "x",
+    arm: "akm",
+    seed: 0,
+    model: "m",
+    outcome: "pass",
+    tokens: { input: 0, output: 0 },
+    wallclockMs: 0,
+    trajectory: { correctAssetLoaded: null, feedbackRecorded: null },
+    events: [],
+    verifierStdout: "",
+    verifierExitCode: 0,
+    ...overrides,
+  };
+}
+
+function feedbackEvent(): EventEnvelope {
+  return {
+    schemaVersion: 1,
+    id: 0,
+    ts: "2026-04-27T00:00:00.000Z",
+    eventType: "feedback",
+    ref: "skill:foo",
+  };
+}
+
+describe("computeTrajectory.correctAssetLoaded", () => {
+  test("null when goldRef is missing on the task", () => {
+    const traj = computeTrajectory({}, fakeRun({ verifierStdout: "akm show skill:irrelevant" }));
+    expect(traj.correctAssetLoaded).toBeNull();
+  });
+
+  test("true when verifierStdout contains `akm show <goldRef>`", () => {
+    const traj = computeTrajectory(
+      { goldRef: "skill:docker-homelab" },
+      fakeRun({
+        verifierStdout: "tool: akm show skill:docker-homelab\nresult: ok\n",
+      }),
+    );
+    expect(traj.correctAssetLoaded).toBe(true);
+  });
+
+  test("true when tool-call JSON form contains the ref", () => {
+    const traj = computeTrajectory(
+      { goldRef: "skill:docker-homelab" },
+      fakeRun({
+        verifierStdout: '{"command":"akm","args":["show","skill:docker-homelab"]}',
+      }),
+    );
+    expect(traj.correctAssetLoaded).toBe(true);
+  });
+
+  test("false when verifierStdout shows a different ref", () => {
+    const traj = computeTrajectory(
+      { goldRef: "skill:docker-homelab" },
+      fakeRun({ verifierStdout: "akm show skill:az-cli\n" }),
+    );
+    expect(traj.correctAssetLoaded).toBe(false);
+  });
+
+  test("false on empty trace", () => {
+    const traj = computeTrajectory({ goldRef: "skill:docker-homelab" }, fakeRun({ verifierStdout: "" }));
+    expect(traj.correctAssetLoaded).toBe(false);
+  });
+
+  test("true when an event metadata.ref carries the goldRef", () => {
+    const event: EventEnvelope = {
+      schemaVersion: 1,
+      id: 1,
+      ts: "2026-04-27T00:00:00.000Z",
+      eventType: "tool_call",
+      metadata: { ref: "skill:docker-homelab" },
+    };
+    const traj = computeTrajectory({ goldRef: "skill:docker-homelab" }, fakeRun({ events: [event] }));
+    expect(traj.correctAssetLoaded).toBe(true);
+  });
+});
+
+describe("computeTrajectory.feedbackRecorded", () => {
+  test("true when events stream contains a `feedback` event", () => {
+    const traj = computeTrajectory({ goldRef: "skill:foo" }, fakeRun({ events: [feedbackEvent()] }));
+    expect(traj.feedbackRecorded).toBe(true);
+  });
+
+  test("false when events stream is empty", () => {
+    const traj = computeTrajectory({ goldRef: "skill:foo" }, fakeRun({ events: [] }));
+    expect(traj.feedbackRecorded).toBe(false);
+  });
+
+  test("false when events contain other types but no `feedback`", () => {
+    const event: EventEnvelope = {
+      schemaVersion: 1,
+      id: 0,
+      ts: "2026-04-27T00:00:00.000Z",
+      eventType: "remember",
+      ref: "memory:alpha",
+    };
+    const traj = computeTrajectory({ goldRef: "skill:foo" }, fakeRun({ events: [event] }));
+    expect(traj.feedbackRecorded).toBe(false);
+  });
+});

--- a/tests/bench/trajectory.test.ts
+++ b/tests/bench/trajectory.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { EventEnvelope } from "../../src/core/events";
 import type { RunResult } from "./driver";
-import { computeTrajectory } from "./trajectory";
+import { computeTrajectory, VERIFIER_STDOUT_SCAN_CAP } from "./trajectory";
 
 function fakeRun(overrides: Partial<RunResult> = {}): RunResult {
   return {
@@ -109,5 +109,46 @@ describe("computeTrajectory.feedbackRecorded", () => {
     };
     const traj = computeTrajectory({ goldRef: "skill:foo" }, fakeRun({ events: [event] }));
     expect(traj.feedbackRecorded).toBe(false);
+  });
+});
+
+describe("computeTrajectory verifierStdout cap", () => {
+  test("trajectory still computes from the prefix when stdout exceeds the cap, and a warning is recorded", () => {
+    // Construct a stdout: prefix has the canonical `akm show` invocation;
+    // the rest is GBs-of-junk simulated as a long filler past the cap.
+    const ref = "skill:docker-homelab";
+    const prefix = `tool: akm show ${ref}\n`;
+    const fillerSize = VERIFIER_STDOUT_SCAN_CAP + 1024;
+    // Use repeated 'a' so total length comfortably exceeds the cap.
+    const filler = "a".repeat(fillerSize);
+    const verifierStdout = prefix + filler;
+    expect(verifierStdout.length).toBeGreaterThan(VERIFIER_STDOUT_SCAN_CAP);
+
+    const warnings: string[] = [];
+    const traj = computeTrajectory({ goldRef: ref }, fakeRun({ verifierStdout }), { warnings });
+    expect(traj.correctAssetLoaded).toBe(true);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("verifierStdout truncated");
+    expect(warnings[0]).toContain(String(VERIFIER_STDOUT_SCAN_CAP));
+  });
+
+  test("no warning when stdout is within the cap", () => {
+    const warnings: string[] = [];
+    computeTrajectory({ goldRef: "skill:foo" }, fakeRun({ verifierStdout: "akm show skill:foo\n" }), { warnings });
+    expect(warnings).toEqual([]);
+  });
+
+  test("match found in the prefix even though tail mentions the ref past the cap", () => {
+    // Prefix has only filler; the gold ref appears only AFTER the cap.
+    // The scan should miss it (correctly — the agent's effective behaviour
+    // within the budgeted prefix did not include the show call).
+    const ref = "skill:never-loaded";
+    const filler = "x".repeat(VERIFIER_STDOUT_SCAN_CAP);
+    const verifierStdout = `${filler}akm show ${ref}\n`;
+    const warnings: string[] = [];
+    const traj = computeTrajectory({ goldRef: ref }, fakeRun({ verifierStdout }), { warnings });
+    expect(traj.correctAssetLoaded).toBe(false);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("verifierStdout truncated");
   });
 });

--- a/tests/bench/trajectory.ts
+++ b/tests/bench/trajectory.ts
@@ -19,10 +19,28 @@
 
 import type { RunResult, TrajectoryRecord } from "./driver";
 
+/**
+ * Cap on the number of characters of `verifierStdout` we substring-scan for
+ * the `akm show <ref>` heuristic. A runaway agent could emit GBs of stdout;
+ * scanning all of it would OOM the bench. The first 16 MiB is plenty to
+ * decide whether the agent invoked `akm show` for the gold ref.
+ */
+export const VERIFIER_STDOUT_SCAN_CAP = 16 * 1024 * 1024;
+
 /** Inputs the trajectory parser cares about — we accept a TaskMetadata-ish duck. */
 export interface TrajectoryTaskInput {
   /** Asset ref like `skill:docker-homelab`. Optional. */
   goldRef?: string;
+}
+
+/** Optional auxiliary inputs for `computeTrajectory`. */
+export interface TrajectoryOptions {
+  /**
+   * Collector for trajectory-scoped warnings (e.g. verifierStdout was
+   * truncated to fit the scan cap). Mirrors the events.jsonl warning path
+   * in `readRunEvents`.
+   */
+  warnings?: string[];
 }
 
 /**
@@ -40,13 +58,21 @@ export interface TrajectoryTaskInput {
  * exact ref and `skill:docker-homelab/anything`. The match is conservative
  * — case-sensitive, exact substring on `akm show <ref>` (whitespace-flexible).
  */
-export function computeTrajectory(task: TrajectoryTaskInput, runResult: RunResult): TrajectoryRecord {
-  const correctAssetLoaded = computeCorrectAssetLoaded(task, runResult);
+export function computeTrajectory(
+  task: TrajectoryTaskInput,
+  runResult: RunResult,
+  opts?: TrajectoryOptions,
+): TrajectoryRecord {
+  const correctAssetLoaded = computeCorrectAssetLoaded(task, runResult, opts);
   const feedbackRecorded = computeFeedbackRecorded(runResult);
   return { correctAssetLoaded, feedbackRecorded };
 }
 
-function computeCorrectAssetLoaded(task: TrajectoryTaskInput, runResult: RunResult): boolean | null {
+function computeCorrectAssetLoaded(
+  task: TrajectoryTaskInput,
+  runResult: RunResult,
+  opts?: TrajectoryOptions,
+): boolean | null {
   if (!task.goldRef) return null;
   const ref = task.goldRef;
 
@@ -68,7 +94,19 @@ function computeCorrectAssetLoaded(task: TrajectoryTaskInput, runResult: RunResu
   //     invokes the akm CLI as a tool), or
   //   - the bare ref appearing on a line that mentions `show` (covers tool-
   //     call JSON like `{"command":"akm","args":["show","skill:foo"]}`).
-  const haystack = runResult.verifierStdout;
+  // Cap the scan at VERIFIER_STDOUT_SCAN_CAP so a runaway agent's GBs of
+  // stdout cannot OOM the bench. When we truncate, push a warning so the
+  // top-level report aggregates it under `warnings[]`.
+  const haystackFull = runResult.verifierStdout;
+  let haystack = haystackFull;
+  if (haystack && haystack.length > VERIFIER_STDOUT_SCAN_CAP) {
+    haystack = haystack.slice(0, VERIFIER_STDOUT_SCAN_CAP);
+    if (opts?.warnings) {
+      opts.warnings.push(
+        `verifierStdout truncated for trajectory scan: ${haystackFull.length} chars exceeds ${VERIFIER_STDOUT_SCAN_CAP}-char cap; correct_asset_loaded computed from the prefix.`,
+      );
+    }
+  }
   if (haystack && containsAkmShow(haystack, ref)) return true;
 
   return false;

--- a/tests/bench/trajectory.ts
+++ b/tests/bench/trajectory.ts
@@ -1,0 +1,107 @@
+/**
+ * akm-bench trajectory parser (spec §6.2).
+ *
+ * Trajectory metrics describe the *path* the agent took through the run, not
+ * just the terminal outcome. For #238 we score two booleans per run:
+ *
+ *   • `correctAssetLoaded` — did the agent invoke `akm show <goldRef>` (or
+ *     a sufficient prefix thereof) at any point during the run? `null` when
+ *     the task carries no `goldRef` (and so the metric is undefined).
+ *   • `feedbackRecorded` — did the agent emit any `feedback` event into
+ *     `events.jsonl` during the run? Always `false` for the `noakm` arm
+ *     because that arm runs without a stash.
+ *
+ * The driver hands us a `RunResult` after the run has finished. We never
+ * mutate it; we return a fresh `TrajectoryRecord` and let the runner splice
+ * it back in. This keeps `runOne`'s signature stable and lets `#239`/`#240`
+ * extend the trajectory shape without touching the driver.
+ */
+
+import type { RunResult, TrajectoryRecord } from "./driver";
+
+/** Inputs the trajectory parser cares about — we accept a TaskMetadata-ish duck. */
+export interface TrajectoryTaskInput {
+  /** Asset ref like `skill:docker-homelab`. Optional. */
+  goldRef?: string;
+}
+
+/**
+ * Compute the trajectory record for a single run.
+ *
+ * The `correctAssetLoaded` heuristic looks for the `akm show <ref>` invocation
+ * in two places:
+ *   1. The `events.jsonl` events array (if `akm show` ever emits an event —
+ *      currently it does not, but we future-proof).
+ *   2. The agent's stdout/verifier stdout (`runResult.verifierStdout`). When
+ *      opencode logs its tool calls, the literal string `akm show <ref>`
+ *      appears verbatim in the trace.
+ *
+ * We accept a "sufficient prefix": `skill:docker-homelab` matches both the
+ * exact ref and `skill:docker-homelab/anything`. The match is conservative
+ * — case-sensitive, exact substring on `akm show <ref>` (whitespace-flexible).
+ */
+export function computeTrajectory(task: TrajectoryTaskInput, runResult: RunResult): TrajectoryRecord {
+  const correctAssetLoaded = computeCorrectAssetLoaded(task, runResult);
+  const feedbackRecorded = computeFeedbackRecorded(runResult);
+  return { correctAssetLoaded, feedbackRecorded };
+}
+
+function computeCorrectAssetLoaded(task: TrajectoryTaskInput, runResult: RunResult): boolean | null {
+  if (!task.goldRef) return null;
+  const ref = task.goldRef;
+
+  // Search the events stream for any tool-call event that carries the ref.
+  // akm itself does not emit an event for `show`, but third parties might,
+  // and the field is forward-compatible.
+  for (const event of runResult.events) {
+    const refField = event.ref;
+    if (typeof refField === "string" && matchesRef(refField, ref)) return true;
+    const meta = event.metadata;
+    if (meta && typeof meta === "object") {
+      const candidate = (meta as Record<string, unknown>).ref;
+      if (typeof candidate === "string" && matchesRef(candidate, ref)) return true;
+    }
+  }
+
+  // Substring scan on the captured agent/verifier stdout. We look for either
+  //   - `akm show <ref>` (the canonical form opencode logs when the agent
+  //     invokes the akm CLI as a tool), or
+  //   - the bare ref appearing on a line that mentions `show` (covers tool-
+  //     call JSON like `{"command":"akm","args":["show","skill:foo"]}`).
+  const haystack = runResult.verifierStdout;
+  if (haystack && containsAkmShow(haystack, ref)) return true;
+
+  return false;
+}
+
+function matchesRef(candidate: string, gold: string): boolean {
+  if (candidate === gold) return true;
+  // Allow goldRef to be a prefix of a more-specific ref (e.g. team//skill:foo
+  // when the task says skill:foo). Keep the check anchored to ref segments.
+  if (candidate.endsWith(`//${gold}`)) return true;
+  if (candidate.startsWith(`${gold}/`)) return true;
+  return false;
+}
+
+function containsAkmShow(text: string, ref: string): boolean {
+  // Whitespace-flexible match for `akm show <ref>`. We escape regex metas in
+  // the ref because asset refs may contain `:` (always) and `/` (origin form).
+  const escaped = ref.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`akm\\s+show\\s+(?:["'])?${escaped}(?:\\b|\\W)`);
+  if (pattern.test(text)) return true;
+
+  // Tool-call JSON form: `"args":["show","<ref>"]` or similar. Cheap heuristic.
+  if (text.includes(`"show"`) && text.includes(ref)) return true;
+
+  return false;
+}
+
+function computeFeedbackRecorded(runResult: RunResult): boolean {
+  // The `noakm` arm runs without an akm stash, so events.jsonl will be empty
+  // by construction. Still honour the same scan — the assertion is an
+  // invariant of the events stream, not arm-specific behaviour.
+  for (const event of runResult.events) {
+    if (event.eventType === "feedback") return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

Wave C of the `akm-bench` rollout (umbrella tracker #234, milestone `akm-bench`). Lands the first end-to-end usable Track A run: `bench utility --tasks <slice>` produces a §13.3 JSON envelope (and markdown summary) operators read to answer "does akm change resolve rate / token economics?" Builds on the merged Wave A foundation (#235 fixture stashes + #236 bench skeleton) and Wave B corpus (#237).

| Issue | Branch | Title |
|---|---|---|
| #238 | `issue-238-bench-utility` | feat(bench): implement bench utility — outcome and trajectory metrics + JSON/markdown report |

Closes #238. **Unlocks #239 (compare), #240 (attribution), #241 (failure modes), #242 (search bridge) — all blocked on this report shape.**

## What landed

### K-seed runner (`tests/bench/runner.ts`)
- Default K=5; per-(task, arm, seed) workspace isolation; stash materialized once per task.
- Cleanup on success and failure; warnings collector threaded through driver/trajectory.

### Trajectory parser (`tests/bench/trajectory.ts`)
- `correctAssetLoaded` — scans agent stdout + `events.jsonl` for `akm show <goldRef>` (akm arm only, null when no `gold_ref`).
- `feedbackRecorded` — uses the canonical `feedback` event type from `src/core/events.ts` (no invented event names).
- Reads capped at 16 MiB per source; cap-hit emits a warning into `report.warnings[]` (defends against runaway-agent OOM).

### Outcome metrics (`tests/bench/metrics.ts`)
- `aggregatePerTask`: pass_rate, pass@1, tokens_per_pass (null on 0 passes), wallclock_ms (mean), pass_rate_stdev (Bessel's correction), budget_exceeded_count, harness_error_count.
- `aggregateCorpus`: per-task-equal weighting per §6.1 (mean of per-task means, not weighted by seed count).

### Report rendering (`tests/bench/report.ts`)
- `renderUtilityReport` produces the §13.3 JSON shape exactly: `{schemaVersion, track, branch, commit, timestamp, agent, corpus, aggregate, trajectory, tasks, warnings}`.
- Single-page markdown summary: corpus header (model/branch/commit/timestamp), 3-row aggregate table (noakm/akm/delta with the three metrics), trajectory percentages, alphabetized per-task pass-rate table.
- `branch` from `git rev-parse --abbrev-ref HEAD`, `commit` short SHA, `timestamp` ISO 8601.

### CLI (`tests/bench/cli.ts`)
```
BENCH_OPENCODE_MODEL=anthropic/claude-opus-4-7 \
  bun run tests/bench/cli.ts utility --tasks all
```
- `--tasks all|train|eval` (unknown values → exit 2 with clear error, not silent coercion).
- `--seeds N` (default 5), `--budget-tokens N` (default 30000), `--budget-wall-ms N` (default 120000).
- `--json` suppresses the markdown summary on stderr; **JSON always goes to stdout** (matches `tests/benchmark-suite.ts` convention; future `bench compare` can pipe stdout reliably).
- Missing `BENCH_OPENCODE_MODEL` → exit 2 with clear error.

### `tests/bench/BENCH.md`
- Schema/trajectory section documents §6.2 normative fields shipped (`correct_asset_loaded`, `feedback_recorded`) vs §13.3 illustrative extras deferred (`searched_before_acting`, `irrelevant_assets_loaded`).
- Documents 16 MiB read caps and the warning emission convention.
- Notes that SIGINT mid-run leaves the current per-(arm, seed) tmpdir under `os.tmpdir()` (operator-on-own-host scope; future hardening).

## Test plan

- `bunx tsc --noEmit` — clean.
- `bunx biome check src/ tests/` — 1 pre-existing info (`tests/architecture/agent-no-llm-sdk-guard.test.ts:86`), no new warnings/errors.
- `bun test` — **2301 pass / 9 skip / 0 fail / 6269 expects across 150 files**.
  - Wave B baseline at `release/1.0.0`@`6a3e674`: 2250 / 9 / 0.
  - Net: +51 tests (runner, trajectory, metrics, report, CLI all expanded; injected fakes everywhere — no real opencode call required).
- Smoke (without `--json`): `BENCH_OPENCODE_MODEL=foo bun run tests/bench/cli.ts utility --tasks train --seeds 1 --budget-tokens 1000 --budget-wall-ms 1000` → valid §13.3 JSON to stdout, markdown summary to stderr, exit 0.
- Smoke (with `--json`): identical JSON to stdout; stderr clean of markdown headings.
- Smoke (`--tasks bogus`): exit 2 with `bench utility: invalid --tasks value "bogus"; expected one of: all, train, eval.`.

## Reviewer pass discipline

- **senior-engineer** — request-changes → approve. Two real findings (CLI stdout contract; §13.3 docs gap) addressed in fixup `02673ca`. The §13.3 trajectory-shape divergence was deliberate per the run-plan note carried since the Wave A planning step; documented in BENCH.md.
- **security** — request-changes → approve. Two real findings (silent argv coercion; unbounded events.jsonl/verifierStdout reads → OOM risk) addressed in fixup `02673ca`: argv exit 2 + 16 MiB caps with warnings.
- **domain-expert** — approve. Smoke run produced a clean §13.3 envelope; per-task pairing discipline correct; markdown readable.

One implementer hallucination caught and corrected in `ba29a53`: the BENCH.md section originally named the deferred fields as `replan_count` and `tool_call_overhead_ms` (not in the spec); corrected to the actual §13.3 illustrative extras (`searched_before_acting` and `irrelevant_assets_loaded`).

## CLAUDE.md compliance

- No `src/` changes — bench reads v1 contract surfaces from outside.
- No new prod dependencies.
- No new URI schemes; no new source-provider-kind branches; no new top-level directory.
- `runAgent` from `src/integrations/agent/spawn.ts` remains the single agent abstraction.

## Follow-ups (queued for subsequent runs, none blocking)

- **#239** `bench compare` — diffs two utility reports.
- **#240** per-asset attribution + `bench attribute` — depends on #238 report shape.
- **#241** failure-mode taxonomy classifier.
- **#242** search-pipeline bridge metrics.
- **#243** Track B `bench evolve` (depends on Phase 1 + #240).
- **#244** feedback-signal integrity confusion matrix (depends on #243).
- **Hardening (advisory, low priority)**: SIGINT trap to clean tmpdirs on Ctrl-C; add `searched_before_acting` and `irrelevant_assets_loaded` if downstream issues want them.

## Run scratch directory

`.akm-run/2983ff0c-a923-4e98-84c9-062560202b68/` (not pushed): intake/plan/prepare-worktrees/integrate notes, `plan.json`, `summaries/issue-238.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)