### PR TITLE
akm-bench Wave D: Phase 1 diagnostics — compare + attribution + failure modes + search bridge

### DIFF
--- a/tests/bench/attribution.test.ts
+++ b/tests/bench/attribution.test.ts
@@ -332,6 +332,96 @@ describe("runMaskedCorpus", () => {
     fs.rmSync(fixturesRoot, { recursive: true, force: true });
   });
 
+  test("rejects path-traversal asset refs without deleting anything outside the tmp stash", async () => {
+    const fixturesRoot = makeFixturesRoot();
+    // A sentinel file outside the fixtures tree — if the masker honoured the
+    // hostile `..`-laden ref, the deletion target would be computed via
+    // `path.join(fixturesRoot/fixtureA/skills/, "..", "..", "..", "sentinel")`
+    // and the sentinel would disappear. The validation must block that.
+    const sentinelDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-bench-sentinel-"));
+    const sentinelFile = path.join(sentinelDir, "sentinel.txt");
+    fs.writeFileSync(sentinelFile, "do-not-delete");
+
+    const baseRuns: RunResult[] = [
+      // Hostile ref: name contains `..` segments. Constructed by hand to
+      // simulate a prompt-injected agent emitting `akm show "skill:../../../etc"`.
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:../../../etc"] }),
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:../../../etc"] }),
+    ];
+    const baseReport = makeReport(baseRuns);
+    baseReport.taskMetadata = [fakeTask()];
+
+    let callCount = 0;
+    const result = await runMaskedCorpus({
+      baseReport,
+      topN: 1,
+      runUtility: async () => {
+        callCount += 1;
+        return {
+          ...baseReport,
+          aggregateAkm: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+        };
+      },
+      baseOptions: { arms: ["akm"] as Arm[], model: "m", seedsPerArm: 1 },
+      fixturesRoot,
+    });
+
+    // The masker rejects the hostile ref → null → runMaskedCorpus falls back
+    // to the original fixture name. The runner is still called (we want the
+    // accounting to be honest), but no rmSync is performed against any path
+    // resolved from the hostile name.
+    expect(result.runsPerformed).toBe(1);
+    expect(callCount).toBe(1);
+    // Sentinel survives.
+    expect(fs.existsSync(sentinelFile)).toBe(true);
+    expect(fs.readFileSync(sentinelFile, "utf8")).toBe("do-not-delete");
+    // Source fixture files survive.
+    expect(fs.existsSync(path.join(fixturesRoot, "fixtureA", "skills", "alpha.md"))).toBe(true);
+    expect(fs.existsSync(path.join(fixturesRoot, "fixtureA", "skills", "beta.md"))).toBe(true);
+
+    fs.rmSync(sentinelDir, { recursive: true, force: true });
+    fs.rmSync(fixturesRoot, { recursive: true, force: true });
+  });
+
+  test("rejects absolute-path asset refs without escaping the tmp stash", async () => {
+    const fixturesRoot = makeFixturesRoot();
+    const sentinelDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-bench-sentinel-abs-"));
+    const sentinelFile = path.join(sentinelDir, "sentinel.txt");
+    fs.writeFileSync(sentinelFile, "do-not-delete");
+
+    const baseRuns: RunResult[] = [
+      // Hostile ref: name is an absolute POSIX path.
+      makeRun({ outcome: "pass", assetsLoaded: [`skill:${sentinelDir}`] }),
+      makeRun({ outcome: "pass", assetsLoaded: [`skill:${sentinelDir}`] }),
+    ];
+    const baseReport = makeReport(baseRuns);
+    baseReport.taskMetadata = [fakeTask()];
+
+    let callCount = 0;
+    const result = await runMaskedCorpus({
+      baseReport,
+      topN: 1,
+      runUtility: async () => {
+        callCount += 1;
+        return {
+          ...baseReport,
+          aggregateAkm: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+        };
+      },
+      baseOptions: { arms: ["akm"] as Arm[], model: "m", seedsPerArm: 1 },
+      fixturesRoot,
+    });
+
+    expect(result.runsPerformed).toBe(1);
+    expect(callCount).toBe(1);
+    expect(fs.existsSync(sentinelFile)).toBe(true);
+    expect(fs.readFileSync(sentinelFile, "utf8")).toBe("do-not-delete");
+    expect(fs.existsSync(sentinelDir)).toBe(true);
+
+    fs.rmSync(sentinelDir, { recursive: true, force: true });
+    fs.rmSync(fixturesRoot, { recursive: true, force: true });
+  });
+
   test("cost accounting: runs N times when N <= asset count", async () => {
     const fixturesRoot = makeFixturesRoot();
     const baseRuns: RunResult[] = [
@@ -452,5 +542,127 @@ describe("bench attribute --top clamping", () => {
     expect(calls).toBe(2);
 
     fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});
+
+describe("runMaskedCorpus marginal_contribution arithmetic", () => {
+  // Distinct from the clamp test in `bench attribute --top clamping`, which
+  // uses passRate 0 for every masked re-run and so cannot detect a sign
+  // error in the marginal-contribution arithmetic. Here we engineer a base
+  // pass_rate of 0.8 and two distinct masked pass_rates (0.4 and 0.5) and
+  // assert the resulting marginal_contribution = base - masked, with the
+  // correct sign and magnitude per masked asset.
+  function makeMarginalFixturesRoot(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "akm-bench-attr-marginal-fixtures-"));
+    const fixDir = path.join(root, "fixtureMarginal");
+    fs.mkdirSync(path.join(fixDir, "skills"), { recursive: true });
+    fs.writeFileSync(
+      path.join(fixDir, "MANIFEST.json"),
+      JSON.stringify({ name: "fixtureMarginal", description: "x", purpose: "x", assets: { skill: 2 }, consumers: [] }),
+    );
+    fs.writeFileSync(
+      path.join(fixDir, "skills", ".stash.json"),
+      JSON.stringify({
+        entries: [
+          { name: "alpha", type: "skill", filename: "alpha.md" },
+          { name: "beta", type: "skill", filename: "beta.md" },
+        ],
+      }),
+    );
+    fs.writeFileSync(path.join(fixDir, "skills", "alpha.md"), "# alpha");
+    fs.writeFileSync(path.join(fixDir, "skills", "beta.md"), "# beta");
+    return root;
+  }
+
+  test("computes marginal_contribution = basePassRate - maskedPassRate per asset", async () => {
+    const fixturesRoot = makeMarginalFixturesRoot();
+    const baseRuns: RunResult[] = [
+      // alpha: 4 pass, 0 fail → load_count 4
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:alpha"] }),
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:alpha"] }),
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:alpha"] }),
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:alpha"] }),
+      // beta: 1 pass, 1 fail → load_count 2
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:beta"] }),
+      makeRun({ outcome: "fail", assetsLoaded: ["skill:beta"] }),
+    ];
+    const baseReport: UtilityRunReport = {
+      timestamp: "2026-04-27T00:00:00Z",
+      branch: "test",
+      commit: "abc",
+      model: "m",
+      corpus: { domains: 1, tasks: 1, slice: "all", seedsPerArm: baseRuns.length },
+      aggregateNoakm: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+      // Engineered base pass rate distinct from the masked rates so the
+      // arithmetic is observable.
+      aggregateAkm: { passRate: 0.8, tokensPerPass: null, wallclockMs: 0 },
+      aggregateDelta: { passRate: 0.8, tokensPerPass: null, wallclockMs: 0 },
+      trajectoryAkm: { correctAssetLoaded: null, feedbackRecorded: 0 },
+      tasks: [],
+      warnings: [],
+      akmRuns: baseRuns,
+      taskMetadata: [
+        {
+          id: "fake/t",
+          title: "t",
+          domain: "fake",
+          difficulty: "easy",
+          stash: "fixtureMarginal",
+          verifier: "regex",
+          expectedMatch: "ok",
+          budget: { tokens: 100, wallMs: 1000 },
+          taskDir: "/tmp",
+        },
+      ],
+    };
+
+    // Map masked-asset → simulated pass rate. The injected runner inspects
+    // the on-disk masked stash to detect which asset is missing.
+    const maskedPassRates: Record<string, number> = {
+      "skill:alpha": 0.4,
+      "skill:beta": 0.5,
+    };
+
+    const result = await runMaskedCorpus({
+      baseReport,
+      topN: 2,
+      runUtility: async (options) => {
+        const stashDir = options.tasks[0]?.stash ?? "";
+        const alphaMissing = !fs.existsSync(path.join(stashDir, "skills", "alpha.md"));
+        const betaMissing = !fs.existsSync(path.join(stashDir, "skills", "beta.md"));
+        const masked = alphaMissing ? "skill:alpha" : betaMissing ? "skill:beta" : "none";
+        const passRate = maskedPassRates[masked] ?? 0;
+        return {
+          ...baseReport,
+          aggregateAkm: { passRate, tokensPerPass: null, wallclockMs: 0 },
+          akmRuns: [],
+        };
+      },
+      baseOptions: { arms: ["akm"] as Arm[], model: "m", seedsPerArm: 1 },
+      fixturesRoot,
+    });
+
+    expect(result.runsPerformed).toBe(2);
+    expect(result.attributions.length).toBe(2);
+
+    const alpha = result.attributions.find((a) => a.assetRef === "skill:alpha");
+    const beta = result.attributions.find((a) => a.assetRef === "skill:beta");
+
+    // Both rows carry the engineered base pass rate.
+    expect(alpha?.basePassRate).toBeCloseTo(0.8, 5);
+    expect(beta?.basePassRate).toBeCloseTo(0.8, 5);
+    // Masked pass rates are the runner-injected values, distinguished per
+    // asset (this is the property the vacuous 0 → 0 → 0 fixture above
+    // could not exercise).
+    expect(alpha?.maskedPassRate).toBeCloseTo(0.4, 5);
+    expect(beta?.maskedPassRate).toBeCloseTo(0.5, 5);
+    // Marginal contribution = base - masked. Positive sign means masking
+    // hurt — the asset was helping. Both must be non-zero.
+    expect(alpha?.marginalContribution).toBeCloseTo(0.4, 5);
+    expect(beta?.marginalContribution).toBeCloseTo(0.3, 5);
+    expect(alpha?.marginalContribution).not.toBe(0);
+    expect(beta?.marginalContribution).not.toBe(0);
+
+    fs.rmSync(fixturesRoot, { recursive: true, force: true });
   });
 });

--- a/tests/bench/attribution.test.ts
+++ b/tests/bench/attribution.test.ts
@@ -1,0 +1,456 @@
+/**
+ * Unit tests for per-asset attribution (spec §6.5).
+ *
+ * Coverage:
+ *   • `extractAssetLoads` — parses both events.jsonl event objects and
+ *     verifierStdout substrings (literal `akm show` and tool-call JSON).
+ *   • `computePerAssetAttribution` — counts pass/fail loads, computes pass
+ *     rate, sorts by load count then pass rate then ref.
+ *   • `runMaskedCorpus` — picks top-N, masks each asset from the source
+ *     fixture, computes marginal contribution. Cost accounting verified
+ *     against the injected runUtility callable. Source fixture is untouched.
+ *   • CLI `attribute --top` clamping when top exceeds asset count.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runAttributeCli } from "./cli";
+import type { TaskMetadata } from "./corpus";
+import type { RunResult } from "./driver";
+import {
+  type Arm,
+  computePerAssetAttribution,
+  extractAssetLoads,
+  type PerAssetAttribution,
+  type RunUtilityOptionsForMask,
+  runMaskedCorpus,
+} from "./metrics";
+import { renderAttributionTable, type UtilityRunReport } from "./report";
+
+function makeRun(overrides: Partial<RunResult> = {}): RunResult {
+  return {
+    schemaVersion: 1,
+    taskId: "t",
+    arm: "akm",
+    seed: 0,
+    model: "m",
+    outcome: "pass",
+    tokens: { input: 0, output: 0 },
+    wallclockMs: 0,
+    trajectory: { correctAssetLoaded: null, feedbackRecorded: null },
+    events: [],
+    verifierStdout: "",
+    verifierExitCode: 0,
+    assetsLoaded: [],
+    ...overrides,
+  };
+}
+
+function makeReport(akmRuns: RunResult[]): UtilityRunReport {
+  return {
+    timestamp: "2026-04-27T00:00:00Z",
+    branch: "test",
+    commit: "abc",
+    model: "m",
+    corpus: { domains: 1, tasks: 1, slice: "all", seedsPerArm: akmRuns.length },
+    aggregateNoakm: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+    aggregateAkm: {
+      passRate: akmRuns.filter((r) => r.outcome === "pass").length / Math.max(1, akmRuns.length),
+      tokensPerPass: null,
+      wallclockMs: 0,
+    },
+    aggregateDelta: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+    trajectoryAkm: { correctAssetLoaded: null, feedbackRecorded: 0 },
+    tasks: [],
+    warnings: [],
+    akmRuns,
+  };
+}
+
+describe("extractAssetLoads", () => {
+  test("parses literal `akm show <ref>` from verifierStdout", () => {
+    const r = makeRun({ verifierStdout: "tool: akm show skill:docker-homelab\nresult: ok\n" });
+    expect(extractAssetLoads(r)).toEqual(["skill:docker-homelab"]);
+  });
+
+  test('parses tool-call JSON form `args:["show","<ref>"]`', () => {
+    const r = makeRun({
+      verifierStdout: '{"command":"akm","args":["show","skill:az-cli"]} done',
+    });
+    expect(extractAssetLoads(r)).toEqual(["skill:az-cli"]);
+  });
+
+  test("dedupes refs and preserves first-seen order", () => {
+    const r = makeRun({
+      verifierStdout: "akm show skill:foo\nakm show skill:bar\nakm show skill:foo\n",
+    });
+    expect(extractAssetLoads(r)).toEqual(["skill:foo", "skill:bar"]);
+  });
+
+  test("parses ref from events.jsonl `show` event", () => {
+    const r = makeRun({
+      events: [
+        {
+          schemaVersion: 1,
+          id: 0,
+          ts: "2026-04-27T00:00:00Z",
+          eventType: "show",
+          ref: "skill:from-event",
+        },
+      ],
+    });
+    expect(extractAssetLoads(r)).toEqual(["skill:from-event"]);
+  });
+
+  test("merges events + stdout sources, dedupes across sources", () => {
+    const r = makeRun({
+      events: [
+        {
+          schemaVersion: 1,
+          id: 0,
+          ts: "2026-04-27T00:00:00Z",
+          eventType: "show",
+          ref: "skill:shared",
+        },
+      ],
+      verifierStdout: "akm show skill:shared\nakm show skill:only-stdout\n",
+    });
+    expect(extractAssetLoads(r)).toEqual(["skill:shared", "skill:only-stdout"]);
+  });
+
+  test("returns empty array when no `akm show` invocations are present", () => {
+    const r = makeRun({ verifierStdout: "agent: I will not search\n" });
+    expect(extractAssetLoads(r)).toEqual([]);
+  });
+
+  test("supports origin-prefixed refs (`team//skill:foo`)", () => {
+    const r = makeRun({ verifierStdout: "akm show team//skill:foo\n" });
+    expect(extractAssetLoads(r)).toEqual(["team//skill:foo"]);
+  });
+});
+
+describe("computePerAssetAttribution", () => {
+  test("counts pass/fail loads and computes pass rate", () => {
+    const runs: RunResult[] = [
+      // skill:a: 2 pass, 1 fail → 0.667
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:a"] }),
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:a"] }),
+      makeRun({ outcome: "fail", assetsLoaded: ["skill:a"] }),
+      // skill:b: 0 pass, 2 fail → 0
+      makeRun({ outcome: "fail", assetsLoaded: ["skill:b"] }),
+      makeRun({ outcome: "fail", assetsLoaded: ["skill:b"] }),
+      // skill:c: 1 pass, 0 fail → 1.0
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:c"] }),
+    ];
+    const attr = computePerAssetAttribution(makeReport(runs));
+    expect(attr.totalAkmRuns).toBe(6);
+    const a = attr.rows.find((r) => r.assetRef === "skill:a");
+    expect(a).toMatchObject({ loadCount: 3, loadCountPassing: 2, loadCountFailing: 1 });
+    expect(a?.loadPassRate).toBeCloseTo(2 / 3, 5);
+    const b = attr.rows.find((r) => r.assetRef === "skill:b");
+    expect(b?.loadPassRate).toBe(0);
+    const c = attr.rows.find((r) => r.assetRef === "skill:c");
+    expect(c?.loadPassRate).toBe(1);
+  });
+
+  test("orders rows by load count desc, pass rate desc, ref asc", () => {
+    const runs: RunResult[] = [
+      // skill:high-load-fail — 4 loads, all fail
+      makeRun({ outcome: "fail", assetsLoaded: ["skill:high-load-fail"] }),
+      makeRun({ outcome: "fail", assetsLoaded: ["skill:high-load-fail"] }),
+      makeRun({ outcome: "fail", assetsLoaded: ["skill:high-load-fail"] }),
+      makeRun({ outcome: "fail", assetsLoaded: ["skill:high-load-fail"] }),
+      // skill:high-load-pass — 4 loads, all pass (same count, higher pass_rate → first)
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:high-load-pass"] }),
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:high-load-pass"] }),
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:high-load-pass"] }),
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:high-load-pass"] }),
+      // skill:low-load — 1 load, pass
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:low-load"] }),
+    ];
+    const attr = computePerAssetAttribution(makeReport(runs));
+    expect(attr.rows.map((r) => r.assetRef)).toEqual([
+      "skill:high-load-pass", // count=4, rate=1
+      "skill:high-load-fail", // count=4, rate=0
+      "skill:low-load", // count=1
+    ]);
+  });
+
+  test("returns empty rows when no assets were loaded", () => {
+    const runs = [makeRun({ outcome: "pass", assetsLoaded: [] })];
+    const attr = computePerAssetAttribution(makeReport(runs));
+    expect(attr.rows).toEqual([]);
+    expect(attr.totalAkmRuns).toBe(1);
+  });
+});
+
+describe("renderAttributionTable", () => {
+  test("highlights well-used-and-working vs well-used-and-not-working", () => {
+    const attr: PerAssetAttribution = {
+      totalAkmRuns: 10,
+      rows: [
+        { assetRef: "skill:works", loadCount: 8, loadCountPassing: 7, loadCountFailing: 1, loadPassRate: 7 / 8 },
+        { assetRef: "skill:broken", loadCount: 6, loadCountPassing: 1, loadCountFailing: 5, loadPassRate: 1 / 6 },
+        { assetRef: "skill:rare", loadCount: 1, loadCountPassing: 1, loadCountFailing: 0, loadPassRate: 1 },
+      ],
+    };
+    const md = renderAttributionTable(attr);
+    expect(md).toContain("Well-used and working");
+    expect(md).toContain("`skill:works`");
+    expect(md).toContain("Well-used and NOT working");
+    expect(md).toContain("`skill:broken`");
+    // skill:rare is below the high-load cutoff so should NOT appear in the working callout (only in the table).
+    const workingSection = md.split("Well-used and working")[1]?.split("Well-used and NOT working")[0] ?? "";
+    expect(workingSection).not.toContain("`skill:rare`");
+  });
+
+  test("renders empty-state message when no rows", () => {
+    const md = renderAttributionTable({ totalAkmRuns: 0, rows: [] });
+    expect(md).toContain("No assets were loaded");
+  });
+});
+
+describe("runMaskedCorpus", () => {
+  function makeFixturesRoot(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "akm-bench-attr-fixtures-"));
+    // fixture A: two assets in one .stash.json
+    const fixA = path.join(root, "fixtureA");
+    fs.mkdirSync(path.join(fixA, "skills"), { recursive: true });
+    fs.writeFileSync(
+      path.join(fixA, "MANIFEST.json"),
+      JSON.stringify({ name: "fixtureA", description: "x", purpose: "x", assets: { skill: 2 }, consumers: [] }),
+    );
+    fs.writeFileSync(
+      path.join(fixA, "skills", ".stash.json"),
+      JSON.stringify({
+        entries: [
+          { name: "alpha", type: "skill", filename: "alpha.md" },
+          { name: "beta", type: "skill", filename: "beta.md" },
+        ],
+      }),
+    );
+    fs.writeFileSync(path.join(fixA, "skills", "alpha.md"), "# alpha");
+    fs.writeFileSync(path.join(fixA, "skills", "beta.md"), "# beta");
+    return root;
+  }
+
+  function fakeTask(overrides: Partial<TaskMetadata> = {}): TaskMetadata {
+    return {
+      id: "fake/t",
+      title: "t",
+      domain: "fake",
+      difficulty: "easy",
+      stash: "fixtureA",
+      verifier: "regex",
+      expectedMatch: "ok",
+      budget: { tokens: 100, wallMs: 1000 },
+      taskDir: "/tmp",
+      ...overrides,
+    };
+  }
+
+  test("masks top-N assets, calls runUtility once per asset, leaves source fixture intact", async () => {
+    const fixturesRoot = makeFixturesRoot();
+    const sourceContents = fs.readFileSync(path.join(fixturesRoot, "fixtureA", "skills", "alpha.md"), "utf8");
+
+    const baseRuns: RunResult[] = [
+      // alpha: 3 pass, 1 fail → load_count 4
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:alpha"] }),
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:alpha"] }),
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:alpha"] }),
+      makeRun({ outcome: "fail", assetsLoaded: ["skill:alpha"] }),
+      // beta: 1 pass, 1 fail → load_count 2
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:beta"] }),
+      makeRun({ outcome: "fail", assetsLoaded: ["skill:beta"] }),
+    ];
+    const baseReport = makeReport(baseRuns);
+    baseReport.taskMetadata = [fakeTask()];
+
+    let callCount = 0;
+    const seenStashDirs: string[] = [];
+    const runUtility = async (
+      options: Omit<RunUtilityOptionsForMask, "spawn" | "materialiseStash"> & {
+        tasks: TaskMetadata[];
+        materialiseStash?: boolean;
+      },
+    ): Promise<UtilityRunReport> => {
+      callCount += 1;
+      // Each masked re-run sees a different tmp stash dir tunneled through `tasks[].stash`.
+      seenStashDirs.push(options.tasks[0]?.stash ?? "");
+      // Simulate that masking alpha drops the pass rate, masking beta does nothing.
+      const stashDir = options.tasks[0]?.stash ?? "";
+      const alphaMissing = !fs.existsSync(path.join(stashDir, "skills", "alpha.md"));
+      const passRate = alphaMissing ? 0.25 : 0.6;
+      return {
+        ...baseReport,
+        aggregateAkm: { passRate, tokensPerPass: null, wallclockMs: 0 },
+        akmRuns: [],
+      };
+    };
+
+    const result = await runMaskedCorpus({
+      baseReport,
+      topN: 5, // > 2 assets, should clamp
+      runUtility,
+      baseOptions: { arms: ["noakm", "akm"] as Arm[], model: "m", seedsPerArm: 1 },
+      fixturesRoot,
+    });
+
+    // Only 2 unique assets exist in the base report → topN clamped to 2.
+    expect(result.runsPerformed).toBe(2);
+    expect(callCount).toBe(2);
+    expect(result.attributions.length).toBe(2);
+
+    // Asset ranking: alpha first (load_count 4), beta second.
+    const alpha = result.attributions[0];
+    expect(alpha?.assetRef).toBe("skill:alpha");
+    expect(alpha?.basePassRate).toBeCloseTo(4 / 6, 5);
+    expect(alpha?.maskedPassRate).toBe(0.25);
+    expect(alpha?.marginalContribution).toBeCloseTo(4 / 6 - 0.25, 5);
+
+    const beta = result.attributions[1];
+    expect(beta?.assetRef).toBe("skill:beta");
+    expect(beta?.maskedPassRate).toBe(0.6);
+
+    // Source fixture content untouched.
+    const sourceContentsAfter = fs.readFileSync(path.join(fixturesRoot, "fixtureA", "skills", "alpha.md"), "utf8");
+    expect(sourceContentsAfter).toBe(sourceContents);
+    // Source .stash.json still has both entries.
+    const stashJsonAfter = JSON.parse(
+      fs.readFileSync(path.join(fixturesRoot, "fixtureA", "skills", ".stash.json"), "utf8"),
+    );
+    expect(stashJsonAfter.entries.length).toBe(2);
+
+    // The two stash dirs the runner saw should be different tmp dirs (not the source).
+    expect(new Set(seenStashDirs).size).toBe(2);
+    for (const d of seenStashDirs) {
+      expect(d.startsWith(os.tmpdir())).toBe(true);
+    }
+
+    fs.rmSync(fixturesRoot, { recursive: true, force: true });
+  });
+
+  test("cost accounting: runs N times when N <= asset count", async () => {
+    const fixturesRoot = makeFixturesRoot();
+    const baseRuns: RunResult[] = [
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:alpha"] }),
+      makeRun({ outcome: "fail", assetsLoaded: ["skill:beta"] }),
+    ];
+    const baseReport = makeReport(baseRuns);
+    baseReport.taskMetadata = [fakeTask()];
+
+    let callCount = 0;
+    const result = await runMaskedCorpus({
+      baseReport,
+      topN: 1,
+      runUtility: async () => {
+        callCount += 1;
+        return {
+          ...baseReport,
+          aggregateAkm: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+        };
+      },
+      baseOptions: { arms: ["akm"] as Arm[], model: "m", seedsPerArm: 1 },
+      fixturesRoot,
+    });
+    expect(result.runsPerformed).toBe(1);
+    expect(callCount).toBe(1);
+    expect(result.attributions.length).toBe(1);
+    fs.rmSync(fixturesRoot, { recursive: true, force: true });
+  });
+});
+
+describe("bench attribute --top clamping", () => {
+  test("clamps --top when fewer assets exist", async () => {
+    // Write a §13.3 envelope to disk with only 2 perAsset rows.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "akm-bench-attr-cli-"));
+    const fixturesRoot = path.join(tmp, "stashes");
+    fs.mkdirSync(fixturesRoot, { recursive: true });
+    // Two-asset fixture so the masked re-runs find their assets to remove.
+    const fixDir = path.join(fixturesRoot, "tiny");
+    fs.mkdirSync(path.join(fixDir, "skills"), { recursive: true });
+    fs.writeFileSync(
+      path.join(fixDir, "MANIFEST.json"),
+      JSON.stringify({ name: "tiny", description: "x", purpose: "x", assets: { skill: 2 }, consumers: [] }),
+    );
+    fs.writeFileSync(
+      path.join(fixDir, "skills", ".stash.json"),
+      JSON.stringify({
+        entries: [
+          { name: "alpha", type: "skill", filename: "alpha.md" },
+          { name: "beta", type: "skill", filename: "beta.md" },
+        ],
+      }),
+    );
+    fs.writeFileSync(path.join(fixDir, "skills", "alpha.md"), "# alpha");
+    fs.writeFileSync(path.join(fixDir, "skills", "beta.md"), "# beta");
+
+    const envelope = {
+      schemaVersion: 1,
+      track: "utility",
+      branch: "test",
+      commit: "abc",
+      timestamp: "2026-04-27T00:00:00Z",
+      agent: { harness: "opencode", model: "test-model" },
+      corpus: { domains: 1, tasks: 1, slice: "all", seedsPerArm: 1 },
+      aggregate: {
+        noakm: { pass_rate: 0, tokens_per_pass: null, wallclock_ms: 0 },
+        akm: { pass_rate: 0.5, tokens_per_pass: null, wallclock_ms: 0 },
+        delta: { pass_rate: 0.5, tokens_per_pass: null, wallclock_ms: 0 },
+      },
+      trajectory: { akm: { correct_asset_loaded: null, feedback_recorded: 0 } },
+      tasks: [],
+      warnings: [],
+      perAsset: {
+        total_akm_runs: 4,
+        rows: [
+          {
+            asset_ref: "skill:alpha",
+            load_count: 2,
+            load_count_passing: 1,
+            load_count_failing: 1,
+            load_pass_rate: 0.5,
+          },
+          { asset_ref: "skill:beta", load_count: 1, load_count_passing: 1, load_count_failing: 0, load_pass_rate: 1 },
+        ],
+      },
+    };
+    const basePath = path.join(tmp, "run.json");
+    fs.writeFileSync(basePath, JSON.stringify(envelope));
+
+    let calls = 0;
+    const result = await runAttributeCli({
+      basePath,
+      topN: 5, // > 2 → clamp to 2
+      json: true,
+      runUtility: async () => {
+        calls += 1;
+        return {
+          timestamp: "2026-04-27T00:00:00Z",
+          branch: "test",
+          commit: "abc",
+          model: "test-model",
+          corpus: { domains: 1, tasks: 0, slice: "all", seedsPerArm: 1 },
+          aggregateNoakm: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+          aggregateAkm: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+          aggregateDelta: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+          trajectoryAkm: { correctAssetLoaded: null, feedbackRecorded: 0 },
+          tasks: [],
+          warnings: [],
+        };
+      },
+      fixturesRoot,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout) as Record<string, unknown>;
+    expect(json.runsPerformed).toBe(2);
+    expect(json.maskingStrategy).toBe("leave-one-out");
+    expect((json.attributions as unknown[]).length).toBe(2);
+    expect(calls).toBe(2);
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});

--- a/tests/bench/cli.test.ts
+++ b/tests/bench/cli.test.ts
@@ -51,8 +51,8 @@ describe("bench CLI", () => {
     expect(r.stderr).toContain("BENCH_OPENCODE_MODEL");
   });
 
-  test("evolve / compare / attribute remain not-implemented", () => {
-    for (const sub of ["evolve", "compare", "attribute"]) {
+  test("evolve / attribute remain not-implemented", () => {
+    for (const sub of ["evolve", "attribute"]) {
       const r = run([sub]);
       expect(r.exitCode).toBe(2);
       expect(r.stderr).toContain("not yet implemented");

--- a/tests/bench/cli.test.ts
+++ b/tests/bench/cli.test.ts
@@ -51,12 +51,24 @@ describe("bench CLI", () => {
     expect(r.stderr).toContain("BENCH_OPENCODE_MODEL");
   });
 
-  test("evolve / compare / attribute remain not-implemented", () => {
-    for (const sub of ["evolve", "compare", "attribute"]) {
+  test("evolve / compare remain not-implemented", () => {
+    for (const sub of ["evolve", "compare"]) {
       const r = run([sub]);
       expect(r.exitCode).toBe(2);
       expect(r.stderr).toContain("not yet implemented");
     }
+  });
+
+  test("attribute without --base exits 2", () => {
+    const r = run(["attribute"]);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain("--base");
+  });
+
+  test("attribute with missing --base file exits 2", () => {
+    const r = run(["attribute", "--base", "/nonexistent/run.json"]);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain("not found");
   });
 
   test("utility --tasks train --seeds 1 --json produces a §13.3 envelope", () => {

--- a/tests/bench/cli.ts
+++ b/tests/bench/cli.ts
@@ -16,10 +16,17 @@
  * hand-rolled parser keeps the dependency graph tight.
  */
 
+import fs from "node:fs";
 import process from "node:process";
 
-import { listTasks } from "./corpus";
-import { renderUtilityReport } from "./report";
+import { listTasks, type TaskMetadata } from "./corpus";
+import {
+  type MaskedCorpusResult,
+  type PerAssetAttribution,
+  type RunUtilityOptionsForMask,
+  runMaskedCorpus,
+} from "./metrics";
+import { renderAttributionTable, renderUtilityReport, type UtilityRunReport } from "./report";
 import { runUtility } from "./runner";
 
 const HELP = `akm-bench — agent-plus-akm evaluation framework
@@ -42,6 +49,11 @@ utility flags:
                            Without --json, JSON still goes to stdout and the markdown
                            summary is also written to stderr for human-friendly reads.
   -h, --help               show this message.
+
+attribute flags:
+  --base <path>            path to a §13.3 utility run JSON (required).
+  --top <N>                number of top-loaded assets to mask (default: 5; clamped).
+  --json                   suppress the markdown summary on stderr.
 
 Environment:
   BENCH_OPENCODE_MODEL   model id stamped into every RunResult. REQUIRED for utility.
@@ -158,6 +170,296 @@ export async function runUtilityCli(options: UtilityCliOptions): Promise<Utility
   return { exitCode: 0, stdout, stderr };
 }
 
+/** Caller-facing options for `runAttributeCli`. */
+export interface AttributeCliOptions {
+  /** Path to a §13.3 utility run JSON file. */
+  basePath: string;
+  /** Top N most-loaded assets to mask. Default 5; clamped to asset count. */
+  topN: number;
+  /** Suppress the markdown summary on stderr. */
+  json: boolean;
+  /**
+   * Test seam: when supplied, this function is used to drive the masked
+   * re-runs instead of `runUtility`. Production omits it and the helper
+   * uses the real runner.
+   */
+  runUtility?: (
+    options: Omit<RunUtilityOptionsForMask, "spawn" | "materialiseStash"> & {
+      tasks: TaskMetadata[];
+      spawn?: RunUtilityOptionsForMask["spawn"];
+      materialiseStash?: boolean;
+    },
+  ) => Promise<UtilityRunReport>;
+  /**
+   * Test seam: override the fixtures directory the masked-stash helper
+   * copies from. Defaults to `tests/fixtures/stashes/`.
+   */
+  fixturesRoot?: string;
+  /** Test seam: override the model stamped on masked re-runs. */
+  modelOverride?: string;
+}
+
+export interface AttributeCliResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * `attribute` subcommand. Loads a base utility report, picks the top-N
+ * most-loaded assets, masks each in turn, re-runs the corpus, and emits a
+ * marginal-contribution report.
+ *
+ * Cost: N × (tasks × arms × seedsPerArm) re-runs. Reported to stderr up
+ * front so the operator can abort if the projection is too expensive.
+ */
+export async function runAttributeCli(options: AttributeCliOptions): Promise<AttributeCliResult> {
+  if (!fs.existsSync(options.basePath)) {
+    return {
+      exitCode: 2,
+      stdout: "",
+      stderr: `bench attribute: base report not found: ${options.basePath}\n`,
+    };
+  }
+
+  let baseEnvelope: Record<string, unknown>;
+  try {
+    baseEnvelope = JSON.parse(fs.readFileSync(options.basePath, "utf8")) as Record<string, unknown>;
+  } catch (err) {
+    return {
+      exitCode: 2,
+      stdout: "",
+      stderr: `bench attribute: failed to parse ${options.basePath}: ${err instanceof Error ? err.message : String(err)}\n`,
+    };
+  }
+
+  const corpus = (baseEnvelope.corpus ?? {}) as Record<string, unknown>;
+  const sliceRaw = (corpus.slice ?? "all") as string;
+  const slice: "train" | "eval" | "all" = sliceRaw === "train" || sliceRaw === "eval" ? sliceRaw : "all";
+  const sliceFilter = slice === "all" ? undefined : slice;
+  const tasks = listTasks(sliceFilter ? { slice: sliceFilter } : {});
+  const seedsPerArm = typeof corpus.seedsPerArm === "number" ? corpus.seedsPerArm : 5;
+  const agent = (baseEnvelope.agent ?? {}) as Record<string, unknown>;
+  const model = options.modelOverride ?? (typeof agent.model === "string" ? agent.model : "unknown");
+
+  // The stored envelope's perAsset is in snake_case. Convert it back to the
+  // PerAssetAttribution shape the metrics module expects so we can pass it
+  // through to runMaskedCorpus.
+  const perAssetSerialised = baseEnvelope.perAsset as
+    | { total_akm_runs?: number; rows?: Array<Record<string, unknown>> }
+    | undefined;
+  const perAsset: PerAssetAttribution = {
+    totalAkmRuns: perAssetSerialised?.total_akm_runs ?? 0,
+    rows: (perAssetSerialised?.rows ?? []).map((r) => ({
+      assetRef: String(r.asset_ref ?? ""),
+      loadCount: Number(r.load_count ?? 0),
+      loadCountPassing: Number(r.load_count_passing ?? 0),
+      loadCountFailing: Number(r.load_count_failing ?? 0),
+      loadPassRate: r.load_pass_rate === null ? null : Number(r.load_pass_rate),
+    })),
+  };
+
+  if (perAsset.rows.length === 0) {
+    return {
+      exitCode: 2,
+      stdout: "",
+      stderr:
+        "bench attribute: base report has no per-asset attribution rows (no assets loaded). Re-run `bench utility` first.\n",
+    };
+  }
+
+  const desired = Math.max(1, options.topN);
+  const clamped = Math.min(desired, perAsset.rows.length);
+
+  // Reconstitute a partial UtilityRunReport so runMaskedCorpus has what it
+  // needs. We don't have the raw RunResults in the on-disk envelope, so the
+  // helper uses the perAsset table directly via computePerAssetAttribution.
+  // To make that work we synthesise akmRuns from the perAsset rows: each
+  // row contributes loadCountPassing pass-stub runs and loadCountFailing
+  // fail-stub runs. This is enough for `computePerAssetAttribution` inside
+  // `runMaskedCorpus` to produce the same top-N ranking we just loaded.
+  const synthesisedAkmRuns = synthesiseAkmRunsFromAttribution(perAsset);
+  const baseReport: UtilityRunReport = {
+    timestamp: String(baseEnvelope.timestamp ?? ""),
+    branch: String(baseEnvelope.branch ?? ""),
+    commit: String(baseEnvelope.commit ?? ""),
+    model,
+    corpus: {
+      domains: typeof corpus.domains === "number" ? corpus.domains : 0,
+      tasks: typeof corpus.tasks === "number" ? corpus.tasks : tasks.length,
+      slice,
+      seedsPerArm,
+    },
+    aggregateNoakm: extractCorpusMetrics(baseEnvelope, "noakm"),
+    aggregateAkm: extractCorpusMetrics(baseEnvelope, "akm"),
+    aggregateDelta: extractCorpusMetrics(baseEnvelope, "delta"),
+    trajectoryAkm: { correctAssetLoaded: null, feedbackRecorded: 0 },
+    tasks: [],
+    warnings: [],
+    perAsset,
+    akmRuns: synthesisedAkmRuns,
+    taskMetadata: tasks,
+  };
+
+  const projection = clamped * tasks.length * 2 * seedsPerArm;
+  let stderr = `bench attribute: masking top ${clamped} of ${perAsset.rows.length} assets; ${clamped} × ${tasks.length} tasks × 2 arms × ${seedsPerArm} seeds = ${projection} re-runs.\n`;
+
+  const baseOptions: RunUtilityOptionsForMask = {
+    arms: ["noakm", "akm"],
+    model,
+    seedsPerArm,
+  };
+
+  const maskedRunner = options.runUtility ?? defaultMaskedRunner;
+  let maskedResult: MaskedCorpusResult;
+  try {
+    maskedResult = await runMaskedCorpus({
+      baseReport,
+      topN: clamped,
+      runUtility: maskedRunner,
+      baseOptions,
+      ...(options.fixturesRoot ? { fixturesRoot: options.fixturesRoot } : {}),
+    });
+  } catch (err) {
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `${stderr}bench attribute: masked-corpus run failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    };
+  }
+
+  const json = {
+    schemaVersion: 1,
+    track: "attribute",
+    base: { path: options.basePath, model },
+    maskingStrategy: "leave-one-out",
+    runsPerformed: maskedResult.runsPerformed,
+    perAsset: {
+      total_akm_runs: perAsset.totalAkmRuns,
+      rows: perAsset.rows.map((r) => ({
+        asset_ref: r.assetRef,
+        load_count: r.loadCount,
+        load_count_passing: r.loadCountPassing,
+        load_count_failing: r.loadCountFailing,
+        load_pass_rate: r.loadPassRate,
+      })),
+    },
+    attributions: maskedResult.attributions.map((a) => ({
+      asset_ref: a.assetRef,
+      base_pass_rate: a.basePassRate,
+      masked_pass_rate: a.maskedPassRate,
+      marginal_contribution: a.marginalContribution,
+    })),
+  };
+
+  const stdout = `${JSON.stringify(json, null, 2)}\n`;
+  if (!options.json) {
+    stderr += `${renderAttributionTable(perAsset)}\n`;
+    stderr += `\n## Marginal contributions (leave-one-out)\n\n`;
+    stderr += `| asset_ref | base_pass_rate | masked_pass_rate | marginal_contribution |\n`;
+    stderr += `|-----------|----------------|------------------|-----------------------|\n`;
+    for (const a of maskedResult.attributions) {
+      stderr += `| \`${a.assetRef}\` | ${a.basePassRate.toFixed(2)} | ${a.maskedPassRate.toFixed(2)} | ${signed(a.marginalContribution.toFixed(2))} |\n`;
+    }
+  }
+
+  return { exitCode: 0, stdout, stderr };
+}
+
+/** Default real-runner wrapper for masked re-runs. */
+async function defaultMaskedRunner(
+  options: Omit<RunUtilityOptionsForMask, "spawn" | "materialiseStash"> & {
+    tasks: TaskMetadata[];
+    spawn?: RunUtilityOptionsForMask["spawn"];
+    materialiseStash?: boolean;
+  },
+): Promise<UtilityRunReport> {
+  const arms = options.arms;
+  return runUtility({
+    tasks: options.tasks,
+    arms,
+    model: options.model,
+    ...(options.seedsPerArm !== undefined ? { seedsPerArm: options.seedsPerArm } : {}),
+    ...(options.budgetTokens !== undefined ? { budgetTokens: options.budgetTokens } : {}),
+    ...(options.budgetWallMs !== undefined ? { budgetWallMs: options.budgetWallMs } : {}),
+    ...(options.slice !== undefined ? { slice: options.slice } : {}),
+    ...(options.timestamp !== undefined ? { timestamp: options.timestamp } : {}),
+    ...(options.branch !== undefined ? { branch: options.branch } : {}),
+    ...(options.commit !== undefined ? { commit: options.commit } : {}),
+    ...(options.spawn ? { spawn: options.spawn } : {}),
+    ...(options.materialiseStash !== undefined ? { materialiseStash: options.materialiseStash } : {}),
+  });
+}
+
+/**
+ * Best-effort extractor for `aggregate.<arm>` corpus metrics from the
+ * persisted §13.3 envelope. The envelope keys are snake-cased.
+ */
+function extractCorpusMetrics(
+  envelope: Record<string, unknown>,
+  key: "noakm" | "akm" | "delta",
+): { passRate: number; tokensPerPass: number | null; wallclockMs: number } {
+  const aggregate = (envelope.aggregate ?? {}) as Record<string, unknown>;
+  const node = (aggregate[key] ?? {}) as Record<string, unknown>;
+  return {
+    passRate: typeof node.pass_rate === "number" ? node.pass_rate : 0,
+    tokensPerPass:
+      node.tokens_per_pass === null ? null : typeof node.tokens_per_pass === "number" ? node.tokens_per_pass : null,
+    wallclockMs: typeof node.wallclock_ms === "number" ? node.wallclock_ms : 0,
+  };
+}
+
+/**
+ * Build a synthetic akm-arm RunResult bag from a previously-computed
+ * attribution table. Used when we load a §13.3 envelope from disk: the
+ * envelope doesn't carry raw RunResults, but the attribution table is
+ * lossless w.r.t. (asset, pass/fail) counts — which is all
+ * `computePerAssetAttribution` needs to reproduce the top-N ranking.
+ *
+ * Each synthetic run loads exactly one asset. This over-counts the run
+ * total but keeps the per-asset counts faithful to the original table. The
+ * synthesised runs are NOT consumed by `runMaskedCorpus` for the masked
+ * runs themselves — those go through the injected runner — they only seed
+ * `report.akmRuns` so that recomputing the attribution gives back the
+ * same top-N ordering.
+ */
+function synthesiseAkmRunsFromAttribution(perAsset: PerAssetAttribution): import("./driver").RunResult[] {
+  const out: import("./driver").RunResult[] = [];
+  for (const row of perAsset.rows) {
+    for (let i = 0; i < row.loadCountPassing; i++) {
+      out.push(makeSyntheticRun("pass", row.assetRef));
+    }
+    for (let i = 0; i < row.loadCountFailing; i++) {
+      out.push(makeSyntheticRun("fail", row.assetRef));
+    }
+  }
+  return out;
+}
+
+function makeSyntheticRun(outcome: "pass" | "fail", ref: string): import("./driver").RunResult {
+  return {
+    schemaVersion: 1,
+    taskId: "synthetic",
+    arm: "akm",
+    seed: 0,
+    model: "synthetic",
+    outcome,
+    tokens: { input: 0, output: 0 },
+    wallclockMs: 0,
+    trajectory: { correctAssetLoaded: null, feedbackRecorded: null },
+    events: [],
+    verifierStdout: "",
+    verifierExitCode: outcome === "pass" ? 0 : 1,
+    assetsLoaded: [ref],
+  };
+}
+
+function signed(text: string): string {
+  if (text.startsWith("-")) return text;
+  if (text === "0" || text === "0.00" || text === "0.0") return text;
+  return `+${text}`;
+}
+
 function getEnv(name: string): string | undefined {
   const value = process.env[name];
   return value && value.length > 0 ? value : undefined;
@@ -209,8 +511,22 @@ async function main(argv: string[]): Promise<number> {
       return notImplemented("evolve", "#239");
     case "compare":
       return notImplemented("compare", "#240");
-    case "attribute":
-      return notImplemented("attribute", "#243");
+    case "attribute": {
+      const basePath = parsed.flags.get("base");
+      if (!basePath) {
+        process.stderr.write("bench attribute: --base <path> is required.\n");
+        return 2;
+      }
+      const topN = parseInt32(parsed.flags.get("top"), 5);
+      const result = await runAttributeCli({
+        basePath,
+        topN,
+        json: parsed.bool.has("json"),
+      });
+      if (result.stdout) process.stdout.write(result.stdout);
+      if (result.stderr) process.stderr.write(result.stderr);
+      return result.exitCode;
+    }
     default:
       process.stderr.write(`unknown subcommand: ${parsed.subcommand}\n`);
       process.stderr.write(HELP);

--- a/tests/bench/cli.ts
+++ b/tests/bench/cli.ts
@@ -16,10 +16,12 @@
  * hand-rolled parser keeps the dependency graph tight.
  */
 
+import fs from "node:fs";
 import process from "node:process";
 
 import { listTasks } from "./corpus";
-import { renderUtilityReport } from "./report";
+import { compareReports, type ParsedReportJson } from "./metrics";
+import { renderCompareMarkdown, renderUtilityReport } from "./report";
 import { runUtility } from "./runner";
 
 const HELP = `akm-bench — agent-plus-akm evaluation framework
@@ -42,6 +44,14 @@ utility flags:
                            Without --json, JSON still goes to stdout and the markdown
                            summary is also written to stderr for human-friendly reads.
   -h, --help               show this message.
+
+compare flags:
+  --base <path>            path to baseline UtilityRunReport JSON file. REQUIRED.
+  --current <path>         path to current  UtilityRunReport JSON file. REQUIRED.
+  --json                   emit the structured CompareResult JSON to stdout instead
+                           of a markdown diff.
+  Exit codes: 0 on successful diff, 1 on refusal (model/hash/schema/track mismatch),
+              2 on input errors (missing files, malformed JSON, unknown flags).
 
 Environment:
   BENCH_OPENCODE_MODEL   model id stamped into every RunResult. REQUIRED for utility.
@@ -158,6 +168,79 @@ export async function runUtilityCli(options: UtilityCliOptions): Promise<Utility
   return { exitCode: 0, stdout, stderr };
 }
 
+export interface CompareCliOptions {
+  basePath: string;
+  currentPath: string;
+  json: boolean;
+}
+
+/**
+ * `compare` subcommand. Reads two UtilityRunReport JSON files from disk,
+ * dispatches to `compareReports`, and renders either markdown (default) or
+ * the structured JSON envelope to stdout.
+ *
+ * Exit-code shape:
+ *   • 0 on a successful diff (regardless of whether the diff shows wins).
+ *   • 1 on a refusal (model/hash/schema/track mismatch).
+ *   • 2 on input errors (file missing, malformed JSON).
+ *
+ * Returned `UtilityCliResult` keeps this unit-testable; the `main()` driver
+ * splices the result onto the actual process.
+ */
+export function runCompareCli(options: CompareCliOptions): UtilityCliResult {
+  let baseRaw: string;
+  let currentRaw: string;
+  try {
+    baseRaw = fs.readFileSync(options.basePath, "utf8");
+  } catch (err) {
+    return {
+      exitCode: 2,
+      stdout: "",
+      stderr: `bench compare: cannot read --base ${options.basePath}: ${(err as Error).message}\n`,
+    };
+  }
+  try {
+    currentRaw = fs.readFileSync(options.currentPath, "utf8");
+  } catch (err) {
+    return {
+      exitCode: 2,
+      stdout: "",
+      stderr: `bench compare: cannot read --current ${options.currentPath}: ${(err as Error).message}\n`,
+    };
+  }
+
+  let base: ParsedReportJson;
+  let current: ParsedReportJson;
+  try {
+    base = JSON.parse(baseRaw) as ParsedReportJson;
+  } catch (err) {
+    return { exitCode: 2, stdout: "", stderr: `bench compare: malformed JSON in --base: ${(err as Error).message}\n` };
+  }
+  try {
+    current = JSON.parse(currentRaw) as ParsedReportJson;
+  } catch (err) {
+    return {
+      exitCode: 2,
+      stdout: "",
+      stderr: `bench compare: malformed JSON in --current: ${(err as Error).message}\n`,
+    };
+  }
+
+  const result = compareReports(base, current);
+  const stdout = options.json ? `${JSON.stringify(result, null, 2)}\n` : `${renderCompareMarkdown(result)}\n`;
+  let stderr = "";
+  if (!result.ok) {
+    stderr = `bench compare: ${result.message}\n`;
+    return { exitCode: 1, stdout, stderr };
+  }
+  // One-line summary on stderr so an interactive operator sees it without
+  // having to scan the markdown body.
+  const agg = result.aggregate;
+  stderr = `bench compare: pass_rate Δ=${agg.passRateDelta.toFixed(2)} (${agg.passRateSign}); ${result.perTask.length} tasks compared.\n`;
+  for (const w of result.warnings) stderr += `warning: ${w}\n`;
+  return { exitCode: 0, stdout, stderr };
+}
+
 function getEnv(name: string): string | undefined {
   const value = process.env[name];
   return value && value.length > 0 ? value : undefined;
@@ -207,8 +290,22 @@ async function main(argv: string[]): Promise<number> {
     }
     case "evolve":
       return notImplemented("evolve", "#239");
-    case "compare":
-      return notImplemented("compare", "#240");
+    case "compare": {
+      const basePath = parsed.flags.get("base");
+      const currentPath = parsed.flags.get("current");
+      if (!basePath || !currentPath) {
+        process.stderr.write("bench compare: --base and --current are both required.\n");
+        return 2;
+      }
+      const result = runCompareCli({
+        basePath,
+        currentPath,
+        json: parsed.bool.has("json"),
+      });
+      if (result.stdout) process.stdout.write(result.stdout);
+      if (result.stderr) process.stderr.write(result.stderr);
+      return result.exitCode;
+    }
     case "attribute":
       return notImplemented("attribute", "#243");
     default:

--- a/tests/bench/compare.test.ts
+++ b/tests/bench/compare.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Unit tests for the `bench compare` subcommand (#239).
+ *
+ * Covers:
+ *   • happy-path comparison: deltas + sign markers correct.
+ *   • model-mismatch refusal: both models named in the message.
+ *   • missing fixture-content hash on either side: proceeds with a warning.
+ *   • markdown output is byte-stable across two calls with identical input.
+ *   • CLI driver: invalid input file (missing path / malformed JSON) → exit 2.
+ *   • CLI driver: refusal → exit 1; success → exit 0.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { runCompareCli } from "./cli";
+import { compareReports, type ParsedReportJson } from "./metrics";
+import { renderCompareMarkdown } from "./report";
+
+const MODEL = "anthropic/claude-opus-4-7";
+
+function makeReport(overrides: Partial<ParsedReportJson> = {}): ParsedReportJson {
+  return {
+    schemaVersion: 1,
+    track: "utility",
+    branch: "release/1.0.0",
+    commit: "deadbee",
+    timestamp: "2026-04-27T12:00:00Z",
+    agent: { harness: "opencode", model: MODEL },
+    corpus: { domains: 2, tasks: 2, slice: "all", seedsPerArm: 5 },
+    aggregate: {
+      noakm: { pass_rate: 0.4, tokens_per_pass: 18000, wallclock_ms: 41000 },
+      akm: { pass_rate: 0.6, tokens_per_pass: 14000, wallclock_ms: 36000 },
+      delta: { pass_rate: 0.2, tokens_per_pass: -4000, wallclock_ms: -5000 },
+    },
+    tasks: [
+      {
+        id: "domain-a/task-1",
+        akm: {
+          pass_rate: 0.6,
+          pass_at_1: 1,
+          tokens_per_pass: 13000,
+          wallclock_ms: 35000,
+          pass_rate_stdev: 0.1,
+          budget_exceeded_count: 0,
+          harness_error_count: 0,
+          count: 5,
+        },
+      },
+      {
+        id: "domain-b/task-2",
+        akm: {
+          pass_rate: 0.6,
+          pass_at_1: 1,
+          tokens_per_pass: 15000,
+          wallclock_ms: 37000,
+          pass_rate_stdev: 0.2,
+          budget_exceeded_count: 0,
+          harness_error_count: 0,
+          count: 5,
+        },
+      },
+    ],
+    warnings: [],
+    ...overrides,
+  } as ParsedReportJson;
+}
+
+describe("compareReports — happy path", () => {
+  test("computes aggregate delta with correct sign markers", () => {
+    const base = makeReport();
+    // Current improves pass_rate by +0.2, reduces tokens by 1000, slower by 1000ms.
+    const current = makeReport({
+      aggregate: {
+        noakm: { pass_rate: 0.4, tokens_per_pass: 18000, wallclock_ms: 41000 },
+        akm: { pass_rate: 0.8, tokens_per_pass: 13000, wallclock_ms: 37000 },
+        delta: { pass_rate: 0.4, tokens_per_pass: -5000, wallclock_ms: -4000 },
+      },
+    });
+    const result = compareReports(base, current);
+    if (!result.ok) throw new Error("expected ok=true");
+    expect(result.aggregate.passRateDelta).toBeCloseTo(0.2);
+    expect(result.aggregate.passRateSign).toBe("improve");
+    expect(result.aggregate.tokensPerPassDelta).toBeCloseTo(-1000);
+    expect(result.aggregate.tokensPerPassSign).toBe("improve"); // lower tokens = better
+    expect(result.aggregate.wallclockMsDelta).toBeCloseTo(1000);
+    expect(result.aggregate.wallclockMsSign).toBe("regress"); // higher wallclock = worse
+    expect(result.perTask.length).toBe(2);
+  });
+
+  test("flat sign for tiny pass-rate jitter", () => {
+    const base = makeReport();
+    const current = makeReport({
+      aggregate: {
+        noakm: { pass_rate: 0.4, tokens_per_pass: 18000, wallclock_ms: 41000 },
+        akm: { pass_rate: 0.602, tokens_per_pass: 14000, wallclock_ms: 36000 },
+        delta: { pass_rate: 0.202, tokens_per_pass: -4000, wallclock_ms: -5000 },
+      },
+    });
+    const result = compareReports(base, current);
+    if (!result.ok) throw new Error("expected ok=true");
+    // 0.602 − 0.6 = 0.002 < 0.005 tolerance
+    expect(result.aggregate.passRateSign).toBe("flat");
+  });
+
+  test("per-task row carries baseMetrics + currentMetrics + signMarker", () => {
+    const base = makeReport();
+    const current = makeReport({
+      tasks: [
+        {
+          id: "domain-a/task-1",
+          akm: {
+            pass_rate: 0.8,
+            pass_at_1: 1,
+            tokens_per_pass: 12000,
+            wallclock_ms: 33000,
+            pass_rate_stdev: 0.05,
+            budget_exceeded_count: 0,
+            harness_error_count: 0,
+            count: 5,
+          },
+        },
+        {
+          id: "domain-b/task-2",
+          akm: {
+            pass_rate: 0.4,
+            pass_at_1: 0,
+            tokens_per_pass: 16000,
+            wallclock_ms: 38000,
+            pass_rate_stdev: 0.3,
+            budget_exceeded_count: 1,
+            harness_error_count: 0,
+            count: 5,
+          },
+        },
+      ],
+    });
+    const result = compareReports(base, current);
+    if (!result.ok) throw new Error("expected ok=true");
+    const row1 = result.perTask.find((r) => r.id === "domain-a/task-1");
+    const row2 = result.perTask.find((r) => r.id === "domain-b/task-2");
+    expect(row1?.signMarker).toBe("improve");
+    expect(row1?.delta.passRate).toBeCloseTo(0.2);
+    expect(row1?.baseMetrics?.pass_rate_stdev).toBeCloseTo(0.1);
+    expect(row1?.currentMetrics?.pass_rate_stdev).toBeCloseTo(0.05);
+    expect(row2?.signMarker).toBe("regress");
+    expect(row2?.delta.passRate).toBeCloseTo(-0.2);
+  });
+});
+
+describe("compareReports — refusal cases", () => {
+  test("model mismatch: ok=false with both models named", () => {
+    const base = makeReport();
+    const current = makeReport({ agent: { harness: "opencode", model: "anthropic/claude-sonnet-4-5" } });
+    const result = compareReports(base, current);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("model_mismatch");
+    expect(result.baseModel).toBe(MODEL);
+    expect(result.currentModel).toBe("anthropic/claude-sonnet-4-5");
+    expect(result.message).toContain(MODEL);
+    expect(result.message).toContain("anthropic/claude-sonnet-4-5");
+  });
+
+  test("schema mismatch: refuses non-v1 envelopes", () => {
+    const base = makeReport({ schemaVersion: 2 });
+    const current = makeReport();
+    const result = compareReports(base, current);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("schema_mismatch");
+  });
+
+  test("track mismatch: refuses non-utility tracks", () => {
+    const base = makeReport({ track: "evolve" });
+    const current = makeReport();
+    const result = compareReports(base, current);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("track_mismatch");
+  });
+
+  test("hash mismatch: refuses with both hashes named", () => {
+    const base = makeReport({
+      corpus: { domains: 2, tasks: 2, slice: "all", seedsPerArm: 5, fixtureContentHash: "abc123" },
+    });
+    const current = makeReport({
+      corpus: { domains: 2, tasks: 2, slice: "all", seedsPerArm: 5, fixtureContentHash: "def456" },
+    });
+    const result = compareReports(base, current);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("hash_mismatch");
+    expect(result.message).toContain("abc123");
+    expect(result.message).toContain("def456");
+  });
+});
+
+describe("compareReports — fixture-hash warnings", () => {
+  test("missing hash on base: proceeds with warning", () => {
+    const base = makeReport(); // no fixtureContentHash
+    const current = makeReport({
+      corpus: { domains: 2, tasks: 2, slice: "all", seedsPerArm: 5, fixtureContentHash: "abc123" },
+    });
+    const result = compareReports(base, current);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.warnings.some((w) => w.includes("base") && w.includes("fixtureContentHash"))).toBe(true);
+  });
+
+  test("missing hash on current: proceeds with warning", () => {
+    const base = makeReport({
+      corpus: { domains: 2, tasks: 2, slice: "all", seedsPerArm: 5, fixtureContentHash: "abc123" },
+    });
+    const current = makeReport(); // no fixtureContentHash
+    const result = compareReports(base, current);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.warnings.some((w) => w.includes("current") && w.includes("fixtureContentHash"))).toBe(true);
+  });
+
+  test("missing on both: two warnings, still ok", () => {
+    const base = makeReport();
+    const current = makeReport();
+    const result = compareReports(base, current);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.warnings.length).toBe(2);
+  });
+
+  test("matching hash: no warnings", () => {
+    const base = makeReport({
+      corpus: { domains: 2, tasks: 2, slice: "all", seedsPerArm: 5, fixtureContentHash: "abc123" },
+    });
+    const current = makeReport({
+      corpus: { domains: 2, tasks: 2, slice: "all", seedsPerArm: 5, fixtureContentHash: "abc123" },
+    });
+    const result = compareReports(base, current);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.warnings.length).toBe(0);
+  });
+});
+
+describe("renderCompareMarkdown determinism", () => {
+  test("byte-stable across two calls with identical input", () => {
+    const base = makeReport();
+    const current = makeReport();
+    const r1 = compareReports(base, current);
+    const r2 = compareReports(base, current);
+    expect(renderCompareMarkdown(r1)).toBe(renderCompareMarkdown(r2));
+  });
+
+  test("contains aggregate header and per-task table", () => {
+    const base = makeReport();
+    const current = makeReport({
+      aggregate: {
+        noakm: { pass_rate: 0.4, tokens_per_pass: 18000, wallclock_ms: 41000 },
+        akm: { pass_rate: 0.8, tokens_per_pass: 13000, wallclock_ms: 36000 },
+        delta: { pass_rate: 0.4, tokens_per_pass: -5000, wallclock_ms: -5000 },
+      },
+    });
+    const md = renderCompareMarkdown(compareReports(base, current));
+    expect(md).toContain("# akm-bench compare");
+    expect(md).toContain("## Aggregate");
+    expect(md).toContain("## Per-task");
+    expect(md).toContain("pass_rate");
+    expect(md).toContain("+0.20"); // pass_rate delta
+    expect(md).toContain("▲"); // improve glyph
+  });
+
+  test("refusal renders as a single error block, not a diff table", () => {
+    const base = makeReport();
+    const current = makeReport({ agent: { harness: "opencode", model: "anthropic/claude-sonnet-4-5" } });
+    const md = renderCompareMarkdown(compareReports(base, current));
+    expect(md).toContain("refused");
+    expect(md).toContain("model_mismatch");
+    expect(md).toContain(MODEL);
+    expect(md).toContain("anthropic/claude-sonnet-4-5");
+    expect(md).not.toContain("## Aggregate"); // no diff body
+  });
+});
+
+// ── CLI driver ────────────────────────────────────────────────────────────
+
+describe("runCompareCli", () => {
+  function withTmpFiles(
+    cb: (paths: { basePath: string; currentPath: string; tmp: string }) => void,
+    base?: object,
+    current?: object,
+  ): void {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bench-compare-"));
+    try {
+      const basePath = path.join(tmp, "base.json");
+      const currentPath = path.join(tmp, "current.json");
+      fs.writeFileSync(basePath, JSON.stringify(base ?? makeReport()));
+      fs.writeFileSync(currentPath, JSON.stringify(current ?? makeReport()));
+      cb({ basePath, currentPath, tmp });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }
+
+  test("happy path: exit 0, markdown to stdout", () => {
+    withTmpFiles(({ basePath, currentPath }) => {
+      const result = runCompareCli({ basePath, currentPath, json: false });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("# akm-bench compare");
+      expect(result.stderr).toContain("pass_rate");
+    });
+  });
+
+  test("happy path with --json: exit 0, structured JSON to stdout", () => {
+    withTmpFiles(({ basePath, currentPath }) => {
+      const result = runCompareCli({ basePath, currentPath, json: true });
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout) as { ok: boolean };
+      expect(parsed.ok).toBe(true);
+    });
+  });
+
+  test("model mismatch: exit 1 + clear stderr", () => {
+    withTmpFiles(
+      ({ basePath, currentPath }) => {
+        const result = runCompareCli({ basePath, currentPath, json: false });
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("different models");
+      },
+      makeReport(),
+      makeReport({ agent: { harness: "opencode", model: "anthropic/claude-sonnet-4-5" } }),
+    );
+  });
+
+  test("hash mismatch: exit 1", () => {
+    withTmpFiles(
+      ({ basePath, currentPath }) => {
+        const result = runCompareCli({ basePath, currentPath, json: false });
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("fixture-content");
+      },
+      makeReport({ corpus: { domains: 2, tasks: 2, slice: "all", seedsPerArm: 5, fixtureContentHash: "h1" } }),
+      makeReport({ corpus: { domains: 2, tasks: 2, slice: "all", seedsPerArm: 5, fixtureContentHash: "h2" } }),
+    );
+  });
+
+  test("malformed JSON in --base: exit 2", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bench-compare-bad-"));
+    try {
+      const basePath = path.join(tmp, "base.json");
+      const currentPath = path.join(tmp, "current.json");
+      fs.writeFileSync(basePath, "{ not valid json");
+      fs.writeFileSync(currentPath, JSON.stringify(makeReport()));
+      const result = runCompareCli({ basePath, currentPath, json: false });
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain("malformed JSON");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("missing --base file: exit 2", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bench-compare-missing-"));
+    try {
+      const currentPath = path.join(tmp, "current.json");
+      fs.writeFileSync(currentPath, JSON.stringify(makeReport()));
+      const result = runCompareCli({
+        basePath: path.join(tmp, "nope.json"),
+        currentPath,
+        json: false,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain("cannot read --base");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/bench/driver.ts
+++ b/tests/bench/driver.ts
@@ -93,6 +93,15 @@ export interface RunResult {
   events: EventEnvelope[];
   verifierStdout: string;
   verifierExitCode: number;
+  /**
+   * Unique asset refs the agent loaded during this run, extracted post-hoc by
+   * scanning `events[]` and `verifierStdout` for `akm show <ref>` invocations.
+   * Populated by the runner; the driver always emits an empty array. Field is
+   * additive — older RunResult JSON without it remains valid (callers that
+   * read older artefacts should default to `[]`). See spec §6.5 (per-asset
+   * attribution).
+   */
+  assetsLoaded: string[];
 }
 
 /** Operator-config env names that MUST NOT leak into per-run children. */
@@ -255,6 +264,7 @@ export async function runOne(options: RunOptions): Promise<RunResult> {
     events: [],
     verifierStdout: "",
     verifierExitCode: -1,
+    assetsLoaded: [],
   };
 
   // Look up the built-in opencode profile defensively. The lookup is a pure

--- a/tests/bench/driver.ts
+++ b/tests/bench/driver.ts
@@ -93,6 +93,14 @@ export interface RunResult {
   events: EventEnvelope[];
   verifierStdout: string;
   verifierExitCode: number;
+  /**
+   * Failure-mode taxonomy label (spec §6.6). Set by the runner via
+   * `classifyFailureMode` for every failed akm-arm RunResult; `null` for
+   * passing runs, budget_exceeded, harness_error, and noakm-arm runs.
+   * Spliced in additively after `runOne` returns; the driver itself never
+   * populates this field.
+   */
+  failureMode?: import("./metrics").FailureMode | null;
 }
 
 /** Operator-config env names that MUST NOT leak into per-run children. */

--- a/tests/bench/failure-modes.test.ts
+++ b/tests/bench/failure-modes.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Unit tests for the §6.6 failure-mode taxonomy classifier.
+ *
+ * The classifier is a pure function over (TaskMetadata, RunResult). We
+ * exercise each of the seven labels with a synthetic event stream / verifier
+ * stdout, verify priority/tie-breaking, and assert the report renderer
+ * orders bins by descending count.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { EventEnvelope } from "../../src/core/events";
+import type { TaskMetadata } from "./corpus";
+import type { RunResult } from "./driver";
+import { aggregateFailureModes, classifyFailureMode, type FailureMode } from "./metrics";
+import { renderFailureModeBreakdown, type UtilityRunReport } from "./report";
+
+function fakeTask(overrides: Partial<TaskMetadata> = {}): TaskMetadata {
+  return {
+    id: "domain-a/task-1",
+    title: "fake",
+    domain: "domain-a",
+    difficulty: "easy",
+    stash: "fake-stash",
+    verifier: "regex",
+    budget: { tokens: 1000, wallMs: 60000 },
+    taskDir: "/tmp/fake",
+    goldRef: "skill:docker-homelab",
+    ...overrides,
+  };
+}
+
+function fakeRun(overrides: Partial<RunResult> = {}): RunResult {
+  return {
+    schemaVersion: 1,
+    taskId: "domain-a/task-1",
+    arm: "akm",
+    seed: 0,
+    model: "m",
+    outcome: "fail",
+    tokens: { input: 0, output: 0 },
+    wallclockMs: 0,
+    trajectory: { correctAssetLoaded: null, feedbackRecorded: null },
+    events: [],
+    verifierStdout: "",
+    verifierExitCode: 1,
+    ...overrides,
+  };
+}
+
+describe("classifyFailureMode — non-failed runs", () => {
+  test("returns null when outcome is 'pass'", () => {
+    const out = classifyFailureMode(fakeTask(), fakeRun({ outcome: "pass" }));
+    expect(out).toBeNull();
+  });
+  test("returns null when outcome is 'budget_exceeded'", () => {
+    const out = classifyFailureMode(fakeTask(), fakeRun({ outcome: "budget_exceeded" }));
+    expect(out).toBeNull();
+  });
+  test("returns null when outcome is 'harness_error'", () => {
+    const out = classifyFailureMode(fakeTask(), fakeRun({ outcome: "harness_error" }));
+    expect(out).toBeNull();
+  });
+});
+
+describe("classifyFailureMode — seven labels", () => {
+  test("no_search: empty trace returns no_search", () => {
+    const out = classifyFailureMode(fakeTask(), fakeRun({ verifierStdout: "" }));
+    expect(out).toBe("no_search");
+  });
+
+  test("no_search: trace mentions show but never search", () => {
+    const out = classifyFailureMode(
+      fakeTask(),
+      fakeRun({ verifierStdout: "akm show skill:docker-homelab\nresult: ok" }),
+    );
+    expect(out).toBe("no_search");
+  });
+
+  test("search_no_gold: search ran, gold ref absent from results", () => {
+    const trace = [
+      "$ akm search homelab",
+      "1. skill:foo",
+      "2. skill:bar",
+      "3. skill:baz",
+      "verifier: missing required output",
+    ].join("\n");
+    const out = classifyFailureMode(fakeTask(), fakeRun({ verifierStdout: trace }));
+    expect(out).toBe("search_no_gold");
+  });
+
+  test("search_low_rank: gold ref appears at rank 7 in numbered list", () => {
+    const lines = ["$ akm search homelab"];
+    for (let i = 1; i <= 6; i += 1) lines.push(`${i}. skill:filler-${i}`);
+    lines.push("7. skill:docker-homelab");
+    const out = classifyFailureMode(fakeTask(), fakeRun({ verifierStdout: lines.join("\n") }));
+    expect(out).toBe("search_low_rank");
+  });
+
+  test("loaded_wrong: agent showed a non-gold ref and never loaded gold", () => {
+    const trace = [
+      "$ akm search homelab",
+      "1. skill:docker-homelab",
+      "2. skill:az-cli",
+      "$ akm show skill:az-cli",
+      "(content of az-cli)",
+      "verifier: action wrong",
+    ].join("\n");
+    const out = classifyFailureMode(fakeTask(), fakeRun({ verifierStdout: trace }));
+    expect(out).toBe("loaded_wrong");
+  });
+
+  test("loaded_ignored: gold loaded but verifier flags ignored guidance", () => {
+    const trace = [
+      "$ akm search homelab",
+      "1. skill:docker-homelab",
+      "$ akm show skill:docker-homelab",
+      "(content of docker-homelab)",
+      "verifier: agent did not follow loaded asset",
+    ].join("\n");
+    const out = classifyFailureMode(fakeTask(), fakeRun({ verifierStdout: trace }));
+    expect(out).toBe("loaded_ignored");
+  });
+
+  test("followed_wrong: gold loaded, no ignored marker, verifier still failed", () => {
+    const trace = [
+      "$ akm search homelab",
+      "1. skill:docker-homelab",
+      "$ akm show skill:docker-homelab",
+      "(content of docker-homelab)",
+      "verifier: pattern mismatch — expected 'X' got 'Y'",
+    ].join("\n");
+    const out = classifyFailureMode(fakeTask(), fakeRun({ verifierStdout: trace }));
+    expect(out).toBe("followed_wrong");
+  });
+
+  test("unrelated_bug: gold ref in search results, agent didn't load anything", () => {
+    // Search ran (so not no_search), gold present at rank 1 (so not search_no_gold,
+    // not search_low_rank), no `akm show` calls at all (so not loaded_wrong,
+    // not loaded_ignored, not followed_wrong) → unrelated_bug.
+    const trace = ["$ akm search homelab", "1. skill:docker-homelab", "verifier: missing config"].join("\n");
+    const out = classifyFailureMode(fakeTask(), fakeRun({ verifierStdout: trace }));
+    expect(out).toBe("unrelated_bug");
+  });
+
+  test("unrelated_bug: task has no goldRef and search ran", () => {
+    const trace = "$ akm search foo\nresults: nothing relevant";
+    const out = classifyFailureMode(fakeTask({ goldRef: undefined }), fakeRun({ verifierStdout: trace }));
+    expect(out).toBe("unrelated_bug");
+  });
+});
+
+describe("classifyFailureMode — tie-breaking and priority", () => {
+  test("no_search beats search_no_gold when both could apply (no search call)", () => {
+    // No `akm search` text, but gold is also missing. The first rule wins.
+    const out = classifyFailureMode(fakeTask(), fakeRun({ verifierStdout: "verifier: nope" }));
+    expect(out).toBe("no_search");
+  });
+
+  test("search_no_gold beats search_low_rank when gold absent", () => {
+    const trace = ["$ akm search homelab", "1. skill:foo", "2. skill:bar"].join("\n");
+    const out = classifyFailureMode(fakeTask(), fakeRun({ verifierStdout: trace }));
+    expect(out).toBe("search_no_gold");
+  });
+
+  test("search_low_rank beats loaded_wrong when gold is present at rank 7 even after wrong show", () => {
+    const lines = ["$ akm search homelab"];
+    for (let i = 1; i <= 6; i += 1) lines.push(`${i}. skill:filler-${i}`);
+    lines.push("7. skill:docker-homelab");
+    lines.push("$ akm show skill:az-cli");
+    lines.push("verifier: failed");
+    const out = classifyFailureMode(fakeTask(), fakeRun({ verifierStdout: lines.join("\n") }));
+    expect(out).toBe("search_low_rank");
+  });
+
+  test("loaded_wrong beats followed_wrong when gold never loaded but other ref shown", () => {
+    const trace = [
+      "$ akm search homelab",
+      "1. skill:docker-homelab",
+      "$ akm show skill:az-cli",
+      "verifier: agent did not follow loaded asset",
+    ].join("\n");
+    // Note `did not follow loaded asset` would otherwise trip loaded_ignored,
+    // but loaded_wrong's "gold never loaded" precondition wins first.
+    const out = classifyFailureMode(fakeTask(), fakeRun({ verifierStdout: trace }));
+    expect(out).toBe("loaded_wrong");
+  });
+
+  test("loaded_ignored beats followed_wrong when verifier flags ignored", () => {
+    const trace = [
+      "$ akm search homelab",
+      "1. skill:docker-homelab",
+      "$ akm show skill:docker-homelab",
+      "verifier: contradicts loaded asset; agent ignored it",
+    ].join("\n");
+    const out = classifyFailureMode(fakeTask(), fakeRun({ verifierStdout: trace }));
+    expect(out).toBe("loaded_ignored");
+  });
+});
+
+describe("classifyFailureMode — input variants", () => {
+  test("event-stream-only search invocation counts as a search call", () => {
+    const event: EventEnvelope = {
+      schemaVersion: 1,
+      id: 0,
+      ts: "2026-04-27T00:00:00Z",
+      eventType: "search_invoked",
+    };
+    // No CLI marker in stdout, but the event makes hasAkmSearch return true.
+    // Gold ref is absent from any result list → search_no_gold.
+    const out = classifyFailureMode(fakeTask(), fakeRun({ events: [event], verifierStdout: "verifier: nope" }));
+    expect(out).toBe("search_no_gold");
+  });
+
+  test("tool-call JSON form for show counts as loading the gold ref", () => {
+    const trace = [
+      "$ akm search homelab",
+      '{"results":["skill:docker-homelab"]}',
+      '{"command":"akm","args":["show","skill:docker-homelab"]}',
+      "verifier: pattern mismatch",
+    ].join("\n");
+    const out = classifyFailureMode(fakeTask(), fakeRun({ verifierStdout: trace }));
+    expect(out).toBe("followed_wrong");
+  });
+
+  test("origin-prefixed gold ref also matches", () => {
+    const task = fakeTask({ goldRef: "skill:docker-homelab" });
+    const trace = [
+      "$ akm search homelab",
+      "1. team//skill:docker-homelab",
+      "$ akm show team//skill:docker-homelab",
+      "verifier: pattern mismatch",
+    ].join("\n");
+    const out = classifyFailureMode(task, fakeRun({ verifierStdout: trace }));
+    expect(out).toBe("followed_wrong");
+  });
+});
+
+describe("classifyFailureMode — purity", () => {
+  test("same input twice yields the same label", () => {
+    const task = fakeTask();
+    const run = fakeRun({
+      verifierStdout: ["$ akm search homelab", "1. skill:docker-homelab", "verifier: missing config"].join("\n"),
+    });
+    const a = classifyFailureMode(task, run);
+    const b = classifyFailureMode(task, run);
+    expect(a).toBe(b);
+  });
+
+  test("classifier does not mutate its inputs", () => {
+    const task = fakeTask();
+    const run = fakeRun({ verifierStdout: "$ akm search foo\n1. skill:docker-homelab" });
+    const taskJson = JSON.stringify(task);
+    const runJson = JSON.stringify(run);
+    classifyFailureMode(task, run);
+    expect(JSON.stringify(task)).toBe(taskJson);
+    expect(JSON.stringify(run)).toBe(runJson);
+  });
+});
+
+describe("aggregateFailureModes", () => {
+  test("counts per label and per task", () => {
+    const agg = aggregateFailureModes([
+      { taskId: "t1", mode: "no_search" },
+      { taskId: "t1", mode: "no_search" },
+      { taskId: "t1", mode: "followed_wrong" },
+      { taskId: "t2", mode: "no_search" },
+    ]);
+    expect(agg.byLabel.no_search).toBe(3);
+    expect(agg.byLabel.followed_wrong).toBe(1);
+    expect(agg.byTask.t1?.no_search).toBe(2);
+    expect(agg.byTask.t1?.followed_wrong).toBe(1);
+    expect(agg.byTask.t2?.no_search).toBe(1);
+  });
+
+  test("empty input produces empty aggregate", () => {
+    const agg = aggregateFailureModes([]);
+    expect(agg.byLabel).toEqual({});
+    expect(agg.byTask).toEqual({});
+  });
+});
+
+describe("renderFailureModeBreakdown", () => {
+  function makeReport(byLabel: Partial<Record<FailureMode, number>>): UtilityRunReport {
+    return {
+      timestamp: "2026-04-27T00:00:00Z",
+      branch: "x",
+      commit: "y",
+      model: "m",
+      corpus: { domains: 1, tasks: 1, slice: "all", seedsPerArm: 5 },
+      aggregateNoakm: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+      aggregateAkm: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+      aggregateDelta: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+      trajectoryAkm: { correctAssetLoaded: null, feedbackRecorded: 0 },
+      failureModes: { byLabel, byTask: {} },
+      tasks: [],
+      warnings: [],
+    };
+  }
+
+  test("orders bins by descending count", () => {
+    const md = renderFailureModeBreakdown(makeReport({ no_search: 3, followed_wrong: 5, search_no_gold: 1 }));
+    const lines = md.split("\n").filter((l) => l.startsWith("- "));
+    expect(lines[0]).toContain("followed_wrong");
+    expect(lines[0]).toContain("5");
+    expect(lines[1]).toContain("no_search");
+    expect(lines[1]).toContain("3");
+    expect(lines[2]).toContain("search_no_gold");
+    expect(lines[2]).toContain("1");
+  });
+
+  test("ties broken alphabetically by label", () => {
+    const md = renderFailureModeBreakdown(makeReport({ followed_wrong: 2, no_search: 2 }));
+    const lines = md.split("\n").filter((l) => l.startsWith("- "));
+    expect(lines[0]).toContain("followed_wrong");
+    expect(lines[1]).toContain("no_search");
+  });
+
+  test("includes percent of failed runs", () => {
+    const md = renderFailureModeBreakdown(makeReport({ no_search: 1, followed_wrong: 3 }));
+    // 3/4 = 75.0%, 1/4 = 25.0%
+    expect(md).toContain("75.0%");
+    expect(md).toContain("25.0%");
+  });
+
+  test("returns empty string when no failures", () => {
+    const md = renderFailureModeBreakdown(makeReport({}));
+    expect(md).toBe("");
+  });
+
+  test("section header present when bins exist", () => {
+    const md = renderFailureModeBreakdown(makeReport({ no_search: 1 }));
+    expect(md).toContain("## Failure modes");
+  });
+});

--- a/tests/bench/metrics.test.ts
+++ b/tests/bench/metrics.test.ts
@@ -29,6 +29,7 @@ function fakeResult(overrides: Partial<RunResult>): RunResult {
     events: [],
     verifierStdout: "",
     verifierExitCode: 0,
+    assetsLoaded: [],
     ...overrides,
   };
 }

--- a/tests/bench/metrics.ts
+++ b/tests/bench/metrics.ts
@@ -5,8 +5,12 @@
  * functions over `RunResult[]` slices so the runner can compose them
  * however it likes. The §6.3+ catalog (proposal-quality, longitudinal,
  * attribution, failure-mode taxonomy) lands in #239/#240/#243.
+ *
+ * The failure-mode taxonomy classifier (§6.6) lives at the bottom of
+ * this file (`classifyFailureMode`).
  */
 
+import type { TaskMetadata } from "./corpus";
 import type { RunResult } from "./driver";
 
 // ── Outcome (§6.1) ─────────────────────────────────────────────────────────
@@ -241,4 +245,302 @@ export function aggregateTrajectory(results: RunResult[]): TrajectoryAggregate {
     correctAssetLoaded: knownAsset === 0 ? null : assetLoaded / knownAsset,
     feedbackRecorded: feedback / results.length,
   };
+}
+
+// ── Failure-mode taxonomy (§6.6) ───────────────────────────────────────────
+
+/**
+ * The seven failure-mode labels defined by spec §6.6. Exactly one applies
+ * to every failed run; `unrelated_bug` is the catch-all when nothing more
+ * specific matches.
+ *
+ *   no_search       — agent never invoked `akm search`. AGENTS.md problem.
+ *   search_no_gold  — search ran but gold ref absent from result list.
+ *   search_low_rank — gold ref present at rank > 5.
+ *   loaded_wrong    — `akm show` on a non-gold ref before the action AND
+ *                     the gold ref was never loaded.
+ *   loaded_ignored  — gold ref loaded; action contradicts its content.
+ *   followed_wrong  — gold ref loaded and apparently followed; verifier
+ *                     still failed (asset itself is wrong).
+ *   unrelated_bug   — none of the above; not an akm problem.
+ */
+export type FailureMode =
+  | "no_search"
+  | "search_no_gold"
+  | "search_low_rank"
+  | "loaded_wrong"
+  | "loaded_ignored"
+  | "followed_wrong"
+  | "unrelated_bug";
+
+/** Maximum rank at which the gold ref still counts as "found"; > this is `search_low_rank`. */
+const SEARCH_RANK_CUTOFF = 5;
+
+/** Cap on the number of characters of `verifierStdout` we substring-scan. Mirrors trajectory.ts. */
+const FAILURE_MODE_STDOUT_SCAN_CAP = 16 * 1024 * 1024;
+
+/**
+ * Classify a single failed run into one of the seven §6.6 labels. Pure
+ * function — string-matches `runResult.events[]` and `runResult.verifierStdout`,
+ * never calls an LLM, never touches the filesystem.
+ *
+ * Decision tree (priority order — first match wins):
+ *   1. Run not failed (`pass`, `budget_exceeded`, `harness_error`) → `null`.
+ *   2. No `akm search` call in the trace → `no_search`.
+ *   3. Search ran; gold ref absent from search results → `search_no_gold`.
+ *   4. Gold ref present in search results at rank > 5 → `search_low_rank`.
+ *   5. `akm show` invoked on a non-gold ref AND gold ref never loaded → `loaded_wrong`.
+ *   6. Gold ref loaded; verifier output suggests the action contradicts the
+ *      asset's guidance (heuristic: verifier mentions the gold pattern was
+ *      explicitly NOT followed) → `loaded_ignored`.
+ *   7. Gold ref loaded and apparently followed → `followed_wrong`.
+ *   8. Default → `unrelated_bug`.
+ *
+ * Tasks without `goldRef`: rules that depend on the gold ref (3-7) are
+ * skipped; only `no_search` and `unrelated_bug` are reachable.
+ */
+export function classifyFailureMode(taskMeta: TaskMetadata, runResult: RunResult): FailureMode | null {
+  if (runResult.outcome !== "fail") return null;
+
+  const trace = collectTrace(runResult);
+  const goldRef = taskMeta.goldRef;
+
+  // 1. no_search — no `akm search` invocation anywhere in the trace.
+  if (!hasAkmSearch(trace, runResult)) {
+    return "no_search";
+  }
+
+  // Without a gold ref the search-based and load-based checks are undefined.
+  // We can only distinguish "no_search" from everything else.
+  if (!goldRef) {
+    return "unrelated_bug";
+  }
+
+  const searchRank = findGoldSearchRank(trace, goldRef);
+  // 2. search_no_gold — search ran (precondition above) but gold ref absent.
+  if (searchRank === null) {
+    return "search_no_gold";
+  }
+  // 3. search_low_rank — present but below the cutoff.
+  if (searchRank > SEARCH_RANK_CUTOFF) {
+    return "search_low_rank";
+  }
+
+  const goldLoaded = hasAkmShow(trace, runResult, goldRef);
+  const otherRefLoaded = hasAkmShowOtherRef(trace, runResult, goldRef);
+
+  // 4. loaded_wrong — agent showed a non-gold ref AND never loaded the gold.
+  if (otherRefLoaded && !goldLoaded) {
+    return "loaded_wrong";
+  }
+
+  // The remaining branches all assume the gold was loaded.
+  if (!goldLoaded) {
+    // Gold ref was found in search at an acceptable rank, but the agent
+    // never loaded anything (gold or otherwise) before failing. The taxonomy
+    // table has no row for "found but never opened" — treat as unrelated_bug.
+    return "unrelated_bug";
+  }
+
+  // 5. loaded_ignored — verifier diagnostic indicates the action contradicts
+  //    the loaded asset. Conservative heuristic: look for explicit "ignored"
+  //    or "not applied" markers in the verifier stdout. Without an LLM we
+  //    cannot detect subtler contradictions, so this branch only fires when
+  //    the verifier itself flagged the contradiction.
+  if (verifierIndicatesIgnored(runResult.verifierStdout)) {
+    return "loaded_ignored";
+  }
+
+  // 6. followed_wrong — gold loaded, apparently followed, verifier still
+  //    failed. The §6.6 spec maps this to "the asset itself is wrong".
+  return "followed_wrong";
+}
+
+/**
+ * Aggregate per-label counts plus a per-task breakdown. Produced once per
+ * `runUtility` call; embedded in `UtilityRunReport.failureModes`.
+ */
+export interface FailureModeAggregate {
+  /** Total count per label across the entire corpus. Missing labels are absent. */
+  byLabel: Partial<Record<FailureMode, number>>;
+  /** Per-task breakdown, keyed by `taskId` then label. */
+  byTask: Record<string, Partial<Record<FailureMode, number>>>;
+}
+
+/** Build a `FailureModeAggregate` from a list of (taskId, label) pairs. */
+export function aggregateFailureModes(entries: Array<{ taskId: string; mode: FailureMode }>): FailureModeAggregate {
+  const byLabel: Partial<Record<FailureMode, number>> = {};
+  const byTask: Record<string, Partial<Record<FailureMode, number>>> = {};
+  for (const { taskId, mode } of entries) {
+    byLabel[mode] = (byLabel[mode] ?? 0) + 1;
+    if (!byTask[taskId]) byTask[taskId] = {};
+    byTask[taskId][mode] = (byTask[taskId][mode] ?? 0) + 1;
+  }
+  return { byLabel, byTask };
+}
+
+// ── Failure-mode classifier helpers ────────────────────────────────────────
+
+/**
+ * Concatenated string used for substring scans. We pre-build this once per
+ * classify call so the helper functions can share it. Stdout is capped per
+ * the trajectory parser convention to keep runaway agents from OOMing the
+ * bench.
+ */
+function collectTrace(runResult: RunResult): string {
+  const stdout = runResult.verifierStdout ?? "";
+  const capped = stdout.length > FAILURE_MODE_STDOUT_SCAN_CAP ? stdout.slice(0, FAILURE_MODE_STDOUT_SCAN_CAP) : stdout;
+  return capped;
+}
+
+/** Does the trace contain any `akm search` invocation (CLI form OR event)? */
+function hasAkmSearch(trace: string, runResult: RunResult): boolean {
+  // Tool-call CLI form, e.g. `akm search "deploy homelab"`.
+  if (/\bakm\s+search\b/.test(trace)) return true;
+  // Tool-call JSON form, e.g. `"args":["search","..."]`.
+  if (trace.includes(`"search"`) && /["']search["']/.test(trace)) return true;
+  // Event-stream form (search verbs aren't currently emitted but the field
+  // is forward-compatible — see core/events.ts).
+  for (const event of runResult.events) {
+    if (event.eventType === "search" || event.eventType === "search_invoked") return true;
+  }
+  return false;
+}
+
+/**
+ * Find the 1-based rank of `goldRef` in the search results captured in the
+ * trace, or `null` if not present. Best-effort heuristics:
+ *   1. Look for an `akm search` block followed by a numbered list (`1. skill:foo`).
+ *   2. Look for a JSON-ish results array containing the ref.
+ *   3. Fall back to substring presence — if the ref appears anywhere after
+ *      a search invocation, treat it as rank-unknown. We err on the side of
+ *      `1` (best case for the agent) so the classifier doesn't false-positive
+ *      on `search_low_rank`.
+ */
+function findGoldSearchRank(trace: string, goldRef: string): number | null {
+  // Locate the first `akm search` invocation; restrict the rank search to
+  // text after it so we don't pick up `akm show` output.
+  const searchMatch = trace.match(/\bakm\s+search\b/);
+  if (!searchMatch || searchMatch.index === undefined) {
+    // Caller already verified search ran; if our regex disagrees, fall back
+    // to scanning the full trace.
+    return findRefRankInText(trace, goldRef);
+  }
+  const after = trace.slice(searchMatch.index);
+  return findRefRankInText(after, goldRef);
+}
+
+function findRefRankInText(text: string, goldRef: string): number | null {
+  const escaped = goldRef.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Numbered list: lines of the form `<rank>. <ref>` or `<rank>) <ref>`.
+  const numberedRe = /^\s*(\d{1,3})[.)]\s+([^\s]+)/gm;
+  let match: RegExpExecArray | null;
+  while (true) {
+    match = numberedRe.exec(text);
+    if (match === null) break;
+    const ref = match[2];
+    if (refsMatch(ref, goldRef)) {
+      return Number.parseInt(match[1], 10);
+    }
+  }
+  // JSON array form: `"results":["a","b","skill:foo"]`. Estimate rank by
+  // splitting on commas after the bracket. Best-effort.
+  const jsonRe = /"results"\s*:\s*\[([^\]]+)\]/;
+  const jsonMatch = text.match(jsonRe);
+  if (jsonMatch) {
+    const items = jsonMatch[1].split(",").map((s) => s.trim().replace(/^["']|["']$/g, ""));
+    const idx = items.findIndex((item) => refsMatch(item, goldRef));
+    if (idx >= 0) return idx + 1;
+  }
+  // Substring presence — assume rank 1 (best case for the agent, conservative
+  // for the `search_low_rank` rule).
+  const refRe = new RegExp(`\\b${escaped}\\b`);
+  if (refRe.test(text)) return 1;
+  return null;
+}
+
+/** True when `candidate` is `goldRef` or a strict ref-extension thereof. */
+function refsMatch(candidate: string, goldRef: string): boolean {
+  if (candidate === goldRef) return true;
+  if (candidate.endsWith(`//${goldRef}`)) return true;
+  if (candidate.startsWith(`${goldRef}/`)) return true;
+  return false;
+}
+
+/** Did the agent invoke `akm show <goldRef>` at any point? */
+function hasAkmShow(trace: string, runResult: RunResult, goldRef: string): boolean {
+  const escaped = goldRef.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // CLI form, exact ref. Also matches origin-prefixed variants like
+  // `akm show team//skill:foo` because the `[\w/]*//` prefix is optional.
+  const cliRe = new RegExp(`\\bakm\\s+show\\s+["']?(?:[\\w-]+//)?${escaped}(?:\\b|\\W)`);
+  if (cliRe.test(trace)) return true;
+  // Tool-call JSON form: `"args":["show","skill:foo"]`.
+  if (trace.includes(`"show"`) && trace.includes(goldRef)) return true;
+  // Event-stream metadata.ref.
+  for (const event of runResult.events) {
+    if (typeof event.ref === "string" && refsMatch(event.ref, goldRef)) {
+      // Only count "show" or "load" eventTypes; a `feedback` event mentioning
+      // the ref doesn't mean the agent loaded it during this run.
+      if (event.eventType === "show" || event.eventType === "load" || event.eventType === "tool_call") return true;
+    }
+    const meta = event.metadata;
+    if (meta && typeof meta === "object") {
+      const candidate = (meta as Record<string, unknown>).ref;
+      if (typeof candidate === "string" && refsMatch(candidate, goldRef)) {
+        if (event.eventType === "show" || event.eventType === "load" || event.eventType === "tool_call") return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** Did the agent invoke `akm show <ref>` for some ref OTHER than `goldRef`? */
+function hasAkmShowOtherRef(trace: string, runResult: RunResult, goldRef: string): boolean {
+  // CLI form: capture the ref argument and reject when it matches the gold.
+  const cliRe = /\bakm\s+show\s+["']?([^\s"'`]+)/g;
+  let match: RegExpExecArray | null;
+  while (true) {
+    match = cliRe.exec(trace);
+    if (match === null) break;
+    if (!refsMatch(match[1], goldRef)) return true;
+  }
+  // Tool-call JSON form: `"args":["show","..."]`. Best-effort scan.
+  const jsonRe = /\["show",\s*"([^"]+)"/g;
+  while (true) {
+    match = jsonRe.exec(trace);
+    if (match === null) break;
+    if (!refsMatch(match[1], goldRef)) return true;
+  }
+  // Event-stream form.
+  for (const event of runResult.events) {
+    if (event.eventType !== "show" && event.eventType !== "load" && event.eventType !== "tool_call") continue;
+    if (typeof event.ref === "string" && !refsMatch(event.ref, goldRef)) return true;
+    const meta = event.metadata;
+    if (meta && typeof meta === "object") {
+      const candidate = (meta as Record<string, unknown>).ref;
+      if (typeof candidate === "string" && !refsMatch(candidate, goldRef)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Conservative heuristic for the `loaded_ignored` branch. Without an LLM we
+ * cannot reliably decide whether an arbitrary action contradicts arbitrary
+ * asset content; we only fire when the verifier's own diagnostic explicitly
+ * flags the gold-asset guidance as ignored.
+ *
+ * The verifier stdout strings are deterministic — they come from
+ * `runVerifier` and the per-task `verify.sh` scripts. Tasks that want to
+ * surface this label should emit one of the agreed-upon markers below.
+ */
+function verifierIndicatesIgnored(verifierStdout: string): boolean {
+  if (!verifierStdout) return false;
+  const lower = verifierStdout.toLowerCase();
+  return (
+    lower.includes("ignored gold guidance") ||
+    lower.includes("guidance ignored") ||
+    lower.includes("did not follow loaded asset") ||
+    lower.includes("contradicts loaded asset")
+  );
 }

--- a/tests/bench/metrics.ts
+++ b/tests/bench/metrics.ts
@@ -253,8 +253,15 @@ const ASSET_LOAD_STDOUT_SCAN_CAP = 16 * 1024 * 1024;
 // name are lowercase letters, digits, `_`, `-`. We deliberately do NOT match
 // `://` schemes (those are install locators, not asset refs). The character
 // class is intentionally tight so we don't mis-pickup arbitrary words after
-// `akm show`.
-const ASSET_REF_PATTERN = /(?:[a-z0-9_-]+\/\/)?[a-z][a-z0-9_-]*:[a-zA-Z0-9_./-]+/g;
+// `akm show`. The `name` segment is restricted to `[A-Za-z0-9_-]+` (no `/`,
+// no `.`) — the v1 grammar in src/core/asset-ref.ts permits `/` and `.` in
+// names (e.g. `script:db/migrate/run.sh`), but the masker treats names as
+// untrusted input and rejects any traversal-shaped value, so the bench-side
+// scanner does not need (or want) to extract such refs from agent stdout.
+// Limiting the regex here is defense-in-depth against a prompt-injected
+// agent emitting `akm show "skill:../../etc"` and us pulling that ref into
+// the masking flow.
+const ASSET_REF_PATTERN = /(?:[a-z0-9_-]+\/\/)?[a-z][a-z0-9_-]*:[A-Za-z0-9_-]+/g;
 
 export function extractAssetLoads(runResult: RunResult): string[] {
   const seen = new Set<string>();
@@ -288,7 +295,7 @@ export function extractAssetLoads(runResult: RunResult): string[] {
 
   // `akm show <ref>` literal form. Accept optional quoting around the ref so
   // shell traces like `akm show "skill:foo"` work too.
-  const literalRe = /akm\s+show\s+["']?((?:[a-z0-9_-]+\/\/)?[a-z][a-z0-9_-]*:[a-zA-Z0-9_./-]+)["']?/g;
+  const literalRe = /akm\s+show\s+["']?((?:[a-z0-9_-]+\/\/)?[a-z][a-z0-9_-]*:[A-Za-z0-9_-]+)["']?/g;
   for (const literalMatch of haystack.matchAll(literalRe)) {
     push(literalMatch[1] as string);
   }
@@ -296,7 +303,7 @@ export function extractAssetLoads(runResult: RunResult): string[] {
   // Tool-call JSON form. `"args":[..., "show", "<ref>", ...]`. We extract
   // every refish token in the haystack that follows a "show" arg in JSON-y
   // form. A second cheap pass keeps the pattern simple.
-  const toolCallRe = /"show"\s*,\s*"((?:[a-z0-9_-]+\/\/)?[a-z][a-z0-9_-]*:[a-zA-Z0-9_./-]+)"/g;
+  const toolCallRe = /"show"\s*,\s*"((?:[a-z0-9_-]+\/\/)?[a-z][a-z0-9_-]*:[A-Za-z0-9_-]+)"/g;
   for (const toolCallMatch of haystack.matchAll(toolCallRe)) {
     push(toolCallMatch[1] as string);
   }
@@ -349,15 +356,8 @@ export function computePerAssetAttribution(report: UtilityRunReport): PerAssetAt
   const failing = new Map<string, number>();
   let totalAkmRuns = 0;
 
-  for (const task of report.tasks) {
-    // The §13.3 task entry doesn't carry RunResults — we read them from the
-    // shared akm-arm runs collection on the report. But the v1 report only
-    // exposes aggregates per task. We rely on `report.akmRuns[]` (added below
-    // by the runner). For backward compat, fall back to scanning whatever
-    // raw runs the report carries.
-    void task;
-  }
-
+  // The §13.3 task entry doesn't carry RunResults — we read them from the
+  // shared akm-arm runs collection that the runner stamps onto `report.akmRuns`.
   const akmRuns = collectAkmRuns(report);
   for (const r of akmRuns) {
     totalAkmRuns += 1;
@@ -477,7 +477,15 @@ export interface RunUtilityOptionsForMask {
   branch?: string;
   commit?: string;
   timestamp?: string;
-  // biome-ignore lint/suspicious/noExplicitAny: SpawnFn lives in src/integrations/agent/spawn — importing it would pull node-specific types we don't need here. A loose type keeps metrics.ts independent of that module.
+  /**
+   * Test-only injection seam for the child-process spawn function. The
+   * masked re-runner forwards this verbatim to `runUtility`, which uses it
+   * to launch the agent harness for each masked task. SECURITY: a non-test
+   * caller MUST NOT set this — production code paths leave it `undefined`
+   * so the runner falls back to the vetted default `SpawnFn`. The field is
+   * typed `any` only to keep metrics.ts independent of `src/integrations/agent/spawn`.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: Test-injection seam (see JSDoc above). SpawnFn lives in src/integrations/agent/spawn; importing it would pull node-specific types into metrics.ts. Production callers leave this undefined.
   spawn?: any;
   materialiseStash?: boolean;
 }
@@ -577,14 +585,29 @@ function materialiseMaskedStash(fixturesRoot: string, stashName: string, assetRe
   const sourceDir = path.join(fixturesRoot, stashName);
   if (!fs.existsSync(path.join(sourceDir, "MANIFEST.json"))) return null;
 
-  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), `akm-bench-masked-${stashName}-`));
-  copyDirRecursive(sourceDir, tmpRoot);
-
   const colonIdx = assetRef.indexOf(":");
-  if (colonIdx < 0) return tmpRoot;
+  if (colonIdx < 0) {
+    // Malformed ref: still produce a tmp copy with no edits so the caller's
+    // re-run sees the unmodified fixture.
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), `akm-bench-masked-${stashName}-`));
+    copyDirRecursive(sourceDir, tmpRoot);
+    return tmpRoot;
+  }
   const typeWithOrigin = assetRef.slice(0, colonIdx);
   const name = assetRef.slice(colonIdx + 1);
   const type = typeWithOrigin.includes("//") ? (typeWithOrigin.split("//")[1] ?? typeWithOrigin) : typeWithOrigin;
+
+  // SECURITY: the asset ref originates from agent stdout (untrusted; the
+  // agent could be prompt-injected). The masking heuristic below will
+  // `fs.rmSync` files under the tmp stash dir whose names are derived from
+  // `name`. A traversal-shaped name (`../etc`, `/abs/path`, `..\\..`) would
+  // escape the tmp root and delete arbitrary disk content. Reject those
+  // shapes BEFORE we materialise — and re-validate after path-resolving
+  // each candidate. Mirrors src/core/asset-ref.ts validateName().
+  if (!isSafeAssetNameSegment(name)) return null;
+
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), `akm-bench-masked-${stashName}-`));
+  copyDirRecursive(sourceDir, tmpRoot);
 
   // Walk every .stash.json under the tmp root and edit in place.
   walkStashJsonFiles(tmpRoot, (jsonPath) => {
@@ -602,21 +625,31 @@ function materialiseMaskedStash(fixturesRoot: string, stashName: string, assetRe
     }
     const entries = parsed.entries ?? [];
     const kept: Array<Record<string, unknown>> = [];
+    const jsonDir = path.dirname(jsonPath);
     for (const entry of entries) {
       if (entry.type === type && entry.name === name) {
-        // Remove the entry's content file(s).
+        // Remove the entry's content file(s). The on-disk `filename` is read
+        // from the fixture .stash.json (trusted) but the value still passes
+        // through path.relative containment so a malicious fixture can't use
+        // this path to escape either.
         const filename = entry.filename;
-        if (typeof filename === "string") {
-          const target = path.join(path.dirname(jsonPath), filename);
-          try {
-            fs.rmSync(target, { force: true });
-          } catch {
-            // ignore
+        if (typeof filename === "string" && isSafeAssetNameSegment(filename)) {
+          const target = path.resolve(jsonDir, filename);
+          if (isPathContained(tmpRoot, target)) {
+            try {
+              fs.rmSync(target, { force: true });
+            } catch {
+              // ignore
+            }
           }
         }
         // Some fixtures keep a per-asset directory (e.g. skills/<name>/SKILL.md).
-        const dirCandidate = path.join(path.dirname(jsonPath), name);
-        if (fs.existsSync(dirCandidate) && fs.statSync(dirCandidate).isDirectory()) {
+        const dirCandidate = path.resolve(jsonDir, name);
+        if (
+          isPathContained(tmpRoot, dirCandidate) &&
+          fs.existsSync(dirCandidate) &&
+          fs.statSync(dirCandidate).isDirectory()
+        ) {
           try {
             fs.rmSync(dirCandidate, { recursive: true, force: true });
           } catch {
@@ -640,6 +673,42 @@ function materialiseMaskedStash(fixturesRoot: string, stashName: string, assetRe
   });
 
   return tmpRoot;
+}
+
+/**
+ * Reject any segment that could escape the tmp stash root when used as a
+ * relative path component:
+ *   - empty string
+ *   - any `/` or `\\` (path separators)
+ *   - a `..` segment in any form
+ *   - a leading `/` (POSIX absolute) or `C:` (Windows drive)
+ *   - any null byte
+ *
+ * Mirrors src/core/asset-ref.ts validateName(), but returns a boolean
+ * (callers map this to "skip" rather than "throw").
+ */
+function isSafeAssetNameSegment(value: string): boolean {
+  if (!value) return false;
+  if (value.includes("\0")) return false;
+  if (value.includes("/") || value.includes("\\")) return false;
+  if (value === ".." || value === ".") return false;
+  if (/^[A-Za-z]:/.test(value)) return false;
+  return true;
+}
+
+/**
+ * After resolving a target path, confirm it lives under `root`. Defense in
+ * depth: even if a traversal-shaped name slipped past the segment check,
+ * this catches escapes via symlinks or odd `path.join` semantics.
+ */
+function isPathContained(root: string, target: string): boolean {
+  const rootResolved = path.resolve(root);
+  const targetResolved = path.resolve(target);
+  const rel = path.relative(rootResolved, targetResolved);
+  if (rel === "") return true;
+  if (rel.startsWith("..")) return false;
+  if (path.isAbsolute(rel)) return false;
+  return true;
 }
 
 function walkStashJsonFiles(root: string, visit: (jsonPath: string) => void): void {

--- a/tests/bench/metrics.ts
+++ b/tests/bench/metrics.ts
@@ -7,7 +7,13 @@
  * attribution, failure-mode taxonomy) lands in #239/#240/#243.
  */
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { TaskMetadata } from "./corpus";
 import type { RunResult } from "./driver";
+import type { UtilityRunReport } from "./report";
 
 // ── Outcome (§6.1) ─────────────────────────────────────────────────────────
 
@@ -220,6 +226,450 @@ export interface TrajectoryAggregate {
   correctAssetLoaded: number | null;
   /** Fraction of runs that emitted a `feedback` event. `0..1`. */
   feedbackRecorded: number;
+}
+
+// ── Per-asset attribution (§6.5) ───────────────────────────────────────────
+
+/**
+ * Extract the unique asset refs an agent loaded during a run by scanning
+ * `events[]` and `verifierStdout` for `akm show <ref>` invocations.
+ *
+ * Detection strategy (all heuristic, all conservative):
+ *   1. `event.eventType === "show"` with `event.ref` (forward-compat — akm
+ *      itself does not currently emit `show` events).
+ *   2. Substring match on `akm show <ref>` in stdout. The ref shape is
+ *      `[origin//]type:name` per the v1 contract; we accept word-boundary
+ *      terminators after the name.
+ *   3. Tool-call JSON `{"args":["show","<ref>"]}` — the form opencode logs
+ *      when the agent invokes the akm CLI as a tool. We extract refs that
+ *      look like asset refs from the args array entries adjacent to "show".
+ *
+ * Returns refs in first-seen order, deduplicated. Bounded scan: stdout is
+ * truncated at 16 MiB (the same cap the trajectory parser uses) to keep
+ * runaway agents from OOMing the bench.
+ */
+const ASSET_LOAD_STDOUT_SCAN_CAP = 16 * 1024 * 1024;
+// Asset ref grammar: optional `origin//` prefix, type:name, where type and
+// name are lowercase letters, digits, `_`, `-`. We deliberately do NOT match
+// `://` schemes (those are install locators, not asset refs). The character
+// class is intentionally tight so we don't mis-pickup arbitrary words after
+// `akm show`.
+const ASSET_REF_PATTERN = /(?:[a-z0-9_-]+\/\/)?[a-z][a-z0-9_-]*:[a-zA-Z0-9_./-]+/g;
+
+export function extractAssetLoads(runResult: RunResult): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const push = (ref: string): void => {
+    if (!ref) return;
+    if (seen.has(ref)) return;
+    seen.add(ref);
+    out.push(ref);
+  };
+
+  // 1. Events stream.
+  for (const event of runResult.events) {
+    if (event.eventType === "show" && typeof event.ref === "string") {
+      push(event.ref);
+    }
+    const meta = event.metadata;
+    if (meta && typeof meta === "object" && event.eventType === "show") {
+      const candidate = (meta as Record<string, unknown>).ref;
+      if (typeof candidate === "string") push(candidate);
+    }
+  }
+
+  // 2 & 3. Stdout scanning. Bound the scan so a runaway agent stdout cannot
+  // OOM the bench. Truncation is silent — the trajectory parser already
+  // surfaces a warning for the same data on its own scan.
+  let haystack = runResult.verifierStdout || "";
+  if (haystack.length > ASSET_LOAD_STDOUT_SCAN_CAP) {
+    haystack = haystack.slice(0, ASSET_LOAD_STDOUT_SCAN_CAP);
+  }
+
+  // `akm show <ref>` literal form. Accept optional quoting around the ref so
+  // shell traces like `akm show "skill:foo"` work too.
+  const literalRe = /akm\s+show\s+["']?((?:[a-z0-9_-]+\/\/)?[a-z][a-z0-9_-]*:[a-zA-Z0-9_./-]+)["']?/g;
+  for (const literalMatch of haystack.matchAll(literalRe)) {
+    push(literalMatch[1] as string);
+  }
+
+  // Tool-call JSON form. `"args":[..., "show", "<ref>", ...]`. We extract
+  // every refish token in the haystack that follows a "show" arg in JSON-y
+  // form. A second cheap pass keeps the pattern simple.
+  const toolCallRe = /"show"\s*,\s*"((?:[a-z0-9_-]+\/\/)?[a-z][a-z0-9_-]*:[a-zA-Z0-9_./-]+)"/g;
+  for (const toolCallMatch of haystack.matchAll(toolCallRe)) {
+    push(toolCallMatch[1] as string);
+  }
+
+  return out;
+}
+
+// Suppress the unused warning for the constant exposed to keep the cap
+// discoverable from this module's surface (mirrors the trajectory cap).
+void ASSET_REF_PATTERN;
+
+/** Per-asset attribution row (§6.5). */
+export interface PerAssetAttributionRow {
+  /** Asset ref, e.g. `skill:docker-homelab`. */
+  assetRef: string;
+  /** Number of akm-arm runs that loaded this asset AND passed. */
+  loadCountPassing: number;
+  /** Number of akm-arm runs that loaded this asset AND failed (or budget/harness). */
+  loadCountFailing: number;
+  /** Total akm-arm runs that loaded this asset (passing + failing). */
+  loadCount: number;
+  /**
+   * Among runs that loaded the asset, the fraction that passed. `null` when
+   * load_count is zero (defensive — that asset would not appear in the table
+   * at all in normal flow, but a future caller might construct one manually).
+   */
+  loadPassRate: number | null;
+}
+
+/** Per-asset attribution table (§6.5). */
+export interface PerAssetAttribution {
+  rows: PerAssetAttributionRow[];
+  /** Total akm-arm runs aggregated. Sample size for the table as a whole. */
+  totalAkmRuns: number;
+}
+
+/**
+ * Aggregate per-asset load + pass counts across all akm-arm runs in a report.
+ *
+ * Sort order (stable, deterministic):
+ *   1. loadCount descending (most-used first)
+ *   2. loadPassRate descending (working assets above broken ones at the same load count)
+ *   3. assetRef ascending (alphabetical tiebreak)
+ *
+ * Only `arm === "akm"` runs contribute. The `noakm` arm has no stash and
+ * cannot load assets, so including it would zero-bias the rates.
+ */
+export function computePerAssetAttribution(report: UtilityRunReport): PerAssetAttribution {
+  const passing = new Map<string, number>();
+  const failing = new Map<string, number>();
+  let totalAkmRuns = 0;
+
+  for (const task of report.tasks) {
+    // The §13.3 task entry doesn't carry RunResults — we read them from the
+    // shared akm-arm runs collection on the report. But the v1 report only
+    // exposes aggregates per task. We rely on `report.akmRuns[]` (added below
+    // by the runner). For backward compat, fall back to scanning whatever
+    // raw runs the report carries.
+    void task;
+  }
+
+  const akmRuns = collectAkmRuns(report);
+  for (const r of akmRuns) {
+    totalAkmRuns += 1;
+    const isPass = r.outcome === "pass";
+    for (const ref of r.assetsLoaded ?? []) {
+      const bucket = isPass ? passing : failing;
+      bucket.set(ref, (bucket.get(ref) ?? 0) + 1);
+    }
+  }
+
+  const refs = new Set<string>([...passing.keys(), ...failing.keys()]);
+  const rows: PerAssetAttributionRow[] = [];
+  for (const ref of refs) {
+    const p = passing.get(ref) ?? 0;
+    const f = failing.get(ref) ?? 0;
+    const total = p + f;
+    rows.push({
+      assetRef: ref,
+      loadCountPassing: p,
+      loadCountFailing: f,
+      loadCount: total,
+      loadPassRate: total === 0 ? null : p / total,
+    });
+  }
+
+  rows.sort((a, b) => {
+    if (b.loadCount !== a.loadCount) return b.loadCount - a.loadCount;
+    const ar = a.loadPassRate ?? -1;
+    const br = b.loadPassRate ?? -1;
+    if (br !== ar) return br - ar;
+    return a.assetRef.localeCompare(b.assetRef);
+  });
+
+  return { rows, totalAkmRuns };
+}
+
+/**
+ * Pull the akm-arm RunResults out of a UtilityRunReport. The runner stamps
+ * them into the optional `akmRuns` field on the report so attribution can
+ * post-process them without re-running.
+ */
+function collectAkmRuns(report: UtilityRunReport): RunResult[] {
+  if (Array.isArray(report.akmRuns)) return report.akmRuns;
+  return [];
+}
+
+// ── runMaskedCorpus (§6.5 leave-one-out) ──────────────────────────────────
+
+/**
+ * Marginal-contribution row for one masked asset.
+ *
+ * `marginalContribution = basePassRate − maskedPassRate`. Positive means the
+ * asset *helped* — masking it hurt pass rate. Negative means the asset hurt
+ * — masking it improved pass rate (a candidate for deletion / rewrite).
+ */
+export interface MaskedAttributionRow {
+  assetRef: string;
+  basePassRate: number;
+  maskedPassRate: number;
+  marginalContribution: number;
+}
+
+/** `runMaskedCorpus` result envelope. */
+export interface MaskedCorpusResult {
+  baseReport: UtilityRunReport;
+  attributions: MaskedAttributionRow[];
+  /**
+   * Number of masked-corpus runs actually performed. Equals `min(topN,
+   * unique-loaded-asset count)`. Operators reading the JSON envelope use this
+   * to verify cost accounting.
+   */
+  runsPerformed: number;
+}
+
+/** Caller-facing options for `runMaskedCorpus`. */
+export interface RunMaskedCorpusOptions {
+  /** Base report from a prior `bench utility` run. Required. */
+  baseReport: UtilityRunReport;
+  /** Top N most-loaded assets to mask. Defaults to 5; clamped to asset count. */
+  topN?: number;
+  /**
+   * Re-runner. Tests inject a fake; production wires to `runUtility`. Receives
+   * options identical to the original run but with each task's stash already
+   * remapped to a tmp dir that has the named asset removed.
+   */
+  runUtility: (
+    options: Omit<RunUtilityOptionsForMask, "spawn" | "materialiseStash"> & {
+      tasks: TaskMetadata[];
+      spawn?: RunUtilityOptionsForMask["spawn"];
+      materialiseStash?: boolean;
+    },
+  ) => Promise<UtilityRunReport>;
+  /**
+   * The original `runUtility` call's options, passed through so the masked
+   * runs use the same model / arms / seedsPerArm / budgets. The caller gives
+   * us this; we reuse it modulo the per-task tasks override.
+   */
+  baseOptions: RunUtilityOptionsForMask;
+  /**
+   * Root directory for the source fixture stashes. Defaults to
+   * `tests/fixtures/stashes/` relative to the repo. Tests inject a tmp dir.
+   */
+  fixturesRoot?: string;
+}
+
+/**
+ * Subset of RunUtilityOptions we need for masked re-runs. We avoid importing
+ * the runner module directly so metrics.ts has no cycle.
+ */
+export interface RunUtilityOptionsForMask {
+  arms: Arm[];
+  model: string;
+  seedsPerArm?: number;
+  budgetTokens?: number;
+  budgetWallMs?: number;
+  slice?: "all" | "train" | "eval";
+  branch?: string;
+  commit?: string;
+  timestamp?: string;
+  // biome-ignore lint/suspicious/noExplicitAny: SpawnFn lives in src/integrations/agent/spawn — importing it would pull node-specific types we don't need here. A loose type keeps metrics.ts independent of that module.
+  spawn?: any;
+  materialiseStash?: boolean;
+}
+
+/** The two arm names. Duplicated here so metrics.ts has no runner.ts import. */
+export type Arm = "noakm" | "akm";
+
+/**
+ * Pick the top-N most-loaded assets from a base report and re-run the corpus
+ * with each one masked from its source stash. Returns a marginal-contribution
+ * row per masked asset.
+ *
+ * Cost: N * (tasks × arms × seedsPerArm) re-runs. Operators clamp N before
+ * calling — but we also clamp internally if `topN` exceeds the unique-asset
+ * count to avoid surprising no-op runs.
+ *
+ * Source-fixture safety: every masked re-run materialises a fresh tmp copy
+ * of the fixture stash, deletes the masked asset's files there, and points
+ * the re-run at the tmp dir. The shipped fixture in `tests/fixtures/stashes/`
+ * is NEVER mutated.
+ */
+export async function runMaskedCorpus(opts: RunMaskedCorpusOptions): Promise<MaskedCorpusResult> {
+  const baseReport = opts.baseReport;
+  const fixturesRoot = opts.fixturesRoot ?? path.resolve(__dirname, "..", "fixtures", "stashes");
+
+  const attribution = computePerAssetAttribution(baseReport);
+  const desired = Math.max(1, opts.topN ?? 5);
+  const clamped = Math.min(desired, attribution.rows.length);
+
+  const baseAkmPassRate = baseReport.aggregateAkm.passRate;
+  const top = attribution.rows.slice(0, clamped);
+  const attributions: MaskedAttributionRow[] = [];
+
+  for (const row of top) {
+    const maskedTasks: TaskMetadata[] = [];
+    const tmpDirs: string[] = [];
+    try {
+      for (const baseTask of baseReport.taskMetadata ?? []) {
+        const maskedStashDir = materialiseMaskedStash(fixturesRoot, baseTask.stash, row.assetRef);
+        if (maskedStashDir) tmpDirs.push(maskedStashDir);
+        // Forward the masked stashDir as a sibling field. Tasks already carry
+        // `stash` (the fixture name), so we tunnel the masked dir through
+        // `taskDir` won't work — instead we mutate `stash` to point at the
+        // tmp dir and rely on the runner's `materialiseStash` flow. The
+        // injected runUtility for masked runs MUST honour `stashDirOverride`.
+        maskedTasks.push({ ...baseTask, stash: maskedStashDir ?? baseTask.stash });
+      }
+
+      const maskedReport = await opts.runUtility({
+        ...opts.baseOptions,
+        tasks: maskedTasks,
+        // The masked stash already has the correct content on disk, so we
+        // skip the runner's own materialisation step (which would otherwise
+        // try to look up the fixture by name).
+        materialiseStash: false,
+      });
+
+      const maskedPassRate = maskedReport.aggregateAkm.passRate;
+      attributions.push({
+        assetRef: row.assetRef,
+        basePassRate: baseAkmPassRate,
+        maskedPassRate,
+        marginalContribution: baseAkmPassRate - maskedPassRate,
+      });
+    } finally {
+      for (const dir of tmpDirs) {
+        try {
+          fs.rmSync(dir, { recursive: true, force: true });
+        } catch {
+          // Best-effort cleanup; tmpfs cleanup will handle leaks.
+        }
+      }
+    }
+  }
+
+  return {
+    baseReport,
+    attributions,
+    runsPerformed: clamped,
+  };
+}
+
+/**
+ * Copy a fixture stash into a fresh tmp dir, delete every file matching the
+ * masked asset ref, and return the tmp dir path. Returns `null` if the named
+ * asset is not present in the fixture (we still re-run, but the result will
+ * mirror the base — which is itself a meaningful diagnostic).
+ *
+ * The masking heuristic:
+ *   1. Walk `<stash>/*<...>/.stash.json` files.
+ *   2. For each entry whose `name` + `type` matches the asset ref, drop the
+ *      entry and delete its `filename` if present.
+ *   3. Rewrite the `.stash.json` with the trimmed entries (or remove it if
+ *      it is now empty).
+ */
+function materialiseMaskedStash(fixturesRoot: string, stashName: string, assetRef: string): string | null {
+  const sourceDir = path.join(fixturesRoot, stashName);
+  if (!fs.existsSync(path.join(sourceDir, "MANIFEST.json"))) return null;
+
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), `akm-bench-masked-${stashName}-`));
+  copyDirRecursive(sourceDir, tmpRoot);
+
+  const colonIdx = assetRef.indexOf(":");
+  if (colonIdx < 0) return tmpRoot;
+  const typeWithOrigin = assetRef.slice(0, colonIdx);
+  const name = assetRef.slice(colonIdx + 1);
+  const type = typeWithOrigin.includes("//") ? (typeWithOrigin.split("//")[1] ?? typeWithOrigin) : typeWithOrigin;
+
+  // Walk every .stash.json under the tmp root and edit in place.
+  walkStashJsonFiles(tmpRoot, (jsonPath) => {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(jsonPath, "utf8");
+    } catch {
+      return;
+    }
+    let parsed: { entries?: Array<Record<string, unknown>> };
+    try {
+      parsed = JSON.parse(raw) as { entries?: Array<Record<string, unknown>> };
+    } catch {
+      return;
+    }
+    const entries = parsed.entries ?? [];
+    const kept: Array<Record<string, unknown>> = [];
+    for (const entry of entries) {
+      if (entry.type === type && entry.name === name) {
+        // Remove the entry's content file(s).
+        const filename = entry.filename;
+        if (typeof filename === "string") {
+          const target = path.join(path.dirname(jsonPath), filename);
+          try {
+            fs.rmSync(target, { force: true });
+          } catch {
+            // ignore
+          }
+        }
+        // Some fixtures keep a per-asset directory (e.g. skills/<name>/SKILL.md).
+        const dirCandidate = path.join(path.dirname(jsonPath), name);
+        if (fs.existsSync(dirCandidate) && fs.statSync(dirCandidate).isDirectory()) {
+          try {
+            fs.rmSync(dirCandidate, { recursive: true, force: true });
+          } catch {
+            // ignore
+          }
+        }
+        continue;
+      }
+      kept.push(entry);
+    }
+    if (kept.length === entries.length) return; // nothing changed
+    if (kept.length === 0) {
+      try {
+        fs.rmSync(jsonPath, { force: true });
+      } catch {
+        // ignore
+      }
+    } else {
+      fs.writeFileSync(jsonPath, `${JSON.stringify({ ...parsed, entries: kept }, null, 2)}\n`);
+    }
+  });
+
+  return tmpRoot;
+}
+
+function walkStashJsonFiles(root: string, visit: (jsonPath: string) => void): void {
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const cur = stack.pop();
+    if (!cur) continue;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(cur, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const abs = path.join(cur, entry.name);
+      if (entry.isDirectory()) stack.push(abs);
+      else if (entry.isFile() && entry.name === ".stash.json") visit(abs);
+    }
+  }
+}
+
+function copyDirRecursive(src: string, dest: string): void {
+  fs.mkdirSync(dest, { recursive: true });
+  const entries = fs.readdirSync(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) copyDirRecursive(s, d);
+    else if (entry.isFile()) fs.copyFileSync(s, d);
+  }
 }
 
 /** Aggregate trajectory booleans across a bag of runs. */

--- a/tests/bench/metrics.ts
+++ b/tests/bench/metrics.ts
@@ -5,6 +5,11 @@
  * functions over `RunResult[]` slices so the runner can compose them
  * however it likes. The §6.3+ catalog (proposal-quality, longitudinal,
  * attribution, failure-mode taxonomy) lands in #239/#240/#243.
+ *
+ * Search-pipeline bridge metrics (§6.7) are below: they tie the synthetic
+ * MRR/Recall@K view in `tests/benchmark-suite.ts` to real-task pass rate
+ * by logging gold-rank-of-search per `akm search` invocation and slicing
+ * pass-rate by the rank of the agent's *chosen* search.
  */
 
 import type { RunResult } from "./driver";
@@ -241,4 +246,301 @@ export function aggregateTrajectory(results: RunResult[]): TrajectoryAggregate {
     correctAssetLoaded: knownAsset === 0 ? null : assetLoaded / knownAsset,
     feedbackRecorded: feedback / results.length,
   };
+}
+
+// ── Search-pipeline bridge (§6.7) ──────────────────────────────────────────
+
+/**
+ * One observed `akm search` invocation in a real run.
+ *
+ * `rankOfGold` is 1-based (rank 1 = first hit). It is `null` when the gold
+ * ref was not present in the top 10 results — that bucket is rendered as
+ * `missing` in the histogram and treated as `Infinity` for percentile math.
+ */
+export interface GoldRankEvent {
+  query: string;
+  /** Result refs in rank order (most relevant first). May be empty. */
+  results: string[];
+  /** 1-based rank of the gold ref in `results`, capped at 10. `null` if absent. */
+  rankOfGold: number | null;
+}
+
+/**
+ * Per-run gold-rank record carried on the report so `computeSearchBridge`
+ * can aggregate without seeing the full RunResult bag again. Owned by the
+ * runner: it stamps one of these per akm-arm run with a goldRef, then we
+ * reduce them at the end of `runUtility`.
+ */
+export interface GoldRankRunRecord {
+  taskId: string;
+  arm: string;
+  seed: number;
+  outcome: RunResult["outcome"];
+  goldRef: string;
+  /** All `akm search` invocations the agent made during this run, in order. */
+  searches: GoldRankEvent[];
+}
+
+/** Histogram of gold rank: keys are `"1".."10"` plus `"missing"`. */
+export type GoldRankHistogram = Record<string, number>;
+
+/** Pass-rate slice keyed by the rank of gold in the agent's *chosen* search. */
+export interface PassRateByRankEntry {
+  /** Rank as a string ("1".."10") or the literal "missing". */
+  rank: string;
+  passRate: number;
+  runCount: number;
+}
+
+export interface SearchBridgeMetrics {
+  /** Histogram across every observed `akm search` (rank 1..10 + missing). */
+  goldRankDistribution: GoldRankHistogram;
+  /** Median rank across observed searches. `null` if no searches. */
+  goldRankP50: number | null;
+  /** 90th-percentile rank. `null` if no searches. */
+  goldRankP90: number | null;
+  /** Fraction of searches where gold was at rank 1. `0` when no searches. */
+  goldAtRank1: number;
+  /** Fraction of searches where gold was missing (not in top 10). */
+  goldMissing: number;
+  /** Pass rate of *runs* split by the rank in their chosen (last) search. */
+  passRateByRank: PassRateByRankEntry[];
+  /** Number of (akm-arm, goldRef) runs aggregated. */
+  runsObserved: number;
+  /** Number of `akm search` invocations aggregated. */
+  searchesObserved: number;
+}
+
+/** Cap on the number of result refs we extract per `akm search` invocation. */
+const TOP_K = 10;
+
+/**
+ * Extract the gold rank for every `akm search` invocation in a run.
+ *
+ * The parser scans `runResult.verifierStdout` (which carries the captured
+ * agent stdout including its tool-call trace) for `akm search` commands
+ * and the result lists that follow them. The first 10 hits are considered;
+ * if the gold ref appears, `rankOfGold` is its 1-based position, else
+ * `null`.
+ *
+ * Pure function: never reads from disk and never mutates inputs. When
+ * `goldRef` is undefined the function returns `[]` — we only attribute
+ * ranks for tasks that actually have a gold asset.
+ */
+export function extractGoldRanks(runResult: RunResult, goldRef: string | undefined): GoldRankEvent[] {
+  if (!goldRef) return [];
+  const haystack = runResult.verifierStdout;
+  if (!haystack) return [];
+
+  const events: GoldRankEvent[] = [];
+
+  // Walk the stdout linearly. A search invocation looks like
+  //   `akm search "<query>"` or `akm search <query>`
+  // and the subsequent block carries the result list. A new `akm` command
+  // (or end of stdout) terminates the previous search's result block.
+  const lines = haystack.split(/\r?\n/);
+  let active: GoldRankEvent | null = null;
+
+  // Regex for an `akm search` invocation. Captures the rest of the line
+  // after `search ` so we can pick up the query whether it's quoted or not.
+  const searchInvocationRe = /\bakm\s+search\s+(.+?)(?:\s+--|$)/;
+  // A different `akm <verb>` (not `search`) terminates the active block.
+  const akmInvocationRe = /\bakm\s+(\w+)/;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    const searchMatch = line.match(searchInvocationRe);
+    if (searchMatch) {
+      // Flush any active block before starting a new one.
+      if (active) {
+        active.rankOfGold = computeRank(active.results, goldRef);
+        events.push(active);
+      }
+      const query = stripQuotes(searchMatch[1].trim());
+      active = { query, results: [], rankOfGold: null };
+      // Some traces inline the JSON result on the same line — try to extract.
+      collectRefsFromLine(line, active.results);
+      continue;
+    }
+
+    if (!active) continue;
+
+    // A non-search akm invocation closes the active search block.
+    const akmMatch = line.match(akmInvocationRe);
+    if (akmMatch && akmMatch[1] !== "search") {
+      active.rankOfGold = computeRank(active.results, goldRef);
+      events.push(active);
+      active = null;
+      continue;
+    }
+
+    collectRefsFromLine(line, active.results);
+  }
+
+  if (active) {
+    active.rankOfGold = computeRank(active.results, goldRef);
+    events.push(active);
+  }
+
+  return events;
+}
+
+/** Trim leading/trailing single or double quotes from a query string. */
+function stripQuotes(s: string): string {
+  if (s.length >= 2) {
+    const first = s[0];
+    const last = s[s.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return s.slice(1, -1);
+    }
+  }
+  return s;
+}
+
+/**
+ * Pull asset refs from a single line into `out`. Matches both plain
+ * `ref: <ref>` lines (text mode) and `"ref":"<ref>"` (JSON mode). We
+ * stop at TOP_K results to mirror the spec's top-10 cutoff.
+ */
+function collectRefsFromLine(line: string, out: string[]): void {
+  if (out.length >= TOP_K) return;
+
+  // JSON form: `"ref":"skill:foo"` or `"ref": "skill:foo"`. Multiple per line possible.
+  const jsonRe = /"ref"\s*:\s*"([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  m = jsonRe.exec(line);
+  while (m !== null) {
+    if (out.length >= TOP_K) return;
+    out.push(m[1]);
+    m = jsonRe.exec(line);
+  }
+
+  // Plain text form: `  ref: skill:foo`. Only treat the line as a ref-bearing
+  // line if it starts with `ref:` (after whitespace). Avoids picking up
+  // every `:` in arbitrary stdout.
+  const textRe = /^ref:\s*([^\s,]+)/;
+  const tm = line.match(textRe);
+  if (tm && out.length < TOP_K) {
+    out.push(tm[1]);
+  }
+}
+
+/**
+ * 1-based rank of `goldRef` in `results`, or `null` if absent within the
+ * top 10. We use `matchesGold` for prefix-tolerant matching so
+ * `team//skill:foo` counts as `skill:foo` (mirrors trajectory parser).
+ */
+function computeRank(results: string[], goldRef: string): number | null {
+  const cap = Math.min(results.length, TOP_K);
+  for (let i = 0; i < cap; i += 1) {
+    if (matchesGold(results[i], goldRef)) return i + 1;
+  }
+  return null;
+}
+
+function matchesGold(candidate: string, gold: string): boolean {
+  if (candidate === gold) return true;
+  if (candidate.endsWith(`//${gold}`)) return true;
+  if (candidate.startsWith(`${gold}/`)) return true;
+  return false;
+}
+
+/**
+ * Aggregate gold-rank records across all akm-arm runs in the corpus.
+ *
+ * The function operates on `report.goldRankRecords`, which the runner
+ * populates per (task, arm, seed). When the corpus has no gold-ref tasks
+ * at all (every record list is empty), every metric collapses to a zero
+ * envelope and the `passRateByRank` table is empty — the renderer turns
+ * that into a single "(N/A)" sentence.
+ */
+export function computeSearchBridge(report: { goldRankRecords?: GoldRankRunRecord[] }): SearchBridgeMetrics {
+  const records = report.goldRankRecords ?? [];
+
+  // Histogram + percentile inputs across every search.
+  const histogram: GoldRankHistogram = emptyHistogram();
+  const allRanks: Array<number | null> = [];
+  let totalSearches = 0;
+
+  for (const rec of records) {
+    for (const ev of rec.searches) {
+      totalSearches += 1;
+      allRanks.push(ev.rankOfGold);
+      const bucket = ev.rankOfGold === null ? "missing" : String(ev.rankOfGold);
+      histogram[bucket] = (histogram[bucket] ?? 0) + 1;
+    }
+  }
+
+  const goldAtRank1 = totalSearches === 0 ? 0 : (histogram["1"] ?? 0) / totalSearches;
+  const goldMissing = totalSearches === 0 ? 0 : (histogram.missing ?? 0) / totalSearches;
+  const goldRankP50 = totalSearches === 0 ? null : percentile(allRanks, 50);
+  const goldRankP90 = totalSearches === 0 ? null : percentile(allRanks, 90);
+
+  // pass_rate_by_rank — split runs by the rank in *the search the agent
+  // actually ran*. We use the last `akm search` of the run (or "missing"
+  // when no search at all happened, or "missing" when the agent searched
+  // but gold wasn't in the top 10 in that final search). Runs without any
+  // `akm search` invocation are dropped from this slice — `pass_rate_by_rank`
+  // only describes what happened given a search.
+  const passRateBuckets = new Map<string, { passes: number; total: number }>();
+  for (const rec of records) {
+    if (rec.searches.length === 0) continue;
+    const chosen = rec.searches[rec.searches.length - 1];
+    const bucket = chosen.rankOfGold === null ? "missing" : String(chosen.rankOfGold);
+    const slot = passRateBuckets.get(bucket) ?? { passes: 0, total: 0 };
+    slot.total += 1;
+    if (rec.outcome === "pass") slot.passes += 1;
+    passRateBuckets.set(bucket, slot);
+  }
+
+  const passRateByRank: PassRateByRankEntry[] = [];
+  for (const rank of histogramKeys()) {
+    const slot = passRateBuckets.get(rank);
+    if (!slot) continue;
+    passRateByRank.push({
+      rank,
+      passRate: slot.total === 0 ? 0 : slot.passes / slot.total,
+      runCount: slot.total,
+    });
+  }
+
+  return {
+    goldRankDistribution: histogram,
+    goldRankP50,
+    goldRankP90,
+    goldAtRank1,
+    goldMissing,
+    passRateByRank,
+    runsObserved: records.length,
+    searchesObserved: totalSearches,
+  };
+}
+
+/** Ordered keys used for both the histogram and the pass_rate_by_rank table. */
+export function histogramKeys(): string[] {
+  return ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "missing"];
+}
+
+function emptyHistogram(): GoldRankHistogram {
+  const out: GoldRankHistogram = {};
+  for (const k of histogramKeys()) out[k] = 0;
+  return out;
+}
+
+/**
+ * Linear-interpolated percentile over a list of ranks. `null` ranks are
+ * treated as `Infinity` so the missing bucket pushes percentiles up
+ * correctly. Returns `Infinity` when the percentile lands in the missing
+ * region; the renderer surfaces that as the literal `"missing"` token so
+ * downstream JSON consumers don't choke on `Infinity`.
+ */
+function percentile(ranks: Array<number | null>, p: number): number {
+  if (ranks.length === 0) return Number.NaN;
+  const sorted = ranks.map((r) => (r === null ? Number.POSITIVE_INFINITY : r)).sort((a, b) => a - b);
+  // Nearest-rank method (avoids interpolation between Infinity and a finite).
+  // index = ceil(p/100 * N) - 1, clamped to [0, N-1].
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[idx];
 }

--- a/tests/bench/metrics.ts
+++ b/tests/bench/metrics.ts
@@ -242,3 +242,298 @@ export function aggregateTrajectory(results: RunResult[]): TrajectoryAggregate {
     feedbackRecorded: feedback / results.length,
   };
 }
+
+// ── Compare (§8, two-run diff) ─────────────────────────────────────────────
+
+/**
+ * Sign marker for delta rendering. `improve` / `regress` / `flat` are
+ * direction labels; the markdown layer turns them into ▲ / ▼ / ▬. Kept as
+ * a tagged label rather than the literal glyphs so JSON consumers don't have
+ * to deal with non-ASCII.
+ */
+export type DeltaSign = "improve" | "regress" | "flat";
+
+/**
+ * One row of the per-task compare table. `baseMetrics` and `currentMetrics`
+ * carry through the §13.3 per-task envelopes verbatim (snake-case keys
+ * preserved) so the JSON consumer can read seed-stdev, budget-exceeded
+ * counts, etc., without re-parsing the source reports.
+ *
+ * `id` may be present in only one side — `presence` distinguishes
+ * "regression" rows (in both) from "added" / "removed" rows.
+ */
+export interface CompareTaskRow {
+  id: string;
+  /** Where this task appears: in both reports, only the base, or only the current. */
+  presence: "both" | "base-only" | "current-only";
+  /** Per-task metrics from the base report. `null` when the task is current-only. */
+  baseMetrics: PerTaskJson | null;
+  /** Per-task metrics from the current report. `null` when the task is base-only. */
+  currentMetrics: PerTaskJson | null;
+  /** akm pass_rate delta, current − base. `null` when one side is missing. */
+  delta: { passRate: number | null; tokensPerPass: number | null; wallclockMs: number | null };
+  /** Direction marker for `passRate`: `flat` when within tolerance or unmeasured. */
+  signMarker: DeltaSign;
+}
+
+/** Snake-case per-task envelope as serialised by `renderUtilityReport`. */
+export interface PerTaskJson {
+  pass_rate: number;
+  pass_at_1: 0 | 1;
+  tokens_per_pass: number | null;
+  wallclock_ms: number;
+  pass_rate_stdev: number;
+  budget_exceeded_count: number;
+  harness_error_count: number;
+  count: number;
+}
+
+/**
+ * Aggregate (corpus-wide) compare row. Same null-safety as `CorpusDelta`:
+ * `tokensPerPassDelta` is `null` when either side lacks a measurement.
+ */
+export interface CompareAggregate {
+  passRateDelta: number;
+  passRateSign: DeltaSign;
+  tokensPerPassDelta: number | null;
+  tokensPerPassSign: DeltaSign;
+  wallclockMsDelta: number;
+  wallclockMsSign: DeltaSign;
+}
+
+/**
+ * Successful compare envelope. The CLI renders this as JSON when `--json` is
+ * passed and as markdown otherwise.
+ */
+export interface CompareReportSuccess {
+  ok: true;
+  baseModel: string;
+  currentModel: string;
+  baseFixtureContentHash: string | null;
+  currentFixtureContentHash: string | null;
+  /** Warnings collected during compare (e.g. missing fixtureContentHash on a side). */
+  warnings: string[];
+  aggregate: CompareAggregate;
+  perTask: CompareTaskRow[];
+}
+
+/** Failure envelope. `reason` is the discrete refusal cause; `message` is human-readable. */
+export interface CompareReportFailure {
+  ok: false;
+  reason: "model_mismatch" | "hash_mismatch" | "schema_mismatch" | "track_mismatch";
+  message: string;
+  baseModel?: string;
+  currentModel?: string;
+  baseFixtureContentHash?: string | null;
+  currentFixtureContentHash?: string | null;
+  /** When `reason === "hash_mismatch"`, the affected fixtures (best-effort). */
+  affectedFixtures?: string[];
+}
+
+export type CompareResult = CompareReportSuccess | CompareReportFailure;
+
+/**
+ * Sign threshold below which a delta is rendered as `flat`. `pass_rate` is
+ * normalised to `[0, 1]`, so a 0.005 (0.5pp) tolerance keeps tiny K-seed
+ * sampling jitter from looking like a regression.
+ */
+const PASS_RATE_FLAT_TOLERANCE = 0.005;
+/** `tokens_per_pass` and `wallclock_ms` use raw counts; 0 is the only "flat". */
+const COUNT_FLAT_TOLERANCE = 0;
+
+function classifyPassRate(delta: number | null): DeltaSign {
+  if (delta === null) return "flat";
+  if (Math.abs(delta) <= PASS_RATE_FLAT_TOLERANCE) return "flat";
+  return delta > 0 ? "improve" : "regress";
+}
+
+function classifyCount(delta: number | null, lowerIsBetter: boolean): DeltaSign {
+  if (delta === null) return "flat";
+  if (Math.abs(delta) <= COUNT_FLAT_TOLERANCE) return "flat";
+  if (lowerIsBetter) return delta < 0 ? "improve" : "regress";
+  return delta > 0 ? "improve" : "regress";
+}
+
+/**
+ * Minimal structural shape we read out of a parsed UtilityRunReport JSON.
+ * We deliberately don't import the renderer's own types — the compare layer
+ * consumes JSON envelopes from disk, so it needs to be tolerant of small
+ * shape drift (e.g. the optional `fixtureContentHash` Wave A may add).
+ */
+export interface ParsedReportJson {
+  schemaVersion?: number;
+  track?: string;
+  agent?: { harness?: string; model?: string };
+  corpus?: {
+    domains?: number;
+    tasks?: number;
+    slice?: string;
+    seedsPerArm?: number;
+    fixtureContentHash?: string | null;
+  };
+  aggregate?: {
+    noakm?: { pass_rate?: number; tokens_per_pass?: number | null; wallclock_ms?: number };
+    akm?: { pass_rate?: number; tokens_per_pass?: number | null; wallclock_ms?: number };
+    delta?: { pass_rate?: number; tokens_per_pass?: number | null; wallclock_ms?: number };
+  };
+  tasks?: Array<{
+    id: string;
+    noakm?: PerTaskJson;
+    akm?: PerTaskJson;
+    delta?: { pass_rate?: number; tokens_per_pass?: number | null; wallclock_ms?: number };
+  }>;
+  warnings?: string[];
+}
+
+function readModel(r: ParsedReportJson): string {
+  return r.agent?.model ?? "<unknown>";
+}
+
+function readFixtureHash(r: ParsedReportJson): string | null {
+  const v = r.corpus?.fixtureContentHash;
+  return v === undefined || v === null ? null : v;
+}
+
+function akmAgg(r: ParsedReportJson): { pass_rate: number; tokens_per_pass: number | null; wallclock_ms: number } {
+  const a = r.aggregate?.akm ?? {};
+  return {
+    pass_rate: a.pass_rate ?? 0,
+    tokens_per_pass: a.tokens_per_pass ?? null,
+    wallclock_ms: a.wallclock_ms ?? 0,
+  };
+}
+
+/**
+ * Diff two parsed UtilityRunReport JSONs.
+ *
+ * Refusal cases:
+ *   • Either side missing `schemaVersion: 1` or `track: "utility"` →
+ *     `schema_mismatch` / `track_mismatch`.
+ *   • `agent.model` differs → `model_mismatch`.
+ *   • Both sides report a `corpus.fixtureContentHash` and they differ →
+ *     `hash_mismatch`. Missing hash on either side proceeds with a warning
+ *     (Wave A may add it; older reports won't have it).
+ *
+ * On success the per-task table includes rows for every task in either side,
+ * plus aggregate deltas computed against the akm arm only (the noakm arm is
+ * the control — its delta is meaningless). `pass_rate` is in `[0, 1]`,
+ * higher is better; `tokens_per_pass` and `wallclock_ms` are counts, lower
+ * is better.
+ */
+export function compareReports(base: ParsedReportJson, current: ParsedReportJson): CompareResult {
+  // Schema-version gate.
+  if (base.schemaVersion !== 1 || current.schemaVersion !== 1) {
+    return {
+      ok: false,
+      reason: "schema_mismatch",
+      message: `compare requires schemaVersion=1 on both sides; got base=${String(
+        base.schemaVersion,
+      )}, current=${String(current.schemaVersion)}`,
+    };
+  }
+  // Track gate. Cross-track diffs are nonsensical.
+  if (base.track !== "utility" || current.track !== "utility") {
+    return {
+      ok: false,
+      reason: "track_mismatch",
+      message: `compare only supports track="utility"; got base="${String(base.track)}", current="${String(
+        current.track,
+      )}"`,
+    };
+  }
+
+  const baseModel = readModel(base);
+  const currentModel = readModel(current);
+  if (baseModel !== currentModel) {
+    return {
+      ok: false,
+      reason: "model_mismatch",
+      message: `cannot compare across different models: base="${baseModel}", current="${currentModel}". Rerun on the same model.`,
+      baseModel,
+      currentModel,
+    };
+  }
+
+  const baseHash = readFixtureHash(base);
+  const currentHash = readFixtureHash(current);
+  const warnings: string[] = [];
+  if (baseHash !== null && currentHash !== null && baseHash !== currentHash) {
+    return {
+      ok: false,
+      reason: "hash_mismatch",
+      message: `cannot compare across different fixture-content hashes: base="${baseHash}", current="${currentHash}". Rerun against matching fixtures.`,
+      baseModel,
+      currentModel,
+      baseFixtureContentHash: baseHash,
+      currentFixtureContentHash: currentHash,
+    };
+  }
+  if (baseHash === null)
+    warnings.push("base report has no corpus.fixtureContentHash; proceeding without fixture-pin check");
+  if (currentHash === null)
+    warnings.push("current report has no corpus.fixtureContentHash; proceeding without fixture-pin check");
+
+  // Aggregate (akm arm is the one that matters — noakm is the control).
+  const ba = akmAgg(base);
+  const ca = akmAgg(current);
+  const passRateDelta = ca.pass_rate - ba.pass_rate;
+  const tokensPerPassDelta =
+    ba.tokens_per_pass === null || ca.tokens_per_pass === null ? null : ca.tokens_per_pass - ba.tokens_per_pass;
+  const wallclockMsDelta = ca.wallclock_ms - ba.wallclock_ms;
+
+  const aggregate: CompareAggregate = {
+    passRateDelta,
+    passRateSign: classifyPassRate(passRateDelta),
+    tokensPerPassDelta,
+    tokensPerPassSign: classifyCount(tokensPerPassDelta, true),
+    wallclockMsDelta,
+    wallclockMsSign: classifyCount(wallclockMsDelta, true),
+  };
+
+  // Per-task rows. Outer-join on task id.
+  const baseTasks = new Map<string, NonNullable<ParsedReportJson["tasks"]>[number]>();
+  for (const t of base.tasks ?? []) baseTasks.set(t.id, t);
+  const currentTasks = new Map<string, NonNullable<ParsedReportJson["tasks"]>[number]>();
+  for (const t of current.tasks ?? []) currentTasks.set(t.id, t);
+
+  const allIds = new Set<string>();
+  for (const id of baseTasks.keys()) allIds.add(id);
+  for (const id of currentTasks.keys()) allIds.add(id);
+
+  const perTask: CompareTaskRow[] = [];
+  for (const id of [...allIds].sort()) {
+    const b = baseTasks.get(id);
+    const c = currentTasks.get(id);
+    const bM = b?.akm ?? null;
+    const cM = c?.akm ?? null;
+    const presence: CompareTaskRow["presence"] =
+      b !== undefined && c !== undefined ? "both" : b !== undefined ? "base-only" : "current-only";
+
+    const passRateDelta_ = bM !== null && cM !== null ? cM.pass_rate - bM.pass_rate : null;
+    const tokensPerPassDelta_ =
+      bM !== null && cM !== null && bM.tokens_per_pass !== null && cM.tokens_per_pass !== null
+        ? cM.tokens_per_pass - bM.tokens_per_pass
+        : null;
+    const wallclockMsDelta_ = bM !== null && cM !== null ? cM.wallclock_ms - bM.wallclock_ms : null;
+
+    perTask.push({
+      id,
+      presence,
+      baseMetrics: bM,
+      currentMetrics: cM,
+      delta: { passRate: passRateDelta_, tokensPerPass: tokensPerPassDelta_, wallclockMs: wallclockMsDelta_ },
+      signMarker: classifyPassRate(passRateDelta_),
+    });
+  }
+
+  return {
+    ok: true,
+    baseModel,
+    currentModel,
+    baseFixtureContentHash: baseHash,
+    currentFixtureContentHash: currentHash,
+    warnings,
+    aggregate,
+    perTask,
+  };
+}

--- a/tests/bench/report.test.ts
+++ b/tests/bench/report.test.ts
@@ -89,6 +89,7 @@ const utilSample: UtilityRunReport = {
   aggregateAkm: { passRate: 0.7, tokensPerPass: 14000, wallclockMs: 36000 },
   aggregateDelta: { passRate: 0.3, tokensPerPass: -4000, wallclockMs: -5000 },
   trajectoryAkm: { correctAssetLoaded: 0.78, feedbackRecorded: 0.65 },
+  failureModes: { byLabel: {}, byTask: {} },
   tasks: [
     {
       id: "domain-a/task-1",

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -14,7 +14,16 @@
  */
 
 import { execSync } from "node:child_process";
-import type { CorpusDelta, CorpusMetrics, OutcomeAggregate, PerTaskMetrics, TrajectoryAggregate } from "./metrics";
+import type {
+  CorpusDelta,
+  CorpusMetrics,
+  GoldRankRunRecord,
+  OutcomeAggregate,
+  PerTaskMetrics,
+  SearchBridgeMetrics,
+  TrajectoryAggregate,
+} from "./metrics";
+import { histogramKeys } from "./metrics";
 
 // ── Legacy envelope (#236) ─────────────────────────────────────────────────
 
@@ -101,6 +110,16 @@ export interface UtilityRunReport {
   trajectoryAkm: TrajectoryAggregate;
   tasks: UtilityReportTaskEntry[];
   warnings: string[];
+  /**
+   * Per-(akm-arm, goldRef) gold-rank records. Populated by the runner; read
+   * by `computeSearchBridge`. Empty when no corpus tasks carry a `goldRef`.
+   */
+  goldRankRecords?: GoldRankRunRecord[];
+  /**
+   * §6.7 search-pipeline bridge metrics. Always present on populated runs;
+   * an "empty" SearchBridgeMetrics envelope renders as the N/A sentence.
+   */
+  searchBridge?: SearchBridgeMetrics;
 }
 
 /**
@@ -146,7 +165,35 @@ function buildUtilityJson(input: UtilityRunReport): object {
     },
     tasks,
     warnings: input.warnings,
+    ...(input.searchBridge ? { searchBridge: serialiseSearchBridge(input.searchBridge) } : {}),
   };
+}
+
+/**
+ * §6.7 envelope. We expose `null` for percentiles that fell into the missing
+ * bucket so JSON consumers don't choke on `Infinity`.
+ */
+function serialiseSearchBridge(s: SearchBridgeMetrics): object {
+  return {
+    runs_observed: s.runsObserved,
+    searches_observed: s.searchesObserved,
+    gold_rank_distribution: s.goldRankDistribution,
+    gold_rank_p50: percentileForJson(s.goldRankP50),
+    gold_rank_p90: percentileForJson(s.goldRankP90),
+    gold_at_rank_1: s.goldAtRank1,
+    gold_missing: s.goldMissing,
+    pass_rate_by_rank: s.passRateByRank.map((e) => ({
+      rank: e.rank,
+      pass_rate: e.passRate,
+      run_count: e.runCount,
+    })),
+  };
+}
+
+function percentileForJson(value: number | null): number | string | null {
+  if (value === null) return null;
+  if (!Number.isFinite(value)) return "missing";
+  return value;
 }
 
 function serialiseCorpus(c: CorpusMetrics): {
@@ -222,6 +269,10 @@ function buildUtilityMarkdown(input: UtilityRunReport): string {
   for (const t of sorted) {
     lines.push(taskRow(t));
   }
+  if (input.searchBridge) {
+    lines.push("");
+    lines.push(renderSearchBridgeTable(input.searchBridge));
+  }
   if (input.warnings.length > 0) {
     lines.push("");
     lines.push("## Warnings");
@@ -229,6 +280,63 @@ function buildUtilityMarkdown(input: UtilityRunReport): string {
     for (const w of input.warnings) lines.push(`- ${w}`);
   }
   return lines.join("\n");
+}
+
+// ── Search-pipeline bridge (§6.7) markdown ─────────────────────────────────
+
+/**
+ * Render the §6.7 search-pipeline bridge as a markdown section.
+ *
+ * When the corpus has no gold-ref tasks (or simply no `akm search`
+ * invocations), the section collapses to a single "(N/A)" sentence so the
+ * report stays compact.
+ */
+export function renderSearchBridgeTable(metrics: SearchBridgeMetrics): string {
+  const lines: string[] = [];
+  lines.push("## Search → outcome bridge");
+  lines.push("");
+
+  if (metrics.searchesObserved === 0 && metrics.runsObserved === 0) {
+    lines.push("(no gold-ref tasks in corpus; bridge metrics N/A)");
+    return lines.join("\n");
+  }
+
+  // Histogram of gold rank.
+  lines.push("| rank | count |");
+  lines.push("|------|-------|");
+  for (const k of histogramKeys()) {
+    const count = metrics.goldRankDistribution[k] ?? 0;
+    lines.push(`| ${k} | ${count} |`);
+  }
+  lines.push("");
+
+  // Summary line.
+  const p50 = formatRank(metrics.goldRankP50);
+  const p90 = formatRank(metrics.goldRankP90);
+  lines.push(
+    `p50=${p50}, p90=${p90}, gold_at_rank_1=${formatPercent(metrics.goldAtRank1)}, gold_missing=${formatPercent(
+      metrics.goldMissing,
+    )}`,
+  );
+  lines.push("");
+
+  // pass_rate_by_rank.
+  lines.push("| rank | pass_rate | run_count |");
+  lines.push("|------|-----------|-----------|");
+  if (metrics.passRateByRank.length === 0) {
+    lines.push("| (no runs with `akm search` invocations) | — | 0 |");
+  } else {
+    for (const entry of metrics.passRateByRank) {
+      lines.push(`| ${entry.rank} | ${entry.passRate.toFixed(2)} | ${entry.runCount} |`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function formatRank(value: number | null): string {
+  if (value === null) return "n/a";
+  if (!Number.isFinite(value)) return "missing";
+  return value.toFixed(1);
 }
 
 function corpusRow(arm: string, c: CorpusMetrics): string {

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -14,7 +14,15 @@
  */
 
 import { execSync } from "node:child_process";
-import type { CorpusDelta, CorpusMetrics, OutcomeAggregate, PerTaskMetrics, TrajectoryAggregate } from "./metrics";
+import type {
+  CorpusDelta,
+  CorpusMetrics,
+  FailureMode,
+  FailureModeAggregate,
+  OutcomeAggregate,
+  PerTaskMetrics,
+  TrajectoryAggregate,
+} from "./metrics";
 
 // ── Legacy envelope (#236) ─────────────────────────────────────────────────
 
@@ -99,6 +107,12 @@ export interface UtilityRunReport {
   aggregateAkm: CorpusMetrics;
   aggregateDelta: CorpusDelta;
   trajectoryAkm: TrajectoryAggregate;
+  /**
+   * Failure-mode taxonomy aggregate (§6.6). Counts and per-task breakdown
+   * across every failed akm-arm run in the corpus. Empty `byLabel` /
+   * `byTask` when no runs failed.
+   */
+  failureModes: FailureModeAggregate;
   tasks: UtilityReportTaskEntry[];
   warnings: string[];
 }
@@ -143,6 +157,10 @@ function buildUtilityJson(input: UtilityRunReport): object {
         correct_asset_loaded: input.trajectoryAkm.correctAssetLoaded,
         feedback_recorded: input.trajectoryAkm.feedbackRecorded,
       },
+    },
+    failure_modes: {
+      by_label: input.failureModes.byLabel,
+      by_task: input.failureModes.byTask,
     },
     tasks,
     warnings: input.warnings,
@@ -222,6 +240,13 @@ function buildUtilityMarkdown(input: UtilityRunReport): string {
   for (const t of sorted) {
     lines.push(taskRow(t));
   }
+  // Failure-mode breakdown (§6.6). Appended near the bottom so the headline
+  // pass-rate / trajectory tables stay visually anchored at the top.
+  const failureSection = renderFailureModeBreakdown(input);
+  if (failureSection.length > 0) {
+    lines.push("");
+    lines.push(failureSection);
+  }
   if (input.warnings.length > 0) {
     lines.push("");
     lines.push("## Warnings");
@@ -254,6 +279,38 @@ function signed(text: string): string {
 function formatPercent(value: number | null): string {
   if (value === null) return "n/a";
   return `${(value * 100).toFixed(1)}%`;
+}
+
+// ── Failure-mode breakdown (§6.6) ──────────────────────────────────────────
+
+/**
+ * Render the §6.6 "Failure modes" markdown section. Lines are sorted by
+ * descending count (ties broken alphabetically by label so output is
+ * byte-stable). Each line:
+ *
+ *   `<label> — <count> (<percent>% of failed runs)`
+ *
+ * Returns an empty string when no failed runs exist (caller decides whether
+ * to append a blank section header).
+ */
+export function renderFailureModeBreakdown(report: UtilityRunReport): string {
+  const entries = Object.entries(report.failureModes.byLabel) as Array<[FailureMode, number]>;
+  if (entries.length === 0) return "";
+  const totalFailures = entries.reduce((acc, [, count]) => acc + count, 0);
+  if (totalFailures === 0) return "";
+
+  // Sort by descending count, tie-break alphabetically for determinism.
+  entries.sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    return a[0].localeCompare(b[0]);
+  });
+
+  const lines: string[] = ["## Failure modes", ""];
+  for (const [label, count] of entries) {
+    const percent = ((count / totalFailures) * 100).toFixed(1);
+    lines.push(`- ${label} — ${count} (${percent}% of failed runs)`);
+  }
+  return lines.join("\n");
 }
 
 // ── Git helpers ────────────────────────────────────────────────────────────

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -14,7 +14,16 @@
  */
 
 import { execSync } from "node:child_process";
-import type { CorpusDelta, CorpusMetrics, OutcomeAggregate, PerTaskMetrics, TrajectoryAggregate } from "./metrics";
+import type { TaskMetadata } from "./corpus";
+import type { RunResult } from "./driver";
+import type {
+  CorpusDelta,
+  CorpusMetrics,
+  OutcomeAggregate,
+  PerAssetAttribution,
+  PerTaskMetrics,
+  TrajectoryAggregate,
+} from "./metrics";
 
 // ── Legacy envelope (#236) ─────────────────────────────────────────────────
 
@@ -101,6 +110,25 @@ export interface UtilityRunReport {
   trajectoryAkm: TrajectoryAggregate;
   tasks: UtilityReportTaskEntry[];
   warnings: string[];
+  /**
+   * Per-asset attribution rows (§6.5). Populated by the runner; aggregated
+   * across every akm-arm RunResult. Older artefacts without this field
+   * remain valid (callers should default to an empty `{ rows: [], totalAkmRuns: 0 }`).
+   */
+  perAsset?: PerAssetAttribution;
+  /**
+   * Raw akm-arm RunResults retained on the report for in-process consumers
+   * (the masked-corpus helper, attribution post-processing). NOT serialised
+   * into the §13.3 JSON envelope — too large and not part of the locked
+   * contract. The field is on the in-memory shape only.
+   */
+  akmRuns?: RunResult[];
+  /**
+   * Task metadata for in-process consumers (the masked-corpus helper needs
+   * to remap each task's stash to a tmp dir). Not serialised into the §13.3
+   * envelope — the existing `tasks[]` carries the public per-task aggregates.
+   */
+  taskMetadata?: TaskMetadata[];
 }
 
 /**
@@ -125,7 +153,7 @@ function buildUtilityJson(input: UtilityRunReport): object {
     delta: serialiseDelta(t.delta),
   }));
 
-  return {
+  const envelope: Record<string, unknown> = {
     schemaVersion: 1,
     track: "utility",
     branch: input.branch,
@@ -147,6 +175,24 @@ function buildUtilityJson(input: UtilityRunReport): object {
     tasks,
     warnings: input.warnings,
   };
+
+  // Per-asset attribution is an additive top-level key (§6.5). Emit it only
+  // when the runner populated it so older code paths (e.g. the empty-corpus
+  // skeleton) don't gain the key spuriously.
+  if (input.perAsset) {
+    envelope.perAsset = {
+      total_akm_runs: input.perAsset.totalAkmRuns,
+      rows: input.perAsset.rows.map((r) => ({
+        asset_ref: r.assetRef,
+        load_count: r.loadCount,
+        load_count_passing: r.loadCountPassing,
+        load_count_failing: r.loadCountFailing,
+        load_pass_rate: r.loadPassRate,
+      })),
+    };
+  }
+
+  return envelope;
 }
 
 function serialiseCorpus(c: CorpusMetrics): {
@@ -252,6 +298,93 @@ function signed(text: string): string {
 }
 
 function formatPercent(value: number | null): string {
+  if (value === null) return "n/a";
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+// ── Attribution table rendering (§6.5) ─────────────────────────────────────
+
+/**
+ * Threshold for the "highly loaded" slice — assets with a load count at or
+ * above this fraction of the per-table maximum get bucketed into the "well
+ * used and working" / "well used and not working" callout sections.
+ */
+const HIGH_LOAD_THRESHOLD = 0.5;
+
+/**
+ * Threshold for "working" pass-rate. An asset is "working" if its
+ * load_pass_rate is at or above this; "not working" if below.
+ */
+const WORKING_PASS_RATE_THRESHOLD = 0.5;
+
+/**
+ * Render a per-asset attribution table as markdown. Sort order matches
+ * `computePerAssetAttribution` (load count desc, pass rate desc, ref asc).
+ *
+ * The output has three sections:
+ *   1. Full sorted table.
+ *   2. "Well-used and working" callout — high load, high pass_rate.
+ *   3. "Well-used and not working" callout — high load, low pass_rate.
+ *
+ * The two callouts are the actionable slices: the first is what curation
+ * should preserve, the second is what should be improved or removed.
+ */
+export function renderAttributionTable(attr: PerAssetAttribution): string {
+  const lines: string[] = [];
+  lines.push("## Per-asset attribution");
+  lines.push("");
+  lines.push(`Total akm-arm runs aggregated: ${attr.totalAkmRuns}`);
+  lines.push("");
+
+  if (attr.rows.length === 0) {
+    lines.push("_No assets were loaded by the agent during akm-arm runs._");
+    return lines.join("\n");
+  }
+
+  lines.push("| asset_ref | load_count | load_count_passing | load_count_failing | load_pass_rate |");
+  lines.push("|-----------|------------|--------------------|--------------------|----------------|");
+  for (const row of attr.rows) {
+    lines.push(
+      `| \`${row.assetRef}\` | ${row.loadCount} | ${row.loadCountPassing} | ${row.loadCountFailing} | ${formatRate(row.loadPassRate)} |`,
+    );
+  }
+
+  // Slice callouts. We compute the high-load threshold relative to the
+  // top-loaded asset's count so this scales whether the corpus has 5 or 500
+  // total runs.
+  const topLoad = attr.rows[0]?.loadCount ?? 0;
+  const highLoadCutoff = Math.max(1, Math.ceil(topLoad * HIGH_LOAD_THRESHOLD));
+  const heavilyLoaded = attr.rows.filter((r) => r.loadCount >= highLoadCutoff);
+
+  const working = heavilyLoaded.filter((r) => (r.loadPassRate ?? 0) >= WORKING_PASS_RATE_THRESHOLD);
+  const notWorking = heavilyLoaded.filter((r) => (r.loadPassRate ?? 0) < WORKING_PASS_RATE_THRESHOLD);
+
+  lines.push("");
+  lines.push("### Well-used and working");
+  lines.push("");
+  if (working.length === 0) {
+    lines.push("_None._");
+  } else {
+    for (const r of working) {
+      lines.push(`- \`${r.assetRef}\` (load_count=${r.loadCount}, load_pass_rate=${formatRate(r.loadPassRate)})`);
+    }
+  }
+
+  lines.push("");
+  lines.push("### Well-used and NOT working");
+  lines.push("");
+  if (notWorking.length === 0) {
+    lines.push("_None._");
+  } else {
+    for (const r of notWorking) {
+      lines.push(`- \`${r.assetRef}\` (load_count=${r.loadCount}, load_pass_rate=${formatRate(r.loadPassRate)})`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatRate(value: number | null): string {
   if (value === null) return "n/a";
   return `${(value * 100).toFixed(1)}%`;
 }

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -14,7 +14,16 @@
  */
 
 import { execSync } from "node:child_process";
-import type { CorpusDelta, CorpusMetrics, OutcomeAggregate, PerTaskMetrics, TrajectoryAggregate } from "./metrics";
+import type {
+  CompareResult,
+  CompareTaskRow,
+  CorpusDelta,
+  CorpusMetrics,
+  DeltaSign,
+  OutcomeAggregate,
+  PerTaskMetrics,
+  TrajectoryAggregate,
+} from "./metrics";
 
 // ── Legacy envelope (#236) ─────────────────────────────────────────────────
 
@@ -254,6 +263,124 @@ function signed(text: string): string {
 function formatPercent(value: number | null): string {
   if (value === null) return "n/a";
   return `${(value * 100).toFixed(1)}%`;
+}
+
+// ── Compare rendering (§8) ─────────────────────────────────────────────────
+
+/**
+ * Render a CompareResult as a deterministic markdown diff.
+ *
+ * Determinism: no timestamps, no run IDs, no git SHAs in the body — the diff
+ * is a pure function of the two inputs' aggregated numbers and per-task
+ * tables. Per-task rows are sorted alphabetically (already done by
+ * `compareReports`, but re-asserted here defensively).
+ *
+ * Refusal cases (model mismatch, hash mismatch, schema/track issues) render
+ * as a single error block instead of a diff table — there's nothing
+ * actionable to show, and the operator's recovery path is in the message.
+ */
+export function renderCompareMarkdown(result: CompareResult): string {
+  if (!result.ok) {
+    return renderCompareFailure(result);
+  }
+  return renderCompareSuccess(result);
+}
+
+function renderCompareFailure(result: Extract<CompareResult, { ok: false }>): string {
+  const lines: string[] = [];
+  lines.push(`# akm-bench compare — refused (${result.reason})`);
+  lines.push("");
+  lines.push(result.message);
+  if (result.reason === "model_mismatch" && result.baseModel !== undefined && result.currentModel !== undefined) {
+    lines.push("");
+    lines.push(`- base model:    \`${result.baseModel}\``);
+    lines.push(`- current model: \`${result.currentModel}\``);
+  }
+  if (
+    result.reason === "hash_mismatch" &&
+    result.baseFixtureContentHash !== undefined &&
+    result.currentFixtureContentHash !== undefined
+  ) {
+    lines.push("");
+    lines.push(`- base fixture hash:    \`${String(result.baseFixtureContentHash)}\``);
+    lines.push(`- current fixture hash: \`${String(result.currentFixtureContentHash)}\``);
+    if (result.affectedFixtures && result.affectedFixtures.length > 0) {
+      lines.push("");
+      lines.push("affected fixtures:");
+      for (const f of result.affectedFixtures) lines.push(`- ${f}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function renderCompareSuccess(result: Extract<CompareResult, { ok: true }>): string {
+  const lines: string[] = [];
+  lines.push(`# akm-bench compare — \`${result.currentModel}\``);
+  lines.push("");
+  if (result.baseFixtureContentHash !== null || result.currentFixtureContentHash !== null) {
+    const b = result.baseFixtureContentHash === null ? "n/a" : `\`${result.baseFixtureContentHash}\``;
+    const c = result.currentFixtureContentHash === null ? "n/a" : `\`${result.currentFixtureContentHash}\``;
+    lines.push(`fixture-content hash: base=${b}, current=${c}`);
+    lines.push("");
+  }
+  lines.push("## Aggregate (akm arm, current − base)");
+  lines.push("");
+  lines.push("| metric | delta | direction |");
+  lines.push("|--------|-------|-----------|");
+  lines.push(
+    `| pass_rate | ${signedFixed(result.aggregate.passRateDelta, 2)} | ${signGlyph(result.aggregate.passRateSign)} |`,
+  );
+  lines.push(
+    `| tokens_per_pass | ${nullableSignedFixed(result.aggregate.tokensPerPassDelta, 0)} | ${signGlyph(result.aggregate.tokensPerPassSign)} |`,
+  );
+  lines.push(
+    `| wallclock_ms | ${signedFixed(result.aggregate.wallclockMsDelta, 0)} | ${signGlyph(result.aggregate.wallclockMsSign)} |`,
+  );
+  lines.push("");
+  lines.push("## Per-task (akm arm)");
+  lines.push("");
+  lines.push("| task | base pass_rate | current pass_rate | delta | dir | base stdev | current stdev |");
+  lines.push("|------|----------------|-------------------|-------|-----|------------|---------------|");
+  const sorted = [...result.perTask].sort((a, b) => a.id.localeCompare(b.id));
+  for (const row of sorted) lines.push(perTaskCompareRow(row));
+  if (result.warnings.length > 0) {
+    lines.push("");
+    lines.push("## Warnings");
+    lines.push("");
+    for (const w of result.warnings) lines.push(`- ${w}`);
+  }
+  return lines.join("\n");
+}
+
+function perTaskCompareRow(row: CompareTaskRow): string {
+  const baseRate = row.baseMetrics === null ? "n/a" : row.baseMetrics.pass_rate.toFixed(2);
+  const currentRate = row.currentMetrics === null ? "n/a" : row.currentMetrics.pass_rate.toFixed(2);
+  const delta = row.delta.passRate === null ? "n/a" : signedFixed(row.delta.passRate, 2);
+  const dir = signGlyph(row.signMarker);
+  const baseStdev = row.baseMetrics === null ? "n/a" : row.baseMetrics.pass_rate_stdev.toFixed(2);
+  const currentStdev = row.currentMetrics === null ? "n/a" : row.currentMetrics.pass_rate_stdev.toFixed(2);
+  const idCell = row.presence === "both" ? row.id : `${row.id} _(${row.presence})_`;
+  return `| ${idCell} | ${baseRate} | ${currentRate} | ${delta} | ${dir} | ${baseStdev} | ${currentStdev} |`;
+}
+
+function signGlyph(sign: DeltaSign): string {
+  if (sign === "improve") return "▲";
+  if (sign === "regress") return "▼";
+  return "▬";
+}
+
+function signedFixed(value: number, digits: number): string {
+  // Treat numerical zero (or values that round to "-0.00") as "0" so we
+  // never emit a misleading "+0.00" or "-0.00" in deterministic output.
+  const fixed = value.toFixed(digits);
+  if (fixed === "-0" || /^-0\.0+$/.test(fixed)) return (0).toFixed(digits);
+  if (value === 0) return fixed;
+  return value > 0 ? `+${fixed}` : fixed;
+}
+
+function nullableSignedFixed(value: number | null, digits: number): string {
+  if (value === null) return "n/a";
+  return signedFixed(value, digits);
 }
 
 // ── Git helpers ────────────────────────────────────────────────────────────

--- a/tests/bench/runner.ts
+++ b/tests/bench/runner.ts
@@ -29,10 +29,13 @@ import type { TaskMetadata, TaskSlice } from "./corpus";
 import { type RunOptions, type RunResult, runOne } from "./driver";
 import {
   aggregateCorpus,
+  aggregateFailureModes,
   aggregatePerTask,
   aggregateTrajectory,
+  classifyFailureMode,
   computeCorpusDelta,
   computePerTaskDelta,
+  type FailureMode,
   type PerTaskMetrics,
 } from "./metrics";
 import { resolveGitBranch, resolveGitCommit, type UtilityReportTaskEntry, type UtilityRunReport } from "./report";
@@ -195,7 +198,11 @@ async function runOneIsolated(args: {
     const trajectory = computeTrajectory({ goldRef: args.task.goldRef }, result, {
       warnings: args.warnings,
     });
-    return { ...result, trajectory };
+    // Splice in the failure-mode label. Only the akm arm carries one; the
+    // noakm baseline is the control and isn't part of the §6.6 to-do list.
+    // `classifyFailureMode` returns null for non-failed runs.
+    const failureMode = args.arm === "akm" ? classifyFailureMode(args.task, { ...result, trajectory }) : null;
+    return { ...result, trajectory, failureMode };
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });
   }
@@ -259,6 +266,14 @@ function buildReport(args: BuildReportArgs): UtilityRunReport {
   const aggregateDelta = computeCorpusDelta(aggregateNoakm, aggregateAkm);
   const trajectoryAkm = aggregateTrajectory(akmRunsAll);
 
+  // Failure-mode aggregate (§6.6). Walks every akm-arm run; runs that are
+  // not "fail" carry `failureMode: null` and are skipped here.
+  const failureEntries: Array<{ taskId: string; mode: FailureMode }> = [];
+  for (const r of akmRunsAll) {
+    if (r.failureMode) failureEntries.push({ taskId: r.taskId, mode: r.failureMode });
+  }
+  const failureModes = aggregateFailureModes(failureEntries);
+
   const domains = new Set(args.options.tasks.map((t) => t.domain)).size;
   const branch = args.options.branch ?? resolveGitBranch();
   const commit = args.options.commit ?? resolveGitCommit();
@@ -279,6 +294,7 @@ function buildReport(args: BuildReportArgs): UtilityRunReport {
     aggregateAkm,
     aggregateDelta,
     trajectoryAkm,
+    failureModes,
     tasks,
     warnings: args.warnings,
   };

--- a/tests/bench/runner.ts
+++ b/tests/bench/runner.ts
@@ -33,6 +33,9 @@ import {
   aggregateTrajectory,
   computeCorpusDelta,
   computePerTaskDelta,
+  computeSearchBridge,
+  extractGoldRanks,
+  type GoldRankRunRecord,
   type PerTaskMetrics,
 } from "./metrics";
 import { resolveGitBranch, resolveGitCommit, type UtilityReportTaskEntry, type UtilityRunReport } from "./report";
@@ -73,6 +76,13 @@ export interface RunUtilityOptions {
 type GroupedRuns = Map<string, Map<Arm, RunResult[]>>;
 
 /**
+ * Internal: gold-rank records collected across all akm-arm runs in the
+ * current `runUtility` call. Reduced into `searchBridge` once every run
+ * lands.
+ */
+type GoldRankAccumulator = GoldRankRunRecord[];
+
+/**
  * Run K seeds × len(arms) × len(tasks) and return the §13.3 report.
  *
  * The function is robust to per-run failures — `runOne` already captures
@@ -89,6 +99,7 @@ export async function runUtility(options: RunUtilityOptions): Promise<UtilityRun
 
   const grouped: GroupedRuns = new Map();
   const warnings: string[] = [];
+  const goldRankRecords: GoldRankAccumulator = [];
 
   for (const task of options.tasks) {
     const taskRuns = new Map<Arm, RunResult[]>();
@@ -136,6 +147,21 @@ export async function runUtility(options: RunUtilityOptions): Promise<UtilityRun
             warnings,
           });
           armRuns.push(run);
+
+          // §6.7 search-pipeline bridge: only the akm arm consults the stash,
+          // and we only attribute ranks for tasks with a gold ref. Both
+          // guards mean noakm and gold-less runs are silently excluded.
+          if (arm === "akm" && task.goldRef) {
+            const searches = extractGoldRanks(run, task.goldRef);
+            goldRankRecords.push({
+              taskId: task.id,
+              arm,
+              seed,
+              outcome: run.outcome,
+              goldRef: task.goldRef,
+              searches,
+            });
+          }
         }
       }
     } finally {
@@ -149,6 +175,7 @@ export async function runUtility(options: RunUtilityOptions): Promise<UtilityRun
     seedsPerArm,
     slice,
     warnings,
+    goldRankRecords,
   });
 }
 
@@ -230,6 +257,7 @@ interface BuildReportArgs {
   seedsPerArm: number;
   slice: "all" | TaskSlice;
   warnings: string[];
+  goldRankRecords: GoldRankAccumulator;
 }
 
 function buildReport(args: BuildReportArgs): UtilityRunReport {
@@ -264,6 +292,11 @@ function buildReport(args: BuildReportArgs): UtilityRunReport {
   const commit = args.options.commit ?? resolveGitCommit();
   const timestamp = args.options.timestamp ?? new Date().toISOString();
 
+  // §6.7 — compute the search-pipeline bridge once over the whole corpus.
+  // The function tolerates an empty record list (renders the N/A sentence
+  // downstream).
+  const searchBridge = computeSearchBridge({ goldRankRecords: args.goldRankRecords });
+
   return {
     timestamp,
     branch,
@@ -281,5 +314,7 @@ function buildReport(args: BuildReportArgs): UtilityRunReport {
     trajectoryAkm,
     tasks,
     warnings: args.warnings,
+    goldRankRecords: args.goldRankRecords,
+    searchBridge,
   };
 }

--- a/tests/bench/runner.ts
+++ b/tests/bench/runner.ts
@@ -32,7 +32,9 @@ import {
   aggregatePerTask,
   aggregateTrajectory,
   computeCorpusDelta,
+  computePerAssetAttribution,
   computePerTaskDelta,
+  extractAssetLoads,
   type PerTaskMetrics,
 } from "./metrics";
 import { resolveGitBranch, resolveGitCommit, type UtilityReportTaskEntry, type UtilityRunReport } from "./report";
@@ -195,7 +197,11 @@ async function runOneIsolated(args: {
     const trajectory = computeTrajectory({ goldRef: args.task.goldRef }, result, {
       warnings: args.warnings,
     });
-    return { ...result, trajectory };
+    // Per-asset attribution is post-processing on the trace; it's free, so we
+    // run it on every (task, arm, seed) result. The driver emits an empty
+    // assetsLoaded[]; this is where the real refs get filled. Spec §6.5.
+    const assetsLoaded = extractAssetLoads(result);
+    return { ...result, trajectory, assetsLoaded };
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });
   }
@@ -264,7 +270,7 @@ function buildReport(args: BuildReportArgs): UtilityRunReport {
   const commit = args.options.commit ?? resolveGitCommit();
   const timestamp = args.options.timestamp ?? new Date().toISOString();
 
-  return {
+  const baseReport: UtilityRunReport = {
     timestamp,
     branch,
     commit,
@@ -281,5 +287,12 @@ function buildReport(args: BuildReportArgs): UtilityRunReport {
     trajectoryAkm,
     tasks,
     warnings: args.warnings,
+    akmRuns: akmRunsAll,
+    taskMetadata: args.options.tasks,
   };
+  // Compute per-asset attribution as post-processing on the akm-arm runs
+  // we just collected. This is the §6.5 "free" diagnostic — it runs on every
+  // utility invocation, no extra spawns.
+  baseReport.perAsset = computePerAssetAttribution(baseReport);
+  return baseReport;
 }

--- a/tests/bench/search-bridge.test.ts
+++ b/tests/bench/search-bridge.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Unit tests for the §6.7 search-pipeline bridge.
+ *
+ * Covers:
+ *   • `extractGoldRanks` — pure-function rank extraction from synthetic
+ *     verifier-stdout traces, including JSON tool-call form, plain-text
+ *     `ref:` lines, multiple searches per run, and gold-not-in-top-10
+ *     (the "missing" bucket).
+ *   • `computeSearchBridge` — histogram, p50/p90, gold_at_rank_1,
+ *     gold_missing, and the keystone `pass_rate_by_rank` slice.
+ *   • Empty-corpus path — no records → renderer emits the N/A sentence.
+ *
+ * No real opencode is invoked; every fixture is a hand-crafted `RunResult`.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { RunResult } from "./driver";
+import { computeSearchBridge, extractGoldRanks, type GoldRankRunRecord } from "./metrics";
+import { renderSearchBridgeTable } from "./report";
+
+function fakeResult(stdout: string, overrides: Partial<RunResult> = {}): RunResult {
+  return {
+    schemaVersion: 1,
+    taskId: "t",
+    arm: "akm",
+    seed: 0,
+    model: "m",
+    outcome: "pass",
+    tokens: { input: 0, output: 0 },
+    wallclockMs: 0,
+    trajectory: { correctAssetLoaded: null, feedbackRecorded: null },
+    events: [],
+    verifierStdout: stdout,
+    verifierExitCode: 0,
+    ...overrides,
+  };
+}
+
+describe("extractGoldRanks", () => {
+  test("returns [] when goldRef is undefined", () => {
+    const r = fakeResult('akm search "foo"\nref: skill:foo');
+    expect(extractGoldRanks(r, undefined)).toEqual([]);
+  });
+
+  test("returns [] when verifierStdout is empty", () => {
+    const r = fakeResult("");
+    expect(extractGoldRanks(r, "skill:foo")).toEqual([]);
+  });
+
+  test("extracts a single search with text-mode ref output, gold at rank 1", () => {
+    const stdout = [
+      `> akm search "redis healthcheck"`,
+      `skill: docker-homelab`,
+      `  ref: skill:docker-homelab`,
+      `  score: 0.92`,
+      `skill: nginx-tls`,
+      `  ref: skill:nginx-tls`,
+      `  score: 0.81`,
+    ].join("\n");
+
+    const events = extractGoldRanks(fakeResult(stdout), "skill:docker-homelab");
+    expect(events).toHaveLength(1);
+    expect(events[0].query).toBe("redis healthcheck");
+    expect(events[0].results).toEqual(["skill:docker-homelab", "skill:nginx-tls"]);
+    expect(events[0].rankOfGold).toBe(1);
+  });
+
+  test("extracts JSON tool-call form, gold at rank 3", () => {
+    const stdout = [
+      'tool: akm search "kubernetes pod restart" --output json',
+      '{"hits":[{"ref":"skill:k8s-debug"},{"ref":"skill:k8s-monitoring"},{"ref":"skill:k8s-restart"},{"ref":"skill:k8s-deploy"}]}',
+    ].join("\n");
+
+    const events = extractGoldRanks(fakeResult(stdout), "skill:k8s-restart");
+    expect(events).toHaveLength(1);
+    expect(events[0].results.slice(0, 4)).toEqual([
+      "skill:k8s-debug",
+      "skill:k8s-monitoring",
+      "skill:k8s-restart",
+      "skill:k8s-deploy",
+    ]);
+    expect(events[0].rankOfGold).toBe(3);
+  });
+
+  test("returns null rank when gold is missing from top 10", () => {
+    const refs = Array.from({ length: 12 }, (_, i) => `  ref: skill:other-${i}`).join("\n");
+    const stdout = `akm search "missing-target"\n${refs}`;
+    const events = extractGoldRanks(fakeResult(stdout), "skill:gold");
+    expect(events).toHaveLength(1);
+    expect(events[0].rankOfGold).toBeNull();
+    // Top-10 cap: only 10 results retained.
+    expect(events[0].results.length).toBeLessThanOrEqual(10);
+  });
+
+  test("multiple searches per run are each emitted in order", () => {
+    const stdout = [
+      'akm search "first query"',
+      "  ref: skill:a",
+      "  ref: skill:b",
+      'akm search "second query"',
+      "  ref: skill:gold",
+      "  ref: skill:c",
+    ].join("\n");
+    const events = extractGoldRanks(fakeResult(stdout), "skill:gold");
+    expect(events).toHaveLength(2);
+    expect(events[0].query).toBe("first query");
+    expect(events[0].rankOfGold).toBeNull();
+    expect(events[1].query).toBe("second query");
+    expect(events[1].rankOfGold).toBe(1);
+  });
+
+  test("non-search akm invocation closes the active search block", () => {
+    const stdout = [
+      'akm search "q"',
+      "  ref: skill:a",
+      "  ref: skill:gold",
+      "akm show skill:gold",
+      "  ref: skill:gold (this should NOT extend the previous search)",
+      "  ref: skill:other",
+    ].join("\n");
+    const events = extractGoldRanks(fakeResult(stdout), "skill:gold");
+    // Only the search block contributes to results; the show block is closed.
+    expect(events).toHaveLength(1);
+    expect(events[0].results).toEqual(["skill:a", "skill:gold"]);
+    expect(events[0].rankOfGold).toBe(2);
+  });
+
+  test("origin-prefixed ref counts as gold (team//skill:foo matches skill:foo)", () => {
+    const stdout = ['akm search "q"', "  ref: team//skill:foo", "  ref: skill:bar"].join("\n");
+    const events = extractGoldRanks(fakeResult(stdout), "skill:foo");
+    expect(events[0].rankOfGold).toBe(1);
+  });
+});
+
+describe("computeSearchBridge — histogram + percentiles", () => {
+  function fakeRecord(
+    seed: number,
+    outcome: RunResult["outcome"],
+    rankOrNullPerSearch: Array<number | null>,
+  ): GoldRankRunRecord {
+    return {
+      taskId: `t${seed}`,
+      arm: "akm",
+      seed,
+      outcome,
+      goldRef: "skill:gold",
+      searches: rankOrNullPerSearch.map((rank, i) => ({
+        query: `q${i}`,
+        // Reconstruct a plausible result list: gold at the requested rank,
+        // others as fillers. The aggregator only looks at rankOfGold.
+        results: rank === null ? Array.from({ length: 10 }, (_, j) => `skill:other-${j}`) : [],
+        rankOfGold: rank,
+      })),
+    };
+  }
+
+  test("empty corpus produces zero envelope", () => {
+    const m = computeSearchBridge({ goldRankRecords: [] });
+    expect(m.runsObserved).toBe(0);
+    expect(m.searchesObserved).toBe(0);
+    expect(m.goldRankP50).toBeNull();
+    expect(m.goldRankP90).toBeNull();
+    expect(m.goldAtRank1).toBe(0);
+    expect(m.goldMissing).toBe(0);
+    expect(m.passRateByRank).toEqual([]);
+    // Histogram is fully zeroed for every key.
+    for (const k of ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "missing"]) {
+      expect(m.goldRankDistribution[k]).toBe(0);
+    }
+  });
+
+  test("histogram counts ranks across all searches", () => {
+    const records: GoldRankRunRecord[] = [
+      fakeRecord(0, "pass", [1, 2]),
+      fakeRecord(1, "fail", [1, null]),
+      fakeRecord(2, "pass", [3]),
+    ];
+    const m = computeSearchBridge({ goldRankRecords: records });
+    expect(m.searchesObserved).toBe(5);
+    expect(m.runsObserved).toBe(3);
+    expect(m.goldRankDistribution["1"]).toBe(2);
+    expect(m.goldRankDistribution["2"]).toBe(1);
+    expect(m.goldRankDistribution["3"]).toBe(1);
+    expect(m.goldRankDistribution.missing).toBe(1);
+    expect(m.goldAtRank1).toBeCloseTo(2 / 5);
+    expect(m.goldMissing).toBeCloseTo(1 / 5);
+  });
+
+  test("p50/p90 use nearest-rank with missing treated as Infinity", () => {
+    // Ranks: [1,1,2,3,5,5,7,9,null,null] across one record.
+    const records = [fakeRecord(0, "pass", [1, 1, 2, 3, 5, 5, 7, 9, null, null])];
+    const m = computeSearchBridge({ goldRankRecords: records });
+    // Sorted: [1,1,2,3,5,5,7,9,Inf,Inf]
+    // p50 = idx ceil(0.5*10)-1 = 4 → 5
+    expect(m.goldRankP50).toBe(5);
+    // p90 = idx ceil(0.9*10)-1 = 8 → Infinity
+    expect(m.goldRankP90).toBe(Number.POSITIVE_INFINITY);
+  });
+});
+
+describe("computeSearchBridge — pass_rate_by_rank uses the agent's chosen search", () => {
+  test("attributes pass/fail to the rank in the LAST search, not the highest-ranked", () => {
+    // Run A passed; first search had gold at rank 1 (great rank!), but the
+    // *chosen* (last) search had gold at rank 5. The bridge must attribute
+    // run A to rank 5, not rank 1, otherwise it overstates the value of
+    // having gold at rank 1.
+    const records: GoldRankRunRecord[] = [
+      {
+        taskId: "ta",
+        arm: "akm",
+        seed: 0,
+        outcome: "pass",
+        goldRef: "skill:gold",
+        searches: [
+          { query: "first", results: [], rankOfGold: 1 },
+          { query: "last", results: [], rankOfGold: 5 },
+        ],
+      },
+      {
+        taskId: "tb",
+        arm: "akm",
+        seed: 0,
+        outcome: "fail",
+        goldRef: "skill:gold",
+        searches: [{ query: "only", results: [], rankOfGold: 5 }],
+      },
+      {
+        taskId: "tc",
+        arm: "akm",
+        seed: 0,
+        outcome: "pass",
+        goldRef: "skill:gold",
+        searches: [{ query: "only", results: [], rankOfGold: 1 }],
+      },
+    ];
+    const m = computeSearchBridge({ goldRankRecords: records });
+    // Buckets: rank 1 → {1 pass / 1 total}, rank 5 → {1 pass / 2 total}.
+    const rank1 = m.passRateByRank.find((e) => e.rank === "1");
+    const rank5 = m.passRateByRank.find((e) => e.rank === "5");
+    expect(rank1).toBeDefined();
+    expect(rank1?.passRate).toBe(1);
+    expect(rank1?.runCount).toBe(1);
+    expect(rank5).toBeDefined();
+    expect(rank5?.passRate).toBe(0.5);
+    expect(rank5?.runCount).toBe(2);
+  });
+
+  test("missing bucket gets its own pass-rate row instead of being dropped", () => {
+    const records: GoldRankRunRecord[] = [
+      {
+        taskId: "tm1",
+        arm: "akm",
+        seed: 0,
+        outcome: "pass",
+        goldRef: "skill:gold",
+        searches: [{ query: "q", results: [], rankOfGold: null }],
+      },
+      {
+        taskId: "tm2",
+        arm: "akm",
+        seed: 0,
+        outcome: "fail",
+        goldRef: "skill:gold",
+        searches: [{ query: "q", results: [], rankOfGold: null }],
+      },
+    ];
+    const m = computeSearchBridge({ goldRankRecords: records });
+    const missing = m.passRateByRank.find((e) => e.rank === "missing");
+    expect(missing).toBeDefined();
+    expect(missing?.runCount).toBe(2);
+    expect(missing?.passRate).toBe(0.5);
+  });
+
+  test("runs without any akm search invocation are excluded from pass_rate_by_rank", () => {
+    const records: GoldRankRunRecord[] = [
+      {
+        taskId: "no-search",
+        arm: "akm",
+        seed: 0,
+        outcome: "fail",
+        goldRef: "skill:gold",
+        searches: [],
+      },
+    ];
+    const m = computeSearchBridge({ goldRankRecords: records });
+    expect(m.runsObserved).toBe(1);
+    expect(m.searchesObserved).toBe(0);
+    expect(m.passRateByRank).toEqual([]);
+  });
+});
+
+describe("renderSearchBridgeTable", () => {
+  test("empty corpus renders the N/A sentence", () => {
+    const md = renderSearchBridgeTable({
+      goldRankDistribution: {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+        "5": 0,
+        "6": 0,
+        "7": 0,
+        "8": 0,
+        "9": 0,
+        "10": 0,
+        missing: 0,
+      },
+      goldRankP50: null,
+      goldRankP90: null,
+      goldAtRank1: 0,
+      goldMissing: 0,
+      passRateByRank: [],
+      runsObserved: 0,
+      searchesObserved: 0,
+    });
+    expect(md).toContain("Search → outcome bridge");
+    expect(md).toContain("(no gold-ref tasks in corpus; bridge metrics N/A)");
+  });
+
+  test("populated corpus surfaces histogram, p50/p90, and pass-rate-by-rank table", () => {
+    const md = renderSearchBridgeTable({
+      goldRankDistribution: {
+        "1": 3,
+        "2": 1,
+        "3": 0,
+        "4": 0,
+        "5": 1,
+        "6": 0,
+        "7": 0,
+        "8": 0,
+        "9": 0,
+        "10": 0,
+        missing: 1,
+      },
+      goldRankP50: 1,
+      goldRankP90: 5,
+      goldAtRank1: 0.5,
+      goldMissing: 1 / 6,
+      passRateByRank: [
+        { rank: "1", passRate: 0.67, runCount: 3 },
+        { rank: "5", passRate: 0, runCount: 1 },
+        { rank: "missing", passRate: 0, runCount: 1 },
+      ],
+      runsObserved: 5,
+      searchesObserved: 6,
+    });
+    expect(md).toContain("| 1 | 3 |");
+    expect(md).toContain("| missing | 1 |");
+    expect(md).toContain("p50=1.0");
+    expect(md).toContain("p90=5.0");
+    expect(md).toContain("gold_at_rank_1=50.0%");
+    expect(md).toContain("| rank | pass_rate | run_count |");
+    expect(md).toContain("| 1 | 0.67 | 3 |");
+    expect(md).toContain("| missing | 0.00 | 1 |");
+  });
+});

--- a/tests/bench/trajectory.test.ts
+++ b/tests/bench/trajectory.test.ts
@@ -22,6 +22,7 @@ function fakeRun(overrides: Partial<RunResult> = {}): RunResult {
     events: [],
     verifierStdout: "",
     verifierExitCode: 0,
+    assetsLoaded: [],
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Wave D of the `akm-bench` rollout (umbrella tracker #234). Lands four parallel Phase 1 diagnostics that build on top of the merged Wave C report shape (#238). All four issues extend the §13.3 JSON envelope additively with new top-level keys.

| Issue | Branch | Title |
|---|---|---|
| #239 | `issue-239-bench-compare` | feat(bench): bench compare for two-run diff |
| #240 | `issue-240-bench-attribution` | feat(bench): per-asset attribution + bench attribute subcommand |
| #241 | `issue-241-failure-modes` | feat(bench): failure-mode taxonomy classifier |
| #242 | `issue-242-search-bridge` | feat(bench): search-pipeline bridge metrics |

Closes #239, #240, #241, #242. **Unlocks #243 (bench evolve / Track B core).**

## What landed

### #239 `bench compare --base a.json --current b.json`
- `compareReports(base, current)` validates schemaVersion 1 + track="utility"; refuses model-mismatch and fixture-content-hash mismatch with structured deltas.
- `renderCompareMarkdown` produces a deterministic side-by-side diff (no embedded timestamps that would break determinism); per-task table includes pass_rate change + sign + seed-stdev for both runs.
- Exit 0 on diff, 1 on refusal, 2 on input error.

### #240 per-asset attribution + `bench attribute --base run.json --top N`
- `extractAssetLoads(runResult)` — three detection paths (events.show, "akm show <ref>" stdout, tool-call JSON) with 16 MiB scan cap.
- Every Track A run carries `assetsLoaded: string[]` (additive on `RunResult`).
- `computePerAssetAttribution(report)` produces per-asset `load_pass_rate`, `load_count_passing`, `load_count_failing`. Top-level `perAsset` key in the envelope.
- `runMaskedCorpus(options)` re-runs the corpus N times with each top-loaded asset masked. **Source fixture stash is never modified** — masking happens in a tmp copy.
- `bench attribute --top N` defaults to 5; clamps to asset count.

### #241 failure-mode taxonomy
- `classifyFailureMode(taskMeta, runResult)` — pure function, no LLM, no IO. Returns one of seven §6.6 labels for failed akm-arm runs: `no_search`, `search_no_gold`, `search_low_rank`, `loaded_wrong`, `loaded_ignored`, `followed_wrong`, `unrelated_bug`.
- Tie-breaking matches spec priority order.
- Each failed akm-arm run carries `failureMode: FailureMode | null`. Top-level `failure_modes: { by_label, by_task }` aggregate.
- `renderFailureModeBreakdown` — markdown sorted by descending count.

### #242 search-pipeline bridge
- `extractGoldRanks(runResult, goldRef)` — for each `akm search` invocation in a run, `{ query, results, rankOfGold | null }`. Top-10 cap.
- `computeSearchBridge(report)` aggregates: `gold_rank_distribution`, `gold_rank_p50/p90` (missing → `"missing"` sentinel in JSON), `gold_at_rank_1`, `gold_missing`, **`pass_rate_by_rank`** (the keystone — pass rate split by rank-of-gold-in-the-search-the-agent-actually-ran).
- `renderSearchBridgeTable` — markdown with histogram + summary line + pass_rate_by_rank table.
- Top-level `searchBridge` JSON key.

## Test plan

- `bunx tsc --noEmit` — clean.
- `bunx biome check src/ tests/` — 1 pre-existing info, no new warnings.
- `bun test` — **2386 pass / 9 skip / 0 fail / 6489 expects across 154 files**.
  - Wave C baseline at `release/1.0.0`@`2bc79d7`: 2301 / 9 / 0.
  - Net: +85 tests across the four issues (and one fixup test count for #240).

## Reviewer pass discipline

Three reviewers (senior-engineer, security, domain-expert) ran in parallel across all four issues.

- **#239 (compare)**: senior-engineer approve · security approve (advisory: nice-to-have file-size guard on report inputs) · domain-expert approve.
- **#240 (attribution)**: senior-engineer request-changes → approve (4 findings, all closed in fixup `978e93c`) · security **request-changes → approve (CRITICAL fixed)** · domain-expert approve.
  - **CRITICAL** finding from security: `materialiseMaskedStash` permitted `..` traversal in `assetRef.name` (originating from agent stdout). A prompt-injected agent could have triggered `fs.rmSync` on an arbitrary directory. **Fixed in `978e93c`**: tightened `ASSET_REF_PATTERN`, validated `name`/`filename` against `..`/`/`/absolute, and added `path.relative` containment check before any `rmSync`. Two tests assert hostile refs leave a sentinel-file outside the fixture untouched.
- **#241 (failure-modes)**: senior-engineer approve · security approve · domain-expert approve.
- **#242 (search-bridge)**: senior-engineer approve · security approve (advisory: explicit 16 MiB stdout cap for parser-boundary defense) · domain-expert approve.

## Integrate-step conflict resolution

All three sets of merge conflicts in this wave resolved additively by focused subagents (notes in `.akm-run/f0a96683-…/notes/integrate.md`). The four issues each touched `tests/bench/{metrics,report,runner}.ts` and (for #239 + #240) `tests/bench/cli.ts`. Per the Wave A plan's per-symbol ownership rule, each issue's exports are uniquely-named so resolution was mechanical.

## CLAUDE.md compliance

- No `src/` changes — bench reads v1 contract surfaces from outside.
- No new prod dependencies.
- No new URI schemes; no new source-provider-kind branches; no new top-level directory.
- Output shape registry unchanged — bench's JSON envelope additions are all under `tests/bench/`.

## Follow-ups (queued; none blocking)

- **#243** Track B core (`bench evolve` — three-phase runner + synthetic arm + longitudinal metrics). Depends on Phase 1 + #240 attribution.
- **#244** feedback-signal integrity (depends on #243).
- **Hardening (advisory, low priority)**:
  - File-size guard on `bench compare` JSON inputs (operator-trusted today).
  - Explicit 16 MiB cap on `verifierStdout` in #242's bridge parser (currently relies on driver-level cap).

## Run scratch directory

`.akm-run/f0a96683-cff4-43d8-b610-d792287038ee/` (not pushed): notes, plan.json, summaries/issue-{239,240,241,242}.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)