### PR TITLE
akm-bench Wave E+F: Track B evolve runner + feedback-signal integrity

### DIFF
--- a/tests/bench/BENCH.md
+++ b/tests/bench/BENCH.md
@@ -148,6 +148,15 @@ single domain (or `--tasks all` for the whole corpus):
    accepted lessons + revisions), and `synthetic` (no stash; the agent
    writes its own scratchpad — "Bring Your Own Skills").
 
+`bench evolve` runs **entirely in tmp directories**. Before Phase 1 starts,
+the runner materialises one dedicated tmp stash per fixture (the
+`evolveStash`) plus a fresh sibling snapshot per fixture (the `preStash`).
+Phase 1 + Phase 2 pin `AKM_STASH_DIR` to the appropriate evolveStash for
+every spawned `akm` invocation; Phase 3's pre arm reads from preStash, the
+post arm reads from the mutated evolveStash, and the synthetic arm reads
+no stash at all. **The operator's real `AKM_STASH_DIR` is never read or
+written.** All tmp stashes are torn down in a top-level try/finally.
+
 The report (§6.3 + §6.4 envelope) carries:
 
 - `proposals` — `acceptance_rate`, `lint_pass_rate`, plus a per-asset table.

--- a/tests/bench/BENCH.md
+++ b/tests/bench/BENCH.md
@@ -166,9 +166,48 @@ The report (§6.3 + §6.4 envelope) carries:
   `failure_mode` from §6.6.
 - `arms.{pre,post,synthetic}` — full §13.3 utility envelopes per arm so the
   per-task pre→post→synthetic delta is reproducible.
+- `feedback_integrity` — §6.8 confusion matrix (TP/FP/TN/FN) joining each
+  Phase 1 feedback event back to the run that produced it. See
+  "Feedback-signal integrity" below.
 
-The headline of the markdown summary is `improvement_slope`. The second
-line is a placeholder for `feedback_agreement`, which lands with #244.
+The headline of the markdown summary is `improvement_slope`. The line
+directly after it carries `feedback_agreement` (#244) — the headline trust
+gate for the run.
+
+### Feedback-signal integrity (§6.8)
+
+Track B's headline numbers (`improvement_slope`, `over_synthetic_lift`)
+are only meaningful when Phase 1 feedback agrees with run outcomes most
+of the time. If the agent calls `akm feedback --positive` on runs that
+actually failed, Phase 2 distillation walks down the wrong branch and the
+post-evolve fixture drifts in a direction that has nothing to do with
+real task success. `feedback_integrity` quantifies this:
+
+- `feedback_agreement = (TP + TN) / total` — fraction of feedback events
+  that match the run's outcome (positive on pass, negative on fail).
+- `false_positive_rate = FP / (FP + TN)` — agent claimed success when
+  the run failed.
+- `false_negative_rate = FN / (FN + TP)` — agent claimed failure when
+  the run passed.
+- `feedback_coverage = (Phase 1 runs with any feedback dispatched) /
+  (total Phase 1 runs)` — how complete the signal stream is.
+
+Per-asset rows surface the same matrix scoped to a single gold ref so
+operators can see whether a single skill is responsible for the
+disagreement.
+
+**Warning threshold:** when `feedback_agreement < 0.80`, the markdown
+summary prepends a warning marker above the headline and the JSON
+envelope's `warnings[]` carries a `feedback_agreement_below_threshold`
+entry. Below this gate, treat `improvement_slope` and
+`over_synthetic_lift` as unreliable until AGENTS.md guidance for `akm
+feedback` is tightened.
+
+Attribution rule: a feedback event is joined to the run that produced
+it (by `taskId` + `seed`), not to a later run that happened to touch
+the same gold ref. Per-asset rows aggregate across runs that share a
+ref, but each individual matrix cell is decided by its own run's
+outcome.
 
 ### Leakage prevention (§7.4)
 

--- a/tests/bench/BENCH.md
+++ b/tests/bench/BENCH.md
@@ -128,6 +128,48 @@ Stashes are referenced by name from `tests/fixtures/stashes/`; the bench
 loader copies the named fixture into a tmp dir per run via
 `loadFixtureStash` from `tests/fixtures/stashes/load.ts`.
 
+## Track B (`bench evolve`)
+
+`bench evolve --tasks <domain>` runs the longitudinal three-phase loop on a
+single domain (or `--tasks all` for the whole corpus):
+
+1. **Phase 1 — accumulate signal.** K seeds × train-slice tasks under the akm
+   arm. After each run lands the runner invokes
+   `akm feedback <gold_ref> --positive` (on pass) or `--negative` (on fail).
+2. **Phase 2 — evolve.** Every asset whose negative feedback crosses the
+   threshold (default: `>= 2` absolute OR `> 50%` ratio) triggers
+   `akm distill` and `akm reflect`. Each resulting proposal is validated via
+   `akm proposal show --json`; lint-passing ones are auto-accepted, lint
+   failures are auto-rejected with a captured reason. Track B is the
+   **auto-accept-only** scope per spec §11; human-in-the-loop is post-v1.
+   The index is rebuilt at the end of the phase.
+3. **Phase 3 — re-evaluate.** Eval-slice tasks are run under three arms:
+   `pre` (the original un-evolved fixture), `post` (the evolved stash with
+   accepted lessons + revisions), and `synthetic` (no stash; the agent
+   writes its own scratchpad — "Bring Your Own Skills").
+
+The report (§6.3 + §6.4 envelope) carries:
+
+- `proposals` — `acceptance_rate`, `lint_pass_rate`, plus a per-asset table.
+- `longitudinal` — `improvement_slope = post − pre`, `over_synthetic_lift =
+  post − synthetic`, and a `degradation_count` of eval tasks where
+  `pre − post > 1 / seedsPerArm`. Each degradation row carries the post-arm
+  `failure_mode` from §6.6.
+- `arms.{pre,post,synthetic}` — full §13.3 utility envelopes per arm so the
+  per-task pre→post→synthetic delta is reproducible.
+
+The headline of the markdown summary is `improvement_slope`. The second
+line is a placeholder for `feedback_agreement`, which lands with #244.
+
+### Leakage prevention (§7.4)
+
+The evolve runner refuses to invoke `akm distill` / `akm reflect` on any
+ref that is also an eval-slice gold ref. It additionally exports
+`AKM_BENCH_EXCLUDE_GOLD_REFS=<csv>` so a future akm version can filter
+its LLM input. Today's `akm distill` does not honour that hint, so the
+runner records a warning when distillation runs on shared content and
+defers the harder filter to a follow-up.
+
 ## Pointers
 
 - Plan: `docs/technical/benchmark.md`.

--- a/tests/bench/cli.test.ts
+++ b/tests/bench/cli.test.ts
@@ -51,12 +51,16 @@ describe("bench CLI", () => {
     expect(r.stderr).toContain("BENCH_OPENCODE_MODEL");
   });
 
-  test("evolve remains not-implemented", () => {
-    for (const sub of ["evolve"]) {
-      const r = run([sub]);
-      expect(r.exitCode).toBe(2);
-      expect(r.stderr).toContain("not yet implemented");
-    }
+  test("evolve without --tasks exits 2 with usage error", () => {
+    const r = run(["evolve"], { BENCH_OPENCODE_MODEL: "anthropic/claude-opus-4-7" });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain("--tasks");
+  });
+
+  test("evolve without BENCH_OPENCODE_MODEL exits 2", () => {
+    const r = run(["evolve", "--tasks", "docker-homelab"], { BENCH_OPENCODE_MODEL: "" });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain("BENCH_OPENCODE_MODEL");
   });
 
   test("attribute without --base exits 2", () => {

--- a/tests/bench/cli.ts
+++ b/tests/bench/cli.ts
@@ -20,6 +20,7 @@ import fs from "node:fs";
 import process from "node:process";
 
 import { listTasks, type TaskMetadata } from "./corpus";
+import { runEvolve } from "./evolve";
 import {
   compareReports,
   type MaskedCorpusResult,
@@ -28,7 +29,13 @@ import {
   type RunUtilityOptionsForMask,
   runMaskedCorpus,
 } from "./metrics";
-import { renderAttributionTable, renderCompareMarkdown, renderUtilityReport, type UtilityRunReport } from "./report";
+import {
+  renderAttributionTable,
+  renderCompareMarkdown,
+  renderEvolveReport,
+  renderUtilityReport,
+  type UtilityRunReport,
+} from "./report";
 import { runUtility } from "./runner";
 
 const HELP = `akm-bench — agent-plus-akm evaluation framework
@@ -51,6 +58,15 @@ utility flags:
                            Without --json, JSON still goes to stdout and the markdown
                            summary is also written to stderr for human-friendly reads.
   -h, --help               show this message.
+
+evolve flags:
+  --tasks <domain>         domain id (e.g., docker-homelab) or 'all'. REQUIRED.
+  --seeds <N>              seeds per arm (default: 5)
+  --budget-tokens <N>      per-run token cap (default: 30000)
+  --budget-wall-ms <N>     per-run wallclock cap in ms (default: 120000)
+  --negative-threshold-count <N>  absolute negative-feedback count to evolve (default: 2)
+  --negative-threshold-ratio <R>  ratio of negatives to total feedback (default: 0.5)
+  --json                   suppress the markdown summary on stderr.
 
 compare flags:
   --base <path>            path to baseline UtilityRunReport JSON file. REQUIRED.
@@ -111,11 +127,6 @@ function parseArgs(argv: string[]): ParsedArgs {
     positional.push(arg);
   }
   return { subcommand, flags, bool, positional };
-}
-
-function notImplemented(name: string, issueRef: string): never {
-  process.stderr.write(`bench ${name}: not yet implemented; see ${issueRef}.\n`);
-  process.exit(2);
 }
 
 export interface UtilityCliOptions {
@@ -555,6 +566,63 @@ function parseInt32(text: string | undefined, fallback: number): number {
   return n;
 }
 
+function parseFloatArg(text: string | undefined, fallback: number): number {
+  if (text === undefined) return fallback;
+  const n = Number.parseFloat(text);
+  if (!Number.isFinite(n) || n < 0) return fallback;
+  return n;
+}
+
+export interface EvolveCliOptions {
+  /** Domain id (e.g., `docker-homelab`) or the literal `all`. */
+  domain: string;
+  json: boolean;
+  seedsPerArm: number;
+  budgetTokens: number;
+  budgetWallMs: number;
+  model: string;
+  negativeThreshold: { absoluteCount: number; ratio: number };
+  branch?: string;
+  commit?: string;
+  timestamp?: string;
+}
+
+/**
+ * `evolve` subcommand. Filters the corpus to one domain (or `all`), then
+ * dispatches `runEvolve` and renders the §6.3+§6.4 envelope.
+ */
+export async function runEvolveCli(options: EvolveCliOptions): Promise<UtilityCliResult> {
+  // Discover all tasks then filter on domain.
+  const allTasks = listTasks();
+  const tasks = options.domain === "all" ? allTasks : allTasks.filter((t) => t.domain === options.domain);
+
+  if (tasks.length === 0) {
+    return {
+      exitCode: 2,
+      stdout: "",
+      stderr: `bench evolve: no tasks matched domain "${options.domain}".\n`,
+    };
+  }
+
+  const report = await runEvolve({
+    tasks,
+    model: options.model,
+    seedsPerArm: options.seedsPerArm,
+    budgetTokens: options.budgetTokens,
+    budgetWallMs: options.budgetWallMs,
+    negativeThreshold: options.negativeThreshold,
+    ...(options.branch !== undefined ? { branch: options.branch } : {}),
+    ...(options.commit !== undefined ? { commit: options.commit } : {}),
+    ...(options.timestamp !== undefined ? { timestamp: options.timestamp } : {}),
+  });
+
+  const { json, markdown } = renderEvolveReport(report);
+  const stdout = `${JSON.stringify(json, null, 2)}\n`;
+  let stderr = options.json ? "" : `${markdown}\n`;
+  stderr += `tasks discovered: ${tasks.length} (domain=${options.domain})\n`;
+  return { exitCode: 0, stdout, stderr };
+}
+
 async function main(argv: string[]): Promise<number> {
   const parsed = parseArgs(argv);
 
@@ -590,8 +658,33 @@ async function main(argv: string[]): Promise<number> {
       if (result.stderr) process.stderr.write(result.stderr);
       return result.exitCode;
     }
-    case "evolve":
-      return notImplemented("evolve", "#243");
+    case "evolve": {
+      const domain = parsed.flags.get("tasks");
+      if (!domain) {
+        process.stderr.write("bench evolve: --tasks <domain> is required (use --tasks all to run the full corpus).\n");
+        return 2;
+      }
+      const model = getEnv("BENCH_OPENCODE_MODEL");
+      if (!model) {
+        process.stderr.write("bench evolve: BENCH_OPENCODE_MODEL environment variable is required.\n");
+        return 2;
+      }
+      const result = await runEvolveCli({
+        domain,
+        json: parsed.bool.has("json"),
+        seedsPerArm: parseInt32(parsed.flags.get("seeds"), 5),
+        budgetTokens: parseInt32(parsed.flags.get("budget-tokens"), 30000),
+        budgetWallMs: parseInt32(parsed.flags.get("budget-wall-ms"), 120000),
+        model,
+        negativeThreshold: {
+          absoluteCount: parseInt32(parsed.flags.get("negative-threshold-count"), 2),
+          ratio: parseFloatArg(parsed.flags.get("negative-threshold-ratio"), 0.5),
+        },
+      });
+      if (result.stdout) process.stdout.write(result.stdout);
+      if (result.stderr) process.stderr.write(result.stderr);
+      return result.exitCode;
+    }
     case "compare": {
       const basePath = parsed.flags.get("base");
       const currentPath = parsed.flags.get("current");

--- a/tests/bench/evolve.test.ts
+++ b/tests/bench/evolve.test.ts
@@ -342,6 +342,157 @@ describe("runEvolve — leakage prevention (§7.4)", () => {
     expect(distillCalls.length).toBe(0);
     expect(report.warnings.some((w) => w.includes("eval-slice gold ref"))).toBe(true);
   });
+
+  test("emits the generic '--exclude-gold-ref' warning at most once per Phase 2", async () => {
+    const observed = { calls: [] as string[][], envSeen: [] as Record<string, string>[] };
+    // Three distinct failing-train refs all cross threshold. None of them
+    // overlap an eval gold ref, so the per-ref skip warning never fires;
+    // the generic warning should appear exactly once regardless of count.
+    const tasks = [
+      fakeTask(taskDir, { id: "fake-d/loser-a", goldRef: "skill:loser-a", slice: "train", expectedMatch: "WONT" }),
+      fakeTask(taskDir, { id: "fake-d/loser-b", goldRef: "skill:loser-b", slice: "train", expectedMatch: "WONT" }),
+      fakeTask(taskDir, { id: "fake-d/loser-c", goldRef: "skill:loser-c", slice: "train", expectedMatch: "WONT" }),
+      fakeTask(taskDir, { id: "fake-d/eval", goldRef: "skill:eval-target", slice: "eval", expectedMatch: "ok" }),
+    ];
+    const spawn = buildFakeSpawn({});
+    const akmCli = buildFakeAkmCli({ observed });
+    const report = await runEvolve({
+      tasks,
+      model: "test-model",
+      seedsPerArm: 3,
+      spawn,
+      akmCli,
+      materialiseStash: false,
+    });
+    const generic = report.warnings.filter((w) =>
+      w.includes("distill/reflect cannot today filter their own LLM input"),
+    );
+    expect(generic.length).toBe(1);
+    // And we did actually evolve all three refs (so the loop body ran 3×).
+    const distillCalls = observed.calls.filter((c) => c[0] === "distill");
+    expect(distillCalls.length).toBe(3);
+  });
+});
+
+describe("runEvolve — Phase 1 fault tolerance", () => {
+  let workspaceRoot: string;
+  let taskDir: string;
+  beforeAll(() => {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bench-evolve-faulty-"));
+    taskDir = path.join(workspaceRoot, "task");
+    fs.mkdirSync(taskDir, { recursive: true });
+  });
+  afterAll(() => {
+    fs.rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  test("a throwing akmCli on one feedback ref does not halt Phase 2", async () => {
+    const observed = { calls: [] as string[][], envSeen: [] as Record<string, string>[] };
+    // Two failing train tasks. The akmCli throws on `feedback skill:bomb`
+    // but otherwise behaves normally. Phase 2 should still proceed and
+    // distill the surviving refs.
+    const tasks = [
+      fakeTask(taskDir, { id: "fake-d/bomb", goldRef: "skill:bomb", slice: "train", expectedMatch: "WONT" }),
+      fakeTask(taskDir, { id: "fake-d/loser", goldRef: "skill:loser", slice: "train", expectedMatch: "WONT" }),
+      fakeTask(taskDir, { id: "fake-d/eval", goldRef: "skill:eval-target", slice: "eval", expectedMatch: "ok" }),
+    ];
+    const spawn = buildFakeSpawn({});
+    const inner = buildFakeAkmCli({ observed });
+    const akmCli: AkmCliFn = async (args, cwd, env) => {
+      if (args[0] === "feedback" && args[1] === "skill:bomb") {
+        throw new Error("subprocess crashed");
+      }
+      return inner(args, cwd, env);
+    };
+    const report = await runEvolve({
+      tasks,
+      model: "test-model",
+      seedsPerArm: 2,
+      spawn,
+      akmCli,
+      materialiseStash: false,
+      negativeThreshold: { absoluteCount: 2, ratio: 0.5 },
+    });
+    // The throwing ref produced a warning of the documented shape.
+    expect(report.warnings.some((w) => w.includes("phase1.feedback_dispatch_failed: skill:bomb"))).toBe(true);
+    // Phase 2 still ran for the surviving ref (skill:loser crosses threshold).
+    const distillCalls = observed.calls.filter((c) => c[0] === "distill");
+    expect(distillCalls.map((c) => c[1])).toContain("skill:loser");
+    // The throwing entries are still in feedbackLog (with ok:false).
+    const bombEntries = report.feedbackLog.filter((e) => e.goldRef === "skill:bomb");
+    expect(bombEntries.length).toBe(2);
+    expect(bombEntries.every((e) => e.ok === false)).toBe(true);
+  });
+});
+
+describe("runEvolve — operator stash sandboxing", () => {
+  let workspaceRoot: string;
+  let taskDir: string;
+  beforeAll(() => {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bench-evolve-sandbox-"));
+    taskDir = path.join(workspaceRoot, "task");
+    fs.mkdirSync(taskDir, { recursive: true });
+  });
+  afterAll(() => {
+    fs.rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  test("does not mutate process.env.AKM_STASH_DIR", async () => {
+    const sentinel = "/tmp/sentinel-operator-stash-must-not-change";
+    const before = process.env.AKM_STASH_DIR;
+    process.env.AKM_STASH_DIR = sentinel;
+    try {
+      const tasks = [
+        fakeTask(taskDir, { id: "fake-d/loser", goldRef: "skill:loser", slice: "train", expectedMatch: "WONT" }),
+        fakeTask(taskDir, { id: "fake-d/eval", goldRef: "skill:eval-target", slice: "eval", expectedMatch: "ok" }),
+      ];
+      const spawn = buildFakeSpawn({});
+      const akmCli = buildFakeAkmCli({});
+      await runEvolve({
+        tasks,
+        model: "test-model",
+        seedsPerArm: 2,
+        spawn,
+        akmCli,
+        materialiseStash: false,
+      });
+      expect(process.env.AKM_STASH_DIR).toBe(sentinel);
+    } finally {
+      if (before === undefined) delete process.env.AKM_STASH_DIR;
+      else process.env.AKM_STASH_DIR = before;
+    }
+  });
+
+  test("akmCli env never carries the operator's AKM_STASH_DIR (materialiseStash:false strips it)", async () => {
+    const sentinel = "/tmp/sentinel-operator-stash-leak-test";
+    const before = process.env.AKM_STASH_DIR;
+    process.env.AKM_STASH_DIR = sentinel;
+    try {
+      const observed = { calls: [] as string[][], envSeen: [] as Record<string, string>[] };
+      const tasks = [
+        fakeTask(taskDir, { id: "fake-d/loser", goldRef: "skill:loser", slice: "train", expectedMatch: "WONT" }),
+        fakeTask(taskDir, { id: "fake-d/eval", goldRef: "skill:eval-target", slice: "eval", expectedMatch: "ok" }),
+      ];
+      const spawn = buildFakeSpawn({});
+      const akmCli = buildFakeAkmCli({ observed });
+      await runEvolve({
+        tasks,
+        model: "test-model",
+        seedsPerArm: 2,
+        spawn,
+        akmCli,
+        materialiseStash: false,
+      });
+      // Every recorded env passed to the fake akmCli must NOT carry the
+      // operator's sentinel value — the runEvolve sandbox strips it.
+      for (const env of observed.envSeen) {
+        expect(env.AKM_STASH_DIR).not.toBe(sentinel);
+      }
+    } finally {
+      if (before === undefined) delete process.env.AKM_STASH_DIR;
+      else process.env.AKM_STASH_DIR = before;
+    }
+  });
 });
 
 describe("computeLongitudinalMetrics", () => {

--- a/tests/bench/evolve.test.ts
+++ b/tests/bench/evolve.test.ts
@@ -1,0 +1,442 @@
+/**
+ * Unit tests for the evolve runner (Track B, #243).
+ *
+ * Every external interaction is mocked via injected fakes:
+ *   • `spawn` — fake SpawnFn forwarded to runOne; produces deterministic
+ *     stdout per arm so the runner's outcome classification is testable.
+ *   • `akmCli` — fake AkmCliFn that records every call and returns scripted
+ *     stdout/stderr/exit codes for `feedback` / `distill` / `reflect` /
+ *     `proposal *` / `index`.
+ *   • `materialiseStash: false` — runUtility never touches the on-disk
+ *     fixture directory.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { SpawnedSubprocess, SpawnFn } from "../../src/integrations/agent/spawn";
+import type { TaskMetadata } from "./corpus";
+import { type AkmCliFn, type AkmCliResult, buildSyntheticPrompt, type FeedbackLogEntry, runEvolve } from "./evolve";
+import { computeLongitudinalMetrics, computeProposalQualityMetrics, type ProposalLogEntry } from "./metrics";
+import type { UtilityRunReport } from "./report";
+
+function asReadableStream(text: string): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(text);
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+/**
+ * Build a fake spawn that drives the agent harness deterministically.
+ * The fake always emits `ok` on agent runs; per-task pass/fail is controlled
+ * by setting `expectedMatch` on the task: `"ok"` to pass, anything else
+ * (e.g. `"WONT_MATCH"`) to fail. This bypasses the verifier-spawn path
+ * because our fake tasks all use `verifier: "regex"`.
+ */
+function buildFakeSpawn(opts: { observed?: { arms: string[]; cwd: (string | undefined)[] } }): SpawnFn {
+  return (_cmd, options) => {
+    if (opts.observed) {
+      opts.observed.arms.push(options.env?.BENCH_EVOLVE_ARM ?? (options.env?.AKM_STASH_DIR ? "akm" : "noakm"));
+      opts.observed.cwd.push(options.cwd);
+    }
+    const proc: SpawnedSubprocess = {
+      exitCode: 0,
+      exited: Promise.resolve(0),
+      stdout: asReadableStream("ok"),
+      stderr: asReadableStream(""),
+      stdin: null,
+      kill() {},
+    };
+    return proc;
+  };
+}
+
+/**
+ * Build a fake akmCli that records calls and returns scripted responses.
+ * `proposalQueue` is the list of proposals returned by `proposal list`.
+ * `lintByProposal` controls lint outcomes for `proposal show`.
+ */
+function buildFakeAkmCli(opts: {
+  proposalQueue?: Array<{ id: string; targetRef: string; kind?: string }>;
+  lintByProposal?: Record<string, { lintPass: boolean; message?: string }>;
+  observed?: { calls: string[][]; envSeen: Record<string, string>[] };
+}): AkmCliFn {
+  return async (args, _cwd, env): Promise<AkmCliResult> => {
+    if (opts.observed) {
+      opts.observed.calls.push(args);
+      opts.observed.envSeen.push({ ...env });
+    }
+    if (args[0] === "feedback") return { exitCode: 0, stdout: "", stderr: "" };
+    if (args[0] === "distill") return { exitCode: 0, stdout: "", stderr: "" };
+    if (args[0] === "reflect") return { exitCode: 0, stdout: "", stderr: "" };
+    if (args[0] === "index") return { exitCode: 0, stdout: "", stderr: "" };
+    if (args[0] === "proposal" && args[1] === "list") {
+      const queue = opts.proposalQueue ?? [];
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify(queue.map((p) => ({ id: p.id, target_ref: p.targetRef, kind: p.kind ?? "lesson" }))),
+        stderr: "",
+      };
+    }
+    if (args[0] === "proposal" && args[1] === "show") {
+      const id = args[2];
+      const lint = opts.lintByProposal?.[id] ?? { lintPass: true };
+      const payload = {
+        id,
+        lint_pass: lint.lintPass,
+        lint: lint.lintPass ? { pass: true, issues: [] } : { pass: false, issues: [lint.message ?? "lint error"] },
+      };
+      return { exitCode: 0, stdout: JSON.stringify(payload), stderr: "" };
+    }
+    if (args[0] === "proposal" && args[1] === "accept") return { exitCode: 0, stdout: "", stderr: "" };
+    if (args[0] === "proposal" && args[1] === "reject") return { exitCode: 0, stdout: "", stderr: "" };
+    return { exitCode: 0, stdout: "", stderr: "" };
+  };
+}
+
+function fakeTask(taskDir: string, overrides: Partial<TaskMetadata> = {}): TaskMetadata {
+  return {
+    id: "fake-d/task-a",
+    title: "Fake A",
+    domain: "fake-d",
+    difficulty: "easy",
+    stash: "minimal",
+    verifier: "regex",
+    expectedMatch: "ok",
+    budget: { tokens: 1000, wallMs: 5000 },
+    taskDir,
+    slice: "train",
+    goldRef: "skill:fake-a",
+    ...overrides,
+  };
+}
+
+describe("runEvolve — Phase 1 feedback", () => {
+  let workspaceRoot: string;
+  let taskDir: string;
+
+  beforeAll(() => {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bench-evolve-test-"));
+    taskDir = path.join(workspaceRoot, "task");
+    fs.mkdirSync(taskDir, { recursive: true });
+  });
+  afterAll(() => {
+    fs.rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  test("records --positive feedback on pass and --negative on fail", async () => {
+    const observed = { calls: [] as string[][], envSeen: [] as Record<string, string>[] };
+    // Two train tasks: one passes (expectedMatch=ok matches "ok" stdout), one fails.
+    const tasks = [
+      fakeTask(taskDir, { id: "fake-d/pass", goldRef: "skill:passing", slice: "train", expectedMatch: "ok" }),
+      fakeTask(taskDir, { id: "fake-d/fail", goldRef: "skill:failing", slice: "train", expectedMatch: "WONT" }),
+      fakeTask(taskDir, { id: "fake-d/eval", goldRef: "skill:eval-target", slice: "eval", expectedMatch: "ok" }),
+    ];
+    const spawn = buildFakeSpawn({});
+    const akmCli = buildFakeAkmCli({ observed });
+
+    const report = await runEvolve({
+      tasks,
+      model: "test-model",
+      seedsPerArm: 2,
+      spawn,
+      akmCli,
+      materialiseStash: false,
+      timestamp: "2026-04-27T00:00:00Z",
+      branch: "test",
+      commit: "abc",
+    });
+
+    // Verify feedback events exist.
+    const feedbackCalls = observed.calls.filter((c) => c[0] === "feedback");
+    expect(feedbackCalls.length).toBeGreaterThan(0);
+    // Each train (passing) seed -> --positive; each train (failing) seed -> --negative.
+    const positives = feedbackCalls.filter((c) => c[2] === "--positive");
+    const negatives = feedbackCalls.filter((c) => c[2] === "--negative");
+    expect(positives.length).toBe(2); // pass task × 2 seeds
+    expect(negatives.length).toBe(2); // fail task × 2 seeds
+    // The feedback log should match.
+    const positiveLog = report.feedbackLog.filter((e: FeedbackLogEntry) => e.signal === "positive");
+    expect(positiveLog.length).toBe(2);
+    expect(positiveLog[0].goldRef).toBe("skill:passing");
+  });
+});
+
+describe("runEvolve — Phase 2 threshold + proposal lifecycle", () => {
+  let workspaceRoot: string;
+  let taskDir: string;
+  beforeAll(() => {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bench-evolve-phase2-"));
+    taskDir = path.join(workspaceRoot, "task");
+    fs.mkdirSync(taskDir, { recursive: true });
+  });
+  afterAll(() => {
+    fs.rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  test("threshold gates distill+reflect", async () => {
+    const observed = { calls: [] as string[][], envSeen: [] as Record<string, string>[] };
+    const tasks = [
+      fakeTask(taskDir, { id: "fake-d/loser", goldRef: "skill:loser", slice: "train", expectedMatch: "WONT" }),
+      fakeTask(taskDir, { id: "fake-d/winner", goldRef: "skill:winner", slice: "train", expectedMatch: "ok" }),
+      fakeTask(taskDir, { id: "fake-d/eval", goldRef: "skill:eval-only", slice: "eval", expectedMatch: "ok" }),
+    ];
+    const spawn = buildFakeSpawn({});
+    const akmCli = buildFakeAkmCli({ observed, proposalQueue: [] });
+    await runEvolve({
+      tasks,
+      model: "test-model",
+      seedsPerArm: 3,
+      spawn,
+      akmCli,
+      materialiseStash: false,
+      negativeThreshold: { absoluteCount: 2, ratio: 0.5 },
+    });
+    const distillCalls = observed.calls.filter((c) => c[0] === "distill");
+    const reflectCalls = observed.calls.filter((c) => c[0] === "reflect");
+    // Loser crosses threshold; winner does not.
+    expect(distillCalls.map((c) => c[1])).toEqual(["skill:loser"]);
+    expect(reflectCalls.map((c) => c[1])).toEqual(["skill:loser"]);
+  });
+
+  test("lint_pass=true → accept, lint_pass=false → reject", async () => {
+    const observed = { calls: [] as string[][], envSeen: [] as Record<string, string>[] };
+    const tasks = [
+      fakeTask(taskDir, { id: "fake-d/loser", goldRef: "skill:loser", slice: "train", expectedMatch: "WONT" }),
+      fakeTask(taskDir, { id: "fake-d/eval", goldRef: "skill:eval-only", slice: "eval", expectedMatch: "ok" }),
+    ];
+    const spawn = buildFakeSpawn({});
+    const akmCli = buildFakeAkmCli({
+      observed,
+      proposalQueue: [
+        { id: "p-good", targetRef: "skill:loser", kind: "lesson" },
+        { id: "p-bad", targetRef: "skill:loser", kind: "revision" },
+      ],
+      lintByProposal: {
+        "p-good": { lintPass: true },
+        "p-bad": { lintPass: false, message: "missing description" },
+      },
+    });
+    const report = await runEvolve({
+      tasks,
+      model: "test-model",
+      seedsPerArm: 2,
+      spawn,
+      akmCli,
+      materialiseStash: false,
+    });
+    const accepted = observed.calls.find((c) => c[0] === "proposal" && c[1] === "accept" && c[2] === "p-good");
+    const rejected = observed.calls.find((c) => c[0] === "proposal" && c[1] === "reject" && c[2] === "p-bad");
+    expect(accepted).toBeDefined();
+    expect(rejected).toBeDefined();
+    expect(report.proposalLog.find((e: ProposalLogEntry) => e.proposalId === "p-good")?.decision).toBe("accept");
+    expect(report.proposalLog.find((e: ProposalLogEntry) => e.proposalId === "p-bad")?.decision).toBe("reject");
+    expect(report.proposals.totalProposals).toBe(2);
+    expect(report.proposals.totalAccepted).toBe(1);
+    expect(report.proposals.acceptanceRate).toBe(0.5);
+  });
+
+  test("rebuilds index after Phase 2", async () => {
+    const observed = { calls: [] as string[][], envSeen: [] as Record<string, string>[] };
+    const tasks = [fakeTask(taskDir, { id: "fake-d/eval-only", slice: "eval", expectedMatch: "ok" })];
+    const spawn = buildFakeSpawn({});
+    const akmCli = buildFakeAkmCli({ observed });
+    await runEvolve({ tasks, model: "test-model", seedsPerArm: 1, spawn, akmCli, materialiseStash: false });
+    expect(observed.calls.some((c) => c[0] === "index")).toBe(true);
+  });
+});
+
+describe("runEvolve — Phase 3 three-arm execution", () => {
+  let workspaceRoot: string;
+  let taskDir: string;
+  beforeAll(() => {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bench-evolve-phase3-"));
+    taskDir = path.join(workspaceRoot, "task");
+    fs.mkdirSync(taskDir, { recursive: true });
+  });
+  afterAll(() => {
+    fs.rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  test("produces pre / post / synthetic arm reports", async () => {
+    const tasks = [
+      fakeTask(taskDir, { id: "fake-d/eval-task", slice: "eval", goldRef: "skill:t", expectedMatch: "ok" }),
+      fakeTask(taskDir, { id: "fake-d/train-task", slice: "train", goldRef: "skill:tr", expectedMatch: "ok" }),
+    ];
+    const spawn = buildFakeSpawn({});
+    const akmCli = buildFakeAkmCli({});
+    const report = await runEvolve({
+      tasks,
+      model: "test-model",
+      seedsPerArm: 2,
+      spawn,
+      akmCli,
+      materialiseStash: false,
+    });
+    expect(report.arms.pre.tasks.length).toBe(1); // eval-only
+    expect(report.arms.post.tasks.length).toBe(1);
+    expect(report.arms.synthetic.tasks.length).toBe(1);
+  });
+
+  test("synthetic arm receives no AKM_STASH_DIR via spawn wrapper", async () => {
+    const observed: { arms: string[]; cwd: (string | undefined)[] } = { arms: [], cwd: [] };
+    const tasks = [fakeTask(taskDir, { id: "fake-d/eval-x", slice: "eval", goldRef: "skill:x", expectedMatch: "ok" })];
+    const spawn = buildFakeSpawn({ observed });
+    const akmCli = buildFakeAkmCli({});
+    await runEvolve({
+      tasks,
+      model: "test-model",
+      seedsPerArm: 1,
+      spawn,
+      akmCli,
+      materialiseStash: false,
+    });
+    // Among the spawn arms, we expect to see the literal "synthetic" tag.
+    expect(observed.arms).toContain("synthetic");
+  });
+
+  test("buildSyntheticPrompt mentions Bring Your Own Skills", () => {
+    const text = buildSyntheticPrompt("docker-homelab/x");
+    expect(text).toContain("Bring Your Own Skills");
+    expect(text).toContain("scratchpad");
+  });
+});
+
+describe("runEvolve — leakage prevention (§7.4)", () => {
+  let workspaceRoot: string;
+  let taskDir: string;
+  beforeAll(() => {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bench-evolve-leak-"));
+    taskDir = path.join(workspaceRoot, "task");
+    fs.mkdirSync(taskDir, { recursive: true });
+  });
+  afterAll(() => {
+    fs.rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  test("skips distill when ref is also an eval-slice gold ref", async () => {
+    const observed = { calls: [] as string[][], envSeen: [] as Record<string, string>[] };
+    // The same `skill:shared` is the gold ref for BOTH a failing train task
+    // AND an eval task. We must NOT distill it.
+    const tasks = [
+      fakeTask(taskDir, { id: "fake-d/train-shared", goldRef: "skill:shared", slice: "train", expectedMatch: "WONT" }),
+      fakeTask(taskDir, { id: "fake-d/eval-shared", goldRef: "skill:shared", slice: "eval", expectedMatch: "ok" }),
+    ];
+    const spawn = buildFakeSpawn({});
+    const akmCli = buildFakeAkmCli({ observed });
+    const report = await runEvolve({
+      tasks,
+      model: "test-model",
+      seedsPerArm: 3,
+      spawn,
+      akmCli,
+      materialiseStash: false,
+    });
+    const distillCalls = observed.calls.filter((c) => c[0] === "distill");
+    expect(distillCalls.length).toBe(0);
+    expect(report.warnings.some((w) => w.includes("eval-slice gold ref"))).toBe(true);
+  });
+});
+
+describe("computeLongitudinalMetrics", () => {
+  // Build a minimal §13.3-shape report with a single task and prescribed pass rate.
+  function makeReport(
+    taskId: string,
+    akmPassRate: number,
+    opts: { seedsPerArm?: number; failureMode?: string } = {},
+  ): UtilityRunReport {
+    const seedsPerArm = opts.seedsPerArm ?? 5;
+    const akm = {
+      passRate: akmPassRate,
+      passAt1: 0 as 0 | 1,
+      tokensPerPass: null,
+      wallclockMs: 0,
+      passRateStdev: 0,
+      budgetExceededCount: 0,
+      harnessErrorCount: 0,
+      count: seedsPerArm,
+    };
+    const noakm = { ...akm, passRate: 0 };
+    return {
+      timestamp: "t",
+      branch: "b",
+      commit: "c",
+      model: "m",
+      corpus: { domains: 1, tasks: 1, slice: "eval", seedsPerArm },
+      aggregateNoakm: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+      aggregateAkm: { passRate: akmPassRate, tokensPerPass: null, wallclockMs: 0 },
+      aggregateDelta: { passRate: akmPassRate, tokensPerPass: null, wallclockMs: 0 },
+      trajectoryAkm: { correctAssetLoaded: null, feedbackRecorded: 0 },
+      failureModes: opts.failureMode
+        ? {
+            byLabel: { [opts.failureMode]: 1 } as Record<string, number>,
+            byTask: { [taskId]: { [opts.failureMode]: 1 } as Record<string, number> },
+          }
+        : { byLabel: {}, byTask: {} },
+      tasks: [{ id: taskId, noakm, akm, delta: { passRate: akmPassRate, tokensPerPass: null, wallclockMs: 0 } }],
+      warnings: [],
+    };
+  }
+
+  test("computes improvement_slope, over_synthetic_lift, degradation_count", () => {
+    const pre = makeReport("t", 0.4);
+    const post = makeReport("t", 0.7);
+    const synthetic = makeReport("t", 0.2);
+    const longi = computeLongitudinalMetrics(pre, post, synthetic);
+    expect(longi.improvementSlope).toBeCloseTo(0.3, 2);
+    expect(longi.overSyntheticLift).toBeCloseTo(0.5, 2);
+    expect(longi.degradationCount).toBe(0);
+  });
+
+  test("flags degradations with > 1 seed drop", () => {
+    const pre = makeReport("t", 0.8, { seedsPerArm: 5 });
+    // 1/5 = 0.2 — drop of 0.4 is way above threshold.
+    const post = makeReport("t", 0.4, { seedsPerArm: 5, failureMode: "search_no_gold" });
+    const synthetic = makeReport("t", 0.5);
+    const longi = computeLongitudinalMetrics(pre, post, synthetic);
+    expect(longi.degradationCount).toBe(1);
+    expect(longi.degradations[0].failureMode).toBe("search_no_gold");
+  });
+
+  test("does NOT flag a 0.1 drop with seedsPerArm=5 (within 1-seed threshold)", () => {
+    const pre = makeReport("t", 0.6, { seedsPerArm: 5 });
+    const post = makeReport("t", 0.5, { seedsPerArm: 5 });
+    const synthetic = makeReport("t", 0.5);
+    const longi = computeLongitudinalMetrics(pre, post, synthetic);
+    // 1/5 = 0.2; drop of 0.1 is below threshold. No degradation.
+    expect(longi.degradationCount).toBe(0);
+  });
+});
+
+describe("computeProposalQualityMetrics", () => {
+  test("aggregates accepted / lint_pass / total per asset", () => {
+    const log: ProposalLogEntry[] = [
+      { proposalId: "p1", assetRef: "skill:a", kind: "lesson", lintPass: true, decision: "accept" },
+      { proposalId: "p2", assetRef: "skill:a", kind: "revision", lintPass: false, decision: "reject" },
+      { proposalId: "p3", assetRef: "skill:b", kind: "lesson", lintPass: true, decision: "accept" },
+    ];
+    const m = computeProposalQualityMetrics(log);
+    expect(m.totalProposals).toBe(3);
+    expect(m.totalAccepted).toBe(2);
+    expect(m.acceptanceRate).toBeCloseTo(2 / 3, 2);
+    expect(m.lintPassRate).toBeCloseTo(2 / 3, 2);
+    const a = m.rows.find((r) => r.assetRef === "skill:a");
+    expect(a?.proposalCount).toBe(2);
+    expect(a?.acceptedCount).toBe(1);
+    expect(a?.lintPassCount).toBe(1);
+  });
+
+  test("zero-proposal log yields zeroes (no NaN)", () => {
+    const m = computeProposalQualityMetrics([]);
+    expect(m.totalProposals).toBe(0);
+    expect(m.acceptanceRate).toBe(0);
+    expect(m.lintPassRate).toBe(0);
+    expect(m.rows.length).toBe(0);
+  });
+});

--- a/tests/bench/evolve.ts
+++ b/tests/bench/evolve.ts
@@ -1,0 +1,584 @@
+/**
+ * akm-bench `evolve` — Track B longitudinal three-phase runner (spec §4 + §6.4).
+ *
+ * `runEvolve()` orchestrates three phases against a single eval-domain corpus:
+ *
+ *   • Phase 1 (signal accumulation): run K seeds × tasks (train slice only)
+ *     under the akm arm, then record `akm feedback <gold_ref> --positive` /
+ *     `--negative` events per outcome.
+ *   • Phase 2 (evolve): for every asset whose negative feedback crosses the
+ *     threshold, invoke `akm distill` and `akm reflect`, validate every
+ *     resulting proposal via `akm proposal show --json`, then accept or
+ *     reject per lint outcome. After processing, rebuild the index.
+ *   • Phase 3 (re-evaluate): run the eval slice under THREE arms — `pre` (the
+ *     original un-evolved fixture), `post` (the evolved fixture), `synthetic`
+ *     (no stash, scratchpad-only "Bring Your Own Skills" prompt).
+ *
+ * Leakage prevention (spec §7.4): before invoking distill/reflect we compute
+ * the set of eval-slice gold refs and pass it to the akm CLI as
+ * `--exclude-gold-ref` env hints. The current `akm distill` doesn't read
+ * that hint — we record a warning when we would have leaked, and the
+ * distill input is otherwise unfiltered. The data we DO control (the
+ * proposal log + Phase 1 feedback stream) is filtered before
+ * computeProposalQualityMetrics ever sees it.
+ *
+ * Test seams: every external interaction is funnelled through one of three
+ * injectable functions:
+ *   - `spawn` — forwarded to `runOne` (drives the agent harness).
+ *   - `akmCli(args, cwd, env)` — invoked for every `akm <verb>` subprocess.
+ *   - `materialiseStash` — when false, `runUtility` doesn't touch
+ *     fixtures/stashes/.
+ * Tests inject fakes; production wires the real `Bun.spawnSync` and the
+ * real `loadFixtureStash`.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { SpawnFn } from "../../src/integrations/agent/spawn";
+import { type LoadedFixtureStash, loadFixtureStash } from "../fixtures/stashes/load";
+import type { TaskMetadata, TaskSlice } from "./corpus";
+import {
+  computeLongitudinalMetrics,
+  computeProposalQualityMetrics,
+  type LongitudinalMetrics,
+  type ProposalLogEntry,
+  type ProposalQualityMetrics,
+} from "./metrics";
+import type { UtilityRunReport } from "./report";
+import { runUtility } from "./runner";
+
+/** Result of an `akm` subprocess invocation. */
+export interface AkmCliResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Subprocess seam — run `akm <args>` with the given cwd + env. */
+export type AkmCliFn = (args: string[], cwd: string, env: Record<string, string>) => Promise<AkmCliResult>;
+
+/** Caller-facing options for `runEvolve`. */
+export interface RunEvolveOptions {
+  tasks: TaskMetadata[];
+  model: string;
+  /** K seeds per arm. Defaults to 5. */
+  seedsPerArm?: number;
+  /** Token budget per run. Defaults to 30000. */
+  budgetTokens?: number;
+  /** Wallclock budget per run in ms. Defaults to 120000. */
+  budgetWallMs?: number;
+  /** Injected agent-spawn for tests. */
+  spawn?: SpawnFn;
+  /** Injected akm subprocess for tests. */
+  akmCli?: AkmCliFn;
+  /**
+   * Threshold for promoting an asset to proposal generation. An asset
+   * crosses the threshold iff `negative >= absoluteCount` OR
+   * `negative / (negative + positive) > ratio`. Defaults: `{ absoluteCount: 2,
+   * ratio: 0.5 }`.
+   */
+  negativeThreshold?: { absoluteCount: number; ratio: number };
+  /**
+   * Test seam: when false, `runUtility` does not materialise fixture stashes.
+   * Defaults to true. Real runs always materialise.
+   */
+  materialiseStash?: boolean;
+  /** Override timestamp (tests). */
+  timestamp?: string;
+  /** Override branch (tests). */
+  branch?: string;
+  /** Override commit (tests). */
+  commit?: string;
+}
+
+/** One Phase-1 feedback event the runner emitted (or attempted). */
+export interface FeedbackLogEntry {
+  taskId: string;
+  seed: number;
+  goldRef: string;
+  signal: "positive" | "negative";
+  /** True when the akmCli invocation exited 0. */
+  ok: boolean;
+}
+
+/** Aggregate evolve report. Renders to JSON + markdown via `renderEvolveReport`. */
+export interface EvolveRunReport {
+  timestamp: string;
+  branch: string;
+  commit: string;
+  model: string;
+  /**
+   * Slice-or-domain label stamped into the §13.3 envelope's `corpus.slice`
+   * for each arm. Evolve always runs the eval slice for arms; we mirror
+   * `runUtility`'s convention.
+   */
+  domain: string;
+  seedsPerArm: number;
+  /** Phase 1 feedback events recorded. */
+  feedbackLog: FeedbackLogEntry[];
+  /** Phase 2 proposal events recorded. */
+  proposalLog: ProposalLogEntry[];
+  /** Aggregate proposal-quality metrics. */
+  proposals: ProposalQualityMetrics;
+  /** Aggregate longitudinal metrics. */
+  longitudinal: LongitudinalMetrics;
+  /** Phase 3 arm reports. Each is a §13.3-shape utility report. */
+  arms: { pre: UtilityRunReport; post: UtilityRunReport; synthetic: UtilityRunReport };
+  /** Operator-visible warnings. */
+  warnings: string[];
+}
+
+/**
+ * Per-asset feedback aggregate computed at the end of Phase 1. The threshold
+ * check operates on this struct.
+ */
+interface FeedbackCounts {
+  positive: number;
+  negative: number;
+}
+
+/**
+ * Drive the three-phase Track B runner.
+ *
+ * Pre: `tasks` is already filtered to one domain (or `all`). The runner
+ * partitions internally on `task.slice`.
+ */
+export async function runEvolve(options: RunEvolveOptions): Promise<EvolveRunReport> {
+  const seedsPerArm = options.seedsPerArm ?? 5;
+  const budgetTokens = options.budgetTokens ?? 30000;
+  const budgetWallMs = options.budgetWallMs ?? 120000;
+  const negativeThreshold = options.negativeThreshold ?? { absoluteCount: 2, ratio: 0.5 };
+  const materialiseStash = options.materialiseStash ?? true;
+  const akmCli = options.akmCli ?? defaultAkmCli;
+  const warnings: string[] = [];
+
+  const trainTasks = options.tasks.filter((t) => effectiveSlice(t) === "train");
+  const evalTasks = options.tasks.filter((t) => effectiveSlice(t) === "eval");
+
+  // Use the first task's domain (or "all") as the corpus label. The CLI
+  // already filtered to one domain; this is just for the report header.
+  const domain = uniqueDomain(options.tasks);
+
+  // ── Phase 1: accumulate signal on the train slice (akm arm only). ────────
+  const phase1Report = await runUtility({
+    tasks: trainTasks,
+    arms: ["akm"],
+    model: options.model,
+    seedsPerArm,
+    budgetTokens,
+    budgetWallMs,
+    slice: "train",
+    ...(options.spawn ? { spawn: options.spawn } : {}),
+    materialiseStash,
+    ...(options.timestamp ? { timestamp: options.timestamp } : {}),
+    ...(options.branch ? { branch: options.branch } : {}),
+    ...(options.commit ? { commit: options.commit } : {}),
+  });
+
+  // Issue feedback events per (task, seed) outcome on the akm arm.
+  const feedbackLog: FeedbackLogEntry[] = [];
+  const feedbackByRef = new Map<string, FeedbackCounts>();
+  const phase1Cwd = options.tasks[0]?.taskDir ?? process.cwd();
+  for (const run of phase1Report.akmRuns ?? []) {
+    const taskMeta = options.tasks.find((t) => t.id === run.taskId);
+    const goldRef = taskMeta?.goldRef;
+    if (!goldRef) continue;
+    if (run.outcome === "harness_error") continue;
+    const signal: "positive" | "negative" = run.outcome === "pass" ? "positive" : "negative";
+    const args = ["feedback", goldRef, signal === "positive" ? "--positive" : "--negative"];
+    const cliResult = await akmCli(args, phase1Cwd, process.env as Record<string, string>);
+    feedbackLog.push({ taskId: run.taskId, seed: run.seed, goldRef, signal, ok: cliResult.exitCode === 0 });
+    if (cliResult.exitCode !== 0) {
+      warnings.push(`phase1: akm feedback for ${goldRef} (${signal}) failed: ${cliResult.stderr.trim()}`);
+    }
+    const counts = feedbackByRef.get(goldRef) ?? { positive: 0, negative: 0 };
+    if (signal === "positive") counts.positive += 1;
+    else counts.negative += 1;
+    feedbackByRef.set(goldRef, counts);
+  }
+
+  // ── Phase 2: evolve. ─────────────────────────────────────────────────────
+  const proposalLog: ProposalLogEntry[] = [];
+  const evalGoldRefs = new Set<string>();
+  for (const t of evalTasks) {
+    if (t.goldRef) evalGoldRefs.add(t.goldRef);
+  }
+
+  const refsToEvolve: string[] = [];
+  for (const [ref, counts] of feedbackByRef.entries()) {
+    if (crossesNegativeThreshold(counts, negativeThreshold)) refsToEvolve.push(ref);
+  }
+  refsToEvolve.sort();
+
+  for (const ref of refsToEvolve) {
+    // §7.4 leakage prevention: if this ref is also an eval-slice gold ref,
+    // we skip evolving it entirely so post-evolve eval can't gain an unfair
+    // advantage. Tasks that share refs across slices are flagged.
+    if (evalGoldRefs.has(ref)) {
+      warnings.push(
+        `phase2: skipping distill/reflect on ${ref} — it is an eval-slice gold ref (§7.4 leakage prevention).`,
+      );
+      continue;
+    }
+    // Pass the eval-gold ref list through env so a future akm version can
+    // honour it. Today's `akm distill` ignores `AKM_BENCH_EXCLUDE_GOLD_REFS`;
+    // we still warn so operators know the protection is partial.
+    const evolveEnv: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      AKM_BENCH_EXCLUDE_GOLD_REFS: [...evalGoldRefs].join(","),
+    };
+    if (evalGoldRefs.size > 0) {
+      warnings.push(
+        "phase2: distill/reflect cannot today filter their own LLM input by --exclude-gold-ref; relying on per-ref skip + env hint only.",
+      );
+    }
+
+    const distillResult = await akmCli(["distill", ref], phase1Cwd, evolveEnv);
+    if (distillResult.exitCode !== 0) {
+      warnings.push(`phase2: akm distill ${ref} failed: ${distillResult.stderr.trim()}`);
+    }
+    const reflectResult = await akmCli(["reflect", ref], phase1Cwd, evolveEnv);
+    if (reflectResult.exitCode !== 0) {
+      // `reflect` requires `agent.default` to be configured — a missing
+      // config is non-fatal for the bench; we record and continue.
+      warnings.push(`phase2: akm reflect ${ref} skipped/failed: ${reflectResult.stderr.trim()}`);
+    }
+  }
+
+  // Walk the proposal queue.
+  const listResult = await akmCli(["proposal", "list", "--json"], phase1Cwd, process.env as Record<string, string>);
+  const proposals = parseProposalList(listResult.stdout);
+  for (const p of proposals) {
+    const showResult = await akmCli(
+      ["proposal", "show", p.id, "--json"],
+      phase1Cwd,
+      process.env as Record<string, string>,
+    );
+    const lintInfo = parseProposalShow(showResult.stdout);
+    const lintPass = lintInfo.lintPass;
+    if (lintPass) {
+      const acceptResult = await akmCli(["proposal", "accept", p.id], phase1Cwd, process.env as Record<string, string>);
+      proposalLog.push({
+        proposalId: p.id,
+        assetRef: p.assetRef,
+        kind: p.kind,
+        lintPass: true,
+        decision: acceptResult.exitCode === 0 ? "accept" : "reject",
+        ...(acceptResult.exitCode === 0 ? {} : { rejectReason: `accept failed: ${acceptResult.stderr.trim()}` }),
+      });
+    } else {
+      const reason = lintInfo.lintMessage ?? "lint failed";
+      const rejectResult = await akmCli(
+        ["proposal", "reject", p.id, "--reason", `lint failed: ${reason}`],
+        phase1Cwd,
+        process.env as Record<string, string>,
+      );
+      proposalLog.push({
+        proposalId: p.id,
+        assetRef: p.assetRef,
+        kind: p.kind,
+        lintPass: false,
+        decision: "reject",
+        rejectReason: reason,
+      });
+      if (rejectResult.exitCode !== 0) {
+        warnings.push(`phase2: akm proposal reject ${p.id} failed: ${rejectResult.stderr.trim()}`);
+      }
+    }
+  }
+
+  // Rebuild the index so accepted lessons surface in Phase 3.
+  const indexResult = await akmCli(["index"], phase1Cwd, process.env as Record<string, string>);
+  if (indexResult.exitCode !== 0) {
+    warnings.push(`phase2: akm index rebuild failed: ${indexResult.stderr.trim()}`);
+  }
+
+  // ── Phase 3: re-evaluate (eval slice). ───────────────────────────────────
+  // pre: original fixture (un-evolved). We snapshot the original by passing
+  // `materialiseStash: true` and trusting the runner to clone the named
+  // fixture from disk fresh — the on-disk fixture was never mutated by
+  // Phase 2 (distill/reflect write to the runtime stash, not the fixture).
+  const preReport = await runUtility({
+    tasks: evalTasks,
+    arms: ["akm"],
+    model: options.model,
+    seedsPerArm,
+    budgetTokens,
+    budgetWallMs,
+    slice: "eval",
+    ...(options.spawn ? { spawn: options.spawn } : {}),
+    materialiseStash,
+    ...(options.timestamp ? { timestamp: options.timestamp } : {}),
+    ...(options.branch ? { branch: options.branch } : {}),
+    ...(options.commit ? { commit: options.commit } : {}),
+  });
+
+  // post: same as pre, but we attach the evolved-stash overlay path via env
+  // so the agent harness picks up the accepted lessons. The default akm CLI
+  // discovers them through the live AKM_STASH_DIR — we override per arm via
+  // the spawn injection seam. Real-runs reuse `loadFixtureStash` then layer
+  // accepted proposals on top; tests use the materialiseStash=false seam.
+  let postStash: LoadedFixtureStash | undefined;
+  let postReport: UtilityRunReport;
+  try {
+    if (materialiseStash && evalTasks.length > 0) {
+      // Try to layer accepted lessons onto a fresh tmp stash. If the source
+      // fixture is missing or `loadFixtureStash` fails, we fall back to the
+      // un-evolved stash with a warning.
+      try {
+        postStash = loadFixtureStash(evalTasks[0].stash, { skipIndex: true });
+        // The accepted-proposal materialisation is handled by the akm CLI's
+        // own stash; we have no portable way to "merge" two stashes here.
+        // Operators running the full bench rely on the operator-managed
+        // AKM_STASH_DIR; tests skip materialiseStash entirely.
+      } catch (err) {
+        warnings.push(`phase3 post-arm: failed to materialise evolved stash: ${(err as Error).message}`);
+      }
+    }
+    postReport = await runUtility({
+      tasks: evalTasks,
+      arms: ["akm"],
+      model: options.model,
+      seedsPerArm,
+      budgetTokens,
+      budgetWallMs,
+      slice: "eval",
+      ...(options.spawn ? { spawn: options.spawn } : {}),
+      // Stamp arm metadata so spawn fakes can distinguish pre-vs-post via
+      // an env probe (BENCH_EVOLVE_ARM is set on every run by the
+      // wrapping runUtility call). We thread it via a fresh `spawn` wrapper
+      // when one was supplied.
+      materialiseStash: false,
+      ...(options.timestamp ? { timestamp: options.timestamp } : {}),
+      ...(options.branch ? { branch: options.branch } : {}),
+      ...(options.commit ? { commit: options.commit } : {}),
+      // Forward the post stashDir override via spawn wrapper.
+      ...(options.spawn
+        ? {
+            spawn: wrapSpawnWithArm(options.spawn, "post", postStash?.stashDir),
+          }
+        : {}),
+    });
+  } finally {
+    postStash?.cleanup();
+  }
+
+  // synthetic: no stash. We pass `materialiseStash: false` and a prompt seam
+  // that injects the "Bring Your Own Skills" instruction. Since `runUtility`
+  // doesn't expose a prompt override, we tag the spawn wrapper with the arm
+  // so test fakes can branch; the production agent harness falls back to
+  // its default prompt (same as noakm) when AKM_STASH_DIR is absent.
+  const syntheticReport = await runUtility({
+    tasks: evalTasks,
+    arms: ["akm"],
+    model: options.model,
+    seedsPerArm,
+    budgetTokens,
+    budgetWallMs,
+    slice: "eval",
+    materialiseStash: false,
+    ...(options.timestamp ? { timestamp: options.timestamp } : {}),
+    ...(options.branch ? { branch: options.branch } : {}),
+    ...(options.commit ? { commit: options.commit } : {}),
+    ...(options.spawn
+      ? {
+          // For the synthetic arm we strip the AKM_STASH_DIR and tell the
+          // agent to write its own scratchpad. The wrapSpawnWithArm helper
+          // adds BENCH_EVOLVE_ARM=synthetic + BENCH_EVOLVE_SCRATCHPAD=1 so
+          // fakes (and a future real harness) can branch.
+          spawn: wrapSpawnWithArm(options.spawn, "synthetic", undefined, true),
+        }
+      : {}),
+  });
+
+  // ── Compute aggregates. ──────────────────────────────────────────────────
+  const proposalsMetrics = computeProposalQualityMetrics(proposalLog);
+  const longitudinal = computeLongitudinalMetrics(preReport, postReport, syntheticReport);
+
+  return {
+    timestamp: options.timestamp ?? new Date().toISOString(),
+    branch: options.branch ?? preReport.branch,
+    commit: options.commit ?? preReport.commit,
+    model: options.model,
+    domain,
+    seedsPerArm,
+    feedbackLog,
+    proposalLog,
+    proposals: proposalsMetrics,
+    longitudinal,
+    arms: { pre: preReport, post: postReport, synthetic: syntheticReport },
+    warnings: [
+      ...warnings,
+      ...phase1Report.warnings,
+      ...preReport.warnings,
+      ...postReport.warnings,
+      ...syntheticReport.warnings,
+    ],
+  };
+}
+
+/**
+ * Default subprocess invoker — runs `bun run src/cli.ts <args>` in `cwd`
+ * with the supplied env. Real runs use this; tests inject a fake.
+ */
+async function defaultAkmCli(args: string[], cwd: string, env: Record<string, string>): Promise<AkmCliResult> {
+  const cli = path.resolve(__dirname, "..", "..", "src", "cli.ts");
+  const proc = Bun.spawnSync({
+    cmd: ["bun", "run", cli, ...args],
+    cwd,
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = proc.stdout ? new TextDecoder().decode(proc.stdout) : "";
+  const stderr = proc.stderr ? new TextDecoder().decode(proc.stderr) : "";
+  return { exitCode: proc.exitCode ?? -1, stdout, stderr };
+}
+
+/**
+ * Threshold check: an asset crosses the negative threshold if either the
+ * absolute negative count meets `absoluteCount` OR the negative *ratio* among
+ * total feedback exceeds `ratio`. Either branch is sufficient — both are
+ * spec-mandated defaults.
+ */
+function crossesNegativeThreshold(
+  counts: FeedbackCounts,
+  threshold: { absoluteCount: number; ratio: number },
+): boolean {
+  if (counts.negative >= threshold.absoluteCount) return true;
+  const total = counts.positive + counts.negative;
+  if (total === 0) return false;
+  return counts.negative / total > threshold.ratio;
+}
+
+/** Best-effort partition. Honours explicit `slice:` and falls back to id-hash. */
+function effectiveSlice(task: TaskMetadata): TaskSlice {
+  if (task.slice) return task.slice;
+  // Mirror corpus.effectiveSlice — SHA-1 first byte parity.
+  // We avoid the import cycle by inlining the trivial fallback.
+  let h = 0;
+  for (let i = 0; i < task.id.length; i += 1) h = (h * 31 + task.id.charCodeAt(i)) | 0;
+  return Math.abs(h) % 2 === 0 ? "train" : "eval";
+}
+
+function uniqueDomain(tasks: TaskMetadata[]): string {
+  const set = new Set(tasks.map((t) => t.domain));
+  if (set.size === 1) return [...set][0] ?? "all";
+  return "all";
+}
+
+/**
+ * Wrap a spawn fake so every child sees `BENCH_EVOLVE_ARM=<arm>` (and
+ * `BENCH_EVOLVE_SCRATCHPAD=1` for the synthetic arm). Used by Phase 3 so
+ * test fakes can distinguish the three arms without us having to expose a
+ * `prompt` override on `runUtility`. Real production runs receive the same
+ * env keys; the real `runAgent` harness ignores them.
+ */
+function wrapSpawnWithArm(inner: SpawnFn, arm: "post" | "synthetic", stashDir?: string, scratchpad = false): SpawnFn {
+  return (cmd, opts) => {
+    const env: Record<string, string> = { ...(opts.env ?? {}) };
+    env.BENCH_EVOLVE_ARM = arm;
+    if (scratchpad) env.BENCH_EVOLVE_SCRATCHPAD = "1";
+    if (stashDir) env.AKM_STASH_DIR = stashDir;
+    if (arm === "synthetic") delete env.AKM_STASH_DIR;
+    return inner(cmd, { ...opts, env });
+  };
+}
+
+/** Lightweight proposal record extracted from `akm proposal list --json`. */
+interface ProposalListEntry {
+  id: string;
+  assetRef: string;
+  kind: ProposalLogEntry["kind"];
+}
+
+/** Tolerant parser for `akm proposal list --json` stdout. */
+function parseProposalList(stdout: string): ProposalListEntry[] {
+  if (!stdout.trim()) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return [];
+  }
+  const arr = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray((parsed as { proposals?: unknown[] }).proposals)
+      ? (parsed as { proposals: unknown[] }).proposals
+      : [];
+  const out: ProposalListEntry[] = [];
+  for (const item of arr) {
+    if (!item || typeof item !== "object") continue;
+    const rec = item as Record<string, unknown>;
+    const id = typeof rec.id === "string" ? rec.id : null;
+    const assetRef =
+      typeof rec.target_ref === "string"
+        ? rec.target_ref
+        : typeof rec.targetRef === "string"
+          ? rec.targetRef
+          : typeof rec.ref === "string"
+            ? rec.ref
+            : null;
+    const kindRaw = typeof rec.kind === "string" ? rec.kind : typeof rec.source === "string" ? rec.source : "unknown";
+    const kind: ProposalLogEntry["kind"] =
+      kindRaw === "lesson" || kindRaw === "distill"
+        ? "lesson"
+        : kindRaw === "revision" || kindRaw === "reflect"
+          ? "revision"
+          : "unknown";
+    if (!id || !assetRef) continue;
+    out.push({ id, assetRef, kind });
+  }
+  return out;
+}
+
+/** Parsed lint outcome from `akm proposal show <id> --json`. */
+interface ParsedProposalShow {
+  lintPass: boolean;
+  lintMessage?: string;
+}
+
+function parseProposalShow(stdout: string): ParsedProposalShow {
+  if (!stdout.trim()) return { lintPass: false, lintMessage: "empty proposal show output" };
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(stdout) as Record<string, unknown>;
+  } catch (err) {
+    return { lintPass: false, lintMessage: `proposal show: parse error (${(err as Error).message})` };
+  }
+  const lintPass =
+    parsed.lint_pass === true ||
+    parsed.lintPass === true ||
+    (typeof parsed.lint === "object" && parsed.lint !== null && (parsed.lint as Record<string, unknown>).pass === true);
+  const lintRaw = parsed.lint;
+  let lintMessage: string | undefined;
+  if (lintRaw && typeof lintRaw === "object") {
+    const issues = (lintRaw as Record<string, unknown>).issues;
+    if (Array.isArray(issues) && issues.length > 0) {
+      lintMessage = issues
+        .map((i) => (typeof i === "string" ? i : ((i as { message?: string })?.message ?? JSON.stringify(i))))
+        .join("; ");
+    }
+  }
+  return { lintPass, ...(lintMessage ? { lintMessage } : {}) };
+}
+
+/** Exposed for tests so the synthetic-arm prompt construction can be asserted. */
+export function buildSyntheticPrompt(taskId: string): string {
+  return [
+    `Task: ${taskId}`,
+    "Arm: synthetic (Bring Your Own Skills)",
+    "No akm stash is available. Before solving the task, write a short scratchpad of the skills",
+    "and steps you intend to use, then proceed. Cite the scratchpad in your trace so the verifier",
+    "can attribute the approach to your own reasoning rather than retrieved guidance.",
+  ].join("\n");
+}
+
+// `os` is imported because Phase 3 may want to materialise a fresh tmp dir
+// for the post-arm overlay. We intentionally keep that path narrow today.
+void os;
+// Re-export the writable file system module so future variants of evolve
+// (e.g. seeding feedback files into a tmp stash) can use the same import.
+void fs;

--- a/tests/bench/evolve.ts
+++ b/tests/bench/evolve.ts
@@ -32,8 +32,6 @@
  * real `loadFixtureStash`.
  */
 
-import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import type { SpawnFn } from "../../src/integrations/agent/spawn";
@@ -144,6 +142,15 @@ interface FeedbackCounts {
  *
  * Pre: `tasks` is already filtered to one domain (or `all`). The runner
  * partitions internally on `task.slice`.
+ *
+ * Sandboxing: at the start of every real run the runner materialises one
+ * dedicated tmp stash per fixture (the `evolveStash`) plus a fresh sibling
+ * snapshot per fixture (the `preStash`). Phase 1 + Phase 2 pin
+ * `AKM_STASH_DIR` to the appropriate `evolveStash` for every spawned `akm`
+ * invocation; Phase 3's pre arm uses `preStash`, the post arm uses
+ * `evolveStash`, and the synthetic arm uses no stash. The operator's real
+ * `process.env.AKM_STASH_DIR` is never read or written by `runEvolve`. All
+ * stashes are cleaned up in a top-level try/finally.
  */
 export async function runEvolve(options: RunEvolveOptions): Promise<EvolveRunReport> {
   const seedsPerArm = options.seedsPerArm ?? 5;
@@ -161,183 +168,234 @@ export async function runEvolve(options: RunEvolveOptions): Promise<EvolveRunRep
   // already filtered to one domain; this is just for the report header.
   const domain = uniqueDomain(options.tasks);
 
-  // ── Phase 1: accumulate signal on the train slice (akm arm only). ────────
-  const phase1Report = await runUtility({
-    tasks: trainTasks,
-    arms: ["akm"],
-    model: options.model,
-    seedsPerArm,
-    budgetTokens,
-    budgetWallMs,
-    slice: "train",
-    ...(options.spawn ? { spawn: options.spawn } : {}),
-    materialiseStash,
-    ...(options.timestamp ? { timestamp: options.timestamp } : {}),
-    ...(options.branch ? { branch: options.branch } : {}),
-    ...(options.commit ? { commit: options.commit } : {}),
-  });
+  // ── Sandbox setup: per-fixture evolveStash + preStash. ───────────────────
+  // We materialise one tmp stash per unique `task.stash` so Phase 1
+  // accumulates feedback into the same on-disk stash that Phase 2 mutates,
+  // and that Phase 3's post arm reads back. The operator's real
+  // AKM_STASH_DIR is never touched. The pre arm gets a fresh snapshot of
+  // the same starting fixture (no Phase 2 mutations applied).
+  const fixtureNames = new Set<string>();
+  for (const t of options.tasks) fixtureNames.add(t.stash);
 
-  // Issue feedback events per (task, seed) outcome on the akm arm.
-  const feedbackLog: FeedbackLogEntry[] = [];
-  const feedbackByRef = new Map<string, FeedbackCounts>();
-  const phase1Cwd = options.tasks[0]?.taskDir ?? process.cwd();
-  for (const run of phase1Report.akmRuns ?? []) {
-    const taskMeta = options.tasks.find((t) => t.id === run.taskId);
-    const goldRef = taskMeta?.goldRef;
-    if (!goldRef) continue;
-    if (run.outcome === "harness_error") continue;
-    const signal: "positive" | "negative" = run.outcome === "pass" ? "positive" : "negative";
-    const args = ["feedback", goldRef, signal === "positive" ? "--positive" : "--negative"];
-    const cliResult = await akmCli(args, phase1Cwd, process.env as Record<string, string>);
-    feedbackLog.push({ taskId: run.taskId, seed: run.seed, goldRef, signal, ok: cliResult.exitCode === 0 });
-    if (cliResult.exitCode !== 0) {
-      warnings.push(`phase1: akm feedback for ${goldRef} (${signal}) failed: ${cliResult.stderr.trim()}`);
-    }
-    const counts = feedbackByRef.get(goldRef) ?? { positive: 0, negative: 0 };
-    if (signal === "positive") counts.positive += 1;
-    else counts.negative += 1;
-    feedbackByRef.set(goldRef, counts);
-  }
+  const evolveStashes = new Map<string, LoadedFixtureStash>();
+  const preStashes = new Map<string, LoadedFixtureStash>();
+  const evolveDirByFixture = new Map<string, string>();
+  const preDirByFixture = new Map<string, string>();
 
-  // ── Phase 2: evolve. ─────────────────────────────────────────────────────
-  const proposalLog: ProposalLogEntry[] = [];
-  const evalGoldRefs = new Set<string>();
-  for (const t of evalTasks) {
-    if (t.goldRef) evalGoldRefs.add(t.goldRef);
-  }
-
-  const refsToEvolve: string[] = [];
-  for (const [ref, counts] of feedbackByRef.entries()) {
-    if (crossesNegativeThreshold(counts, negativeThreshold)) refsToEvolve.push(ref);
-  }
-  refsToEvolve.sort();
-
-  for (const ref of refsToEvolve) {
-    // §7.4 leakage prevention: if this ref is also an eval-slice gold ref,
-    // we skip evolving it entirely so post-evolve eval can't gain an unfair
-    // advantage. Tasks that share refs across slices are flagged.
-    if (evalGoldRefs.has(ref)) {
-      warnings.push(
-        `phase2: skipping distill/reflect on ${ref} — it is an eval-slice gold ref (§7.4 leakage prevention).`,
-      );
-      continue;
-    }
-    // Pass the eval-gold ref list through env so a future akm version can
-    // honour it. Today's `akm distill` ignores `AKM_BENCH_EXCLUDE_GOLD_REFS`;
-    // we still warn so operators know the protection is partial.
-    const evolveEnv: Record<string, string> = {
-      ...(process.env as Record<string, string>),
-      AKM_BENCH_EXCLUDE_GOLD_REFS: [...evalGoldRefs].join(","),
-    };
-    if (evalGoldRefs.size > 0) {
-      warnings.push(
-        "phase2: distill/reflect cannot today filter their own LLM input by --exclude-gold-ref; relying on per-ref skip + env hint only.",
-      );
-    }
-
-    const distillResult = await akmCli(["distill", ref], phase1Cwd, evolveEnv);
-    if (distillResult.exitCode !== 0) {
-      warnings.push(`phase2: akm distill ${ref} failed: ${distillResult.stderr.trim()}`);
-    }
-    const reflectResult = await akmCli(["reflect", ref], phase1Cwd, evolveEnv);
-    if (reflectResult.exitCode !== 0) {
-      // `reflect` requires `agent.default` to be configured — a missing
-      // config is non-fatal for the bench; we record and continue.
-      warnings.push(`phase2: akm reflect ${ref} skipped/failed: ${reflectResult.stderr.trim()}`);
-    }
-  }
-
-  // Walk the proposal queue.
-  const listResult = await akmCli(["proposal", "list", "--json"], phase1Cwd, process.env as Record<string, string>);
-  const proposals = parseProposalList(listResult.stdout);
-  for (const p of proposals) {
-    const showResult = await akmCli(
-      ["proposal", "show", p.id, "--json"],
-      phase1Cwd,
-      process.env as Record<string, string>,
-    );
-    const lintInfo = parseProposalShow(showResult.stdout);
-    const lintPass = lintInfo.lintPass;
-    if (lintPass) {
-      const acceptResult = await akmCli(["proposal", "accept", p.id], phase1Cwd, process.env as Record<string, string>);
-      proposalLog.push({
-        proposalId: p.id,
-        assetRef: p.assetRef,
-        kind: p.kind,
-        lintPass: true,
-        decision: acceptResult.exitCode === 0 ? "accept" : "reject",
-        ...(acceptResult.exitCode === 0 ? {} : { rejectReason: `accept failed: ${acceptResult.stderr.trim()}` }),
-      });
-    } else {
-      const reason = lintInfo.lintMessage ?? "lint failed";
-      const rejectResult = await akmCli(
-        ["proposal", "reject", p.id, "--reason", `lint failed: ${reason}`],
-        phase1Cwd,
-        process.env as Record<string, string>,
-      );
-      proposalLog.push({
-        proposalId: p.id,
-        assetRef: p.assetRef,
-        kind: p.kind,
-        lintPass: false,
-        decision: "reject",
-        rejectReason: reason,
-      });
-      if (rejectResult.exitCode !== 0) {
-        warnings.push(`phase2: akm proposal reject ${p.id} failed: ${rejectResult.stderr.trim()}`);
-      }
-    }
-  }
-
-  // Rebuild the index so accepted lessons surface in Phase 3.
-  const indexResult = await akmCli(["index"], phase1Cwd, process.env as Record<string, string>);
-  if (indexResult.exitCode !== 0) {
-    warnings.push(`phase2: akm index rebuild failed: ${indexResult.stderr.trim()}`);
-  }
-
-  // ── Phase 3: re-evaluate (eval slice). ───────────────────────────────────
-  // pre: original fixture (un-evolved). We snapshot the original by passing
-  // `materialiseStash: true` and trusting the runner to clone the named
-  // fixture from disk fresh — the on-disk fixture was never mutated by
-  // Phase 2 (distill/reflect write to the runtime stash, not the fixture).
-  const preReport = await runUtility({
-    tasks: evalTasks,
-    arms: ["akm"],
-    model: options.model,
-    seedsPerArm,
-    budgetTokens,
-    budgetWallMs,
-    slice: "eval",
-    ...(options.spawn ? { spawn: options.spawn } : {}),
-    materialiseStash,
-    ...(options.timestamp ? { timestamp: options.timestamp } : {}),
-    ...(options.branch ? { branch: options.branch } : {}),
-    ...(options.commit ? { commit: options.commit } : {}),
-  });
-
-  // post: same as pre, but we attach the evolved-stash overlay path via env
-  // so the agent harness picks up the accepted lessons. The default akm CLI
-  // discovers them through the live AKM_STASH_DIR — we override per arm via
-  // the spawn injection seam. Real-runs reuse `loadFixtureStash` then layer
-  // accepted proposals on top; tests use the materialiseStash=false seam.
-  let postStash: LoadedFixtureStash | undefined;
-  let postReport: UtilityRunReport;
-  try {
-    if (materialiseStash && evalTasks.length > 0) {
-      // Try to layer accepted lessons onto a fresh tmp stash. If the source
-      // fixture is missing or `loadFixtureStash` fails, we fall back to the
-      // un-evolved stash with a warning.
+  if (materialiseStash) {
+    for (const name of fixtureNames) {
       try {
-        postStash = loadFixtureStash(evalTasks[0].stash, { skipIndex: true });
-        // The accepted-proposal materialisation is handled by the akm CLI's
-        // own stash; we have no portable way to "merge" two stashes here.
-        // Operators running the full bench rely on the operator-managed
-        // AKM_STASH_DIR; tests skip materialiseStash entirely.
+        const evolved = loadFixtureStash(name, { skipIndex: false });
+        evolveStashes.set(name, evolved);
+        evolveDirByFixture.set(name, evolved.stashDir);
       } catch (err) {
-        warnings.push(`phase3 post-arm: failed to materialise evolved stash: ${(err as Error).message}`);
+        warnings.push(`evolve: failed to materialise evolve stash for fixture "${name}": ${(err as Error).message}`);
+      }
+      try {
+        const pre = loadFixtureStash(name, { skipIndex: false });
+        preStashes.set(name, pre);
+        preDirByFixture.set(name, pre.stashDir);
+      } catch (err) {
+        warnings.push(`evolve: failed to materialise pre stash for fixture "${name}": ${(err as Error).message}`);
       }
     }
-    postReport = await runUtility({
+  }
+
+  // Resolve the evolveStash dir for a given asset ref. We map ref → fixture
+  // by looking up which task's gold ref it matches; if no task owns it (or
+  // multiple do, which is unusual), we fall back to the first available
+  // evolveStash. The simple — and most common — case is a single fixture
+  // per `--tasks <domain>` invocation.
+  const refToFixture = new Map<string, string>();
+  for (const t of options.tasks) {
+    if (t.goldRef) refToFixture.set(t.goldRef, t.stash);
+  }
+  const fallbackEvolveDir = [...evolveDirByFixture.values()][0];
+  function envForRef(ref: string | undefined): Record<string, string> {
+    const baseEnv = { ...(process.env as Record<string, string>) };
+    if (!materialiseStash) {
+      // Tests opt out of fixture materialisation entirely; we still strip
+      // the operator's AKM_STASH_DIR so the fake CLI sees a known sentinel.
+      delete baseEnv.AKM_STASH_DIR;
+      return baseEnv;
+    }
+    const fixture = ref ? refToFixture.get(ref) : undefined;
+    const dir = (fixture && evolveDirByFixture.get(fixture)) ?? fallbackEvolveDir;
+    if (dir) baseEnv.AKM_STASH_DIR = dir;
+    else delete baseEnv.AKM_STASH_DIR;
+    return baseEnv;
+  }
+
+  let preReport: UtilityRunReport;
+  let postReport: UtilityRunReport;
+  let syntheticReport: UtilityRunReport;
+  let phase1Report: UtilityRunReport;
+  const feedbackLog: FeedbackLogEntry[] = [];
+  const proposalLog: ProposalLogEntry[] = [];
+
+  try {
+    // ── Phase 1: accumulate signal on the train slice (akm arm only). ─────
+    phase1Report = await runUtility({
+      tasks: trainTasks,
+      arms: ["akm"],
+      model: options.model,
+      seedsPerArm,
+      budgetTokens,
+      budgetWallMs,
+      slice: "train",
+      ...(options.spawn ? { spawn: options.spawn } : {}),
+      // We pre-materialised the per-fixture evolve stash above; tell the
+      // runner to forward those dirs and skip its own per-task materialise.
+      materialiseStash,
+      ...(materialiseStash ? { stashDirByFixture: evolveDirByFixture } : {}),
+      ...(options.timestamp ? { timestamp: options.timestamp } : {}),
+      ...(options.branch ? { branch: options.branch } : {}),
+      ...(options.commit ? { commit: options.commit } : {}),
+    });
+
+    // Issue feedback events per (task, seed) outcome on the akm arm.
+    const feedbackByRef = new Map<string, FeedbackCounts>();
+    const phase1Cwd = options.tasks[0]?.taskDir ?? process.cwd();
+    for (const run of phase1Report.akmRuns ?? []) {
+      const taskMeta = options.tasks.find((t) => t.id === run.taskId);
+      const goldRef = taskMeta?.goldRef;
+      if (!goldRef) continue;
+      if (run.outcome === "harness_error") continue;
+      const signal: "positive" | "negative" = run.outcome === "pass" ? "positive" : "negative";
+      const args = ["feedback", goldRef, signal === "positive" ? "--positive" : "--negative"];
+      // Wrap in try/catch so a single throwing akmCli (e.g. subprocess
+      // crash) cannot leave `feedbackByRef` partially populated and let
+      // Phase 2 proceed on corrupt state.
+      try {
+        const cliResult = await akmCli(args, phase1Cwd, envForRef(goldRef));
+        feedbackLog.push({ taskId: run.taskId, seed: run.seed, goldRef, signal, ok: cliResult.exitCode === 0 });
+        if (cliResult.exitCode !== 0) {
+          warnings.push(`phase1: akm feedback for ${goldRef} (${signal}) failed: ${cliResult.stderr.trim()}`);
+        }
+      } catch (err) {
+        feedbackLog.push({ taskId: run.taskId, seed: run.seed, goldRef, signal, ok: false });
+        warnings.push(`phase1.feedback_dispatch_failed: ${goldRef} ${(err as Error).message}`);
+      }
+      const counts = feedbackByRef.get(goldRef) ?? { positive: 0, negative: 0 };
+      if (signal === "positive") counts.positive += 1;
+      else counts.negative += 1;
+      feedbackByRef.set(goldRef, counts);
+    }
+
+    // ── Phase 2: evolve. ────────────────────────────────────────────────────
+    const evalGoldRefs = new Set<string>();
+    for (const t of evalTasks) {
+      if (t.goldRef) evalGoldRefs.add(t.goldRef);
+    }
+
+    const refsToEvolve: string[] = [];
+    for (const [ref, counts] of feedbackByRef.entries()) {
+      if (crossesNegativeThreshold(counts, negativeThreshold)) refsToEvolve.push(ref);
+    }
+    refsToEvolve.sort();
+
+    // Emit the generic leakage warning at most once per Phase 2 invocation;
+    // per-ref skip warnings (which name the specific ref) stay in the loop.
+    let leakageWarningEmitted = false;
+    for (const ref of refsToEvolve) {
+      // §7.4 leakage prevention: if this ref is also an eval-slice gold ref,
+      // we skip evolving it entirely so post-evolve eval can't gain an unfair
+      // advantage. Tasks that share refs across slices are flagged.
+      if (evalGoldRefs.has(ref)) {
+        warnings.push(
+          `phase2: skipping distill/reflect on ${ref} — it is an eval-slice gold ref (§7.4 leakage prevention).`,
+        );
+        continue;
+      }
+      // Pass the eval-gold ref list through env so a future akm version can
+      // honour it. Today's `akm distill` ignores `AKM_BENCH_EXCLUDE_GOLD_REFS`;
+      // we still warn so operators know the protection is partial — but only
+      // once per phase, regardless of how many refs we evolve.
+      const evolveEnv: Record<string, string> = {
+        ...envForRef(ref),
+        AKM_BENCH_EXCLUDE_GOLD_REFS: [...evalGoldRefs].join(","),
+      };
+      if (evalGoldRefs.size > 0 && !leakageWarningEmitted) {
+        warnings.push(
+          "phase2: distill/reflect cannot today filter their own LLM input by --exclude-gold-ref; relying on per-ref skip + env hint only.",
+        );
+        leakageWarningEmitted = true;
+      }
+
+      const distillResult = await akmCli(["distill", ref], phase1Cwd, evolveEnv);
+      if (distillResult.exitCode !== 0) {
+        warnings.push(`phase2: akm distill ${ref} failed: ${distillResult.stderr.trim()}`);
+      }
+      const reflectResult = await akmCli(["reflect", ref], phase1Cwd, evolveEnv);
+      if (reflectResult.exitCode !== 0) {
+        // `reflect` requires `agent.default` to be configured — a missing
+        // config is non-fatal for the bench; we record and continue.
+        warnings.push(`phase2: akm reflect ${ref} skipped/failed: ${reflectResult.stderr.trim()}`);
+      }
+    }
+
+    // Walk the proposal queue per fixture (each evolveStash has its own
+    // proposal log on disk). When we materialised stashes we iterate every
+    // fixture that produced proposals; in the common single-fixture case
+    // this is one pass.
+    const proposalFixtures = materialiseStash ? [...evolveDirByFixture.keys()] : [undefined];
+    for (const fixtureName of proposalFixtures) {
+      const proposalEnv: Record<string, string> = { ...(process.env as Record<string, string>) };
+      if (materialiseStash && fixtureName) {
+        const dir = evolveDirByFixture.get(fixtureName);
+        if (dir) proposalEnv.AKM_STASH_DIR = dir;
+      } else if (!materialiseStash) {
+        delete proposalEnv.AKM_STASH_DIR;
+      }
+      const listResult = await akmCli(["proposal", "list", "--json"], phase1Cwd, proposalEnv);
+      const proposals = parseProposalList(listResult.stdout);
+      for (const p of proposals) {
+        const showResult = await akmCli(["proposal", "show", p.id, "--json"], phase1Cwd, proposalEnv);
+        const lintInfo = parseProposalShow(showResult.stdout);
+        const lintPass = lintInfo.lintPass;
+        if (lintPass) {
+          const acceptResult = await akmCli(["proposal", "accept", p.id], phase1Cwd, proposalEnv);
+          proposalLog.push({
+            proposalId: p.id,
+            assetRef: p.assetRef,
+            kind: p.kind,
+            lintPass: true,
+            decision: acceptResult.exitCode === 0 ? "accept" : "reject",
+            ...(acceptResult.exitCode === 0 ? {} : { rejectReason: `accept failed: ${acceptResult.stderr.trim()}` }),
+          });
+        } else {
+          const reason = lintInfo.lintMessage ?? "lint failed";
+          const rejectResult = await akmCli(
+            ["proposal", "reject", p.id, "--reason", `lint failed: ${reason}`],
+            phase1Cwd,
+            proposalEnv,
+          );
+          proposalLog.push({
+            proposalId: p.id,
+            assetRef: p.assetRef,
+            kind: p.kind,
+            lintPass: false,
+            decision: "reject",
+            rejectReason: reason,
+          });
+          if (rejectResult.exitCode !== 0) {
+            warnings.push(`phase2: akm proposal reject ${p.id} failed: ${rejectResult.stderr.trim()}`);
+          }
+        }
+      }
+
+      // Rebuild the index so accepted lessons surface in Phase 3.
+      const indexResult = await akmCli(["index"], phase1Cwd, proposalEnv);
+      if (indexResult.exitCode !== 0) {
+        warnings.push(`phase2: akm index rebuild failed: ${indexResult.stderr.trim()}`);
+      }
+    }
+
+    // ── Phase 3: re-evaluate (eval slice). ─────────────────────────────────
+    // pre arm: fresh snapshot of the starting fixture (no Phase 2 mutations
+    // applied). post arm: the mutated evolveStash so accepted lessons reach
+    // the eval slice. synthetic arm: no stash.
+    preReport = await runUtility({
       tasks: evalTasks,
       arms: ["akm"],
       model: options.model,
@@ -346,52 +404,65 @@ export async function runEvolve(options: RunEvolveOptions): Promise<EvolveRunRep
       budgetWallMs,
       slice: "eval",
       ...(options.spawn ? { spawn: options.spawn } : {}),
+      materialiseStash,
+      ...(materialiseStash ? { stashDirByFixture: preDirByFixture } : {}),
+      ...(options.timestamp ? { timestamp: options.timestamp } : {}),
+      ...(options.branch ? { branch: options.branch } : {}),
+      ...(options.commit ? { commit: options.commit } : {}),
+    });
+
+    postReport = await runUtility({
+      tasks: evalTasks,
+      arms: ["akm"],
+      model: options.model,
+      seedsPerArm,
+      budgetTokens,
+      budgetWallMs,
+      slice: "eval",
       // Stamp arm metadata so spawn fakes can distinguish pre-vs-post via
-      // an env probe (BENCH_EVOLVE_ARM is set on every run by the
-      // wrapping runUtility call). We thread it via a fresh `spawn` wrapper
-      // when one was supplied.
+      // an env probe. We thread it via a fresh `spawn` wrapper when one
+      // was supplied.
+      materialiseStash,
+      ...(materialiseStash ? { stashDirByFixture: evolveDirByFixture } : {}),
+      ...(options.timestamp ? { timestamp: options.timestamp } : {}),
+      ...(options.branch ? { branch: options.branch } : {}),
+      ...(options.commit ? { commit: options.commit } : {}),
+      ...(options.spawn ? { spawn: wrapSpawnWithArm(options.spawn, "post") } : {}),
+    });
+
+    // synthetic: no stash. We pass a spawn wrapper that strips
+    // AKM_STASH_DIR and injects the "Bring Your Own Skills" tag so test
+    // fakes (and a future real harness) can branch.
+    syntheticReport = await runUtility({
+      tasks: evalTasks,
+      arms: ["akm"],
+      model: options.model,
+      seedsPerArm,
+      budgetTokens,
+      budgetWallMs,
+      slice: "eval",
       materialiseStash: false,
       ...(options.timestamp ? { timestamp: options.timestamp } : {}),
       ...(options.branch ? { branch: options.branch } : {}),
       ...(options.commit ? { commit: options.commit } : {}),
-      // Forward the post stashDir override via spawn wrapper.
-      ...(options.spawn
-        ? {
-            spawn: wrapSpawnWithArm(options.spawn, "post", postStash?.stashDir),
-          }
-        : {}),
+      ...(options.spawn ? { spawn: wrapSpawnWithArm(options.spawn, "synthetic", undefined, true) } : {}),
     });
   } finally {
-    postStash?.cleanup();
+    for (const s of evolveStashes.values()) {
+      try {
+        s.cleanup();
+      } catch {
+        /* swallow — best-effort tmp cleanup */
+      }
+    }
+    for (const s of preStashes.values()) {
+      try {
+        s.cleanup();
+      } catch {
+        /* swallow — best-effort tmp cleanup */
+      }
+    }
   }
-
-  // synthetic: no stash. We pass `materialiseStash: false` and a prompt seam
-  // that injects the "Bring Your Own Skills" instruction. Since `runUtility`
-  // doesn't expose a prompt override, we tag the spawn wrapper with the arm
-  // so test fakes can branch; the production agent harness falls back to
-  // its default prompt (same as noakm) when AKM_STASH_DIR is absent.
-  const syntheticReport = await runUtility({
-    tasks: evalTasks,
-    arms: ["akm"],
-    model: options.model,
-    seedsPerArm,
-    budgetTokens,
-    budgetWallMs,
-    slice: "eval",
-    materialiseStash: false,
-    ...(options.timestamp ? { timestamp: options.timestamp } : {}),
-    ...(options.branch ? { branch: options.branch } : {}),
-    ...(options.commit ? { commit: options.commit } : {}),
-    ...(options.spawn
-      ? {
-          // For the synthetic arm we strip the AKM_STASH_DIR and tell the
-          // agent to write its own scratchpad. The wrapSpawnWithArm helper
-          // adds BENCH_EVOLVE_ARM=synthetic + BENCH_EVOLVE_SCRATCHPAD=1 so
-          // fakes (and a future real harness) can branch.
-          spawn: wrapSpawnWithArm(options.spawn, "synthetic", undefined, true),
-        }
-      : {}),
-  });
 
   // ── Compute aggregates. ──────────────────────────────────────────────────
   const proposalsMetrics = computeProposalQualityMetrics(proposalLog);
@@ -575,10 +646,3 @@ export function buildSyntheticPrompt(taskId: string): string {
     "can attribute the approach to your own reasoning rather than retrieved guidance.",
   ].join("\n");
 }
-
-// `os` is imported because Phase 3 may want to materialise a fresh tmp dir
-// for the post-arm overlay. We intentionally keep that path narrow today.
-void os;
-// Re-export the writable file system module so future variants of evolve
-// (e.g. seeding feedback files into a tmp stash) can use the same import.
-void fs;

--- a/tests/bench/evolve.ts
+++ b/tests/bench/evolve.ts
@@ -38,8 +38,10 @@ import type { SpawnFn } from "../../src/integrations/agent/spawn";
 import { type LoadedFixtureStash, loadFixtureStash } from "../fixtures/stashes/load";
 import type { TaskMetadata, TaskSlice } from "./corpus";
 import {
+  computeFeedbackIntegrity,
   computeLongitudinalMetrics,
   computeProposalQualityMetrics,
+  type FeedbackIntegrityMetrics,
   type LongitudinalMetrics,
   type ProposalLogEntry,
   type ProposalQualityMetrics,
@@ -122,6 +124,20 @@ export interface EvolveRunReport {
   proposals: ProposalQualityMetrics;
   /** Aggregate longitudinal metrics. */
   longitudinal: LongitudinalMetrics;
+  /**
+   * Feedback-signal integrity 2x2 confusion matrix (§6.8). Joins each
+   * Phase 1 feedback event to the akm-arm run that produced it (per
+   * `feedbackLog[i].taskId`/`seed`) and labels TP/FP/TN/FN per the run's
+   * outcome. Computed by `computeFeedbackIntegrity`.
+   */
+  feedbackIntegrity: FeedbackIntegrityMetrics;
+  /**
+   * Phase 1 utility report (akm arm only, train slice). Exposed so
+   * downstream metrics like `computeFeedbackIntegrity` can join feedback
+   * events back to the run that produced them. Additive in the report
+   * envelope.
+   */
+  phase1: UtilityRunReport;
   /** Phase 3 arm reports. Each is a §13.3-shape utility report. */
   arms: { pre: UtilityRunReport; post: UtilityRunReport; synthetic: UtilityRunReport };
   /** Operator-visible warnings. */
@@ -467,6 +483,7 @@ export async function runEvolve(options: RunEvolveOptions): Promise<EvolveRunRep
   // ── Compute aggregates. ──────────────────────────────────────────────────
   const proposalsMetrics = computeProposalQualityMetrics(proposalLog);
   const longitudinal = computeLongitudinalMetrics(preReport, postReport, syntheticReport);
+  const feedbackIntegrity = computeFeedbackIntegrity({ phase1: phase1Report, feedbackLog });
 
   return {
     timestamp: options.timestamp ?? new Date().toISOString(),
@@ -479,6 +496,8 @@ export async function runEvolve(options: RunEvolveOptions): Promise<EvolveRunRep
     proposalLog,
     proposals: proposalsMetrics,
     longitudinal,
+    feedbackIntegrity,
+    phase1: phase1Report,
     arms: { pre: preReport, post: postReport, synthetic: syntheticReport },
     warnings: [
       ...warnings,

--- a/tests/bench/feedback-integrity.test.ts
+++ b/tests/bench/feedback-integrity.test.ts
@@ -1,0 +1,490 @@
+/**
+ * Unit tests for §6.8 feedback-signal integrity (#244).
+ *
+ * Coverage:
+ *   • All four 2×2 quadrants (TP, FP, TN, FN).
+ *   • Per-asset breakdown when an asset has mixed signals across runs.
+ *   • `feedback_agreement < 0.80` triggers the warning marker (markdown +
+ *     structured `warnings[]` JSON entry).
+ *   • `feedback_coverage` correctly counts runs with feedback dispatched
+ *     vs total Phase 1 runs.
+ *   • NaN-safety: zero-feedback asset emits all rates as `null`, never
+ *     `0` or `NaN`.
+ *   • Attribution rule (§6.8): a feedback event is attributed to the run
+ *     that produced it, not to a later run touching the same asset.
+ *
+ * The metric is a pure function over RunResult[] + feedbackLog[]; no spawn
+ * fakes are needed. We build small synthetic streams directly.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { RunResult } from "./driver";
+import { computeFeedbackIntegrity, type FeedbackIntegrityInput, type FeedbackIntegrityMetrics } from "./metrics";
+import { FEEDBACK_AGREEMENT_WARNING_THRESHOLD, renderEvolveReport, renderFeedbackIntegrityTable } from "./report";
+
+function fakeRun(overrides: Partial<RunResult>): RunResult {
+  return {
+    schemaVersion: 1,
+    taskId: "t",
+    arm: "akm",
+    seed: 0,
+    model: "m",
+    outcome: "pass",
+    tokens: { input: 0, output: 0 },
+    wallclockMs: 0,
+    trajectory: { correctAssetLoaded: null, feedbackRecorded: null },
+    events: [],
+    verifierStdout: "",
+    verifierExitCode: 0,
+    assetsLoaded: [],
+    ...overrides,
+  };
+}
+
+function fb(
+  overrides: Partial<FeedbackIntegrityInput["feedbackLog"][number]>,
+): FeedbackIntegrityInput["feedbackLog"][number] {
+  return {
+    taskId: "t",
+    seed: 0,
+    goldRef: "skill:s",
+    signal: "positive",
+    ok: true,
+    ...overrides,
+  };
+}
+
+describe("computeFeedbackIntegrity — 2x2 quadrants", () => {
+  test("TP: feedback + on a passed run", () => {
+    const phase1 = { akmRuns: [fakeRun({ taskId: "t1", seed: 0, outcome: "pass" })] };
+    const feedbackLog = [fb({ taskId: "t1", seed: 0, goldRef: "skill:a", signal: "positive" })];
+    const m = computeFeedbackIntegrity({ phase1, feedbackLog });
+    expect(m.aggregate.truePositive).toBe(1);
+    expect(m.aggregate.falsePositive).toBe(0);
+    expect(m.aggregate.trueNegative).toBe(0);
+    expect(m.aggregate.falseNegative).toBe(0);
+    expect(m.aggregate.feedback_agreement).toBeCloseTo(1);
+    expect(m.aggregate.feedback_coverage).toBeCloseTo(1);
+    expect(m.perAsset).toHaveLength(1);
+    expect(m.perAsset[0].ref).toBe("skill:a");
+    expect(m.perAsset[0].truePositive).toBe(1);
+    expect(m.perAsset[0].feedback_agreement).toBeCloseTo(1);
+  });
+
+  test("FP: feedback + on a failed run", () => {
+    const phase1 = { akmRuns: [fakeRun({ taskId: "t1", seed: 0, outcome: "fail" })] };
+    const feedbackLog = [fb({ taskId: "t1", seed: 0, goldRef: "skill:a", signal: "positive" })];
+    const m = computeFeedbackIntegrity({ phase1, feedbackLog });
+    expect(m.aggregate.truePositive).toBe(0);
+    expect(m.aggregate.falsePositive).toBe(1);
+    expect(m.aggregate.trueNegative).toBe(0);
+    expect(m.aggregate.falseNegative).toBe(0);
+    expect(m.aggregate.feedback_agreement).toBeCloseTo(0);
+    expect(m.aggregate.false_positive_rate).toBeCloseTo(1);
+    expect(m.perAsset[0].falsePositive).toBe(1);
+  });
+
+  test("TN: feedback - on a failed run", () => {
+    const phase1 = { akmRuns: [fakeRun({ taskId: "t1", seed: 0, outcome: "fail" })] };
+    const feedbackLog = [fb({ taskId: "t1", seed: 0, goldRef: "skill:a", signal: "negative" })];
+    const m = computeFeedbackIntegrity({ phase1, feedbackLog });
+    expect(m.aggregate.trueNegative).toBe(1);
+    expect(m.aggregate.feedback_agreement).toBeCloseTo(1);
+    expect(m.aggregate.false_positive_rate).toBeCloseTo(0);
+    expect(m.perAsset[0].trueNegative).toBe(1);
+  });
+
+  test("FN: feedback - on a passed run", () => {
+    const phase1 = { akmRuns: [fakeRun({ taskId: "t1", seed: 0, outcome: "pass" })] };
+    const feedbackLog = [fb({ taskId: "t1", seed: 0, goldRef: "skill:a", signal: "negative" })];
+    const m = computeFeedbackIntegrity({ phase1, feedbackLog });
+    expect(m.aggregate.falseNegative).toBe(1);
+    expect(m.aggregate.feedback_agreement).toBeCloseTo(0);
+    expect(m.aggregate.false_negative_rate).toBeCloseTo(1);
+    expect(m.perAsset[0].falseNegative).toBe(1);
+  });
+});
+
+describe("computeFeedbackIntegrity — aggregate over mixed quadrants", () => {
+  test("computes feedback_agreement and rates correctly across mixed runs", () => {
+    // 4 runs covering all four quadrants — exactly one of each.
+    const phase1 = {
+      akmRuns: [
+        fakeRun({ taskId: "tp", seed: 0, outcome: "pass" }),
+        fakeRun({ taskId: "fp", seed: 0, outcome: "fail" }),
+        fakeRun({ taskId: "tn", seed: 0, outcome: "fail" }),
+        fakeRun({ taskId: "fn", seed: 0, outcome: "pass" }),
+      ],
+    };
+    const feedbackLog = [
+      fb({ taskId: "tp", seed: 0, goldRef: "skill:tp", signal: "positive" }),
+      fb({ taskId: "fp", seed: 0, goldRef: "skill:fp", signal: "positive" }),
+      fb({ taskId: "tn", seed: 0, goldRef: "skill:tn", signal: "negative" }),
+      fb({ taskId: "fn", seed: 0, goldRef: "skill:fn", signal: "negative" }),
+    ];
+    const m = computeFeedbackIntegrity({ phase1, feedbackLog });
+    expect(m.aggregate.truePositive).toBe(1);
+    expect(m.aggregate.falsePositive).toBe(1);
+    expect(m.aggregate.trueNegative).toBe(1);
+    expect(m.aggregate.falseNegative).toBe(1);
+    expect(m.aggregate.feedback_agreement).toBeCloseTo(0.5); // 2/4
+    expect(m.aggregate.false_positive_rate).toBeCloseTo(0.5); // 1 / (1+1)
+    expect(m.aggregate.false_negative_rate).toBeCloseTo(0.5); // 1 / (1+1)
+    expect(m.aggregate.feedback_coverage).toBeCloseTo(1);
+    expect(m.perAsset).toHaveLength(4);
+    // Per-asset rows should be sorted by ref
+    expect(m.perAsset.map((r) => r.ref)).toEqual(["skill:fn", "skill:fp", "skill:tn", "skill:tp"]);
+  });
+});
+
+describe("computeFeedbackIntegrity — per-asset mixed signals", () => {
+  test("aggregates correctly when one asset appears across multiple Phase 1 runs", () => {
+    // skill:shared has 2 TP, 1 FP, 1 TN, 1 FN across 5 runs.
+    const phase1 = {
+      akmRuns: [
+        fakeRun({ taskId: "t", seed: 0, outcome: "pass" }),
+        fakeRun({ taskId: "t", seed: 1, outcome: "pass" }),
+        fakeRun({ taskId: "t", seed: 2, outcome: "fail" }),
+        fakeRun({ taskId: "t", seed: 3, outcome: "fail" }),
+        fakeRun({ taskId: "t", seed: 4, outcome: "pass" }),
+      ],
+    };
+    const feedbackLog = [
+      fb({ taskId: "t", seed: 0, goldRef: "skill:shared", signal: "positive" }), // TP
+      fb({ taskId: "t", seed: 1, goldRef: "skill:shared", signal: "positive" }), // TP
+      fb({ taskId: "t", seed: 2, goldRef: "skill:shared", signal: "positive" }), // FP
+      fb({ taskId: "t", seed: 3, goldRef: "skill:shared", signal: "negative" }), // TN
+      fb({ taskId: "t", seed: 4, goldRef: "skill:shared", signal: "negative" }), // FN
+    ];
+    const m = computeFeedbackIntegrity({ phase1, feedbackLog });
+    expect(m.perAsset).toHaveLength(1);
+    const row = m.perAsset[0];
+    expect(row.ref).toBe("skill:shared");
+    expect(row.truePositive).toBe(2);
+    expect(row.falsePositive).toBe(1);
+    expect(row.trueNegative).toBe(1);
+    expect(row.falseNegative).toBe(1);
+    expect(row.feedback_agreement).toBeCloseTo(3 / 5);
+    expect(row.false_positive_rate).toBeCloseTo(1 / 2); // FP / (FP+TN) = 1/2
+    expect(row.false_negative_rate).toBeCloseTo(1 / 3); // FN / (FN+TP) = 1/3
+  });
+});
+
+describe("computeFeedbackIntegrity — attribution rule", () => {
+  test("attributes feedback to the run that produced it, not a later run touching the same asset", () => {
+    // skill:contested appears across two Phase 1 runs:
+    //   run #0: passed, feedback +  → TP
+    //   run #1: failed, feedback +  → FP
+    // The naive (wrong) implementation would conflate both events with
+    // run #1's outcome and label both as FP. The correct implementation
+    // joins each event to its own (taskId, seed) → gets one TP, one FP.
+    const phase1 = {
+      akmRuns: [fakeRun({ taskId: "t", seed: 0, outcome: "pass" }), fakeRun({ taskId: "t", seed: 1, outcome: "fail" })],
+    };
+    const feedbackLog = [
+      fb({ taskId: "t", seed: 0, goldRef: "skill:contested", signal: "positive" }),
+      fb({ taskId: "t", seed: 1, goldRef: "skill:contested", signal: "positive" }),
+    ];
+    const m = computeFeedbackIntegrity({ phase1, feedbackLog });
+    expect(m.aggregate.truePositive).toBe(1);
+    expect(m.aggregate.falsePositive).toBe(1);
+    expect(m.aggregate.trueNegative).toBe(0);
+    expect(m.aggregate.falseNegative).toBe(0);
+    expect(m.perAsset[0].truePositive).toBe(1);
+    expect(m.perAsset[0].falsePositive).toBe(1);
+  });
+});
+
+describe("computeFeedbackIntegrity — feedback_coverage", () => {
+  test("counts runs with feedback dispatched vs total Phase 1 runs", () => {
+    // 4 phase-1 runs, only 2 had feedback dispatched.
+    const phase1 = {
+      akmRuns: [
+        fakeRun({ taskId: "t", seed: 0, outcome: "pass" }),
+        fakeRun({ taskId: "t", seed: 1, outcome: "fail" }),
+        fakeRun({ taskId: "t", seed: 2, outcome: "harness_error" }),
+        fakeRun({ taskId: "t", seed: 3, outcome: "budget_exceeded" }),
+      ],
+    };
+    const feedbackLog = [
+      fb({ taskId: "t", seed: 0, goldRef: "skill:a", signal: "positive" }),
+      fb({ taskId: "t", seed: 1, goldRef: "skill:a", signal: "negative" }),
+    ];
+    const m = computeFeedbackIntegrity({ phase1, feedbackLog });
+    expect(m.aggregate.feedback_coverage).toBeCloseTo(0.5); // 2 of 4
+  });
+
+  test("zero coverage when no feedback dispatched", () => {
+    const phase1 = { akmRuns: [fakeRun({ taskId: "t", seed: 0, outcome: "pass" })] };
+    const m = computeFeedbackIntegrity({ phase1, feedbackLog: [] });
+    expect(m.aggregate.feedback_coverage).toBe(0);
+    expect(m.aggregate.feedback_agreement).toBe(0);
+    expect(m.perAsset).toEqual([]);
+  });
+
+  test("zero coverage and zero runs returns 0 (not NaN)", () => {
+    const m = computeFeedbackIntegrity({ phase1: { akmRuns: [] }, feedbackLog: [] });
+    expect(m.aggregate.feedback_coverage).toBe(0);
+    expect(m.aggregate.feedback_agreement).toBe(0);
+    expect(m.aggregate.false_positive_rate).toBe(0);
+    expect(m.aggregate.false_negative_rate).toBe(0);
+    expect(Number.isFinite(m.aggregate.feedback_coverage)).toBe(true);
+    expect(Number.isFinite(m.aggregate.feedback_agreement)).toBe(true);
+  });
+});
+
+describe("computeFeedbackIntegrity — NaN safety", () => {
+  test("per-asset row with FP+TN === 0 emits null false_positive_rate (only positive feedback on passes)", () => {
+    const phase1 = {
+      akmRuns: [fakeRun({ taskId: "t", seed: 0, outcome: "pass" }), fakeRun({ taskId: "t", seed: 1, outcome: "pass" })],
+    };
+    const feedbackLog = [
+      fb({ taskId: "t", seed: 0, goldRef: "skill:only-tp", signal: "positive" }),
+      fb({ taskId: "t", seed: 1, goldRef: "skill:only-tp", signal: "positive" }),
+    ];
+    const m = computeFeedbackIntegrity({ phase1, feedbackLog });
+    const row = m.perAsset[0];
+    expect(row.feedback_agreement).toBeCloseTo(1);
+    expect(row.false_positive_rate).toBeNull(); // FP+TN === 0
+    expect(row.false_negative_rate).toBeCloseTo(0); // FN/(FN+TP) = 0/2 = 0
+  });
+
+  test("per-asset row with FN+TP === 0 emits null false_negative_rate (only negative feedback on fails)", () => {
+    const phase1 = {
+      akmRuns: [fakeRun({ taskId: "t", seed: 0, outcome: "fail" }), fakeRun({ taskId: "t", seed: 1, outcome: "fail" })],
+    };
+    const feedbackLog = [
+      fb({ taskId: "t", seed: 0, goldRef: "skill:only-tn", signal: "negative" }),
+      fb({ taskId: "t", seed: 1, goldRef: "skill:only-tn", signal: "negative" }),
+    ];
+    const m = computeFeedbackIntegrity({ phase1, feedbackLog });
+    const row = m.perAsset[0];
+    expect(row.feedback_agreement).toBeCloseTo(1);
+    expect(row.false_negative_rate).toBeNull(); // FN+TP === 0
+    expect(row.false_positive_rate).toBeCloseTo(0); // FP/(FP+TN) = 0/2 = 0
+  });
+
+  test("ok=false feedback events are excluded from the matrix but still count toward coverage", () => {
+    const phase1 = {
+      akmRuns: [fakeRun({ taskId: "t", seed: 0, outcome: "pass" }), fakeRun({ taskId: "t", seed: 1, outcome: "fail" })],
+    };
+    const feedbackLog = [
+      fb({ taskId: "t", seed: 0, goldRef: "skill:a", signal: "positive", ok: true }),
+      fb({ taskId: "t", seed: 1, goldRef: "skill:a", signal: "negative", ok: false }),
+    ];
+    const m = computeFeedbackIntegrity({ phase1, feedbackLog });
+    // Only the ok=true entry contributes to the matrix (TP=1).
+    expect(m.aggregate.truePositive).toBe(1);
+    expect(m.aggregate.trueNegative).toBe(0);
+    // But coverage counts both attempts.
+    expect(m.aggregate.feedback_coverage).toBeCloseTo(1);
+  });
+
+  test("harness_error runs are excluded from the matrix even with a stamped feedback event", () => {
+    const phase1 = { akmRuns: [fakeRun({ taskId: "t", seed: 0, outcome: "harness_error" })] };
+    const feedbackLog = [fb({ taskId: "t", seed: 0, goldRef: "skill:a", signal: "positive" })];
+    const m = computeFeedbackIntegrity({ phase1, feedbackLog });
+    expect(m.aggregate.truePositive).toBe(0);
+    expect(m.aggregate.falsePositive).toBe(0);
+    expect(m.perAsset).toEqual([]);
+  });
+
+  test("feedback for a run not present in akmRuns is silently dropped", () => {
+    const phase1 = { akmRuns: [fakeRun({ taskId: "real", seed: 0, outcome: "pass" })] };
+    const feedbackLog = [fb({ taskId: "ghost", seed: 99, goldRef: "skill:a", signal: "positive" })];
+    const m = computeFeedbackIntegrity({ phase1, feedbackLog });
+    expect(m.aggregate.truePositive).toBe(0);
+    expect(m.perAsset).toEqual([]);
+    // Coverage still records the dispatch attempt — operator wanted feedback.
+    expect(m.aggregate.feedback_coverage).toBeCloseTo(1);
+  });
+});
+
+// ── Render-side coverage ───────────────────────────────────────────────────
+
+function emptyUtilityReport(): import("./report").UtilityRunReport {
+  // Build a minimal §13.3-shaped utility report. The renderer reads
+  // many subfields; we stub them to safe zeros.
+  return {
+    timestamp: "2026-04-27T00:00:00Z",
+    branch: "test",
+    commit: "deadbee",
+    model: "m",
+    corpus: { domains: 0, tasks: 0, slice: "all", seedsPerArm: 1 },
+    aggregateNoakm: { passRate: 0, tokensPerPass: 0, wallclockMs: 0, budgetExceeded: 0 },
+    aggregateAkm: { passRate: 0, tokensPerPass: 0, wallclockMs: 0, budgetExceeded: 0 },
+    aggregateDelta: {
+      passRate: { delta: 0, sign: "neutral" },
+      tokensPerPass: { delta: 0, sign: "neutral" },
+      wallclockMs: { delta: 0, sign: "neutral" },
+    },
+    trajectoryAkm: {
+      assetLoadCorrectness: { correct: 0, incorrect: 0, missing: 0, count: 0, correctRate: 0 },
+      feedbackRecorded: { recorded: 0, notRecorded: 0, count: 0, recordedRate: 0 },
+    },
+    failureModes: { byLabel: {}, byTask: {} },
+    tasks: [],
+    warnings: [],
+    akmRuns: [],
+    taskMetadata: [],
+    goldRankRecords: [],
+  };
+}
+
+function evolveInputWith(metrics: FeedbackIntegrityMetrics | undefined) {
+  return {
+    timestamp: "2026-04-27T00:00:00Z",
+    branch: "test",
+    commit: "deadbee",
+    model: "m",
+    domain: "test",
+    seedsPerArm: 1,
+    proposals: { rows: [], totalProposals: 0, totalAccepted: 0, acceptanceRate: 0, lintPassRate: 0 },
+    longitudinal: {
+      improvementSlope: 0.1,
+      overSyntheticLift: 0.05,
+      degradationCount: 0,
+      degradations: [],
+      prePassRate: 0.5,
+      postPassRate: 0.6,
+      syntheticPassRate: 0.55,
+    },
+    arms: { pre: emptyUtilityReport(), post: emptyUtilityReport(), synthetic: emptyUtilityReport() },
+    warnings: [],
+    ...(metrics ? { feedbackIntegrity: metrics } : {}),
+  };
+}
+
+describe("renderFeedbackIntegrityTable", () => {
+  test("emits aggregate matrix + per-asset rows", () => {
+    const phase1 = {
+      akmRuns: [fakeRun({ taskId: "t", seed: 0, outcome: "pass" }), fakeRun({ taskId: "t", seed: 1, outcome: "fail" })],
+    };
+    const feedbackLog = [
+      fb({ taskId: "t", seed: 0, goldRef: "skill:a", signal: "positive" }),
+      fb({ taskId: "t", seed: 1, goldRef: "skill:a", signal: "negative" }),
+    ];
+    const m = computeFeedbackIntegrity({ phase1, feedbackLog });
+    const md = renderFeedbackIntegrityTable(m);
+    expect(md).toContain("Feedback-signal integrity");
+    expect(md).toContain("feedback_agreement | 1.00");
+    expect(md).toContain("feedback_coverage | 1.00");
+    expect(md).toContain("`skill:a`");
+  });
+
+  test("renders n/a when a per-asset rate is null", () => {
+    const phase1 = { akmRuns: [fakeRun({ taskId: "t", seed: 0, outcome: "pass" })] };
+    const feedbackLog = [fb({ taskId: "t", seed: 0, goldRef: "skill:a", signal: "positive" })];
+    const m = computeFeedbackIntegrity({ phase1, feedbackLog });
+    const md = renderFeedbackIntegrityTable(m);
+    // Only TP — false_positive_rate denom is 0 → null → "n/a".
+    expect(md).toContain("n/a");
+  });
+
+  test("renders 'No feedback events recorded' when perAsset is empty", () => {
+    const m: FeedbackIntegrityMetrics = {
+      aggregate: {
+        truePositive: 0,
+        falsePositive: 0,
+        trueNegative: 0,
+        falseNegative: 0,
+        feedback_agreement: 0,
+        false_positive_rate: 0,
+        false_negative_rate: 0,
+        feedback_coverage: 0,
+      },
+      perAsset: [],
+    };
+    expect(renderFeedbackIntegrityTable(m)).toContain("No feedback events recorded");
+  });
+});
+
+describe("renderEvolveReport — feedback_agreement headline + warning marker", () => {
+  test("places real feedback_agreement after improvement_slope when metrics provided", () => {
+    const metrics = computeFeedbackIntegrity({
+      phase1: { akmRuns: [fakeRun({ taskId: "t", seed: 0, outcome: "pass" })] },
+      feedbackLog: [fb({ taskId: "t", seed: 0, goldRef: "skill:a", signal: "positive" })],
+    });
+    const { markdown, json } = renderEvolveReport(evolveInputWith(metrics));
+    // feedback_agreement is on a line directly after improvement_slope.
+    const slopeIdx = markdown.indexOf("improvement_slope:");
+    const agreementIdx = markdown.indexOf("feedback_agreement:");
+    expect(slopeIdx).toBeGreaterThanOrEqual(0);
+    expect(agreementIdx).toBeGreaterThan(slopeIdx);
+    expect(markdown).toContain("feedback_agreement: 1.00");
+    expect(markdown).not.toContain("pending (#244)");
+    // JSON envelope carries `feedback_integrity` as a top-level key.
+    const parsed = json as { feedback_integrity?: object; warnings: string[] };
+    expect(parsed.feedback_integrity).toBeDefined();
+    expect(parsed.warnings.some((w) => w.startsWith("feedback_agreement_below_threshold"))).toBe(false);
+  });
+
+  test("placeholder remains when metrics omitted (legacy path)", () => {
+    const { markdown, json } = renderEvolveReport(evolveInputWith(undefined));
+    expect(markdown).toContain("_feedback_agreement: pending (#244)_");
+    const parsed = json as { feedback_integrity?: object };
+    expect(parsed.feedback_integrity).toBeUndefined();
+  });
+
+  test("agreement < 0.80 prepends warning marker to markdown and structured warnings[]", () => {
+    // 1 TP + 4 FP → agreement = 1/5 = 0.20.
+    const phase1 = {
+      akmRuns: [
+        fakeRun({ taskId: "t", seed: 0, outcome: "pass" }),
+        fakeRun({ taskId: "t", seed: 1, outcome: "fail" }),
+        fakeRun({ taskId: "t", seed: 2, outcome: "fail" }),
+        fakeRun({ taskId: "t", seed: 3, outcome: "fail" }),
+        fakeRun({ taskId: "t", seed: 4, outcome: "fail" }),
+      ],
+    };
+    const feedbackLog = [
+      fb({ taskId: "t", seed: 0, goldRef: "skill:a", signal: "positive" }),
+      fb({ taskId: "t", seed: 1, goldRef: "skill:a", signal: "positive" }),
+      fb({ taskId: "t", seed: 2, goldRef: "skill:a", signal: "positive" }),
+      fb({ taskId: "t", seed: 3, goldRef: "skill:a", signal: "positive" }),
+      fb({ taskId: "t", seed: 4, goldRef: "skill:a", signal: "positive" }),
+    ];
+    const metrics = computeFeedbackIntegrity({ phase1, feedbackLog });
+    expect(metrics.aggregate.feedback_agreement).toBeCloseTo(0.2);
+    expect(metrics.aggregate.feedback_agreement).toBeLessThan(FEEDBACK_AGREEMENT_WARNING_THRESHOLD);
+
+    const { markdown, json } = renderEvolveReport(evolveInputWith(metrics));
+    // Marker appears above the headline, not after it.
+    const warnIdx = markdown.indexOf("feedback_agreement = 0.20");
+    const slopeIdx = markdown.indexOf("**improvement_slope:");
+    expect(warnIdx).toBeGreaterThanOrEqual(0);
+    expect(warnIdx).toBeLessThan(slopeIdx);
+    expect(markdown).toContain("Track B headline numbers");
+    // Structured warning surfaces in the JSON envelope.
+    const parsed = json as { warnings: string[] };
+    expect(parsed.warnings.some((w) => w.startsWith("feedback_agreement_below_threshold"))).toBe(true);
+  });
+
+  test("agreement at exactly 0.80 does NOT trigger the warning marker", () => {
+    // 4 TP + 1 FP → agreement = 4/5 = 0.80 exactly.
+    const phase1 = {
+      akmRuns: [
+        fakeRun({ taskId: "t", seed: 0, outcome: "pass" }),
+        fakeRun({ taskId: "t", seed: 1, outcome: "pass" }),
+        fakeRun({ taskId: "t", seed: 2, outcome: "pass" }),
+        fakeRun({ taskId: "t", seed: 3, outcome: "pass" }),
+        fakeRun({ taskId: "t", seed: 4, outcome: "fail" }),
+      ],
+    };
+    const feedbackLog = [
+      fb({ taskId: "t", seed: 0, goldRef: "skill:a", signal: "positive" }),
+      fb({ taskId: "t", seed: 1, goldRef: "skill:a", signal: "positive" }),
+      fb({ taskId: "t", seed: 2, goldRef: "skill:a", signal: "positive" }),
+      fb({ taskId: "t", seed: 3, goldRef: "skill:a", signal: "positive" }),
+      fb({ taskId: "t", seed: 4, goldRef: "skill:a", signal: "positive" }),
+    ];
+    const metrics = computeFeedbackIntegrity({ phase1, feedbackLog });
+    expect(metrics.aggregate.feedback_agreement).toBeCloseTo(0.8);
+
+    const { markdown, json } = renderEvolveReport(evolveInputWith(metrics));
+    expect(markdown).not.toContain("Track B headline numbers");
+    const parsed = json as { warnings: string[] };
+    expect(parsed.warnings.some((w) => w.startsWith("feedback_agreement_below_threshold"))).toBe(false);
+  });
+});

--- a/tests/bench/metrics.ts
+++ b/tests/bench/metrics.ts
@@ -1836,3 +1836,211 @@ export function computeLongitudinalMetrics(
     syntheticPassRate,
   };
 }
+
+// ── Feedback-signal integrity (§6.8) ───────────────────────────────────────
+
+/**
+ * Per-asset 2×2 confusion matrix row.
+ *
+ * `feedback_agreement`, `false_positive_rate`, and `false_negative_rate`
+ * are `null` (NaN-safe sentinel) when the relevant denominator is 0 — i.e.
+ * an asset with zero feedback events emits all rates as `null`, never `0`
+ * or `NaN`.
+ */
+export interface FeedbackIntegrityPerAssetRow {
+  ref: string;
+  /** Feedback `+`, run passed. */
+  truePositive: number;
+  /** Feedback `+`, run failed (agent was wrong). */
+  falsePositive: number;
+  /** Feedback `−`, run failed. */
+  trueNegative: number;
+  /** Feedback `−`, run passed. */
+  falseNegative: number;
+  /** `(TP+TN) / total`, or `null` when no feedback events. */
+  feedback_agreement: number | null;
+  /** `FP / (FP+TN)`, or `null` when `FP+TN === 0`. */
+  false_positive_rate: number | null;
+  /** `FN / (FN+TP)`, or `null` when `FN+TP === 0`. */
+  false_negative_rate: number | null;
+}
+
+/**
+ * Aggregate confusion-matrix envelope. The aggregate fields use the same
+ * NaN-safe rules as per-asset, except `feedback_coverage` which is always
+ * a finite number in `[0, 1]` (denominator is total Phase 1 runs; a
+ * caller with zero runs gets `0`).
+ */
+export interface FeedbackIntegrityAggregate {
+  truePositive: number;
+  falsePositive: number;
+  trueNegative: number;
+  falseNegative: number;
+  feedback_agreement: number;
+  false_positive_rate: number;
+  false_negative_rate: number;
+  /** (Phase-1 runs with any feedback dispatched) / (total Phase 1 runs). */
+  feedback_coverage: number;
+}
+
+/** §6.8 envelope: aggregate matrix + per-asset breakdown. */
+export interface FeedbackIntegrityMetrics {
+  aggregate: FeedbackIntegrityAggregate;
+  perAsset: FeedbackIntegrityPerAssetRow[];
+}
+
+/**
+ * Inputs to `computeFeedbackIntegrity`.
+ *
+ * `phase1` is the Phase 1 utility report (akm arm, train slice). Each
+ * `phase1.akmRuns[i]` carries `taskId`, `seed`, and `outcome`. The bench's
+ * Phase 1 dispatches at most one feedback event per run (positive on pass,
+ * negative on fail; harness_error runs are skipped). `feedbackLog[i]` is
+ * the dispatched record carrying `taskId`, `seed`, `goldRef`, and the
+ * dispatched `signal`.
+ *
+ * Attribution rule (§6.8): each `feedbackLog` entry is joined to the run
+ * with the matching `(taskId, seed)`. The run's `outcome` (NOT the asset's
+ * later state) decides the matrix cell. Runs whose feedback failed to
+ * dispatch (`feedbackLog[i].ok === false`) are excluded from the matrix
+ * but still count toward `feedback_coverage` denominators only when they
+ * appear in `phase1.akmRuns`. Specifically, a feedback event that the
+ * runner *attempted* to dispatch counts against `feedback_coverage` — but
+ * if it failed (ok=false) it is not labelled into TP/FP/TN/FN. This
+ * mirrors how the runner treats the dispatch as best-effort.
+ */
+export interface FeedbackIntegrityInput {
+  /**
+   * Phase 1 utility report. Only `akmRuns` is consulted (each carries
+   * `taskId`, `seed`, `outcome`).
+   */
+  phase1: { akmRuns?: RunResult[] };
+  /**
+   * Phase 1 feedback dispatch log produced by the runner. Each entry
+   * carries `taskId`, `seed`, `goldRef`, the dispatched `signal`, and a
+   * boolean `ok` (true iff the akm CLI exited 0).
+   */
+  feedbackLog: Array<{
+    taskId: string;
+    seed: number;
+    goldRef: string;
+    signal: "positive" | "negative";
+    ok: boolean;
+  }>;
+}
+
+/**
+ * Compute the §6.8 feedback-signal integrity confusion matrix.
+ *
+ * Pure function — does not touch disk and does not invoke any subprocess.
+ * The join is by `(taskId, seed)` so that a feedback event is attributed
+ * to the run that produced it, NOT to a later run that happens to touch
+ * the same gold ref. This matters when the same gold ref appears across
+ * multiple Phase 1 runs (e.g. multiple seeds, or two tasks sharing a
+ * skill); the per-asset row aggregates across all runs that referenced it
+ * in feedback, but each individual feedback event's matrix cell is
+ * decided by its own run's outcome.
+ *
+ * NaN-safety: a per-asset row with zero feedback events (cannot happen via
+ * this function — every row is derived from at least one feedback entry —
+ * but defensive against future callers passing curated subsets) emits all
+ * three rates as `null`. `false_positive_rate` is `null` when `FP+TN===0`
+ * even if the row has `FN+TP>0`, and vice versa.
+ */
+export function computeFeedbackIntegrity(input: FeedbackIntegrityInput): FeedbackIntegrityMetrics {
+  const akmRuns = input.phase1.akmRuns ?? [];
+  // Build a (taskId, seed) → outcome lookup so every feedback event
+  // resolves in O(1). When two runs share the same key (shouldn't happen
+  // — runner emits unique seeds per task — but defensive) the first
+  // wins.
+  const runOutcomeByKey = new Map<string, RunResult["outcome"]>();
+  for (const r of akmRuns) {
+    const key = `${r.taskId}::${r.seed}`;
+    if (!runOutcomeByKey.has(key)) runOutcomeByKey.set(key, r.outcome);
+  }
+
+  // Per-asset accumulator. We key on goldRef.
+  interface AssetCounts {
+    truePositive: number;
+    falsePositive: number;
+    trueNegative: number;
+    falseNegative: number;
+  }
+  const perRef = new Map<string, AssetCounts>();
+  let aggTP = 0;
+  let aggFP = 0;
+  let aggTN = 0;
+  let aggFN = 0;
+
+  // Track which (taskId, seed) keys had any feedback dispatched (ok or
+  // not), for the coverage denominator. We count an attempted dispatch as
+  // covered — if `ok===false`, the operator wanted feedback but the CLI
+  // failed; that's still a covered run for the purpose of §6.8 (and is
+  // surfaced in the warnings list elsewhere).
+  const coveredKeys = new Set<string>();
+
+  for (const fb of input.feedbackLog) {
+    const key = `${fb.taskId}::${fb.seed}`;
+    coveredKeys.add(key);
+    if (!fb.ok) continue; // failed dispatches don't label a matrix cell.
+    const outcome = runOutcomeByKey.get(key);
+    if (outcome === undefined) continue; // run not found — defensive, drop.
+    // harness_error runs are not labelled (the bench skips dispatching
+    // feedback for them; if a fake test injects one, we drop it from the
+    // matrix to avoid mislabelling).
+    if (outcome === "harness_error") continue;
+    const passed = outcome === "pass";
+
+    let row = perRef.get(fb.goldRef);
+    if (!row) {
+      row = { truePositive: 0, falsePositive: 0, trueNegative: 0, falseNegative: 0 };
+      perRef.set(fb.goldRef, row);
+    }
+    if (fb.signal === "positive" && passed) {
+      row.truePositive += 1;
+      aggTP += 1;
+    } else if (fb.signal === "positive" && !passed) {
+      row.falsePositive += 1;
+      aggFP += 1;
+    } else if (fb.signal === "negative" && !passed) {
+      row.trueNegative += 1;
+      aggTN += 1;
+    } else if (fb.signal === "negative" && passed) {
+      row.falseNegative += 1;
+      aggFN += 1;
+    }
+  }
+
+  const aggTotal = aggTP + aggFP + aggTN + aggFN;
+  const totalPhase1Runs = akmRuns.length;
+
+  const aggregate: FeedbackIntegrityAggregate = {
+    truePositive: aggTP,
+    falsePositive: aggFP,
+    trueNegative: aggTN,
+    falseNegative: aggFN,
+    feedback_agreement: aggTotal === 0 ? 0 : (aggTP + aggTN) / aggTotal,
+    false_positive_rate: aggFP + aggTN === 0 ? 0 : aggFP / (aggFP + aggTN),
+    false_negative_rate: aggFN + aggTP === 0 ? 0 : aggFN / (aggFN + aggTP),
+    feedback_coverage: totalPhase1Runs === 0 ? 0 : coveredKeys.size / totalPhase1Runs,
+  };
+
+  const perAsset: FeedbackIntegrityPerAssetRow[] = [];
+  for (const [ref, row] of [...perRef.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    const total = row.truePositive + row.falsePositive + row.trueNegative + row.falseNegative;
+    const fpDenom = row.falsePositive + row.trueNegative;
+    const fnDenom = row.falseNegative + row.truePositive;
+    perAsset.push({
+      ref,
+      truePositive: row.truePositive,
+      falsePositive: row.falsePositive,
+      trueNegative: row.trueNegative,
+      falseNegative: row.falseNegative,
+      feedback_agreement: total === 0 ? null : (row.truePositive + row.trueNegative) / total,
+      false_positive_rate: fpDenom === 0 ? null : row.falsePositive / fpDenom,
+      false_negative_rate: fnDenom === 0 ? null : row.falseNegative / fnDenom,
+    });
+  }
+
+  return { aggregate, perAsset };
+}

--- a/tests/bench/metrics.ts
+++ b/tests/bench/metrics.ts
@@ -1658,3 +1658,181 @@ function percentile(ranks: Array<number | null>, p: number): number {
   const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
   return sorted[idx];
 }
+
+// ── Proposal-quality metrics (§6.3) ────────────────────────────────────────
+
+/**
+ * One proposal-lifecycle entry recorded by the evolve runner. The runner
+ * collects these as it walks the queue produced by `akm distill` and `akm
+ * reflect`. Each event captures the proposal id, its source asset ref, the
+ * proposal kind (lesson vs revision), the lint outcome, and whether it was
+ * accepted or rejected.
+ */
+export interface ProposalLogEntry {
+  proposalId: string;
+  /** Asset ref the proposal targets (the ref passed to distill/reflect). */
+  assetRef: string;
+  kind: "lesson" | "revision" | "unknown";
+  /** Whether `akm proposal show --json` reported `lint_pass: true`. */
+  lintPass: boolean;
+  /** Terminal state. `accept` if the runner ran `proposal accept`; `reject` otherwise. */
+  decision: "accept" | "reject";
+  /** Reason recorded on rejection (lint failure detail, etc.). Empty on accept. */
+  rejectReason?: string;
+}
+
+/** Per-asset row in the proposal-quality table (§6.3). */
+export interface ProposalQualityRow {
+  assetRef: string;
+  proposalCount: number;
+  lintPassCount: number;
+  acceptedCount: number;
+}
+
+/** Aggregate proposal-quality metrics (§6.3). */
+export interface ProposalQualityMetrics {
+  rows: ProposalQualityRow[];
+  totalProposals: number;
+  totalAccepted: number;
+  /** `accepted / proposals`. `0` when there are no proposals. */
+  acceptanceRate: number;
+  /** `lint_pass / proposals`. `0` when there are no proposals. */
+  lintPassRate: number;
+}
+
+/**
+ * Aggregate proposal-quality metrics from the evolve runner's proposal log.
+ * Pure function — does not touch disk and does not invoke any subprocess.
+ */
+export function computeProposalQualityMetrics(proposalLog: ProposalLogEntry[]): ProposalQualityMetrics {
+  const byRef = new Map<string, ProposalQualityRow>();
+  let totalAccepted = 0;
+  let totalLintPass = 0;
+  for (const entry of proposalLog) {
+    let row = byRef.get(entry.assetRef);
+    if (!row) {
+      row = { assetRef: entry.assetRef, proposalCount: 0, lintPassCount: 0, acceptedCount: 0 };
+      byRef.set(entry.assetRef, row);
+    }
+    row.proposalCount += 1;
+    if (entry.lintPass) {
+      row.lintPassCount += 1;
+      totalLintPass += 1;
+    }
+    if (entry.decision === "accept") {
+      row.acceptedCount += 1;
+      totalAccepted += 1;
+    }
+  }
+  const rows = [...byRef.values()].sort((a, b) => a.assetRef.localeCompare(b.assetRef));
+  const totalProposals = proposalLog.length;
+  return {
+    rows,
+    totalProposals,
+    totalAccepted,
+    acceptanceRate: totalProposals === 0 ? 0 : totalAccepted / totalProposals,
+    lintPassRate: totalProposals === 0 ? 0 : totalLintPass / totalProposals,
+  };
+}
+
+// ── Longitudinal metrics (§6.4) ────────────────────────────────────────────
+
+/** Per-task longitudinal degradation row. */
+export interface DegradationRow {
+  taskId: string;
+  prePassRate: number;
+  postPassRate: number;
+  delta: number;
+  /** Failure-mode label for the post arm if the task failed (for §6.6 cross-link). */
+  failureMode: FailureMode | null;
+}
+
+/** Longitudinal metrics envelope (§6.4). */
+export interface LongitudinalMetrics {
+  /** `pass_rate(post) - pass_rate(pre)`, akm arm of each report. */
+  improvementSlope: number;
+  /** `pass_rate(post) - pass_rate(synthetic)`. */
+  overSyntheticLift: number;
+  /**
+   * Number of eval tasks where pass_rate(post) < pass_rate(pre) by more than
+   * 1 seed (i.e. `pre - post > 1 / seedsPerArm`). Lists the offending tasks
+   * with their post-arm failureMode label.
+   */
+  degradationCount: number;
+  degradations: DegradationRow[];
+  /** Echo of the pre / post / synthetic akm pass rates for the report header. */
+  prePassRate: number;
+  postPassRate: number;
+  syntheticPassRate: number;
+}
+
+/**
+ * Compute longitudinal metrics from three §13.3 utility-shaped reports. Each
+ * input report is expected to share the same eval-slice corpus, with one arm
+ * driving the akm side: `pre` = pre-evolve stash, `post` = evolved stash,
+ * `synthetic` = no-stash scratchpad arm.
+ *
+ * The "arm" we read off each report is `aggregateAkm.passRate` — the runners
+ * produce the akm arm for all three (synthetic is just the akm arm with a
+ * stripped stashDir; pre/post differ by stash content). `seedsPerArm` for
+ * the degradation threshold is taken from the post report's corpus envelope.
+ */
+export function computeLongitudinalMetrics(
+  preReport: UtilityRunReport,
+  postReport: UtilityRunReport,
+  syntheticReport: UtilityRunReport,
+): LongitudinalMetrics {
+  const prePassRate = preReport.aggregateAkm.passRate;
+  const postPassRate = postReport.aggregateAkm.passRate;
+  const syntheticPassRate = syntheticReport.aggregateAkm.passRate;
+
+  const seedsPerArm = Math.max(1, postReport.corpus.seedsPerArm);
+  const oneSeedFraction = 1 / seedsPerArm;
+
+  // Per-task degradation: outer-join pre and post on task id.
+  const preTasks = new Map<string, UtilityRunReport["tasks"][number]>();
+  for (const t of preReport.tasks) preTasks.set(t.id, t);
+  const postTasks = new Map<string, UtilityRunReport["tasks"][number]>();
+  for (const t of postReport.tasks) postTasks.set(t.id, t);
+
+  // Index post failure-mode labels by task id (one mode per task — first
+  // failed run wins; matches the §6.6 by-task aggregate's natural ordering).
+  const postFailureByTask: Record<string, FailureMode | undefined> = {};
+  const postFailureByTaskMap = postReport.failureModes?.byTask ?? {};
+  for (const [taskId, byMode] of Object.entries(postFailureByTaskMap)) {
+    const labels = Object.keys(byMode) as FailureMode[];
+    if (labels.length > 0) postFailureByTask[taskId] = labels[0];
+  }
+
+  const degradations: DegradationRow[] = [];
+  const allIds = new Set<string>();
+  for (const id of preTasks.keys()) allIds.add(id);
+  for (const id of postTasks.keys()) allIds.add(id);
+  for (const id of [...allIds].sort()) {
+    const pre = preTasks.get(id);
+    const post = postTasks.get(id);
+    if (!pre || !post) continue;
+    const preRate = pre.akm.passRate;
+    const postRate = post.akm.passRate;
+    const dropped = preRate - postRate;
+    if (dropped > oneSeedFraction) {
+      degradations.push({
+        taskId: id,
+        prePassRate: preRate,
+        postPassRate: postRate,
+        delta: postRate - preRate,
+        failureMode: postFailureByTask[id] ?? null,
+      });
+    }
+  }
+
+  return {
+    improvementSlope: postPassRate - prePassRate,
+    overSyntheticLift: postPassRate - syntheticPassRate,
+    degradationCount: degradations.length,
+    degradations,
+    prePassRate,
+    postPassRate,
+    syntheticPassRate,
+  };
+}

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -25,9 +25,11 @@ import type {
   FailureMode,
   FailureModeAggregate,
   GoldRankRunRecord,
+  LongitudinalMetrics,
   OutcomeAggregate,
   PerAssetAttribution,
   PerTaskMetrics,
+  ProposalQualityMetrics,
   SearchBridgeMetrics,
   TrajectoryAggregate,
 } from "./metrics";
@@ -693,4 +695,191 @@ function tryGit(args: string[], cwd?: string): string {
   } catch {
     return "unknown";
   }
+}
+
+// ── Evolve-track report (§6.3 + §6.4) ──────────────────────────────────────
+
+/**
+ * Top-level evolve report shape. Mirrors `EvolveRunReport` from `evolve.ts`
+ * — re-declared here as a structural subtype so report.ts has no cycle on
+ * evolve.ts.
+ */
+export interface EvolveReportInput {
+  timestamp: string;
+  branch: string;
+  commit: string;
+  model: string;
+  domain: string;
+  seedsPerArm: number;
+  proposals: ProposalQualityMetrics;
+  longitudinal: LongitudinalMetrics;
+  arms: { pre: UtilityRunReport; post: UtilityRunReport; synthetic: UtilityRunReport };
+  warnings: string[];
+}
+
+/**
+ * Render an evolve run as the §6.3+§6.4 JSON envelope plus a markdown
+ * summary. Mirrors `renderUtilityReport` — caller wires stdout/stderr.
+ */
+export function renderEvolveReport(input: EvolveReportInput): { json: object; markdown: string } {
+  const json = buildEvolveJson(input);
+  const markdown = buildEvolveMarkdown(input);
+  return { json, markdown };
+}
+
+function buildEvolveJson(input: EvolveReportInput): object {
+  // For each arm we re-render the §13.3 utility envelope so downstream
+  // consumers can treat each arm exactly like a `bench utility` artefact.
+  const armEnvelope = (r: UtilityRunReport): object => buildUtilityJson(r);
+
+  return {
+    schemaVersion: 1,
+    track: "evolve",
+    branch: input.branch,
+    commit: input.commit,
+    timestamp: input.timestamp,
+    agent: { harness: "opencode", model: input.model },
+    corpus: {
+      domain: input.domain,
+      seedsPerArm: input.seedsPerArm,
+    },
+    proposals: {
+      total_proposals: input.proposals.totalProposals,
+      total_accepted: input.proposals.totalAccepted,
+      acceptance_rate: input.proposals.acceptanceRate,
+      lint_pass_rate: input.proposals.lintPassRate,
+      rows: input.proposals.rows.map((r) => ({
+        asset_ref: r.assetRef,
+        proposal_count: r.proposalCount,
+        lint_pass_count: r.lintPassCount,
+        accepted_count: r.acceptedCount,
+      })),
+    },
+    longitudinal: {
+      improvement_slope: input.longitudinal.improvementSlope,
+      over_synthetic_lift: input.longitudinal.overSyntheticLift,
+      degradation_count: input.longitudinal.degradationCount,
+      pre_pass_rate: input.longitudinal.prePassRate,
+      post_pass_rate: input.longitudinal.postPassRate,
+      synthetic_pass_rate: input.longitudinal.syntheticPassRate,
+      degradations: input.longitudinal.degradations.map((d) => ({
+        task_id: d.taskId,
+        pre_pass_rate: d.prePassRate,
+        post_pass_rate: d.postPassRate,
+        delta: d.delta,
+        failure_mode: d.failureMode,
+      })),
+    },
+    arms: {
+      pre: armEnvelope(input.arms.pre),
+      post: armEnvelope(input.arms.post),
+      synthetic: armEnvelope(input.arms.synthetic),
+    },
+    perAsset: input.arms.post.perAsset
+      ? {
+          total_akm_runs: input.arms.post.perAsset.totalAkmRuns,
+          rows: input.arms.post.perAsset.rows.map((r) => ({
+            asset_ref: r.assetRef,
+            load_count: r.loadCount,
+            load_count_passing: r.loadCountPassing,
+            load_count_failing: r.loadCountFailing,
+            load_pass_rate: r.loadPassRate,
+          })),
+        }
+      : { total_akm_runs: 0, rows: [] },
+    failure_modes: {
+      by_label: input.arms.post.failureModes.byLabel,
+      by_task: input.arms.post.failureModes.byTask,
+    },
+    ...(input.arms.post.searchBridge ? { searchBridge: serialiseSearchBridge(input.arms.post.searchBridge) } : {}),
+    warnings: input.warnings,
+  };
+}
+
+function buildEvolveMarkdown(input: EvolveReportInput): string {
+  const lines: string[] = [];
+  lines.push(`# akm-bench evolve — ${input.model}`);
+  lines.push("");
+  lines.push(`branch \`${input.branch}\` @ \`${input.commit}\` — ${input.timestamp}`);
+  lines.push(`corpus: domain=\`${input.domain}\`, seedsPerArm=${input.seedsPerArm}`);
+  lines.push("");
+  // Headline: improvement_slope.
+  lines.push(
+    `**improvement_slope: ${signedFixed(input.longitudinal.improvementSlope, 2)}** (post=${input.longitudinal.postPassRate.toFixed(2)}, pre=${input.longitudinal.prePassRate.toFixed(2)})`,
+  );
+  // Second line: feedback_agreement placeholder for #244.
+  lines.push("_feedback_agreement: pending (#244)_");
+  lines.push("");
+
+  lines.push("## Longitudinal");
+  lines.push("");
+  lines.push("| metric | value |");
+  lines.push("|--------|-------|");
+  lines.push(`| improvement_slope | ${signedFixed(input.longitudinal.improvementSlope, 2)} |`);
+  lines.push(`| over_synthetic_lift | ${signedFixed(input.longitudinal.overSyntheticLift, 2)} |`);
+  lines.push(`| degradation_count | ${input.longitudinal.degradationCount} |`);
+  lines.push(`| pre_pass_rate | ${input.longitudinal.prePassRate.toFixed(2)} |`);
+  lines.push(`| post_pass_rate | ${input.longitudinal.postPassRate.toFixed(2)} |`);
+  lines.push(`| synthetic_pass_rate | ${input.longitudinal.syntheticPassRate.toFixed(2)} |`);
+  lines.push("");
+
+  if (input.longitudinal.degradations.length > 0) {
+    lines.push("### Degradations");
+    lines.push("");
+    lines.push("| task | pre | post | delta | failure_mode |");
+    lines.push("|------|-----|------|-------|--------------|");
+    for (const d of input.longitudinal.degradations) {
+      lines.push(
+        `| ${d.taskId} | ${d.prePassRate.toFixed(2)} | ${d.postPassRate.toFixed(2)} | ${signedFixed(d.delta, 2)} | ${d.failureMode ?? "n/a"} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  lines.push("## Proposals");
+  lines.push("");
+  lines.push(
+    `acceptance_rate=${input.proposals.acceptanceRate.toFixed(2)}, lint_pass_rate=${input.proposals.lintPassRate.toFixed(2)}, total=${input.proposals.totalProposals}`,
+  );
+  lines.push("");
+  if (input.proposals.rows.length > 0) {
+    lines.push("| asset_ref | proposals | lint_pass | accepted |");
+    lines.push("|-----------|-----------|-----------|----------|");
+    for (const row of input.proposals.rows) {
+      lines.push(`| \`${row.assetRef}\` | ${row.proposalCount} | ${row.lintPassCount} | ${row.acceptedCount} |`);
+    }
+    lines.push("");
+  } else {
+    lines.push("_No proposals generated._");
+    lines.push("");
+  }
+
+  lines.push("## Per-task pre → post → synthetic");
+  lines.push("");
+  lines.push("| task | pre | post | synthetic | post − pre |");
+  lines.push("|------|-----|------|-----------|------------|");
+  const preTasks = new Map<string, UtilityReportTaskEntry>();
+  for (const t of input.arms.pre.tasks) preTasks.set(t.id, t);
+  const postTasks = new Map<string, UtilityReportTaskEntry>();
+  for (const t of input.arms.post.tasks) postTasks.set(t.id, t);
+  const synthTasks = new Map<string, UtilityReportTaskEntry>();
+  for (const t of input.arms.synthetic.tasks) synthTasks.set(t.id, t);
+  const allIds = new Set<string>([...preTasks.keys(), ...postTasks.keys(), ...synthTasks.keys()]);
+  for (const id of [...allIds].sort()) {
+    const pre = preTasks.get(id)?.akm.passRate;
+    const post = postTasks.get(id)?.akm.passRate;
+    const synth = synthTasks.get(id)?.akm.passRate;
+    const delta = pre !== undefined && post !== undefined ? signedFixed(post - pre, 2) : "n/a";
+    lines.push(
+      `| ${id} | ${pre === undefined ? "n/a" : pre.toFixed(2)} | ${post === undefined ? "n/a" : post.toFixed(2)} | ${synth === undefined ? "n/a" : synth.toFixed(2)} | ${delta} |`,
+    );
+  }
+
+  if (input.warnings.length > 0) {
+    lines.push("");
+    lines.push("## Warnings");
+    lines.push("");
+    for (const w of input.warnings) lines.push(`- ${w}`);
+  }
+  return lines.join("\n");
 }

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -24,6 +24,7 @@ import type {
   DeltaSign,
   FailureMode,
   FailureModeAggregate,
+  FeedbackIntegrityMetrics,
   GoldRankRunRecord,
   LongitudinalMetrics,
   OutcomeAggregate,
@@ -713,9 +714,26 @@ export interface EvolveReportInput {
   seedsPerArm: number;
   proposals: ProposalQualityMetrics;
   longitudinal: LongitudinalMetrics;
+  /**
+   * Feedback-signal integrity 2x2 confusion matrix (§6.8). When omitted,
+   * the markdown summary surfaces the legacy `_feedback_agreement: pending_`
+   * placeholder; the JSON envelope omits the `feedback_integrity` key so
+   * older artefacts remain valid.
+   */
+  feedbackIntegrity?: FeedbackIntegrityMetrics;
   arms: { pre: UtilityRunReport; post: UtilityRunReport; synthetic: UtilityRunReport };
   warnings: string[];
 }
+
+/**
+ * Threshold below which the markdown summary prepends a warning marker
+ * and the JSON envelope's `warnings[]` carries a structured
+ * `feedback_agreement_below_threshold` entry. Track B's headline numbers
+ * (`improvement_slope`, `over_synthetic_lift`) are unreliable when
+ * Phase 1 feedback disagrees with run outcomes more than 20% of the
+ * time. Spec §6.8.
+ */
+export const FEEDBACK_AGREEMENT_WARNING_THRESHOLD = 0.8;
 
 /**
  * Render an evolve run as the §6.3+§6.4 JSON envelope plus a markdown
@@ -731,6 +749,18 @@ function buildEvolveJson(input: EvolveReportInput): object {
   // For each arm we re-render the §13.3 utility envelope so downstream
   // consumers can treat each arm exactly like a `bench utility` artefact.
   const armEnvelope = (r: UtilityRunReport): object => buildUtilityJson(r);
+
+  // §6.8 — derive an additive `warnings[]` entry when the headline
+  // feedback_agreement falls below the trust threshold.
+  const augmentedWarnings: string[] = [...input.warnings];
+  if (input.feedbackIntegrity) {
+    const agreement = input.feedbackIntegrity.aggregate.feedback_agreement;
+    if (agreement < FEEDBACK_AGREEMENT_WARNING_THRESHOLD) {
+      augmentedWarnings.push(
+        `feedback_agreement_below_threshold: ${agreement.toFixed(2)} < ${FEEDBACK_AGREEMENT_WARNING_THRESHOLD.toFixed(2)} — Track B headline numbers (improvement_slope, over_synthetic_lift) may be unreliable until AGENTS.md guidance for \`akm feedback\` is tightened.`,
+      );
+    }
+  }
 
   return {
     schemaVersion: 1,
@@ -792,8 +822,76 @@ function buildEvolveJson(input: EvolveReportInput): object {
       by_task: input.arms.post.failureModes.byTask,
     },
     ...(input.arms.post.searchBridge ? { searchBridge: serialiseSearchBridge(input.arms.post.searchBridge) } : {}),
-    warnings: input.warnings,
+    ...(input.feedbackIntegrity ? { feedback_integrity: serialiseFeedbackIntegrity(input.feedbackIntegrity) } : {}),
+    warnings: augmentedWarnings,
   };
+}
+
+/** §6.8 — flatten the FeedbackIntegrityMetrics envelope into JSON. */
+function serialiseFeedbackIntegrity(metrics: FeedbackIntegrityMetrics): object {
+  return {
+    aggregate: {
+      truePositive: metrics.aggregate.truePositive,
+      falsePositive: metrics.aggregate.falsePositive,
+      trueNegative: metrics.aggregate.trueNegative,
+      falseNegative: metrics.aggregate.falseNegative,
+      feedback_agreement: metrics.aggregate.feedback_agreement,
+      false_positive_rate: metrics.aggregate.false_positive_rate,
+      false_negative_rate: metrics.aggregate.false_negative_rate,
+      feedback_coverage: metrics.aggregate.feedback_coverage,
+    },
+    perAsset: metrics.perAsset.map((row) => ({
+      ref: row.ref,
+      truePositive: row.truePositive,
+      falsePositive: row.falsePositive,
+      trueNegative: row.trueNegative,
+      falseNegative: row.falseNegative,
+      feedback_agreement: row.feedback_agreement,
+      false_positive_rate: row.false_positive_rate,
+      false_negative_rate: row.false_negative_rate,
+    })),
+  };
+}
+
+/**
+ * Render the §6.8 confusion-matrix table — aggregate 2×2 followed by
+ * per-asset breakdown. Used by `renderEvolveReport`'s markdown body and
+ * exported for tests.
+ */
+export function renderFeedbackIntegrityTable(metrics: FeedbackIntegrityMetrics): string {
+  const lines: string[] = [];
+  const agg = metrics.aggregate;
+  lines.push("## Feedback-signal integrity");
+  lines.push("");
+  lines.push("|              | run passed | run failed |");
+  lines.push("|--------------|-----------:|-----------:|");
+  lines.push(`| feedback +   | ${agg.truePositive} (TP) | ${agg.falsePositive} (FP) |`);
+  lines.push(`| feedback -   | ${agg.falseNegative} (FN) | ${agg.trueNegative} (TN) |`);
+  lines.push("");
+  lines.push("| metric | value |");
+  lines.push("|--------|-------|");
+  lines.push(`| feedback_agreement | ${agg.feedback_agreement.toFixed(2)} |`);
+  lines.push(`| false_positive_rate | ${agg.false_positive_rate.toFixed(2)} |`);
+  lines.push(`| false_negative_rate | ${agg.false_negative_rate.toFixed(2)} |`);
+  lines.push(`| feedback_coverage | ${agg.feedback_coverage.toFixed(2)} |`);
+  lines.push("");
+  if (metrics.perAsset.length > 0) {
+    lines.push("| ref | TP | FP | TN | FN | agreement | FP rate | FN rate |");
+    lines.push("|-----|----|----|----|----|-----------|---------|---------|");
+    for (const row of metrics.perAsset) {
+      lines.push(
+        `| \`${row.ref}\` | ${row.truePositive} | ${row.falsePositive} | ${row.trueNegative} | ${row.falseNegative} | ${formatNullableRate(row.feedback_agreement)} | ${formatNullableRate(row.false_positive_rate)} | ${formatNullableRate(row.false_negative_rate)} |`,
+      );
+    }
+  } else {
+    lines.push("_No feedback events recorded._");
+  }
+  return lines.join("\n");
+}
+
+function formatNullableRate(value: number | null): string {
+  if (value === null) return "n/a";
+  return value.toFixed(2);
 }
 
 function buildEvolveMarkdown(input: EvolveReportInput): string {
@@ -803,12 +901,32 @@ function buildEvolveMarkdown(input: EvolveReportInput): string {
   lines.push(`branch \`${input.branch}\` @ \`${input.commit}\` — ${input.timestamp}`);
   lines.push(`corpus: domain=\`${input.domain}\`, seedsPerArm=${input.seedsPerArm}`);
   lines.push("");
+
+  // §6.8 warning marker — prepended above the headline so operators can't
+  // miss it. We also still surface the structured warning in `warnings[]`.
+  if (
+    input.feedbackIntegrity &&
+    input.feedbackIntegrity.aggregate.feedback_agreement < FEEDBACK_AGREEMENT_WARNING_THRESHOLD
+  ) {
+    lines.push(
+      `:warning: feedback_agreement = ${input.feedbackIntegrity.aggregate.feedback_agreement.toFixed(2)} — Track B headline numbers (improvement_slope, over_synthetic_lift) may be unreliable until AGENTS.md guidance for \`akm feedback\` is tightened.`,
+    );
+    lines.push("");
+  }
+
   // Headline: improvement_slope.
   lines.push(
     `**improvement_slope: ${signedFixed(input.longitudinal.improvementSlope, 2)}** (post=${input.longitudinal.postPassRate.toFixed(2)}, pre=${input.longitudinal.prePassRate.toFixed(2)})`,
   );
-  // Second line: feedback_agreement placeholder for #244.
-  lines.push("_feedback_agreement: pending (#244)_");
+  // Second line: real feedback_agreement (per #244), or placeholder when
+  // metrics not supplied.
+  if (input.feedbackIntegrity) {
+    lines.push(
+      `**feedback_agreement: ${input.feedbackIntegrity.aggregate.feedback_agreement.toFixed(2)}** (coverage=${input.feedbackIntegrity.aggregate.feedback_coverage.toFixed(2)})`,
+    );
+  } else {
+    lines.push("_feedback_agreement: pending (#244)_");
+  }
   lines.push("");
 
   lines.push("## Longitudinal");
@@ -873,6 +991,11 @@ function buildEvolveMarkdown(input: EvolveReportInput): string {
     lines.push(
       `| ${id} | ${pre === undefined ? "n/a" : pre.toFixed(2)} | ${post === undefined ? "n/a" : post.toFixed(2)} | ${synth === undefined ? "n/a" : synth.toFixed(2)} | ${delta} |`,
     );
+  }
+
+  if (input.feedbackIntegrity) {
+    lines.push("");
+    lines.push(renderFeedbackIntegrityTable(input.feedbackIntegrity));
   }
 
   if (input.warnings.length > 0) {

--- a/tests/bench/runner.ts
+++ b/tests/bench/runner.ts
@@ -75,6 +75,16 @@ export interface RunUtilityOptions {
    * Defaults to `true`.
    */
   materialiseStash?: boolean;
+  /**
+   * Optional override map keyed by `task.stash` (fixture name). When provided,
+   * the runner skips per-task `loadFixtureStash` and forwards the supplied
+   * directory as `AKM_STASH_DIR` for the akm arm of every task whose
+   * `task.stash` is in the map. Used by `runEvolve` so a single
+   * pre-materialised stash persists across Phase 1 / Phase 2 / Phase 3.
+   * When set, `materialiseStash` is ignored for tasks whose fixture is
+   * present in this map.
+   */
+  stashDirByFixture?: Map<string, string>;
 }
 
 /** Internal: raw run records grouped by (taskId, arm). */
@@ -110,12 +120,17 @@ export async function runUtility(options: RunUtilityOptions): Promise<UtilityRun
     const taskRuns = new Map<Arm, RunResult[]>();
     grouped.set(task.id, taskRuns);
 
+    // Resolve a caller-supplied stash override before materialising. When
+    // `stashDirByFixture` provides a directory for this task's fixture, we
+    // skip `loadFixtureStash` entirely and forward the override.
+    const overrideStashDir = options.stashDirByFixture?.get(task.stash);
+
     // Materialise the akm-arm stash once per task. We share it across the K
     // seeds because the stash content is identical and re-running `akm
     // index` for every seed is wasted work.
     let stash: LoadedFixtureStash | undefined;
     let stashError: string | undefined;
-    if (options.arms.includes("akm") && materialiseStash) {
+    if (options.arms.includes("akm") && materialiseStash && !overrideStashDir) {
       try {
         stash = loadFixtureStash(task.stash, { skipIndex: true });
       } catch (err) {
@@ -137,7 +152,8 @@ export async function runUtility(options: RunUtilityOptions): Promise<UtilityRun
           // stable placeholder so the env keys are wired correctly.
           let stashDir: string | undefined;
           if (arm === "akm") {
-            if (stash) stashDir = stash.stashDir;
+            if (overrideStashDir) stashDir = overrideStashDir;
+            else if (stash) stashDir = stash.stashDir;
             else if (!materialiseStash) stashDir = path.join(task.taskDir, "__no-stash__");
           }
           const run = await runOneIsolated({


### PR DESCRIPTION
## Summary

Final wave of the `akm-bench` rollout (umbrella tracker #234, milestone `akm-bench`). Lands the Track B longitudinal evolution loop (#243) and the feedback-signal integrity confusion matrix (#244) that gates trust in #243's headline numbers. Bundled into one PR so the integrity check ships alongside the loop it protects.

| Issue | Branch | Title |
|---|---|---|
| #243 | `issue-243-bench-evolve` | feat(bench): three-phase Track B runner with synthetic arm and longitudinal metrics |
| #244 | `issue-244-feedback-integrity` | feat(bench): feedback-signal integrity confusion matrix |

Closes #243, #244. **This is the final implementation PR for the akm-bench v1 rollout** — once merged, the planning doc `docs/technical/benchmark.md` is fully realized in code.

## Why these two together

#244's role is to protect #243's `improvement_slope` headline. If the agent's `akm feedback ±` calls don't agree with verifier outcomes, the distill input is noise and Track B's lift number is unreliable. Per spec §6.8 the `feedback_agreement` number is placed immediately after `improvement_slope` so an operator sees the integrity signal next to the headline. Shipping #244 in the same PR as #243 means the moment Track B is reachable, operators see the integrity check too.

## What landed — #243 (`bench evolve`)

### Three-phase runner — `tests/bench/evolve.ts`
- **Phase 1**: `runUtility` over the train slice (akm arm only), with `akm feedback ± <ref>` dispatched after each run via the `akmCli` injectable seam. Outcome → polarity (pass=`+`, fail=`-`). `harness_error` skipped.
- **Phase 2**: assets crossing the threshold (`negative >= 2 OR negative/(pos+neg) > 0.5`) → `akm distill <ref>` + `akm reflect <ref>`. Each proposal validated via `akm proposal show --json`; lint-pass → `akm proposal accept`, lint-fail → `akm proposal reject --reason`. Index rebuilt after the round.
- **Phase 3**: `runUtility` on the eval slice under three arms — `pre` (snapshotted starting state), `post` (mutated stash with accepted lessons), `synthetic` (no stash; agent on its own).

### Operator stash isolation (CRITICAL fix in `f76ed61`)
The first cut of #243 ran Phase 2 against the operator's real `AKM_STASH_DIR`, mutating their curated stash. Fixed by materializing per-fixture sandboxed tmp stashes (`evolveStash` + `preStash`) at the top of `runEvolve` and pinning `AKM_STASH_DIR` to them across all phases. **The operator's real stash is never touched** (verified via sentinel-file smoke test). This also makes Phase 3's post arm correct — it now actually carries the accepted lessons forward.

### Metrics — extends `tests/bench/metrics.ts`
- `ProposalQualityMetrics` (§6.3): per-asset `lint_pass`, `accepted`; aggregate `acceptance_rate`, `lint_pass_rate`.
- `LongitudinalMetrics` (§6.4): `improvement_slope = pass_rate(post) − pass_rate(pre)`, `over_synthetic_lift = pass_rate(post) − pass_rate(synthetic)`, `degradation_count` (eval tasks where post < pre by > 1 seed; each carries its `failureMode` from #241).
- Phase 1 diagnostic reuse: per-asset attribution (#240), failure-mode taxonomy (#241), search bridge (#242) all reported on the evolved stash.

### CLI — `bench evolve --tasks <domain>`
- Mirrors `bench utility` flag conventions (`--seeds`, `--budget-tokens`, `--budget-wall-ms`, `--json`).
- `--negative-threshold-count`, `--negative-threshold-ratio` to tune Phase 2.
- JSON to stdout, markdown summary to stderr unless `--json`.

### Leakage prevention (§7.4 — partial)
Eval-slice gold refs are **skipped** from distill/reflect with a one-time generic warning + per-ref skip warnings. The proper "filter the LLM-visible feedback view inside `akm distill`" mechanism is out of scope for the bench; deferred to a follow-up against `src/commands/distill.ts`. The skip is the correct floor — eval-slice contamination cannot occur.

## What landed — #244 (feedback-signal integrity)

### `computeFeedbackIntegrity(evolveReport)` — pure function
- Joins each `feedback` event with the verifier outcome of the run that produced it via `(taskId, seed)` key — per §6.8 attribution rule, NOT a global asset-level join.
- Per-asset and aggregate 2×2 confusion matrix: TP (`+` on pass), FP (`+` on fail), TN (`−` on fail), FN (`−` on pass).
- Rates: `feedback_agreement = (TP+TN)/total`, `false_positive_rate = FP/(FP+TN)`, `false_negative_rate = FN/(FN+TP)`, `feedback_coverage = runs_with_feedback / total_runs`.
- NaN-safe: per-asset rates are `null` (not NaN) when an asset has 0 feedback events.

### Top-level `feedback_integrity` JSON key + markdown layout
- Markdown summary places `feedback_agreement` directly after `improvement_slope` (replaces #243's placeholder).
- Strict `< 0.80` threshold fires a clearly visible `:warning:` line above the headline AND a structured entry in `warnings[]`. Boundary test confirms 0.80 itself does not fire.

## Test plan

- `bunx tsc --noEmit` — clean.
- `bunx biome check src/ tests/` — 1 pre-existing info, no new warnings/errors.
- `bun test` — **2426 pass / 9 skip / 0 fail / 6613 expects across 156 files**.
  - Wave D baseline at `release/1.0.0`@`307da5c`: 2386 / 9 / 0.
  - Net: +40 tests (18 from #243 + 22 from #244 + a couple from the #243 fixup).
- Smoke #243: `BENCH_OPENCODE_MODEL=foo bun run tests/bench/cli.ts evolve --tasks docker-homelab --seeds 1 --budget-tokens 1000 --budget-wall-ms 1000 --json` → valid §6.3+§6.4 envelope; sentinel file in operator's `AKM_STASH_DIR` proven untouched.
- Smoke #244: `... | jq '.feedback_integrity'` → valid `FeedbackIntegrityMetrics` shape.

## Reviewer pass discipline

### #243
- **senior-engineer**: request-changes → approve. 4 findings; 3 fixed in `f76ed61` (Phase 1 try/catch around feedback dispatch, leakage warning deduplicated, sandboxing also addresses overlay correctness); 1 cosmetic skipped (postReport scoping).
- **security**: **request-changes → approve (CRITICAL fixed)**. Phase 2 was mutating operator's real `AKM_STASH_DIR`. **Fixed in `f76ed61`** with per-fixture sandboxed tmp stashes pinned across all phases.
- **domain-expert**: approve. Three-phase shape, threshold, auto-accept, leakage-skip, longitudinal math match spec. Two advisory deviations (synthetic prompt not fully piped through runUtility; post-arm overlay was a no-op pre-fix) — first is acceptable v1, second resolved by the sandboxing fixup.

### #244
- **senior-engineer**: approve. All §6.8 cells/formulas/attribution correct. NaN-safety intact.
- **security**: approve. Pure post-processing; no IO/spawn/env reads.
- **domain-expert**: approve. 2×2 shape, attribution rule, granularity, layout, warning, coverage all match §6.8.

## CLAUDE.md compliance

- No `src/` changes — bench reads v1 contract surfaces from outside.
- No new prod dependencies.
- No new URI schemes; no new source-provider-kind branches; no new top-level directory.
- `bench evolve` invokes `akm distill`/`reflect`/`feedback`/`proposal` purely via subprocess — preserves the §11 single-LLM-seam discipline.

## Follow-ups (none blocking; all advisory)

- **Synthetic-arm prompt override**: `buildSyntheticPrompt` is exported but not piped into `runUtility` (no per-arm prompt-override seam yet). Acceptable v1 minimum — synthetic arm still meaningfully differs by stash-presence. Add a `prompt:` injection seam on `RunUtilityOptions` in a follow-up.
- **Distill feedback-view filtering**: §7.4 says eval-slice gold-ref content should be stripped from distill input. Today's bench skips those refs entirely with a warning; a proper feedback-view filter inside `src/commands/distill.ts` would let the loop benefit from those refs' positive feedback in non-eval contexts. Follow-up issue.
- **SIGINT handler**: long evolve runs leak tmp dirs on Ctrl-C. Operator-on-own-host scope; low priority.
- **Markdown header wording**: domain-expert noted "run passed/failed" vs spec's "verifier passed/failed" — semantically identical, cosmetic.

## Run scratch directory

`.akm-run/5c2768f8-39dd-4357-bb3d-c98398280187/` (not pushed): notes, plan.json, summaries/issue-{243,244}.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)