### PR TITLE
akm-bench Wave 1: persist runs[] + corpus hashes + masked-stash fix + token measurement

### DIFF
--- a/tests/bench/attribution.test.ts
+++ b/tests/bench/attribution.test.ts
@@ -270,6 +270,7 @@ describe("runMaskedCorpus", () => {
 
     let callCount = 0;
     const seenStashDirs: string[] = [];
+    const seenStashFieldUnchanged: boolean[] = [];
     const runUtility = async (
       options: Omit<RunUtilityOptionsForMask, "spawn" | "materialiseStash"> & {
         tasks: TaskMetadata[];
@@ -277,10 +278,14 @@ describe("runMaskedCorpus", () => {
       },
     ): Promise<UtilityRunReport> => {
       callCount += 1;
-      // Each masked re-run sees a different tmp stash dir tunneled through `tasks[].stash`.
-      seenStashDirs.push(options.tasks[0]?.stash ?? "");
+      // Issue #251: masked re-runs receive the tmp dir through the explicit
+      // `stashDirOverride` field, NEVER by mutating `task.stash`. Assert
+      // both sides of the contract here.
+      const task = options.tasks[0];
+      seenStashDirs.push(task?.stashDirOverride ?? "");
+      seenStashFieldUnchanged.push(task?.stash === "fixtureA");
       // Simulate that masking alpha drops the pass rate, masking beta does nothing.
-      const stashDir = options.tasks[0]?.stash ?? "";
+      const stashDir = task?.stashDirOverride ?? "";
       const alphaMissing = !fs.existsSync(path.join(stashDir, "skills", "alpha.md"));
       const passRate = alphaMissing ? 0.25 : 0.6;
       return {
@@ -327,6 +332,185 @@ describe("runMaskedCorpus", () => {
     expect(new Set(seenStashDirs).size).toBe(2);
     for (const d of seenStashDirs) {
       expect(d.startsWith(os.tmpdir())).toBe(true);
+    }
+    // Issue #251: the original `task.stash` field was NEVER mutated.
+    expect(seenStashFieldUnchanged.every(Boolean)).toBe(true);
+    // The masking strategy + masked refs are surfaced on the result envelope.
+    expect(result.maskingStrategy).toBe("leave-one-out");
+    expect(result.maskedRefs).toEqual(["skill:alpha", "skill:beta"]);
+
+    fs.rmSync(fixturesRoot, { recursive: true, force: true });
+  });
+
+  test("issue #251: regression — runner uses stashDirOverride, NOT __no-stash__ placeholder", async () => {
+    // Bug under fix: when runMaskedCorpus mutated `task.stash` and called
+    // runUtility with `materialiseStash: false`, the runner was falling back
+    // to `path.join(task.taskDir, "__no-stash__")` for the AKM-arm stashDir,
+    // because the runner only consulted `task.stash` to call
+    // `loadFixtureStash` (which it skipped) — there was no path that
+    // forwarded the masked tmp dir to the agent.
+    //
+    // This test would FAIL before #251: the masked re-run would see the
+    // `__no-stash__` placeholder, `alpha.md` would never appear missing, and
+    // the marginal contribution would be 0 (false negative).
+    const fixturesRoot = makeFixturesRoot();
+    const baseRuns: RunResult[] = [
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:alpha"] }),
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:alpha"] }),
+    ];
+    const baseReport = makeReport(baseRuns);
+    baseReport.taskMetadata = [fakeTask({ taskDir: "/some/task/dir" })];
+
+    let observedStashDir: string | undefined;
+    let observedExistedDuringRun = false;
+    let observedAlphaMissing = false;
+    let observedBetaPresent = false;
+    let observedTaskStashUnchanged = false;
+    const result = await runMaskedCorpus({
+      baseReport,
+      topN: 1,
+      runUtility: async (options) => {
+        const task = options.tasks[0];
+        observedStashDir = task?.stashDirOverride;
+        // The runner-equivalent resolution we are guarding: if the override
+        // is missing, the bug would have us fall back to `taskDir/__no-stash__`.
+        // Capture state INSIDE the runUtility callback because the tmp dir is
+        // reaped in `runMaskedCorpus`'s `finally` after this returns.
+        if (observedStashDir) {
+          observedExistedDuringRun = fs.existsSync(observedStashDir);
+          observedAlphaMissing = !fs.existsSync(path.join(observedStashDir, "skills", "alpha.md"));
+          observedBetaPresent = fs.existsSync(path.join(observedStashDir, "skills", "beta.md"));
+        }
+        observedTaskStashUnchanged = task?.stash === "fixtureA";
+        return {
+          ...baseReport,
+          aggregateAkm: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+          akmRuns: [],
+        };
+      },
+      baseOptions: { arms: ["akm"] as Arm[], model: "m", seedsPerArm: 1 },
+      fixturesRoot,
+    });
+
+    expect(result.runsPerformed).toBe(1);
+    // The override MUST be set — that is the whole fix.
+    expect(observedStashDir).toBeDefined();
+    // It must NOT be the `__no-stash__` placeholder the buggy fallback used.
+    expect(observedStashDir?.endsWith("__no-stash__")).toBe(false);
+    // While the run was active, the override pointed at a real tmp dir with
+    // the masked asset removed and the unmasked asset still present.
+    expect(observedExistedDuringRun).toBe(true);
+    expect(observedAlphaMissing).toBe(true);
+    expect(observedBetaPresent).toBe(true);
+    // The stash (fixture name) field was NEVER mutated.
+    expect(observedTaskStashUnchanged).toBe(true);
+    // After the run, the tmp dir is reaped (cleanup contract).
+    expect(observedStashDir && fs.existsSync(observedStashDir)).toBe(false);
+
+    fs.rmSync(fixturesRoot, { recursive: true, force: true });
+  });
+
+  test("issue #251: source fixture sentinel survives masked-corpus run", async () => {
+    // Sentinel-file smoke test (review addendum #251): plant a known file
+    // inside the source fixture stash, run a masked-corpus pass, then assert
+    // the sentinel is byte-identical. Guards against a recurrence of #243's
+    // operator-config-exposure pattern.
+    const fixturesRoot = makeFixturesRoot();
+    const sentinelPath = path.join(fixturesRoot, "fixtureA", "skills", "__sentinel_251__");
+    const sentinelBody = `do-not-touch-${Date.now()}`;
+    fs.writeFileSync(sentinelPath, sentinelBody);
+
+    const baseRuns: RunResult[] = [
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:alpha"] }),
+      makeRun({ outcome: "fail", assetsLoaded: ["skill:beta"] }),
+    ];
+    const baseReport = makeReport(baseRuns);
+    baseReport.taskMetadata = [fakeTask()];
+
+    await runMaskedCorpus({
+      baseReport,
+      topN: 2,
+      runUtility: async () => ({
+        ...baseReport,
+        aggregateAkm: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+        akmRuns: [],
+      }),
+      baseOptions: { arms: ["akm"] as Arm[], model: "m", seedsPerArm: 1 },
+      fixturesRoot,
+    });
+
+    // Sentinel survives unchanged.
+    expect(fs.existsSync(sentinelPath)).toBe(true);
+    expect(fs.readFileSync(sentinelPath, "utf8")).toBe(sentinelBody);
+    // The masked entry's source-fixture content is untouched.
+    expect(fs.existsSync(path.join(fixturesRoot, "fixtureA", "skills", "alpha.md"))).toBe(true);
+    expect(fs.readFileSync(path.join(fixturesRoot, "fixtureA", "skills", "alpha.md"), "utf8")).toBe("# alpha");
+
+    fs.rmSync(fixturesRoot, { recursive: true, force: true });
+  });
+
+  test("issue #251: tmp masked stash dirs are cleaned up after success AND failure", async () => {
+    // Cleanup contract from acceptance criteria: try/finally guarantees the
+    // tmp dirs are reaped whether the injected runner returns normally or
+    // throws. Capture observed dirs from inside the injected runner; after
+    // the await they must NOT exist.
+    const fixturesRoot = makeFixturesRoot();
+    const baseRuns: RunResult[] = [
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:alpha"] }),
+      makeRun({ outcome: "fail", assetsLoaded: ["skill:beta"] }),
+    ];
+    const baseReport = makeReport(baseRuns);
+    baseReport.taskMetadata = [fakeTask()];
+
+    // Success path.
+    const successDirs: string[] = [];
+    await runMaskedCorpus({
+      baseReport,
+      topN: 2,
+      runUtility: async (options) => {
+        const dir = options.tasks[0]?.stashDirOverride;
+        if (dir) successDirs.push(dir);
+        return {
+          ...baseReport,
+          aggregateAkm: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+          akmRuns: [],
+        };
+      },
+      baseOptions: { arms: ["akm"] as Arm[], model: "m", seedsPerArm: 1 },
+      fixturesRoot,
+    });
+    expect(successDirs.length).toBe(2);
+    for (const d of successDirs) {
+      expect(fs.existsSync(d)).toBe(false);
+    }
+
+    // Failure path: the injected runner throws on the second call.
+    const failureDirs: string[] = [];
+    let calls = 0;
+    await expect(
+      runMaskedCorpus({
+        baseReport,
+        topN: 2,
+        runUtility: async (options) => {
+          calls += 1;
+          const dir = options.tasks[0]?.stashDirOverride;
+          if (dir) failureDirs.push(dir);
+          if (calls === 2) throw new Error("simulated runner failure");
+          return {
+            ...baseReport,
+            aggregateAkm: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+            akmRuns: [],
+          };
+        },
+        baseOptions: { arms: ["akm"] as Arm[], model: "m", seedsPerArm: 1 },
+        fixturesRoot,
+      }),
+    ).rejects.toThrow("simulated runner failure");
+    // Both tmp dirs created so far are reaped (the second call's dir is
+    // created in the try-block before the throw, and the finally-block
+    // cleans it up).
+    for (const d of failureDirs) {
+      expect(fs.existsSync(d)).toBe(false);
     }
 
     fs.rmSync(fixturesRoot, { recursive: true, force: true });
@@ -627,7 +811,10 @@ describe("runMaskedCorpus marginal_contribution arithmetic", () => {
       baseReport,
       topN: 2,
       runUtility: async (options) => {
-        const stashDir = options.tasks[0]?.stash ?? "";
+        // Issue #251: read the masked tmp dir from the explicit
+        // `stashDirOverride` field — the original `task.stash` (fixture
+        // name) is intentionally unchanged.
+        const stashDir = options.tasks[0]?.stashDirOverride ?? "";
         const alphaMissing = !fs.existsSync(path.join(stashDir, "skills", "alpha.md"));
         const betaMissing = !fs.existsSync(path.join(stashDir, "skills", "beta.md"));
         const masked = alphaMissing ? "skill:alpha" : betaMissing ? "skill:beta" : "none";

--- a/tests/bench/attribution.test.ts
+++ b/tests/bench/attribution.test.ts
@@ -666,3 +666,267 @@ describe("runMaskedCorpus marginal_contribution arithmetic", () => {
     fs.rmSync(fixturesRoot, { recursive: true, force: true });
   });
 });
+
+// ── #249 round-trip: persisted runs[] → attribute → compute paths ──────────
+
+describe("bench attribute prefers persisted runs[] (#249)", () => {
+  test("hydrates persisted runs[] and feeds them to runMaskedCorpus", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "akm-bench-attr-runs-"));
+    const fixturesRoot = path.join(tmp, "stashes");
+    fs.mkdirSync(fixturesRoot, { recursive: true });
+    const fixDir = path.join(fixturesRoot, "tiny");
+    fs.mkdirSync(path.join(fixDir, "skills"), { recursive: true });
+    fs.writeFileSync(
+      path.join(fixDir, "MANIFEST.json"),
+      JSON.stringify({ name: "tiny", description: "x", purpose: "x", assets: { skill: 2 }, consumers: [] }),
+    );
+    fs.writeFileSync(
+      path.join(fixDir, "skills", ".stash.json"),
+      JSON.stringify({
+        entries: [
+          { name: "alpha", type: "skill", filename: "alpha.md" },
+          { name: "beta", type: "skill", filename: "beta.md" },
+        ],
+      }),
+    );
+    fs.writeFileSync(path.join(fixDir, "skills", "alpha.md"), "# alpha");
+    fs.writeFileSync(path.join(fixDir, "skills", "beta.md"), "# beta");
+
+    // Build a §13.3 envelope WITH a persisted runs[] array. The compact rows
+    // mirror what the runner would have emitted — both arms, multiple seeds.
+    const envelope = {
+      schemaVersion: 1,
+      track: "utility",
+      branch: "test",
+      commit: "abc",
+      timestamp: "2026-04-27T00:00:00Z",
+      agent: { harness: "opencode", model: "test-model" },
+      corpus: { domains: 1, tasks: 1, slice: "all", seedsPerArm: 2 },
+      aggregate: {
+        noakm: { pass_rate: 0, tokens_per_pass: null, wallclock_ms: 0 },
+        akm: { pass_rate: 0.5, tokens_per_pass: null, wallclock_ms: 0 },
+        delta: { pass_rate: 0.5, tokens_per_pass: null, wallclock_ms: 0 },
+      },
+      trajectory: { akm: { correct_asset_loaded: null, feedback_recorded: 0 } },
+      tasks: [],
+      warnings: [],
+      runs: [
+        // noakm — should be filtered out of attribution.
+        {
+          task_id: "t",
+          arm: "noakm",
+          seed: 0,
+          model: "test-model",
+          outcome: "fail",
+          tokens: { input: 0, output: 0 },
+          wallclock_ms: 0,
+          verifier_exit_code: 1,
+          trajectory: { correct_asset_loaded: null, feedback_recorded: null },
+          assets_loaded: [],
+          failure_mode: null,
+        },
+        // akm — alpha:1pass+1fail, beta:1pass.
+        {
+          task_id: "t",
+          arm: "akm",
+          seed: 0,
+          model: "test-model",
+          outcome: "pass",
+          tokens: { input: 1, output: 2 },
+          wallclock_ms: 100,
+          verifier_exit_code: 0,
+          trajectory: { correct_asset_loaded: true, feedback_recorded: false },
+          assets_loaded: ["skill:alpha", "skill:beta"],
+          failure_mode: null,
+        },
+        {
+          task_id: "t",
+          arm: "akm",
+          seed: 1,
+          model: "test-model",
+          outcome: "fail",
+          tokens: { input: 3, output: 4 },
+          wallclock_ms: 110,
+          verifier_exit_code: 1,
+          trajectory: { correct_asset_loaded: false, feedback_recorded: false },
+          assets_loaded: ["skill:alpha"],
+          failure_mode: "wrong_asset",
+        },
+      ],
+      // perAsset is also present (older path) — but the persisted runs[]
+      // should take precedence.
+      perAsset: {
+        total_akm_runs: 2,
+        rows: [
+          {
+            asset_ref: "skill:alpha",
+            load_count: 2,
+            load_count_passing: 1,
+            load_count_failing: 1,
+            load_pass_rate: 0.5,
+          },
+          {
+            asset_ref: "skill:beta",
+            load_count: 1,
+            load_count_passing: 1,
+            load_count_failing: 0,
+            load_pass_rate: 1,
+          },
+        ],
+      },
+    };
+    const basePath = path.join(tmp, "run.json");
+    fs.writeFileSync(basePath, JSON.stringify(envelope));
+
+    let observedAkmAssetsLoaded: string[][] = [];
+    const result = await runAttributeCli({
+      basePath,
+      topN: 2,
+      json: true,
+      runUtility: async (options) => {
+        // Capture the akmRuns the masked runner sees so we can prove the
+        // hydrated runs[] flowed through unchanged.
+        observedAkmAssetsLoaded = options.tasks.map((t) => [t.id]);
+        return {
+          timestamp: "2026-04-27T00:00:00Z",
+          branch: "test",
+          commit: "abc",
+          model: "test-model",
+          corpus: { domains: 1, tasks: 1, slice: "all", seedsPerArm: 2 },
+          aggregateNoakm: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+          aggregateAkm: { passRate: 0.25, tokensPerPass: null, wallclockMs: 0 },
+          aggregateDelta: { passRate: 0.25, tokensPerPass: null, wallclockMs: 0 },
+          trajectoryAkm: { correctAssetLoaded: null, feedbackRecorded: 0 },
+          tasks: [],
+          warnings: [],
+        };
+      },
+      fixturesRoot,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout) as Record<string, unknown>;
+    // 2 attributions = 2 distinct loaded assets, both came from the persisted
+    // runs[] (alpha + beta). The noakm row is excluded.
+    expect((json.attributions as unknown[]).length).toBe(2);
+    expect(observedAkmAssetsLoaded.length).toBeGreaterThan(0);
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("falls back to perAsset synthesis when runs[] is absent (legacy report)", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "akm-bench-attr-legacy-"));
+    const fixturesRoot = path.join(tmp, "stashes");
+    fs.mkdirSync(fixturesRoot, { recursive: true });
+    const fixDir = path.join(fixturesRoot, "tiny");
+    fs.mkdirSync(path.join(fixDir, "skills"), { recursive: true });
+    fs.writeFileSync(
+      path.join(fixDir, "MANIFEST.json"),
+      JSON.stringify({ name: "tiny", description: "x", purpose: "x", assets: { skill: 1 }, consumers: [] }),
+    );
+    fs.writeFileSync(
+      path.join(fixDir, "skills", ".stash.json"),
+      JSON.stringify({ entries: [{ name: "alpha", type: "skill", filename: "alpha.md" }] }),
+    );
+    fs.writeFileSync(path.join(fixDir, "skills", "alpha.md"), "# alpha");
+
+    // Legacy envelope: NO runs[] key.
+    const envelope = {
+      schemaVersion: 1,
+      track: "utility",
+      branch: "test",
+      commit: "abc",
+      timestamp: "2026-04-27T00:00:00Z",
+      agent: { harness: "opencode", model: "test-model" },
+      corpus: { domains: 1, tasks: 0, slice: "all", seedsPerArm: 1 },
+      aggregate: {
+        noakm: { pass_rate: 0, tokens_per_pass: null, wallclock_ms: 0 },
+        akm: { pass_rate: 0.5, tokens_per_pass: null, wallclock_ms: 0 },
+        delta: { pass_rate: 0.5, tokens_per_pass: null, wallclock_ms: 0 },
+      },
+      trajectory: { akm: { correct_asset_loaded: null, feedback_recorded: 0 } },
+      tasks: [],
+      warnings: [],
+      perAsset: {
+        total_akm_runs: 2,
+        rows: [
+          {
+            asset_ref: "skill:alpha",
+            load_count: 2,
+            load_count_passing: 1,
+            load_count_failing: 1,
+            load_pass_rate: 0.5,
+          },
+        ],
+      },
+    };
+    const basePath = path.join(tmp, "run.json");
+    fs.writeFileSync(basePath, JSON.stringify(envelope));
+
+    let calls = 0;
+    const result = await runAttributeCli({
+      basePath,
+      topN: 5,
+      json: true,
+      runUtility: async () => {
+        calls += 1;
+        return {
+          timestamp: "2026-04-27T00:00:00Z",
+          branch: "test",
+          commit: "abc",
+          model: "test-model",
+          corpus: { domains: 1, tasks: 0, slice: "all", seedsPerArm: 1 },
+          aggregateNoakm: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+          aggregateAkm: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+          aggregateDelta: { passRate: 0, tokensPerPass: null, wallclockMs: 0 },
+          trajectoryAkm: { correctAssetLoaded: null, feedbackRecorded: 0 },
+          tasks: [],
+          warnings: [],
+        };
+      },
+      fixturesRoot,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout) as Record<string, unknown>;
+    // Legacy path still works: clamps to 1 attribution row from perAsset.
+    expect(json.runsPerformed).toBe(1);
+    expect((json.attributions as unknown[]).length).toBe(1);
+    expect(calls).toBe(1);
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});
+
+// ── #249 metrics-level round-trip: aggregate from runs[] + reduce parity ───
+
+describe("aggregateRunsForReport + rehydrate round-trip (#249)", () => {
+  test("recomputes computePerAssetAttribution identically from persisted rows", async () => {
+    const {
+      aggregateRunsForReport,
+      rehydrateRunFromSerialized,
+      computePerAssetAttribution: cpa,
+    } = await import("./metrics");
+    const original: RunResult[] = [
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:alpha", "skill:beta"] }),
+      makeRun({ outcome: "fail", assetsLoaded: ["skill:alpha"], verifierStdout: "junk" }),
+      makeRun({ outcome: "pass", assetsLoaded: ["skill:beta"] }),
+    ];
+    const reportBefore = makeReport(original);
+    const before = cpa(reportBefore);
+
+    // Round-trip through compact persisted rows.
+    const rows = aggregateRunsForReport(original);
+    const hydrated = rows.map(rehydrateRunFromSerialized);
+    const reportAfter = makeReport(hydrated);
+    const after = cpa(reportAfter);
+
+    expect(after.totalAkmRuns).toBe(before.totalAkmRuns);
+    expect(after.rows.length).toBe(before.rows.length);
+    for (let i = 0; i < before.rows.length; i++) {
+      expect(after.rows[i]?.assetRef).toBe(before.rows[i]?.assetRef);
+      expect(after.rows[i]?.loadCount).toBe(before.rows[i]?.loadCount);
+      expect(after.rows[i]?.loadPassRate).toBe(before.rows[i]?.loadPassRate);
+    }
+  });
+});

--- a/tests/bench/cli.ts
+++ b/tests/bench/cli.ts
@@ -426,7 +426,16 @@ export async function runAttributeCli(options: AttributeCliOptions): Promise<Att
     schemaVersion: 1,
     track: "attribute",
     base: { path: options.basePath, model },
-    maskingStrategy: "leave-one-out",
+    // Issue #251: surface the masking strategy + the exact masked refs in
+    // the JSON envelope so operators can audit the marginal-contribution
+    // numbers without re-running the masker. The `maskedRefs` order matches
+    // `attributions[]`. Strategy is currently always `"leave-one-out"`;
+    // future strategies extend the union in `MaskedCorpusResult`.
+    attribution: {
+      maskingStrategy: maskedResult.maskingStrategy,
+      maskedRefs: maskedResult.maskedRefs,
+    },
+    maskingStrategy: maskedResult.maskingStrategy,
     runsPerformed: maskedResult.runsPerformed,
     perAsset: {
       total_akm_runs: perAsset.totalAkmRuns,

--- a/tests/bench/cli.ts
+++ b/tests/bench/cli.ts
@@ -27,9 +27,11 @@ import {
   type ParsedReportJson,
   type PerAssetAttribution,
   type RunUtilityOptionsForMask,
+  rehydrateRunFromSerialized,
   runMaskedCorpus,
 } from "./metrics";
 import {
+  type RunRecordSerialized,
   renderAttributionTable,
   renderCompareMarkdown,
   renderEvolveReport,
@@ -365,14 +367,15 @@ export async function runAttributeCli(options: AttributeCliOptions): Promise<Att
   const desired = Math.max(1, options.topN);
   const clamped = Math.min(desired, perAsset.rows.length);
 
-  // Reconstitute a partial UtilityRunReport so runMaskedCorpus has what it
-  // needs. We don't have the raw RunResults in the on-disk envelope, so the
-  // helper uses the perAsset table directly via computePerAssetAttribution.
-  // To make that work we synthesise akmRuns from the perAsset rows: each
-  // row contributes loadCountPassing pass-stub runs and loadCountFailing
-  // fail-stub runs. This is enough for `computePerAssetAttribution` inside
-  // `runMaskedCorpus` to produce the same top-N ranking we just loaded.
-  const synthesisedAkmRuns = synthesiseAkmRunsFromAttribution(perAsset);
+  // Prefer the persisted `runs[]` array (#249). When the report carries
+  // serialised raw runs we hydrate them back into RunResult shape and feed
+  // them to `runMaskedCorpus` directly — that keeps attribution faithful to
+  // the original (task, arm, seed) bag instead of synthesising stubs from
+  // the per-asset aggregate. Falls back to the legacy aggregate path when
+  // the report pre-dates the `runs[]` field.
+  const persistedRuns = readPersistedRuns(baseEnvelope);
+  const akmRuns =
+    persistedRuns !== null ? persistedRuns.filter((r) => r.arm === "akm") : synthesiseAkmRunsFromAttribution(perAsset);
   const baseReport: UtilityRunReport = {
     timestamp: String(baseEnvelope.timestamp ?? ""),
     branch: String(baseEnvelope.branch ?? ""),
@@ -391,7 +394,7 @@ export async function runAttributeCli(options: AttributeCliOptions): Promise<Att
     tasks: [],
     warnings: [],
     perAsset,
-    akmRuns: synthesisedAkmRuns,
+    akmRuns,
     taskMetadata: tasks,
   };
 
@@ -501,6 +504,54 @@ function extractCorpusMetrics(
       node.tokens_per_pass === null ? null : typeof node.tokens_per_pass === "number" ? node.tokens_per_pass : null,
     wallclockMs: typeof node.wallclock_ms === "number" ? node.wallclock_ms : 0,
   };
+}
+
+/**
+ * Read the persisted `runs[]` array (#249) from a §13.3 envelope and hydrate
+ * each row back into the in-memory `RunResult` shape. Returns `null` when the
+ * envelope pre-dates the field (legacy reports) so callers can fall back to
+ * the aggregate-only path.
+ *
+ * Structurally validates each row: rows that don't carry the required keys
+ * are skipped silently. We intentionally avoid throwing — older envelopes
+ * with partial shapes still want to flow through the legacy path.
+ */
+function readPersistedRuns(envelope: Record<string, unknown>): import("./driver").RunResult[] | null {
+  const raw = envelope.runs;
+  if (!Array.isArray(raw)) return null;
+  const out: import("./driver").RunResult[] = [];
+  for (const r of raw) {
+    if (!r || typeof r !== "object") continue;
+    const row = r as Partial<RunRecordSerialized> & Record<string, unknown>;
+    if (typeof row.task_id !== "string") continue;
+    if (typeof row.arm !== "string") continue;
+    if (typeof row.seed !== "number") continue;
+    if (typeof row.outcome !== "string") continue;
+    // Trajectory shape: tolerate missing/partial sub-object so we don't
+    // reject otherwise-valid rows.
+    const traj = (row.trajectory ?? {}) as {
+      correct_asset_loaded?: boolean | null;
+      feedback_recorded?: boolean | null;
+    };
+    const normalised: RunRecordSerialized = {
+      task_id: row.task_id,
+      arm: row.arm,
+      seed: row.seed,
+      model: typeof row.model === "string" ? row.model : "unknown",
+      outcome: row.outcome,
+      tokens: (row.tokens as Record<string, unknown>) ?? { input: 0, output: 0 },
+      wallclock_ms: typeof row.wallclock_ms === "number" ? row.wallclock_ms : 0,
+      verifier_exit_code: typeof row.verifier_exit_code === "number" ? row.verifier_exit_code : 0,
+      trajectory: {
+        correct_asset_loaded: traj.correct_asset_loaded ?? null,
+        feedback_recorded: traj.feedback_recorded ?? null,
+      },
+      assets_loaded: Array.isArray(row.assets_loaded) ? (row.assets_loaded as string[]) : [],
+      failure_mode: typeof row.failure_mode === "string" ? row.failure_mode : null,
+    };
+    out.push(rehydrateRunFromSerialized(normalised));
+  }
+  return out;
 }
 
 /**

--- a/tests/bench/cli.ts
+++ b/tests/bench/cli.ts
@@ -69,11 +69,17 @@ evolve flags:
   --json                   suppress the markdown summary on stderr.
 
 compare flags:
-  --base <path>            path to baseline UtilityRunReport JSON file. REQUIRED.
-  --current <path>         path to current  UtilityRunReport JSON file. REQUIRED.
-  --json                   emit the structured CompareResult JSON to stdout instead
-                           of a markdown diff.
-  Exit codes: 0 on successful diff, 1 on refusal (model/hash/schema/track mismatch),
+  --base <path>                 path to baseline UtilityRunReport JSON file. REQUIRED.
+  --current <path>              path to current  UtilityRunReport JSON file. REQUIRED.
+  --json                        emit the structured CompareResult JSON to stdout instead
+                                of a markdown diff.
+  --allow-corpus-mismatch       proceed even when the two reports disagree on the
+                                selected task IDs / taskCorpusHash. The diff is
+                                rendered with a warning instead of being refused.
+  --allow-fixture-mismatch      proceed even when the two reports disagree on the
+                                fixtureContentHash. Renders a warning instead of
+                                refusing.
+  Exit codes: 0 on successful diff, 1 on refusal (model/corpus/fixture-hash/schema/track mismatch),
               2 on input errors (missing files, malformed JSON, unknown flags).
 
 attribute flags:
@@ -195,6 +201,10 @@ export interface CompareCliOptions {
   basePath: string;
   currentPath: string;
   json: boolean;
+  /** #250 — accept mismatched task corpora and emit a warning instead. */
+  allowCorpusMismatch?: boolean;
+  /** #250 — accept mismatched fixture-content hashes and emit a warning instead. */
+  allowFixtureMismatch?: boolean;
 }
 
 /**
@@ -249,7 +259,10 @@ export function runCompareCli(options: CompareCliOptions): UtilityCliResult {
     };
   }
 
-  const result = compareReports(base, current);
+  const result = compareReports(base, current, {
+    ...(options.allowCorpusMismatch ? { allowCorpusMismatch: true } : {}),
+    ...(options.allowFixtureMismatch ? { allowFixtureMismatch: true } : {}),
+  });
   const stdout = options.json ? `${JSON.stringify(result, null, 2)}\n` : `${renderCompareMarkdown(result)}\n`;
   let stderr = "";
   if (!result.ok) {
@@ -696,6 +709,8 @@ async function main(argv: string[]): Promise<number> {
         basePath,
         currentPath,
         json: parsed.bool.has("json"),
+        allowCorpusMismatch: parsed.bool.has("allow-corpus-mismatch"),
+        allowFixtureMismatch: parsed.bool.has("allow-fixture-mismatch"),
       });
       if (result.stdout) process.stdout.write(result.stdout);
       if (result.stderr) process.stderr.write(result.stderr);

--- a/tests/bench/compare.test.ts
+++ b/tests/bench/compare.test.ts
@@ -221,16 +221,16 @@ describe("compareReports — fixture-hash warnings", () => {
     expect(result.warnings.some((w) => w.includes("current") && w.includes("fixtureContentHash"))).toBe(true);
   });
 
-  test("missing on both: two warnings, still ok", () => {
+  test("missing on both: two fixture warnings (#250 also adds two corpus warnings)", () => {
     const base = makeReport();
     const current = makeReport();
     const result = compareReports(base, current);
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.warnings.length).toBe(2);
+    expect(result.warnings.filter((w) => w.includes("fixtureContentHash")).length).toBe(2);
   });
 
-  test("matching hash: no warnings", () => {
+  test("matching fixture hash: no fixture warnings", () => {
     const base = makeReport({
       corpus: { domains: 2, tasks: 2, slice: "all", seedsPerArm: 5, fixtureContentHash: "abc123" },
     });
@@ -240,7 +240,112 @@ describe("compareReports — fixture-hash warnings", () => {
     const result = compareReports(base, current);
     expect(result.ok).toBe(true);
     if (!result.ok) return;
+    expect(result.warnings.filter((w) => w.includes("fixtureContentHash")).length).toBe(0);
+  });
+});
+
+describe("compareReports — corpus identity (#250)", () => {
+  function withCorpusIdentity(taskCorpusHash: string, selectedTaskIds: string[], fixtureContentHash?: string) {
+    return makeReport({
+      corpus: {
+        domains: 2,
+        tasks: selectedTaskIds.length,
+        slice: "all",
+        seedsPerArm: 5,
+        taskCorpusHash,
+        selectedTaskIds,
+        ...(fixtureContentHash ? { fixtureContentHash } : {}),
+      },
+    });
+  }
+
+  test("matching corpus + fixture hashes: ok=true, no warnings", () => {
+    const base = withCorpusIdentity("tc-a", ["a/one", "b/two"], "fh-a");
+    const current = withCorpusIdentity("tc-a", ["a/one", "b/two"], "fh-a");
+    const result = compareReports(base, current);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
     expect(result.warnings.length).toBe(0);
+  });
+
+  test("taskCorpusHash mismatch: refuses by default", () => {
+    const base = withCorpusIdentity("tc-a", ["a/one", "b/two"]);
+    const current = withCorpusIdentity("tc-b", ["a/one", "b/two"]);
+    const result = compareReports(base, current);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("corpus_mismatch");
+    expect(result.message).toContain("tc-a");
+    expect(result.message).toContain("tc-b");
+    expect(result.baseTaskCorpusHash).toBe("tc-a");
+    expect(result.currentTaskCorpusHash).toBe("tc-b");
+  });
+
+  test("selectedTaskIds differ but hashes both present and matching: still ok", () => {
+    // Defensive: in practice two reports with identical taskCorpusHash should
+    // also share IDs; but if a producer ever forgets to align them, the hash
+    // dominates so we don't false-positive.
+    const base = withCorpusIdentity("tc-a", ["a/one", "b/two"]);
+    const current = withCorpusIdentity("tc-a", ["a/one", "b/two", "c/three"]);
+    const result = compareReports(base, current);
+    expect(result.ok).toBe(true);
+  });
+
+  test("allowCorpusMismatch converts refusal to warning", () => {
+    const base = withCorpusIdentity("tc-a", ["a/one", "b/two"]);
+    const current = withCorpusIdentity("tc-b", ["a/one", "b/two"]);
+    const result = compareReports(base, current, { allowCorpusMismatch: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.warnings.some((w) => w.includes("--allow-corpus-mismatch"))).toBe(true);
+  });
+
+  test("legacy report (missing taskCorpusHash) gets a warning, not refusal", () => {
+    const base = makeReport(); // no taskCorpusHash
+    const current = withCorpusIdentity("tc-a", ["a/one", "b/two"]);
+    const result = compareReports(base, current);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.warnings.some((w) => w.includes("base") && w.includes("taskCorpusHash"))).toBe(true);
+  });
+
+  test("legacy on both sides: two warnings, still ok", () => {
+    const base = makeReport();
+    const current = makeReport();
+    const result = compareReports(base, current);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // 2 missing taskCorpusHash + 2 missing fixtureContentHash warnings.
+    expect(result.warnings.filter((w) => w.includes("taskCorpusHash")).length).toBe(2);
+    expect(result.warnings.filter((w) => w.includes("fixtureContentHash")).length).toBe(2);
+  });
+
+  test("fixture-content hash mismatch: refuses by default (existing behaviour)", () => {
+    const base = withCorpusIdentity("tc-a", ["a/one", "b/two"], "fh-a");
+    const current = withCorpusIdentity("tc-a", ["a/one", "b/two"], "fh-b");
+    const result = compareReports(base, current);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("hash_mismatch");
+  });
+
+  test("allowFixtureMismatch converts fixture-hash refusal to warning", () => {
+    const base = withCorpusIdentity("tc-a", ["a/one", "b/two"], "fh-a");
+    const current = withCorpusIdentity("tc-a", ["a/one", "b/two"], "fh-b");
+    const result = compareReports(base, current, { allowFixtureMismatch: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.warnings.some((w) => w.includes("--allow-fixture-mismatch"))).toBe(true);
+  });
+
+  test("corpus mismatch is checked before fixture mismatch (refusal precedence)", () => {
+    // When both differ and neither flag is set, the corpus refusal wins.
+    const base = withCorpusIdentity("tc-a", ["a/one"], "fh-a");
+    const current = withCorpusIdentity("tc-b", ["a/one"], "fh-b");
+    const result = compareReports(base, current);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("corpus_mismatch");
   });
 });
 
@@ -358,6 +463,90 @@ describe("runCompareCli", () => {
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
+  });
+
+  test("corpus mismatch: exit 1 (#250)", () => {
+    withTmpFiles(
+      ({ basePath, currentPath }) => {
+        const result = runCompareCli({ basePath, currentPath, json: false });
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("task corpora");
+      },
+      makeReport({
+        corpus: {
+          domains: 2,
+          tasks: 2,
+          slice: "all",
+          seedsPerArm: 5,
+          taskCorpusHash: "tc1",
+          selectedTaskIds: ["a/one", "b/two"],
+        },
+      }),
+      makeReport({
+        corpus: {
+          domains: 2,
+          tasks: 2,
+          slice: "all",
+          seedsPerArm: 5,
+          taskCorpusHash: "tc2",
+          selectedTaskIds: ["a/one", "b/two"],
+        },
+      }),
+    );
+  });
+
+  test("corpus mismatch with --allow-corpus-mismatch: exit 0 + warning (#250)", () => {
+    withTmpFiles(
+      ({ basePath, currentPath }) => {
+        const result = runCompareCli({
+          basePath,
+          currentPath,
+          json: false,
+          allowCorpusMismatch: true,
+        });
+        expect(result.exitCode).toBe(0);
+        expect(result.stderr).toContain("warning");
+        expect(result.stderr).toContain("task corpus");
+      },
+      makeReport({
+        corpus: {
+          domains: 2,
+          tasks: 2,
+          slice: "all",
+          seedsPerArm: 5,
+          taskCorpusHash: "tc1",
+          selectedTaskIds: ["a/one", "b/two"],
+        },
+      }),
+      makeReport({
+        corpus: {
+          domains: 2,
+          tasks: 2,
+          slice: "all",
+          seedsPerArm: 5,
+          taskCorpusHash: "tc2",
+          selectedTaskIds: ["a/one", "b/two"],
+        },
+      }),
+    );
+  });
+
+  test("fixture mismatch with --allow-fixture-mismatch: exit 0 + warning (#250)", () => {
+    withTmpFiles(
+      ({ basePath, currentPath }) => {
+        const result = runCompareCli({
+          basePath,
+          currentPath,
+          json: false,
+          allowFixtureMismatch: true,
+        });
+        expect(result.exitCode).toBe(0);
+        expect(result.stderr).toContain("warning");
+        expect(result.stderr).toContain("fixture-content");
+      },
+      makeReport({ corpus: { domains: 2, tasks: 2, slice: "all", seedsPerArm: 5, fixtureContentHash: "h1" } }),
+      makeReport({ corpus: { domains: 2, tasks: 2, slice: "all", seedsPerArm: 5, fixtureContentHash: "h2" } }),
+    );
   });
 
   test("missing --base file: exit 2", () => {

--- a/tests/bench/compare.test.ts
+++ b/tests/bench/compare.test.ts
@@ -360,6 +360,40 @@ describe("runCompareCli", () => {
     }
   });
 
+  test("round-trip: reports with persisted runs[] (#249) compare cleanly", () => {
+    // The runs[] field is additive — compare ignores it but must NOT reject
+    // reports that carry it. Confirms the new key is forward-compatible with
+    // the existing aggregate-based diff path.
+    const baseWithRuns = {
+      ...(makeReport() as unknown as Record<string, unknown>),
+      runs: [
+        {
+          task_id: "domain-a/task-1",
+          arm: "akm",
+          seed: 0,
+          model: MODEL,
+          outcome: "pass",
+          tokens: { input: 1, output: 2 },
+          wallclock_ms: 100,
+          verifier_exit_code: 0,
+          trajectory: { correct_asset_loaded: true, feedback_recorded: false },
+          assets_loaded: ["skill:foo"],
+          failure_mode: null,
+        },
+      ],
+    };
+    withTmpFiles(
+      ({ basePath, currentPath }) => {
+        const result = runCompareCli({ basePath, currentPath, json: true });
+        expect(result.exitCode).toBe(0);
+        const parsed = JSON.parse(result.stdout) as { ok: boolean };
+        expect(parsed.ok).toBe(true);
+      },
+      baseWithRuns,
+      baseWithRuns,
+    );
+  });
+
   test("missing --base file: exit 2", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bench-compare-missing-"));
     try {

--- a/tests/bench/corpus.test.ts
+++ b/tests/bench/corpus.test.ts
@@ -12,7 +12,16 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { effectiveSlice, getTasksRoot, listTasks, loadTask, partitionSlice, type TaskMetadata } from "./corpus";
+import {
+  computeTaskCorpusHash,
+  effectiveSlice,
+  getTasksRoot,
+  listTasks,
+  loadTask,
+  partitionSlice,
+  readTaskBody,
+  type TaskMetadata,
+} from "./corpus";
 
 describe("listTasks", () => {
   test("the corpus root resolves under tests/fixtures/bench/tasks", () => {
@@ -141,6 +150,30 @@ describe("partitionSlice", () => {
     const b = partitionSlice(corpus);
     expect(a.train.map((t) => t.id)).toEqual(b.train.map((t) => t.id));
     expect(a.eval.map((t) => t.id)).toEqual(b.eval.map((t) => t.id));
+  });
+
+  test("computeTaskCorpusHash is deterministic and order-independent (#250)", () => {
+    const bodies = new Map<string, string>([
+      ["a/one", "id: a/one\ntitle: One\n"],
+      ["b/two", "id: b/two\ntitle: Two\n"],
+    ]);
+    const h1 = computeTaskCorpusHash(["a/one", "b/two"], bodies);
+    const h2 = computeTaskCorpusHash(["b/two", "a/one"], bodies);
+    expect(h1).toBe(h2);
+    expect(h1).toMatch(/^[0-9a-f]{64}$/);
+
+    // Body change → hash change.
+    const altBodies = new Map(bodies);
+    altBodies.set("a/one", "id: a/one\ntitle: Different\n");
+    const h3 = computeTaskCorpusHash(["a/one", "b/two"], altBodies);
+    expect(h3).not.toBe(h1);
+
+    // ID-set change → hash change.
+    const h4 = computeTaskCorpusHash(["a/one"], bodies);
+    expect(h4).not.toBe(h1);
+
+    // readTaskBody returns "" for a missing taskDir without throwing.
+    expect(readTaskBody("/does/not/exist")).toBe("");
   });
 
   test("a task without explicit slice is bucketed deterministically and goes to exactly one slice", () => {

--- a/tests/bench/corpus.ts
+++ b/tests/bench/corpus.ts
@@ -49,6 +49,50 @@ export function getTasksRoot(): string {
 }
 
 /**
+ * Compute a deterministic SHA-256 hash over a selected task corpus (#250).
+ *
+ * Two reports with the same selected task IDs and the same task body bytes
+ * produce the same hash. The hash is order-independent: callers may pass IDs
+ * in any order — the function sorts them lexicographically before hashing.
+ *
+ * The `taskBodies` map is keyed by task id and carries the raw `task.yaml`
+ * bytes (or any deterministic per-task identity payload). Tasks present in
+ * `taskIds` but missing from `taskBodies` are hashed with an empty body so
+ * the hash still distinguishes the selection.
+ *
+ * Encoding (per id, in sorted order):
+ *   `<id>\0<body-bytes>\0`
+ *
+ * Used by `bench compare` to refuse mismatched corpora unless the operator
+ * explicitly opts in via `--allow-corpus-mismatch`.
+ */
+export function computeTaskCorpusHash(taskIds: string[], taskBodies: Map<string, string>): string {
+  const sortedIds = [...taskIds].sort();
+  const hash = createHash("sha256");
+  for (const id of sortedIds) {
+    hash.update(id);
+    hash.update("\0");
+    hash.update(taskBodies.get(id) ?? "");
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+/**
+ * Read the raw `task.yaml` bytes for a task whose `taskDir` is known. Returns
+ * the empty string when the file is missing — callers should still hash the
+ * id so the selection's identity is preserved.
+ */
+export function readTaskBody(taskDir: string): string {
+  const yamlPath = path.join(taskDir, "task.yaml");
+  try {
+    return fs.readFileSync(yamlPath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+/**
  * The `_example/` task tree is reserved for loader unit tests; real corpus
  * statistics must exclude it. The path-prefix check matches both POSIX (`/`)
  * and Windows (`\`) separators.

--- a/tests/bench/corpus.ts
+++ b/tests/bench/corpus.ts
@@ -39,6 +39,21 @@ export interface TaskMetadata {
   budget: { tokens: number; wallMs: number };
   /** Absolute path to the directory containing `task.yaml`. */
   taskDir: string;
+  /**
+   * Optional override for the akm-arm `stashDir` plumbed into `runOne`.
+   *
+   * Used by `runMaskedCorpus` (#251) to redirect the runner at a tmp stash
+   * with one asset removed without mutating the on-disk fixture stash named
+   * by `stash`. When set, the runner forwards this directory verbatim as
+   * `AKM_STASH_DIR` for every akm-arm invocation of this task — bypassing
+   * the per-task `loadFixtureStash` step (which would otherwise re-resolve
+   * `stash` against `tests/fixtures/stashes/`) and the `__no-stash__`
+   * placeholder used when `materialiseStash` is `false`.
+   *
+   * MUST be a directory the caller created and is responsible for cleaning
+   * up. The runner does not delete it.
+   */
+  stashDirOverride?: string;
 }
 
 const TASKS_ROOT = path.resolve(__dirname, "..", "fixtures", "bench", "tasks");

--- a/tests/bench/driver.test.ts
+++ b/tests/bench/driver.test.ts
@@ -163,6 +163,37 @@ describe("runOne", () => {
     expect(result.tokens.input + result.tokens.output).toBeGreaterThan(100_000);
     expect(result.tokens.input).toBe(70_000);
     expect(result.tokens.output).toBe(50_000);
+    expect(result.tokenMeasurement).toBe("parsed");
+  });
+
+  test("tokenMeasurement: parsed when stdout reports tokens", async () => {
+    const { spawn } = scriptedSpawn({
+      exitCode: 0,
+      stdout: "ok\ninput_tokens: 10 output_tokens: 5",
+    });
+    const result = await runOne({ ...baseOptions, workspace, spawn });
+    expect(result.outcome).toBe("pass");
+    expect(result.tokenMeasurement).toBe("parsed");
+    expect(result.tokens.input).toBe(10);
+    expect(result.tokens.output).toBe(5);
+  });
+
+  test("tokenMeasurement: missing when stdout has no token line — and budget is NOT enforced", async () => {
+    // Agent never reports tokens. budgetTokens is 1, but the harness must not
+    // mark this as budget_exceeded (issue #252) — measurement is missing.
+    const { spawn } = scriptedSpawn({ exitCode: 0, stdout: "ok" });
+    const result = await runOne({ ...baseOptions, workspace, spawn, budgetTokens: 1 });
+    expect(result.tokenMeasurement).toBe("missing");
+    expect(result.tokens).toEqual({ input: 0, output: 0 });
+    expect(result.outcome).not.toBe("budget_exceeded");
+  });
+
+  test("tokenMeasurement: harness_error path leaves measurement as 'missing'", async () => {
+    const { spawn } = scriptedSpawn({ exitCode: 0, throwSync: new Error("ENOENT") });
+    const result = await runOne({ ...baseOptions, workspace, spawn });
+    expect(result.outcome).toBe("harness_error");
+    // No agent stdout was ever observed → measurement stays at the default.
+    expect(result.tokenMeasurement).toBe("missing");
   });
 
   test("isolation: child env carries pinned XDG/OPENCODE/AKM dirs and not operator values", async () => {
@@ -225,10 +256,19 @@ describe("driver helpers", () => {
     }
   });
 
-  test("parseTokenUsage extracts numbers when present, zero otherwise", () => {
-    expect(parseTokenUsage("")).toEqual({ input: 0, output: 0 });
-    expect(parseTokenUsage("noise")).toEqual({ input: 0, output: 0 });
-    expect(parseTokenUsage("input_tokens: 123 output_tokens: 456")).toEqual({ input: 123, output: 456 });
+  test("parseTokenUsage extracts numbers when present, missing otherwise", () => {
+    // No matchable token line at all → measurement is "missing", not a real zero (issue #252).
+    expect(parseTokenUsage("")).toEqual({ input: 0, output: 0, measurement: "missing" });
+    expect(parseTokenUsage("noise")).toEqual({ input: 0, output: 0, measurement: "missing" });
+    // Both keys present → "parsed" with the actual numbers.
+    expect(parseTokenUsage("input_tokens: 123 output_tokens: 456")).toEqual({
+      input: 123,
+      output: 456,
+      measurement: "parsed",
+    });
+    // Only one key present → still "parsed", missing key defaults to 0.
+    expect(parseTokenUsage("input_tokens: 99")).toEqual({ input: 99, output: 0, measurement: "parsed" });
+    expect(parseTokenUsage("output_tokens: 55")).toEqual({ input: 0, output: 55, measurement: "parsed" });
   });
 
   test("readRunEvents returns [] when events.jsonl is missing and parses lines when present", () => {

--- a/tests/bench/driver.ts
+++ b/tests/bench/driver.ts
@@ -79,6 +79,19 @@ export interface TrajectoryRecord {
   feedbackRecorded: boolean | null;
 }
 
+/**
+ * Distinguishes real zero-token measurements from missing or unsupported
+ * token reporting (issue #252). Aggregations MUST skip runs where this is
+ * not `"parsed"` rather than treating numeric zero as a measured value.
+ *
+ *   - `"parsed"`     — token usage was extracted from agent stdout.
+ *   - `"missing"`    — agent emits token usage in some configurations but
+ *                      we could not parse it on this run.
+ *   - `"unsupported"`— the agent profile / harness does not report tokens
+ *                      at all (e.g. a synthetic-arm fake).
+ */
+export type TokenMeasurementStatus = "parsed" | "missing" | "unsupported";
+
 /** Run result envelope (spec §5.2). */
 export interface RunResult {
   schemaVersion: 1;
@@ -88,6 +101,16 @@ export interface RunResult {
   model: string;
   outcome: "pass" | "fail" | "budget_exceeded" | "harness_error";
   tokens: { input: number; output: number };
+  /**
+   * Status of the token-usage measurement on this run (issue #252). Aggregate
+   * metrics MUST skip runs whose measurement is not `"parsed"` and report-
+   * level surfaces SHOULD warn when any run lacks parsed token usage. The
+   * field is optional on the type for backward compatibility — older
+   * artefacts (and older test fixtures) without this field are treated as
+   * `"parsed"` so historical reports remain analysable. New runs always
+   * stamp a value.
+   */
+  tokenMeasurement?: TokenMeasurementStatus;
   wallclockMs: number;
   trajectory: TrajectoryRecord;
   events: EventEnvelope[];
@@ -156,16 +179,35 @@ export function buildIsolatedEnv(dirs: IsolationDirs, model: string): Record<str
   return env;
 }
 
-/** Best-effort token-usage parser for opencode stdout. Returns zeros if absent. */
-export function parseTokenUsage(stdout: string): { input: number; output: number } {
+/**
+ * Best-effort token-usage parser for opencode stdout. Returns numeric token
+ * counts AND a measurement status so callers can distinguish a real zero
+ * (`"parsed"`, both fields legitimately 0) from an unparseable / absent
+ * report (`"missing"`, both fields default to 0 but downstream aggregation
+ * MUST skip the run rather than treat that 0 as measured).
+ *
+ * The harness never emits `"unsupported"` from this parser — that label is
+ * stamped on results from arms that don't run a token-reporting agent
+ * (e.g. the synthetic arm), and is set by the caller, not here.
+ */
+export function parseTokenUsage(stdout: string): {
+  input: number;
+  output: number;
+  measurement: TokenMeasurementStatus;
+} {
   // opencode prints lines like `tokens: input=1234 output=5678` in some
-  // configurations. We look for the keys defensively; missing values stay 0.
-  const out = { input: 0, output: 0 };
+  // configurations. We look for the keys defensively; absent values mean we
+  // could not measure (`measurement: "missing"`).
   const inputMatch = stdout.match(/(?:input[_\s-]?tokens?|tokens?[_\s-]?input)[\s:=]+(\d+)/i);
   const outputMatch = stdout.match(/(?:output[_\s-]?tokens?|tokens?[_\s-]?output)[\s:=]+(\d+)/i);
-  if (inputMatch) out.input = Number.parseInt(inputMatch[1], 10);
-  if (outputMatch) out.output = Number.parseInt(outputMatch[1], 10);
-  return out;
+  if (!inputMatch && !outputMatch) {
+    return { input: 0, output: 0, measurement: "missing" };
+  }
+  return {
+    input: inputMatch ? Number.parseInt(inputMatch[1], 10) : 0,
+    output: outputMatch ? Number.parseInt(outputMatch[1], 10) : 0,
+    measurement: "parsed",
+  };
 }
 
 /**
@@ -267,6 +309,7 @@ export async function runOne(options: RunOptions): Promise<RunResult> {
     model: options.model,
     outcome: "harness_error",
     tokens: { input: 0, output: 0 },
+    tokenMeasurement: "missing",
     wallclockMs: 0,
     trajectory: { correctAssetLoaded: null, feedbackRecorded: null },
     events: [],
@@ -304,7 +347,9 @@ export async function runOne(options: RunOptions): Promise<RunResult> {
     });
 
     result.wallclockMs = agentResult.durationMs;
-    result.tokens = parseTokenUsage(agentResult.stdout);
+    const parsed = parseTokenUsage(agentResult.stdout);
+    result.tokens = { input: parsed.input, output: parsed.output };
+    result.tokenMeasurement = parsed.measurement;
     result.events = readRunEvents(dirs.cacheHome, { warnings: options.warnings });
 
     if (!agentResult.ok) {
@@ -326,11 +371,15 @@ export async function runOne(options: RunOptions): Promise<RunResult> {
     }
 
     // Token-budget enforcement is best-effort: only mark `budget_exceeded`
-    // if we could parse a number AND it exceeds the cap.
-    const totalTokens = result.tokens.input + result.tokens.output;
-    if (totalTokens > 0 && totalTokens > options.budgetTokens) {
-      result.outcome = "budget_exceeded";
-      return result;
+    // if measurement was actually parsed (issue #252) AND the total exceeds
+    // the cap. A `"missing"` / `"unsupported"` measurement MUST NOT silently
+    // mask a budget overrun as a pass — it leaves the verifier to decide.
+    if (result.tokenMeasurement === "parsed") {
+      const totalTokens = result.tokens.input + result.tokens.output;
+      if (totalTokens > options.budgetTokens) {
+        result.outcome = "budget_exceeded";
+        return result;
+      }
     }
 
     const verifierResult = await runVerifier(options.taskDir, options.workspace, options.verifier, {

--- a/tests/bench/evolve.test.ts
+++ b/tests/bench/evolve.test.ts
@@ -569,6 +569,7 @@ describe("computeLongitudinalMetrics", () => {
       budgetExceededCount: 0,
       harnessErrorCount: 0,
       count: seedsPerArm,
+      runsWithMeasuredTokens: 0,
     };
     const noakm = { ...akm, passRate: 0 };
     return {

--- a/tests/bench/metrics.test.ts
+++ b/tests/bench/metrics.test.ts
@@ -41,6 +41,7 @@ describe("computeOutcomeAggregate", () => {
       tokensPerPass: 0,
       wallclockMs: 0,
       budgetExceeded: 0,
+      runsWithMeasuredTokens: 0,
     });
   });
 
@@ -63,6 +64,42 @@ describe("computeOutcomeAggregate", () => {
     const agg = computeOutcomeAggregate(results);
     expect(agg.passRate).toBe(0);
     expect(agg.tokensPerPass).toBe(0);
+  });
+
+  test("missing token measurement is NOT silently treated as zero (issue #252)", () => {
+    // Two passes: one parsed at 1000, one missing measurement. The mean must
+    // be 1000 (the measured pass), not (1000+0)/2 = 500.
+    const results = [
+      fakeResult({
+        outcome: "pass",
+        tokens: { input: 700, output: 300 },
+        tokenMeasurement: "parsed",
+      }),
+      fakeResult({
+        outcome: "pass",
+        tokens: { input: 0, output: 0 },
+        tokenMeasurement: "missing",
+      }),
+    ];
+    const agg = computeOutcomeAggregate(results);
+    expect(agg.passRate).toBeCloseTo(1);
+    expect(agg.tokensPerPass).toBeCloseTo(1000);
+    expect(agg.runsWithMeasuredTokens).toBe(1);
+  });
+
+  test("unsupported token measurement is also skipped from token aggregation", () => {
+    const results = [
+      fakeResult({
+        outcome: "pass",
+        tokens: { input: 0, output: 0 },
+        tokenMeasurement: "unsupported",
+      }),
+    ];
+    const agg = computeOutcomeAggregate(results);
+    // No measured passes → tokensPerPass collapses to 0, but runsWithMeasuredTokens=0
+    // signals that the 0 is "unknown", not "free".
+    expect(agg.tokensPerPass).toBe(0);
+    expect(agg.runsWithMeasuredTokens).toBe(0);
   });
 });
 
@@ -125,6 +162,53 @@ describe("aggregatePerTask", () => {
     expect(m.count).toBe(0);
     expect(m.passRate).toBe(0);
     expect(m.tokensPerPass).toBeNull();
+    expect(m.runsWithMeasuredTokens).toBe(0);
+  });
+
+  test("aggregatePerTask: passes with missing measurement do NOT pull tokensPerPass to zero", () => {
+    const runs = [
+      fakeResult({
+        seed: 0,
+        outcome: "pass",
+        tokens: { input: 800, output: 200 },
+        tokenMeasurement: "parsed",
+        wallclockMs: 1000,
+      }),
+      fakeResult({
+        seed: 1,
+        outcome: "pass",
+        tokens: { input: 0, output: 0 },
+        tokenMeasurement: "missing",
+        wallclockMs: 1000,
+      }),
+    ];
+    const m = aggregatePerTask(runs);
+    expect(m.passRate).toBe(1);
+    // Mean is over the single measured pass, not (1000 + 0) / 2.
+    expect(m.tokensPerPass).toBeCloseTo(1000);
+    expect(m.runsWithMeasuredTokens).toBe(1);
+    expect(m.count).toBe(2);
+  });
+
+  test("aggregatePerTask: tokensPerPass is null when every pass has missing measurement", () => {
+    const runs = [
+      fakeResult({
+        seed: 0,
+        outcome: "pass",
+        tokens: { input: 0, output: 0 },
+        tokenMeasurement: "missing",
+      }),
+      fakeResult({
+        seed: 1,
+        outcome: "pass",
+        tokens: { input: 0, output: 0 },
+        tokenMeasurement: "unsupported",
+      }),
+    ];
+    const m = aggregatePerTask(runs);
+    expect(m.passRate).toBe(1);
+    expect(m.tokensPerPass).toBeNull();
+    expect(m.runsWithMeasuredTokens).toBe(0);
   });
 });
 
@@ -140,6 +224,7 @@ describe("aggregateCorpus", () => {
         budgetExceededCount: 0,
         harnessErrorCount: 0,
         count: 5,
+        runsWithMeasuredTokens: 5,
       },
       b: {
         passRate: 0,
@@ -150,6 +235,7 @@ describe("aggregateCorpus", () => {
         budgetExceededCount: 0,
         harnessErrorCount: 0,
         count: 1,
+        runsWithMeasuredTokens: 0,
       },
     };
     const corpus = aggregateCorpus(perTask);
@@ -169,6 +255,7 @@ describe("aggregateCorpus", () => {
         budgetExceededCount: 0,
         harnessErrorCount: 0,
         count: 1,
+        runsWithMeasuredTokens: 0,
       },
     };
     const corpus = aggregateCorpus(perTask);
@@ -208,6 +295,7 @@ describe("delta helpers", () => {
       budgetExceededCount: 0,
       harnessErrorCount: 0,
       count: 1,
+      runsWithMeasuredTokens: 0,
     };
     const akm: PerTaskMetrics = {
       passRate: 1,
@@ -218,6 +306,7 @@ describe("delta helpers", () => {
       budgetExceededCount: 0,
       harnessErrorCount: 0,
       count: 1,
+      runsWithMeasuredTokens: 1,
     };
     expect(computePerTaskDelta(noakm, akm).tokensPerPass).toBeNull();
   });

--- a/tests/bench/metrics.ts
+++ b/tests/bench/metrics.ts
@@ -847,7 +847,7 @@ export interface CompareReportSuccess {
 /** Failure envelope. `reason` is the discrete refusal cause; `message` is human-readable. */
 export interface CompareReportFailure {
   ok: false;
-  reason: "model_mismatch" | "hash_mismatch" | "schema_mismatch" | "track_mismatch";
+  reason: "model_mismatch" | "hash_mismatch" | "corpus_mismatch" | "schema_mismatch" | "track_mismatch";
   message: string;
   baseModel?: string;
   currentModel?: string;
@@ -855,6 +855,26 @@ export interface CompareReportFailure {
   currentFixtureContentHash?: string | null;
   /** When `reason === "hash_mismatch"`, the affected fixtures (best-effort). */
   affectedFixtures?: string[];
+  /** #250 — task corpus hashes when `reason === "corpus_mismatch"`. */
+  baseTaskCorpusHash?: string | null;
+  currentTaskCorpusHash?: string | null;
+  /** #250 — selected task IDs that diverge between base and current. */
+  baseSelectedTaskIds?: string[];
+  currentSelectedTaskIds?: string[];
+}
+
+/**
+ * Caller-controlled overrides for `compareReports` (#250). When both flags
+ * are false (the default), the comparator refuses mismatched corpora /
+ * fixtures. Setting a flag converts the corresponding refusal into a
+ * warning so an operator can still inspect a cross-corpus or cross-fixture
+ * diff when they explicitly opt in.
+ */
+export interface CompareOptions {
+  /** When true, accept mismatched task IDs / `taskCorpusHash`; emit a warning instead. */
+  allowCorpusMismatch?: boolean;
+  /** When true, accept mismatched `fixtureContentHash`; emit a warning instead. */
+  allowFixtureMismatch?: boolean;
 }
 
 export type CompareResult = CompareReportSuccess | CompareReportFailure;
@@ -897,6 +917,12 @@ export interface ParsedReportJson {
     slice?: string;
     seedsPerArm?: number;
     fixtureContentHash?: string | null;
+    /** #250 — stable-sorted list of task IDs the run selected. */
+    selectedTaskIds?: string[];
+    /** #250 — deterministic hash over `selectedTaskIds` + per-task body bytes. */
+    taskCorpusHash?: string | null;
+    /** #250 — per-fixture content hash (fixture name → sha256 hex). */
+    fixtures?: Record<string, string>;
   };
   aggregate?: {
     noakm?: { pass_rate?: number; tokens_per_pass?: number | null; wallclock_ms?: number };
@@ -919,6 +945,24 @@ function readModel(r: ParsedReportJson): string {
 function readFixtureHash(r: ParsedReportJson): string | null {
   const v = r.corpus?.fixtureContentHash;
   return v === undefined || v === null ? null : v;
+}
+
+function readTaskCorpusHash(r: ParsedReportJson): string | null {
+  const v = r.corpus?.taskCorpusHash;
+  return v === undefined || v === null ? null : v;
+}
+
+function readSelectedTaskIds(r: ParsedReportJson): string[] | null {
+  const v = r.corpus?.selectedTaskIds;
+  return Array.isArray(v) ? v : null;
+}
+
+function arraysEqualIgnoringOrder(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  for (let i = 0; i < sa.length; i += 1) if (sa[i] !== sb[i]) return false;
+  return true;
 }
 
 function akmAgg(r: ParsedReportJson): { pass_rate: number; tokens_per_pass: number | null; wallclock_ms: number } {
@@ -947,7 +991,11 @@ function akmAgg(r: ParsedReportJson): { pass_rate: number; tokens_per_pass: numb
  * higher is better; `tokens_per_pass` and `wallclock_ms` are counts, lower
  * is better.
  */
-export function compareReports(base: ParsedReportJson, current: ParsedReportJson): CompareResult {
+export function compareReports(
+  base: ParsedReportJson,
+  current: ParsedReportJson,
+  options: CompareOptions = {},
+): CompareResult {
   // Schema-version gate.
   if (base.schemaVersion !== 1 || current.schemaVersion !== 1) {
     return {
@@ -984,16 +1032,75 @@ export function compareReports(base: ParsedReportJson, current: ParsedReportJson
   const baseHash = readFixtureHash(base);
   const currentHash = readFixtureHash(current);
   const warnings: string[] = [];
+
+  // #250 — task corpus hash + selected task IDs. Refused unless either side
+  // is legacy (missing the hash) or the operator passed
+  // `allowCorpusMismatch`. Legacy reports (no taskCorpusHash) degrade to a
+  // warning so older artefacts can still be diffed.
+  const baseTaskHash = readTaskCorpusHash(base);
+  const currentTaskHash = readTaskCorpusHash(current);
+  const baseIds = readSelectedTaskIds(base);
+  const currentIds = readSelectedTaskIds(current);
+  if (baseTaskHash !== null && currentTaskHash !== null && baseTaskHash !== currentTaskHash) {
+    if (!options.allowCorpusMismatch) {
+      return {
+        ok: false,
+        reason: "corpus_mismatch",
+        message: `cannot compare across different task corpora: base taskCorpusHash="${baseTaskHash}", current="${currentTaskHash}". Rerun against the same task selection or pass --allow-corpus-mismatch to override.`,
+        baseModel,
+        currentModel,
+        baseTaskCorpusHash: baseTaskHash,
+        currentTaskCorpusHash: currentTaskHash,
+        ...(baseIds ? { baseSelectedTaskIds: baseIds } : {}),
+        ...(currentIds ? { currentSelectedTaskIds: currentIds } : {}),
+      };
+    }
+    warnings.push(
+      `task corpus hashes differ (base="${baseTaskHash}", current="${currentTaskHash}") — diff requested via --allow-corpus-mismatch`,
+    );
+  } else if (
+    baseTaskHash === null &&
+    currentTaskHash === null &&
+    baseIds !== null &&
+    currentIds !== null &&
+    !arraysEqualIgnoringOrder(baseIds, currentIds)
+  ) {
+    // Both sides legacy (no taskCorpusHash) but both expose selectedTaskIds
+    // and they differ. We can still detect a mismatched corpus from the ID
+    // list alone — refuse unless the operator opted in.
+    if (!options.allowCorpusMismatch) {
+      return {
+        ok: false,
+        reason: "corpus_mismatch",
+        message: `cannot compare across different selected task IDs. Rerun against the same task selection or pass --allow-corpus-mismatch to override.`,
+        baseModel,
+        currentModel,
+        baseSelectedTaskIds: baseIds,
+        currentSelectedTaskIds: currentIds,
+      };
+    }
+    warnings.push("selected task IDs differ — diff requested via --allow-corpus-mismatch");
+  }
+  if (baseTaskHash === null)
+    warnings.push("base report has no corpus.taskCorpusHash; proceeding without task-corpus-pin check");
+  if (currentTaskHash === null)
+    warnings.push("current report has no corpus.taskCorpusHash; proceeding without task-corpus-pin check");
+
   if (baseHash !== null && currentHash !== null && baseHash !== currentHash) {
-    return {
-      ok: false,
-      reason: "hash_mismatch",
-      message: `cannot compare across different fixture-content hashes: base="${baseHash}", current="${currentHash}". Rerun against matching fixtures.`,
-      baseModel,
-      currentModel,
-      baseFixtureContentHash: baseHash,
-      currentFixtureContentHash: currentHash,
-    };
+    if (!options.allowFixtureMismatch) {
+      return {
+        ok: false,
+        reason: "hash_mismatch",
+        message: `cannot compare across different fixture-content hashes: base="${baseHash}", current="${currentHash}". Rerun against matching fixtures or pass --allow-fixture-mismatch to override.`,
+        baseModel,
+        currentModel,
+        baseFixtureContentHash: baseHash,
+        currentFixtureContentHash: currentHash,
+      };
+    }
+    warnings.push(
+      `fixture-content hashes differ (base="${baseHash}", current="${currentHash}") — diff requested via --allow-fixture-mismatch`,
+    );
   }
   if (baseHash === null)
     warnings.push("base report has no corpus.fixtureContentHash; proceeding without fixture-pin check");

--- a/tests/bench/metrics.ts
+++ b/tests/bench/metrics.ts
@@ -21,7 +21,8 @@ import path from "node:path";
 
 import type { TaskMetadata } from "./corpus";
 import type { RunResult } from "./driver";
-import type { UtilityRunReport } from "./report";
+import type { RunRecordSerialized, UtilityRunReport } from "./report";
+import { serializeRunForReport } from "./report";
 
 // ── Outcome (§6.1) ─────────────────────────────────────────────────────────
 
@@ -410,6 +411,73 @@ export function computePerAssetAttribution(report: UtilityRunReport): PerAssetAt
 function collectAkmRuns(report: UtilityRunReport): RunResult[] {
   if (Array.isArray(report.akmRuns)) return report.akmRuns;
   return [];
+}
+
+// ── runs[] serialisation (#249) ────────────────────────────────────────────
+
+/**
+ * Project a list of RunResults onto the compact `runs[]` rows persisted
+ * inside the §13.3 JSON envelope (#249). One row per (task, arm, seed)
+ * triple; the renderer walks the input order verbatim, which the runner
+ * already builds deterministically (per-task block, noakm before akm,
+ * seeds in ascending order).
+ *
+ * Aggregate metrics (per-task, trajectory, failure-mode, search-bridge,
+ * attribution) MUST be recomputable from these rows + task metadata. This
+ * helper is the canonical projection — keep it in lockstep with the field
+ * list in the issue body.
+ */
+export function aggregateRunsForReport(runs: RunResult[]): RunRecordSerialized[] {
+  return runs.map(serializeRunForReport);
+}
+
+/**
+ * Hydrate a persisted `runs[]` row back into the `RunResult` shape that
+ * downstream metrics helpers (`computePerAssetAttribution`, `aggregateCorpus`,
+ * etc.) expect. Used by `bench attribute` / `bench compare` when they read a
+ * §13.3 envelope from disk: the persisted row carries a compact subset, but
+ * it carries everything those helpers need.
+ *
+ * Fields the row deliberately does NOT carry are filled with safe defaults:
+ *   • `events: []` — events.jsonl is not persisted; downstream attribution
+ *     only consults `assetsLoaded` and `verifierStdout`.
+ *   • `verifierStdout: ""` — full stdout is intentionally omitted from the
+ *     envelope (#249 acceptance criterion). `assetsLoaded` already carries
+ *     the post-hoc extraction the agent run produced.
+ *   • `schemaVersion: 1` — the report schema implies it.
+ *
+ * Tokens are passed through as-is so a future `measurement` field added by
+ * #252 lands on the rehydrated row automatically. TODO(#252): keep this
+ * spread.
+ */
+export function rehydrateRunFromSerialized(row: RunRecordSerialized): RunResult {
+  // The compact row uses a permissive Record shape for tokens (see
+  // RunRecordSerialized). Coerce defensively so older artefacts with only
+  // {input, output} hydrate cleanly.
+  const tok = row.tokens as { input?: number; output?: number } & Record<string, unknown>;
+  return {
+    schemaVersion: 1,
+    taskId: row.task_id,
+    arm: row.arm,
+    seed: row.seed,
+    model: row.model,
+    outcome: row.outcome as RunResult["outcome"],
+    tokens: {
+      ...tok,
+      input: typeof tok.input === "number" ? tok.input : 0,
+      output: typeof tok.output === "number" ? tok.output : 0,
+    } as RunResult["tokens"],
+    wallclockMs: row.wallclock_ms,
+    trajectory: {
+      correctAssetLoaded: row.trajectory.correct_asset_loaded,
+      feedbackRecorded: row.trajectory.feedback_recorded,
+    },
+    events: [],
+    verifierStdout: "",
+    verifierExitCode: row.verifier_exit_code,
+    assetsLoaded: [...row.assets_loaded],
+    failureMode: (row.failure_mode ?? null) as RunResult["failureMode"],
+  };
 }
 
 // ── runMaskedCorpus (§6.5 leave-one-out) ──────────────────────────────────

--- a/tests/bench/metrics.ts
+++ b/tests/bench/metrics.ts
@@ -319,9 +319,37 @@ export function extractAssetLoads(runResult: RunResult): string[] {
   return out;
 }
 
-// Suppress the unused warning for the constant exposed to keep the cap
-// discoverable from this module's surface (mirrors the trajectory cap).
+// Suppress the unused warning for `ASSET_REF_PATTERN` above. The constant is
+// retained as the documentation seam called out by the #251 review addenda,
+// even though `extractAssetLoads` uses inline regexes for its two scan forms.
 void ASSET_REF_PATTERN;
+
+/**
+ * Anchored variant of `ASSET_REF_PATTERN` for whole-string validation.
+ *
+ * Used by `materialiseMaskedStash` (#251) to gate every asset ref BEFORE we
+ * touch the filesystem. The base `ASSET_REF_PATTERN` is `/g`-flagged for
+ * scanning agent stdout; we re-anchor here so a hostile string like
+ * `skill:foo/../../etc` is rejected as a whole even though the regex would
+ * happily match a `skill:foo` substring under `/g`.
+ *
+ * Rejects `..`, absolute paths, drive letters, null bytes, `/`, `\`, and
+ * anything else outside the v1 ref grammar (mirrors src/core/asset-ref.ts).
+ */
+const ASSET_REF_ANCHORED = /^(?:[a-z0-9_-]+\/\/)?[a-z][a-z0-9_-]*:[A-Za-z0-9_-]+$/;
+
+/**
+ * Reject hostile asset refs before they reach any `fs.rmSync` call. The ref
+ * comes from agent stdout (untrusted; the agent could be prompt-injected) so
+ * we apply the anchored grammar pattern first, then the per-segment shape
+ * check after the colon-split. Defense in depth — each layer is sufficient
+ * on its own; the layered structure makes a future grammar relax safe.
+ */
+function isSafeAssetRef(ref: string): boolean {
+  if (!ref) return false;
+  if (ref.includes("\0")) return false;
+  return ASSET_REF_ANCHORED.test(ref);
+}
 
 /** Per-asset attribution row (§6.5). */
 export interface PerAssetAttributionRow {
@@ -438,6 +466,20 @@ export interface MaskedCorpusResult {
    * to verify cost accounting.
    */
   runsPerformed: number;
+  /**
+   * Strategy used to construct each masked stash. Currently always
+   * `"leave-one-out"`: every re-run masks exactly one asset ref from the
+   * source fixture stash. Recorded in the JSON envelope so operators can
+   * tell at a glance whether a future strategy (e.g. `"leave-pair-out"`)
+   * was used.
+   */
+  maskingStrategy: "leave-one-out";
+  /**
+   * The exact asset refs masked, one per masked re-run. Order matches
+   * `attributions[]`. Recorded in the JSON envelope so the operator can
+   * audit which assets contributed to the marginal-contribution numbers.
+   */
+  maskedRefs: string[];
 }
 
 /** Caller-facing options for `runMaskedCorpus`. */
@@ -526,6 +568,7 @@ export async function runMaskedCorpus(opts: RunMaskedCorpusOptions): Promise<Mas
   const baseAkmPassRate = baseReport.aggregateAkm.passRate;
   const top = attribution.rows.slice(0, clamped);
   const attributions: MaskedAttributionRow[] = [];
+  const maskedRefs: string[] = [];
 
   for (const row of top) {
     const maskedTasks: TaskMetadata[] = [];
@@ -534,20 +577,36 @@ export async function runMaskedCorpus(opts: RunMaskedCorpusOptions): Promise<Mas
       for (const baseTask of baseReport.taskMetadata ?? []) {
         const maskedStashDir = materialiseMaskedStash(fixturesRoot, baseTask.stash, row.assetRef);
         if (maskedStashDir) tmpDirs.push(maskedStashDir);
-        // Forward the masked stashDir as a sibling field. Tasks already carry
-        // `stash` (the fixture name), so we tunnel the masked dir through
-        // `taskDir` won't work — instead we mutate `stash` to point at the
-        // tmp dir and rely on the runner's `materialiseStash` flow. The
-        // injected runUtility for masked runs MUST honour `stashDirOverride`.
-        maskedTasks.push({ ...baseTask, stash: maskedStashDir ?? baseTask.stash });
+        // Issue #251: forward the masked stashDir via the explicit
+        // `stashDirOverride` field on the cloned TaskMetadata. We MUST NOT
+        // mutate `baseTask.stash` (the fixture name) — the runner uses that
+        // to call `loadFixtureStash`, and overloading it breaks the
+        // `__no-stash__` resolution branch in runner.ts. The runner's AKM-arm
+        // branch checks `task.stashDirOverride` first.
+        //
+        // When `materialiseMaskedStash` returned `null` (asset not present in
+        // this fixture, or hostile ref shape rejected by the validator), we
+        // intentionally leave both fields untouched. The runner falls back to
+        // the normal materialisation flow against the unchanged source
+        // fixture — so the re-run still happens, but the result mirrors the
+        // base. This is a meaningful diagnostic (the ref didn't bind in this
+        // fixture) and is the same accounting `cost-accounting`-style tests
+        // assert against.
+        if (maskedStashDir) {
+          maskedTasks.push({ ...baseTask, stashDirOverride: maskedStashDir });
+        } else {
+          maskedTasks.push({ ...baseTask });
+        }
       }
 
       const maskedReport = await opts.runUtility({
         ...opts.baseOptions,
         tasks: maskedTasks,
-        // The masked stash already has the correct content on disk, so we
-        // skip the runner's own materialisation step (which would otherwise
-        // try to look up the fixture by name).
+        // The masked stash already has the correct content on disk, and the
+        // runner now resolves it via `task.stashDirOverride`. We still pass
+        // `materialiseStash: false` so the runner does not call
+        // `loadFixtureStash` against the (unmasked) named fixture — that
+        // would waste work and risk re-indexing the source dir.
         materialiseStash: false,
       });
 
@@ -558,7 +617,11 @@ export async function runMaskedCorpus(opts: RunMaskedCorpusOptions): Promise<Mas
         maskedPassRate,
         marginalContribution: baseAkmPassRate - maskedPassRate,
       });
+      maskedRefs.push(row.assetRef);
     } finally {
+      // Cleanup runs in BOTH success and failure paths (acceptance criterion).
+      // Best-effort: a tmpfs failure here is logged via the `try/catch` below
+      // and the host OS reaps the tmp dir on reboot.
       for (const dir of tmpDirs) {
         try {
           fs.rmSync(dir, { recursive: true, force: true });
@@ -573,6 +636,8 @@ export async function runMaskedCorpus(opts: RunMaskedCorpusOptions): Promise<Mas
     baseReport,
     attributions,
     runsPerformed: clamped,
+    maskingStrategy: "leave-one-out",
+    maskedRefs,
   };
 }
 
@@ -592,6 +657,11 @@ export async function runMaskedCorpus(opts: RunMaskedCorpusOptions): Promise<Mas
 function materialiseMaskedStash(fixturesRoot: string, stashName: string, assetRef: string): string | null {
   const sourceDir = path.join(fixturesRoot, stashName);
   if (!fs.existsSync(path.join(sourceDir, "MANIFEST.json"))) return null;
+
+  // Issue #251 review addendum: validate the WHOLE ref against the anchored
+  // grammar before we touch the filesystem. The downstream `isSafeAssetNameSegment`
+  // + `isPathContained` checks are still applied — this is defense in depth.
+  if (!isSafeAssetRef(assetRef)) return null;
 
   const colonIdx = assetRef.indexOf(":");
   if (colonIdx < 0) {

--- a/tests/bench/metrics.ts
+++ b/tests/bench/metrics.ts
@@ -29,14 +29,23 @@ export interface OutcomeAggregate {
   /** Fraction of runs whose outcome is `pass`. Zero when results is empty. */
   passRate: number;
   /**
-   * Mean total tokens across runs that passed; `0` when there are no passes
-   * (avoids `Infinity` and `NaN` polluting downstream JSON).
+   * Mean total tokens across runs that passed AND have a parsed token
+   * measurement; `0` when no such runs exist (avoids `Infinity` and `NaN`
+   * polluting downstream JSON). Runs with `tokenMeasurement !== "parsed"`
+   * are deliberately skipped so a `0` here means "no parsed passes" rather
+   * than "free run" (issue #252).
    */
   tokensPerPass: number;
   /** Mean wallclock ms across all runs (not just passes). */
   wallclockMs: number;
   /** Number of runs whose outcome is `budget_exceeded`. */
   budgetExceeded: number;
+  /**
+   * Total runs (any outcome) with `tokenMeasurement === "parsed"`. Reports
+   * use this to surface token-measurement coverage; aggregations with low
+   * coverage cannot be trusted for token economics (issue #252).
+   */
+  runsWithMeasuredTokens: number;
 }
 
 /**
@@ -48,27 +57,47 @@ export interface OutcomeAggregate {
  */
 export function computeOutcomeAggregate(results: RunResult[]): OutcomeAggregate {
   if (results.length === 0) {
-    return { passRate: 0, tokensPerPass: 0, wallclockMs: 0, budgetExceeded: 0 };
+    return { passRate: 0, tokensPerPass: 0, wallclockMs: 0, budgetExceeded: 0, runsWithMeasuredTokens: 0 };
   }
   let passes = 0;
   let budgetExceeded = 0;
-  let totalTokensInPasses = 0;
+  let totalTokensInMeasuredPasses = 0;
+  let measuredPasses = 0;
+  let runsWithMeasuredTokens = 0;
   let totalWallclock = 0;
   for (const r of results) {
     totalWallclock += r.wallclockMs;
+    if (isMeasured(r)) {
+      runsWithMeasuredTokens += 1;
+    }
     if (r.outcome === "pass") {
       passes += 1;
-      totalTokensInPasses += r.tokens.input + r.tokens.output;
+      // Only fold tokens into the mean when we actually measured them
+      // (issue #252) — otherwise a `0` would silently understate cost.
+      if (isMeasured(r)) {
+        measuredPasses += 1;
+        totalTokensInMeasuredPasses += r.tokens.input + r.tokens.output;
+      }
     } else if (r.outcome === "budget_exceeded") {
       budgetExceeded += 1;
     }
   }
   return {
     passRate: passes / results.length,
-    tokensPerPass: passes === 0 ? 0 : totalTokensInPasses / passes,
+    tokensPerPass: measuredPasses === 0 ? 0 : totalTokensInMeasuredPasses / measuredPasses,
     wallclockMs: totalWallclock / results.length,
     budgetExceeded,
+    runsWithMeasuredTokens,
   };
+}
+
+/**
+ * Treat older artefacts without `tokenMeasurement` as `"parsed"` for backward
+ * compatibility — pre-#252 reports always returned numeric zero, and rejecting
+ * them entirely would break compare/attribute over historical runs.
+ */
+function isMeasured(r: RunResult): boolean {
+  return (r.tokenMeasurement ?? "parsed") === "parsed";
 }
 
 // ── Per-task aggregation (§6.1, K seeds per arm) ───────────────────────────
@@ -85,7 +114,12 @@ export interface PerTaskMetrics {
   passRate: number;
   /** Pass-or-fail of seed 0 (or first run when seed 0 is absent). */
   passAt1: 0 | 1;
-  /** Mean total tokens in passing runs. `null` when 0 passes. */
+  /**
+   * Mean total tokens in passing runs that also carry a parsed token
+   * measurement. `null` when 0 passes OR when every passing run has missing /
+   * unsupported token measurement (issue #252) — downstream renderers must
+   * treat `null` as "not enough measurement to know" rather than zero cost.
+   */
   tokensPerPass: number | null;
   /** Mean wallclock ms across all K runs. */
   wallclockMs: number;
@@ -97,6 +131,12 @@ export interface PerTaskMetrics {
   harnessErrorCount: number;
   /** Number of runs aggregated. Useful when K varies (last seed dropped, etc.). */
   count: number;
+  /**
+   * Count of runs (any outcome) with `tokenMeasurement === "parsed"` (issue
+   * #252). Reports use this to surface token-measurement coverage so
+   * operators can tell when token economics are unreliable.
+   */
+  runsWithMeasuredTokens: number;
 }
 
 /**
@@ -114,23 +154,35 @@ export function aggregatePerTask(results: RunResult[]): PerTaskMetrics {
       budgetExceededCount: 0,
       harnessErrorCount: 0,
       count: 0,
+      runsWithMeasuredTokens: 0,
     };
   }
 
   let passes = 0;
-  let totalTokensInPasses = 0;
+  let measuredPasses = 0;
+  let totalTokensInMeasuredPasses = 0;
   let totalWallclock = 0;
   let budgetExceeded = 0;
   let harnessError = 0;
+  let runsWithMeasuredTokens = 0;
   // For the standard deviation we need a fixed-iteration buffer of pass/fail.
   const passSamples: number[] = [];
   for (const r of results) {
     totalWallclock += r.wallclockMs;
+    if (isMeasured(r)) {
+      runsWithMeasuredTokens += 1;
+    }
     const isPass = r.outcome === "pass" ? 1 : 0;
     passSamples.push(isPass);
     if (isPass === 1) {
       passes += 1;
-      totalTokensInPasses += r.tokens.input + r.tokens.output;
+      // Only count tokens for measured passes (issue #252). A pass with
+      // missing measurement contributes to `passRate` but NOT to
+      // `tokensPerPass` — preserving "tokens per measured pass" semantics.
+      if (isMeasured(r)) {
+        measuredPasses += 1;
+        totalTokensInMeasuredPasses += r.tokens.input + r.tokens.output;
+      }
     } else if (r.outcome === "budget_exceeded") {
       budgetExceeded += 1;
     } else if (r.outcome === "harness_error") {
@@ -144,12 +196,13 @@ export function aggregatePerTask(results: RunResult[]): PerTaskMetrics {
   return {
     passRate: passes / results.length,
     passAt1,
-    tokensPerPass: passes === 0 ? null : totalTokensInPasses / passes,
+    tokensPerPass: measuredPasses === 0 ? null : totalTokensInMeasuredPasses / measuredPasses,
     wallclockMs: totalWallclock / results.length,
     passRateStdev: stdev(passSamples),
     budgetExceededCount: budgetExceeded,
     harnessErrorCount: harnessError,
     count: results.length,
+    runsWithMeasuredTokens,
   };
 }
 

--- a/tests/bench/report.test.ts
+++ b/tests/bench/report.test.ts
@@ -24,8 +24,20 @@ const sample: ReportInput = {
   model: "anthropic/claude-opus-4-7",
   track: "utility",
   arms: {
-    noakm: { passRate: 0.4, tokensPerPass: 18000, wallclockMs: 41000, budgetExceeded: 0 },
-    akm: { passRate: 0.7, tokensPerPass: 14000, wallclockMs: 36000, budgetExceeded: 1 },
+    noakm: {
+      passRate: 0.4,
+      tokensPerPass: 18000,
+      wallclockMs: 41000,
+      budgetExceeded: 0,
+      runsWithMeasuredTokens: 4,
+    },
+    akm: {
+      passRate: 0.7,
+      tokensPerPass: 14000,
+      wallclockMs: 36000,
+      budgetExceeded: 1,
+      runsWithMeasuredTokens: 7,
+    },
   },
 };
 

--- a/tests/bench/report.test.ts
+++ b/tests/bench/report.test.ts
@@ -76,6 +76,7 @@ function pt(passRate: number, tokens: number | null, wall: number, count = 5): P
     budgetExceededCount: 0,
     harnessErrorCount: 0,
     count,
+    runsWithMeasuredTokens: count,
   };
 }
 
@@ -179,6 +180,83 @@ describe("renderUtilityReport markdown", () => {
     const { markdown } = renderUtilityReport(withWarn);
     expect(markdown).toContain("## Warnings");
     expect(markdown).toContain("stash xyz failed to load");
+  });
+});
+
+describe("token-measurement surface (issue #252)", () => {
+  function fakeRun(overrides: Partial<import("./driver").RunResult>): import("./driver").RunResult {
+    return {
+      schemaVersion: 1,
+      taskId: "t",
+      arm: "akm",
+      seed: 0,
+      model: "m",
+      outcome: "pass",
+      tokens: { input: 0, output: 0 },
+      tokenMeasurement: "parsed",
+      wallclockMs: 0,
+      trajectory: { correctAssetLoaded: null, feedbackRecorded: null },
+      events: [],
+      verifierStdout: "",
+      verifierExitCode: 0,
+      assetsLoaded: [],
+      ...overrides,
+    };
+  }
+
+  test("JSON envelope has token_measurement coverage block + warning when any run is missing", () => {
+    const akmRuns = [
+      fakeRun({ seed: 0, tokenMeasurement: "parsed", tokens: { input: 100, output: 50 } }),
+      fakeRun({ seed: 1, tokenMeasurement: "missing" }),
+      fakeRun({ seed: 2, tokenMeasurement: "unsupported" }),
+    ];
+    const sampleWithRuns: UtilityRunReport = { ...utilSample, akmRuns };
+    const { json, markdown } = renderUtilityReport(sampleWithRuns);
+    const obj = json as Record<string, unknown>;
+    const tm = obj.token_measurement as Record<string, unknown>;
+    expect(tm.total_runs).toBe(3);
+    expect(tm.runs_with_measured_tokens).toBe(1);
+    expect(tm.runs_missing_measurement).toBe(1);
+    expect(tm.runs_unsupported_measurement).toBe(1);
+    expect(tm.coverage).toBeCloseTo(1 / 3);
+    expect(tm.reliable).toBe(false);
+
+    const warnings = obj.warnings as string[];
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("token measurement unreliable");
+
+    expect(markdown).toContain("## Token measurement (akm)");
+    expect(markdown).toContain("unreliable");
+    expect(markdown).toContain("## Warnings");
+    expect(markdown).toContain("token measurement unreliable");
+  });
+
+  test("JSON envelope marks reliable=true and emits no warning when every run is parsed", () => {
+    const akmRuns = [
+      fakeRun({ seed: 0, tokenMeasurement: "parsed", tokens: { input: 100, output: 50 } }),
+      fakeRun({ seed: 1, tokenMeasurement: "parsed", tokens: { input: 200, output: 75 } }),
+    ];
+    const sampleWithRuns: UtilityRunReport = { ...utilSample, akmRuns };
+    const { json, markdown } = renderUtilityReport(sampleWithRuns);
+    const obj = json as Record<string, unknown>;
+    const tm = obj.token_measurement as Record<string, unknown>;
+    expect(tm.total_runs).toBe(2);
+    expect(tm.runs_with_measured_tokens).toBe(2);
+    expect(tm.coverage).toBeCloseTo(1);
+    expect(tm.reliable).toBe(true);
+    expect(obj.warnings).toEqual([]);
+    expect(markdown).toContain("reliable");
+    expect(markdown).not.toContain("token measurement unreliable");
+  });
+
+  test("coverage is null and section is skipped when no akm runs are attached", () => {
+    const { json, markdown } = renderUtilityReport(utilSample);
+    const obj = json as Record<string, unknown>;
+    const tm = obj.token_measurement as Record<string, unknown>;
+    expect(tm.total_runs).toBe(0);
+    expect(tm.coverage).toBeNull();
+    expect(tm.reliable).toBe(false);
+    expect(markdown).not.toContain("## Token measurement");
   });
 });
 

--- a/tests/bench/report.test.ts
+++ b/tests/bench/report.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { RunResult } from "./driver";
 import type { PerTaskMetrics } from "./metrics";
 import {
   type ReportInput,
@@ -14,6 +15,7 @@ import {
   renderUtilityReport,
   resolveGitBranch,
   resolveGitCommit,
+  serializeRunForReport,
   type UtilityRunReport,
 } from "./report";
 
@@ -179,6 +181,102 @@ describe("renderUtilityReport markdown", () => {
     const { markdown } = renderUtilityReport(withWarn);
     expect(markdown).toContain("## Warnings");
     expect(markdown).toContain("stash xyz failed to load");
+  });
+});
+
+// ── Compact runs[] serialisation (#249) ───────────────────────────────────
+
+function makeRun(overrides: Partial<RunResult> = {}): RunResult {
+  const base: RunResult = {
+    schemaVersion: 1,
+    taskId: "domain-a/task-1",
+    arm: "akm",
+    seed: 0,
+    model: "anthropic/claude-opus-4-7",
+    outcome: "pass",
+    tokens: { input: 1234, output: 5678 },
+    wallclockMs: 4200,
+    trajectory: { correctAssetLoaded: true, feedbackRecorded: false },
+    events: [
+      // events[] MUST be filtered out of the persisted row.
+      { id: 0, ts: "2026-04-27T12:00:00Z", kind: "noop" } as unknown as RunResult["events"][number],
+    ],
+    verifierStdout: "x".repeat(1024 * 1024),
+    verifierExitCode: 0,
+    assetsLoaded: ["skill:foo"],
+    failureMode: null,
+  };
+  return { ...base, ...overrides };
+}
+
+describe("serializeRunForReport", () => {
+  test("omits events[] and verifierStdout, keeps the compact field set", () => {
+    const row = serializeRunForReport(makeRun());
+    expect(row).toEqual({
+      task_id: "domain-a/task-1",
+      arm: "akm",
+      seed: 0,
+      model: "anthropic/claude-opus-4-7",
+      outcome: "pass",
+      tokens: { input: 1234, output: 5678 },
+      wallclock_ms: 4200,
+      verifier_exit_code: 0,
+      trajectory: { correct_asset_loaded: true, feedback_recorded: false },
+      assets_loaded: ["skill:foo"],
+      failure_mode: null,
+    });
+    // No events / stdout leakage even when the source carries large data.
+    expect(Object.keys(row)).not.toContain("events");
+    expect(Object.keys(row)).not.toContain("verifierStdout");
+    expect(Object.keys(row)).not.toContain("verifier_stdout");
+  });
+
+  test("passes unknown token-shape keys through (token-shape seam for #252)", () => {
+    // Simulate a future RunResult.tokens that grows a `measurement` field.
+    const futureRun = makeRun({
+      tokens: { input: 10, output: 20, measurement: "parsed" } as unknown as RunResult["tokens"],
+    });
+    const row = serializeRunForReport(futureRun);
+    expect(row.tokens).toEqual({ input: 10, output: 20, measurement: "parsed" });
+  });
+
+  test("propagates failure_mode label when present", () => {
+    const run = makeRun({ outcome: "fail", failureMode: "wrong_asset" as RunResult["failureMode"] });
+    const row = serializeRunForReport(run);
+    expect(row.outcome).toBe("fail");
+    expect(row.failure_mode).toBe("wrong_asset");
+  });
+});
+
+describe("renderUtilityReport runs[] persistence (#249)", () => {
+  test("emits one row per (task, arm, seed) when allRuns is supplied", () => {
+    const allRuns = [
+      makeRun({ taskId: "domain-a/task-1", arm: "noakm", seed: 0 }),
+      makeRun({ taskId: "domain-a/task-1", arm: "noakm", seed: 1 }),
+      makeRun({ taskId: "domain-a/task-1", arm: "akm", seed: 0 }),
+      makeRun({ taskId: "domain-a/task-1", arm: "akm", seed: 1, outcome: "fail" }),
+    ];
+    const report: UtilityRunReport = { ...utilSample, allRuns };
+    const { json } = renderUtilityReport(report);
+    const obj = json as Record<string, unknown>;
+    const runs = obj.runs as Array<Record<string, unknown>>;
+    expect(Array.isArray(runs)).toBe(true);
+    expect(runs.length).toBe(4);
+    // Order matches the runner's deterministic emission order.
+    expect(runs[0]?.arm).toBe("noakm");
+    expect(runs[2]?.arm).toBe("akm");
+    expect(runs[3]?.outcome).toBe("fail");
+    // verifier stdout / events MUST be absent.
+    for (const r of runs) {
+      expect(Object.keys(r)).not.toContain("events");
+      expect(Object.keys(r)).not.toContain("verifierStdout");
+    }
+  });
+
+  test("omits the runs key entirely when allRuns is not supplied (legacy shape)", () => {
+    const { json } = renderUtilityReport(utilSample);
+    const obj = json as Record<string, unknown>;
+    expect("runs" in obj).toBe(false);
   });
 });
 

--- a/tests/bench/report.test.ts
+++ b/tests/bench/report.test.ts
@@ -107,6 +107,36 @@ const utilSample: UtilityRunReport = {
   warnings: [],
 };
 
+describe("renderUtilityReport JSON corpus identity (#250)", () => {
+  test("emits selectedTaskIds, taskCorpusHash, fixtures, fixtureContentHash when present", () => {
+    const stamped: UtilityRunReport = {
+      ...utilSample,
+      corpus: {
+        ...utilSample.corpus,
+        selectedTaskIds: ["domain-a/task-1", "domain-b/task-2"],
+        taskCorpusHash: "deadbeef".repeat(8),
+        fixtures: { "fixture-a": "aa".repeat(32), "fixture-b": "bb".repeat(32) },
+        fixtureContentHash: "ff".repeat(32),
+      },
+    };
+    const { json } = renderUtilityReport(stamped);
+    const corpus = (json as { corpus: Record<string, unknown> }).corpus;
+    expect(corpus.selectedTaskIds).toEqual(["domain-a/task-1", "domain-b/task-2"]);
+    expect(corpus.taskCorpusHash).toBe("deadbeef".repeat(8));
+    expect(corpus.fixtureContentHash).toBe("ff".repeat(32));
+    expect(corpus.fixtures).toEqual({ "fixture-a": "aa".repeat(32), "fixture-b": "bb".repeat(32) });
+  });
+
+  test("legacy reports without identity stamps still render (#250 backward compat)", () => {
+    const { json } = renderUtilityReport(utilSample);
+    const corpus = (json as { corpus: Record<string, unknown> }).corpus;
+    // The four #250 keys are absent on legacy inputs and the renderer does
+    // not synthesise placeholders.
+    expect(corpus.taskCorpusHash).toBeUndefined();
+    expect(corpus.fixtureContentHash).toBeUndefined();
+  });
+});
+
 describe("renderUtilityReport JSON", () => {
   test("conforms to the §13.3 shape", () => {
     const { json } = renderUtilityReport(utilSample);

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -114,6 +114,16 @@ export interface UtilityRunReport {
     tasks: number;
     slice: "all" | "train" | "eval";
     seedsPerArm: number;
+    /**
+     * Identity stamps used by `bench compare` to refuse cross-corpus diffs
+     * (#250). All four are populated by `runUtility` at finalize time. Older
+     * reports (pre-#250) lack these keys and degrade to a warning instead of
+     * a refusal — see `compareReports`.
+     */
+    selectedTaskIds?: string[];
+    taskCorpusHash?: string;
+    fixtures?: Record<string, string>;
+    fixtureContentHash?: string;
   };
   aggregateNoakm: CorpusMetrics;
   aggregateAkm: CorpusMetrics;
@@ -472,6 +482,29 @@ function renderCompareFailure(result: Extract<CompareResult, { ok: false }>): st
       lines.push("");
       lines.push("affected fixtures:");
       for (const f of result.affectedFixtures) lines.push(`- ${f}`);
+    }
+  }
+  if (result.reason === "corpus_mismatch") {
+    if (result.baseTaskCorpusHash !== undefined || result.currentTaskCorpusHash !== undefined) {
+      lines.push("");
+      lines.push(`- base taskCorpusHash:    \`${String(result.baseTaskCorpusHash ?? "n/a")}\``);
+      lines.push(`- current taskCorpusHash: \`${String(result.currentTaskCorpusHash ?? "n/a")}\``);
+    }
+    if (result.baseSelectedTaskIds && result.currentSelectedTaskIds) {
+      const baseSet = new Set(result.baseSelectedTaskIds);
+      const currentSet = new Set(result.currentSelectedTaskIds);
+      const addedToCurrent = result.currentSelectedTaskIds.filter((id) => !baseSet.has(id)).sort();
+      const droppedFromBase = result.baseSelectedTaskIds.filter((id) => !currentSet.has(id)).sort();
+      if (addedToCurrent.length > 0) {
+        lines.push("");
+        lines.push("only in current:");
+        for (const id of addedToCurrent) lines.push(`- ${id}`);
+      }
+      if (droppedFromBase.length > 0) {
+        lines.push("");
+        lines.push("only in base:");
+        for (const id of droppedFromBase) lines.push(`- ${id}`);
+      }
     }
   }
   return lines.join("\n");

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -180,6 +180,14 @@ function buildUtilityJson(input: UtilityRunReport): object {
     delta: serialiseDelta(t.delta),
   }));
 
+  // Token-measurement coverage (issue #252). Folds the corpus-wide picture so
+  // operators can tell at a glance whether token economics are reliable. The
+  // warning string mirrors what we add to `warnings[]` in markdown output.
+  const tokenMeasurement = summariseTokenMeasurement(input);
+
+  const warnings = [...input.warnings];
+  if (tokenMeasurement.warning) warnings.push(tokenMeasurement.warning);
+
   const envelope: Record<string, unknown> = {
     schemaVersion: 1,
     track: "utility",
@@ -203,8 +211,16 @@ function buildUtilityJson(input: UtilityRunReport): object {
       by_label: input.failureModes.byLabel,
       by_task: input.failureModes.byTask,
     },
+    token_measurement: {
+      total_runs: tokenMeasurement.totalRuns,
+      runs_with_measured_tokens: tokenMeasurement.measuredRuns,
+      runs_missing_measurement: tokenMeasurement.missingRuns,
+      runs_unsupported_measurement: tokenMeasurement.unsupportedRuns,
+      coverage: tokenMeasurement.coverage,
+      reliable: tokenMeasurement.reliable,
+    },
     tasks,
-    warnings: input.warnings,
+    warnings,
     ...(input.searchBridge ? { searchBridge: serialiseSearchBridge(input.searchBridge) } : {}),
   };
 
@@ -283,6 +299,7 @@ function serialisePerTaskMetrics(m: PerTaskMetrics): {
   budget_exceeded_count: number;
   harness_error_count: number;
   count: number;
+  runs_with_measured_tokens: number;
 } {
   return {
     pass_rate: m.passRate,
@@ -293,6 +310,61 @@ function serialisePerTaskMetrics(m: PerTaskMetrics): {
     budget_exceeded_count: m.budgetExceededCount,
     harness_error_count: m.harnessErrorCount,
     count: m.count,
+    runs_with_measured_tokens: m.runsWithMeasuredTokens,
+  };
+}
+
+/**
+ * Token-measurement coverage summary (issue #252). The `warning` string is
+ * non-null whenever any run lacks parsed token measurement; report renderers
+ * splice it into `warnings[]` so the markdown "## Warnings" section and the
+ * JSON `warnings` array surface the same prose.
+ *
+ * `coverage` is `null` when there are no akm-arm runs (nothing to measure
+ * against — distinct from "0 / 0 = NaN"). `reliable` is `true` only when
+ * every akm run carried `tokenMeasurement === "parsed"`.
+ */
+interface TokenMeasurementSummary {
+  totalRuns: number;
+  measuredRuns: number;
+  missingRuns: number;
+  unsupportedRuns: number;
+  coverage: number | null;
+  reliable: boolean;
+  warning: string | null;
+}
+
+function summariseTokenMeasurement(input: UtilityRunReport): TokenMeasurementSummary {
+  const runs = input.akmRuns ?? [];
+  let measured = 0;
+  let missing = 0;
+  let unsupported = 0;
+  for (const r of runs) {
+    const m = r.tokenMeasurement ?? "parsed";
+    if (m === "parsed") measured += 1;
+    else if (m === "missing") missing += 1;
+    else if (m === "unsupported") unsupported += 1;
+  }
+  const total = runs.length;
+  const coverage = total === 0 ? null : measured / total;
+  const reliable = total > 0 && missing === 0 && unsupported === 0;
+  let warning: string | null = null;
+  if (total > 0 && !reliable) {
+    const parts: string[] = [];
+    if (missing > 0) parts.push(`${missing} missing`);
+    if (unsupported > 0) parts.push(`${unsupported} unsupported`);
+    warning =
+      `token measurement unreliable: ${parts.join(", ")} of ${total} akm-arm runs lack parsed token usage; ` +
+      `tokens_per_pass and token-budget signals reflect only the ${measured} measured runs.`;
+  }
+  return {
+    totalRuns: total,
+    measuredRuns: measured,
+    missingRuns: missing,
+    unsupportedRuns: unsupported,
+    coverage,
+    reliable,
+    warning,
   };
 }
 
@@ -338,11 +410,29 @@ function buildUtilityMarkdown(input: UtilityRunReport): string {
     lines.push("");
     lines.push(renderSearchBridgeTable(input.searchBridge));
   }
-  if (input.warnings.length > 0) {
+
+  // Token-measurement section (issue #252). Always rendered when there are
+  // akm-arm runs to report on, so operators can tell whether tokens economics
+  // are trustworthy without scrolling to the warnings block.
+  const tokenSummary = summariseTokenMeasurement(input);
+  if (tokenSummary.totalRuns > 0) {
+    lines.push("");
+    lines.push("## Token measurement (akm)");
+    lines.push("");
+    const cov = tokenSummary.coverage === null ? "n/a" : `${(tokenSummary.coverage * 100).toFixed(1)}%`;
+    lines.push(
+      `- runs: ${tokenSummary.totalRuns} total, ${tokenSummary.measuredRuns} measured, ${tokenSummary.missingRuns} missing, ${tokenSummary.unsupportedRuns} unsupported`,
+    );
+    lines.push(`- coverage: ${cov} (${tokenSummary.reliable ? "reliable" : "unreliable — see warning below"})`);
+  }
+
+  const warnings = [...input.warnings];
+  if (tokenSummary.warning) warnings.push(tokenSummary.warning);
+  if (warnings.length > 0) {
     lines.push("");
     lines.push("## Warnings");
     lines.push("");
-    for (const w of input.warnings) lines.push(`- ${w}`);
+    for (const w of warnings) lines.push(`- ${w}`);
   }
   return lines.join("\n");
 }

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -90,6 +90,70 @@ export function renderMarkdownSummary(input: ReportInput): string {
 // ── Utility-track report (§13.3) ───────────────────────────────────────────
 
 /**
+ * Compact serialised RunResult row persisted into the §13.3 JSON envelope
+ * under the top-level `runs[]` key (#249).
+ *
+ * One row per `(task, arm, seed)` execution, both `noakm` and `akm`. Contains
+ * enough fields to recompute every aggregate metric (per-task, trajectory,
+ * failure-mode, search-bridge, attribution) plus task metadata, but
+ * deliberately omits the full `events[]` and unbounded `verifierStdout` so the
+ * envelope stays compact. Older artefacts that pre-date this field are still
+ * valid: callers that need run-level data should fall back to the per-task
+ * aggregate path.
+ */
+export interface RunRecordSerialized {
+  task_id: string;
+  arm: string;
+  seed: number;
+  model: string;
+  outcome: string;
+  /**
+   * Spread of `RunResult.tokens` so future fields (e.g. `measurement` from
+   * #252) flow through automatically without a renderer change. Today the
+   * shape is `{input: number, output: number}`; #252 will add a sibling
+   * `measurement` field. TODO(#252): keep this pass-through.
+   */
+  tokens: Record<string, unknown>;
+  wallclock_ms: number;
+  verifier_exit_code: number;
+  trajectory: {
+    correct_asset_loaded: boolean | null;
+    feedback_recorded: boolean | null;
+  };
+  assets_loaded: string[];
+  failure_mode: string | null;
+}
+
+/**
+ * Project a RunResult onto its compact serialised form for the §13.3 JSON
+ * envelope (#249). Mirrors the field list in the issue body.
+ *
+ * Token-shape seam: `tokens` is spread verbatim from `result.tokens` so when
+ * #252 adds a `measurement` field the renderer doesn't need a code change.
+ * Do NOT hardcode `{input, output}` projections here.
+ */
+export function serializeRunForReport(result: RunResult): RunRecordSerialized {
+  return {
+    task_id: result.taskId,
+    arm: result.arm,
+    seed: result.seed,
+    model: result.model,
+    outcome: result.outcome,
+    // TODO(#252): when RunResult.tokens grows a `measurement` key, this spread
+    // carries it forward without a renderer change.
+    tokens: { ...result.tokens },
+    wallclock_ms: result.wallclockMs,
+    verifier_exit_code: result.verifierExitCode,
+    trajectory: {
+      correct_asset_loaded: result.trajectory.correctAssetLoaded,
+      feedback_recorded: result.trajectory.feedbackRecorded,
+    },
+    assets_loaded: [...(result.assetsLoaded ?? [])],
+    failure_mode: result.failureMode ?? null,
+  };
+}
+
+/**
  * Per-task envelope inside `tasks[]`. Mirrors the §13.3 layout: `noakm` and
  * `akm` are PerTaskMetrics, `delta` is the akm − noakm difference.
  */
@@ -140,6 +204,14 @@ export interface UtilityRunReport {
    * contract. The field is on the in-memory shape only.
    */
   akmRuns?: RunResult[];
+  /**
+   * Raw RunResults across both arms (`noakm` + `akm`), retained on the
+   * report so `buildUtilityJson` can serialise the compact §13.3 `runs[]`
+   * array (#249). Populated by the runner. When omitted, the envelope simply
+   * does not gain a `runs` key — backward-compat with code paths that
+   * construct a UtilityRunReport without raw runs.
+   */
+  allRuns?: RunResult[];
   /**
    * Task metadata for in-process consumers (the masked-corpus helper needs
    * to remap each task's stash to a tmp dir). Not serialised into the §13.3
@@ -207,6 +279,14 @@ function buildUtilityJson(input: UtilityRunReport): object {
     warnings: input.warnings,
     ...(input.searchBridge ? { searchBridge: serialiseSearchBridge(input.searchBridge) } : {}),
   };
+
+  // Compact raw runs[] — additive top-level key (#249). One row per
+  // (task, arm, seed) execution; both noakm and akm. Older artefacts that
+  // pre-date this field stay valid because we only emit it when the runner
+  // actually populated `allRuns`.
+  if (input.allRuns) {
+    envelope.runs = input.allRuns.map(serializeRunForReport);
+  }
 
   // Per-asset attribution is an additive top-level key (§6.5). Emit it only
   // when the runner populated it so older code paths (e.g. the empty-corpus

--- a/tests/bench/runner.test.ts
+++ b/tests/bench/runner.test.ts
@@ -104,6 +104,44 @@ describe("runUtility", () => {
     fs.rmSync(workspaceRoot, { recursive: true, force: true });
   });
 
+  test("stamps corpus identity (selectedTaskIds, taskCorpusHash, fixtures, fixtureContentHash) (#250)", async () => {
+    const { spawn } = fakeSpawnFactory({ noakm: "ok", akm: "ok" });
+    const report = await runUtility({
+      tasks: [fakeTask(taskDir, { id: "domain-a/task-z" }), fakeTask(taskDir, { id: "domain-a/task-a" })],
+      arms: ["noakm"],
+      model: "test-model",
+      seedsPerArm: 1,
+      spawn,
+      materialiseStash: false,
+      branch: "test-branch",
+      commit: "abc123",
+      timestamp: "2026-04-27T00:00:00Z",
+    });
+    // selectedTaskIds is sorted alphabetically.
+    expect(report.corpus.selectedTaskIds).toEqual(["domain-a/task-a", "domain-a/task-z"]);
+    expect(report.corpus.taskCorpusHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(report.corpus.fixtureContentHash).toMatch(/^[0-9a-f]{64}$/);
+    // The "minimal" fixture is referenced by both fakeTasks; one entry expected.
+    expect(report.corpus.fixtures).toBeDefined();
+    expect(Object.keys(report.corpus.fixtures ?? {})).toEqual(["minimal"]);
+    expect(report.corpus.fixtures?.minimal).toMatch(/^[0-9a-f]{64}$/);
+
+    // Re-running with the same inputs yields the same hashes (determinism).
+    const report2 = await runUtility({
+      tasks: [fakeTask(taskDir, { id: "domain-a/task-z" }), fakeTask(taskDir, { id: "domain-a/task-a" })],
+      arms: ["noakm"],
+      model: "test-model",
+      seedsPerArm: 1,
+      spawn: fakeSpawnFactory({ noakm: "ok", akm: "ok" }).spawn,
+      materialiseStash: false,
+      branch: "test-branch",
+      commit: "abc123",
+      timestamp: "2026-04-27T00:00:00Z",
+    });
+    expect(report2.corpus.taskCorpusHash).toBe(report.corpus.taskCorpusHash);
+    expect(report2.corpus.fixtureContentHash).toBe(report.corpus.fixtureContentHash);
+  });
+
   test("produces tasks × arms × seeds run records (cardinality)", async () => {
     const { spawn, observed } = fakeSpawnFactory({ noakm: "ok", akm: "ok" });
     const report = await runUtility({

--- a/tests/bench/runner.test.ts
+++ b/tests/bench/runner.test.ts
@@ -331,6 +331,86 @@ describe("runUtility", () => {
     expect(noakmInvocation?.some((t) => t.startsWith("BYOS"))).toBe(false);
   });
 
+  // ── #251: TaskMetadata.stashDirOverride ───────────────────────────────────
+
+  test("stashDirOverride: AKM_STASH_DIR points at the override, never at __no-stash__", async () => {
+    // Issue #251 regression. Before the fix, `runMaskedCorpus` mutated
+    // `task.stash` and called the runner with `materialiseStash: false`,
+    // which ended up wiring `AKM_STASH_DIR` to `<taskDir>/__no-stash__` —
+    // so masked re-runs never saw the masked content. The fix is a
+    // dedicated `stashDirOverride` field that the runner consults FIRST.
+    const observedAkmStashDirs: string[] = [];
+    const spawn: SpawnFn = (cmd, opts) => {
+      const isAgent = cmd[0] === "opencode";
+      if (isAgent && opts.env?.AKM_STASH_DIR) {
+        observedAkmStashDirs.push(opts.env.AKM_STASH_DIR);
+      }
+      return {
+        exitCode: 0,
+        exited: Promise.resolve(0),
+        stdout: asReadableStream("ok"),
+        stderr: asReadableStream(""),
+        stdin: null,
+        kill() {},
+      };
+    };
+    const overrideDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-bench-251-override-"));
+    try {
+      await runUtility({
+        tasks: [fakeTask(taskDir, { stashDirOverride: overrideDir })],
+        arms: ["akm"],
+        model: "test",
+        seedsPerArm: 1,
+        spawn,
+        materialiseStash: false,
+      });
+      expect(observedAkmStashDirs.length).toBe(1);
+      expect(observedAkmStashDirs[0]).toBe(overrideDir);
+      // Critical: the runner MUST NOT have fallen back to the __no-stash__
+      // placeholder. This is the regression guard.
+      expect(observedAkmStashDirs[0]?.endsWith("__no-stash__")).toBe(false);
+    } finally {
+      fs.rmSync(overrideDir, { recursive: true, force: true });
+    }
+  });
+
+  test("stashDirOverride: takes precedence over stashDirByFixture and materialised stash", async () => {
+    // Resolution order acceptance criterion: per-task override beats both
+    // the per-fixture map and the runner's own loadFixtureStash.
+    const observedAkmStashDirs: string[] = [];
+    const spawn: SpawnFn = (cmd, opts) => {
+      const isAgent = cmd[0] === "opencode";
+      if (isAgent && opts.env?.AKM_STASH_DIR) {
+        observedAkmStashDirs.push(opts.env.AKM_STASH_DIR);
+      }
+      return {
+        exitCode: 0,
+        exited: Promise.resolve(0),
+        stdout: asReadableStream("ok"),
+        stderr: asReadableStream(""),
+        stdin: null,
+        kill() {},
+      };
+    };
+    const overrideDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-bench-251-prec-"));
+    const fixtureMapDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-bench-251-mapdir-"));
+    try {
+      await runUtility({
+        tasks: [fakeTask(taskDir, { stashDirOverride: overrideDir, stash: "ignored-fixture" })],
+        arms: ["akm"],
+        model: "test",
+        seedsPerArm: 1,
+        spawn,
+        materialiseStash: false,
+        stashDirByFixture: new Map([["ignored-fixture", fixtureMapDir]]),
+      });
+      expect(observedAkmStashDirs).toEqual([overrideDir]);
+    } finally {
+      fs.rmSync(overrideDir, { recursive: true, force: true });
+      fs.rmSync(fixtureMapDir, { recursive: true, force: true });
+    }
+  });
+
   test("buildPrompt returning undefined keeps the default prompt path", async () => {
     const capturedAgentCmds: string[][] = [];
     const spawn: SpawnFn = (cmd, _opts) => {

--- a/tests/bench/runner.ts
+++ b/tests/bench/runner.ts
@@ -190,7 +190,19 @@ export async function runUtility(options: RunUtilityOptions): Promise<UtilityRun
           // stable placeholder so the env keys are wired correctly.
           let stashDir: string | undefined;
           if (arm === "akm") {
-            if (overrideStashDir) stashDir = overrideStashDir;
+            // Resolution order (must match the issue #251 acceptance criteria):
+            //   1. Per-task explicit override (used by `runMaskedCorpus` to
+            //      point at a tmp stash with one asset removed). Highest
+            //      priority because attribution correctness depends on this
+            //      branch never being shadowed by the `__no-stash__`
+            //      placeholder fallback.
+            //   2. Per-(task, arm)-call `stashDirByFixture` override (Phase
+            //      3 evolve persistence).
+            //   3. Per-task materialised fixture stash from `loadFixtureStash`.
+            //   4. `materialiseStash: false` placeholder so AKM_STASH_DIR is
+            //      still wired into the child env.
+            if (task.stashDirOverride) stashDir = task.stashDirOverride;
+            else if (overrideStashDir) stashDir = overrideStashDir;
             else if (stash) stashDir = stash.stashDir;
             else if (!materialiseStash) stashDir = path.join(task.taskDir, "__no-stash__");
           }

--- a/tests/bench/runner.ts
+++ b/tests/bench/runner.ts
@@ -354,6 +354,7 @@ function buildReport(args: BuildReportArgs): UtilityRunReport {
   const noakmPerTask: Record<string, PerTaskMetrics> = {};
   const akmPerTask: Record<string, PerTaskMetrics> = {};
   const akmRunsAll: RunResult[] = [];
+  const allRuns: RunResult[] = [];
 
   for (const task of args.options.tasks) {
     const taskRuns = args.grouped.get(task.id);
@@ -367,6 +368,9 @@ function buildReport(args: BuildReportArgs): UtilityRunReport {
     noakmPerTask[task.id] = noakmMetrics;
     akmPerTask[task.id] = akmMetrics;
     akmRunsAll.push(...akmRuns);
+    // Preserve arm order (noakm first, then akm) so the persisted runs[]
+    // array is deterministic across reruns. #249.
+    allRuns.push(...noakmRuns, ...akmRuns);
 
     tasks.push({ id: task.id, noakm: noakmMetrics, akm: akmMetrics, delta });
   }
@@ -413,6 +417,7 @@ function buildReport(args: BuildReportArgs): UtilityRunReport {
     tasks,
     warnings: args.warnings,
     akmRuns: akmRunsAll,
+    allRuns,
     taskMetadata: args.options.tasks,
     goldRankRecords: args.goldRankRecords,
     searchBridge,

--- a/tests/bench/runner.ts
+++ b/tests/bench/runner.ts
@@ -19,14 +19,15 @@
  * tmp dirs even on harness exceptions.
  */
 
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
 import type { SpawnFn } from "../../src/integrations/agent/spawn";
-import { type LoadedFixtureStash, loadFixtureStash } from "../fixtures/stashes/load";
+import { computeFixtureContentHash, type LoadedFixtureStash, loadFixtureStash } from "../fixtures/stashes/load";
 import { registerCleanup } from "./cleanup";
-import type { TaskMetadata, TaskSlice } from "./corpus";
+import { computeTaskCorpusHash, readTaskBody, type TaskMetadata, type TaskSlice } from "./corpus";
 import { type RunOptions, type RunResult, runOne } from "./driver";
 import {
   aggregateCorpus,
@@ -394,6 +395,40 @@ function buildReport(args: BuildReportArgs): UtilityRunReport {
   // downstream).
   const searchBridge = computeSearchBridge({ goldRankRecords: args.goldRankRecords });
 
+  // #250 — stamp deterministic corpus + fixture identity into the report
+  // so `bench compare` can refuse cross-corpus / cross-fixture diffs unless
+  // the operator explicitly opts in via --allow-corpus-mismatch /
+  // --allow-fixture-mismatch.
+  const selectedTaskIds = [...args.options.tasks.map((t) => t.id)].sort();
+  const taskBodies = new Map<string, string>();
+  for (const t of args.options.tasks) taskBodies.set(t.id, readTaskBody(t.taskDir));
+  const taskCorpusHash = computeTaskCorpusHash(selectedTaskIds, taskBodies);
+
+  const fixtureNames = [...new Set(args.options.tasks.map((t) => t.stash))].sort();
+  const fixtures: Record<string, string> = {};
+  for (const name of fixtureNames) {
+    try {
+      fixtures[name] = computeFixtureContentHash(name);
+    } catch (err) {
+      // Loader-test tasks point at fixtures that may not exist on disk; we
+      // still want to stamp identity for the present fixtures, so we record
+      // the failure as a warning and continue with the remaining set.
+      args.warnings.push(
+        `corpus stamp: cannot hash fixture "${name}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+  // Combined fixture-content hash. Hash input is the same `<name>\0<hash>\0`
+  // pattern used elsewhere — order-stable because `fixtureNames` is sorted.
+  const combinedHash = createHash("sha256");
+  for (const name of fixtureNames) {
+    combinedHash.update(name);
+    combinedHash.update("\0");
+    combinedHash.update(fixtures[name] ?? "");
+    combinedHash.update("\0");
+  }
+  const fixtureContentHash = combinedHash.digest("hex");
+
   const baseReport: UtilityRunReport = {
     timestamp,
     branch,
@@ -404,6 +439,10 @@ function buildReport(args: BuildReportArgs): UtilityRunReport {
       tasks: args.options.tasks.length,
       slice: args.slice,
       seedsPerArm: args.seedsPerArm,
+      selectedTaskIds,
+      taskCorpusHash,
+      fixtures,
+      fixtureContentHash,
     },
     aggregateNoakm,
     aggregateAkm,

--- a/tests/fixtures/stashes/load.test.ts
+++ b/tests/fixtures/stashes/load.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
-import { fixtureContentHash, listFixtures, loadFixtureStash } from "./load";
+import { computeFixtureContentHash, fixtureContentHash, listFixtures, loadFixtureStash } from "./load";
 
 describe("loadFixtureStash", () => {
   test("materialises the minimal fixture and cleanup removes it", () => {
@@ -81,6 +81,14 @@ describe("fixtureContentHash", () => {
     const b = fixtureContentHash("minimal");
     expect(a).toBe(b);
     expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("computeFixtureContentHash is the same implementation (#250)", () => {
+    // Critical addendum: there must be exactly one fixture-content hash
+    // function. Two diverging hash implementations for the same content
+    // would be a bug.
+    expect(computeFixtureContentHash).toBe(fixtureContentHash);
+    expect(computeFixtureContentHash("minimal")).toBe(fixtureContentHash("minimal"));
   });
 });
 

--- a/tests/fixtures/stashes/load.ts
+++ b/tests/fixtures/stashes/load.ts
@@ -50,6 +50,12 @@ export function listFixtures(): string[] {
  * fixture. Hash input is `<relative-path>\0<file-bytes>\0` for each file in
  * sorted-relative-path order. Used by `bench compare` to refuse cross-fixture
  * diffs.
+ *
+ * Also exported as `computeFixtureContentHash` for callers that prefer the
+ * `compute*` naming convention used by sibling helpers in `tests/bench/`
+ * (see `computeTaskCorpusHash` in corpus.ts). The two names point at the
+ * SAME implementation — there is exactly one fixture-content hash function
+ * in this codebase, and `LoadedFixtureStash.contentHash` reuses it.
  */
 export function fixtureContentHash(name: string): string {
   const root = fixtureSourceDir(name);
@@ -63,6 +69,14 @@ export function fixtureContentHash(name: string): string {
   }
   return hash.digest("hex");
 }
+
+/**
+ * Alias for `fixtureContentHash` matching the `compute*` naming used by
+ * sibling helpers in `tests/bench/`. Reuses the SAME implementation —
+ * defining a separate hash function for the same content would risk drift
+ * between the report-stamping path and `LoadedFixtureStash.contentHash`.
+ */
+export const computeFixtureContentHash = fixtureContentHash;
 
 /**
  * Options for `loadFixtureStash`.


### PR DESCRIPTION
## Summary
Wave 1 of the akm-bench v2 follow-on rollout. Bundles four independent infra fixes against `tests/bench/` so the benchmark suite produces auditable, comparable, attribution-correct, and economics-honest reports.

- **#249** persist compact raw run records (`runs[]`) in utility JSON reports.
- **#250** stamp corpus and fixture hashes into utility reports; refuse mismatched compares unless explicitly allowed.
- **#251** wire attribute masked stash directories into the runner via a new `stashDirOverride` (CRITICAL CORRECTNESS FIX — marginal contribution numbers were meaningless without this).
- **#252** record token-measurement status (`parsed`/`missing`/`unsupported`) so missing tokens don't silently degrade to numeric zero.

Closes #249, closes #250, closes #251, closes #252.
Tracker: #234.

## Highlights
- **Path-traversal hardening (#251)**: anchored `ASSET_REF_ANCHORED` regex + `path.relative` containment + per-segment safe-name guard. Defense in depth, mirrors the #240 fixup pattern.
- **Source fixture mutation guard (#251)**: sentinel-file smoke test verifies the source fixture stash is byte-identical after attribute runs.
- **Backward compatibility**:
  - Legacy reports without `runs[]` fall through to the existing aggregate-based attribute path (#249).
  - Legacy reports without corpus hashes get a warning, not refusal; `--allow-corpus-mismatch` / `--allow-fixture-mismatch` provide explicit overrides (#250).
  - `RunResult.tokenMeasurement` is optional; absent values default to `parsed` so older artefacts still round-trip (#252).
- **Token-shape seam**: `serializeRunForReport` spreads `tokens` so #252's `measurement` field flows through #249's persisted rows automatically.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bunx biome check --write src/ tests/` (1 pre-existing info, unchanged)
- [x] `bun test`: **2495 pass / 9 skip / 0 fail / 6847 expects across 159 files** (Wave 1 baseline 2454; net +41)
- [x] `bun test tests/bench/`: 287 pass / 0 fail
- [ ] Reviewer should spot-check the additive merge resolutions in `tests/bench/compare.test.ts` and `tests/bench/report.test.ts` (both kept both branches' tests).

## Per-issue summaries
- `.akm-run/c5111ad6-bb05-4be2-ba39-c5c09966bc12/summaries/issue-{249,250,251,252}.md`
- Run notes: `.akm-run/c5111ad6-bb05-4be2-ba39-c5c09966bc12/notes/{intake,integrate}.md`
- Plan: `.akm-run/c5111ad6-bb05-4be2-ba39-c5c09966bc12/plan.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)