### PR TITLE
akm-bench Waves 2-5: workflow compliance + corpus diagnostics + Track B metrics (13 issues)

### DIFF
--- a/tests/bench/BENCH.md
+++ b/tests/bench/BENCH.md
@@ -116,6 +116,14 @@ Tasks live at `tests/fixtures/bench/tasks/<domain>/<task-id>/` and consist of:
 
 - `task.yaml` — metadata (id, title, domain, difficulty, slice, gold_ref,
   stash, verifier, budget). See `docs/technical/benchmark.md` §13.1.
+  Optional memory-operation tags (#262): `memory_ability` (closed set —
+  see `tests/bench/corpus.ts` `MEMORY_ABILITY_VALUES`), `task_family`
+  (`<domain>/<short-name>`), `workflow_focus`, `expected_transfer_from`,
+  `abstention_case`, `conflict_case`, `stale_guidance_case`. The utility
+  report's `corpus_coverage` block aggregates pass rate / delta / negative
+  transfer per ability and per family. See
+  `tests/fixtures/bench/tasks/CORPUS.md` for the closed set + current
+  per-family coverage.
 - `workspace/` — initial files copied into the agent's cwd.
 - `verify.sh` (script verifier), `tests/test_*.py` (pytest), or
   `expected_match` regex in `task.yaml` (regex verifier).

--- a/tests/bench/BENCH.md
+++ b/tests/bench/BENCH.md
@@ -264,8 +264,63 @@ double-fire. On signal, the handler:
 Re-entrant signals while cleanup is in flight are dropped. Operators who
 need a hard kill can press Ctrl-C twice.
 
+### Workflow specs (#255)
+
+Declarative workflow rules live under `tests/fixtures/bench/workflows/*.yaml`
+and define what AKM agent behavior we expect for each task category. They
+are loaded by `tests/bench/workflow-spec.ts` and consumed by Wave 3's
+compliance evaluator (#256).
+
+**Authoring a spec.** Each YAML file holds one `WorkflowSpec`:
+
+```yaml
+id: akm-lookup-before-edit            # unique within the dir
+title: "Agent searches AKM before editing"
+description: "..."                    # optional
+applies_to:                           # optional filters
+  arms: ["akm"]                       # arms this spec applies to
+  task_domains: ["docker-homelab"]    # domain prefixes from task_id
+required_sequence:                    # ordered required events
+  - event: agent_started
+  - event: akm_search
+    before: first_workspace_write     # must occur before this event
+forbidden:                            # events that must NOT occur
+  - event: first_workspace_write
+    before: akm_search
+scoring:                              # weights must sum to 1
+  required_steps_weight: 0.7
+  forbidden_steps_weight: 0.2
+  evidence_quality_weight: 0.1
+```
+
+The loader rejects:
+- malformed YAML or missing required fields,
+- unknown event names (validated against the 14-name `KNOWN_EVENT_NAMES`
+  set, hardcoded from #254's brief; Wave 3 will reconcile by importing
+  from `workflow-trace.ts` directly),
+- scoring weights outside `[0,1]` or whose sum is not `1.0` (1e-6
+  tolerance),
+- `gold_ref` values that fail `parseAssetRef` from `src/core/asset-ref.ts`,
+- specs larger than 1 MiB (DoS guard),
+- file paths that resolve outside the supplied workflows root
+  (path-traversal guard via `path.relative` containment),
+- duplicate `id` within a single `loadAllWorkflowSpecs(dir)` call.
+
+**Loading specs.** Use `loadAllWorkflowSpecs(dir)` to load every
+`*.yaml` under `dir`. Use `loadWorkflowSpec(path, root?)` to load one;
+when `root` is supplied the path-traversal guard is enforced.
+
+**Applying specs.** `specApplies(spec, { arm, taskId })` returns whether
+the spec's `applies_to` filters match the run. Wave 3's evaluator calls
+this once per (run, spec) before scoring.
+
+**Errors.** All loader failures throw `WorkflowSpecError`, which carries
+`.code === "WORKFLOW_SPEC_INVALID"` for v1 contract compliance and
+`.specPath` for diagnostics.
+
 ## Pointers
 
 - Plan: `docs/technical/benchmark.md`.
 - Search-pipeline benchmark sibling: `tests/BENCHMARKS.md`.
 - Fixture stashes: `tests/fixtures/stashes/`.
+- Workflow specs: `tests/fixtures/bench/workflows/`.

--- a/tests/bench/BENCH.md
+++ b/tests/bench/BENCH.md
@@ -32,18 +32,37 @@ BENCH_OPENCODE_MODEL=anthropic/claude-haiku-4-5 \
 Subcommands:
 
 - `utility` — Track A: paired noakm vs akm utility benchmark.
-- `evolve` — Track B: longitudinal evolution loop. Stub in #236; lands in #239.
-- `compare` — diff two report JSON files. Stub in #236; lands in #240.
-- `attribute` — per-asset marginal contribution. Stub in #236; lands in #243.
+- `evolve` — Track B: longitudinal evolution loop.
+- `compare` — diff two report JSON files (refuses cross-model / cross-corpus / cross-fixture diffs).
+- `attribute` — per-asset marginal contribution via leave-one-out masking.
 
-`--tasks` accepts `train | eval | all`; any other value exits 2 with a clear
-error rather than silently coercing. The JSON envelope is **always** written
-to stdout — that is the bench's machine-readable contract and matches
-`tests/benchmark-suite.ts`. The `--json` flag means "machine-readable only":
-it suppresses the human-friendly markdown summary that is otherwise written to
-stderr alongside the JSON. Without `--json`, both stdout (JSON) and stderr
-(markdown summary) get content; with `--json`, stderr only carries minor trace
-lines (e.g. the `tasks discovered: …` line).
+### Implementation status
+
+Operators reading this guide want to know what's safe to trust. As of the
+current branch:
+
+| Subcommand | Status | Notes |
+|---|---|---|
+| `utility` | Implemented | Paired `noakm`/`akm` Track A over the seeded corpus. Persists raw `runs[]` (#249), stamps `taskCorpusHash` + `fixtureContentHash` (#250), tracks `token_measurement.coverage` (#252), aggregates `corpus_coverage` per memory ability + task family (#262). Optional `--include-synthetic` adds a third self-notes arm (#261). |
+| `compare` | Implemented | Refuses model / `taskCorpusHash` / `fixtureContentHash` / schema / track mismatches (exit 1); `--allow-corpus-mismatch` and `--allow-fixture-mismatch` downgrade to warnings (#250). Input/parse errors exit 2. |
+| `attribute` | Implemented | Top-N leave-one-out masking. Hydrates `runs[]` from the base envelope when present (#249), falls back to synthesising runs from the per-asset table for legacy reports. Masked-stash wiring fixed by #251 (`TaskMetadata.stashDirOverride`); always run a smoke check that the `attribution.maskedRefs` order matches the rows you expect before trusting marginal-contribution numbers. |
+| `evolve` | Stub | Track B (longitudinal feedback → distill → propose loop) is wired in `runEvolve`/`renderEvolveReport` for the wave-3 corpus, but the auto-accept evolution path is gated behind further validation. Treat numbers as exploratory until announced. |
+
+### stdout / stderr contract
+
+`utility`, `compare`, and `attribute` follow the same pattern:
+
+- **stdout** always carries the JSON envelope. This is the machine-readable
+  contract and is what `tests/benchmark-suite.ts` consumes.
+- **stderr** carries a short markdown summary (and a one-line trace such as
+  `tasks discovered: …`).
+- `--json` suppresses the markdown summary on stderr; the JSON on stdout is
+  unaffected. Trace lines (`tasks discovered`, compare's one-line aggregate,
+  attribute's projected re-run count) are still emitted on stderr.
+- `--tasks` accepts `train | eval | all`; any other value exits 2 with a
+  clear error rather than silently coercing.
+- Exit codes: `0` success, `1` refusal (e.g. `compare` model mismatch,
+  `attribute` masked-corpus failure), `2` input/usage error.
 
 ## Trajectory metrics — what the v1 contract emits
 
@@ -103,12 +122,111 @@ Every `RunResult` carries one of four outcomes:
 
 ## Reports
 
-`renderJsonReport` produces a stamped envelope with `branch`, `commit`,
-`model`, `timestamp`, and per-arm aggregates. `renderMarkdownSummary`
-produces a 5-ish-line summary suitable for PR descriptions.
+`renderUtilityReport` produces a stamped envelope (`branch`, `commit`,
+`model`, `timestamp`, per-arm aggregates) on stdout and a short markdown
+summary on stderr suitable for PR descriptions. The envelope additionally
+carries:
 
-For #236 reports go to stdout/stderr; persisting them to disk under a
-predictable path is part of #238.
+- `runs[]` — one compact row per (task, arm, seed) run (#249). Required
+  input for faithful `attribute` re-runs.
+- `taskCorpusHash` / `fixtureContentHash` — deterministic identity stamps
+  used by `compare` to refuse cross-corpus / cross-fixture diffs (#250).
+- `token_measurement` — `total_runs`, `runs_with_measured_tokens`,
+  `runs_missing_measurement`, `runs_unsupported_measurement`, `coverage`,
+  `reliable` (#252). The markdown summary's "Token measurement" block
+  surfaces this.
+- `corpus_coverage` — per-`memory_ability` and per-`task_family` pass
+  rate / delta / negative-transfer counts (#262).
+- `warnings[]` — additive trust signals (e.g. low token-measurement
+  coverage, oversized event log, leakage filtering on evolve).
+
+The bench does not persist reports to a predictable path on its own; the
+operator (or CI) is responsible for capturing stdout JSON to disk. The
+`tests/benchmark-suite.ts` runner does this for the regression harness.
+
+## Validity checklist
+
+A `utility` report is **only** trustworthy when all of the following hold.
+Operators should sanity-check these before quoting numbers in a PR or a
+roadmap doc.
+
+- **Hash match (#250).** When comparing two runs, both reports must agree
+  on `taskCorpusHash` AND `fixtureContentHash`. Mismatches mean the
+  corpus or the fixture stashes drifted between runs and the diff is
+  apples-to-oranges. `compare` refuses by default; only override with
+  `--allow-corpus-mismatch` / `--allow-fixture-mismatch` if you know
+  which task or fixture changed and why.
+- **Persisted runs[] (#249).** `runs.length` should equal
+  `corpus.tasks × arms × seedsPerArm`. A short `runs[]` array means some
+  driver invocations crashed or were truncated; pass-rate numbers built
+  from aggregates over a partial bag are misleading.
+- **Token measurement coverage (#252).** Don't trust token-economics
+  numbers (`tokens_per_pass`, cost regressions) when
+  `token_measurement.coverage < 0.95` or `token_measurement.reliable ===
+  false`. Re-run with a model/profile that emits parseable token
+  accounting before quoting cost deltas.
+- **Outcome distribution.** A meaningful run has both arms producing a
+  mix of `pass` / `fail`. If every run is `harness_error`, you're
+  measuring opencode availability, not akm utility — fix the runtime
+  (`pytest` on PATH, `opencode` model auth, etc.) and re-run.
+- **Trajectory presence.** `trajectory.akm.correct_asset_loaded` and
+  `trajectory.akm.feedback_recorded` should be non-null on the akm arm.
+  All-null trajectories usually mean the events.jsonl stream wasn't
+  captured (per-run isolation broken, or the cap in §"Trajectory
+  metrics" was hit).
+- **Compare prerequisites.** `bench compare` only emits a meaningful
+  diff when both reports share the same `model`, `schemaVersion`, and
+  `track`. The first two are stamped at envelope build time; mismatches
+  exit 1.
+- **Attribute prerequisites (#251).** `bench attribute` only produces
+  faithful marginal-contribution numbers when the base report carries
+  `runs[]` (#249) AND the masked-stash override is wired correctly so
+  the masked corpus genuinely runs without each top-N asset. Verify
+  `attribution.maskedRefs` lists the assets you expected before quoting
+  marginal contributions, and confirm `attribute.runsPerformed` matches
+  `topN × tasks × arms × seedsPerArm`.
+- **Workflow-compliance signal (#256, #259, #260).** The
+  `corpus_coverage` workflow-focus rows are only meaningful when the
+  workflow-compliance domain ran with non-zero seeds AND the spec set
+  in `tests/fixtures/bench/workflows/` matches what was loaded. A
+  zero-coverage row indicates the spec wasn't applied, not that the
+  agent passed.
+
+If any of the above fails, treat the report as a smoke test: useful for
+"did the harness run end-to-end?", not for utility decisions.
+
+## Known caveats
+
+- **Token measurement is opencode-dependent.** Some opencode profiles
+  don't emit a parseable token total per turn. Those runs are flagged
+  `tokenMeasurement: "unsupported"` (issue #252) and excluded from
+  `tokens_per_pass`. The aggregate stays reliable as long as
+  `coverage >= 0.95`; below that, the markdown summary annotates the
+  numbers as "unreliable".
+- **Attribution masking is leave-one-out only.** The masking strategy
+  is a single value (`"leave-one-out"`); interaction effects between
+  two assets are NOT measured. Reading `marginal_contribution` as
+  "removing only this asset" is correct; reading it as "this asset's
+  share of the total uplift" is not.
+- **Attribution masking validation.** The `attribute` path depends on
+  the per-task `stashDirOverride` wiring landed in #251. Before
+  trusting marginal contributions on a new corpus, run `bench
+  attribute --top 1` and confirm the masked stash actually has the
+  named asset removed (the markdown table on stderr will show
+  `masked_pass_rate` distinctly from `base_pass_rate`).
+- **Trajectory metrics are intentionally minimal.** v1 emits only
+  `correct_asset_loaded` and `feedback_recorded` (see §6.2).
+  `searched_before_acting` and `irrelevant_assets_loaded` from the
+  §13.3 sketch are NOT computed today.
+- **Evolve numbers are exploratory.** `improvement_slope` and
+  `over_synthetic_lift` depend on `feedback_agreement >= 0.80`;
+  below that, the JSON envelope's `warnings[]` carries
+  `feedback_agreement_below_threshold` and the headline numbers
+  should not be quoted.
+- **No on-disk persistence by default.** `bench utility` writes JSON to
+  stdout; capturing it for later `compare` / `attribute` runs is the
+  operator's job. CI pipelines should redirect stdout to a hashed path
+  before invoking compare.
 
 ## Adding tasks
 

--- a/tests/bench/cli.test.ts
+++ b/tests/bench/cli.test.ts
@@ -160,6 +160,52 @@ describe("bench CLI", () => {
     expect(r.stderr).toContain("tasks discovered:");
   }, 60_000);
 
+  // ── #261: --include-synthetic flag ─────────────────────────────────────────
+
+  test("utility help mentions --include-synthetic flag", () => {
+    const r = run(["help"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("--include-synthetic");
+  });
+
+  test("utility --include-synthetic adds aggregate.synthetic + akm_over_synthetic_lift", () => {
+    const r = run(
+      [
+        "utility",
+        "--tasks",
+        "train",
+        "--seeds",
+        "1",
+        "--budget-tokens",
+        "1000",
+        "--budget-wall-ms",
+        "1000",
+        "--include-synthetic",
+        "--json",
+      ],
+      { BENCH_OPENCODE_MODEL: "anthropic/claude-opus-4-7" },
+    );
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.stdout) as Record<string, unknown>;
+    const aggregate = parsed.aggregate as Record<string, unknown>;
+    expect(aggregate.synthetic).toBeDefined();
+    expect("akm_over_synthetic_lift" in aggregate).toBe(true);
+  }, 60_000);
+
+  test("utility WITHOUT --include-synthetic: aggregate has no synthetic / akm_over_synthetic_lift", () => {
+    // Byte-identical default contract: no spurious 'synthetic' keys when the
+    // flag is absent.
+    const r = run(
+      ["utility", "--tasks", "train", "--seeds", "1", "--budget-tokens", "1000", "--budget-wall-ms", "1000", "--json"],
+      { BENCH_OPENCODE_MODEL: "anthropic/claude-opus-4-7" },
+    );
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.stdout) as Record<string, unknown>;
+    const aggregate = parsed.aggregate as Record<string, unknown>;
+    expect(aggregate.synthetic).toBeUndefined();
+    expect("akm_over_synthetic_lift" in aggregate).toBe(false);
+  }, 60_000);
+
   test("with --json: stderr carries no markdown summary", () => {
     const r = run(
       ["utility", "--tasks", "train", "--seeds", "1", "--budget-tokens", "1000", "--budget-wall-ms", "1000", "--json"],

--- a/tests/bench/cli.ts
+++ b/tests/bench/cli.ts
@@ -56,6 +56,9 @@ utility flags:
   --seeds <N>              seeds per arm  (default: 5)
   --budget-tokens <N>      per-run token cap (default: 30000)
   --budget-wall-ms <N>     per-run wallclock cap in ms (default: 120000)
+  --include-synthetic      add a third 'synthetic' arm where the model writes/uses its own
+                           scratch notes (no AKM stash). Reports akm_over_synthetic_lift so
+                           operators can see whether AKM beats a self-notes baseline.
   --json                   suppress the markdown summary on stderr (machine-readable only).
                            Without --json, JSON still goes to stdout and the markdown
                            summary is also written to stderr for human-friendly reads.
@@ -144,6 +147,12 @@ export interface UtilityCliOptions {
   budgetTokens: number;
   budgetWallMs: number;
   model: string;
+  /**
+   * Track A synthetic-arm gate (#261). Threaded into `runUtility` as
+   * `includeSynthetic`. Default `false` keeps the envelope byte-identical to
+   * the pre-#261 two-arm shape.
+   */
+  includeSynthetic?: boolean;
   branch?: string;
   commit?: string;
   timestamp?: string;
@@ -174,6 +183,9 @@ export async function runUtilityCli(options: UtilityCliOptions): Promise<Utility
     budgetTokens: options.budgetTokens,
     budgetWallMs: options.budgetWallMs,
     slice: options.slice,
+    // #261: thread the synthetic-arm gate. Default off — the envelope shape
+    // is byte-identical to the pre-#261 output unless the operator opts in.
+    ...(options.includeSynthetic ? { includeSynthetic: true } : {}),
     ...(options.branch !== undefined ? { branch: options.branch } : {}),
     ...(options.commit !== undefined ? { commit: options.commit } : {}),
     ...(options.timestamp !== undefined ? { timestamp: options.timestamp } : {}),
@@ -726,6 +738,7 @@ async function main(argv: string[]): Promise<number> {
         budgetTokens: parseInt32(parsed.flags.get("budget-tokens"), 30000),
         budgetWallMs: parseInt32(parsed.flags.get("budget-wall-ms"), 120000),
         model,
+        ...(parsed.bool.has("include-synthetic") ? { includeSynthetic: true } : {}),
       });
       if (result.stdout) process.stdout.write(result.stdout);
       if (result.stderr) process.stderr.write(result.stderr);

--- a/tests/bench/cli.ts
+++ b/tests/bench/cli.ts
@@ -4,12 +4,11 @@
  *
  * Subcommands:
  *   • `utility`    — paired noakm vs akm utility benchmark (Track A).
+ *   • `compare`    — diff two report JSON files; refuses on hash/model mismatch.
+ *   • `attribute`  — per-asset marginal contribution via leave-one-out masking.
  *   • `evolve`     — longitudinal evolution loop (Track B). Stub.
- *   • `compare`    — diff two report JSON files. Stub.
- *   • `attribute`  — per-asset marginal contribution. Stub.
  *
- * #238 wires `utility` to the K-seed runner and §13.3 report renderer. The
- * other three subcommands stay as "not yet implemented" pointers.
+ * Implementation status and validity rules live in `tests/bench/BENCH.md`.
  *
  * NOTE: The bench binary is intentionally argv-light. citty is the project's
  * CLI framework but the bench is not part of the public CLI surface, so a

--- a/tests/bench/corpus.test.ts
+++ b/tests/bench/corpus.test.ts
@@ -4,8 +4,9 @@
  *   • `listTasks()` returns `[]` cleanly when the corpus dir is missing.
  *   • The shipped sample task at `_example/example-task` is excluded by
  *     default but loadable via `{ includeExamples: true }`.
- *   • The seeded corpus contains 17 tasks (issue #237) and every entry
- *     validates against the §13.1 schema.
+ *   • The seeded corpus contains 23 tasks (issue #237 seeded 17 across
+ *     three domains; #259 added six workflow-compliance tasks) and every
+ *     entry validates against the §13.1 schema.
  *   • `partitionSlice` is deterministic — same input → same partitioning
  *     across calls.
  */
@@ -49,19 +50,22 @@ describe("listTasks", () => {
     expect(sample?.budget.wallMs).toBe(30_000);
   });
 
-  test("seeds 17 hand-authored tasks across three domains (issue #237)", () => {
+  test("seeds 23 hand-authored tasks across four domains (issues #237, #259)", () => {
     const tasks = listTasks();
-    expect(tasks).toHaveLength(17);
+    expect(tasks).toHaveLength(23);
     const byDomain = new Map<string, TaskMetadata[]>();
     for (const task of tasks) {
       const list = byDomain.get(task.domain) ?? [];
       list.push(task);
       byDomain.set(task.domain, list);
     }
-    expect(new Set(byDomain.keys())).toEqual(new Set(["docker-homelab", "az-cli", "opencode"]));
+    expect(new Set(byDomain.keys())).toEqual(new Set(["docker-homelab", "az-cli", "opencode", "workflow-compliance"]));
     expect(byDomain.get("docker-homelab")).toHaveLength(6);
     expect(byDomain.get("az-cli")).toHaveLength(6);
     expect(byDomain.get("opencode")).toHaveLength(5);
+    // Workflow-compliance domain (#259): one task per failure category,
+    // plus the matched pair for repeated-failure-reflection-trigger.
+    expect(byDomain.get("workflow-compliance")).toHaveLength(6);
   });
 
   test("every task validates against the §13.1 schema", () => {
@@ -87,9 +91,10 @@ describe("listTasks", () => {
     const evalTasks = listTasks({ slice: "eval" });
     expect(train.every((t) => t.slice === "train")).toBe(true);
     expect(evalTasks.every((t) => t.slice === "eval")).toBe(true);
-    // The seeded corpus is split 9 train / 8 eval.
-    expect(train).toHaveLength(9);
-    expect(evalTasks).toHaveLength(8);
+    // The seeded corpus is split 13 train / 10 eval after the
+    // workflow-compliance tasks landed (#259 added 4 train + 2 eval).
+    expect(train).toHaveLength(13);
+    expect(evalTasks).toHaveLength(10);
   });
 });
 

--- a/tests/bench/corpus.test.ts
+++ b/tests/bench/corpus.test.ts
@@ -12,12 +12,17 @@
 
 import { describe, expect, test } from "bun:test";
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import {
   computeTaskCorpusHash,
   effectiveSlice,
   getTasksRoot,
   listTasks,
   loadTask,
+  MEMORY_ABILITY_VALUES,
   partitionSlice,
   readTaskBody,
   type TaskMetadata,
@@ -202,6 +207,86 @@ describe("partitionSlice", () => {
     } else {
       expect(evalSlice.map((t) => t.id)).toEqual([synthetic.id]);
       expect(train).toEqual([]);
+    }
+  });
+});
+
+// ── Memory-operation tags (#262) ───────────────────────────────────────────
+
+describe("memory-operation tags (#262)", () => {
+  test("MEMORY_ABILITY_VALUES is the documented closed set", () => {
+    expect(new Set(MEMORY_ABILITY_VALUES)).toEqual(
+      new Set([
+        "procedural_lookup",
+        "multi_asset_composition",
+        "temporal_update",
+        "conflict_resolution",
+        "abstention",
+        "noisy_retrieval",
+      ]),
+    );
+  });
+
+  test("loader leaves tag fields undefined for legacy tasks (without new fields)", () => {
+    // The shipped `_example/example-task` carries no #262 tags — it
+    // continues to load cleanly with every new field undefined.
+    const meta = loadTask("_example/example-task", { includeExamples: true });
+    expect(meta.memoryAbility).toBeUndefined();
+    expect(meta.taskFamily).toBeUndefined();
+    expect(meta.workflowFocus).toBeUndefined();
+    expect(meta.expectedTransferFrom).toBeUndefined();
+    expect(meta.abstentionCase).toBeUndefined();
+    expect(meta.conflictCase).toBeUndefined();
+    expect(meta.staleGuidanceCase).toBeUndefined();
+  });
+
+  test("loader parses memory_ability + task_family from a tagged task", () => {
+    // Every seeded corpus task is tagged with at least these two fields by
+    // #262. Pick a representative entry and assert the round-trip.
+    const meta = loadTask("docker-homelab/restart-policy");
+    expect(meta.memoryAbility).toBe("procedural_lookup");
+    expect(meta.taskFamily).toBe("docker-homelab/compose-basics");
+  });
+
+  test("every seeded corpus task carries memory_ability + task_family", () => {
+    for (const task of listTasks()) {
+      expect(task.memoryAbility).toBeDefined();
+      expect(MEMORY_ABILITY_VALUES).toContain(task.memoryAbility as string);
+      expect(task.taskFamily).toBeDefined();
+      expect(task.taskFamily).toMatch(/^[a-z0-9][a-z0-9-]*\/[a-z0-9][a-z0-9-]*$/);
+    }
+  });
+
+  test("invalid memory_ability values are dropped (loader stays permissive)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-bench-tag-"));
+    try {
+      const taskDir = path.join(dir, "_example", "bad-tag");
+      fs.mkdirSync(taskDir, { recursive: true });
+      // Write a clone of `_example/example-task` augmented with a bogus tag.
+      const yaml = [
+        "id: _example/bad-tag",
+        'title: "Bogus tag"',
+        "domain: _example",
+        "difficulty: easy",
+        "slice: train",
+        "stash: minimal",
+        "verifier: script",
+        "budget:",
+        "  tokens: 1000",
+        "  wallMs: 30000",
+        "memory_ability: not_a_real_ability",
+        "task_family: _example/bad",
+        "",
+      ].join("\n");
+      fs.writeFileSync(path.join(taskDir, "task.yaml"), yaml, "utf8");
+      // We can't redirect TASKS_ROOT without changing process state, so we
+      // can't assert via listTasks. Instead, exercise the public
+      // `readTaskBody` round-trip + a quick re-parse via the loader on the
+      // shipped sample is sufficient evidence that the schema only rejects
+      // bad values rather than throwing.
+      expect(readTaskBody(taskDir).length).toBeGreaterThan(0);
+    } finally {
+      fs.rmSync(dir, { recursive: true });
     }
   });
 });

--- a/tests/bench/corpus.test.ts
+++ b/tests/bench/corpus.test.ts
@@ -24,6 +24,7 @@ import {
   listTasks,
   loadTask,
   MEMORY_ABILITY_VALUES,
+  parseTaskYaml,
   partitionSlice,
   readTaskBody,
   type TaskMetadata,
@@ -284,12 +285,11 @@ describe("memory-operation tags (#262)", () => {
         "",
       ].join("\n");
       fs.writeFileSync(path.join(taskDir, "task.yaml"), yaml, "utf8");
-      // We can't redirect TASKS_ROOT without changing process state, so we
-      // can't assert via listTasks. Instead, exercise the public
-      // `readTaskBody` round-trip + a quick re-parse via the loader on the
-      // shipped sample is sufficient evidence that the schema only rejects
-      // bad values rather than throwing.
-      expect(readTaskBody(taskDir).length).toBeGreaterThan(0);
+      const parsed = parseTaskYaml(readTaskBody(taskDir), taskDir);
+      expect(parsed).toBeDefined();
+      expect(parsed?.id).toBe("_example/bad-tag");
+      expect(parsed?.memoryAbility).toBeUndefined();
+      expect(parsed?.taskFamily).toBe("_example/bad");
     } finally {
       fs.rmSync(dir, { recursive: true });
     }

--- a/tests/bench/corpus.ts
+++ b/tests/bench/corpus.ts
@@ -337,6 +337,10 @@ function readTask(taskDir: string): TaskMetadata | undefined {
   } catch {
     return undefined;
   }
+  return parseTaskYaml(text, taskDir);
+}
+
+export function parseTaskYaml(text: string, taskDir: string): TaskMetadata | undefined {
   let raw: RawTask;
   try {
     raw = parseYaml(text) as RawTask;

--- a/tests/bench/corpus.ts
+++ b/tests/bench/corpus.ts
@@ -20,6 +20,30 @@ export type TaskSlice = "train" | "eval";
 export type TaskDifficulty = "easy" | "medium" | "hard";
 export type TaskVerifier = "script" | "pytest" | "regex";
 
+/**
+ * Closed set of memory-operation labels (#262).
+ *
+ * Each value names the kind of memory / knowledge ability the task exercises:
+ * - `procedural_lookup` — find and apply a single procedural skill.
+ * - `multi_asset_composition` — combine guidance from two+ assets.
+ * - `temporal_update` — apply the most recent guidance over older versions.
+ * - `conflict_resolution` — choose between conflicting assets.
+ * - `abstention` — recognise no relevant asset exists and decline to load.
+ * - `noisy_retrieval` — succeed despite distractor / irrelevant assets.
+ *
+ * Adding a value here is a CORPUS-schema change; callers iterate the closed
+ * set when laying out coverage tables.
+ */
+export const MEMORY_ABILITY_VALUES = [
+  "procedural_lookup",
+  "multi_asset_composition",
+  "temporal_update",
+  "conflict_resolution",
+  "abstention",
+  "noisy_retrieval",
+] as const;
+export type MemoryAbility = (typeof MEMORY_ABILITY_VALUES)[number];
+
 export interface TaskMetadata {
   /** `<domain>/<task-name>`, kebab-case. */
   id: string;
@@ -54,6 +78,60 @@ export interface TaskMetadata {
    * up. The runner does not delete it.
    */
   stashDirOverride?: string;
+
+  // ── Memory-operation tags (#262) ─────────────────────────────────────────
+  // All seven fields below are OPTIONAL. Tasks that pre-date #262 still load
+  // unchanged — the loader does not synthesise defaults. Aggregations skip
+  // tasks where the relevant tag is undefined.
+
+  /**
+   * Closed set: see {@link MEMORY_ABILITY_VALUES}. Names the memory / knowledge
+   * ability the task exercises. Optional; tasks tagged with `memory_ability`
+   * participate in `aggregateByMemoryAbility` slices in the utility report.
+   */
+  memoryAbility?: MemoryAbility;
+
+  /**
+   * Free-form tag naming the workflow the task is meant to drive
+   * (e.g. `lookup_before_edit`, `propose_then_apply`). Optional; matched
+   * against #255's declarative workflow specs at runtime when present.
+   */
+  workflowFocus?: string;
+
+  /**
+   * Stable cross-task family identifier. Format: `<domain>/<short-name>`,
+   * lowercase, kebab-case (e.g. `docker-homelab/compose-basics`). Tasks
+   * sharing a `task_family` are expected to transfer knowledge between
+   * each other. Optional but RECOMMENDED for every real task — coverage
+   * reports collapse single-task families into one bucket.
+   */
+  taskFamily?: string;
+
+  /**
+   * Task-family identifiers from which a successful agent SHOULD have
+   * carried over knowledge. Optional. Each entry follows the same
+   * `<domain>/<short-name>` grammar as `task_family`.
+   */
+  expectedTransferFrom?: string[];
+
+  /**
+   * `true` when the canonical "correct" behaviour is to abstain from loading
+   * any asset (no relevant asset exists). Optional; defaults to `false`
+   * downstream when undefined.
+   */
+  abstentionCase?: boolean;
+
+  /**
+   * `true` when the task pits two conflicting assets against each other and
+   * the agent must pick the right one. Optional.
+   */
+  conflictCase?: boolean;
+
+  /**
+   * `true` when the task contains stale guidance that must be overridden by
+   * a newer asset. Optional.
+   */
+  staleGuidanceCase?: boolean;
 }
 
 const TASKS_ROOT = path.resolve(__dirname, "..", "fixtures", "bench", "tasks");
@@ -241,6 +319,14 @@ interface RawTask {
   verifier?: unknown;
   expected_match?: unknown;
   budget?: { tokens?: unknown; wallMs?: unknown };
+  // #262 memory-operation tags. All optional.
+  memory_ability?: unknown;
+  workflow_focus?: unknown;
+  task_family?: unknown;
+  expected_transfer_from?: unknown;
+  abstention_case?: unknown;
+  conflict_case?: unknown;
+  stale_guidance_case?: unknown;
 }
 
 function readTask(taskDir: string): TaskMetadata | undefined {
@@ -291,7 +377,41 @@ function readTask(taskDir: string): TaskMetadata | undefined {
   if (goldRef !== undefined) meta.goldRef = goldRef;
   if (stashOverlay !== undefined) meta.stashOverlay = stashOverlay;
   if (expectedMatch !== undefined) meta.expectedMatch = expectedMatch;
+
+  // #262 memory-operation tags. Each tag is OPTIONAL — invalid values are
+  // silently ignored so a malformed tag never breaks an existing task. This
+  // matches the broader "loader returns undefined on bad core fields, drops
+  // bad tags" contract documented in the §13.1 schema.
+  const memoryAbility = asEnum<MemoryAbility>(raw.memory_ability, MEMORY_ABILITY_VALUES);
+  if (memoryAbility !== undefined) meta.memoryAbility = memoryAbility;
+  const workflowFocus = asString(raw.workflow_focus);
+  if (workflowFocus !== undefined) meta.workflowFocus = workflowFocus;
+  const taskFamily = asString(raw.task_family);
+  if (taskFamily !== undefined) meta.taskFamily = taskFamily;
+  const expectedTransferFrom = asStringArray(raw.expected_transfer_from);
+  if (expectedTransferFrom !== undefined) meta.expectedTransferFrom = expectedTransferFrom;
+  const abstentionCase = asBoolean(raw.abstention_case);
+  if (abstentionCase !== undefined) meta.abstentionCase = abstentionCase;
+  const conflictCase = asBoolean(raw.conflict_case);
+  if (conflictCase !== undefined) meta.conflictCase = conflictCase;
+  const staleGuidanceCase = asBoolean(raw.stale_guidance_case);
+  if (staleGuidanceCase !== undefined) meta.staleGuidanceCase = staleGuidanceCase;
+
   return meta;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  return undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === "string" && entry.length > 0) out.push(entry);
+  }
+  return out;
 }
 
 function asString(value: unknown): string | undefined {

--- a/tests/bench/driver.test.ts
+++ b/tests/bench/driver.test.ts
@@ -19,6 +19,7 @@ import {
   type RunOptions,
   readRunEvents,
   runOne,
+  stripAkmStashDir,
 } from "./driver";
 
 function asReadableStream(text: string): ReadableStream<Uint8Array> {
@@ -227,6 +228,49 @@ describe("runOne", () => {
       }
     }
   });
+
+  // ── #261: synthetic-arm AKM_STASH_DIR isolation ─────────────────────────────
+
+  test("synthetic arm: child env never carries AKM_STASH_DIR (recurrence guard for #243 fixup)", async () => {
+    // CRITICAL: synthetic-arm runs MUST NOT carry AKM_STASH_DIR. Without
+    // this guard the operator's real AKM_STASH_DIR leaks in via parent-env
+    // inheritance — exactly the failure mode the #243 fixup chased. We
+    // exercise both the explicit-stashDir case (bad caller passes one
+    // anyway) and the no-stashDir case.
+    const operatorStash = "/tmp/operator-stash-must-never-leak-into-synthetic";
+    const prior = process.env.AKM_STASH_DIR;
+    process.env.AKM_STASH_DIR = operatorStash;
+    try {
+      // 1) Synthetic arm with NO stashDir option: AKM_STASH_DIR must be
+      //    absent in the child env.
+      const { spawn, invocations } = scriptedSpawn({ exitCode: 0, stdout: "ok" });
+      await runOne({
+        ...baseOptions,
+        workspace,
+        arm: "synthetic",
+        spawn,
+      });
+      const childEnv1 = invocations[0]?.env ?? {};
+      expect(childEnv1.AKM_STASH_DIR).toBeUndefined();
+      expect(childEnv1.AKM_STASH_DIR).not.toBe(operatorStash);
+
+      // 2) Even when a buggy caller forwards a stashDir to the synthetic
+      //    arm, the driver MUST refuse to wire it into the child env.
+      const { spawn: spawn2, invocations: invocations2 } = scriptedSpawn({ exitCode: 0, stdout: "ok" });
+      await runOne({
+        ...baseOptions,
+        workspace,
+        arm: "synthetic",
+        stashDir: "/tmp/buggy-caller-stash",
+        spawn: spawn2,
+      });
+      const childEnv2 = invocations2[0]?.env ?? {};
+      expect(childEnv2.AKM_STASH_DIR).toBeUndefined();
+    } finally {
+      if (prior === undefined) delete process.env.AKM_STASH_DIR;
+      else process.env.AKM_STASH_DIR = prior;
+    }
+  });
 });
 
 describe("driver helpers", () => {
@@ -240,6 +284,21 @@ describe("driver helpers", () => {
     } finally {
       fs.rmSync(dirs.root, { recursive: true, force: true });
     }
+  });
+
+  test("stripAkmStashDir deletes AKM_STASH_DIR in place (#261 synthetic-arm guard)", () => {
+    const env: Record<string, string | undefined> = {
+      AKM_STASH_DIR: "/tmp/operator-stash",
+      XDG_CACHE_HOME: "/tmp/cache",
+    };
+    const result = stripAkmStashDir(env);
+    expect(result).toBe(env); // mutates in place + returns same ref
+    expect(env.AKM_STASH_DIR).toBeUndefined();
+    expect(env.XDG_CACHE_HOME).toBe("/tmp/cache"); // siblings untouched
+    // No-op on env without AKM_STASH_DIR.
+    const env2: Record<string, string | undefined> = { XDG_CACHE_HOME: "/tmp/cache" };
+    stripAkmStashDir(env2);
+    expect(env2).toEqual({ XDG_CACHE_HOME: "/tmp/cache" });
   });
 
   test("buildIsolatedEnv pins the four isolation keys plus model", () => {

--- a/tests/bench/driver.ts
+++ b/tests/bench/driver.ts
@@ -180,6 +180,20 @@ export function buildIsolatedEnv(dirs: IsolationDirs, model: string): Record<str
 }
 
 /**
+ * Strip `AKM_STASH_DIR` from a child env object. Used by the synthetic-arm
+ * spawn path (#261) so the operator's real `AKM_STASH_DIR` cannot leak in
+ * via the parent process even when the harness has copied a wider env via
+ * `{ ...process.env, ...env }`. This is the recurrence guard for the #243
+ * fixup pattern — a synthetic-arm child must NEVER inherit a stash.
+ *
+ * Mutates `env` in place and returns it for ergonomic chaining.
+ */
+export function stripAkmStashDir(env: Record<string, string | undefined>): Record<string, string | undefined> {
+  delete env.AKM_STASH_DIR;
+  return env;
+}
+
+/**
  * Best-effort token-usage parser for opencode stdout. Returns numeric token
  * counts AND a measurement status so callers can distinguish a real zero
  * (`"parsed"`, both fields legitimately 0) from an unparseable / absent
@@ -334,8 +348,18 @@ export async function runOne(options: RunOptions): Promise<RunResult> {
     return result;
   }
 
-  const dirs = createIsolationDirs(options.stashDir);
+  // #261: synthetic-arm runs MUST NOT carry AKM_STASH_DIR. We refuse to
+  // forward a stashDir for the synthetic arm even when the caller mistakenly
+  // supplies one, and we explicitly delete the key from the built env so the
+  // operator's real AKM_STASH_DIR can never leak in through any parent-env
+  // inheritance the harness happens to do downstream. Recurrence guard for
+  // the #243 fixup pattern.
+  const stashDir = options.arm === "synthetic" ? undefined : options.stashDir;
+  const dirs = createIsolationDirs(stashDir);
   const env = buildIsolatedEnv(dirs, options.model);
+  if (options.arm === "synthetic") {
+    stripAkmStashDir(env);
+  }
 
   try {
     const agentResult = await runAgent(profile, options.prompt ?? defaultPrompt(options), {

--- a/tests/bench/evolve-metrics.test.ts
+++ b/tests/bench/evolve-metrics.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit tests for `computeLessonMetrics` (#264).
+ *
+ * The four required scenarios are covered explicitly:
+ *   1. accepted lesson reused successfully on an eval task,
+ *   2. accepted lesson never reused (`first_reused_on === null`),
+ *   3. rejected proposal — surfaced as a lesson row but `accepted: false`,
+ *   4. accepted lesson causing regression on an eval task that previously
+ *      passed (negative_transfer_count === 1).
+ *
+ * Plus a fifth test for the leakage-risk classifier so the verifier-source
+ * 4+-token rule has a direct unit test.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { RunResult } from "./driver";
+import type { FeedbackLogEntry } from "./evolve";
+import { classifyLeakageRisk, computeLessonMetrics } from "./evolve-metrics";
+import type { ProposalLogEntry } from "./metrics";
+
+function fakeRun(overrides: Partial<RunResult>): RunResult {
+  return {
+    schemaVersion: 1,
+    taskId: "t",
+    arm: "akm",
+    seed: 0,
+    model: "m",
+    outcome: "pass",
+    tokens: { input: 0, output: 0 },
+    wallclockMs: 0,
+    trajectory: { correctAssetLoaded: null, feedbackRecorded: null },
+    events: [],
+    verifierStdout: "",
+    verifierExitCode: 0,
+    assetsLoaded: [],
+    ...overrides,
+  };
+}
+
+describe("computeLessonMetrics", () => {
+  test("accepted lesson reused successfully on an eval task", () => {
+    const proposalLog: ProposalLogEntry[] = [
+      { proposalId: "p1", assetRef: "lesson:docker-healthchecks", kind: "lesson", lintPass: true, decision: "accept" },
+    ];
+    const feedbackLog: FeedbackLogEntry[] = [
+      {
+        taskId: "docker-homelab/redis-healthcheck",
+        seed: 0,
+        goldRef: "lesson:docker-healthchecks",
+        signal: "negative",
+        ok: true,
+      },
+    ];
+    const preRuns = [
+      fakeRun({ taskId: "docker-homelab/named-volume", seed: 0, outcome: "fail" }),
+      fakeRun({ taskId: "docker-homelab/named-volume", seed: 1, outcome: "fail" }),
+    ];
+    const postRuns = [
+      fakeRun({
+        taskId: "docker-homelab/named-volume",
+        seed: 0,
+        outcome: "pass",
+        assetsLoaded: ["lesson:docker-healthchecks"],
+      }),
+      fakeRun({
+        taskId: "docker-homelab/named-volume",
+        seed: 1,
+        outcome: "pass",
+        assetsLoaded: ["lesson:docker-healthchecks"],
+      }),
+    ];
+
+    const m = computeLessonMetrics({ proposalLog, feedbackLog, preRuns, postRuns });
+    expect(m.lessons_created_count).toBe(1);
+    expect(m.lessons_accepted_count).toBe(1);
+    expect(m.proposal_lint_pass_rate).toBe(1);
+    expect(m.proposal_acceptance_rate).toBe(1);
+    expect(m.lesson_reuse_rate).toBe(1);
+    expect(m.lesson_reuse_success_rate).toBe(1);
+    expect(m.lesson_negative_transfer_count).toBe(0);
+
+    const lesson = m.lessons[0];
+    expect(lesson?.ref).toBe("lesson:docker-healthchecks");
+    expect(lesson?.accepted).toBe(true);
+    expect(lesson?.source_failures).toEqual(["docker-homelab/redis-healthcheck"]);
+    expect(lesson?.first_reused_on).toBe("docker-homelab/named-volume");
+    expect(lesson?.reuse_count).toBe(2);
+    expect(lesson?.reuse_pass_rate).toBe(1);
+    expect(lesson?.negative_transfer_count).toBe(0);
+    expect(lesson?.leakage_risk).toBe("low");
+  });
+
+  test("accepted lesson never reused yields first_reused_on=null and reuse_count=0", () => {
+    const proposalLog: ProposalLogEntry[] = [
+      { proposalId: "p1", assetRef: "lesson:lonely", kind: "lesson", lintPass: true, decision: "accept" },
+    ];
+    const postRuns = [fakeRun({ taskId: "task-a", seed: 0, outcome: "pass", assetsLoaded: ["skill:other"] })];
+
+    const m = computeLessonMetrics({ proposalLog, postRuns });
+    expect(m.lessons_accepted_count).toBe(1);
+    expect(m.lesson_reuse_rate).toBe(0);
+    expect(m.lesson_reuse_success_rate).toBe(0);
+    expect(m.lesson_negative_transfer_count).toBe(0);
+
+    const lesson = m.lessons[0];
+    expect(lesson?.first_reused_on).toBeNull();
+    expect(lesson?.reuse_count).toBe(0);
+    expect(lesson?.reuse_pass_rate).toBe(0);
+  });
+
+  test("rejected proposal surfaces row with accepted=false and no reuse stats", () => {
+    const proposalLog: ProposalLogEntry[] = [
+      {
+        proposalId: "p1",
+        assetRef: "lesson:bad",
+        kind: "lesson",
+        lintPass: false,
+        decision: "reject",
+        rejectReason: "lint failed: empty body",
+      },
+    ];
+    // Even if a post run happened to load the same ref, a rejected proposal
+    // must NOT be credited with reuse — the lesson never reached the stash.
+    const postRuns = [fakeRun({ taskId: "task-a", seed: 0, outcome: "pass", assetsLoaded: ["lesson:bad"] })];
+
+    const m = computeLessonMetrics({ proposalLog, postRuns });
+    expect(m.lessons_created_count).toBe(1);
+    expect(m.lessons_accepted_count).toBe(0);
+    expect(m.proposal_lint_pass_rate).toBe(0);
+    expect(m.proposal_acceptance_rate).toBe(0);
+    expect(m.lesson_reuse_rate).toBe(0);
+
+    const lesson = m.lessons[0];
+    expect(lesson?.accepted).toBe(false);
+    expect(lesson?.lint_pass).toBe(false);
+    expect(lesson?.reuse_count).toBe(0);
+    expect(lesson?.first_reused_on).toBeNull();
+    expect(lesson?.negative_transfer_count).toBe(0);
+  });
+
+  test("accepted lesson causing regression attributes negative_transfer_count=1", () => {
+    const proposalLog: ProposalLogEntry[] = [
+      { proposalId: "p1", assetRef: "lesson:overfit", kind: "lesson", lintPass: true, decision: "accept" },
+    ];
+    // Pre-arm: task passed. Post-arm: same (taskId, seed) failed AND loaded
+    // the lesson. That counts as one negative transfer attribution.
+    const preRuns = [fakeRun({ taskId: "adjacent-task", seed: 0, outcome: "pass" })];
+    const postRuns = [
+      fakeRun({ taskId: "adjacent-task", seed: 0, outcome: "fail", assetsLoaded: ["lesson:overfit"] }),
+      // Same task, different seed — also failed with the lesson loaded; the
+      // attribution dedupes by taskId so the count stays at 1.
+      fakeRun({ taskId: "adjacent-task", seed: 1, outcome: "fail", assetsLoaded: ["lesson:overfit"] }),
+    ];
+
+    const m = computeLessonMetrics({ proposalLog, preRuns, postRuns });
+    expect(m.lesson_negative_transfer_count).toBe(1);
+
+    const lesson = m.lessons[0];
+    expect(lesson?.negative_transfer_count).toBe(1);
+    expect(lesson?.reuse_count).toBe(2);
+    expect(lesson?.reuse_pass_rate).toBe(0);
+  });
+
+  test("zero-proposal log yields all zeroes with empty lessons[]", () => {
+    const m = computeLessonMetrics({ proposalLog: [] });
+    expect(m.lessons_created_count).toBe(0);
+    expect(m.lessons_accepted_count).toBe(0);
+    expect(m.proposal_lint_pass_rate).toBe(0);
+    expect(m.proposal_acceptance_rate).toBe(0);
+    expect(m.lesson_reuse_rate).toBe(0);
+    expect(m.lesson_reuse_success_rate).toBe(0);
+    expect(m.lesson_negative_transfer_count).toBe(0);
+    expect(m.lessons).toEqual([]);
+  });
+
+  test("revision-kind proposals are filtered out (lessons[] only)", () => {
+    const proposalLog: ProposalLogEntry[] = [
+      { proposalId: "p1", assetRef: "lesson:a", kind: "lesson", lintPass: true, decision: "accept" },
+      { proposalId: "p2", assetRef: "skill:b", kind: "revision", lintPass: true, decision: "accept" },
+    ];
+    const m = computeLessonMetrics({ proposalLog });
+    expect(m.lessons.map((l) => l.ref)).toEqual(["lesson:a"]);
+  });
+});
+
+describe("classifyLeakageRisk", () => {
+  test("returns 'low' when body or verifier sources are missing", () => {
+    expect(classifyLeakageRisk(undefined, ["some text"])).toBe("low");
+    expect(classifyLeakageRisk("some text", undefined)).toBe("low");
+    expect(classifyLeakageRisk("some text", [])).toBe("low");
+  });
+
+  test("returns 'high' on a verbatim 4-word phrase from the verifier", () => {
+    const verifier = "assert services.redis.healthcheck.test == ['CMD', 'redis-cli', 'ping']";
+    const body = "Always set services redis healthcheck test to a CMD ping.";
+    expect(classifyLeakageRisk(body, [verifier])).toBe("high");
+  });
+
+  test("returns 'medium' on a 3-word overlap but no 4-word overlap", () => {
+    const verifier = "alpha beta gamma delta epsilon";
+    const body = "alpha beta gamma is the prefix and zeta eta theta is the suffix";
+    expect(classifyLeakageRisk(body, [verifier])).toBe("medium");
+  });
+
+  test("returns 'low' when overlap is at most 2 tokens", () => {
+    const verifier = "alpha beta is required";
+    const body = "alpha beta gamma never appears verbatim from the verifier";
+    expect(classifyLeakageRisk(body, [verifier])).toBe("low");
+  });
+});

--- a/tests/bench/evolve-metrics.ts
+++ b/tests/bench/evolve-metrics.ts
@@ -1,0 +1,294 @@
+/**
+ * Track B lesson quality + reuse metrics (issue #264, spec §6.3 follow-up).
+ *
+ * `computeLessonMetrics` walks the evolve runner's proposal log and the
+ * Phase 3 pre/post arm `RunResult[]`s and emits one `LessonRecord` per
+ * lesson-kind proposal. The record captures:
+ *
+ *   - `source_failures` — eval/train tasks whose negative feedback events
+ *     targeted this asset ref (joined via the supplied `feedbackLog`).
+ *   - `lint_pass` / `accepted` — verbatim from the proposal log entry.
+ *   - `first_reused_on` / `reuse_count` / `reuse_pass_rate` — how often the
+ *     accepted lesson's ref appeared in post-arm runs' `assetsLoaded`, and
+ *     the pass-rate among those reuses.
+ *   - `negative_transfer_count` — count of (taskId, seed) pairs where the
+ *     same task PASSED in pre but FAILED in post AND the post run loaded
+ *     this lesson's ref. Spec §6.4 negative-transfer attribution.
+ *   - `leakage_risk` — `"high"` when any verbatim 4-token-or-longer phrase
+ *     in the supplied verifier source(s) appears verbatim in the lesson
+ *     body; `"medium"` for 3-token leakage; `"low"` otherwise. Mirrors the
+ *     Wave 3 `leakage.test.ts` philosophy: structural fragments are red
+ *     flags, lone tokens are not.
+ *
+ * The function is pure: no disk I/O, no subprocess. Callers (the evolve
+ * runner) thread lesson bodies + verifier sources through optional maps so
+ * the leakage check is fully deterministic and testable with mock inputs.
+ */
+
+import type { RunResult } from "./driver";
+import type { FeedbackLogEntry } from "./evolve";
+import type { ProposalLogEntry } from "./metrics";
+
+/** Per-lesson record exposed in the Track B `lessons[]` report block. */
+export interface LessonRecord {
+  /** Asset ref the lesson targets (mirrors proposal.assetRef). */
+  ref: string;
+  /**
+   * Train/Phase-1 task ids whose negative feedback against this ref
+   * contributed to the proposal being generated. Sorted, deduplicated.
+   * Empty when no feedback log was supplied or no negative event matches.
+   */
+  source_failures: string[];
+  /** Whether `akm proposal show --json` reported `lint_pass: true`. */
+  lint_pass: boolean;
+  /** Whether the runner ran `proposal accept` on this proposal. */
+  accepted: boolean;
+  /**
+   * First eval-arm task that loaded this lesson after acceptance (i.e. the
+   * lesson's ref appeared in `assetsLoaded`). `null` if never reused. The
+   * "first" is determined by `(taskId, seed)` lexicographic order over the
+   * supplied `postRuns` — `postRuns` is intentionally NOT re-sorted by the
+   * function so callers that already pre-sort by wallclock get that order.
+   */
+  first_reused_on: string | null;
+  /**
+   * Number of post-arm (taskId, seed) runs that loaded this lesson's ref.
+   * A single task across multiple seeds counts as multiple reuses.
+   */
+  reuse_count: number;
+  /**
+   * Fraction of reuse runs whose outcome was `pass`. `0` when
+   * `reuse_count === 0` (NaN-safe sentinel).
+   */
+  reuse_pass_rate: number;
+  /**
+   * Count of (taskId, seed) pairs where the same task passed in `preRuns`
+   * but failed in `postRuns` AND the post run loaded this lesson's ref.
+   * The same task counted at most once across seeds (matches §6.4 spirit:
+   * the lesson made the task worse, regardless of how many seeds saw it).
+   */
+  negative_transfer_count: number;
+  /**
+   * `"high"` when verbatim 4+-token phrases from any supplied
+   * `verifierSources[ref]` entry appear in `lessonBodies[ref]`; `"medium"`
+   * for 3-token overlap; `"low"` otherwise (including when the lesson body
+   * or verifier source is missing).
+   */
+  leakage_risk: "low" | "medium" | "high";
+}
+
+/** Aggregate envelope returned by `computeLessonMetrics`. */
+export interface LessonMetrics {
+  /** One row per lesson-kind proposal, sorted by ref. */
+  lessons: LessonRecord[];
+  /** Total lesson-kind proposals (accepted + rejected). */
+  lessons_created_count: number;
+  /** Lesson-kind proposals whose `decision === "accept"`. */
+  lessons_accepted_count: number;
+  /** `lint_pass / total`. `0` when there are no lessons. */
+  proposal_lint_pass_rate: number;
+  /** `accepted / total`. `0` when there are no lessons. */
+  proposal_acceptance_rate: number;
+  /**
+   * Fraction of accepted lessons that were reused at least once. `0` when
+   * there are no accepted lessons.
+   */
+  lesson_reuse_rate: number;
+  /**
+   * Mean `reuse_pass_rate` across reused lessons. `0` when no reuse.
+   */
+  lesson_reuse_success_rate: number;
+  /** Sum of `negative_transfer_count` across all lessons. */
+  lesson_negative_transfer_count: number;
+}
+
+/**
+ * Inputs to `computeLessonMetrics`. All non-`proposalLog` fields are
+ * optional so callers can compute partial metrics from mocked inputs in
+ * tests; missing inputs collapse to safe defaults (no source failures, no
+ * reuse, low leakage).
+ */
+export interface ComputeLessonMetricsInput {
+  proposalLog: ProposalLogEntry[];
+  /**
+   * Phase 1 feedback events. Used to populate `source_failures` per lesson
+   * (joined on `goldRef === lesson.ref` with `signal === "negative"`).
+   */
+  feedbackLog?: FeedbackLogEntry[];
+  /** Eval-slice pre-arm runs (no Phase 2 mutations applied). */
+  preRuns?: RunResult[];
+  /** Eval-slice post-arm runs (with accepted lessons in scope). */
+  postRuns?: RunResult[];
+  /**
+   * Map from lesson ref → lesson body content. Supplied by the runner from
+   * the on-disk lesson file after acceptance; tests pass mocks. When a
+   * ref is absent the leakage check defaults to `"low"`.
+   */
+  lessonBodies?: Record<string, string>;
+  /**
+   * Map from lesson ref → verifier source text(s) to leakage-check
+   * against. The runner concatenates the verifier files for tasks whose
+   * gold ref matches the lesson; tests pass mocks. When absent the
+   * leakage check defaults to `"low"`.
+   */
+  verifierSources?: Record<string, string[]>;
+}
+
+/**
+ * Compute lesson-quality + reuse metrics from the evolve runner's outputs.
+ * Pure function — does not touch disk and does not invoke any subprocess.
+ *
+ * Only `proposalLog` entries with `kind === "lesson"` are surfaced as
+ * `LessonRecord`s. Revision-kind proposals are tracked elsewhere (the
+ * §6.3 `proposals` block already covers them) and would skew the lesson
+ * reuse rate if mixed in.
+ */
+export function computeLessonMetrics(input: ComputeLessonMetricsInput): LessonMetrics {
+  const lessons = input.proposalLog.filter((p) => p.kind === "lesson");
+  const feedbackLog = input.feedbackLog ?? [];
+  const preRuns = input.preRuns ?? [];
+  const postRuns = input.postRuns ?? [];
+  const lessonBodies = input.lessonBodies ?? {};
+  const verifierSources = input.verifierSources ?? {};
+
+  // Pre-index pre-arm task → seed → outcome so negative-transfer attribution
+  // is a constant-time lookup per post run.
+  const preOutcomes = new Map<string, Map<number, RunResult["outcome"]>>();
+  for (const r of preRuns) {
+    let inner = preOutcomes.get(r.taskId);
+    if (!inner) {
+      inner = new Map();
+      preOutcomes.set(r.taskId, inner);
+    }
+    inner.set(r.seed, r.outcome);
+  }
+
+  // Pre-index negative feedback by ref so source_failures is O(events).
+  const negativeFeedbackByRef = new Map<string, Set<string>>();
+  for (const ev of feedbackLog) {
+    if (ev.signal !== "negative") continue;
+    let set = negativeFeedbackByRef.get(ev.goldRef);
+    if (!set) {
+      set = new Set();
+      negativeFeedbackByRef.set(ev.goldRef, set);
+    }
+    set.add(ev.taskId);
+  }
+
+  const records: LessonRecord[] = lessons.map((p) => {
+    const ref = p.assetRef;
+    const sourceFailures = [...(negativeFeedbackByRef.get(ref) ?? [])].sort();
+
+    // Reuse: post-arm runs that loaded this ref.
+    let firstReusedOn: string | null = null;
+    let reuseCount = 0;
+    let reusePassCount = 0;
+    // Negative transfer: post-FAIL where pre-PASS for the same (task, seed)
+    // AND this lesson was loaded in the post run. Dedupe by taskId so a
+    // task that regresses across multiple seeds counts once.
+    const negativeTransferTasks = new Set<string>();
+    if (p.decision === "accept") {
+      for (const r of postRuns) {
+        if (!r.assetsLoaded?.includes(ref)) continue;
+        if (firstReusedOn === null) firstReusedOn = r.taskId;
+        reuseCount += 1;
+        if (r.outcome === "pass") reusePassCount += 1;
+        if (r.outcome === "fail" || r.outcome === "budget_exceeded") {
+          const prePerSeed = preOutcomes.get(r.taskId);
+          if (prePerSeed && prePerSeed.get(r.seed) === "pass") {
+            negativeTransferTasks.add(r.taskId);
+          }
+        }
+      }
+    }
+    const reusePassRate = reuseCount === 0 ? 0 : reusePassCount / reuseCount;
+
+    const leakageRisk = classifyLeakageRisk(lessonBodies[ref], verifierSources[ref]);
+
+    return {
+      ref,
+      source_failures: sourceFailures,
+      lint_pass: p.lintPass,
+      accepted: p.decision === "accept",
+      first_reused_on: firstReusedOn,
+      reuse_count: reuseCount,
+      reuse_pass_rate: reusePassRate,
+      negative_transfer_count: negativeTransferTasks.size,
+      leakage_risk: leakageRisk,
+    };
+  });
+
+  records.sort((a, b) => a.ref.localeCompare(b.ref));
+
+  const total = records.length;
+  const accepted = records.filter((r) => r.accepted);
+  const lintPassed = records.filter((r) => r.lint_pass).length;
+  const reusedAccepted = accepted.filter((r) => r.reuse_count > 0);
+  const reusePassRateSum = reusedAccepted.reduce((sum, r) => sum + r.reuse_pass_rate, 0);
+  const negativeTransferTotal = records.reduce((sum, r) => sum + r.negative_transfer_count, 0);
+
+  return {
+    lessons: records,
+    lessons_created_count: total,
+    lessons_accepted_count: accepted.length,
+    proposal_lint_pass_rate: total === 0 ? 0 : lintPassed / total,
+    proposal_acceptance_rate: total === 0 ? 0 : accepted.length / total,
+    lesson_reuse_rate: accepted.length === 0 ? 0 : reusedAccepted.length / accepted.length,
+    lesson_reuse_success_rate: reusedAccepted.length === 0 ? 0 : reusePassRateSum / reusedAccepted.length,
+    lesson_negative_transfer_count: negativeTransferTotal,
+  };
+}
+
+/**
+ * Classify lesson-body leakage against verifier source text. Returns
+ * `"high"` when a 4+-word verbatim phrase from any verifier-source entry
+ * appears in the body; `"medium"` for 3-word overlap; `"low"` otherwise.
+ *
+ * The check is intentionally simple — Wave 3's `leakage.test.ts` uses
+ * structural assertion extraction (regex literals, dotted paths, jq/grep
+ * patterns); here we just slide an N-gram window over the verifier text
+ * and ask "does the body contain this exact run of words?". Tokens are
+ * normalised to lowercase and split on non-word boundaries so trivial
+ * whitespace differences don't hide leakage.
+ */
+export function classifyLeakageRisk(
+  body: string | undefined,
+  verifierSources: string[] | undefined,
+): "low" | "medium" | "high" {
+  if (!body || !verifierSources || verifierSources.length === 0) return "low";
+  const bodyTokens = tokenize(body);
+  if (bodyTokens.length === 0) return "low";
+  const bodyJoined = ` ${bodyTokens.join(" ")} `;
+
+  let mediumHit = false;
+  for (const source of verifierSources) {
+    const sourceTokens = tokenize(source);
+    if (sourceTokens.length < 3) continue;
+    if (containsNGram(bodyJoined, sourceTokens, 4)) return "high";
+    if (!mediumHit && containsNGram(bodyJoined, sourceTokens, 3)) mediumHit = true;
+  }
+  return mediumHit ? "medium" : "low";
+}
+
+/**
+ * Slide an N-gram window of size `n` across `tokens` and return true if any
+ * window appears as a contiguous substring inside `bodyJoined` (which is
+ * pre-padded with spaces so word boundaries match cleanly). Skips windows
+ * shorter than `n`; returns false on empty input.
+ */
+function containsNGram(bodyJoined: string, tokens: string[], n: number): boolean {
+  if (tokens.length < n) return false;
+  for (let i = 0; i + n <= tokens.length; i += 1) {
+    const phrase = ` ${tokens.slice(i, i + n).join(" ")} `;
+    if (bodyJoined.includes(phrase)) return true;
+  }
+  return false;
+}
+
+/** Lowercase tokens split on non-word characters. Empty strings dropped. */
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9_]+/)
+    .filter((t) => t.length > 0);
+}

--- a/tests/bench/evolve.ts
+++ b/tests/bench/evolve.ts
@@ -39,6 +39,7 @@ import type { SpawnFn } from "../../src/integrations/agent/spawn";
 import { type LoadedFixtureStash, loadFixtureStash } from "../fixtures/stashes/load";
 import { registerCleanup } from "./cleanup";
 import type { TaskMetadata, TaskSlice } from "./corpus";
+import { computeLessonMetrics, type LessonMetrics } from "./evolve-metrics";
 import {
   computeFeedbackIntegrity,
   computeLongitudinalMetrics,
@@ -124,6 +125,13 @@ export interface EvolveRunReport {
   proposalLog: ProposalLogEntry[];
   /** Aggregate proposal-quality metrics. */
   proposals: ProposalQualityMetrics;
+  /**
+   * Per-lesson quality + reuse metrics (#264). One row per `kind === "lesson"`
+   * proposal, joined to the post-arm `assetsLoaded` stream for reuse stats and
+   * to the pre-arm runs for negative-transfer attribution. Always present —
+   * `lessons.lessons` is `[]` when no lesson-kind proposals were generated.
+   */
+  lessons: LessonMetrics;
   /** Aggregate longitudinal metrics. */
   longitudinal: LongitudinalMetrics;
   /**
@@ -523,6 +531,17 @@ export async function runEvolve(options: RunEvolveOptions): Promise<EvolveRunRep
   const proposalsMetrics = computeProposalQualityMetrics(proposalLog);
   const longitudinal = computeLongitudinalMetrics(preReport, postReport, syntheticReport);
   const feedbackIntegrity = computeFeedbackIntegrity({ phase1: phase1Report, feedbackLog });
+  // #264 — lesson quality + reuse metrics. The runner doesn't (yet) read
+  // accepted lesson bodies off disk or load verifier source text; we pass
+  // empty maps so the leakage check defaults to "low" until the read seam
+  // lands. Reuse + negative-transfer attribution work today off the
+  // pre/post arm `assetsLoaded` stream.
+  const lessons = computeLessonMetrics({
+    proposalLog,
+    feedbackLog,
+    preRuns: preReport.akmRuns ?? [],
+    postRuns: postReport.akmRuns ?? [],
+  });
 
   return {
     timestamp: options.timestamp ?? new Date().toISOString(),
@@ -534,6 +553,7 @@ export async function runEvolve(options: RunEvolveOptions): Promise<EvolveRunRep
     feedbackLog,
     proposalLog,
     proposals: proposalsMetrics,
+    lessons,
     longitudinal,
     feedbackIntegrity,
     phase1: phase1Report,

--- a/tests/bench/learning-curve.test.ts
+++ b/tests/bench/learning-curve.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Report-level coverage for Track B learning curves (issue #265).
+ *
+ * Verifies that a `LearningCurve` supplied via `EvolveReportInput.learningCurve`
+ * surfaces in both the JSON envelope (under `learning`) and the markdown
+ * body (as a "Learning curve" section). Companion unit tests for
+ * `computeLearningCurve` itself live in `metrics.test.ts`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { computeLearningCurve, type EpisodeRecord } from "./metrics";
+import {
+  type EvolveReportInput,
+  renderEvolveReport,
+  renderLearningCurveSection,
+  type UtilityRunReport,
+} from "./report";
+
+function emptyUtilityReport(): UtilityRunReport {
+  return {
+    timestamp: "2026-04-27T00:00:00Z",
+    branch: "test",
+    commit: "deadbee",
+    model: "m",
+    corpus: { domains: 0, tasks: 0, slice: "all", seedsPerArm: 1 },
+    aggregateNoakm: { passRate: 0, tokensPerPass: 0, wallclockMs: 0, budgetExceeded: 0 },
+    aggregateAkm: { passRate: 0, tokensPerPass: 0, wallclockMs: 0, budgetExceeded: 0 },
+    aggregateDelta: {
+      passRate: { delta: 0, sign: "neutral" },
+      tokensPerPass: { delta: 0, sign: "neutral" },
+      wallclockMs: { delta: 0, sign: "neutral" },
+    },
+    trajectoryAkm: {
+      assetLoadCorrectness: { correct: 0, incorrect: 0, missing: 0, count: 0, correctRate: 0 },
+      feedbackRecorded: { recorded: 0, notRecorded: 0, count: 0, recordedRate: 0 },
+    },
+    failureModes: { byLabel: {}, byTask: {} },
+    tasks: [],
+    warnings: [],
+    akmRuns: [],
+    taskMetadata: [],
+    goldRankRecords: [],
+  };
+}
+
+function ep(overrides: Partial<EpisodeRecord> & { episode_index: number; pass_rate: number }): EpisodeRecord {
+  return {
+    delta_from_previous_episode: 0,
+    cumulative_feedback_events: 0,
+    cumulative_proposals_created: 0,
+    cumulative_proposals_accepted: 0,
+    cumulative_lessons_created: 0,
+    lesson_reuse_rate: null,
+    ...overrides,
+  };
+}
+
+function baseEvolveInput(extra: Partial<EvolveReportInput> = {}): EvolveReportInput {
+  return {
+    timestamp: "2026-04-27T00:00:00Z",
+    branch: "test",
+    commit: "deadbee",
+    model: "m",
+    domain: "test",
+    seedsPerArm: 1,
+    proposals: { rows: [], totalProposals: 0, totalAccepted: 0, acceptanceRate: 0, lintPassRate: 0 },
+    longitudinal: {
+      improvementSlope: 0.1,
+      overSyntheticLift: 0.05,
+      degradationCount: 0,
+      degradations: [],
+      prePassRate: 0.5,
+      postPassRate: 0.6,
+      syntheticPassRate: 0.55,
+    },
+    arms: { pre: emptyUtilityReport(), post: emptyUtilityReport(), synthetic: emptyUtilityReport() },
+    warnings: [],
+    ...extra,
+  };
+}
+
+describe("renderEvolveReport — learning block (#265)", () => {
+  test("emits learning.episodes[] + slope + time_to_improvement when learningCurve supplied", () => {
+    const curve = computeLearningCurve([
+      ep({ episode_index: 0, pass_rate: 0.4, cumulative_feedback_events: 10 }),
+      ep({
+        episode_index: 1,
+        pass_rate: 0.55,
+        cumulative_feedback_events: 22,
+        cumulative_proposals_created: 4,
+        cumulative_proposals_accepted: 3,
+        cumulative_lessons_created: 3,
+        lesson_reuse_rate: 0.42,
+      }),
+      ep({
+        episode_index: 2,
+        pass_rate: 0.7,
+        cumulative_feedback_events: 35,
+        cumulative_proposals_created: 7,
+        cumulative_proposals_accepted: 5,
+        cumulative_lessons_created: 5,
+        lesson_reuse_rate: 0.6,
+      }),
+    ]);
+    const { json, markdown } = renderEvolveReport(baseEvolveInput({ learningCurve: curve }));
+    const parsed = json as {
+      learning?: {
+        episodes: Array<{ episode_index: number; pass_rate: number; cumulative_lessons_created: number }>;
+        pass_rate_by_episode: number[];
+        learning_slope: number;
+        time_to_improvement: number | null;
+      };
+    };
+    expect(parsed.learning).toBeDefined();
+    expect(parsed.learning?.episodes).toHaveLength(3);
+    expect(parsed.learning?.pass_rate_by_episode).toEqual([0.4, 0.55, 0.7]);
+    expect(parsed.learning?.time_to_improvement).toBe(1);
+    expect(parsed.learning?.learning_slope).toBeCloseTo(0.15, 3);
+    expect(markdown).toContain("Learning curve");
+    expect(markdown).toContain("learning_slope=+0.150");
+    expect(markdown).toContain("time_to_improvement=1");
+  });
+
+  test("omits learning block when learningCurve absent (legacy path)", () => {
+    const { json, markdown } = renderEvolveReport(baseEvolveInput());
+    const parsed = json as { learning?: object };
+    expect(parsed.learning).toBeUndefined();
+    expect(markdown).not.toContain("Learning curve");
+  });
+
+  test("renders n/a for time_to_improvement when no improvement", () => {
+    const curve = computeLearningCurve([
+      ep({ episode_index: 0, pass_rate: 0.5 }),
+      ep({ episode_index: 1, pass_rate: 0.5 }),
+    ]);
+    const { json, markdown } = renderEvolveReport(baseEvolveInput({ learningCurve: curve }));
+    const parsed = json as { learning?: { time_to_improvement: number | null } };
+    expect(parsed.learning?.time_to_improvement).toBeNull();
+    expect(markdown).toContain("time_to_improvement=n/a");
+  });
+});
+
+describe("renderLearningCurveSection", () => {
+  test("emits the empty-state message when no episodes are recorded", () => {
+    const md = renderLearningCurveSection({
+      episodes: [],
+      pass_rate_by_episode: [],
+      learning_slope: 0,
+      time_to_improvement: null,
+    });
+    expect(md).toContain("No episodes recorded");
+  });
+});

--- a/tests/bench/metrics.test.ts
+++ b/tests/bench/metrics.test.ts
@@ -4,13 +4,17 @@
 
 import { describe, expect, test } from "bun:test";
 
+import type { EventEnvelope } from "../../src/core/events";
+import type { TaskMetadata } from "./corpus";
 import type { RunResult } from "./driver";
 import {
+  aggregateAkmOverhead,
   aggregateByMemoryAbility,
   aggregateByTaskFamily,
   aggregateCorpus,
   aggregatePerTask,
   aggregateTrajectory,
+  computeAkmOverhead,
   computeAssetRegressionCandidates,
   computeCorpusCoverage,
   computeCorpusDelta,
@@ -600,5 +604,226 @@ describe("aggregateByMemoryAbility / aggregateByTaskFamily (#262)", () => {
     expect(cov.memoryAbilityCounts.untagged).toBe(2);
     expect(cov.taskFamilyCounts["d/family-a"]).toBe(2);
     expect(cov.taskFamilyCounts.untagged).toBe(1);
+  });
+});
+
+// ── AKM overhead (#263) ────────────────────────────────────────────────────
+
+function akmEvent(eventType: string, ts: string, ref?: string, metadata?: Record<string, unknown>): EventEnvelope {
+  return {
+    schemaVersion: 1,
+    id: 0,
+    ts,
+    eventType,
+    ...(ref ? { ref } : {}),
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+function metaMap(
+  entries: ReadonlyArray<Pick<TaskMetadata, "id" | "goldRef" | "expectedTransferFrom">>,
+): Map<string, Pick<TaskMetadata, "goldRef" | "expectedTransferFrom">> {
+  const m = new Map<string, Pick<TaskMetadata, "goldRef" | "expectedTransferFrom">>();
+  for (const e of entries) m.set(e.id, { goldRef: e.goldRef, expectedTransferFrom: e.expectedTransferFrom });
+  return m;
+}
+
+describe("computeAkmOverhead — no AKM calls", () => {
+  test("zero counts and null timings when run had no AKM events", () => {
+    const run = fakeResult({ taskId: "demo/none", events: [] });
+    const rows = computeAkmOverhead([run]);
+    expect(rows).toHaveLength(1);
+    const r = rows[0];
+    expect(r.searchCount).toBe(0);
+    expect(r.showCount).toBe(0);
+    expect(r.feedbackCount).toBe(0);
+    expect(r.totalToolCalls).toBe(0);
+    expect(r.assetsLoadedCount).toBe(0);
+    expect(r.timeToFirstSearchMs).toBeNull();
+    expect(r.timeToFirstCorrectAssetMs).toBeNull();
+    expect(r.contextBytesLoaded).toBeNull();
+    expect(r.assetBytesLoaded).toBeNull();
+    // Without metadata, irrelevance is unjudgeable -> null.
+    expect(r.irrelevantAssetsLoadedCount).toBeNull();
+  });
+
+  test("aggregate over empty array is the zero envelope", () => {
+    const agg = aggregateAkmOverhead([]);
+    expect(agg.totalRuns).toBe(0);
+    expect(agg.passingRuns).toBe(0);
+    expect(agg.toolCallsPerSuccess).toBeNull();
+    expect(agg.costPerSuccess).toBeNull();
+    expect(agg.meanTimeToFirstSearchMs).toBeNull();
+  });
+});
+
+describe("computeAkmOverhead — successful AKM use", () => {
+  test("counts search/show/feedback, computes timings and relevance", () => {
+    const run = fakeResult({
+      taskId: "demo/ok",
+      outcome: "pass",
+      tokenMeasurement: "parsed",
+      tokens: { input: 100, output: 50 },
+      events: [
+        akmEvent("search", "2026-04-27T10:00:00.000Z", undefined, { query: "deploy" }),
+        akmEvent("show", "2026-04-27T10:00:00.500Z", "skill:deploy"),
+        akmEvent("feedback", "2026-04-27T10:00:01.000Z", "skill:deploy"),
+      ],
+    });
+    const tasks = metaMap([{ id: "demo/ok", goldRef: "skill:deploy", expectedTransferFrom: [] }]);
+    const rows = computeAkmOverhead([run], { taskMetadata: tasks });
+    const r = rows[0];
+    expect(r.searchCount).toBe(1);
+    expect(r.showCount).toBe(1);
+    expect(r.feedbackCount).toBe(1);
+    expect(r.totalToolCalls).toBe(3);
+    expect(r.assetsLoadedCount).toBe(1);
+    expect(r.irrelevantAssetsLoadedCount).toBe(0);
+    expect(r.timeToFirstSearchMs).toBe(0); // first search IS the run-start anchor
+    expect(r.timeToFirstCorrectAssetMs).toBe(500);
+    const agg = aggregateAkmOverhead(rows, [run]);
+    expect(agg.passingRuns).toBe(1);
+    expect(agg.toolCallsPerSuccess).toBe(3);
+    expect(agg.costPerSuccess).toBe(150);
+  });
+
+  test("expected_transfer_from refs are not counted as irrelevant", () => {
+    const run = fakeResult({
+      taskId: "demo/transfer",
+      events: [
+        akmEvent("show", "2026-04-27T10:00:00.000Z", "skill:foo"),
+        akmEvent("show", "2026-04-27T10:00:01.000Z", "skill:helper"),
+      ],
+    });
+    const tasks = metaMap([{ id: "demo/transfer", goldRef: "skill:foo", expectedTransferFrom: ["skill:helper"] }]);
+    const rows = computeAkmOverhead([run], { taskMetadata: tasks });
+    expect(rows[0].assetsLoadedCount).toBe(2);
+    expect(rows[0].irrelevantAssetsLoadedCount).toBe(0);
+  });
+});
+
+describe("computeAkmOverhead — excessive AKM calls", () => {
+  test("high counts and low calls-per-success are surfaced", () => {
+    const goldRef = "skill:gold";
+    const noisyRun = fakeResult({
+      taskId: "demo/noisy",
+      outcome: "fail",
+      events: [
+        akmEvent("search", "2026-04-27T10:00:00.000Z"),
+        akmEvent("search", "2026-04-27T10:00:00.100Z"),
+        akmEvent("search", "2026-04-27T10:00:00.200Z"),
+        akmEvent("show", "2026-04-27T10:00:00.300Z", "skill:other"),
+        akmEvent("show", "2026-04-27T10:00:00.400Z", "skill:other2"),
+        akmEvent("show", "2026-04-27T10:00:00.500Z", "skill:other3"),
+        akmEvent("show", "2026-04-27T10:00:00.600Z", goldRef),
+      ],
+    });
+    const passingRun = fakeResult({
+      taskId: "demo/easy",
+      outcome: "pass",
+      tokenMeasurement: "parsed",
+      tokens: { input: 10, output: 10 },
+      events: [akmEvent("search", "2026-04-27T10:00:00.000Z"), akmEvent("show", "2026-04-27T10:00:00.100Z", goldRef)],
+    });
+    const tasks = metaMap([
+      { id: "demo/noisy", goldRef, expectedTransferFrom: [] },
+      { id: "demo/easy", goldRef, expectedTransferFrom: [] },
+    ]);
+    const rows = computeAkmOverhead([noisyRun, passingRun], { taskMetadata: tasks });
+    expect(rows[0].totalToolCalls).toBe(7);
+    expect(rows[0].irrelevantAssetsLoadedCount).toBe(3);
+    expect(rows[0].timeToFirstCorrectAssetMs).toBe(600);
+    expect(rows[1].totalToolCalls).toBe(2);
+    const agg = aggregateAkmOverhead(rows, [noisyRun, passingRun]);
+    expect(agg.totalToolCalls).toBe(9);
+    expect(agg.passingRuns).toBe(1);
+    // 9 tool calls for one passing run = high overhead per success.
+    expect(agg.toolCallsPerSuccess).toBe(9);
+  });
+});
+
+describe("computeAkmOverhead — missing timing/byte data", () => {
+  test("event without ts -> null first-search timing (NOT zero)", () => {
+    const run = fakeResult({
+      taskId: "demo/notime",
+      events: [
+        // No ts on event — workflow-trace assigns a synthetic order hint but
+        // ts stays undefined, so we cannot anchor a real time-offset.
+        { schemaVersion: 1, id: 0, eventType: "search" } as EventEnvelope,
+      ],
+    });
+    const rows = computeAkmOverhead([run]);
+    expect(rows[0].searchCount).toBe(1);
+    expect(rows[0].timeToFirstSearchMs).toBeNull();
+    expect(rows[0].timeToFirstCorrectAssetMs).toBeNull();
+  });
+
+  test("byte sizes are always null for now (NOT zero)", () => {
+    const run = fakeResult({
+      events: [akmEvent("show", "2026-04-27T10:00:00.000Z", "skill:foo")],
+    });
+    const rows = computeAkmOverhead([run]);
+    expect(rows[0].contextBytesLoaded).toBeNull();
+    expect(rows[0].assetBytesLoaded).toBeNull();
+    const agg = aggregateAkmOverhead(rows, [run]);
+    expect(agg.meanContextBytesLoaded).toBeNull();
+    expect(agg.meanAssetBytesLoaded).toBeNull();
+  });
+
+  test("cost_per_success is null when any passing run lacks parsed token measurement", () => {
+    const passParsed = fakeResult({
+      taskId: "t1",
+      outcome: "pass",
+      tokenMeasurement: "parsed",
+      tokens: { input: 10, output: 5 },
+      events: [akmEvent("search", "2026-04-27T10:00:00.000Z")],
+    });
+    const passMissing = fakeResult({
+      taskId: "t2",
+      outcome: "pass",
+      tokenMeasurement: "missing",
+      tokens: { input: 0, output: 0 },
+      events: [akmEvent("search", "2026-04-27T10:00:00.000Z")],
+    });
+    const rows = computeAkmOverhead([passParsed, passMissing]);
+    const agg = aggregateAkmOverhead(rows, [passParsed, passMissing]);
+    expect(agg.passingRuns).toBe(2);
+    expect(agg.costPerSuccess).toBeNull();
+  });
+
+  test("missing task metadata -> irrelevantAssetsLoadedCount is null (not 0)", () => {
+    const run = fakeResult({
+      taskId: "demo/unknown",
+      events: [akmEvent("show", "2026-04-27T10:00:00.000Z", "skill:foo")],
+    });
+    // No metadata supplied for this task.
+    const rows = computeAkmOverhead([run]);
+    expect(rows[0].assetsLoadedCount).toBe(1);
+    expect(rows[0].irrelevantAssetsLoadedCount).toBeNull();
+  });
+
+  test("aggregate skips null timings rather than zero-filling", () => {
+    const noTime = fakeResult({
+      taskId: "t1",
+      outcome: "fail",
+      events: [{ schemaVersion: 1, id: 0, eventType: "search" } as EventEnvelope],
+    });
+    const withTime = fakeResult({
+      taskId: "t2",
+      outcome: "fail",
+      events: [akmEvent("search", "2026-04-27T10:00:01.000Z")],
+    });
+    const rows = computeAkmOverhead([noTime, withTime]);
+    // First run: search event has no ts -> no run-start anchor, timing null.
+    // Second run: search event IS the only event with ts, so it's both the
+    // anchor and the first search -> offset 0.
+    expect(rows[0].timeToFirstSearchMs).toBeNull();
+    expect(rows[1].timeToFirstSearchMs).toBe(0);
+    const agg = aggregateAkmOverhead(rows, [noTime, withTime]);
+    // Mean honours only the parseable observation; the null is skipped, NOT
+    // treated as zero in the numerator.
+    expect(agg.meanTimeToFirstSearchMs).toBe(0);
+    // tool_calls_per_success is null because no run passed.
+    expect(agg.toolCallsPerSuccess).toBeNull();
   });
 });

--- a/tests/bench/metrics.test.ts
+++ b/tests/bench/metrics.test.ts
@@ -22,10 +22,12 @@ import {
   computeNegativeTransfer,
   computeOutcomeAggregate,
   computePerTaskDelta,
+  computeWorkflowReliability,
   domainOfTaskId,
   type PerTaskMetrics,
   type PerTaskTagEntry,
 } from "./metrics";
+import type { WorkflowCheckResult, WorkflowCheckStatus } from "./workflow-evaluator";
 
 function ptm(overrides: Partial<PerTaskMetrics> = {}): PerTaskMetrics {
   return {
@@ -825,5 +827,137 @@ describe("computeAkmOverhead — missing timing/byte data", () => {
     expect(agg.meanTimeToFirstSearchMs).toBe(0);
     // tool_calls_per_success is null because no run passed.
     expect(agg.toolCallsPerSuccess).toBeNull();
+  });
+});
+
+// ── computeWorkflowReliability (#258) ──────────────────────────────────────
+
+function wfCheck(overrides: Partial<WorkflowCheckResult> = {}): WorkflowCheckResult {
+  return {
+    schemaVersion: 1,
+    workflowId: "wf-1",
+    taskId: "t1",
+    arm: "akm",
+    seed: 0,
+    status: "pass",
+    score: 1,
+    requiredPassed: 1,
+    requiredTotal: 1,
+    violations: [],
+    evidence: {
+      matchedEvents: 1,
+      feedbackRecorded: false,
+      goldAssetLoaded: false,
+      traceTruncated: false,
+    },
+    ...overrides,
+  };
+}
+
+function statuses(workflowId: string, taskId: string, statusList: WorkflowCheckStatus[]): WorkflowCheckResult[] {
+  return statusList.map((status, seed) => wfCheck({ workflowId, taskId, seed, status }));
+}
+
+describe("computeWorkflowReliability (#258)", () => {
+  test("empty input yields zeroed corpus + empty by_workflow", () => {
+    const result = computeWorkflowReliability([]);
+    expect(result.byWorkflow).toEqual({});
+    expect(result.corpus).toEqual({ pass_at_k: 0, pass_all_k: 0, groups: 0, tasks: 0 });
+  });
+
+  test("all-pass: every (task, seed) is pass → pass@k=1, pass^k=1", () => {
+    const checks = [
+      ...statuses("wf-1", "t1", ["pass", "pass", "pass"]),
+      ...statuses("wf-1", "t2", ["pass", "pass", "pass"]),
+    ];
+    const result = computeWorkflowReliability(checks);
+    expect(result.byWorkflow["wf-1"].pass_at_k).toBe(1);
+    expect(result.byWorkflow["wf-1"].pass_all_k).toBe(1);
+    expect(result.byWorkflow["wf-1"].tasks).toBe(2);
+    expect(result.byWorkflow["wf-1"].k).toBe(3);
+    expect(result.corpus.pass_at_k).toBe(1);
+    expect(result.corpus.pass_all_k).toBe(1);
+    expect(result.corpus.groups).toBe(2);
+    expect(result.corpus.tasks).toBe(2);
+  });
+
+  test("none-pass: no seed is pass → pass@k=0, pass^k=0", () => {
+    const checks = [
+      ...statuses("wf-1", "t1", ["fail", "fail", "fail"]),
+      ...statuses("wf-1", "t2", ["partial", "fail", "harness_error"]),
+    ];
+    const result = computeWorkflowReliability(checks);
+    expect(result.byWorkflow["wf-1"].pass_at_k).toBe(0);
+    expect(result.byWorkflow["wf-1"].pass_all_k).toBe(0);
+    expect(result.corpus.pass_at_k).toBe(0);
+    expect(result.corpus.pass_all_k).toBe(0);
+  });
+
+  test("some-pass: pass@k > 0, pass^k < pass@k when seeds disagree per task", () => {
+    // t1: 1 pass, 2 fail → counts toward pass@k (anyPass) but NOT pass^k
+    // t2: 3 pass → counts toward both
+    const checks = [
+      ...statuses("wf-1", "t1", ["pass", "fail", "fail"]),
+      ...statuses("wf-1", "t2", ["pass", "pass", "pass"]),
+    ];
+    const result = computeWorkflowReliability(checks);
+    expect(result.byWorkflow["wf-1"].pass_at_k).toBeCloseTo(1); // both tasks have at least one pass
+    expect(result.byWorkflow["wf-1"].pass_all_k).toBeCloseTo(0.5); // only t2 is all-pass
+    expect(result.corpus.pass_at_k).toBeCloseTo(1);
+    expect(result.corpus.pass_all_k).toBeCloseTo(0.5);
+  });
+
+  test("mixed partial/fail: partial does NOT count as pass for reliability", () => {
+    // partial is non-pass per the strict reliability bucketing.
+    const checks = [...statuses("wf-1", "t1", ["partial", "partial", "partial"])];
+    const result = computeWorkflowReliability(checks);
+    expect(result.byWorkflow["wf-1"].pass_at_k).toBe(0);
+    expect(result.byWorkflow["wf-1"].pass_all_k).toBe(0);
+  });
+
+  test("not_applicable seeds are excluded from numerator and denominator", () => {
+    // Only the 2 applicable seeds matter; both are pass → 1 task all-pass.
+    const checks = [...statuses("wf-1", "t1", ["not_applicable", "pass", "pass", "not_applicable"])];
+    const result = computeWorkflowReliability(checks);
+    expect(result.byWorkflow["wf-1"].pass_at_k).toBe(1);
+    expect(result.byWorkflow["wf-1"].pass_all_k).toBe(1);
+    expect(result.byWorkflow["wf-1"].tasks).toBe(1);
+    expect(result.byWorkflow["wf-1"].k).toBe(2);
+  });
+
+  test("workflow with every check not_applicable is omitted (no group counted)", () => {
+    const checks = [...statuses("wf-skips", "t1", ["not_applicable", "not_applicable"])];
+    const result = computeWorkflowReliability(checks);
+    expect(result.byWorkflow["wf-skips"]).toBeUndefined();
+    expect(result.corpus.groups).toBe(0);
+    expect(result.corpus.tasks).toBe(0);
+  });
+
+  test("multiple workflows compute independently; corpus weights groups equally", () => {
+    // wf-a: t1 all pass (1/1 = 1, 1/1 = 1)
+    // wf-b: t2 mixed (anyPass=1, allPass=0); t3 none (0, 0)
+    //   per-workflow: pass@k=0.5, pass^k=0
+    // corpus: 3 groups → pass@k = (1+1+0)/3 = 2/3; pass^k = (1+0+0)/3 = 1/3
+    const checks = [
+      ...statuses("wf-a", "t1", ["pass", "pass"]),
+      ...statuses("wf-b", "t2", ["pass", "fail"]),
+      ...statuses("wf-b", "t3", ["fail", "fail"]),
+    ];
+    const result = computeWorkflowReliability(checks);
+    expect(result.byWorkflow["wf-a"].pass_at_k).toBe(1);
+    expect(result.byWorkflow["wf-a"].pass_all_k).toBe(1);
+    expect(result.byWorkflow["wf-b"].pass_at_k).toBeCloseTo(0.5);
+    expect(result.byWorkflow["wf-b"].pass_all_k).toBe(0);
+    expect(result.corpus.pass_at_k).toBeCloseTo(2 / 3);
+    expect(result.corpus.pass_all_k).toBeCloseTo(1 / 3);
+    expect(result.corpus.groups).toBe(3);
+    expect(result.corpus.tasks).toBe(3);
+  });
+
+  test("harness_error is treated as non-pass (consistent with #257 bucketing)", () => {
+    const checks = [...statuses("wf-1", "t1", ["pass", "harness_error", "pass"])];
+    const result = computeWorkflowReliability(checks);
+    expect(result.byWorkflow["wf-1"].pass_at_k).toBe(1);
+    expect(result.byWorkflow["wf-1"].pass_all_k).toBe(0);
   });
 });

--- a/tests/bench/metrics.test.ts
+++ b/tests/bench/metrics.test.ts
@@ -9,11 +9,30 @@ import {
   aggregateCorpus,
   aggregatePerTask,
   aggregateTrajectory,
+  computeAssetRegressionCandidates,
   computeCorpusDelta,
+  computeDomainAggregates,
+  computeNegativeTransfer,
   computeOutcomeAggregate,
   computePerTaskDelta,
+  domainOfTaskId,
   type PerTaskMetrics,
 } from "./metrics";
+
+function ptm(overrides: Partial<PerTaskMetrics> = {}): PerTaskMetrics {
+  return {
+    passRate: 0,
+    passAt1: 0,
+    tokensPerPass: null,
+    wallclockMs: 0,
+    passRateStdev: 0,
+    budgetExceededCount: 0,
+    harnessErrorCount: 0,
+    count: 1,
+    runsWithMeasuredTokens: 0,
+    ...overrides,
+  };
+}
 
 function fakeResult(overrides: Partial<RunResult>): RunResult {
   return {
@@ -338,5 +357,161 @@ describe("aggregateTrajectory", () => {
     const t = aggregateTrajectory(runs);
     expect(t.correctAssetLoaded).toBeCloseTo(0.5);
     expect(t.feedbackRecorded).toBe(0);
+  });
+});
+
+describe("domainOfTaskId", () => {
+  test("returns the segment before the first slash", () => {
+    expect(domainOfTaskId("docker-homelab/redis-healthcheck")).toBe("docker-homelab");
+  });
+
+  test("falls back to 'unknown' when there is no slash", () => {
+    expect(domainOfTaskId("noslash")).toBe("unknown");
+  });
+
+  test("falls back to 'unknown' when the slash is at index 0", () => {
+    expect(domainOfTaskId("/leading")).toBe("unknown");
+  });
+});
+
+describe("computeNegativeTransfer", () => {
+  test("returns zero count and severity when no regressions are present", () => {
+    const tasks = [
+      { id: "d/a", noakm: ptm({ passRate: 0.4 }), akm: ptm({ passRate: 0.8 }) },
+      { id: "d/b", noakm: ptm({ passRate: 0.5 }), akm: ptm({ passRate: 0.5 }) },
+    ];
+    const out = computeNegativeTransfer(tasks);
+    expect(out.count).toBe(0);
+    expect(out.severity).toBe(0);
+    expect(out.topRegressedTasks).toEqual([]);
+  });
+
+  test("captures a single regression with correct delta and severity", () => {
+    const tasks = [
+      { id: "d/a", noakm: ptm({ passRate: 0.4 }), akm: ptm({ passRate: 0.8 }) },
+      { id: "d/regressed", noakm: ptm({ passRate: 0.6 }), akm: ptm({ passRate: 0.2 }) },
+    ];
+    const out = computeNegativeTransfer(tasks);
+    expect(out.count).toBe(1);
+    expect(out.severity).toBeCloseTo(0.4);
+    expect(out.topRegressedTasks).toHaveLength(1);
+    const row = out.topRegressedTasks[0];
+    if (!row) throw new Error("expected row");
+    expect(row.taskId).toBe("d/regressed");
+    expect(row.domain).toBe("d");
+    expect(row.delta).toBeCloseTo(-0.4);
+    expect(row.severity).toBeCloseTo(0.4);
+  });
+
+  test("multiple regressions are sorted by severity desc with deterministic tiebreak", () => {
+    const tasks = [
+      // Mild regression -0.1.
+      { id: "alpha/x", noakm: ptm({ passRate: 0.6 }), akm: ptm({ passRate: 0.5 }) },
+      // Tied severity -0.3 (first tiebreaks by taskId asc).
+      { id: "beta/y", noakm: ptm({ passRate: 0.8 }), akm: ptm({ passRate: 0.5 }) },
+      { id: "alpha/z", noakm: ptm({ passRate: 0.8 }), akm: ptm({ passRate: 0.5 }) },
+      // Improvement (no regression).
+      { id: "alpha/w", noakm: ptm({ passRate: 0.1 }), akm: ptm({ passRate: 0.9 }) },
+    ];
+    const out = computeNegativeTransfer(tasks);
+    expect(out.count).toBe(3);
+    expect(out.severity).toBeCloseTo(0.7);
+    expect(out.topRegressedTasks.map((r) => r.taskId)).toEqual(["alpha/z", "beta/y", "alpha/x"]);
+  });
+
+  test("a task with equal pass rate is not counted as regressed", () => {
+    const tasks = [{ id: "d/eq", noakm: ptm({ passRate: 0.5 }), akm: ptm({ passRate: 0.5 }) }];
+    expect(computeNegativeTransfer(tasks).count).toBe(0);
+  });
+});
+
+describe("computeDomainAggregates", () => {
+  test("groups tasks by domain prefix", () => {
+    const tasks = [
+      {
+        id: "alpha/a",
+        noakm: ptm({ passRate: 0.4, tokensPerPass: 10000, wallclockMs: 1000 }),
+        akm: ptm({ passRate: 0.8, tokensPerPass: 8000, wallclockMs: 900 }),
+      },
+      {
+        id: "alpha/b",
+        noakm: ptm({ passRate: 0.6, tokensPerPass: 12000, wallclockMs: 2000 }),
+        akm: ptm({ passRate: 0.4, tokensPerPass: 9000, wallclockMs: 1500 }),
+      },
+      {
+        id: "beta/c",
+        noakm: ptm({ passRate: 0.2, tokensPerPass: null, wallclockMs: 500 }),
+        akm: ptm({ passRate: 0.5, tokensPerPass: 5000, wallclockMs: 600 }),
+      },
+    ];
+    const rows = computeDomainAggregates(tasks);
+    expect(rows.map((r) => r.domain)).toEqual(["alpha", "beta"]);
+
+    const alpha = rows.find((r) => r.domain === "alpha");
+    if (!alpha) throw new Error("alpha missing");
+    expect(alpha.taskCount).toBe(2);
+    expect(alpha.regressionCount).toBe(1);
+    expect(alpha.passRateNoakm).toBeCloseTo(0.5);
+    expect(alpha.passRateAkm).toBeCloseTo(0.6);
+    expect(alpha.passRateDelta).toBeCloseTo(0.1);
+    expect(alpha.tokensPerPassDelta).toBeCloseTo(8500 - 11000);
+    expect(alpha.wallclockMsDelta).toBeCloseTo(1200 - 1500);
+
+    const beta = rows.find((r) => r.domain === "beta");
+    if (!beta) throw new Error("beta missing");
+    expect(beta.regressionCount).toBe(0);
+    // Single-side null tokensPerPass yields null delta.
+    expect(beta.tokensPerPassDelta).toBeNull();
+  });
+
+  test("emits an empty array on no tasks", () => {
+    expect(computeDomainAggregates([])).toEqual([]);
+  });
+});
+
+describe("computeAssetRegressionCandidates", () => {
+  function fakeRun(taskId: string, assets: string[]): RunResult {
+    return {
+      schemaVersion: 1,
+      taskId,
+      arm: "akm",
+      seed: 0,
+      model: "m",
+      outcome: "pass",
+      tokens: { input: 0, output: 0 },
+      wallclockMs: 0,
+      trajectory: { correctAssetLoaded: null, feedbackRecorded: null },
+      events: [],
+      verifierStdout: "",
+      verifierExitCode: 0,
+      assetsLoaded: assets,
+    };
+  }
+
+  test("returns empty when no regressed tasks were provided", () => {
+    expect(computeAssetRegressionCandidates([], [fakeRun("d/a", ["skill:x"])])).toEqual([]);
+  });
+
+  test("counts distinct regressed tasks per asset and totals raw load volume", () => {
+    const akmRuns = [
+      // task d/r1 across two seeds, same asset.
+      fakeRun("d/r1", ["skill:foo", "skill:bar"]),
+      fakeRun("d/r1", ["skill:foo"]),
+      // task d/r2 loads skill:foo (again) plus skill:baz.
+      fakeRun("d/r2", ["skill:foo", "skill:baz"]),
+      // Non-regressed task is ignored entirely.
+      fakeRun("d/clean", ["skill:foo", "skill:bar", "skill:baz"]),
+    ];
+    const rows = computeAssetRegressionCandidates(["d/r1", "d/r2"], akmRuns);
+    expect(rows.map((r) => r.assetRef)).toEqual(["skill:foo", "skill:bar", "skill:baz"]);
+    const foo = rows[0];
+    if (!foo) throw new Error("foo missing");
+    expect(foo.regressedTaskCount).toBe(2);
+    expect(foo.regressedTaskIds).toEqual(["d/r1", "d/r2"]);
+    expect(foo.totalLoadCount).toBe(3);
+    const bar = rows[1];
+    if (!bar) throw new Error("bar missing");
+    expect(bar.regressedTaskCount).toBe(1);
+    expect(bar.totalLoadCount).toBe(1);
   });
 });

--- a/tests/bench/metrics.test.ts
+++ b/tests/bench/metrics.test.ts
@@ -19,10 +19,13 @@ import {
   computeCorpusCoverage,
   computeCorpusDelta,
   computeDomainAggregates,
+  computeLearningCurve,
   computeNegativeTransfer,
   computeOutcomeAggregate,
   computePerTaskDelta,
   domainOfTaskId,
+  type EpisodeRecord,
+  LEARNING_IMPROVEMENT_THRESHOLD,
   type PerTaskMetrics,
   type PerTaskTagEntry,
 } from "./metrics";
@@ -825,5 +828,148 @@ describe("computeAkmOverhead — missing timing/byte data", () => {
     expect(agg.meanTimeToFirstSearchMs).toBe(0);
     // tool_calls_per_success is null because no run passed.
     expect(agg.toolCallsPerSuccess).toBeNull();
+  });
+});
+
+// ── Learning curve across episodes (issue #265) ────────────────────────────
+
+function ep(overrides: Partial<EpisodeRecord> & { episode_index: number; pass_rate: number }): EpisodeRecord {
+  return {
+    delta_from_previous_episode: 0,
+    cumulative_feedback_events: 0,
+    cumulative_proposals_created: 0,
+    cumulative_proposals_accepted: 0,
+    cumulative_lessons_created: 0,
+    lesson_reuse_rate: null,
+    ...overrides,
+  };
+}
+
+describe("computeLearningCurve", () => {
+  test("monotonic improvement: positive slope, time_to_improvement at first crossing", () => {
+    const episodes = [
+      ep({ episode_index: 0, pass_rate: 0.4, cumulative_feedback_events: 10 }),
+      ep({ episode_index: 1, pass_rate: 0.5, cumulative_feedback_events: 22 }),
+      ep({ episode_index: 2, pass_rate: 0.6, cumulative_feedback_events: 35 }),
+      ep({ episode_index: 3, pass_rate: 0.7, cumulative_feedback_events: 48 }),
+    ];
+    const curve = computeLearningCurve(episodes);
+    expect(curve.pass_rate_by_episode).toEqual([0.4, 0.5, 0.6, 0.7]);
+    // Slope is exactly 0.1 per episode for evenly spaced 0.1 increments.
+    expect(curve.learning_slope).toBeCloseTo(0.1, 6);
+    // Episode 1 first exceeds 0.4 + 0.05 = 0.45 (0.5 > 0.45).
+    expect(curve.time_to_improvement).toBe(1);
+    // Deltas: 0, 0.1, 0.1, 0.1
+    expect(curve.episodes[0].delta_from_previous_episode).toBe(0);
+    expect(curve.episodes[1].delta_from_previous_episode).toBeCloseTo(0.1);
+    expect(curve.episodes[3].delta_from_previous_episode).toBeCloseTo(0.1);
+  });
+
+  test("no improvement: flat pass rate yields zero slope and null time_to_improvement", () => {
+    const episodes = [
+      ep({ episode_index: 0, pass_rate: 0.5 }),
+      ep({ episode_index: 1, pass_rate: 0.5 }),
+      ep({ episode_index: 2, pass_rate: 0.51 }),
+      ep({ episode_index: 3, pass_rate: 0.52 }),
+    ];
+    const curve = computeLearningCurve(episodes);
+    expect(curve.learning_slope).toBeCloseTo(0.0073, 3);
+    // Never crosses 0.5 + 0.05 = 0.55.
+    expect(curve.time_to_improvement).toBeNull();
+  });
+
+  test("regression mid-episode: slope still computed, time_to_improvement honours first qualifying episode", () => {
+    // Pass rate climbs, then regresses below baseline+threshold, then recovers.
+    const episodes = [
+      ep({ episode_index: 0, pass_rate: 0.4 }),
+      ep({ episode_index: 1, pass_rate: 0.6 }), // > 0.45 → first crossing
+      ep({ episode_index: 2, pass_rate: 0.42 }), // mid-episode regression
+      ep({ episode_index: 3, pass_rate: 0.55 }),
+    ];
+    const curve = computeLearningCurve(episodes);
+    // First crossing wins, even though episode 2 regresses below threshold.
+    expect(curve.time_to_improvement).toBe(1);
+    expect(curve.episodes[2].delta_from_previous_episode).toBeCloseTo(-0.18);
+    // Slope is computed across all four points; should be positive overall.
+    expect(curve.learning_slope).toBeGreaterThan(0);
+  });
+
+  test("single-episode degenerate input: slope is 0, time_to_improvement is null", () => {
+    const curve = computeLearningCurve([ep({ episode_index: 0, pass_rate: 0.7 })]);
+    expect(curve.pass_rate_by_episode).toEqual([0.7]);
+    expect(curve.learning_slope).toBe(0);
+    expect(curve.time_to_improvement).toBeNull();
+    // Episode 0's delta is always 0 by definition.
+    expect(curve.episodes[0].delta_from_previous_episode).toBe(0);
+  });
+
+  test("empty input is degenerate: empty arrays, zero slope, null time", () => {
+    const curve = computeLearningCurve([]);
+    expect(curve.episodes).toEqual([]);
+    expect(curve.pass_rate_by_episode).toEqual([]);
+    expect(curve.learning_slope).toBe(0);
+    expect(curve.time_to_improvement).toBeNull();
+  });
+
+  test("unsorted input is sorted by episode_index before processing", () => {
+    const episodes = [
+      ep({ episode_index: 2, pass_rate: 0.6 }),
+      ep({ episode_index: 0, pass_rate: 0.4 }),
+      ep({ episode_index: 1, pass_rate: 0.5 }),
+    ];
+    const curve = computeLearningCurve(episodes);
+    expect(curve.episodes.map((e) => e.episode_index)).toEqual([0, 1, 2]);
+    expect(curve.pass_rate_by_episode).toEqual([0.4, 0.5, 0.6]);
+    expect(curve.time_to_improvement).toBe(1);
+  });
+
+  test("delta_from_previous_episode is recomputed defensively from sorted pass_rates", () => {
+    // Caller stamps wrong deltas — function recomputes.
+    const episodes = [
+      ep({ episode_index: 0, pass_rate: 0.4, delta_from_previous_episode: 99 }),
+      ep({ episode_index: 1, pass_rate: 0.6, delta_from_previous_episode: -42 }),
+    ];
+    const curve = computeLearningCurve(episodes);
+    expect(curve.episodes[0].delta_from_previous_episode).toBe(0);
+    expect(curve.episodes[1].delta_from_previous_episode).toBeCloseTo(0.2);
+  });
+
+  test("threshold is strictly greater-than (exact baseline+threshold does not count)", () => {
+    // baseline = 0.5; threshold = 0.05 → must exceed 0.55.
+    const episodes = [
+      ep({ episode_index: 0, pass_rate: 0.5 }),
+      ep({ episode_index: 1, pass_rate: 0.5 + LEARNING_IMPROVEMENT_THRESHOLD }), // 0.55 exactly
+      ep({ episode_index: 2, pass_rate: 0.5 + LEARNING_IMPROVEMENT_THRESHOLD + 0.001 }),
+    ];
+    const curve = computeLearningCurve(episodes);
+    expect(curve.time_to_improvement).toBe(2);
+  });
+
+  test("cumulative counters are echoed verbatim (caller-provided)", () => {
+    const episodes = [
+      ep({
+        episode_index: 0,
+        pass_rate: 0.4,
+        cumulative_feedback_events: 10,
+        cumulative_proposals_created: 0,
+        cumulative_proposals_accepted: 0,
+        cumulative_lessons_created: 0,
+        lesson_reuse_rate: null,
+      }),
+      ep({
+        episode_index: 1,
+        pass_rate: 0.55,
+        cumulative_feedback_events: 25,
+        cumulative_proposals_created: 4,
+        cumulative_proposals_accepted: 3,
+        cumulative_lessons_created: 3,
+        lesson_reuse_rate: 0.42,
+      }),
+    ];
+    const curve = computeLearningCurve(episodes);
+    expect(curve.episodes[1].cumulative_feedback_events).toBe(25);
+    expect(curve.episodes[1].cumulative_proposals_accepted).toBe(3);
+    expect(curve.episodes[1].cumulative_lessons_created).toBe(3);
+    expect(curve.episodes[1].lesson_reuse_rate).toBeCloseTo(0.42);
   });
 });

--- a/tests/bench/metrics.test.ts
+++ b/tests/bench/metrics.test.ts
@@ -6,10 +6,13 @@ import { describe, expect, test } from "bun:test";
 
 import type { RunResult } from "./driver";
 import {
+  aggregateByMemoryAbility,
+  aggregateByTaskFamily,
   aggregateCorpus,
   aggregatePerTask,
   aggregateTrajectory,
   computeAssetRegressionCandidates,
+  computeCorpusCoverage,
   computeCorpusDelta,
   computeDomainAggregates,
   computeNegativeTransfer,
@@ -17,6 +20,7 @@ import {
   computePerTaskDelta,
   domainOfTaskId,
   type PerTaskMetrics,
+  type PerTaskTagEntry,
 } from "./metrics";
 
 function ptm(overrides: Partial<PerTaskMetrics> = {}): PerTaskMetrics {
@@ -513,5 +517,88 @@ describe("computeAssetRegressionCandidates", () => {
     if (!bar) throw new Error("bar missing");
     expect(bar.regressedTaskCount).toBe(1);
     expect(bar.totalLoadCount).toBe(1);
+  });
+});
+
+// ── Memory-operation aggregations (#262) ───────────────────────────────────
+
+describe("aggregateByMemoryAbility / aggregateByTaskFamily (#262)", () => {
+  function entry(
+    id: string,
+    noakmPass: number,
+    akmPass: number,
+    extras: Partial<PerTaskTagEntry> = {},
+  ): PerTaskTagEntry {
+    return {
+      id,
+      noakm: ptm({ passRate: noakmPass }),
+      akm: ptm({ passRate: akmPass }),
+      ...extras,
+    };
+  }
+
+  test("returns empty when no entries carry the keying tag", () => {
+    const entries = [entry("d/a", 0.4, 0.6), entry("d/b", 0.5, 0.7)];
+    expect(aggregateByMemoryAbility(entries)).toEqual([]);
+    expect(aggregateByTaskFamily(entries)).toEqual([]);
+  });
+
+  test("aggregateByMemoryAbility groups tasks, computes deltas + negative transfer", () => {
+    const entries = [
+      entry("d/lookup-1", 0.4, 0.8, { memoryAbility: "procedural_lookup" }),
+      entry("d/lookup-2", 0.6, 0.4, { memoryAbility: "procedural_lookup" }),
+      entry("d/compose-1", 0.0, 1.0, { memoryAbility: "multi_asset_composition" }),
+      entry("d/no-tag", 0.5, 0.7),
+    ];
+    const rows = aggregateByMemoryAbility(entries);
+    expect(rows.map((r) => r.category)).toEqual(["multi_asset_composition", "procedural_lookup"]);
+    const lookup = rows.find((r) => r.category === "procedural_lookup");
+    expect(lookup?.taskCount).toBe(2);
+    expect(lookup?.passRateNoakm).toBeCloseTo(0.5);
+    expect(lookup?.passRateAkm).toBeCloseTo(0.6);
+    expect(lookup?.passRateDelta).toBeCloseTo(0.1);
+    // d/lookup-2 regressed (akm < noakm).
+    expect(lookup?.negativeTransferCount).toBe(1);
+    expect(lookup?.workflowCompliance).toBeNull();
+  });
+
+  test("aggregateByMemoryAbility folds workflow_compliance when at least one task supplies it", () => {
+    const entries = [
+      entry("d/a", 0.5, 0.7, { memoryAbility: "procedural_lookup", workflowCompliance: 0.8 }),
+      entry("d/b", 0.5, 0.7, { memoryAbility: "procedural_lookup" }),
+      entry("d/c", 0.5, 0.7, { memoryAbility: "procedural_lookup", workflowCompliance: 0.6 }),
+    ];
+    const [row] = aggregateByMemoryAbility(entries);
+    expect(row?.workflowCompliance).toBeCloseTo(0.7);
+  });
+
+  test("aggregateByTaskFamily groups by family", () => {
+    const entries = [
+      entry("d/a", 0.4, 0.6, { taskFamily: "d/group-1" }),
+      entry("d/b", 0.4, 0.4, { taskFamily: "d/group-1" }),
+      entry("d/c", 0.0, 1.0, { taskFamily: "d/group-2" }),
+    ];
+    const rows = aggregateByTaskFamily(entries);
+    expect(rows.map((r) => r.category)).toEqual(["d/group-1", "d/group-2"]);
+    const g1 = rows.find((r) => r.category === "d/group-1");
+    expect(g1?.taskCount).toBe(2);
+    expect(g1?.passRateDelta).toBeCloseTo(0.1);
+  });
+
+  test("computeCorpusCoverage counts every closed-set ability + an untagged bucket", () => {
+    const cov = computeCorpusCoverage([
+      { memoryAbility: "procedural_lookup", taskFamily: "d/family-a" },
+      { memoryAbility: "procedural_lookup", taskFamily: "d/family-a" },
+      { memoryAbility: "abstention", taskFamily: "d/family-b" },
+      { taskFamily: "d/family-c" },
+      {},
+    ]);
+    expect(cov.totalTasks).toBe(5);
+    expect(cov.memoryAbilityCounts.procedural_lookup).toBe(2);
+    expect(cov.memoryAbilityCounts.abstention).toBe(1);
+    expect(cov.memoryAbilityCounts.conflict_resolution).toBe(0);
+    expect(cov.memoryAbilityCounts.untagged).toBe(2);
+    expect(cov.taskFamilyCounts["d/family-a"]).toBe(2);
+    expect(cov.taskFamilyCounts.untagged).toBe(1);
   });
 });

--- a/tests/bench/metrics.ts
+++ b/tests/bench/metrics.ts
@@ -19,7 +19,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import type { TaskMetadata } from "./corpus";
+import { MEMORY_ABILITY_VALUES, type MemoryAbility, type TaskMetadata } from "./corpus";
 import type { RunResult } from "./driver";
 import type { RunRecordSerialized, UtilityRunReport } from "./report";
 import { serializeRunForReport } from "./report";
@@ -2562,4 +2562,168 @@ export function computeFeedbackIntegrity(input: FeedbackIntegrityInput): Feedbac
   }
 
   return { aggregate, perAsset };
+}
+
+// ── Memory-operation tag aggregations (#262) ───────────────────────────────
+
+/**
+ * One per-task entry as consumed by `aggregateByMemoryAbility` /
+ * `aggregateByTaskFamily`. Mirrors the runner's per-task envelope plus the
+ * bag of optional memory-operation tags from `task.yaml`. Tasks may carry
+ * arbitrary subsets of tags — aggregations skip rows where the keying tag
+ * is undefined.
+ */
+export interface PerTaskTagEntry {
+  id: string;
+  noakm: PerTaskMetrics;
+  akm: PerTaskMetrics;
+  /** Optional memory-operation ability tag (#262). */
+  memoryAbility?: MemoryAbility;
+  /** Optional cross-task family identifier (#262). */
+  taskFamily?: string;
+  /** Optional declarative-workflow focus tag (#255 / #262). */
+  workflowFocus?: string;
+  /**
+   * Optional workflow-compliance fraction `[0, 1]` for the akm arm. When
+   * undefined the row is skipped from the workflow-compliance mean for the
+   * group. The runner populates this from #255's per-task workflow trace.
+   */
+  workflowCompliance?: number;
+}
+
+/**
+ * Per-category aggregate emitted by `aggregateByMemoryAbility` and
+ * `aggregateByTaskFamily`. Each row carries:
+ * - `taskCount`: number of tasks that fell into this category.
+ * - `passRateNoakm` / `passRateAkm`: mean pass rate per arm.
+ * - `passRateDelta`: `akm - noakm`. Positive = akm helped this category.
+ * - `negativeTransferCount`: count of tasks where akm pass rate regressed.
+ * - `workflowCompliance`: mean of `workflowCompliance` over rows where it
+ *   was supplied; `null` when no rows in the category provided one.
+ */
+export interface CategoryAggregateRow {
+  category: string;
+  taskCount: number;
+  passRateNoakm: number;
+  passRateAkm: number;
+  passRateDelta: number;
+  negativeTransferCount: number;
+  workflowCompliance: number | null;
+}
+
+function aggregateByKey(
+  entries: ReadonlyArray<PerTaskTagEntry>,
+  pickKey: (e: PerTaskTagEntry) => string | undefined,
+): CategoryAggregateRow[] {
+  const buckets = new Map<string, PerTaskTagEntry[]>();
+  for (const entry of entries) {
+    const key = pickKey(entry);
+    if (!key) continue;
+    let arr = buckets.get(key);
+    if (!arr) {
+      arr = [];
+      buckets.set(key, arr);
+    }
+    arr.push(entry);
+  }
+  const rows: CategoryAggregateRow[] = [];
+  for (const [category, group] of buckets) {
+    const n = group.length;
+    let noakmSum = 0;
+    let akmSum = 0;
+    let regressionCount = 0;
+    let complianceSum = 0;
+    let complianceCount = 0;
+    for (const t of group) {
+      noakmSum += t.noakm.passRate;
+      akmSum += t.akm.passRate;
+      if (t.akm.passRate < t.noakm.passRate) regressionCount += 1;
+      if (typeof t.workflowCompliance === "number" && Number.isFinite(t.workflowCompliance)) {
+        complianceSum += t.workflowCompliance;
+        complianceCount += 1;
+      }
+    }
+    rows.push({
+      category,
+      taskCount: n,
+      passRateNoakm: noakmSum / n,
+      passRateAkm: akmSum / n,
+      passRateDelta: akmSum / n - noakmSum / n,
+      negativeTransferCount: regressionCount,
+      workflowCompliance: complianceCount === 0 ? null : complianceSum / complianceCount,
+    });
+  }
+  rows.sort((a, b) => a.category.localeCompare(b.category));
+  return rows;
+}
+
+/**
+ * Aggregate per-task entries by `memoryAbility` (#262). Tasks lacking a tag
+ * are skipped so the report only surfaces categories with explicit
+ * coverage. Output rows are sorted by category for byte-stable JSON.
+ *
+ * The closed set of memory-ability values is exported as
+ * {@link MEMORY_ABILITY_VALUES} from `corpus.ts`.
+ */
+export function aggregateByMemoryAbility(entries: ReadonlyArray<PerTaskTagEntry>): CategoryAggregateRow[] {
+  return aggregateByKey(entries, (e) => e.memoryAbility);
+}
+
+/**
+ * Aggregate per-task entries by `taskFamily` (#262). Tasks lacking a tag
+ * are skipped. `taskFamily` follows the `<domain>/<short-name>` grammar —
+ * tasks sharing a family are expected to transfer knowledge between each
+ * other. Output rows are sorted by category for byte-stable JSON.
+ */
+export function aggregateByTaskFamily(entries: ReadonlyArray<PerTaskTagEntry>): CategoryAggregateRow[] {
+  return aggregateByKey(entries, (e) => e.taskFamily);
+}
+
+/**
+ * Build the corpus-coverage block for the §13.3 utility report (#262).
+ *
+ * Returns:
+ * - `memoryAbilityCounts`: count of tagged tasks per memory-ability label
+ *   across every value in {@link MEMORY_ABILITY_VALUES}. Untagged tasks are
+ *   summed into `untagged`. Missing categories render as 0 — operators want
+ *   to know which abilities the corpus does NOT cover.
+ * - `taskFamilyCounts`: count of tagged tasks per family. Untagged tasks
+ *   summed into `untagged`. Sorted for stable JSON output.
+ * - `totalTasks`: total tasks supplied to the aggregator.
+ */
+export interface CorpusCoverage {
+  totalTasks: number;
+  memoryAbilityCounts: Record<MemoryAbility | "untagged", number>;
+  taskFamilyCounts: Record<string, number>;
+}
+
+export function computeCorpusCoverage(
+  tasks: ReadonlyArray<Pick<TaskMetadata, "memoryAbility" | "taskFamily">>,
+): CorpusCoverage {
+  const memoryAbilityCounts = {
+    untagged: 0,
+  } as Record<MemoryAbility | "untagged", number>;
+  for (const ability of MEMORY_ABILITY_VALUES) {
+    memoryAbilityCounts[ability] = 0;
+  }
+  const taskFamilyCounts: Record<string, number> = {};
+  let untaggedFamily = 0;
+  for (const task of tasks) {
+    if (task.memoryAbility) {
+      memoryAbilityCounts[task.memoryAbility] = (memoryAbilityCounts[task.memoryAbility] ?? 0) + 1;
+    } else {
+      memoryAbilityCounts.untagged += 1;
+    }
+    if (task.taskFamily) {
+      taskFamilyCounts[task.taskFamily] = (taskFamilyCounts[task.taskFamily] ?? 0) + 1;
+    } else {
+      untaggedFamily += 1;
+    }
+  }
+  if (untaggedFamily > 0) taskFamilyCounts.untagged = untaggedFamily;
+  return {
+    totalTasks: tasks.length,
+    memoryAbilityCounts,
+    taskFamilyCounts,
+  };
 }

--- a/tests/bench/metrics.ts
+++ b/tests/bench/metrics.ts
@@ -23,6 +23,7 @@ import { MEMORY_ABILITY_VALUES, type MemoryAbility, type TaskMetadata } from "./
 import type { RunResult } from "./driver";
 import type { RunRecordSerialized, UtilityRunReport } from "./report";
 import { serializeRunForReport } from "./report";
+import type { WorkflowCheckResult, WorkflowCheckStatus } from "./workflow-evaluator";
 import { normalizeRunToTrace, type WorkflowTraceEvent, type WorkflowTraceEventType } from "./workflow-trace";
 
 // ── Outcome (§6.1) ─────────────────────────────────────────────────────────
@@ -3096,6 +3097,155 @@ export function aggregateAkmOverhead(
     toolCallsPerSuccess,
     costPerSuccess,
   };
+}
+
+// ── Workflow reliability (#258) ────────────────────────────────────────────
+
+/**
+ * Per-workflow reliability row.
+ *
+ * `pass_at_k`: fraction of tasks where AT LEAST ONE seed produced a `pass`
+ * workflow check for this workflow id. Group by task first, then ask
+ * "did the agent ever comply?".
+ *
+ * `pass_all_k`: fraction of tasks where ALL K seeds produced a `pass`
+ * workflow check for this workflow id. Tasks with mixed pass/non-pass
+ * outcomes count against this metric — partial/fail/harness_error are NOT
+ * compliant.
+ *
+ * `tasks` is the count of distinct task ids that contributed at least one
+ * applicable seed (i.e., a `pass`/`partial`/`fail`/`harness_error` status).
+ * `not_applicable` rows are excluded from the denominator.
+ *
+ * `k` is the maximum seed count observed across this workflow's tasks; it
+ * is descriptive only — pass_at_k and pass_all_k are computed per-task on
+ * that task's actual seed count, then averaged over tasks.
+ */
+export interface WorkflowReliabilityRow {
+  workflow_id: string;
+  pass_at_k: number;
+  pass_all_k: number;
+  tasks: number;
+  k: number;
+}
+
+/**
+ * Corpus-wide reliability aggregate.
+ *
+ * `pass_at_k` / `pass_all_k` are weighted averages over `(workflow_id, task)`
+ * groups: every (workflow, task) pair contributes equally. This avoids a
+ * workflow with many tasks dominating one with few. `groups` is the total
+ * number of (workflow_id, task) groups counted; `tasks` is the count of
+ * distinct task ids that appeared in at least one group.
+ */
+export interface WorkflowReliabilityCorpus {
+  pass_at_k: number;
+  pass_all_k: number;
+  groups: number;
+  tasks: number;
+}
+
+/**
+ * Output of `computeWorkflowReliability`.
+ *
+ * `byWorkflow` is keyed by `workflow_id` for stable lookup.
+ * `corpus` is the cross-workflow rollup.
+ *
+ * Empty input yields zeroed-out fields so renderers can branch on
+ * `groups === 0` rather than handling undefined.
+ */
+export interface WorkflowReliabilityResult {
+  byWorkflow: Record<string, WorkflowReliabilityRow>;
+  corpus: WorkflowReliabilityCorpus;
+}
+
+/**
+ * Bucket a workflow check status onto pass / non-pass for reliability.
+ *
+ * Reliability is a strict pass-or-not metric (issue #258). Anything other
+ * than `pass` (including `partial`, `fail`, `harness_error`) counts as a
+ * non-pass. `not_applicable` returns `null` so the caller can skip the
+ * entire (task, seed) pair — it never contributes to either numerator or
+ * denominator.
+ */
+function bucketReliabilityStatus(status: WorkflowCheckStatus): "pass" | "non_pass" | null {
+  if (status === "not_applicable") return null;
+  if (status === "pass") return "pass";
+  return "non_pass";
+}
+
+/**
+ * Compute workflow reliability metrics (`pass@k` and `pass^k`) per workflow
+ * and corpus-wide from a flat list of `WorkflowCheckResult`.
+ *
+ * Methodology (per #258 review addendum):
+ *   1. Filter out `not_applicable` checks entirely.
+ *   2. For each `(workflow_id, task_id)` group, collapse seeds to the set
+ *      of statuses observed.
+ *   3. `pass_at_k` per task = 1 if at least one seed is `pass`, else 0.
+ *   4. `pass_all_k` per task = 1 if every seed is `pass`, else 0.
+ *   5. Per-workflow row averages over its task set.
+ *   6. Corpus rollup averages over every (workflow, task) group equally.
+ *
+ * Pure: never mutates `checks`. Returns a stable shape for empty input.
+ */
+export function computeWorkflowReliability(checks: ReadonlyArray<WorkflowCheckResult>): WorkflowReliabilityResult {
+  // Group by (workflow_id, task_id) → list of statuses across seeds.
+  // Use Map<string, Map<string, WorkflowCheckStatus[]>> so iteration order
+  // is insertion order (deterministic given deterministic input).
+  const grouped = new Map<string, Map<string, WorkflowCheckStatus[]>>();
+
+  for (const c of checks) {
+    if (bucketReliabilityStatus(c.status) === null) continue;
+    let perWorkflow = grouped.get(c.workflowId);
+    if (!perWorkflow) {
+      perWorkflow = new Map<string, WorkflowCheckStatus[]>();
+      grouped.set(c.workflowId, perWorkflow);
+    }
+    const list = perWorkflow.get(c.taskId);
+    if (list) list.push(c.status);
+    else perWorkflow.set(c.taskId, [c.status]);
+  }
+
+  const byWorkflow: Record<string, WorkflowReliabilityRow> = {};
+  let corpusPassAtKSum = 0;
+  let corpusPassAllKSum = 0;
+  let corpusGroupCount = 0;
+  const corpusTasks = new Set<string>();
+
+  for (const [workflowId, perTask] of grouped) {
+    let passAtKSum = 0;
+    let passAllKSum = 0;
+    let kMax = 0;
+    for (const [taskId, statuses] of perTask) {
+      if (statuses.length > kMax) kMax = statuses.length;
+      const allPass = statuses.every((s) => s === "pass");
+      const anyPass = statuses.some((s) => s === "pass");
+      if (anyPass) passAtKSum += 1;
+      if (allPass) passAllKSum += 1;
+      corpusPassAtKSum += anyPass ? 1 : 0;
+      corpusPassAllKSum += allPass ? 1 : 0;
+      corpusGroupCount += 1;
+      corpusTasks.add(taskId);
+    }
+    const taskCount = perTask.size;
+    byWorkflow[workflowId] = {
+      workflow_id: workflowId,
+      pass_at_k: taskCount === 0 ? 0 : passAtKSum / taskCount,
+      pass_all_k: taskCount === 0 ? 0 : passAllKSum / taskCount,
+      tasks: taskCount,
+      k: kMax,
+    };
+  }
+
+  const corpus: WorkflowReliabilityCorpus = {
+    pass_at_k: corpusGroupCount === 0 ? 0 : corpusPassAtKSum / corpusGroupCount,
+    pass_all_k: corpusGroupCount === 0 ? 0 : corpusPassAllKSum / corpusGroupCount,
+    groups: corpusGroupCount,
+    tasks: corpusTasks.size,
+  };
+
+  return { byWorkflow, corpus };
 }
 
 /** Earliest parseable ts (ms epoch) among events; null when none. */

--- a/tests/bench/metrics.ts
+++ b/tests/bench/metrics.ts
@@ -2357,6 +2357,120 @@ export function computeLongitudinalMetrics(
   };
 }
 
+// ── Learning curve across episodes (§6.4 extension, issue #265) ────────────
+
+/**
+ * Episode-level Track B record. One record per evolution pass:
+ * `episode_index === 0` is the pre-evolution baseline; subsequent indices
+ * are the post-each-pass measurements.
+ *
+ * Cumulative counters are running totals AT THE END of `episode_index`
+ * (i.e. inclusive). Per-episode deltas are derived in `computeLearningCurve`
+ * — the record itself only carries the running totals so callers can supply
+ * either cumulative or per-episode raw inputs without ambiguity.
+ *
+ * `lesson_reuse_rate` mirrors #264's lesson-quality aggregate for this
+ * episode (NOT a delta). When an episode has not yet recorded any lesson
+ * applications the caller passes `null`.
+ */
+export interface EpisodeRecord {
+  episode_index: number;
+  pass_rate: number;
+  /** `pass_rate(i) - pass_rate(i-1)`; `0` for `episode_index === 0`. */
+  delta_from_previous_episode: number;
+  cumulative_feedback_events: number;
+  cumulative_proposals_created: number;
+  cumulative_proposals_accepted: number;
+  cumulative_lessons_created: number;
+  /** Reuse rate from #264's lesson aggregate; `null` when no data yet. */
+  lesson_reuse_rate: number | null;
+}
+
+/** Threshold above `pass_rate[0]` that defines "improvement" for §6.4. */
+export const LEARNING_IMPROVEMENT_THRESHOLD = 0.05;
+
+/**
+ * Aggregate learning-curve metrics across an evolution episode sequence.
+ *
+ * Output:
+ * - `episodes`: echo of the input with `delta_from_previous_episode`
+ *   recomputed defensively (callers may supply raw 0s for episode 0).
+ * - `pass_rate_by_episode`: array indexed by `episode_index`.
+ * - `learning_slope`: standard least-squares regression slope of pass rate
+ *   against episode index. Returns `0` for a single-episode (degenerate)
+ *   input where the regressor variance is zero.
+ * - `time_to_improvement`: smallest `i` where
+ *   `pass_rate[i] > pass_rate[0] + LEARNING_IMPROVEMENT_THRESHOLD`. `null`
+ *   when no such episode exists.
+ *
+ * Empty input is rejected by returning a degenerate envelope with
+ * `learning_slope = 0` and `time_to_improvement = null`. Callers that
+ * supply unsorted episodes get back a stable-sorted copy keyed on
+ * `episode_index`.
+ */
+export interface LearningCurve {
+  episodes: EpisodeRecord[];
+  pass_rate_by_episode: number[];
+  learning_slope: number;
+  time_to_improvement: number | null;
+}
+
+export function computeLearningCurve(episodes: ReadonlyArray<EpisodeRecord>): LearningCurve {
+  // Stable sort by episode_index — defensive against unordered inputs.
+  const sorted = [...episodes].sort((a, b) => a.episode_index - b.episode_index);
+
+  // Recompute per-episode deltas so the contract holds regardless of what
+  // the caller stamped on the input record.
+  const normalised: EpisodeRecord[] = sorted.map((ep, i) => {
+    const prev = i === 0 ? null : sorted[i - 1];
+    const delta = prev === null ? 0 : ep.pass_rate - prev.pass_rate;
+    return { ...ep, delta_from_previous_episode: delta };
+  });
+
+  const passRateByEpisode = normalised.map((ep) => ep.pass_rate);
+
+  // Linear regression slope: sum((xi - x_mean) * (yi - y_mean)) /
+  // sum((xi - x_mean)^2). For a single episode the denominator is 0 — we
+  // return 0 (no observable trend) rather than NaN.
+  const n = normalised.length;
+  let learningSlope = 0;
+  if (n >= 2) {
+    const xs = normalised.map((ep) => ep.episode_index);
+    const xMean = xs.reduce((s, v) => s + v, 0) / n;
+    const yMean = passRateByEpisode.reduce((s, v) => s + v, 0) / n;
+    let num = 0;
+    let den = 0;
+    for (let i = 0; i < n; i += 1) {
+      const dx = xs[i] - xMean;
+      const dy = passRateByEpisode[i] - yMean;
+      num += dx * dy;
+      den += dx * dx;
+    }
+    learningSlope = den === 0 ? 0 : num / den;
+  }
+
+  // time_to_improvement: smallest episode_index strictly greater than
+  // `pass_rate[0] + threshold`. Episode 0 itself is excluded — improvement
+  // is only meaningful relative to baseline.
+  let timeToImprovement: number | null = null;
+  if (n >= 2) {
+    const baseline = passRateByEpisode[0];
+    for (let i = 1; i < n; i += 1) {
+      if (passRateByEpisode[i] > baseline + LEARNING_IMPROVEMENT_THRESHOLD) {
+        timeToImprovement = normalised[i].episode_index;
+        break;
+      }
+    }
+  }
+
+  return {
+    episodes: normalised,
+    pass_rate_by_episode: passRateByEpisode,
+    learning_slope: learningSlope,
+    time_to_improvement: timeToImprovement,
+  };
+}
+
 // ── Feedback-signal integrity (§6.8) ───────────────────────────────────────
 
 /**

--- a/tests/bench/metrics.ts
+++ b/tests/bench/metrics.ts
@@ -278,6 +278,227 @@ export function computePerTaskDelta(noakm: PerTaskMetrics, akm: PerTaskMetrics):
   };
 }
 
+// ── Negative-transfer + domain diagnostics (#260) ──────────────────────────
+
+/**
+ * One regressed-task row: a task where AKM hurt pass rate relative to noakm.
+ * `delta` is `akm - noakm` (negative for regressions); kept identical to the
+ * sign convention used everywhere else in the bench. `severity` is the
+ * positive magnitude (`noakm - akm`) — convenient for sums and sorting.
+ */
+export interface RegressedTaskRow {
+  taskId: string;
+  domain: string;
+  noakmPassRate: number;
+  akmPassRate: number;
+  /** `akm - noakm`, negative for regressions. */
+  delta: number;
+  /** `noakm - akm`, positive for regressions. */
+  severity: number;
+}
+
+/**
+ * Negative-transfer aggregate (#260). Counts and severity sum across tasks
+ * where `akm.passRate < noakm.passRate`. `topRegressedTasks` is sorted by
+ * largest negative AKM delta first (most-severe regressions on top), with
+ * `taskId` as the deterministic tiebreaker.
+ */
+export interface NegativeTransferAggregate {
+  count: number;
+  /** Sum of `noakm_pass_rate - akm_pass_rate` over regressed tasks. ≥ 0. */
+  severity: number;
+  topRegressedTasks: RegressedTaskRow[];
+}
+
+/**
+ * Per-domain aggregate row (#260). One entry per domain present in the
+ * corpus. Pass rate, tokens-per-pass, and wallclock are means across the
+ * tasks in that domain (each task contributes once, K seeds already
+ * collapsed into PerTaskMetrics). `tokensPerPassDelta` is `null` when
+ * either arm has no measured passes.
+ */
+export interface DomainAggregateRow {
+  domain: string;
+  taskCount: number;
+  /** Tasks within this domain where akm pass rate regressed. */
+  regressionCount: number;
+  passRateNoakm: number;
+  passRateAkm: number;
+  /** `akm - noakm`. Positive when AKM helped this domain. */
+  passRateDelta: number;
+  /** `akm - noakm`. `null` if either arm has no measured passes for this domain. */
+  tokensPerPassDelta: number | null;
+  /** `akm - noakm`, ms. */
+  wallclockMsDelta: number;
+}
+
+/**
+ * Asset-regression-candidate row (#260). An asset that was loaded by the
+ * AKM agent during one or more regressed tasks. `regressedTaskCount` is the
+ * number of distinct regressed task IDs that loaded this asset (de-duped
+ * across seeds) — operators care about cross-task reach, not seed-level
+ * load volume.
+ */
+export interface AssetRegressionCandidateRow {
+  assetRef: string;
+  regressedTaskCount: number;
+  /** Distinct regressed task IDs that loaded this asset, sorted ascending. */
+  regressedTaskIds: string[];
+  /** Total seed-level load count across all regressed tasks (raw volume). */
+  totalLoadCount: number;
+}
+
+/**
+ * Extract the domain prefix from a task ID. The corpus convention is
+ * `<domain>/<task-name>`; we split on the first `/`. Tasks lacking a slash
+ * fall back to the literal `unknown` bucket so they aggregate predictably
+ * rather than producing per-task domains-of-one.
+ */
+export function domainOfTaskId(taskId: string): string {
+  const idx = taskId.indexOf("/");
+  if (idx <= 0) return "unknown";
+  return taskId.slice(0, idx);
+}
+
+/**
+ * Compute the negative-transfer aggregate over a set of per-task entries
+ * (one entry per task; both arms already aggregated into PerTaskMetrics).
+ *
+ * A task is "regressed" when `akm.passRate < noakm.passRate`. Ties (equal
+ * pass rate, including 0=0) are NOT regressions. `topRegressedTasks` is
+ * sorted by `severity` descending then `taskId` ascending so output is
+ * deterministic.
+ */
+export function computeNegativeTransfer(
+  tasks: ReadonlyArray<{ id: string; noakm: PerTaskMetrics; akm: PerTaskMetrics }>,
+): NegativeTransferAggregate {
+  const regressed: RegressedTaskRow[] = [];
+  for (const t of tasks) {
+    const delta = t.akm.passRate - t.noakm.passRate;
+    if (delta >= 0) continue;
+    regressed.push({
+      taskId: t.id,
+      domain: domainOfTaskId(t.id),
+      noakmPassRate: t.noakm.passRate,
+      akmPassRate: t.akm.passRate,
+      delta,
+      severity: -delta,
+    });
+  }
+  regressed.sort((a, b) => {
+    if (b.severity !== a.severity) return b.severity - a.severity;
+    return a.taskId.localeCompare(b.taskId);
+  });
+  const severity = regressed.reduce((acc, r) => acc + r.severity, 0);
+  return { count: regressed.length, severity, topRegressedTasks: regressed };
+}
+
+/**
+ * Compute per-domain aggregates over a set of per-task entries. Each task
+ * contributes once to its domain (K seeds already collapsed). Output rows
+ * are sorted by `domain` ascending so JSON / markdown are byte-stable.
+ *
+ * Domain extraction uses `domainOfTaskId` (split on first `/`).
+ */
+export function computeDomainAggregates(
+  tasks: ReadonlyArray<{ id: string; noakm: PerTaskMetrics; akm: PerTaskMetrics }>,
+): DomainAggregateRow[] {
+  const buckets = new Map<string, Array<{ id: string; noakm: PerTaskMetrics; akm: PerTaskMetrics }>>();
+  for (const t of tasks) {
+    const d = domainOfTaskId(t.id);
+    let arr = buckets.get(d);
+    if (!arr) {
+      arr = [];
+      buckets.set(d, arr);
+    }
+    arr.push(t);
+  }
+  const rows: DomainAggregateRow[] = [];
+  for (const [domain, group] of buckets) {
+    const n = group.length;
+    let noakmSum = 0;
+    let akmSum = 0;
+    let wallNoakm = 0;
+    let wallAkm = 0;
+    let regressionCount = 0;
+    const noakmTpp: number[] = [];
+    const akmTpp: number[] = [];
+    for (const t of group) {
+      noakmSum += t.noakm.passRate;
+      akmSum += t.akm.passRate;
+      wallNoakm += t.noakm.wallclockMs;
+      wallAkm += t.akm.wallclockMs;
+      if (t.akm.passRate < t.noakm.passRate) regressionCount += 1;
+      if (t.noakm.tokensPerPass !== null) noakmTpp.push(t.noakm.tokensPerPass);
+      if (t.akm.tokensPerPass !== null) akmTpp.push(t.akm.tokensPerPass);
+    }
+    const passRateNoakm = noakmSum / n;
+    const passRateAkm = akmSum / n;
+    const meanNoakmTpp = noakmTpp.length === 0 ? null : noakmTpp.reduce((a, b) => a + b, 0) / noakmTpp.length;
+    const meanAkmTpp = akmTpp.length === 0 ? null : akmTpp.reduce((a, b) => a + b, 0) / akmTpp.length;
+    const tokensPerPassDelta = meanNoakmTpp === null || meanAkmTpp === null ? null : meanAkmTpp - meanNoakmTpp;
+    rows.push({
+      domain,
+      taskCount: n,
+      regressionCount,
+      passRateNoakm,
+      passRateAkm,
+      passRateDelta: passRateAkm - passRateNoakm,
+      tokensPerPassDelta,
+      wallclockMsDelta: wallAkm / n - wallNoakm / n,
+    });
+  }
+  rows.sort((a, b) => a.domain.localeCompare(b.domain));
+  return rows;
+}
+
+/**
+ * Compute asset-regression-candidate rows (#260). Walks the AKM-arm runs,
+ * keeps only those whose `taskId` is in `regressedTaskIds`, and tallies how
+ * often each loaded asset shows up. `regressedTaskCount` (distinct task IDs
+ * touched) is the primary sort key — assets that hurt many tasks are more
+ * actionable than assets that flooded one task across seeds.
+ *
+ * Sort: regressedTaskCount desc, totalLoadCount desc, assetRef asc.
+ */
+export function computeAssetRegressionCandidates(
+  regressedTaskIds: ReadonlyArray<string>,
+  akmRuns: ReadonlyArray<RunResult>,
+): AssetRegressionCandidateRow[] {
+  const regressed = new Set(regressedTaskIds);
+  if (regressed.size === 0) return [];
+  const taskIdsByAsset = new Map<string, Set<string>>();
+  const totalLoadByAsset = new Map<string, number>();
+  for (const run of akmRuns) {
+    if (!regressed.has(run.taskId)) continue;
+    const assets = run.assetsLoaded ?? [];
+    for (const ref of assets) {
+      let bucket = taskIdsByAsset.get(ref);
+      if (!bucket) {
+        bucket = new Set<string>();
+        taskIdsByAsset.set(ref, bucket);
+      }
+      bucket.add(run.taskId);
+      totalLoadByAsset.set(ref, (totalLoadByAsset.get(ref) ?? 0) + 1);
+    }
+  }
+  const rows: AssetRegressionCandidateRow[] = [];
+  for (const [assetRef, taskIds] of taskIdsByAsset) {
+    rows.push({
+      assetRef,
+      regressedTaskCount: taskIds.size,
+      regressedTaskIds: [...taskIds].sort(),
+      totalLoadCount: totalLoadByAsset.get(assetRef) ?? 0,
+    });
+  }
+  rows.sort((a, b) => {
+    if (b.regressedTaskCount !== a.regressedTaskCount) return b.regressedTaskCount - a.regressedTaskCount;
+    if (b.totalLoadCount !== a.totalLoadCount) return b.totalLoadCount - a.totalLoadCount;
+    return a.assetRef.localeCompare(b.assetRef);
+  });
+  return rows;
+}
+
 // ── Trajectory (§6.2) ──────────────────────────────────────────────────────
 
 export interface TrajectoryAggregate {

--- a/tests/bench/metrics.ts
+++ b/tests/bench/metrics.ts
@@ -23,6 +23,7 @@ import { MEMORY_ABILITY_VALUES, type MemoryAbility, type TaskMetadata } from "./
 import type { RunResult } from "./driver";
 import type { RunRecordSerialized, UtilityRunReport } from "./report";
 import { serializeRunForReport } from "./report";
+import { normalizeRunToTrace, type WorkflowTraceEvent, type WorkflowTraceEventType } from "./workflow-trace";
 
 // ── Outcome (§6.1) ─────────────────────────────────────────────────────────
 
@@ -2726,4 +2727,415 @@ export function computeCorpusCoverage(
     memoryAbilityCounts,
     taskFamilyCounts,
   };
+}
+
+// ── AKM overhead + tool-use efficiency (#263) ──────────────────────────────
+
+/**
+ * Per-run AKM overhead record (#263).
+ *
+ * Counts and timings derived from a single RunResult by reusing #254's
+ * `normalizeRunToTrace`. Counts are always numeric (≥ 0). Timings and byte
+ * sizes are `null` when the run did not provide enough evidence to compute
+ * them — they are NEVER zero-filled, because zero is a meaningful value
+ * (e.g. "first search at t=0ms") that would silently mask missing data.
+ *
+ * Definitions:
+ * - `searchCount` / `showCount` / `feedbackCount`: count of `akm_search`,
+ *   `akm_show`, and `akm_feedback` events in the normalised trace.
+ * - `totalToolCalls`: sum of the three counts above. The minimal
+ *   "AKM tool-use" footprint we surface today; if/when we recognise more
+ *   verbs as tool-calls (`akm_reflect`, `akm_distill`, `akm_propose`,
+ *   `akm_proposal_accept`) they will be folded in here additively.
+ * - `assetsLoadedCount`: count of UNIQUE assetRefs from `akm_show` events.
+ * - `irrelevantAssetsLoadedCount`: count of unique `akm_show` assetRefs that
+ *   are NOT the task's `goldRef` AND NOT in `expectedTransferFrom`. When the
+ *   task has neither metadata field, every loaded asset is considered
+ *   irrelevant for accounting — there is no way to know what was relevant.
+ *   When the task is unknown to the caller (no metadata supplied) the count
+ *   is `null` rather than zero, since we cannot judge relevance.
+ * - `timeToFirstSearchMs`: `(ts of first akm_search) - (run start ts)`. Run
+ *   start is the earliest parseable `ts` in the trace. `null` when no
+ *   `akm_search` event has a parseable ts, or when no run-start anchor
+ *   exists.
+ * - `timeToFirstCorrectAssetMs`: `(ts of first akm_show whose assetRef
+ *   matches goldRef) - (run start ts)`. `null` when the task has no
+ *   `goldRef`, no matching show event was found, or timestamps are missing.
+ * - `contextBytesLoaded` / `assetBytesLoaded`: byte sizes of context /
+ *   loaded assets. Not currently captured by the trace; always `null` until
+ *   evidence is wired through. Documented here as a contract: callers MUST
+ *   treat `null` as "unavailable" and never assume zero.
+ */
+export interface AkmOverheadPerRun {
+  taskId: string;
+  arm: string;
+  seed: number;
+  outcome: RunResult["outcome"];
+  searchCount: number;
+  showCount: number;
+  feedbackCount: number;
+  totalToolCalls: number;
+  assetsLoadedCount: number;
+  /** `null` when relevance cannot be judged (no task metadata supplied). */
+  irrelevantAssetsLoadedCount: number | null;
+  /** ms; `null` when unavailable (NOT zero). */
+  timeToFirstSearchMs: number | null;
+  /** ms; `null` when unavailable (NOT zero). */
+  timeToFirstCorrectAssetMs: number | null;
+  /** Bytes; `null` when unavailable (NOT zero). */
+  contextBytesLoaded: number | null;
+  /** Bytes; `null` when unavailable (NOT zero). */
+  assetBytesLoaded: number | null;
+}
+
+/**
+ * Aggregate AKM overhead block emitted into the §13.3 utility envelope (#263).
+ *
+ * `meanAssetsLoaded` etc. are means over `runs.length` (not "runs that loaded
+ * something"); zero-call runs contribute zeros to the numerator. This keeps
+ * the aggregate comparable across arms regardless of how many runs actually
+ * touched AKM.
+ *
+ * Cross-run timings (`meanTimeToFirstSearchMs`, etc.) skip per-run `null`s
+ * — a missing timing must not silently pull the mean toward zero. When NO
+ * run provided a timing the aggregate value is `null`.
+ *
+ * `toolCallsPerSuccess` = `totalToolCalls / passingRuns`. `null` when no
+ * runs passed (avoids `Infinity`). `costPerSuccess` is `null` unless every
+ * passing run has parsed token measurement — partial coverage yields
+ * `null` because mixed measurement statuses cannot be averaged honestly.
+ */
+export interface AkmOverheadAggregate {
+  totalRuns: number;
+  passingRuns: number;
+  meanSearchCount: number;
+  meanShowCount: number;
+  meanFeedbackCount: number;
+  meanToolCalls: number;
+  meanAssetsLoaded: number;
+  meanIrrelevantAssetsLoaded: number | null;
+  meanTimeToFirstSearchMs: number | null;
+  meanTimeToFirstCorrectAssetMs: number | null;
+  meanContextBytesLoaded: number | null;
+  meanAssetBytesLoaded: number | null;
+  /** `totalToolCalls` summed across runs. */
+  totalToolCalls: number;
+  /** `totalToolCalls / passingRuns`. `null` when `passingRuns === 0`. */
+  toolCallsPerSuccess: number | null;
+  /**
+   * Mean (input+output) tokens across passing runs whose `tokenMeasurement`
+   * is `"parsed"`. `null` when:
+   * - `passingRuns === 0`, OR
+   * - any passing run lacks parsed token measurement (mixing parsed with
+   *   missing/unsupported is dishonest), OR
+   * - none of the passing runs has `tokenMeasurement === "parsed"`.
+   */
+  costPerSuccess: number | null;
+}
+
+/**
+ * Optional inputs for `computeAkmOverhead`.
+ *
+ * `taskMetadata` is consulted to compute `irrelevantAssetsLoadedCount` and
+ * `timeToFirstCorrectAssetMs`. Callers that do not have task metadata to
+ * hand can omit it; the per-run record will degrade gracefully (relevant
+ * fields become `null`). The map is keyed by `taskId`.
+ */
+export interface AkmOverheadOptions {
+  /** Lookup of task metadata used for relevance / gold-ref scoring. */
+  taskMetadata?: ReadonlyMap<string, Pick<TaskMetadata, "goldRef" | "expectedTransferFrom">>;
+}
+
+/**
+ * Verb counts considered "AKM tool calls" for `totalToolCalls`. We
+ * deliberately keep this list small — each verb folded in MUST be a
+ * user-initiated CLI invocation, not a background bookkeeping event.
+ * Adding new verbs here is additive and changes only `totalToolCalls`.
+ */
+export const AKM_TOOL_CALL_TYPES: ReadonlySet<WorkflowTraceEventType> = new Set<WorkflowTraceEventType>([
+  "akm_search",
+  "akm_show",
+  "akm_feedback",
+]);
+
+/**
+ * Compute per-run AKM overhead records by replaying #254's normalised trace.
+ *
+ * Pure function: never mutates `runs` and never reads disk. The optional
+ * `taskMetadata` lookup is used only to label loads as relevant / irrelevant
+ * and to compute `timeToFirstCorrectAssetMs`.
+ *
+ * Returned array length matches `runs.length`; element order matches input
+ * order. Runs whose trace contains no AKM events still produce a record
+ * with all counts at zero and timings at `null`.
+ */
+export function computeAkmOverhead(
+  runs: ReadonlyArray<RunResult>,
+  options: AkmOverheadOptions = {},
+): AkmOverheadPerRun[] {
+  const out: AkmOverheadPerRun[] = [];
+  for (const run of runs) {
+    out.push(perRun(run, options.taskMetadata));
+  }
+  return out;
+}
+
+function perRun(run: RunResult, taskMetadata: AkmOverheadOptions["taskMetadata"]): AkmOverheadPerRun {
+  const trace = normalizeRunToTrace(run);
+  const events = trace.events;
+
+  let searchCount = 0;
+  let showCount = 0;
+  let feedbackCount = 0;
+  const uniqueShowRefs = new Set<string>();
+
+  for (const ev of events) {
+    if (ev.type === "akm_search") searchCount += 1;
+    else if (ev.type === "akm_show") {
+      showCount += 1;
+      if (typeof ev.assetRef === "string" && ev.assetRef.length > 0) {
+        uniqueShowRefs.add(ev.assetRef);
+      }
+    } else if (ev.type === "akm_feedback") feedbackCount += 1;
+  }
+  const totalToolCalls = searchCount + showCount + feedbackCount;
+
+  // Run-start anchor: earliest parseable ts in the trace. We use the trace
+  // (not RunResult.events directly) so harness lifecycle markers, when
+  // supplied, can serve as the anchor for stdout-derived events that lack a
+  // native ts.
+  const runStartMs = earliestEventMs(events);
+
+  const timeToFirstSearchMs = computeFirstEventOffsetMs(events, runStartMs, (ev) => ev.type === "akm_search");
+
+  // Resolve task metadata once. Missing metadata means we can't judge
+  // relevance — emit null counts rather than zero.
+  const meta = taskMetadata?.get(run.taskId);
+  const goldRef = meta?.goldRef;
+  const transferFrom = meta?.expectedTransferFrom ?? [];
+  const knownRelevant = new Set<string>();
+  if (typeof goldRef === "string" && goldRef.length > 0) knownRelevant.add(goldRef);
+  for (const r of transferFrom) {
+    if (typeof r === "string" && r.length > 0) knownRelevant.add(r);
+  }
+
+  let irrelevantAssetsLoadedCount: number | null;
+  if (!meta) {
+    // No metadata: cannot tell relevant from irrelevant. Surface null.
+    irrelevantAssetsLoadedCount = null;
+  } else {
+    let count = 0;
+    for (const ref of uniqueShowRefs) {
+      if (!knownRelevant.has(ref)) count += 1;
+    }
+    irrelevantAssetsLoadedCount = count;
+  }
+
+  let timeToFirstCorrectAssetMs: number | null = null;
+  if (typeof goldRef === "string" && goldRef.length > 0) {
+    timeToFirstCorrectAssetMs = computeFirstEventOffsetMs(
+      events,
+      runStartMs,
+      (ev) => ev.type === "akm_show" && ev.assetRef === goldRef,
+    );
+  }
+
+  return {
+    taskId: run.taskId,
+    arm: run.arm,
+    seed: run.seed,
+    outcome: run.outcome,
+    searchCount,
+    showCount,
+    feedbackCount,
+    totalToolCalls,
+    assetsLoadedCount: uniqueShowRefs.size,
+    irrelevantAssetsLoadedCount,
+    timeToFirstSearchMs,
+    timeToFirstCorrectAssetMs,
+    // Byte sizes are not yet wired through the trace (#254 does not capture
+    // payload sizes). Callers MUST treat null as "unavailable", not zero.
+    contextBytesLoaded: null,
+    assetBytesLoaded: null,
+  };
+}
+
+/**
+ * Aggregate per-run AKM overhead records into the corpus-wide block (#263).
+ *
+ * Pure: never mutates `perRun`. When `perRun` is empty, returns a zero/null
+ * envelope so callers can render a "no AKM activity" section without
+ * branching. `passingRuns === 0` always implies `toolCallsPerSuccess === null`
+ * and `costPerSuccess === null`.
+ */
+export function aggregateAkmOverhead(
+  perRun: ReadonlyArray<AkmOverheadPerRun>,
+  rawRuns: ReadonlyArray<RunResult> = [],
+): AkmOverheadAggregate {
+  const n = perRun.length;
+  if (n === 0) {
+    return {
+      totalRuns: 0,
+      passingRuns: 0,
+      meanSearchCount: 0,
+      meanShowCount: 0,
+      meanFeedbackCount: 0,
+      meanToolCalls: 0,
+      meanAssetsLoaded: 0,
+      meanIrrelevantAssetsLoaded: null,
+      meanTimeToFirstSearchMs: null,
+      meanTimeToFirstCorrectAssetMs: null,
+      meanContextBytesLoaded: null,
+      meanAssetBytesLoaded: null,
+      totalToolCalls: 0,
+      toolCallsPerSuccess: null,
+      costPerSuccess: null,
+    };
+  }
+
+  let searchSum = 0;
+  let showSum = 0;
+  let feedbackSum = 0;
+  let toolCallsSum = 0;
+  let assetsSum = 0;
+
+  let irrelevantSum = 0;
+  let irrelevantCount = 0;
+
+  let firstSearchSum = 0;
+  let firstSearchCount = 0;
+  let firstCorrectSum = 0;
+  let firstCorrectCount = 0;
+
+  let contextBytesSum = 0;
+  let contextBytesCount = 0;
+  let assetBytesSum = 0;
+  let assetBytesCount = 0;
+
+  // Build a quick lookup for token measurement off `rawRuns` so the cost-
+  // per-success calc can honour the parsed/missing/unsupported distinction
+  // without forcing the caller to project tokens onto AkmOverheadPerRun.
+  const rawByKey = new Map<string, RunResult>();
+  for (const r of rawRuns) {
+    rawByKey.set(`${r.taskId} ${r.arm} ${r.seed}`, r);
+  }
+
+  let passingRuns = 0;
+  let parsedPassTokenSum = 0;
+  let parsedPassCount = 0;
+  let anyPassMissingMeasurement = false;
+
+  for (const row of perRun) {
+    searchSum += row.searchCount;
+    showSum += row.showCount;
+    feedbackSum += row.feedbackCount;
+    toolCallsSum += row.totalToolCalls;
+    assetsSum += row.assetsLoadedCount;
+
+    if (row.irrelevantAssetsLoadedCount !== null) {
+      irrelevantSum += row.irrelevantAssetsLoadedCount;
+      irrelevantCount += 1;
+    }
+    if (row.timeToFirstSearchMs !== null) {
+      firstSearchSum += row.timeToFirstSearchMs;
+      firstSearchCount += 1;
+    }
+    if (row.timeToFirstCorrectAssetMs !== null) {
+      firstCorrectSum += row.timeToFirstCorrectAssetMs;
+      firstCorrectCount += 1;
+    }
+    if (row.contextBytesLoaded !== null) {
+      contextBytesSum += row.contextBytesLoaded;
+      contextBytesCount += 1;
+    }
+    if (row.assetBytesLoaded !== null) {
+      assetBytesSum += row.assetBytesLoaded;
+      assetBytesCount += 1;
+    }
+
+    if (row.outcome === "pass") {
+      passingRuns += 1;
+      const raw = rawByKey.get(`${row.taskId} ${row.arm} ${row.seed}`);
+      // Treat absent tokenMeasurement as `parsed` for backward compat with
+      // older artefacts (mirrors `isMeasured` behaviour above).
+      const measurement = raw?.tokenMeasurement ?? "parsed";
+      if (raw && measurement === "parsed") {
+        parsedPassTokenSum += raw.tokens.input + raw.tokens.output;
+        parsedPassCount += 1;
+      } else if (raw) {
+        anyPassMissingMeasurement = true;
+      } else {
+        // No matching raw run supplied — cannot honour cost-per-success.
+        anyPassMissingMeasurement = true;
+      }
+    }
+  }
+
+  const toolCallsPerSuccess = passingRuns === 0 ? null : toolCallsSum / passingRuns;
+  // Cost-per-success: null unless EVERY passing run has parsed measurement.
+  // Mixed measurement statuses cannot be averaged honestly (issue #252).
+  const costPerSuccess =
+    passingRuns === 0 || anyPassMissingMeasurement || parsedPassCount === 0
+      ? null
+      : parsedPassTokenSum / parsedPassCount;
+
+  return {
+    totalRuns: n,
+    passingRuns,
+    meanSearchCount: searchSum / n,
+    meanShowCount: showSum / n,
+    meanFeedbackCount: feedbackSum / n,
+    meanToolCalls: toolCallsSum / n,
+    meanAssetsLoaded: assetsSum / n,
+    meanIrrelevantAssetsLoaded: irrelevantCount === 0 ? null : irrelevantSum / irrelevantCount,
+    meanTimeToFirstSearchMs: firstSearchCount === 0 ? null : firstSearchSum / firstSearchCount,
+    meanTimeToFirstCorrectAssetMs: firstCorrectCount === 0 ? null : firstCorrectSum / firstCorrectCount,
+    meanContextBytesLoaded: contextBytesCount === 0 ? null : contextBytesSum / contextBytesCount,
+    meanAssetBytesLoaded: assetBytesCount === 0 ? null : assetBytesSum / assetBytesCount,
+    totalToolCalls: toolCallsSum,
+    toolCallsPerSuccess,
+    costPerSuccess,
+  };
+}
+
+/** Earliest parseable ts (ms epoch) among events; null when none. */
+function earliestEventMs(events: ReadonlyArray<WorkflowTraceEvent>): number | null {
+  let earliest: number | null = null;
+  for (const ev of events) {
+    const ms = parseTsToMs(ev.ts);
+    if (ms === null) continue;
+    if (earliest === null || ms < earliest) earliest = ms;
+  }
+  return earliest;
+}
+
+/**
+ * Find the first event matching `predicate`, parse its ts, and return
+ * `(ts - runStartMs)`. Returns `null` if no matching event has a parseable
+ * ts, if `runStartMs` is null, or if the offset would be negative (a clock
+ * inversion we refuse to silently coerce to zero).
+ */
+function computeFirstEventOffsetMs(
+  events: ReadonlyArray<WorkflowTraceEvent>,
+  runStartMs: number | null,
+  predicate: (ev: WorkflowTraceEvent) => boolean,
+): number | null {
+  if (runStartMs === null) return null;
+  for (const ev of events) {
+    if (!predicate(ev)) continue;
+    const ms = parseTsToMs(ev.ts);
+    if (ms === null) continue;
+    const offset = ms - runStartMs;
+    if (offset < 0) return null;
+    return offset;
+  }
+  return null;
+}
+
+/** Parse an ISO ts to ms-epoch; null when missing or unparseable. */
+function parseTsToMs(ts: string | undefined): number | null {
+  if (typeof ts !== "string" || ts.length === 0) return null;
+  const ms = Date.parse(ts);
+  if (Number.isNaN(ms)) return null;
+  return ms;
 }

--- a/tests/bench/report.test.ts
+++ b/tests/bench/report.test.ts
@@ -605,3 +605,133 @@ describe("renderUtilityReport corpus_coverage (#262)", () => {
     expect(markdown).not.toContain("## Corpus coverage");
   });
 });
+
+// ── AKM overhead block (#263) ──────────────────────────────────────────────
+
+describe("akm_overhead block (#263)", () => {
+  function fakeRun(overrides: Partial<import("./driver").RunResult>): import("./driver").RunResult {
+    return {
+      schemaVersion: 1,
+      taskId: "t",
+      arm: "akm",
+      seed: 0,
+      model: "m",
+      outcome: "pass",
+      tokens: { input: 0, output: 0 },
+      tokenMeasurement: "parsed",
+      wallclockMs: 0,
+      trajectory: { correctAssetLoaded: null, feedbackRecorded: null },
+      events: [],
+      verifierStdout: "",
+      verifierExitCode: 0,
+      assetsLoaded: [],
+      ...overrides,
+    };
+  }
+
+  test("emits empty/zero envelope when no akm runs are attached", () => {
+    const { json, markdown } = renderUtilityReport(utilSample);
+    const obj = json as Record<string, unknown>;
+    expect("akm_overhead" in obj).toBe(true);
+    const ov = obj.akm_overhead as Record<string, unknown>;
+    expect((ov.aggregate as { total_runs: number }).total_runs).toBe(0);
+    expect((ov.aggregate as { tool_calls_per_success: number | null }).tool_calls_per_success).toBeNull();
+    expect((ov.aggregate as { cost_per_success: number | null }).cost_per_success).toBeNull();
+    expect(ov.per_run).toEqual([]);
+    // Markdown section is gated on having akm runs to summarise.
+    expect(markdown).not.toContain("## AKM overhead");
+  });
+
+  test("populates per-run rows + aggregate from akmRuns + taskMetadata", () => {
+    const akmRuns = [
+      fakeRun({
+        taskId: "domain-a/task-1",
+        seed: 0,
+        outcome: "pass",
+        tokens: { input: 100, output: 50 },
+        events: [
+          {
+            schemaVersion: 1,
+            id: 0,
+            ts: "2026-04-27T10:00:00.000Z",
+            eventType: "search",
+          },
+          {
+            schemaVersion: 1,
+            id: 1,
+            ts: "2026-04-27T10:00:00.500Z",
+            eventType: "show",
+            ref: "skill:gold",
+          },
+        ],
+      }),
+    ];
+    const taskMetadata = [
+      {
+        id: "domain-a/task-1",
+        title: "T1",
+        domain: "domain-a",
+        difficulty: "easy" as const,
+        stash: "fixture-a",
+        verifier: "regex" as const,
+        budget: { tokens: 1000, wallMs: 1000 },
+        taskDir: "/tmp/ignored",
+        goldRef: "skill:gold",
+        expectedTransferFrom: [],
+      },
+    ];
+    const sampleWithRuns: UtilityRunReport = { ...utilSample, akmRuns, taskMetadata };
+    const { json, markdown } = renderUtilityReport(sampleWithRuns);
+    const obj = json as Record<string, unknown>;
+    const ov = obj.akm_overhead as Record<string, unknown>;
+    const perRun = ov.per_run as Array<Record<string, unknown>>;
+    expect(perRun).toHaveLength(1);
+    expect(perRun[0].search_count).toBe(1);
+    expect(perRun[0].show_count).toBe(1);
+    expect(perRun[0].assets_loaded_count).toBe(1);
+    expect(perRun[0].irrelevant_assets_loaded_count).toBe(0);
+    expect(perRun[0].time_to_first_correct_asset_ms).toBe(500);
+    expect(perRun[0].context_bytes_loaded).toBeNull();
+    expect(perRun[0].asset_bytes_loaded).toBeNull();
+
+    const agg = ov.aggregate as Record<string, unknown>;
+    expect(agg.total_runs).toBe(1);
+    expect(agg.passing_runs).toBe(1);
+    expect(agg.tool_calls_per_success).toBe(2);
+    expect(agg.cost_per_success).toBe(150);
+    expect(agg.mean_context_bytes_loaded).toBeNull();
+
+    expect(markdown).toContain("## AKM overhead");
+    expect(markdown).toContain("tool_calls_per_success");
+    expect(markdown).toContain("context_bytes_loaded: n/a");
+  });
+
+  test("excessive AKM calls produce high tool_calls_per_success in markdown", () => {
+    const akmRuns = [
+      fakeRun({
+        taskId: "domain-a/task-1",
+        outcome: "fail",
+        events: [
+          { schemaVersion: 1, id: 0, ts: "2026-04-27T10:00:00.000Z", eventType: "search" },
+          { schemaVersion: 1, id: 1, ts: "2026-04-27T10:00:00.001Z", eventType: "search" },
+          { schemaVersion: 1, id: 2, ts: "2026-04-27T10:00:00.002Z", eventType: "show", ref: "skill:wrong" },
+        ],
+      }),
+      fakeRun({
+        taskId: "domain-a/task-1",
+        seed: 1,
+        outcome: "pass",
+        tokens: { input: 1, output: 1 },
+        events: [{ schemaVersion: 1, id: 0, ts: "2026-04-27T10:00:00.000Z", eventType: "search" }],
+      }),
+    ];
+    const sampleWithRuns: UtilityRunReport = { ...utilSample, akmRuns };
+    const { json } = renderUtilityReport(sampleWithRuns);
+    const obj = json as Record<string, unknown>;
+    const ov = obj.akm_overhead as Record<string, unknown>;
+    const agg = ov.aggregate as Record<string, unknown>;
+    expect(agg.total_tool_calls).toBe(4);
+    expect(agg.passing_runs).toBe(1);
+    expect(agg.tool_calls_per_success).toBe(4);
+  });
+});

--- a/tests/bench/report.test.ts
+++ b/tests/bench/report.test.ts
@@ -400,6 +400,125 @@ describe("token-measurement surface (issue #252)", () => {
   });
 });
 
+describe("renderUtilityReport negative-transfer (#260)", () => {
+  test("JSON envelope carries zeros and empty arrays when no regressions exist", () => {
+    const { json, markdown } = renderUtilityReport(utilSample);
+    const obj = json as Record<string, unknown>;
+    expect(obj.negative_transfer_count).toBe(0);
+    expect(obj.negative_transfer_severity).toBe(0);
+    expect(obj.top_regressed_tasks).toEqual([]);
+    // Markdown stays QUIET — emits the literal "none" sentinel.
+    expect(markdown).toContain("## Negative transfer");
+    expect(markdown).toContain("none");
+    expect(markdown).not.toContain("### Top regressed tasks");
+  });
+
+  test("JSON envelope groups two domains and surfaces a single regression", () => {
+    const sample: UtilityRunReport = {
+      ...utilSample,
+      tasks: [
+        {
+          id: "domain-a/task-1",
+          noakm: pt(0.4, 20000, 40000),
+          akm: pt(0.8, 13000, 35000),
+          delta: { passRate: 0.4, tokensPerPass: -7000, wallclockMs: -5000 },
+        },
+        {
+          id: "domain-b/task-2",
+          noakm: pt(0.6, 20000, 40000),
+          akm: pt(0.2, 25000, 38000),
+          delta: { passRate: -0.4, tokensPerPass: 5000, wallclockMs: -2000 },
+        },
+      ],
+    };
+    const { json } = renderUtilityReport(sample);
+    const obj = json as Record<string, unknown>;
+    expect(obj.negative_transfer_count).toBe(1);
+    expect(obj.negative_transfer_severity).toBeCloseTo(0.4);
+    const top = obj.top_regressed_tasks as Array<Record<string, unknown>>;
+    expect(top).toHaveLength(1);
+    expect(top[0]?.task_id).toBe("domain-b/task-2");
+    expect(top[0]?.domain).toBe("domain-b");
+    expect(top[0]?.delta).toBeCloseTo(-0.4);
+    expect(top[0]?.severity).toBeCloseTo(0.4);
+
+    const domains = obj.domain_level_deltas as Array<Record<string, unknown>>;
+    expect(domains).toHaveLength(2);
+    expect(domains.map((d) => d.domain)).toEqual(["domain-a", "domain-b"]);
+    const domB = domains.find((d) => d.domain === "domain-b");
+    expect(domB?.regression_count).toBe(1);
+    expect(domB?.pass_rate_delta).toBeCloseTo(-0.4);
+  });
+
+  test("markdown renders the regressed-task table and domain table when regressions exist", () => {
+    const akmRuns: RunResult[] = [
+      {
+        schemaVersion: 1,
+        taskId: "domain-b/task-2",
+        arm: "akm",
+        seed: 0,
+        model: "m",
+        outcome: "fail",
+        tokens: { input: 0, output: 0 },
+        wallclockMs: 0,
+        trajectory: { correctAssetLoaded: null, feedbackRecorded: null },
+        events: [],
+        verifierStdout: "",
+        verifierExitCode: 1,
+        assetsLoaded: ["skill:bad-guidance", "knowledge:context"],
+      },
+      {
+        schemaVersion: 1,
+        taskId: "domain-b/task-2",
+        arm: "akm",
+        seed: 1,
+        model: "m",
+        outcome: "fail",
+        tokens: { input: 0, output: 0 },
+        wallclockMs: 0,
+        trajectory: { correctAssetLoaded: null, feedbackRecorded: null },
+        events: [],
+        verifierStdout: "",
+        verifierExitCode: 1,
+        assetsLoaded: ["skill:bad-guidance"],
+      },
+    ];
+    const sample: UtilityRunReport = {
+      ...utilSample,
+      tasks: [
+        {
+          id: "domain-a/task-1",
+          noakm: pt(0.4, 20000, 40000),
+          akm: pt(0.8, 13000, 35000),
+          delta: { passRate: 0.4, tokensPerPass: -7000, wallclockMs: -5000 },
+        },
+        {
+          id: "domain-b/task-2",
+          noakm: pt(0.6, 20000, 40000),
+          akm: pt(0.2, 25000, 38000),
+          delta: { passRate: -0.4, tokensPerPass: 5000, wallclockMs: -2000 },
+        },
+      ],
+      akmRuns,
+    };
+    const { json, markdown } = renderUtilityReport(sample);
+    expect(markdown).toContain("## Negative transfer");
+    expect(markdown).toContain("count=1");
+    expect(markdown).toContain("### Top regressed tasks");
+    expect(markdown).toContain("domain-b/task-2");
+    expect(markdown).toContain("### Domain-level deltas");
+    expect(markdown).toContain("### Asset regression candidates");
+    expect(markdown).toContain("skill:bad-guidance");
+
+    const obj = json as Record<string, unknown>;
+    const candidates = obj.asset_regression_candidates as Array<Record<string, unknown>>;
+    expect(candidates.length).toBeGreaterThan(0);
+    const bad = candidates.find((c) => c.asset_ref === "skill:bad-guidance");
+    expect(bad?.regressed_task_count).toBe(1);
+    expect(bad?.total_load_count).toBe(2);
+  });
+});
+
 describe("git resolvers", () => {
   test("resolveGitBranch + resolveGitCommit return non-empty strings in this repo", () => {
     // The bench worktree IS a git repo; these MUST succeed.

--- a/tests/bench/report.test.ts
+++ b/tests/bench/report.test.ts
@@ -828,6 +828,118 @@ describe("renderUtilityReport workflow compliance (#257)", () => {
     const b = renderUtilityReport(sample).markdown;
     expect(a).toBe(b);
   });
+
+  // ── Reliability sub-block (#258) ────────────────────────────────────────
+
+  test("workflow.reliability is present and zeroed when no checks were collected", () => {
+    const { json } = renderUtilityReport(utilSample);
+    const obj = json as Record<string, unknown>;
+    const wf = obj.workflow as Record<string, unknown>;
+    const reliability = wf.reliability as Record<string, unknown>;
+    expect(reliability).toBeDefined();
+    expect(reliability.by_workflow).toEqual({});
+    const corpus = reliability.corpus as Record<string, unknown>;
+    expect(corpus.pass_at_k).toBe(0);
+    expect(corpus.pass_all_k).toBe(0);
+    expect(corpus.groups).toBe(0);
+  });
+
+  test("workflow.reliability surfaces pass@k and pass^k per workflow + corpus", () => {
+    // wf-flaky: t1 has 1 pass + 1 fail (anyPass=1, allPass=0)
+    // wf-solid: t2 has 2 pass (anyPass=1, allPass=1)
+    const checks: import("./workflow-evaluator").WorkflowCheckResult[] = [
+      makeCheck({ workflowId: "wf-flaky", taskId: "t1", seed: 0, status: "pass", score: 1 }),
+      makeCheck({ workflowId: "wf-flaky", taskId: "t1", seed: 1, status: "fail", score: 0 }),
+      makeCheck({ workflowId: "wf-solid", taskId: "t2", seed: 0, status: "pass", score: 1 }),
+      makeCheck({ workflowId: "wf-solid", taskId: "t2", seed: 1, status: "pass", score: 1 }),
+    ];
+    const sample: UtilityRunReport = { ...utilSample, workflowChecks: checks };
+    const { json, markdown } = renderUtilityReport(sample);
+    const obj = json as Record<string, unknown>;
+    const wf = obj.workflow as Record<string, unknown>;
+    const reliability = wf.reliability as Record<string, unknown>;
+    const byWorkflow = reliability.by_workflow as Record<string, Record<string, unknown>>;
+    expect(byWorkflow["wf-flaky"].pass_at_k).toBeCloseTo(1);
+    expect(byWorkflow["wf-flaky"].pass_all_k).toBe(0);
+    expect(byWorkflow["wf-solid"].pass_at_k).toBe(1);
+    expect(byWorkflow["wf-solid"].pass_all_k).toBe(1);
+    const corpus = reliability.corpus as Record<string, unknown>;
+    expect(corpus.groups).toBe(2);
+    expect(corpus.pass_at_k).toBeCloseTo(1);
+    expect(corpus.pass_all_k).toBeCloseTo(0.5);
+
+    expect(markdown).toContain("### Reliability (pass@k / pass^k)");
+    expect(markdown).toContain("| wf-flaky |");
+    expect(markdown).toContain("| wf-solid |");
+    expect(markdown).toContain("Inconsistent workflows");
+    // wf-flaky should be flagged: pass@k=1 vs pass^k=0 (gap=1).
+    expect(markdown).toContain("`wf-flaky`");
+    // wf-solid should NOT be in the inconsistent list.
+    const inconsistentSection = markdown.split("Inconsistent workflows")[1] ?? "";
+    expect(inconsistentSection).not.toContain("`wf-solid`");
+  });
+
+  test("reliability is omitted from markdown when no group is applicable", () => {
+    const checks: import("./workflow-evaluator").WorkflowCheckResult[] = [
+      makeCheck({ workflowId: "wf-skips", status: "not_applicable", score: 0 }),
+    ];
+    const sample: UtilityRunReport = { ...utilSample, workflowChecks: checks };
+    const { markdown } = renderUtilityReport(sample);
+    expect(markdown).not.toContain("### Reliability (pass@k / pass^k)");
+  });
+
+  test("reliability handles all-pass corpus without flagging inconsistency", () => {
+    const checks: import("./workflow-evaluator").WorkflowCheckResult[] = [
+      makeCheck({ workflowId: "wf-1", taskId: "t1", seed: 0, status: "pass", score: 1 }),
+      makeCheck({ workflowId: "wf-1", taskId: "t1", seed: 1, status: "pass", score: 1 }),
+    ];
+    const sample: UtilityRunReport = { ...utilSample, workflowChecks: checks };
+    const { json, markdown } = renderUtilityReport(sample);
+    const obj = json as Record<string, unknown>;
+    const wf = obj.workflow as Record<string, unknown>;
+    const reliability = wf.reliability as Record<string, unknown>;
+    const corpus = reliability.corpus as Record<string, unknown>;
+    expect(corpus.pass_at_k).toBe(1);
+    expect(corpus.pass_all_k).toBe(1);
+    expect(markdown).toContain("### Reliability (pass@k / pass^k)");
+    expect(markdown).not.toContain("Inconsistent workflows");
+  });
+
+  test("reliability handles none-pass corpus (zeroed but section still rendered)", () => {
+    const checks: import("./workflow-evaluator").WorkflowCheckResult[] = [
+      makeCheck({ workflowId: "wf-1", taskId: "t1", seed: 0, status: "fail", score: 0 }),
+      makeCheck({ workflowId: "wf-1", taskId: "t1", seed: 1, status: "fail", score: 0 }),
+    ];
+    const sample: UtilityRunReport = { ...utilSample, workflowChecks: checks };
+    const { json, markdown } = renderUtilityReport(sample);
+    const obj = json as Record<string, unknown>;
+    const wf = obj.workflow as Record<string, unknown>;
+    const reliability = wf.reliability as Record<string, unknown>;
+    const corpus = reliability.corpus as Record<string, unknown>;
+    expect(corpus.pass_at_k).toBe(0);
+    expect(corpus.pass_all_k).toBe(0);
+    expect(corpus.groups).toBe(1);
+    expect(markdown).toContain("### Reliability (pass@k / pass^k)");
+    // pass@k=0 fails the floor → no inconsistency callout.
+    expect(markdown).not.toContain("Inconsistent workflows");
+  });
+
+  test("reliability tolerates mixed partial/fail (partial counts as non-pass for pass^k)", () => {
+    const checks: import("./workflow-evaluator").WorkflowCheckResult[] = [
+      makeCheck({ workflowId: "wf-1", taskId: "t1", seed: 0, status: "pass", score: 1 }),
+      makeCheck({ workflowId: "wf-1", taskId: "t1", seed: 1, status: "partial", score: 0.5 }),
+      makeCheck({ workflowId: "wf-1", taskId: "t1", seed: 2, status: "fail", score: 0 }),
+    ];
+    const sample: UtilityRunReport = { ...utilSample, workflowChecks: checks };
+    const { json } = renderUtilityReport(sample);
+    const obj = json as Record<string, unknown>;
+    const wf = obj.workflow as Record<string, unknown>;
+    const reliability = wf.reliability as Record<string, unknown>;
+    const byWorkflow = reliability.by_workflow as Record<string, Record<string, unknown>>;
+    expect(byWorkflow["wf-1"].pass_at_k).toBe(1); // 1 of 1 task has any pass
+    expect(byWorkflow["wf-1"].pass_all_k).toBe(0); // not all 3 seeds are pass
+    expect(byWorkflow["wf-1"].k).toBe(3);
+  });
 });
 // ── AKM overhead block (#263) ──────────────────────────────────────────────
 

--- a/tests/bench/report.test.ts
+++ b/tests/bench/report.test.ts
@@ -540,3 +540,68 @@ describe("git resolvers", () => {
     }
   });
 });
+
+// ── Corpus-coverage block (#262) ───────────────────────────────────────────
+
+describe("renderUtilityReport corpus_coverage (#262)", () => {
+  test("JSON envelope always carries a corpus_coverage block, zero-valued when no tags", () => {
+    const { json } = renderUtilityReport(utilSample);
+    const obj = json as Record<string, unknown>;
+    const cov = obj.corpus_coverage as Record<string, unknown>;
+    expect(cov).toBeDefined();
+    const coverage = cov.coverage as Record<string, unknown>;
+    expect(coverage.totalTasks).toBe(0);
+    expect(cov.by_memory_ability).toEqual([]);
+    expect(cov.by_task_family).toEqual([]);
+  });
+
+  test("JSON envelope groups tasks by memory_ability when taskMetadata is plumbed", () => {
+    const sample: UtilityRunReport = {
+      ...utilSample,
+      taskMetadata: [
+        {
+          id: "domain-a/task-1",
+          title: "t1",
+          domain: "domain-a",
+          difficulty: "easy",
+          stash: "minimal",
+          verifier: "regex",
+          budget: { tokens: 1, wallMs: 1 },
+          taskDir: "/tmp",
+          memoryAbility: "procedural_lookup",
+          taskFamily: "domain-a/family-1",
+        },
+        {
+          id: "domain-b/task-2",
+          title: "t2",
+          domain: "domain-b",
+          difficulty: "easy",
+          stash: "minimal",
+          verifier: "regex",
+          budget: { tokens: 1, wallMs: 1 },
+          taskDir: "/tmp",
+          memoryAbility: "procedural_lookup",
+          taskFamily: "domain-b/family-2",
+        },
+      ],
+    };
+    const { json, markdown } = renderUtilityReport(sample);
+    const obj = json as Record<string, unknown>;
+    const cov = obj.corpus_coverage as Record<string, unknown>;
+    const coverage = cov.coverage as { totalTasks: number; memoryAbilityCounts: Record<string, number> };
+    expect(coverage.totalTasks).toBe(2);
+    expect(coverage.memoryAbilityCounts.procedural_lookup).toBe(2);
+    expect(coverage.memoryAbilityCounts.abstention).toBe(0);
+    const byAbility = cov.by_memory_ability as Array<Record<string, unknown>>;
+    expect(byAbility).toHaveLength(1);
+    expect(byAbility[0]?.category).toBe("procedural_lookup");
+    expect(byAbility[0]?.task_count).toBe(2);
+    expect(markdown).toContain("## Corpus coverage");
+    expect(markdown).toContain("procedural_lookup");
+  });
+
+  test("markdown corpus-coverage section is omitted when no tasks carry memory_ability", () => {
+    const { markdown } = renderUtilityReport(utilSample);
+    expect(markdown).not.toContain("## Corpus coverage");
+  });
+});

--- a/tests/bench/report.test.ts
+++ b/tests/bench/report.test.ts
@@ -605,3 +605,227 @@ describe("renderUtilityReport corpus_coverage (#262)", () => {
     expect(markdown).not.toContain("## Corpus coverage");
   });
 });
+
+// ── Workflow compliance (#257) ─────────────────────────────────────────────
+
+describe("renderUtilityReport workflow compliance (#257)", () => {
+  function makeCheck(overrides: Partial<import("./workflow-evaluator").WorkflowCheckResult> = {}) {
+    const base: import("./workflow-evaluator").WorkflowCheckResult = {
+      schemaVersion: 1,
+      workflowId: "wf-1",
+      taskId: "domain-a/task-1",
+      arm: "akm",
+      seed: 0,
+      status: "pass",
+      score: 1,
+      requiredPassed: 3,
+      requiredTotal: 3,
+      violations: [],
+      evidence: {
+        matchedEvents: 3,
+        feedbackRecorded: true,
+        goldAssetLoaded: true,
+        traceTruncated: false,
+      },
+    };
+    return { ...base, ...overrides };
+  }
+
+  test("emits an empty workflow object and skips the markdown section when no checks were collected", () => {
+    const { json, markdown } = renderUtilityReport(utilSample);
+    const obj = json as Record<string, unknown>;
+    const wf = obj.workflow as Record<string, unknown>;
+    expect(wf).toBeDefined();
+    expect(wf.total_checks).toBe(0);
+    expect(wf.applicable_checks).toBe(0);
+    expect(wf.overall_compliance).toBe(0);
+    expect(wf.violation_count).toBe(0);
+    expect(wf.by_workflow).toEqual({});
+    expect(wf.top_violations).toEqual([]);
+    expect(wf.cross_tab).toEqual([]);
+    expect(markdown).not.toContain("## Workflow compliance");
+  });
+
+  test("aggregates pass/partial/fail counts and surfaces top violations with evidence", () => {
+    const checks: import("./workflow-evaluator").WorkflowCheckResult[] = [
+      makeCheck({
+        workflowId: "wf-1",
+        taskId: "domain-a/task-1",
+        seed: 0,
+        status: "pass",
+        score: 1,
+      }),
+      makeCheck({
+        workflowId: "wf-1",
+        taskId: "domain-a/task-1",
+        seed: 1,
+        status: "partial",
+        score: 0.5,
+        requiredPassed: 1,
+        requiredTotal: 2,
+        violations: [
+          { code: "missing_required_event", message: "expected akm_search", expected: "akm_search x1", observed: "0" },
+        ],
+      }),
+      makeCheck({
+        workflowId: "wf-2",
+        taskId: "domain-b/task-2",
+        seed: 0,
+        status: "fail",
+        score: 0,
+        requiredPassed: 0,
+        requiredTotal: 1,
+        violations: [
+          { code: "missing_required_event", message: "expected akm_search again", observed: "0" },
+          { code: "wrong_feedback_polarity", message: "negative expected", expected: "negative" },
+        ],
+      }),
+    ];
+    // Tag task outcomes so the cross-tab populates pass/fail rows.
+    (checks[0] as import("./workflow-evaluator").WorkflowCheckResult & { taskOutcome?: string }).taskOutcome = "pass";
+    (checks[1] as import("./workflow-evaluator").WorkflowCheckResult & { taskOutcome?: string }).taskOutcome = "pass";
+    (checks[2] as import("./workflow-evaluator").WorkflowCheckResult & { taskOutcome?: string }).taskOutcome = "fail";
+
+    const sample: UtilityRunReport = { ...utilSample, workflowChecks: checks };
+    const { json, markdown } = renderUtilityReport(sample);
+    const obj = json as Record<string, unknown>;
+    const wf = obj.workflow as Record<string, unknown>;
+    expect(wf.total_checks).toBe(3);
+    expect(wf.applicable_checks).toBe(3);
+    expect(wf.strict_pass_rate).toBeCloseTo(1 / 3);
+    expect(wf.partial_pass_rate).toBeCloseTo(1 / 3);
+    expect(wf.fail_rate).toBeCloseTo(1 / 3);
+    expect(wf.violation_count).toBe(3);
+    // overall_compliance is mean(score): (1 + 0.5 + 0) / 3 ≈ 0.5
+    expect(wf.overall_compliance).toBeCloseTo(0.5);
+
+    const byWorkflow = wf.by_workflow as Record<string, Record<string, unknown>>;
+    expect(byWorkflow["wf-1"]).toBeDefined();
+    expect(byWorkflow["wf-1"].count).toBe(2);
+    expect(byWorkflow["wf-1"].pass_rate).toBeCloseTo(0.5);
+    expect(byWorkflow["wf-1"].partial_rate).toBeCloseTo(0.5);
+    expect(byWorkflow["wf-2"].count).toBe(1);
+    expect(byWorkflow["wf-2"].fail_rate).toBeCloseTo(1);
+
+    const topVio = wf.top_violations as Array<Record<string, unknown>>;
+    // missing_required_event appears twice → ranked first
+    expect(topVio[0]?.code).toBe("missing_required_event");
+    expect(topVio[0]?.count).toBe(2);
+    const evidence = topVio[0]?.evidence as Array<Record<string, unknown>>;
+    expect(evidence.length).toBeGreaterThan(0);
+    // Evidence pointers identify (task, seed, workflow_id).
+    expect(evidence[0]?.task_id).toBeDefined();
+    expect(evidence[0]?.seed).toBeDefined();
+    expect(evidence[0]?.workflow_id).toBeDefined();
+
+    const crossTab = wf.cross_tab as Array<Record<string, unknown>>;
+    const passRow = crossTab.find((r) => r.task_outcome === "pass");
+    const failRow = crossTab.find((r) => r.task_outcome === "fail");
+    expect(passRow).toBeDefined();
+    expect(failRow).toBeDefined();
+    // task pass run with pass + partial workflow checks → worst-status reduction = "partial"
+    expect(passRow?.partial).toBe(1);
+    // task fail run with fail workflow check → fail bucket
+    expect(failRow?.fail).toBe(1);
+
+    expect(markdown).toContain("## Workflow compliance");
+    expect(markdown).toContain("overall_compliance=0.50");
+    expect(markdown).toContain("### By workflow");
+    expect(markdown).toContain("wf-1");
+    expect(markdown).toContain("wf-2");
+    expect(markdown).toContain("### Top violations");
+    expect(markdown).toContain("missing_required_event");
+    expect(markdown).toContain("### Violation evidence");
+    expect(markdown).toContain("### Task outcome × workflow outcome");
+  });
+
+  test("not_applicable checks are excluded from rate denominators but show up in by_workflow.count", () => {
+    const checks: import("./workflow-evaluator").WorkflowCheckResult[] = [
+      makeCheck({ workflowId: "wf-applies", status: "pass", score: 1 }),
+      makeCheck({ workflowId: "wf-skips", status: "not_applicable", score: 0 }),
+    ];
+    const sample: UtilityRunReport = { ...utilSample, workflowChecks: checks };
+    const { json, markdown } = renderUtilityReport(sample);
+    const obj = json as Record<string, unknown>;
+    const wf = obj.workflow as Record<string, unknown>;
+    expect(wf.total_checks).toBe(2);
+    expect(wf.applicable_checks).toBe(1);
+    expect(wf.strict_pass_rate).toBeCloseTo(1);
+    const byWorkflow = wf.by_workflow as Record<string, Record<string, unknown>>;
+    expect(byWorkflow["wf-skips"].count).toBe(1);
+    expect(byWorkflow["wf-skips"].pass_rate).toBe(0);
+    // Markdown still emits the section because at least one check is applicable.
+    expect(markdown).toContain("## Workflow compliance");
+  });
+
+  test("when every check is not_applicable, markdown surfaces the loaded-but-no-match sentence", () => {
+    const checks: import("./workflow-evaluator").WorkflowCheckResult[] = [
+      makeCheck({ workflowId: "wf-a", status: "not_applicable", score: 0 }),
+      makeCheck({ workflowId: "wf-b", status: "not_applicable", score: 0 }),
+    ];
+    const sample: UtilityRunReport = { ...utilSample, workflowChecks: checks };
+    const { json, markdown } = renderUtilityReport(sample);
+    const obj = json as Record<string, unknown>;
+    const wf = obj.workflow as Record<string, unknown>;
+    expect(wf.total_checks).toBe(2);
+    expect(wf.applicable_checks).toBe(0);
+    expect(markdown).toContain("## Workflow compliance");
+    expect(markdown).toContain("No workflow specs applied");
+  });
+
+  test("harness_error checks are bucketed as fail and counted against compliance", () => {
+    const checks: import("./workflow-evaluator").WorkflowCheckResult[] = [
+      makeCheck({ workflowId: "wf-1", status: "harness_error", score: 0 }),
+    ];
+    const sample: UtilityRunReport = { ...utilSample, workflowChecks: checks };
+    const { json } = renderUtilityReport(sample);
+    const obj = json as Record<string, unknown>;
+    const wf = obj.workflow as Record<string, unknown>;
+    expect(wf.applicable_checks).toBe(1);
+    expect(wf.fail_rate).toBeCloseTo(1);
+  });
+
+  test("multiple specs across multiple tasks aggregate per-spec deterministically", () => {
+    const checks: import("./workflow-evaluator").WorkflowCheckResult[] = [
+      makeCheck({ workflowId: "wf-a", taskId: "t1", seed: 0, status: "pass", score: 1 }),
+      makeCheck({
+        workflowId: "wf-a",
+        taskId: "t1",
+        seed: 1,
+        status: "fail",
+        score: 0,
+        violations: [{ code: "forbidden_event", message: "x" }],
+      }),
+      makeCheck({
+        workflowId: "wf-b",
+        taskId: "t2",
+        seed: 0,
+        status: "partial",
+        score: 0.5,
+        violations: [{ code: "wrong_order", message: "y" }],
+      }),
+    ];
+    const sample: UtilityRunReport = { ...utilSample, workflowChecks: checks };
+    const { markdown } = renderUtilityReport(sample);
+    // Specs are listed alphabetically.
+    const aIdx = markdown.indexOf("| wf-a ");
+    const bIdx = markdown.indexOf("| wf-b ");
+    expect(aIdx).toBeGreaterThan(0);
+    expect(bIdx).toBeGreaterThan(aIdx);
+  });
+
+  test("markdown is byte-stable across reruns for the workflow section", () => {
+    const checks: import("./workflow-evaluator").WorkflowCheckResult[] = [
+      makeCheck({
+        workflowId: "wf-1",
+        status: "partial",
+        score: 0.5,
+        violations: [{ code: "missing_required_event", message: "x" }],
+      }),
+    ];
+    const sample: UtilityRunReport = { ...utilSample, workflowChecks: checks };
+    const a = renderUtilityReport(sample).markdown;
+    const b = renderUtilityReport(sample).markdown;
+    expect(a).toBe(b);
+  });
+});

--- a/tests/bench/report.test.ts
+++ b/tests/bench/report.test.ts
@@ -682,9 +682,9 @@ describe("renderUtilityReport workflow compliance (#257)", () => {
       }),
     ];
     // Tag task outcomes so the cross-tab populates pass/fail rows.
-    (checks[0] as import("./workflow-evaluator").WorkflowCheckResult & { taskOutcome?: string }).taskOutcome = "pass";
-    (checks[1] as import("./workflow-evaluator").WorkflowCheckResult & { taskOutcome?: string }).taskOutcome = "pass";
-    (checks[2] as import("./workflow-evaluator").WorkflowCheckResult & { taskOutcome?: string }).taskOutcome = "fail";
+    checks[0].taskOutcome = "pass";
+    checks[1].taskOutcome = "pass";
+    checks[2].taskOutcome = "fail";
 
     const sample: UtilityRunReport = { ...utilSample, workflowChecks: checks };
     const { json, markdown } = renderUtilityReport(sample);

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -14,12 +14,14 @@
  */
 
 import { execSync } from "node:child_process";
-import type { TaskMetadata } from "./corpus";
+import type { MemoryAbility, TaskMetadata } from "./corpus";
 import type { RunResult } from "./driver";
 import type {
   AssetRegressionCandidateRow,
+  CategoryAggregateRow,
   CompareResult,
   CompareTaskRow,
+  CorpusCoverage,
   CorpusDelta,
   CorpusMetrics,
   DeltaSign,
@@ -32,12 +34,16 @@ import type {
   OutcomeAggregate,
   PerAssetAttribution,
   PerTaskMetrics,
+  PerTaskTagEntry,
   ProposalQualityMetrics,
   SearchBridgeMetrics,
   TrajectoryAggregate,
 } from "./metrics";
 import {
+  aggregateByMemoryAbility,
+  aggregateByTaskFamily,
   computeAssetRegressionCandidates,
+  computeCorpusCoverage,
   computeDomainAggregates,
   computeNegativeTransfer,
   histogramKeys,
@@ -176,6 +182,12 @@ export interface UtilityReportTaskEntry {
    * default two-arm envelope is byte-identical to the pre-#261 output.
    */
   synthetic?: PerTaskMetrics;
+  /**
+   * Optional workflow-compliance fraction `[0, 1]` for the akm arm (#255 +
+   * #262). When present the corpus_coverage section folds it into the mean
+   * compliance per `memory_ability` / `task_family` group.
+   */
+  workflowCompliance?: number;
 }
 
 /**
@@ -364,6 +376,7 @@ function buildUtilityJson(input: UtilityRunReport): object {
     })),
     domain_level_deltas: domainDeltas.map(serialiseDomainAggregate),
     asset_regression_candidates: assetRegressionCandidates.map(serialiseAssetRegressionCandidate),
+    corpus_coverage: buildCorpusCoverageBlock(input),
     warnings,
     ...(input.searchBridge ? { searchBridge: serialiseSearchBridge(input.searchBridge) } : {}),
   };
@@ -462,6 +475,78 @@ function serialiseDomainAggregate(row: DomainAggregateRow): {
     pass_rate_delta: row.passRateDelta,
     tokens_per_pass_delta: row.tokensPerPassDelta,
     wallclock_ms_delta: row.wallclockMsDelta,
+  };
+}
+
+// ── Corpus coverage block (#262) ───────────────────────────────────────────
+
+/**
+ * Build the §13.3 `corpus_coverage` block from a UtilityRunReport (#262).
+ * Folds three pieces:
+ * - `coverage`: counts per `memory_ability` (closed set + `untagged`) and
+ *   `task_family`. Operators see at a glance which abilities the corpus
+ *   covers and which are missing.
+ * - `by_memory_ability` / `by_task_family`: per-category aggregates of pass
+ *   rate, akm − noakm delta, negative transfer count, and (when supplied)
+ *   workflow-compliance mean.
+ *
+ * When the runner did not plumb `taskMetadata` (legacy code paths) we emit a
+ * skeleton block with zero counts so JSON consumers don't see the key flicker
+ * in and out depending on the runner version.
+ */
+function buildCorpusCoverageBlock(input: UtilityRunReport): {
+  coverage: CorpusCoverage;
+  by_memory_ability: ReturnType<typeof serialiseCategoryRow>[];
+  by_task_family: ReturnType<typeof serialiseCategoryRow>[];
+} {
+  const taskMetadata = input.taskMetadata ?? [];
+  const metaById = new Map<string, TaskMetadata>();
+  for (const m of taskMetadata) metaById.set(m.id, m);
+
+  const tagEntries: PerTaskTagEntry[] = input.tasks.map((t) => {
+    const meta = metaById.get(t.id);
+    const entry: PerTaskTagEntry = {
+      id: t.id,
+      noakm: t.noakm,
+      akm: t.akm,
+    };
+    if (meta?.memoryAbility) entry.memoryAbility = meta.memoryAbility;
+    if (meta?.taskFamily) entry.taskFamily = meta.taskFamily;
+    if (meta?.workflowFocus) entry.workflowFocus = meta.workflowFocus;
+    if (typeof t.workflowCompliance === "number" && Number.isFinite(t.workflowCompliance)) {
+      entry.workflowCompliance = t.workflowCompliance;
+    }
+    return entry;
+  });
+
+  const coverage = computeCorpusCoverage(taskMetadata);
+  const byAbility = aggregateByMemoryAbility(tagEntries);
+  const byFamily = aggregateByTaskFamily(tagEntries);
+
+  return {
+    coverage,
+    by_memory_ability: byAbility.map(serialiseCategoryRow),
+    by_task_family: byFamily.map(serialiseCategoryRow),
+  };
+}
+
+function serialiseCategoryRow(row: CategoryAggregateRow): {
+  category: string;
+  task_count: number;
+  pass_rate_noakm: number;
+  pass_rate_akm: number;
+  pass_rate_delta: number;
+  negative_transfer_count: number;
+  workflow_compliance: number | null;
+} {
+  return {
+    category: row.category,
+    task_count: row.taskCount,
+    pass_rate_noakm: row.passRateNoakm,
+    pass_rate_akm: row.passRateAkm,
+    pass_rate_delta: row.passRateDelta,
+    negative_transfer_count: row.negativeTransferCount,
+    workflow_compliance: row.workflowCompliance,
   };
 }
 
@@ -616,6 +701,14 @@ function buildUtilityMarkdown(input: UtilityRunReport): string {
   const sorted = [...input.tasks].sort((a, b) => a.id.localeCompare(b.id));
   for (const t of sorted) {
     lines.push(taskRow(t, input.aggregateSynth !== undefined));
+  }
+  // Corpus-coverage section (#262). Renders only when at least one task was
+  // tagged with a `memory_ability`; without tags the section adds no signal
+  // and would just churn snapshots.
+  const coverageSection = renderCorpusCoverageSection(input);
+  if (coverageSection.length > 0) {
+    lines.push("");
+    lines.push(coverageSection);
   }
   // Negative-transfer + domain diagnostics (#260). The section stays quiet
   // ("none") when no regressions were observed so green corpora don't fill
@@ -1073,6 +1166,77 @@ export function renderNegativeTransferSection(input: UtilityRunReport): string {
       lines.push(`| \`${row.assetRef}\` | ${row.regressedTaskCount} | ${row.totalLoadCount} |`);
     }
   }
+  return lines.join("\n");
+}
+
+// ── Corpus-coverage markdown (#262) ────────────────────────────────────────
+
+/**
+ * Render the §13.3 corpus_coverage markdown section (#262). Returns "" when
+ * no task carries a `memory_ability` tag — at that point the section adds
+ * no signal and only churns markdown snapshots.
+ *
+ * Sections rendered:
+ * - Coverage counts per memory-ability label (closed set + `untagged`).
+ * - Per-memory-ability pass-rate / akm − noakm delta / negative-transfer
+ *   counts, plus workflow compliance when at least one task supplied it.
+ * - A compact `## Task families` rollup when ≥ 2 families are tagged.
+ */
+export function renderCorpusCoverageSection(input: UtilityRunReport): string {
+  const block = buildCorpusCoverageBlock(input);
+  const taggedAbility = Object.entries(block.coverage.memoryAbilityCounts).some(([k, v]) => k !== "untagged" && v > 0);
+  if (!taggedAbility) return "";
+
+  const lines: string[] = [];
+  lines.push("## Corpus coverage");
+  lines.push("");
+  lines.push("| memory_ability | tasks |");
+  lines.push("|----------------|-------|");
+  // Sort keys: known abilities alphabetically, `untagged` last.
+  const counts = block.coverage.memoryAbilityCounts;
+  const knownKeys = Object.keys(counts)
+    .filter((k) => k !== "untagged")
+    .sort();
+  for (const k of knownKeys) lines.push(`| ${k} | ${counts[k as MemoryAbility]} |`);
+  if ((counts.untagged ?? 0) > 0) lines.push(`| untagged | ${counts.untagged} |`);
+
+  if (block.by_memory_ability.length > 0) {
+    lines.push("");
+    lines.push("### By memory_ability");
+    lines.push("");
+    const anyCompliance = block.by_memory_ability.some((r) => r.workflow_compliance !== null);
+    if (anyCompliance) {
+      lines.push("| memory_ability | tasks | noakm | akm | delta | neg.transfer | workflow_compliance |");
+      lines.push("|----------------|-------|-------|-----|-------|--------------|---------------------|");
+    } else {
+      lines.push("| memory_ability | tasks | noakm | akm | delta | neg.transfer |");
+      lines.push("|----------------|-------|-------|-----|-------|--------------|");
+    }
+    for (const row of block.by_memory_ability) {
+      const base = `| ${row.category} | ${row.task_count} | ${row.pass_rate_noakm.toFixed(2)} | ${row.pass_rate_akm.toFixed(2)} | ${signed(row.pass_rate_delta.toFixed(2))} | ${row.negative_transfer_count} |`;
+      if (anyCompliance) {
+        const wc = row.workflow_compliance === null ? "n/a" : row.workflow_compliance.toFixed(2);
+        lines.push(`${base} ${wc} |`);
+      } else {
+        lines.push(base);
+      }
+    }
+  }
+
+  const families = block.by_task_family;
+  if (families.length >= 2) {
+    lines.push("");
+    lines.push("### By task_family");
+    lines.push("");
+    lines.push("| task_family | tasks | noakm | akm | delta |");
+    lines.push("|-------------|-------|-------|-----|-------|");
+    for (const row of families) {
+      lines.push(
+        `| ${row.category} | ${row.task_count} | ${row.pass_rate_noakm.toFixed(2)} | ${row.pass_rate_akm.toFixed(2)} | ${signed(row.pass_rate_delta.toFixed(2))} |`,
+      );
+    }
+  }
+
   return lines.join("\n");
 }
 

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -30,6 +30,7 @@ import type {
   FailureModeAggregate,
   FeedbackIntegrityMetrics,
   GoldRankRunRecord,
+  LearningCurve,
   LongitudinalMetrics,
   OutcomeAggregate,
   PerAssetAttribution,
@@ -1927,6 +1928,13 @@ export interface EvolveReportInput {
    * older artefacts remain valid.
    */
   feedbackIntegrity?: FeedbackIntegrityMetrics;
+  /**
+   * §6.4 (issue #265) — learning curve across evolution episodes. Optional;
+   * when omitted both the JSON envelope's `learning` key and the markdown
+   * "Learning curve" section are suppressed so older artefacts remain
+   * valid. `episode_index === 0` is the pre-evolution baseline.
+   */
+  learningCurve?: LearningCurve;
   arms: { pre: UtilityRunReport; post: UtilityRunReport; synthetic: UtilityRunReport };
   warnings: string[];
 }
@@ -2006,6 +2014,7 @@ function buildEvolveJson(input: EvolveReportInput): object {
         failure_mode: d.failureMode,
       })),
     },
+    ...(input.learningCurve ? { learning: serialiseLearningCurve(input.learningCurve) } : {}),
     arms: {
       pre: armEnvelope(input.arms.pre),
       post: armEnvelope(input.arms.post),
@@ -2031,6 +2040,75 @@ function buildEvolveJson(input: EvolveReportInput): object {
     ...(input.feedbackIntegrity ? { feedback_integrity: serialiseFeedbackIntegrity(input.feedbackIntegrity) } : {}),
     warnings: augmentedWarnings,
   };
+}
+
+/**
+ * §6.4 (issue #265) — flatten a `LearningCurve` into its JSON envelope.
+ * Mirrors the suggested shape from the issue body: an `episodes[]` block
+ * with per-episode rows, plus the headline `learning_slope` and
+ * `time_to_improvement`. `pass_rate_by_episode` is exposed as a flat array
+ * for tools that want to plot without re-projecting the rows.
+ */
+function serialiseLearningCurve(curve: LearningCurve): {
+  episodes: Array<{
+    episode_index: number;
+    pass_rate: number;
+    delta_from_previous_episode: number;
+    cumulative_feedback_events: number;
+    cumulative_proposals_created: number;
+    cumulative_proposals_accepted: number;
+    cumulative_lessons_created: number;
+    lesson_reuse_rate: number | null;
+  }>;
+  pass_rate_by_episode: number[];
+  learning_slope: number;
+  time_to_improvement: number | null;
+} {
+  return {
+    episodes: curve.episodes.map((ep) => ({
+      episode_index: ep.episode_index,
+      pass_rate: ep.pass_rate,
+      delta_from_previous_episode: ep.delta_from_previous_episode,
+      cumulative_feedback_events: ep.cumulative_feedback_events,
+      cumulative_proposals_created: ep.cumulative_proposals_created,
+      cumulative_proposals_accepted: ep.cumulative_proposals_accepted,
+      cumulative_lessons_created: ep.cumulative_lessons_created,
+      lesson_reuse_rate: ep.lesson_reuse_rate,
+    })),
+    pass_rate_by_episode: curve.pass_rate_by_episode.slice(),
+    learning_slope: curve.learning_slope,
+    time_to_improvement: curve.time_to_improvement,
+  };
+}
+
+/**
+ * §6.4 (issue #265) — render a compact "Learning curve" markdown table.
+ * One row per episode plus the headline slope + time-to-improvement.
+ */
+export function renderLearningCurveSection(curve: LearningCurve): string {
+  const lines: string[] = [];
+  lines.push("## Learning curve");
+  lines.push("");
+  lines.push(
+    `learning_slope=${signedFixed(curve.learning_slope, 3)}, time_to_improvement=${
+      curve.time_to_improvement === null ? "n/a" : String(curve.time_to_improvement)
+    }`,
+  );
+  lines.push("");
+  if (curve.episodes.length === 0) {
+    lines.push("_No episodes recorded._");
+    return lines.join("\n");
+  }
+  lines.push("| episode | pass_rate | Δ prev | feedback | proposals | accepted | lessons | reuse |");
+  lines.push("|--------:|----------:|-------:|---------:|----------:|---------:|--------:|------:|");
+  for (const ep of curve.episodes) {
+    lines.push(
+      `| ${ep.episode_index} | ${ep.pass_rate.toFixed(2)} | ${signedFixed(ep.delta_from_previous_episode, 2)} | ${ep.cumulative_feedback_events} | ${ep.cumulative_proposals_created} | ${ep.cumulative_proposals_accepted} | ${ep.cumulative_lessons_created} | ${
+        ep.lesson_reuse_rate === null ? "n/a" : ep.lesson_reuse_rate.toFixed(2)
+      } |`,
+    );
+  }
+  return lines.join("\n");
 }
 
 /** §6.8 — flatten the FeedbackIntegrityMetrics envelope into JSON. */
@@ -2202,6 +2280,11 @@ function buildEvolveMarkdown(input: EvolveReportInput): string {
   if (input.feedbackIntegrity) {
     lines.push("");
     lines.push(renderFeedbackIntegrityTable(input.feedbackIntegrity));
+  }
+
+  if (input.learningCurve) {
+    lines.push("");
+    lines.push(renderLearningCurveSection(input.learningCurve));
   }
 
   if (input.warnings.length > 0) {

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -162,6 +162,13 @@ export interface UtilityReportTaskEntry {
   noakm: PerTaskMetrics;
   akm: PerTaskMetrics;
   delta: CorpusDelta;
+  /**
+   * Per-task synthetic-arm metrics (#261). Present only on reports built by
+   * `runUtility({ includeSynthetic: true, ... })`. When absent the per-task
+   * row in the §13.3 envelope omits the `synthetic` key entirely so the
+   * default two-arm envelope is byte-identical to the pre-#261 output.
+   */
+  synthetic?: PerTaskMetrics;
 }
 
 /**
@@ -192,6 +199,14 @@ export interface UtilityRunReport {
   aggregateNoakm: CorpusMetrics;
   aggregateAkm: CorpusMetrics;
   aggregateDelta: CorpusDelta;
+  /**
+   * Synthetic-arm corpus aggregate (#261). Present only when `runUtility`
+   * was called with `includeSynthetic: true`. Renderers gate every
+   * synthetic-related output (`arms.synthetic`, `akm_over_synthetic_lift`,
+   * markdown subsection) on the presence of this field so the default
+   * two-arm envelope stays byte-identical to the pre-#261 shape.
+   */
+  aggregateSynth?: CorpusMetrics;
   trajectoryAkm: TrajectoryAggregate;
   /**
    * Failure-mode taxonomy aggregate (§6.6). Counts and per-task breakdown
@@ -255,11 +270,17 @@ export function renderUtilityReport(input: UtilityRunReport): { json: object; ma
 }
 
 function buildUtilityJson(input: UtilityRunReport): object {
+  const includeSynth = input.aggregateSynth !== undefined;
   const tasks = input.tasks.map((t) => ({
     id: t.id,
     noakm: serialisePerTaskMetrics(t.noakm),
     akm: serialisePerTaskMetrics(t.akm),
     delta: serialiseDelta(t.delta),
+    // #261: per-task synthetic block is emitted ONLY when the runner opted
+    // into the synthetic arm AND this task carries a synthetic aggregate.
+    // When the arm was not run we leave the key absent — a missing arm is
+    // not a zero-pass arm.
+    ...(includeSynth && t.synthetic ? { synthetic: serialisePerTaskMetrics(t.synthetic) } : {}),
   }));
 
   // Token-measurement coverage (issue #252). Folds the corpus-wide picture so
@@ -282,6 +303,17 @@ function buildUtilityJson(input: UtilityRunReport): object {
       noakm: serialiseCorpus(input.aggregateNoakm),
       akm: serialiseCorpus(input.aggregateAkm),
       delta: serialiseDelta(input.aggregateDelta),
+      // #261: synthetic aggregate is emitted ONLY when includeSynthetic
+      // was set on the runner. Absent otherwise — byte-identical to the
+      // pre-#261 envelope.
+      ...(input.aggregateSynth ? { synthetic: serialiseCorpus(input.aggregateSynth) } : {}),
+      // #261: akm_over_synthetic_lift = passRate(akm) - passRate(synthetic).
+      // Only computed when the synthetic arm ran. Positive => AKM beats the
+      // synthetic-notes baseline; non-positive flags AKM is not adding value
+      // beyond what the model can synthesise on its own.
+      ...(input.aggregateSynth
+        ? { akm_over_synthetic_lift: input.aggregateAkm.passRate - input.aggregateSynth.passRate }
+        : {}),
     },
     trajectory: {
       akm: {
@@ -472,8 +504,29 @@ function buildUtilityMarkdown(input: UtilityRunReport): string {
   lines.push("| arm | pass_rate | tokens_per_pass | wallclock_ms |");
   lines.push("|-----|-----------|-----------------|--------------|");
   lines.push(corpusRow("noakm", input.aggregateNoakm));
+  // #261: synthetic row sits between noakm and akm so the columns read
+  // baseline → synthetic → akm in the natural progression. Only rendered
+  // when the runner opted into the synthetic arm.
+  if (input.aggregateSynth) {
+    lines.push(corpusRow("synthetic", input.aggregateSynth));
+  }
   lines.push(corpusRow("akm", input.aggregateAkm));
   lines.push(deltaRow(input.aggregateDelta));
+  // #261: akm_over_synthetic_lift summary line. When AKM does not beat the
+  // synthetic baseline (lift <= 0) we surface a warning marker so operators
+  // cannot miss the regression. Otherwise we render the lift as an
+  // informative line.
+  if (input.aggregateSynth) {
+    const lift = input.aggregateAkm.passRate - input.aggregateSynth.passRate;
+    lines.push("");
+    if (lift <= 0) {
+      lines.push(
+        `:warning: **akm_over_synthetic_lift = ${signedFixed(lift, 2)}** — AKM did not beat the synthetic-notes baseline.`,
+      );
+    } else {
+      lines.push(`**akm_over_synthetic_lift: ${signedFixed(lift, 2)}**`);
+    }
+  }
   lines.push("");
   lines.push("## Trajectory (akm)");
   lines.push("");
@@ -482,12 +535,19 @@ function buildUtilityMarkdown(input: UtilityRunReport): string {
   lines.push("");
   lines.push("## Per-task pass rates");
   lines.push("");
-  lines.push("| task | noakm | akm | delta |");
-  lines.push("|------|-------|-----|-------|");
+  // #261: synthetic column is rendered only when the synthetic arm ran.
+  // The default header/row stays identical to the pre-#261 output.
+  if (input.aggregateSynth) {
+    lines.push("| task | noakm | synthetic | akm | delta |");
+    lines.push("|------|-------|-----------|-----|-------|");
+  } else {
+    lines.push("| task | noakm | akm | delta |");
+    lines.push("|------|-------|-----|-------|");
+  }
   // Sort tasks alphabetically for byte-stable markdown output.
   const sorted = [...input.tasks].sort((a, b) => a.id.localeCompare(b.id));
   for (const t of sorted) {
-    lines.push(taskRow(t));
+    lines.push(taskRow(t, input.aggregateSynth !== undefined));
   }
   // Failure-mode breakdown (§6.6). Appended near the bottom so the headline
   // pass-rate / trajectory tables stay visually anchored at the top.
@@ -594,7 +654,14 @@ function deltaRow(d: CorpusDelta): string {
   return `| **delta** | ${signed(d.passRate.toFixed(2))} | ${tpp} | ${signed(d.wallclockMs.toFixed(0))} |`;
 }
 
-function taskRow(t: UtilityReportTaskEntry): string {
+function taskRow(t: UtilityReportTaskEntry, includeSynthetic = false): string {
+  if (includeSynthetic) {
+    // #261: render the synthetic-arm pass-rate when present; "n/a" when the
+    // arm did not run for this task. A missing arm is NOT a zero-pass arm —
+    // a 0.00 cell would be misleading because the model never tried.
+    const synth = t.synthetic ? t.synthetic.passRate.toFixed(2) : "n/a";
+    return `| ${t.id} | ${t.noakm.passRate.toFixed(2)} | ${synth} | ${t.akm.passRate.toFixed(2)} | ${signed(t.delta.passRate.toFixed(2))} |`;
+  }
   return `| ${t.id} | ${t.noakm.passRate.toFixed(2)} | ${t.akm.passRate.toFixed(2)} | ${signed(t.delta.passRate.toFixed(2))} |`;
 }
 

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -17,11 +17,13 @@ import { execSync } from "node:child_process";
 import type { TaskMetadata } from "./corpus";
 import type { RunResult } from "./driver";
 import type {
+  AssetRegressionCandidateRow,
   CompareResult,
   CompareTaskRow,
   CorpusDelta,
   CorpusMetrics,
   DeltaSign,
+  DomainAggregateRow,
   FailureMode,
   FailureModeAggregate,
   FeedbackIntegrityMetrics,
@@ -34,7 +36,12 @@ import type {
   SearchBridgeMetrics,
   TrajectoryAggregate,
 } from "./metrics";
-import { histogramKeys } from "./metrics";
+import {
+  computeAssetRegressionCandidates,
+  computeDomainAggregates,
+  computeNegativeTransfer,
+  histogramKeys,
+} from "./metrics";
 
 // ── Legacy envelope (#236) ─────────────────────────────────────────────────
 
@@ -262,6 +269,17 @@ function buildUtilityJson(input: UtilityRunReport): object {
     delta: serialiseDelta(t.delta),
   }));
 
+  // Negative-transfer + domain-level diagnostics (#260). Pure post-processing
+  // off `input.tasks` and `input.akmRuns` — runner.ts is intentionally
+  // untouched so this slots in alongside the per-task entries that already
+  // carry both arms via UtilityReportTaskEntry.
+  const negativeTransfer = computeNegativeTransfer(input.tasks);
+  const domainDeltas = computeDomainAggregates(input.tasks);
+  const assetRegressionCandidates = computeAssetRegressionCandidates(
+    negativeTransfer.topRegressedTasks.map((r) => r.taskId),
+    input.akmRuns ?? [],
+  );
+
   // Token-measurement coverage (issue #252). Folds the corpus-wide picture so
   // operators can tell at a glance whether token economics are reliable. The
   // warning string mirrors what we add to `warnings[]` in markdown output.
@@ -302,6 +320,18 @@ function buildUtilityJson(input: UtilityRunReport): object {
       reliable: tokenMeasurement.reliable,
     },
     tasks,
+    negative_transfer_count: negativeTransfer.count,
+    negative_transfer_severity: negativeTransfer.severity,
+    top_regressed_tasks: negativeTransfer.topRegressedTasks.map((r) => ({
+      task_id: r.taskId,
+      domain: r.domain,
+      noakm_pass_rate: r.noakmPassRate,
+      akm_pass_rate: r.akmPassRate,
+      delta: r.delta,
+      severity: r.severity,
+    })),
+    domain_level_deltas: domainDeltas.map(serialiseDomainAggregate),
+    asset_regression_candidates: assetRegressionCandidates.map(serialiseAssetRegressionCandidate),
     warnings,
     ...(input.searchBridge ? { searchBridge: serialiseSearchBridge(input.searchBridge) } : {}),
   };
@@ -377,6 +407,44 @@ function serialiseDelta(d: CorpusDelta): { pass_rate: number; tokens_per_pass: n
     pass_rate: d.passRate,
     tokens_per_pass: d.tokensPerPass,
     wallclock_ms: d.wallclockMs,
+  };
+}
+
+/** Snake-case wire shape for one row of `domain_level_deltas` (#260). */
+function serialiseDomainAggregate(row: DomainAggregateRow): {
+  domain: string;
+  task_count: number;
+  regression_count: number;
+  pass_rate_noakm: number;
+  pass_rate_akm: number;
+  pass_rate_delta: number;
+  tokens_per_pass_delta: number | null;
+  wallclock_ms_delta: number;
+} {
+  return {
+    domain: row.domain,
+    task_count: row.taskCount,
+    regression_count: row.regressionCount,
+    pass_rate_noakm: row.passRateNoakm,
+    pass_rate_akm: row.passRateAkm,
+    pass_rate_delta: row.passRateDelta,
+    tokens_per_pass_delta: row.tokensPerPassDelta,
+    wallclock_ms_delta: row.wallclockMsDelta,
+  };
+}
+
+/** Snake-case wire shape for one row of `asset_regression_candidates` (#260). */
+function serialiseAssetRegressionCandidate(row: AssetRegressionCandidateRow): {
+  asset_ref: string;
+  regressed_task_count: number;
+  regressed_task_ids: string[];
+  total_load_count: number;
+} {
+  return {
+    asset_ref: row.assetRef,
+    regressed_task_count: row.regressedTaskCount,
+    regressed_task_ids: row.regressedTaskIds,
+    total_load_count: row.totalLoadCount,
   };
 }
 
@@ -489,6 +557,12 @@ function buildUtilityMarkdown(input: UtilityRunReport): string {
   for (const t of sorted) {
     lines.push(taskRow(t));
   }
+  // Negative-transfer + domain diagnostics (#260). The section stays quiet
+  // ("none") when no regressions were observed so green corpora don't fill
+  // the report with empty subheaders.
+  const negativeTransferSection = renderNegativeTransferSection(input);
+  lines.push("");
+  lines.push(negativeTransferSection);
   // Failure-mode breakdown (§6.6). Appended near the bottom so the headline
   // pass-rate / trajectory tables stay visually anchored at the top.
   const failureSection = renderFailureModeBreakdown(input);
@@ -865,6 +939,72 @@ export function renderFailureModeBreakdown(report: UtilityRunReport): string {
   for (const [label, count] of entries) {
     const percent = ((count / totalFailures) * 100).toFixed(1);
     lines.push(`- ${label} — ${count} (${percent}% of failed runs)`);
+  }
+  return lines.join("\n");
+}
+
+// ── Negative-transfer + domain diagnostics markdown (#260) ─────────────────
+
+/**
+ * Render the §260 negative-transfer section. Stays quiet when no
+ * regressions exist — emits a single `## Negative transfer\n\nnone` block so
+ * the report remains scannable for green corpora. When regressions exist,
+ * renders headline counts, the top-regressed-task table, the per-domain
+ * delta table, and the asset-regression-candidate table.
+ */
+export function renderNegativeTransferSection(input: UtilityRunReport): string {
+  const negativeTransfer = computeNegativeTransfer(input.tasks);
+  const lines: string[] = ["## Negative transfer", ""];
+  if (negativeTransfer.count === 0) {
+    lines.push("none");
+    return lines.join("\n");
+  }
+  lines.push(
+    `count=${negativeTransfer.count}, severity=${negativeTransfer.severity.toFixed(2)} (sum of noakm − akm pass rate over regressed tasks)`,
+  );
+  lines.push("");
+  lines.push("### Top regressed tasks");
+  lines.push("");
+  lines.push("| task | domain | noakm | akm | delta |");
+  lines.push("|------|--------|-------|-----|-------|");
+  for (const row of negativeTransfer.topRegressedTasks) {
+    lines.push(
+      `| ${row.taskId} | ${row.domain} | ${row.noakmPassRate.toFixed(2)} | ${row.akmPassRate.toFixed(2)} | ${signed(row.delta.toFixed(2))} |`,
+    );
+  }
+
+  const domainRows = computeDomainAggregates(input.tasks);
+  if (domainRows.length > 0) {
+    lines.push("");
+    lines.push("### Domain-level deltas");
+    lines.push("");
+    lines.push(
+      "| domain | tasks | regressions | noakm pass | akm pass | delta | tokens delta | wallclock delta (ms) |",
+    );
+    lines.push(
+      "|--------|-------|-------------|------------|----------|-------|--------------|----------------------|",
+    );
+    for (const row of domainRows) {
+      const tppDelta = row.tokensPerPassDelta === null ? "n/a" : signed(row.tokensPerPassDelta.toFixed(0));
+      lines.push(
+        `| ${row.domain} | ${row.taskCount} | ${row.regressionCount} | ${row.passRateNoakm.toFixed(2)} | ${row.passRateAkm.toFixed(2)} | ${signed(row.passRateDelta.toFixed(2))} | ${tppDelta} | ${signed(row.wallclockMsDelta.toFixed(0))} |`,
+      );
+    }
+  }
+
+  const candidates = computeAssetRegressionCandidates(
+    negativeTransfer.topRegressedTasks.map((r) => r.taskId),
+    input.akmRuns ?? [],
+  );
+  if (candidates.length > 0) {
+    lines.push("");
+    lines.push("### Asset regression candidates");
+    lines.push("");
+    lines.push("| asset_ref | regressed tasks | total loads |");
+    lines.push("|-----------|-----------------|-------------|");
+    for (const row of candidates) {
+      lines.push(`| \`${row.assetRef}\` | ${row.regressedTaskCount} | ${row.totalLoadCount} |`);
+    }
   }
   return lines.join("\n");
 }

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -48,6 +48,7 @@ import {
   computeNegativeTransfer,
   histogramKeys,
 } from "./metrics";
+import type { WorkflowCheckResult, WorkflowCheckStatus, WorkflowViolationCode } from "./workflow-evaluator";
 
 // ── Legacy envelope (#236) ─────────────────────────────────────────────────
 
@@ -272,6 +273,14 @@ export interface UtilityRunReport {
    * an "empty" SearchBridgeMetrics envelope renders as the N/A sentence.
    */
   searchBridge?: SearchBridgeMetrics;
+  /**
+   * Per-(akm-arm-run, spec) workflow compliance results (#257). Populated by
+   * `runUtility` when at least one workflow spec applies. Aggregated into the
+   * top-level `workflow` block at JSON-render time, and rendered as the
+   * `## Workflow compliance` markdown section. Empty array (or missing field)
+   * renders an empty `workflow` object — never crashes.
+   */
+  workflowChecks?: WorkflowCheckResult[];
 }
 
 /**
@@ -377,6 +386,7 @@ function buildUtilityJson(input: UtilityRunReport): object {
     domain_level_deltas: domainDeltas.map(serialiseDomainAggregate),
     asset_regression_candidates: assetRegressionCandidates.map(serialiseAssetRegressionCandidate),
     corpus_coverage: buildCorpusCoverageBlock(input),
+    workflow: buildWorkflowAggregate(input.workflowChecks ?? []),
     warnings,
     ...(input.searchBridge ? { searchBridge: serialiseSearchBridge(input.searchBridge) } : {}),
   };
@@ -726,6 +736,15 @@ function buildUtilityMarkdown(input: UtilityRunReport): string {
   if (input.searchBridge) {
     lines.push("");
     lines.push(renderSearchBridgeTable(input.searchBridge));
+  }
+
+  // #257: workflow compliance section. `renderWorkflowComplianceSection`
+  // returns "" when there are no checks, so we only push the blank-line
+  // separator when there's actually content to render.
+  const workflowSection = renderWorkflowComplianceSection(input);
+  if (workflowSection.length > 0) {
+    lines.push("");
+    lines.push(workflowSection);
   }
 
   // Token-measurement section (issue #252). Always rendered when there are
@@ -1101,6 +1120,456 @@ export function renderFailureModeBreakdown(report: UtilityRunReport): string {
     lines.push(`- ${label} — ${count} (${percent}% of failed runs)`);
   }
   return lines.join("\n");
+}
+
+// ── Workflow compliance aggregation (#257) ─────────────────────────────────
+
+/**
+ * Top-violation entry with enough detail to identify which (task, seed)
+ * caused each occurrence. The `evidence` array is capped at
+ * `MAX_VIOLATION_EVIDENCE` per code so a pathological corpus cannot blow up
+ * the report.
+ */
+const MAX_VIOLATION_EVIDENCE = 10;
+
+/**
+ * Maximum number of top-violation entries to surface in JSON / markdown.
+ * Operators care about the head of the distribution; the long tail is
+ * recoverable from `workflowChecks` if needed.
+ */
+const MAX_TOP_VIOLATIONS = 10;
+
+interface WorkflowViolationEvidence {
+  task_id: string;
+  arm: string;
+  seed: number;
+  workflow_id: string;
+  message?: string;
+  expected?: string;
+  observed?: string;
+}
+
+interface WorkflowTopViolation {
+  code: WorkflowViolationCode;
+  count: number;
+  evidence: WorkflowViolationEvidence[];
+}
+
+interface WorkflowPerSpecAggregate {
+  workflow_id: string;
+  count: number;
+  score: number;
+  pass_rate: number;
+  partial_rate: number;
+  fail_rate: number;
+  violation_count: number;
+}
+
+interface WorkflowOutcomeCounts {
+  pass: number;
+  partial: number;
+  fail: number;
+}
+
+interface WorkflowCrossTabRow {
+  task_outcome: string;
+  pass: number;
+  partial: number;
+  fail: number;
+  total: number;
+}
+
+interface WorkflowAggregate {
+  total_checks: number;
+  applicable_checks: number;
+  overall_compliance: number;
+  strict_pass_rate: number;
+  partial_pass_rate: number;
+  fail_rate: number;
+  violation_count: number;
+  by_workflow: Record<string, WorkflowPerSpecAggregate>;
+  top_violations: WorkflowTopViolation[];
+  cross_tab: WorkflowCrossTabRow[];
+}
+
+/**
+ * Map a workflow check `status` onto the public pass/partial/fail bucket.
+ * `not_applicable` returns `null` (excluded from the aggregate counts).
+ * `harness_error` is bucketed as `fail` so corrupt traces are visibly
+ * counted against compliance.
+ */
+function bucketWorkflowStatus(status: WorkflowCheckStatus): "pass" | "partial" | "fail" | null {
+  if (status === "pass") return "pass";
+  if (status === "partial") return "partial";
+  if (status === "fail") return "fail";
+  if (status === "harness_error") return "fail";
+  return null; // not_applicable
+}
+
+/**
+ * Compute the §257 `workflow` block from a flat list of `WorkflowCheckResult`.
+ * Empty input yields an empty (zero-filled) aggregate so JSON consumers
+ * always see the same shape.
+ */
+function buildWorkflowAggregate(checks: readonly WorkflowCheckResult[]): WorkflowAggregate {
+  const empty: WorkflowAggregate = {
+    total_checks: checks.length,
+    applicable_checks: 0,
+    overall_compliance: 0,
+    strict_pass_rate: 0,
+    partial_pass_rate: 0,
+    fail_rate: 0,
+    violation_count: 0,
+    by_workflow: {},
+    top_violations: [],
+    cross_tab: [],
+  };
+
+  if (checks.length === 0) return empty;
+
+  // Bucket counts (corpus-wide) and accumulate per-spec / per-violation /
+  // cross-tab in a single pass.
+  let strict = 0;
+  let partial = 0;
+  let fail = 0;
+  let scoreSum = 0;
+  let applicable = 0;
+  let violationCount = 0;
+
+  const perSpecAcc = new Map<
+    string,
+    { count: number; scoreSum: number; pass: number; partial: number; fail: number; violationCount: number }
+  >();
+  const violationAcc = new Map<WorkflowViolationCode, WorkflowViolationEvidence[]>();
+  const crossTabAcc = new Map<string, WorkflowOutcomeCounts>();
+  // We need each (task_outcome, run) bucketed against the WORST workflow
+  // outcome that run produced — otherwise a run with one passing and one
+  // failing spec gets double-counted across cross-tab rows. Reduce per-run.
+  const runWorstOutcome = new Map<string, { taskOutcome: string; workflowOutcome: "pass" | "partial" | "fail" }>();
+  // Track which run keys have at least one applicable check; non-applicable
+  // runs do not contribute to the cross-tab.
+  const runHasApplicable = new Set<string>();
+
+  // Collect all check identities so we can pull task_outcome from the
+  // task-side metadata. The run context inside WorkflowCheckResult does not
+  // carry the task outcome — but we can recover the dominant outcome by
+  // looking up the run's underlying outcome via the harness's enrichment
+  // map. For now, derive task outcome via worst-status semantics: the
+  // evaluator already encodes verifierFailed via run.outcome internally.
+  // The check itself does not carry outcome, so we rebuild it from
+  // `WorkflowCheckResult` with a heuristic: if any check status is
+  // `harness_error`, treat the run as failed; otherwise treat as
+  // pass (conservative — cross-tab key uses workflow-side counters).
+  // The runner stamps task outcome onto the check via `WorkflowEvalRunContext`
+  // but the check shape does not preserve it. We accept that limitation
+  // and label cross-tab rows by the `workflowChecks` evaluator's
+  // perspective: `task_outcome=pass` row counts checks emitted on
+  // run.outcome=pass via the `taskOutcome` field added below at #257.
+  // (See `attachTaskOutcomeToChecks` for the wire attribute.)
+
+  for (const c of checks) {
+    const bucket = bucketWorkflowStatus(c.status);
+    const runKey = `${c.taskId}::${c.arm}::${c.seed}`;
+
+    // Per-spec: include `not_applicable` in the spec's `count` column
+    // (operators want to see whether the spec ever fired) but exclude
+    // it from rate denominators.
+    const specEntry = perSpecAcc.get(c.workflowId) ?? {
+      count: 0,
+      scoreSum: 0,
+      pass: 0,
+      partial: 0,
+      fail: 0,
+      violationCount: 0,
+    };
+    specEntry.count += 1;
+    if (bucket !== null) {
+      specEntry.scoreSum += c.score;
+      specEntry[bucket] += 1;
+    }
+    specEntry.violationCount += c.violations.length;
+    perSpecAcc.set(c.workflowId, specEntry);
+
+    if (bucket === null) continue;
+
+    applicable += 1;
+    scoreSum += c.score;
+    violationCount += c.violations.length;
+    runHasApplicable.add(runKey);
+
+    if (bucket === "pass") strict += 1;
+    else if (bucket === "partial") partial += 1;
+    else fail += 1;
+
+    // Per-violation evidence collection. Cap evidence per code so one noisy
+    // failure mode cannot dominate the section.
+    for (const v of c.violations) {
+      const list = violationAcc.get(v.code) ?? [];
+      if (list.length < MAX_VIOLATION_EVIDENCE) {
+        const ev: WorkflowViolationEvidence = {
+          task_id: c.taskId,
+          arm: c.arm,
+          seed: c.seed,
+          workflow_id: c.workflowId,
+        };
+        if (v.message) ev.message = v.message;
+        if (v.expected !== undefined) ev.expected = v.expected;
+        if (v.observed !== undefined) ev.observed = v.observed;
+        list.push(ev);
+      }
+      violationAcc.set(v.code, list);
+    }
+
+    // Cross-tab bookkeeping: keep the WORST workflow outcome per run so we
+    // get one cell per run (not per (run × spec)).
+    const taskOutcome = readCheckTaskOutcome(c) ?? "unknown";
+    const worst = runWorstOutcome.get(runKey);
+    if (!worst) {
+      runWorstOutcome.set(runKey, { taskOutcome, workflowOutcome: bucket });
+    } else if (severityRank(bucket) > severityRank(worst.workflowOutcome)) {
+      worst.workflowOutcome = bucket;
+    }
+  }
+
+  // Reduce runWorstOutcome into the public cross_tab rows. We always emit
+  // entries for `pass` and `fail` task outcomes so the table shape is
+  // stable; additional outcomes ("budget_exceeded", "harness_error",
+  // "unknown") only appear when at least one run carried them.
+  const stableOutcomes: string[] = ["pass", "fail"];
+  for (const [, entry] of runWorstOutcome) {
+    if (!stableOutcomes.includes(entry.taskOutcome) && entry.taskOutcome !== "unknown") {
+      stableOutcomes.push(entry.taskOutcome);
+    }
+  }
+  for (const [, entry] of runWorstOutcome) {
+    const counts = crossTabAcc.get(entry.taskOutcome) ?? { pass: 0, partial: 0, fail: 0 };
+    counts[entry.workflowOutcome] += 1;
+    crossTabAcc.set(entry.taskOutcome, counts);
+  }
+
+  const cross_tab: WorkflowCrossTabRow[] = [];
+  for (const outcome of stableOutcomes) {
+    const counts = crossTabAcc.get(outcome) ?? { pass: 0, partial: 0, fail: 0 };
+    cross_tab.push({
+      task_outcome: outcome,
+      pass: counts.pass,
+      partial: counts.partial,
+      fail: counts.fail,
+      total: counts.pass + counts.partial + counts.fail,
+    });
+  }
+  // Append "unknown" row only if any run actually carried it.
+  if (crossTabAcc.has("unknown")) {
+    const counts = crossTabAcc.get("unknown") ?? { pass: 0, partial: 0, fail: 0 };
+    cross_tab.push({
+      task_outcome: "unknown",
+      pass: counts.pass,
+      partial: counts.partial,
+      fail: counts.fail,
+      total: counts.pass + counts.partial + counts.fail,
+    });
+  }
+
+  if (applicable === 0) {
+    // Every check was `not_applicable`. Surface a non-empty `by_workflow`
+    // (so operators see which specs ran) but leave the rate fields zeroed.
+    const by_workflow: Record<string, WorkflowPerSpecAggregate> = {};
+    for (const [id, e] of perSpecAcc) {
+      by_workflow[id] = {
+        workflow_id: id,
+        count: e.count,
+        score: 0,
+        pass_rate: 0,
+        partial_rate: 0,
+        fail_rate: 0,
+        violation_count: e.violationCount,
+      };
+    }
+    return {
+      total_checks: checks.length,
+      applicable_checks: 0,
+      overall_compliance: 0,
+      strict_pass_rate: 0,
+      partial_pass_rate: 0,
+      fail_rate: 0,
+      violation_count: 0,
+      by_workflow,
+      top_violations: [],
+      cross_tab,
+    };
+  }
+
+  const by_workflow: Record<string, WorkflowPerSpecAggregate> = {};
+  for (const [id, e] of perSpecAcc) {
+    const applicableForSpec = e.pass + e.partial + e.fail;
+    const score = applicableForSpec === 0 ? 0 : e.scoreSum / applicableForSpec;
+    const passRate = applicableForSpec === 0 ? 0 : e.pass / applicableForSpec;
+    const partialRate = applicableForSpec === 0 ? 0 : e.partial / applicableForSpec;
+    const failRate = applicableForSpec === 0 ? 0 : e.fail / applicableForSpec;
+    by_workflow[id] = {
+      workflow_id: id,
+      count: e.count,
+      score,
+      pass_rate: passRate,
+      partial_rate: partialRate,
+      fail_rate: failRate,
+      violation_count: e.violationCount,
+    };
+  }
+
+  // Top-violation list: sort by count desc, tie-break alphabetically by
+  // code so rendering is byte-stable.
+  const top_violations: WorkflowTopViolation[] = [];
+  for (const [code, evidence] of violationAcc) {
+    top_violations.push({
+      code,
+      count: evidence.length, // bounded; raw count below for accuracy
+      evidence,
+    });
+  }
+  // Recount: `evidence.length` is capped at MAX_VIOLATION_EVIDENCE; we want
+  // the true count for sorting/reporting. Re-derive from violationAcc by
+  // scanning checks again — cheap.
+  const trueCounts = new Map<WorkflowViolationCode, number>();
+  for (const c of checks) {
+    if (bucketWorkflowStatus(c.status) === null) continue;
+    for (const v of c.violations) {
+      trueCounts.set(v.code, (trueCounts.get(v.code) ?? 0) + 1);
+    }
+  }
+  for (const tv of top_violations) {
+    tv.count = trueCounts.get(tv.code) ?? tv.count;
+  }
+  top_violations.sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    return a.code.localeCompare(b.code);
+  });
+  const trimmedViolations = top_violations.slice(0, MAX_TOP_VIOLATIONS);
+
+  return {
+    total_checks: checks.length,
+    applicable_checks: applicable,
+    overall_compliance: scoreSum / applicable,
+    strict_pass_rate: strict / applicable,
+    partial_pass_rate: partial / applicable,
+    fail_rate: fail / applicable,
+    violation_count: violationCount,
+    by_workflow,
+    top_violations: trimmedViolations,
+    cross_tab,
+  };
+}
+
+/**
+ * Severity rank for cross-tab "WORST workflow outcome per run" reduction.
+ * fail > partial > pass.
+ */
+function severityRank(b: "pass" | "partial" | "fail"): number {
+  if (b === "fail") return 2;
+  if (b === "partial") return 1;
+  return 0;
+}
+
+/**
+ * Recover the task-level outcome that produced a check, when available.
+ * The check shape does not carry it directly; the runner stashes it on a
+ * non-public side-channel field. Returns `undefined` when no task outcome
+ * was attached (older callers, hand-written tests).
+ */
+function readCheckTaskOutcome(c: WorkflowCheckResult): string | undefined {
+  // Side-channel field added by the runner to ferry run.outcome through the
+  // check. Optional — the WorkflowCheckResult contract does not include
+  // task outcome, so we read it defensively.
+  const maybe = c as WorkflowCheckResult & { taskOutcome?: string };
+  return typeof maybe.taskOutcome === "string" ? maybe.taskOutcome : undefined;
+}
+
+/**
+ * Render the §257 `## Workflow compliance` markdown section. Returns "" when
+ * there are no checks so the report stays compact for runs without
+ * applicable workflow specs.
+ */
+export function renderWorkflowComplianceSection(input: UtilityRunReport): string {
+  const checks = input.workflowChecks ?? [];
+  const agg = buildWorkflowAggregate(checks);
+  if (agg.total_checks === 0) return "";
+
+  const lines: string[] = [];
+  lines.push("## Workflow compliance");
+  lines.push("");
+  if (agg.applicable_checks === 0) {
+    lines.push("_No workflow specs applied to this corpus._");
+    if (Object.keys(agg.by_workflow).length > 0) {
+      lines.push("");
+      lines.push("Loaded specs (none matched the run): " + Object.keys(agg.by_workflow).sort().join(", "));
+    }
+    return lines.join("\n");
+  }
+
+  lines.push(
+    `overall_compliance=${agg.overall_compliance.toFixed(2)}, ` +
+      `strict_pass_rate=${agg.strict_pass_rate.toFixed(2)}, ` +
+      `partial_pass_rate=${agg.partial_pass_rate.toFixed(2)}, ` +
+      `fail_rate=${agg.fail_rate.toFixed(2)}, ` +
+      `violations=${agg.violation_count}`,
+  );
+  lines.push("");
+  lines.push("### By workflow");
+  lines.push("");
+  lines.push("| workflow_id | applicable | score | pass | partial | fail | violations |");
+  lines.push("|-------------|-----------:|------:|-----:|--------:|-----:|-----------:|");
+  const sortedSpecs = Object.values(agg.by_workflow).sort((a, b) => a.workflow_id.localeCompare(b.workflow_id));
+  for (const spec of sortedSpecs) {
+    lines.push(
+      `| ${spec.workflow_id} | ${spec.count} | ${spec.score.toFixed(2)} | ${spec.pass_rate.toFixed(2)} | ${spec.partial_rate.toFixed(2)} | ${spec.fail_rate.toFixed(2)} | ${spec.violation_count} |`,
+    );
+  }
+
+  if (agg.top_violations.length > 0) {
+    lines.push("");
+    lines.push("### Top violations");
+    lines.push("");
+    lines.push("| code | count |");
+    lines.push("|------|------:|");
+    for (const tv of agg.top_violations) {
+      lines.push(`| ${tv.code} | ${tv.count} |`);
+    }
+    // Surface the first evidence pointer per top-violation so operators can
+    // jump to a concrete (task, seed) without parsing the JSON envelope.
+    lines.push("");
+    lines.push("### Violation evidence");
+    lines.push("");
+    lines.push("| code | task | seed | workflow | observed |");
+    lines.push("|------|------|-----:|----------|----------|");
+    for (const tv of agg.top_violations) {
+      for (const ev of tv.evidence) {
+        const observed = ev.observed ?? ev.message ?? "";
+        lines.push(`| ${tv.code} | ${ev.task_id} | ${ev.seed} | ${ev.workflow_id} | ${truncateCell(observed)} |`);
+      }
+    }
+  }
+
+  if (agg.cross_tab.length > 0) {
+    lines.push("");
+    lines.push("### Task outcome × workflow outcome");
+    lines.push("");
+    lines.push("| task_outcome | wf_pass | wf_partial | wf_fail | total |");
+    lines.push("|--------------|--------:|-----------:|--------:|------:|");
+    for (const row of agg.cross_tab) {
+      lines.push(`| ${row.task_outcome} | ${row.pass} | ${row.partial} | ${row.fail} | ${row.total} |`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Trim a single cell so the markdown table stays scannable. We keep the
+ * head 80 chars and append `…` when clamped.
+ */
+function truncateCell(s: string): string {
+  if (s.length <= 80) return s.replace(/\|/g, "\\|");
+  return `${s.slice(0, 80).replace(/\|/g, "\\|")}…`;
 }
 
 // ── Negative-transfer + domain diagnostics markdown (#260) ─────────────────

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -1439,23 +1439,6 @@ function buildWorkflowAggregate(checks: readonly WorkflowCheckResult[]): Workflo
   // runs do not contribute to the cross-tab.
   const runHasApplicable = new Set<string>();
 
-  // Collect all check identities so we can pull task_outcome from the
-  // task-side metadata. The run context inside WorkflowCheckResult does not
-  // carry the task outcome — but we can recover the dominant outcome by
-  // looking up the run's underlying outcome via the harness's enrichment
-  // map. For now, derive task outcome via worst-status semantics: the
-  // evaluator already encodes verifierFailed via run.outcome internally.
-  // The check itself does not carry outcome, so we rebuild it from
-  // `WorkflowCheckResult` with a heuristic: if any check status is
-  // `harness_error`, treat the run as failed; otherwise treat as
-  // pass (conservative — cross-tab key uses workflow-side counters).
-  // The runner stamps task outcome onto the check via `WorkflowEvalRunContext`
-  // but the check shape does not preserve it. We accept that limitation
-  // and label cross-tab rows by the `workflowChecks` evaluator's
-  // perspective: `task_outcome=pass` row counts checks emitted on
-  // run.outcome=pass via the `taskOutcome` field added below at #257.
-  // (See `attachTaskOutcomeToChecks` for the wire attribute.)
-
   for (const c of checks) {
     const bucket = bucketWorkflowStatus(c.status);
     const runKey = `${c.taskId}::${c.arm}::${c.seed}`;
@@ -1668,11 +1651,7 @@ function severityRank(b: "pass" | "partial" | "fail"): number {
  * was attached (older callers, hand-written tests).
  */
 function readCheckTaskOutcome(c: WorkflowCheckResult): string | undefined {
-  // Side-channel field added by the runner to ferry run.outcome through the
-  // check. Optional — the WorkflowCheckResult contract does not include
-  // task outcome, so we read it defensively.
-  const maybe = c as WorkflowCheckResult & { taskOutcome?: string };
-  return typeof maybe.taskOutcome === "string" ? maybe.taskOutcome : undefined;
+  return typeof c.taskOutcome === "string" ? c.taskOutcome : undefined;
 }
 
 /**
@@ -1692,7 +1671,7 @@ export function renderWorkflowComplianceSection(input: UtilityRunReport): string
     lines.push("_No workflow specs applied to this corpus._");
     if (Object.keys(agg.by_workflow).length > 0) {
       lines.push("");
-      lines.push("Loaded specs (none matched the run): " + Object.keys(agg.by_workflow).sort().join(", "));
+      lines.push(`Loaded specs (none matched the run): ${Object.keys(agg.by_workflow).sort().join(", ")}`);
     }
     return lines.join("\n");
   }

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -50,7 +50,10 @@ import {
   computeCorpusCoverage,
   computeDomainAggregates,
   computeNegativeTransfer,
+  computeWorkflowReliability,
   histogramKeys,
+  type WorkflowReliabilityCorpus,
+  type WorkflowReliabilityRow,
 } from "./metrics";
 import type { WorkflowCheckResult, WorkflowCheckStatus, WorkflowViolationCode } from "./workflow-evaluator";
 
@@ -1342,6 +1345,16 @@ interface WorkflowCrossTabRow {
   total: number;
 }
 
+/**
+ * Workflow reliability sub-block (#258) attached under the existing #257
+ * `workflow` envelope. Always present; `corpus.groups === 0` and an empty
+ * `by_workflow` record indicate "no applicable checks contributed".
+ */
+interface WorkflowReliabilityBlock {
+  by_workflow: Record<string, WorkflowReliabilityRow>;
+  corpus: WorkflowReliabilityCorpus;
+}
+
 interface WorkflowAggregate {
   total_checks: number;
   applicable_checks: number;
@@ -1353,6 +1366,8 @@ interface WorkflowAggregate {
   by_workflow: Record<string, WorkflowPerSpecAggregate>;
   top_violations: WorkflowTopViolation[];
   cross_tab: WorkflowCrossTabRow[];
+  /** #258 reliability metrics (pass@k / pass^k). */
+  reliability: WorkflowReliabilityBlock;
 }
 
 /**
@@ -1375,6 +1390,14 @@ function bucketWorkflowStatus(status: WorkflowCheckStatus): "pass" | "partial" |
  * always see the same shape.
  */
 function buildWorkflowAggregate(checks: readonly WorkflowCheckResult[]): WorkflowAggregate {
+  // #258: Compute reliability up front so all early-return paths share the
+  // same shape. Reliability tolerates empty input (`groups === 0`).
+  const reliabilityResult = computeWorkflowReliability(checks);
+  const reliability: WorkflowReliabilityBlock = {
+    by_workflow: reliabilityResult.byWorkflow,
+    corpus: reliabilityResult.corpus,
+  };
+
   const empty: WorkflowAggregate = {
     total_checks: checks.length,
     applicable_checks: 0,
@@ -1386,6 +1409,7 @@ function buildWorkflowAggregate(checks: readonly WorkflowCheckResult[]): Workflo
     by_workflow: {},
     top_violations: [],
     cross_tab: [],
+    reliability,
   };
 
   if (checks.length === 0) return empty;
@@ -1559,6 +1583,7 @@ function buildWorkflowAggregate(checks: readonly WorkflowCheckResult[]): Workflo
       by_workflow,
       top_violations: [],
       cross_tab,
+      reliability,
     };
   }
 
@@ -1620,6 +1645,7 @@ function buildWorkflowAggregate(checks: readonly WorkflowCheckResult[]): Workflo
     by_workflow,
     top_violations: trimmedViolations,
     cross_tab,
+    reliability,
   };
 }
 
@@ -1720,6 +1746,51 @@ export function renderWorkflowComplianceSection(input: UtilityRunReport): string
     lines.push("|--------------|--------:|-----------:|--------:|------:|");
     for (const row of agg.cross_tab) {
       lines.push(`| ${row.task_outcome} | ${row.pass} | ${row.partial} | ${row.fail} | ${row.total} |`);
+    }
+  }
+
+  // #258: Reliability sub-section. Skip when no group contributed (all
+  // checks were `not_applicable` or input was empty).
+  const reliability = agg.reliability;
+  if (reliability.corpus.groups > 0) {
+    lines.push("");
+    lines.push("### Reliability (pass@k / pass^k)");
+    lines.push("");
+    lines.push(
+      `corpus pass@k=${reliability.corpus.pass_at_k.toFixed(2)}, ` +
+        `pass^k=${reliability.corpus.pass_all_k.toFixed(2)} ` +
+        `(over ${reliability.corpus.groups} workflow×task groups, ${reliability.corpus.tasks} distinct tasks)`,
+    );
+    lines.push("");
+    lines.push("| workflow_id | tasks | k | pass@k | pass^k |");
+    lines.push("|-------------|------:|--:|-------:|-------:|");
+    const sortedReliability = Object.values(reliability.by_workflow).sort((a, b) =>
+      a.workflow_id.localeCompare(b.workflow_id),
+    );
+    for (const row of sortedReliability) {
+      lines.push(
+        `| ${row.workflow_id} | ${row.tasks} | ${row.k} | ${row.pass_at_k.toFixed(2)} | ${row.pass_all_k.toFixed(2)} |`,
+      );
+    }
+    // Inconsistency callout: workflows where the agent CAN comply
+    // (pass@k high) but does not RELIABLY comply (pass^k materially lower).
+    // Threshold: pass@k ≥ 0.5 AND (pass@k − pass^k) ≥ 0.25.
+    const INCONSISTENCY_GAP = 0.25;
+    const PASS_AT_K_FLOOR = 0.5;
+    const inconsistent = sortedReliability.filter(
+      (r) => r.pass_at_k >= PASS_AT_K_FLOOR && r.pass_at_k - r.pass_all_k >= INCONSISTENCY_GAP,
+    );
+    if (inconsistent.length > 0) {
+      lines.push("");
+      lines.push("**Inconsistent workflows** (high pass@k but low pass^k — agent can comply but does not reliably):");
+      lines.push("");
+      for (const row of inconsistent) {
+        lines.push(
+          `- \`${row.workflow_id}\`: pass@k=${row.pass_at_k.toFixed(2)} vs pass^k=${row.pass_all_k.toFixed(2)} (gap ${(
+            row.pass_at_k - row.pass_all_k
+          ).toFixed(2)})`,
+        );
+      }
     }
   }
 

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -16,6 +16,7 @@
 import { execSync } from "node:child_process";
 import type { MemoryAbility, TaskMetadata } from "./corpus";
 import type { RunResult } from "./driver";
+import type { LessonMetrics, LessonRecord } from "./evolve-metrics";
 import type {
   AssetRegressionCandidateRow,
   CategoryAggregateRow,
@@ -1919,6 +1920,12 @@ export interface EvolveReportInput {
   domain: string;
   seedsPerArm: number;
   proposals: ProposalQualityMetrics;
+  /**
+   * Per-lesson quality + reuse metrics (#264). Optional so older artefacts
+   * pre-#264 keep rendering without the `lessons` JSON block. When omitted,
+   * the markdown summary skips the lessons section entirely.
+   */
+  lessons?: LessonMetrics;
   longitudinal: LongitudinalMetrics;
   /**
    * Feedback-signal integrity 2x2 confusion matrix (§6.8). When omitted,
@@ -1991,6 +1998,7 @@ function buildEvolveJson(input: EvolveReportInput): object {
         accepted_count: r.acceptedCount,
       })),
     },
+    ...(input.lessons ? { lessons: serialiseLessons(input.lessons) } : {}),
     longitudinal: {
       improvement_slope: input.longitudinal.improvementSlope,
       over_synthetic_lift: input.longitudinal.overSyntheticLift,
@@ -2033,6 +2041,34 @@ function buildEvolveJson(input: EvolveReportInput): object {
   };
 }
 
+/**
+ * #264 — flatten the LessonMetrics envelope into JSON. Aggregate counters
+ * sit alongside `lessons[]` so consumers can pick the headline numbers off
+ * without walking every row.
+ */
+function serialiseLessons(metrics: LessonMetrics): object {
+  return {
+    lessons_created_count: metrics.lessons_created_count,
+    lessons_accepted_count: metrics.lessons_accepted_count,
+    proposal_lint_pass_rate: metrics.proposal_lint_pass_rate,
+    proposal_acceptance_rate: metrics.proposal_acceptance_rate,
+    lesson_reuse_rate: metrics.lesson_reuse_rate,
+    lesson_reuse_success_rate: metrics.lesson_reuse_success_rate,
+    lesson_negative_transfer_count: metrics.lesson_negative_transfer_count,
+    lessons: metrics.lessons.map((l: LessonRecord) => ({
+      ref: l.ref,
+      source_failures: l.source_failures,
+      lint_pass: l.lint_pass,
+      accepted: l.accepted,
+      first_reused_on: l.first_reused_on,
+      reuse_count: l.reuse_count,
+      reuse_pass_rate: l.reuse_pass_rate,
+      negative_transfer_count: l.negative_transfer_count,
+      leakage_risk: l.leakage_risk,
+    })),
+  };
+}
+
 /** §6.8 — flatten the FeedbackIntegrityMetrics envelope into JSON. */
 function serialiseFeedbackIntegrity(metrics: FeedbackIntegrityMetrics): object {
   return {
@@ -2057,6 +2093,33 @@ function serialiseFeedbackIntegrity(metrics: FeedbackIntegrityMetrics): object {
       false_negative_rate: row.false_negative_rate,
     })),
   };
+}
+
+/**
+ * Render the #264 lessons block — aggregate counters followed by one row
+ * per lesson. Exported for tests so the rendered shape can be asserted
+ * directly without going through `renderEvolveReport`.
+ */
+export function renderLessonsTable(metrics: LessonMetrics): string {
+  const lines: string[] = [];
+  lines.push("## Lessons");
+  lines.push("");
+  lines.push(
+    `created=${metrics.lessons_created_count}, accepted=${metrics.lessons_accepted_count}, reuse_rate=${metrics.lesson_reuse_rate.toFixed(2)}, reuse_success_rate=${metrics.lesson_reuse_success_rate.toFixed(2)}, negative_transfer=${metrics.lesson_negative_transfer_count}`,
+  );
+  lines.push("");
+  if (metrics.lessons.length === 0) {
+    lines.push("_No lessons generated._");
+    return lines.join("\n");
+  }
+  lines.push("| ref | accepted | lint | reuse | reuse_pass | first_reused_on | neg_transfer | leakage |");
+  lines.push("|-----|----------|------|-------|------------|-----------------|--------------|---------|");
+  for (const l of metrics.lessons) {
+    lines.push(
+      `| \`${l.ref}\` | ${l.accepted ? "yes" : "no"} | ${l.lint_pass ? "pass" : "fail"} | ${l.reuse_count} | ${l.reuse_pass_rate.toFixed(2)} | ${l.first_reused_on ?? "n/a"} | ${l.negative_transfer_count} | ${l.leakage_risk} |`,
+    );
+  }
+  return lines.join("\n");
 }
 
 /**
@@ -2175,6 +2238,11 @@ function buildEvolveMarkdown(input: EvolveReportInput): string {
     lines.push("");
   } else {
     lines.push("_No proposals generated._");
+    lines.push("");
+  }
+
+  if (input.lessons) {
+    lines.push(renderLessonsTable(input.lessons));
     lines.push("");
   }
 

--- a/tests/bench/report.ts
+++ b/tests/bench/report.ts
@@ -40,8 +40,12 @@ import type {
   TrajectoryAggregate,
 } from "./metrics";
 import {
+  type AkmOverheadAggregate,
+  type AkmOverheadPerRun,
+  aggregateAkmOverhead,
   aggregateByMemoryAbility,
   aggregateByTaskFamily,
+  computeAkmOverhead,
   computeAssetRegressionCandidates,
   computeCorpusCoverage,
   computeDomainAggregates,
@@ -405,7 +409,158 @@ function buildUtilityJson(input: UtilityRunReport): object {
     };
   }
 
+  // AKM overhead + tool-use efficiency block (#263). Computed from the akm-
+  // arm RunResults attached to the report; missing akmRuns yields an empty
+  // aggregate so the key shape stays stable.
+  envelope.akm_overhead = buildAkmOverheadBlock(input);
+
   return envelope;
+}
+
+// ── AKM overhead block (#263) ──────────────────────────────────────────────
+
+/**
+ * Build the §13.3 `akm_overhead` block from the akm-arm RunResults and (when
+ * supplied) per-task metadata. `taskMetadata` lets us split irrelevant from
+ * relevant asset loads and compute time-to-first-correct-asset; without it
+ * those fields surface as `null` rather than misleading zeros.
+ */
+function buildAkmOverheadBlock(input: UtilityRunReport): {
+  per_run: ReturnType<typeof serialiseAkmOverheadPerRun>[];
+  aggregate: ReturnType<typeof serialiseAkmOverheadAggregate>;
+} {
+  const akmRuns = input.akmRuns ?? [];
+  const meta = new Map<string, Pick<TaskMetadata, "goldRef" | "expectedTransferFrom">>();
+  for (const t of input.taskMetadata ?? []) {
+    meta.set(t.id, { goldRef: t.goldRef, expectedTransferFrom: t.expectedTransferFrom });
+  }
+  const perRun = computeAkmOverhead(akmRuns, { taskMetadata: meta });
+  const aggregate = aggregateAkmOverhead(perRun, akmRuns);
+  return {
+    per_run: perRun.map(serialiseAkmOverheadPerRun),
+    aggregate: serialiseAkmOverheadAggregate(aggregate),
+  };
+}
+
+function serialiseAkmOverheadPerRun(row: AkmOverheadPerRun): {
+  task_id: string;
+  arm: string;
+  seed: number;
+  outcome: string;
+  search_count: number;
+  show_count: number;
+  feedback_count: number;
+  total_tool_calls: number;
+  assets_loaded_count: number;
+  irrelevant_assets_loaded_count: number | null;
+  time_to_first_search_ms: number | null;
+  time_to_first_correct_asset_ms: number | null;
+  context_bytes_loaded: number | null;
+  asset_bytes_loaded: number | null;
+} {
+  return {
+    task_id: row.taskId,
+    arm: row.arm,
+    seed: row.seed,
+    outcome: row.outcome,
+    search_count: row.searchCount,
+    show_count: row.showCount,
+    feedback_count: row.feedbackCount,
+    total_tool_calls: row.totalToolCalls,
+    assets_loaded_count: row.assetsLoadedCount,
+    irrelevant_assets_loaded_count: row.irrelevantAssetsLoadedCount,
+    time_to_first_search_ms: row.timeToFirstSearchMs,
+    time_to_first_correct_asset_ms: row.timeToFirstCorrectAssetMs,
+    context_bytes_loaded: row.contextBytesLoaded,
+    asset_bytes_loaded: row.assetBytesLoaded,
+  };
+}
+
+function serialiseAkmOverheadAggregate(agg: AkmOverheadAggregate): {
+  total_runs: number;
+  passing_runs: number;
+  mean_search_count: number;
+  mean_show_count: number;
+  mean_feedback_count: number;
+  mean_tool_calls: number;
+  mean_assets_loaded: number;
+  mean_irrelevant_assets_loaded: number | null;
+  mean_time_to_first_search_ms: number | null;
+  mean_time_to_first_correct_asset_ms: number | null;
+  mean_context_bytes_loaded: number | null;
+  mean_asset_bytes_loaded: number | null;
+  total_tool_calls: number;
+  tool_calls_per_success: number | null;
+  cost_per_success: number | null;
+} {
+  return {
+    total_runs: agg.totalRuns,
+    passing_runs: agg.passingRuns,
+    mean_search_count: agg.meanSearchCount,
+    mean_show_count: agg.meanShowCount,
+    mean_feedback_count: agg.meanFeedbackCount,
+    mean_tool_calls: agg.meanToolCalls,
+    mean_assets_loaded: agg.meanAssetsLoaded,
+    mean_irrelevant_assets_loaded: agg.meanIrrelevantAssetsLoaded,
+    mean_time_to_first_search_ms: agg.meanTimeToFirstSearchMs,
+    mean_time_to_first_correct_asset_ms: agg.meanTimeToFirstCorrectAssetMs,
+    mean_context_bytes_loaded: agg.meanContextBytesLoaded,
+    mean_asset_bytes_loaded: agg.meanAssetBytesLoaded,
+    total_tool_calls: agg.totalToolCalls,
+    tool_calls_per_success: agg.toolCallsPerSuccess,
+    cost_per_success: agg.costPerSuccess,
+  };
+}
+
+/**
+ * Render the §13.3 AKM overhead summary as a compact markdown section (#263).
+ * Skipped entirely when the corpus had no akm-arm runs so the report stays
+ * tight on the no-akm code path.
+ */
+export function renderAkmOverheadSection(input: UtilityRunReport): string {
+  const akmRuns = input.akmRuns ?? [];
+  if (akmRuns.length === 0) return "";
+  const meta = new Map<string, Pick<TaskMetadata, "goldRef" | "expectedTransferFrom">>();
+  for (const t of input.taskMetadata ?? []) {
+    meta.set(t.id, { goldRef: t.goldRef, expectedTransferFrom: t.expectedTransferFrom });
+  }
+  const perRun = computeAkmOverhead(akmRuns, { taskMetadata: meta });
+  const agg = aggregateAkmOverhead(perRun, akmRuns);
+  const lines: string[] = [];
+  lines.push("## AKM overhead");
+  lines.push("");
+  lines.push(`- runs: ${agg.totalRuns} (${agg.passingRuns} passed)`);
+  lines.push(
+    `- tool calls: search=${formatMean(agg.meanSearchCount)} show=${formatMean(agg.meanShowCount)} feedback=${formatMean(agg.meanFeedbackCount)} (mean per run)`,
+  );
+  lines.push(`- total tool calls: ${agg.totalToolCalls} (mean ${formatMean(agg.meanToolCalls)} per run)`);
+  lines.push(
+    `- tool_calls_per_success: ${agg.toolCallsPerSuccess === null ? "n/a" : formatMean(agg.toolCallsPerSuccess)}`,
+  );
+  lines.push(`- assets loaded (mean unique per run): ${formatMean(agg.meanAssetsLoaded)}`);
+  lines.push(`- irrelevant assets loaded (mean per tagged run): ${formatNullableMean(agg.meanIrrelevantAssetsLoaded)}`);
+  lines.push(`- time_to_first_search: ${formatNullableMs(agg.meanTimeToFirstSearchMs)}`);
+  lines.push(`- time_to_first_correct_asset: ${formatNullableMs(agg.meanTimeToFirstCorrectAssetMs)}`);
+  lines.push(`- context_bytes_loaded: ${formatNullableBytes(agg.meanContextBytesLoaded)}`);
+  lines.push(`- asset_bytes_loaded: ${formatNullableBytes(agg.meanAssetBytesLoaded)}`);
+  lines.push(`- cost_per_success: ${agg.costPerSuccess === null ? "n/a" : formatMean(agg.costPerSuccess)} tokens`);
+  return lines.join("\n");
+}
+
+function formatMean(value: number): string {
+  return value.toFixed(2);
+}
+
+function formatNullableMean(value: number | null): string {
+  return value === null ? "n/a" : value.toFixed(2);
+}
+
+function formatNullableMs(value: number | null): string {
+  return value === null ? "n/a" : `${Math.round(value)}ms`;
+}
+
+function formatNullableBytes(value: number | null): string {
+  return value === null ? "n/a" : `${Math.round(value)} bytes`;
 }
 
 /**
@@ -726,6 +881,14 @@ function buildUtilityMarkdown(input: UtilityRunReport): string {
   if (input.searchBridge) {
     lines.push("");
     lines.push(renderSearchBridgeTable(input.searchBridge));
+  }
+
+  // AKM overhead + tool-use efficiency (#263). Skipped when the corpus had
+  // no akm-arm runs so the report stays compact on the no-akm path.
+  const overheadSection = renderAkmOverheadSection(input);
+  if (overheadSection.length > 0) {
+    lines.push("");
+    lines.push(overheadSection);
   }
 
   // Token-measurement section (issue #252). Always rendered when there are

--- a/tests/bench/runner.test.ts
+++ b/tests/bench/runner.test.ts
@@ -837,9 +837,104 @@ describe("runUtility workflow compliance (#257)", () => {
       spawn,
       materialiseStash: false,
     });
-    type CheckWithTaskOutcome = (typeof report.workflowChecks)[number] & { taskOutcome?: string };
-    const c = (report.workflowChecks ?? [])[0] as CheckWithTaskOutcome | undefined;
+    const c = (report.workflowChecks ?? [])[0];
     expect(c).toBeDefined();
     expect(typeof c?.taskOutcome).toBe("string");
+  });
+
+  test("passes search/result and test-presence flags into workflow evaluation", async () => {
+    const workflowsDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-bench-workflow-flags-"));
+    const spawn: SpawnFn = (cmd, opts) => {
+      const isAgent = cmd[0] === "opencode";
+      if (isAgent && opts.env?.XDG_CACHE_HOME) {
+        const akmDir = path.join(opts.env.XDG_CACHE_HOME, "akm");
+        fs.mkdirSync(akmDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(akmDir, "events.jsonl"),
+          [
+            JSON.stringify({
+              schemaVersion: 1,
+              ts: "2026-04-27T00:00:00Z",
+              eventType: "search",
+              metadata: { query: "deploy", resultRefs: ["skill:foo"] },
+            }),
+            JSON.stringify({
+              schemaVersion: 1,
+              ts: "2026-04-27T00:00:01Z",
+              eventType: "propose_invoked",
+            }),
+            JSON.stringify({
+              schemaVersion: 1,
+              ts: "2026-04-27T00:00:02Z",
+              eventType: "promoted",
+            }),
+          ].join("\n"),
+        );
+      }
+      return {
+        exitCode: 0,
+        exited: Promise.resolve(0),
+        stdout: asReadableStream("ok"),
+        stderr: asReadableStream(""),
+        stdin: null,
+        kill() {},
+      };
+    };
+    try {
+      fs.writeFileSync(
+        path.join(workflowsDir, "search.yaml"),
+        `id: search-guard
+title: search guard
+applies_to:
+  arms: ["akm"]
+required_sequence:
+  - event: akm_search
+  - event: akm_show
+    required_if: search_has_relevant_result
+scoring:
+  required_steps_weight: 0.7
+  forbidden_steps_weight: 0.2
+  evidence_quality_weight: 0.1
+`,
+        "utf8",
+      );
+      fs.writeFileSync(
+        path.join(workflowsDir, "tests.yaml"),
+        `id: tests-guard
+title: tests guard
+applies_to:
+  arms: ["akm"]
+required_sequence:
+  - event: akm_propose
+  - event: test_run
+    required_if: task_has_tests
+  - event: akm_proposal_accept
+scoring:
+  required_steps_weight: 0.7
+  forbidden_steps_weight: 0.2
+  evidence_quality_weight: 0.1
+`,
+        "utf8",
+      );
+      const testsDir = path.join(taskDir, "tests");
+      fs.mkdirSync(testsDir, { recursive: true });
+      fs.writeFileSync(path.join(testsDir, "test_sample.py"), "def test_ok():\n    assert True\n");
+
+      const report = await runUtility({
+        tasks: [fakeTask(taskDir, { verifier: "pytest", goldRef: "skill:foo" })],
+        arms: ["akm"],
+        model: "test",
+        seedsPerArm: 1,
+        spawn,
+        materialiseStash: false,
+        workflowsDir,
+      });
+      const byId = new Map((report.workflowChecks ?? []).map((check) => [check.workflowId, check]));
+      expect(byId.get("search-guard")?.violations.some((v) => v.code === "missing_required_event")).toBe(true);
+      expect(byId.get("tests-guard")?.violations.some((v) => v.code === "missing_required_event")).toBe(true);
+    } finally {
+      fs.rmSync(workflowsDir, { recursive: true, force: true });
+      fs.rmSync(path.join(taskDir, "tests"), { recursive: true, force: true });
+    }
   });
 });

--- a/tests/bench/runner.test.ts
+++ b/tests/bench/runner.test.ts
@@ -937,4 +937,83 @@ scoring:
       fs.rmSync(path.join(taskDir, "tests"), { recursive: true, force: true });
     }
   });
+
+  test("skips required_if workflow steps when runner-derived flags are false", async () => {
+    const workflowsDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-bench-workflow-flags-off-"));
+    const spawn: SpawnFn = (cmd, opts) => {
+      const isAgent = cmd[0] === "opencode";
+      if (isAgent && opts.env?.XDG_CACHE_HOME) {
+        const akmDir = path.join(opts.env.XDG_CACHE_HOME, "akm");
+        fs.mkdirSync(akmDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(akmDir, "events.jsonl"),
+          `${JSON.stringify({
+            schemaVersion: 1,
+            ts: "2026-04-27T00:00:00Z",
+            eventType: "search",
+            metadata: { query: "deploy", resultRefs: ["skill:other"] },
+          })}\n`,
+        );
+      }
+      return {
+        exitCode: 0,
+        exited: Promise.resolve(0),
+        stdout: asReadableStream("ok"),
+        stderr: asReadableStream(""),
+        stdin: null,
+        kill() {},
+      };
+    };
+    try {
+      fs.writeFileSync(
+        path.join(workflowsDir, "search.yaml"),
+        `id: search-guard
+title: search guard
+applies_to:
+  arms: ["akm"]
+required_sequence:
+  - event: akm_search
+  - event: akm_show
+    required_if: search_has_relevant_result
+scoring:
+  required_steps_weight: 0.7
+  forbidden_steps_weight: 0.2
+  evidence_quality_weight: 0.1
+`,
+        "utf8",
+      );
+      fs.writeFileSync(
+        path.join(workflowsDir, "tests.yaml"),
+        `id: tests-guard
+title: tests guard
+applies_to:
+  arms: ["akm"]
+required_sequence:
+  - event: akm_search
+  - event: test_run
+    required_if: task_has_tests
+scoring:
+  required_steps_weight: 0.7
+  forbidden_steps_weight: 0.2
+  evidence_quality_weight: 0.1
+`,
+        "utf8",
+      );
+
+      const report = await runUtility({
+        tasks: [fakeTask(taskDir, { verifier: "regex", goldRef: "skill:foo" })],
+        arms: ["akm"],
+        model: "test",
+        seedsPerArm: 1,
+        spawn,
+        materialiseStash: false,
+        workflowsDir,
+      });
+      const byId = new Map((report.workflowChecks ?? []).map((check) => [check.workflowId, check]));
+      expect(byId.get("search-guard")?.status).toBe("pass");
+      expect(byId.get("tests-guard")?.status).toBe("pass");
+    } finally {
+      fs.rmSync(workflowsDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/bench/runner.test.ts
+++ b/tests/bench/runner.test.ts
@@ -754,3 +754,92 @@ describe("runUtility", () => {
     expect(markdown).toContain("AKM did not beat the synthetic-notes baseline");
   });
 });
+
+// ── Workflow compliance plumbing (#257) ────────────────────────────────────
+
+describe("runUtility workflow compliance (#257)", () => {
+  let workspaceRoot: string;
+  let taskDir: string;
+
+  beforeAll(() => {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bench-runner-wf-"));
+    taskDir = path.join(workspaceRoot, "task");
+    fs.mkdirSync(taskDir, { recursive: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  test("loads workflow specs from the default directory and stamps workflowChecks on the report", async () => {
+    const { spawn } = fakeSpawnFactory({ noakm: "ok", akm: "ok" });
+    const report = await runUtility({
+      tasks: [
+        // domain-name needs to match a task_domain in at least one shipping spec
+        // so the evaluator emits applicable checks (not_applicable rows are
+        // expected for the rest).
+        fakeTask(taskDir, { id: "docker-homelab/redis", domain: "docker-homelab" }),
+      ],
+      arms: ["akm"],
+      model: "test",
+      seedsPerArm: 1,
+      spawn,
+      materialiseStash: false,
+    });
+    expect(Array.isArray(report.workflowChecks)).toBe(true);
+    // At least one shipping spec applies to docker-homelab → some checks emitted.
+    expect((report.workflowChecks ?? []).length).toBeGreaterThan(0);
+  });
+
+  test("workflowsDir: '' disables workflow evaluation and yields no workflowChecks", async () => {
+    const { spawn } = fakeSpawnFactory({ noakm: "ok", akm: "ok" });
+    const report = await runUtility({
+      tasks: [fakeTask(taskDir)],
+      arms: ["akm"],
+      model: "test",
+      seedsPerArm: 1,
+      spawn,
+      materialiseStash: false,
+      workflowsDir: "",
+    });
+    expect(report.workflowChecks).toEqual([]);
+  });
+
+  test("missing workflowsDir is recorded as a warning, not a crash", async () => {
+    const { setQuiet, resetQuiet } = await import("../../src/core/warn");
+    setQuiet(true);
+    try {
+      const { spawn } = fakeSpawnFactory({ noakm: "ok", akm: "ok" });
+      const report = await runUtility({
+        tasks: [fakeTask(taskDir)],
+        arms: ["akm"],
+        model: "test",
+        seedsPerArm: 1,
+        spawn,
+        materialiseStash: false,
+        workflowsDir: "/path/that/does/not/exist",
+      });
+      expect(report.workflowChecks).toEqual([]);
+      const hasWarn = report.warnings.some((w) => w.includes("workflow specs"));
+      expect(hasWarn).toBe(true);
+    } finally {
+      resetQuiet();
+    }
+  });
+
+  test("runner attaches taskOutcome to each workflowCheck so the cross-tab can attribute it", async () => {
+    const { spawn } = fakeSpawnFactory({ noakm: "ok", akm: "ok" });
+    const report = await runUtility({
+      tasks: [fakeTask(taskDir, { id: "docker-homelab/redis", domain: "docker-homelab" })],
+      arms: ["akm"],
+      model: "test",
+      seedsPerArm: 1,
+      spawn,
+      materialiseStash: false,
+    });
+    type CheckWithTaskOutcome = (typeof report.workflowChecks)[number] & { taskOutcome?: string };
+    const c = (report.workflowChecks ?? [])[0] as CheckWithTaskOutcome | undefined;
+    expect(c).toBeDefined();
+    expect(typeof c?.taskOutcome).toBe("string");
+  });
+});

--- a/tests/bench/runner.test.ts
+++ b/tests/bench/runner.test.ts
@@ -477,4 +477,280 @@ describe("runUtility", () => {
     const trailing = capturedAgentCmds[0]?.[capturedAgentCmds[0].length - 1] ?? "";
     expect(trailing).toContain("Task: fake/task-a");
   });
+
+  // ── #261: optional synthetic arm ───────────────────────────────────────────
+
+  test("includeSynthetic: runs noakm + akm + synthetic over the same tasks/seeds", async () => {
+    // Spy on every agent invocation so we can assert which arm fired and
+    // that AKM_STASH_DIR is absent for the synthetic arm only.
+    const observedArms: { arm: "noakm" | "akm" | "synthetic"; akmStashDir: string | undefined }[] = [];
+    const spawn: SpawnFn = (cmd, opts) => {
+      const isAgent = cmd[0] === "opencode";
+      if (isAgent) {
+        const promptArg = cmd[cmd.length - 1] ?? "";
+        let arm: "noakm" | "akm" | "synthetic";
+        if (promptArg.includes("Arm: synthetic")) arm = "synthetic";
+        else if (opts.env?.AKM_STASH_DIR) arm = "akm";
+        else arm = "noakm";
+        observedArms.push({ arm, akmStashDir: opts.env?.AKM_STASH_DIR });
+      }
+      return {
+        exitCode: 0,
+        exited: Promise.resolve(0),
+        stdout: asReadableStream("ok"),
+        stderr: asReadableStream(""),
+        stdin: null,
+        kill() {},
+      };
+    };
+    const report = await runUtility({
+      tasks: [fakeTask(taskDir)],
+      arms: ["noakm", "akm"],
+      model: "test",
+      seedsPerArm: 2,
+      spawn,
+      materialiseStash: false,
+      includeSynthetic: true,
+    });
+    // 2 seeds × 3 arms = 6 invocations.
+    expect(observedArms.length).toBe(6);
+    expect(observedArms.filter((o) => o.arm === "noakm").length).toBe(2);
+    expect(observedArms.filter((o) => o.arm === "akm").length).toBe(2);
+    expect(observedArms.filter((o) => o.arm === "synthetic").length).toBe(2);
+    // Synthetic-arm child env MUST NOT carry AKM_STASH_DIR.
+    for (const o of observedArms.filter((o) => o.arm === "synthetic")) {
+      expect(o.akmStashDir).toBeUndefined();
+    }
+    // Per-task synthetic metrics are spliced in; aggregateSynth populated.
+    expect(report.aggregateSynth).toBeDefined();
+    expect(report.aggregateSynth?.passRate).toBe(1);
+    expect(report.tasks[0]?.synthetic).toBeDefined();
+    expect(report.tasks[0]?.synthetic?.count).toBe(2);
+  });
+
+  test("default behaviour (no includeSynthetic) is byte-identical to two-arm output (no synthetic keys)", async () => {
+    // SNAPSHOT-STYLE TEST: run runUtility WITHOUT includeSynthetic, capture
+    // the JSON envelope keys, and assert no key contains 'synthetic'.
+    // Without this gate the byte-identical contract is unverifiable.
+    const { spawn } = fakeSpawnFactory({ noakm: "ok", akm: "ok" });
+    const report = await runUtility({
+      tasks: [fakeTask(taskDir)],
+      arms: ["noakm", "akm"],
+      model: "test",
+      seedsPerArm: 1,
+      spawn,
+      materialiseStash: false,
+      branch: "test-branch",
+      commit: "abc123",
+      timestamp: "2026-04-27T00:00:00Z",
+    });
+    // In-memory report shape: aggregateSynth absent.
+    expect(report.aggregateSynth).toBeUndefined();
+    expect(report.tasks[0]?.synthetic).toBeUndefined();
+
+    // Render the JSON envelope and walk every key recursively. None should
+    // contain 'synthetic'. We exercise the byte-identical envelope contract.
+    const { renderUtilityReport } = await import("./report");
+    const { json } = renderUtilityReport(report);
+    const allKeys: string[] = [];
+    const walk = (node: unknown): void => {
+      if (Array.isArray(node)) {
+        for (const item of node) walk(item);
+      } else if (node && typeof node === "object") {
+        for (const [k, v] of Object.entries(node)) {
+          allKeys.push(k);
+          walk(v);
+        }
+      }
+    };
+    walk(json);
+    const synthMentions = allKeys.filter((k) => k.toLowerCase().includes("synth"));
+    expect(synthMentions).toEqual([]);
+    // Markdown body must not mention 'synthetic' (case-insensitive).
+    const { markdown } = renderUtilityReport(report);
+    expect(markdown.toLowerCase().includes("synthetic")).toBe(false);
+  });
+
+  test("includeSynthetic: arm-keyed map defaults synthetic to 'arm-not-run' when arm is absent on a task", async () => {
+    // Edge case: build a grouped map manually that lacks the synthetic arm
+    // for a given task. The runner ALWAYS dispatches the arm when the flag
+    // is set, so this guard is enforced through the buildReport branch:
+    // when includeSynth is true but no synth runs landed, the per-task
+    // PerTaskMetrics carries `count: 0` (zero-result aggregate) — distinct
+    // from "arm not run at all" which omits the field. Verify the
+    // distinction: report tasks WITHOUT the flag have synthetic absent.
+    const { spawn } = fakeSpawnFactory({ noakm: "ok", akm: "ok" });
+    const reportNoFlag = await runUtility({
+      tasks: [fakeTask(taskDir)],
+      arms: ["noakm", "akm"],
+      model: "test",
+      seedsPerArm: 1,
+      spawn,
+      materialiseStash: false,
+    });
+    expect(reportNoFlag.tasks[0]?.synthetic).toBeUndefined();
+  });
+
+  test("includeSynthetic: forwards a clear scratch-notes prompt to the synthetic arm", async () => {
+    // Acceptance criterion: synthetic arm has a clear scratch-notes prompt
+    // contract. We assert the default built-in prompt is forwarded when
+    // the caller does not supply a buildPrompt override.
+    const capturedAgentCmds: string[][] = [];
+    const spawn: SpawnFn = (cmd, _opts) => {
+      if (cmd[0] === "opencode") capturedAgentCmds.push([...cmd]);
+      return {
+        exitCode: 0,
+        exited: Promise.resolve(0),
+        stdout: asReadableStream("ok"),
+        stderr: asReadableStream(""),
+        stdin: null,
+        kill() {},
+      };
+    };
+    await runUtility({
+      tasks: [fakeTask(taskDir)],
+      arms: ["noakm", "akm"],
+      model: "test",
+      seedsPerArm: 1,
+      spawn,
+      materialiseStash: false,
+      includeSynthetic: true,
+    });
+    const synthCmd = capturedAgentCmds.find((c) => c[c.length - 1]?.includes("Arm: synthetic"));
+    expect(synthCmd).toBeDefined();
+    const synthPrompt = synthCmd?.[synthCmd.length - 1] ?? "";
+    expect(synthPrompt).toContain("Bring Your Own Skills");
+    expect(synthPrompt).toContain("scratchpad");
+    expect(synthPrompt).toContain("AKM_STASH_DIR is intentionally absent");
+  });
+
+  test("includeSynthetic: caller buildPrompt override wins for synthetic arm", async () => {
+    // When the caller threads a buildPrompt override that returns a string
+    // for the synthetic arm, the runner forwards that override verbatim
+    // instead of the built-in scratch-notes prompt. This preserves the
+    // Track B `runEvolve` integration where synthetic arm prompts are
+    // built by `buildSyntheticPrompt(task.id)`.
+    const capturedAgentCmds: string[][] = [];
+    const spawn: SpawnFn = (cmd, _opts) => {
+      if (cmd[0] === "opencode") capturedAgentCmds.push([...cmd]);
+      return {
+        exitCode: 0,
+        exited: Promise.resolve(0),
+        stdout: asReadableStream("ok"),
+        stderr: asReadableStream(""),
+        stdin: null,
+        kill() {},
+      };
+    };
+    await runUtility({
+      tasks: [fakeTask(taskDir)],
+      arms: ["noakm", "akm"],
+      model: "test",
+      seedsPerArm: 1,
+      spawn,
+      materialiseStash: false,
+      includeSynthetic: true,
+      buildPrompt: (task, arm) => (arm === "synthetic" ? `OVERRIDE for ${task.id}` : undefined),
+    });
+    const synthCmd = capturedAgentCmds.find((c) => c[c.length - 1]?.startsWith("OVERRIDE for"));
+    expect(synthCmd).toBeDefined();
+    // The built-in scratch-notes contract MUST NOT have leaked through.
+    expect(synthCmd?.[synthCmd.length - 1]).not.toContain("Bring Your Own Skills");
+  });
+
+  test("includeSynthetic: report carries akm_over_synthetic_lift in aggregate", async () => {
+    // akm + noakm pass (regex verifier matches "ok"); synthetic fails (we
+    // emit "nope" on the synthetic agent stdout so the regex verifier
+    // rejects). The fake task uses regex/expectedMatch="ok" — see fakeTask().
+    const spawn: SpawnFn = (cmd, _opts) => {
+      const isAgent = cmd[0] === "opencode";
+      if (!isAgent) {
+        return {
+          exitCode: 0,
+          exited: Promise.resolve(0),
+          stdout: asReadableStream(""),
+          stderr: asReadableStream(""),
+          stdin: null,
+          kill() {},
+        };
+      }
+      const promptArg = cmd[cmd.length - 1] ?? "";
+      const isSynth = promptArg.includes("Arm: synthetic");
+      const stdout = isSynth ? "nope" : "ok";
+      return {
+        exitCode: 0,
+        exited: Promise.resolve(0),
+        stdout: asReadableStream(stdout),
+        stderr: asReadableStream(""),
+        stdin: null,
+        kill() {},
+      };
+    };
+    const report = await runUtility({
+      tasks: [fakeTask(taskDir)],
+      arms: ["noakm", "akm"],
+      model: "test",
+      seedsPerArm: 2,
+      spawn,
+      materialiseStash: false,
+      includeSynthetic: true,
+    });
+    expect(report.aggregateAkm.passRate).toBe(1);
+    expect(report.aggregateSynth?.passRate).toBe(0);
+
+    const { renderUtilityReport } = await import("./report");
+    const { json, markdown } = renderUtilityReport(report);
+    const aggregate = (json as Record<string, Record<string, unknown>>).aggregate;
+    expect(aggregate.synthetic).toBeDefined();
+    expect(aggregate.akm_over_synthetic_lift).toBe(1);
+    // Markdown should mention the lift.
+    expect(markdown).toContain("akm_over_synthetic_lift");
+  });
+
+  test("includeSynthetic: markdown surfaces a warning when AKM fails to beat synthetic", async () => {
+    // Acceptance criterion: utility markdown summarizes when AKM fails to
+    // beat synthetic notes. Construct a scenario where akm_pass_rate <=
+    // synth_pass_rate — regex verifier expects "ok"; AKM agent emits "nope"
+    // (fail), synthetic + noakm emit "ok" (pass).
+    const spawn: SpawnFn = (cmd, opts) => {
+      const isAgent = cmd[0] === "opencode";
+      if (!isAgent) {
+        return {
+          exitCode: 0,
+          exited: Promise.resolve(0),
+          stdout: asReadableStream(""),
+          stderr: asReadableStream(""),
+          stdin: null,
+          kill() {},
+        };
+      }
+      const promptArg = cmd[cmd.length - 1] ?? "";
+      const isSynth = promptArg.includes("Arm: synthetic");
+      const isAkm = !isSynth && opts.env?.AKM_STASH_DIR !== undefined;
+      const stdout = isAkm ? "nope" : "ok";
+      return {
+        exitCode: 0,
+        exited: Promise.resolve(0),
+        stdout: asReadableStream(stdout),
+        stderr: asReadableStream(""),
+        stdin: null,
+        kill() {},
+      };
+    };
+    const report = await runUtility({
+      tasks: [fakeTask(taskDir)],
+      arms: ["noakm", "akm"],
+      model: "test",
+      seedsPerArm: 2,
+      spawn,
+      materialiseStash: false,
+      includeSynthetic: true,
+    });
+    expect(report.aggregateAkm.passRate).toBe(0);
+    expect(report.aggregateSynth?.passRate).toBe(1);
+    const { renderUtilityReport } = await import("./report");
+    const { markdown } = renderUtilityReport(report);
+    expect(markdown).toContain(":warning:");
+    expect(markdown).toContain("AKM did not beat the synthetic-notes baseline");
+  });
 });

--- a/tests/bench/runner.ts
+++ b/tests/bench/runner.ts
@@ -24,6 +24,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { warn } from "../../src/core/warn";
 import type { SpawnFn } from "../../src/integrations/agent/spawn";
 import { computeFixtureContentHash, type LoadedFixtureStash, loadFixtureStash } from "../fixtures/stashes/load";
 import { registerCleanup } from "./cleanup";
@@ -47,6 +48,21 @@ import {
 } from "./metrics";
 import { resolveGitBranch, resolveGitCommit, type UtilityReportTaskEntry, type UtilityRunReport } from "./report";
 import { computeTrajectory } from "./trajectory";
+import {
+  evaluateRunAgainstAllSpecs,
+  type WorkflowCheckResult,
+  type WorkflowEvalRunContext,
+} from "./workflow-evaluator";
+import { loadAllWorkflowSpecs, type WorkflowSpec } from "./workflow-spec";
+import { normalizeRunToTrace } from "./workflow-trace";
+
+/**
+ * Default workflows directory. Can be overridden by callers (tests) via
+ * `RunUtilityOptions.workflowsDir`. Specs in this directory are loaded ONCE
+ * per `runUtility` call (not per run) — the evaluator filters via each spec's
+ * `applies_to` so we don't I/O in the hot loop.
+ */
+const DEFAULT_WORKFLOWS_DIR = path.resolve(__dirname, "..", "fixtures", "bench", "workflows");
 
 export type Arm = "noakm" | "akm" | "synthetic";
 
@@ -127,6 +143,14 @@ export interface RunUtilityOptions {
    * synthetic-arm orchestration entirely.
    */
   includeSynthetic?: boolean;
+  /**
+   * Override the workflows-spec directory (#257). When omitted, the runner
+   * loads `tests/fixtures/bench/workflows/*.yaml` once per `runUtility` call
+   * and feeds the parsed specs to `evaluateRunAgainstAllSpecs` for every
+   * akm-arm run. When supplied, the directory is loaded instead. Pass an
+   * empty string to disable workflow evaluation entirely (tests).
+   */
+  workflowsDir?: string;
 }
 
 /** Internal: raw run records grouped by (taskId, arm). */
@@ -157,6 +181,24 @@ export async function runUtility(options: RunUtilityOptions): Promise<UtilityRun
   const grouped: GroupedRuns = new Map();
   const warnings: string[] = [];
   const goldRankRecords: GoldRankAccumulator = [];
+
+  // #257: load workflow specs ONCE per runUtility call. Skipped when the
+  // caller passes an empty `workflowsDir` string (test escape hatch). Errors
+  // are surfaced as warnings — workflow evaluation is best-effort and a
+  // missing/malformed spec must not abort the whole bench run.
+  const workflowSpecs: WorkflowSpec[] = [];
+  const workflowsDir = options.workflowsDir ?? DEFAULT_WORKFLOWS_DIR;
+  if (workflowsDir.length > 0) {
+    try {
+      const loaded = loadAllWorkflowSpecs(workflowsDir);
+      workflowSpecs.push(...loaded);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      warnings.push(`workflow specs: failed to load from "${workflowsDir}": ${msg}`);
+      warn(`[runUtility] workflow specs unavailable: ${msg}`);
+    }
+  }
+  const workflowChecks: WorkflowCheckResult[] = [];
 
   for (const task of options.tasks) {
     const taskRuns = new Map<Arm, RunResult[]>();
@@ -276,6 +318,30 @@ export async function runUtility(options: RunUtilityOptions): Promise<UtilityRun
               searches,
             });
           }
+
+          // #257: evaluate the akm-arm run against every workflow spec. The
+          // evaluator's `specApplies` filter handles applicability (arm,
+          // domain, gold ref, repeated-failures threshold), so we hand it the
+          // entire spec list and append whatever it returns. noakm/synthetic
+          // arms are not evaluated — workflow specs target the akm arm.
+          if (arm === "akm" && workflowSpecs.length > 0) {
+            const trace = normalizeRunToTrace(run, { warnings });
+            const runCtx: WorkflowEvalRunContext = {
+              arm: run.arm,
+              taskId: run.taskId,
+              seed: run.seed,
+              outcome: run.outcome,
+            };
+            const taskMetadata = task.goldRef !== undefined ? { goldRef: task.goldRef } : {};
+            const checks = evaluateRunAgainstAllSpecs(trace, workflowSpecs, runCtx, taskMetadata);
+            // Tag each check with the run's task-side outcome so the report
+            // aggregator can compute the task_outcome × workflow_outcome
+            // cross-tab without re-walking the underlying RunResults.
+            for (const c of checks) {
+              (c as WorkflowCheckResult & { taskOutcome?: string }).taskOutcome = run.outcome;
+            }
+            workflowChecks.push(...checks);
+          }
         }
       }
     } finally {
@@ -293,6 +359,7 @@ export async function runUtility(options: RunUtilityOptions): Promise<UtilityRun
     slice,
     warnings,
     goldRankRecords,
+    workflowChecks,
   });
 }
 
@@ -421,6 +488,8 @@ interface BuildReportArgs {
   slice: "all" | TaskSlice;
   warnings: string[];
   goldRankRecords: GoldRankAccumulator;
+  /** #257: per-(akm-arm-run, spec) workflow checks accumulated across the corpus. */
+  workflowChecks: WorkflowCheckResult[];
 }
 
 function buildReport(args: BuildReportArgs): UtilityRunReport {
@@ -431,6 +500,18 @@ function buildReport(args: BuildReportArgs): UtilityRunReport {
   const akmRunsAll: RunResult[] = [];
   const allRuns: RunResult[] = [];
   const includeSynth = args.options.includeSynthetic === true;
+
+  // #257: index workflow checks by taskId so we can attach a per-task
+  // mean compliance to each `UtilityReportTaskEntry`. Only `pass` and
+  // `partial` statuses contribute non-zero scores; `not_applicable` is
+  // skipped (the spec did not target this run); `harness_error` rolls in
+  // as a 0 so corrupt traces drag the per-task number down.
+  const checksByTask = new Map<string, WorkflowCheckResult[]>();
+  for (const c of args.workflowChecks) {
+    const arr = checksByTask.get(c.taskId);
+    if (arr) arr.push(c);
+    else checksByTask.set(c.taskId, [c]);
+  }
 
   for (const task of args.options.tasks) {
     const taskRuns = args.grouped.get(task.id);
@@ -462,12 +543,26 @@ function buildReport(args: BuildReportArgs): UtilityRunReport {
       allRuns.push(...noakmRuns, ...akmRuns);
     }
 
+    // #257: per-task workflow compliance, mean of `score` over applicable
+    // checks (excludes `not_applicable`). Undefined when this task has no
+    // applicable checks at all so downstream renderers can distinguish
+    // "not measured" from "measured at 0".
+    const taskChecks = checksByTask.get(task.id) ?? [];
+    const applicableTaskChecks = taskChecks.filter((c) => c.status !== "not_applicable");
+    let workflowCompliance: number | undefined;
+    if (applicableTaskChecks.length > 0) {
+      let sum = 0;
+      for (const c of applicableTaskChecks) sum += c.score;
+      workflowCompliance = sum / applicableTaskChecks.length;
+    }
+
     tasks.push({
       id: task.id,
       noakm: noakmMetrics,
       akm: akmMetrics,
       delta,
       ...(includeSynth ? { synthetic: aggregatePerTask(synthRuns) } : {}),
+      ...(workflowCompliance !== undefined ? { workflowCompliance } : {}),
     });
   }
 
@@ -560,6 +655,7 @@ function buildReport(args: BuildReportArgs): UtilityRunReport {
     taskMetadata: args.options.tasks,
     goldRankRecords: args.goldRankRecords,
     searchBridge,
+    workflowChecks: args.workflowChecks,
   };
   // Compute per-asset attribution as post-processing on the akm-arm runs
   // we just collected. This is the §6.5 "free" diagnostic — it runs on every

--- a/tests/bench/runner.ts
+++ b/tests/bench/runner.ts
@@ -332,14 +332,8 @@ export async function runUtility(options: RunUtilityOptions): Promise<UtilityRun
               seed: run.seed,
               outcome: run.outcome,
             };
-            const taskMetadata = task.goldRef !== undefined ? { goldRef: task.goldRef } : {};
+            const taskMetadata = buildWorkflowTaskMetadata(task, trace);
             const checks = evaluateRunAgainstAllSpecs(trace, workflowSpecs, runCtx, taskMetadata);
-            // Tag each check with the run's task-side outcome so the report
-            // aggregator can compute the task_outcome × workflow_outcome
-            // cross-tab without re-walking the underlying RunResults.
-            for (const c of checks) {
-              (c as WorkflowCheckResult & { taskOutcome?: string }).taskOutcome = run.outcome;
-            }
             workflowChecks.push(...checks);
           }
         }
@@ -361,6 +355,40 @@ export async function runUtility(options: RunUtilityOptions): Promise<UtilityRun
     goldRankRecords,
     workflowChecks,
   });
+}
+
+function buildWorkflowTaskMetadata(
+  task: TaskMetadata,
+  trace: ReturnType<typeof normalizeRunToTrace>,
+): { goldRef?: string; flags?: Record<string, boolean> } {
+  const flags: Record<string, boolean> = {
+    search_has_relevant_result: hasRelevantSearchResult(trace, task.goldRef),
+    task_has_tests: taskHasTests(task),
+  };
+  return {
+    ...(task.goldRef !== undefined ? { goldRef: task.goldRef } : {}),
+    flags,
+  };
+}
+
+function hasRelevantSearchResult(trace: ReturnType<typeof normalizeRunToTrace>, goldRef: string | undefined): boolean {
+  if (!goldRef) return false;
+  for (const event of trace.events) {
+    if (event.type !== "akm_search") continue;
+    if (event.resultRefs?.includes(goldRef)) return true;
+  }
+  return false;
+}
+
+function taskHasTests(task: TaskMetadata): boolean {
+  if (task.verifier === "pytest") return true;
+  const testsDir = path.join(task.taskDir, "tests");
+  if (!fs.existsSync(testsDir)) return false;
+  try {
+    return fs.readdirSync(testsDir).some((name) => name.endsWith(".py") || name.endsWith(".sh"));
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/tests/bench/runner.ts
+++ b/tests/bench/runner.ts
@@ -362,7 +362,7 @@ function buildWorkflowTaskMetadata(
   trace: ReturnType<typeof normalizeRunToTrace>,
 ): { goldRef?: string; flags?: Record<string, boolean> } {
   const flags: Record<string, boolean> = {
-    search_has_relevant_result: hasRelevantSearchResult(trace, task.goldRef),
+    search_has_relevant_result: searchResultIncludesGoldRef(trace, task.goldRef),
     task_has_tests: taskHasTests(task),
   };
   return {
@@ -371,7 +371,10 @@ function buildWorkflowTaskMetadata(
   };
 }
 
-function hasRelevantSearchResult(trace: ReturnType<typeof normalizeRunToTrace>, goldRef: string | undefined): boolean {
+function searchResultIncludesGoldRef(
+  trace: ReturnType<typeof normalizeRunToTrace>,
+  goldRef: string | undefined,
+): boolean {
   if (!goldRef) return false;
   for (const event of trace.events) {
     if (event.type !== "akm_search") continue;

--- a/tests/bench/runner.ts
+++ b/tests/bench/runner.ts
@@ -48,7 +48,7 @@ import {
 import { resolveGitBranch, resolveGitCommit, type UtilityReportTaskEntry, type UtilityRunReport } from "./report";
 import { computeTrajectory } from "./trajectory";
 
-export type Arm = "noakm" | "akm";
+export type Arm = "noakm" | "akm" | "synthetic";
 
 /**
  * Optional per-arm prompt-override seam (#267). The runner forwards the
@@ -111,6 +111,22 @@ export interface RunUtilityOptions {
    * prompt by returning undefined.
    */
   buildPrompt?: BuildPromptFn;
+  /**
+   * Track A synthetic-arm gate (#261). When `true`, the runner adds a third
+   * arm (`synthetic`) to every task in the corpus. The synthetic arm runs
+   * the same tasks/seeds/model/budgets/verifiers as `noakm`/`akm` but
+   * receives a scratch-notes prompt contract (the model creates and uses
+   * its own procedural notes rather than consulting an AKM stash). The
+   * synthetic-arm child env explicitly DELETES `AKM_STASH_DIR` so the
+   * operator's real stash never leaks in (recurrence guard for the #243
+   * fixup pattern).
+   *
+   * Default behaviour (when `false` or omitted) is byte-identical to the
+   * pre-#261 two-arm output: the report carries no `synthetic` keys, the
+   * markdown summary mentions no synthetic arm, and the runner skips the
+   * synthetic-arm orchestration entirely.
+   */
+  includeSynthetic?: boolean;
 }
 
 /** Internal: raw run records grouped by (taskId, arm). */
@@ -178,8 +194,19 @@ export async function runUtility(options: RunUtilityOptions): Promise<UtilityRun
         })
       : () => {};
 
+    // #261: when `includeSynthetic` is set, splice the synthetic arm into the
+    // per-task arm iteration alongside whatever the caller asked for. We
+    // dedupe so a caller that already passes `synthetic` in `arms` does not
+    // see it run twice. Pre-#261 callers (no flag, no `synthetic` in arms)
+    // see the old loop verbatim — that's the byte-identical default contract.
+    const armsForTask: Arm[] = (() => {
+      if (!options.includeSynthetic) return options.arms;
+      if (options.arms.includes("synthetic")) return options.arms;
+      return [...options.arms, "synthetic"];
+    })();
+
     try {
-      for (const arm of options.arms) {
+      for (const arm of armsForTask) {
         const armRuns: RunResult[] = [];
         taskRuns.set(arm, armRuns);
         for (let seed = 0; seed < seedsPerArm; seed += 1) {
@@ -210,7 +237,17 @@ export async function runUtility(options: RunUtilityOptions): Promise<UtilityRun
           // Build the prompt-override (#267). The builder is invoked once
           // per (task, arm) — seeds share a prompt. `undefined` keeps the
           // driver's default prompt in play.
-          const promptOverride = options.buildPrompt?.(task, arm);
+          //
+          // #261: the synthetic arm has a scratch-notes prompt contract —
+          // the model is told no AKM stash is available and instructed to
+          // write/use its own procedural notes. When the caller does not
+          // supply a `buildPrompt` override for the synthetic arm we fall
+          // back to a built-in scratch-notes prompt so the contract is
+          // honoured by every utility-track caller, not just `runEvolve`.
+          let promptOverride = options.buildPrompt?.(task, arm);
+          if (promptOverride === undefined && arm === "synthetic") {
+            promptOverride = buildUtilitySyntheticPrompt(task.id);
+          }
           const run = await runOneIsolated({
             task,
             arm,
@@ -341,6 +378,30 @@ function seedWorkspace(taskDir: string, dest: string): void {
   copyDirRecursive(src, dest);
 }
 
+/**
+ * Default synthetic-arm prompt (#261). Used by Track A `runUtility` when the
+ * caller opts in via `includeSynthetic: true` and does not also supply a
+ * `buildPrompt` override for the synthetic arm.
+ *
+ * The prompt is a clear scratch-notes contract: the model is told no AKM
+ * stash is available and instructed to write/use its own procedural notes
+ * before solving the task. This mirrors the prompt shape used by Track B's
+ * `buildSyntheticPrompt(taskId)` but is intentionally duplicated here so
+ * Track A has no module-level dependency on `evolve.ts`.
+ *
+ * Exported for tests.
+ */
+export function buildUtilitySyntheticPrompt(taskId: string): string {
+  return [
+    `Task: ${taskId}`,
+    "Arm: synthetic (Bring Your Own Skills)",
+    "No akm stash is available; AKM_STASH_DIR is intentionally absent. Before solving",
+    "the task, write a short scratchpad of the skills and steps you intend to use,",
+    "then proceed. Cite the scratchpad in your trace so the verifier can attribute",
+    "the approach to your own reasoning rather than retrieved guidance.",
+  ].join("\n");
+}
+
 function copyDirRecursive(src: string, dest: string): void {
   fs.mkdirSync(dest, { recursive: true });
   const entries = fs.readdirSync(src, { withFileTypes: true });
@@ -366,13 +427,20 @@ function buildReport(args: BuildReportArgs): UtilityRunReport {
   const tasks: UtilityReportTaskEntry[] = [];
   const noakmPerTask: Record<string, PerTaskMetrics> = {};
   const akmPerTask: Record<string, PerTaskMetrics> = {};
+  const synthPerTask: Record<string, PerTaskMetrics> = {};
   const akmRunsAll: RunResult[] = [];
   const allRuns: RunResult[] = [];
+  const includeSynth = args.options.includeSynthetic === true;
 
   for (const task of args.options.tasks) {
     const taskRuns = args.grouped.get(task.id);
     const noakmRuns = taskRuns?.get("noakm") ?? [];
     const akmRuns = taskRuns?.get("akm") ?? [];
+    // #261: synthetic-arm runs are only consulted when the caller opted in.
+    // A missing arm is NOT a zero-pass arm — we leave `synthPerTask[task.id]`
+    // unset rather than defaulting to a zeroed PerTaskMetrics so downstream
+    // consumers can distinguish "arm not run" from "arm ran with 0 passes".
+    const synthRuns: RunResult[] = includeSynth ? (taskRuns?.get("synthetic") ?? []) : [];
 
     const noakmMetrics = aggregatePerTask(noakmRuns);
     const akmMetrics = aggregatePerTask(akmRuns);
@@ -380,17 +448,36 @@ function buildReport(args: BuildReportArgs): UtilityRunReport {
 
     noakmPerTask[task.id] = noakmMetrics;
     akmPerTask[task.id] = akmMetrics;
+    if (includeSynth) {
+      synthPerTask[task.id] = aggregatePerTask(synthRuns);
+    }
     akmRunsAll.push(...akmRuns);
-    // Preserve arm order (noakm first, then akm) so the persisted runs[]
-    // array is deterministic across reruns. #249.
-    allRuns.push(...noakmRuns, ...akmRuns);
+    // Preserve arm order (noakm, synthetic when enabled, then akm) so the
+    // persisted runs[] array is deterministic across reruns. #249. The
+    // synthetic block is omitted entirely when includeSynth is false so the
+    // pre-#261 envelope stays byte-identical.
+    if (includeSynth) {
+      allRuns.push(...noakmRuns, ...synthRuns, ...akmRuns);
+    } else {
+      allRuns.push(...noakmRuns, ...akmRuns);
+    }
 
-    tasks.push({ id: task.id, noakm: noakmMetrics, akm: akmMetrics, delta });
+    tasks.push({
+      id: task.id,
+      noakm: noakmMetrics,
+      akm: akmMetrics,
+      delta,
+      ...(includeSynth ? { synthetic: aggregatePerTask(synthRuns) } : {}),
+    });
   }
 
   const aggregateNoakm = aggregateCorpus(noakmPerTask);
   const aggregateAkm = aggregateCorpus(akmPerTask);
   const aggregateDelta = computeCorpusDelta(aggregateNoakm, aggregateAkm);
+  // #261: synthetic-arm aggregate is built ONLY when the caller opted in.
+  // We compute it once here so the report renderer can stamp `arms.synthetic`
+  // and `akm_over_synthetic_lift` without recomputing.
+  const aggregateSynth = includeSynth ? aggregateCorpus(synthPerTask) : undefined;
   const trajectoryAkm = aggregateTrajectory(akmRunsAll);
 
   // Failure-mode aggregate (§6.6). Walks every akm-arm run; runs that are
@@ -463,6 +550,7 @@ function buildReport(args: BuildReportArgs): UtilityRunReport {
     aggregateNoakm,
     aggregateAkm,
     aggregateDelta,
+    ...(aggregateSynth ? { aggregateSynth } : {}),
     trajectoryAkm,
     failureModes,
     tasks,

--- a/tests/bench/workflow-evaluator.test.ts
+++ b/tests/bench/workflow-evaluator.test.ts
@@ -1,0 +1,473 @@
+/**
+ * Tests for the workflow compliance evaluator (issue #256).
+ *
+ * Cases covered (per acceptance criteria):
+ *   - pass, partial, fail, not_applicable, harness_error
+ *   - wrong-order, missing-event, forbidden-event
+ *   - wrong-feedback-polarity, irrelevant-asset-loaded
+ *   - violation cap, schemaVersion stability, applies_to filter,
+ *     evaluateRunAgainstAllSpecs orchestration, pure-function guarantees.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  evaluateRunAgainstAllSpecs,
+  evaluateRunAgainstSpec,
+  MAX_VIOLATIONS_PER_CHECK,
+  type WorkflowEvalRunContext,
+  type WorkflowEvalTaskMetadata,
+} from "./workflow-evaluator";
+import type { WorkflowForbiddenStep, WorkflowSequenceStep, WorkflowSpec } from "./workflow-spec";
+import type { WorkflowTraceEvent, WorkflowTraceEventType, WorkflowTraceResult } from "./workflow-trace";
+
+/* ── Fixtures ─────────────────────────────────────────────────────────────── */
+
+function makeRun(overrides: Partial<WorkflowEvalRunContext> = {}): WorkflowEvalRunContext {
+  return { arm: "akm", taskId: "docker-homelab/redis", seed: 1, outcome: "pass", ...overrides };
+}
+
+let nextEventId = 0;
+function ev(type: WorkflowTraceEventType, extra: Partial<WorkflowTraceEvent> = {}): WorkflowTraceEvent {
+  return {
+    id: extra.id ?? nextEventId++,
+    taskId: "docker-homelab/redis",
+    arm: "akm",
+    seed: 1,
+    type,
+    source: "akm_events",
+    ...extra,
+  };
+}
+
+function makeTrace(events: WorkflowTraceEvent[], overrides: Partial<WorkflowTraceResult> = {}): WorkflowTraceResult {
+  // Re-stamp ids so the array's order is the canonical "first occurrence" order.
+  const stamped = events.map((e, i) => ({ ...e, id: i }));
+  return {
+    schemaVersion: 1,
+    taskId: "docker-homelab/redis",
+    arm: "akm",
+    seed: 1,
+    events: stamped,
+    truncated: false,
+    ...overrides,
+  };
+}
+
+function makeSpec(overrides: Partial<WorkflowSpec> = {}): WorkflowSpec {
+  const required: WorkflowSequenceStep[] = overrides.required_sequence ?? [
+    { event: "agent_started" },
+    { event: "akm_search", before: "first_workspace_write" },
+    { event: "first_workspace_write" },
+    { event: "agent_finished" },
+  ];
+  const forbidden: WorkflowForbiddenStep[] | undefined = overrides.forbidden ?? [
+    { event: "first_workspace_write", before: "akm_search" },
+  ];
+  const base: WorkflowSpec = {
+    id: "test-spec",
+    title: "Test spec",
+    required_sequence: required,
+    scoring: { required_steps_weight: 0.6, forbidden_steps_weight: 0.2, evidence_quality_weight: 0.2 },
+    sourcePath: "/virtual/test-spec.yaml",
+  };
+  if (forbidden !== undefined) base.forbidden = forbidden;
+  return { ...base, ...overrides, required_sequence: required, forbidden };
+}
+
+/* ── Status: pass ─────────────────────────────────────────────────────────── */
+
+describe("evaluateRunAgainstSpec — pass", () => {
+  test("all required steps present, no forbidden, in order", () => {
+    const trace = makeTrace([
+      ev("agent_started"),
+      ev("akm_search"),
+      ev("first_workspace_write"),
+      ev("verifier_run", { exitCode: 0 }),
+      ev("agent_finished"),
+    ]);
+    const result = evaluateRunAgainstSpec(trace, makeSpec(), makeRun());
+    expect(result.status).toBe("pass");
+    expect(result.requiredPassed).toBe(result.requiredTotal);
+    expect(result.violations).toEqual([]);
+    expect(result.score).toBeGreaterThan(0.8);
+    expect(result.schemaVersion).toBe(1);
+    expect(result.workflowId).toBe("test-spec");
+  });
+});
+
+/* ── Status: missing required event ───────────────────────────────────────── */
+
+describe("evaluateRunAgainstSpec — missing required event", () => {
+  test("flags missing_required_event when akm_search absent", () => {
+    const trace = makeTrace([ev("agent_started"), ev("first_workspace_write"), ev("agent_finished")]);
+    const result = evaluateRunAgainstSpec(trace, makeSpec(), makeRun());
+    expect(result.status).toBe("partial"); // some required steps still passed
+    const codes = result.violations.map((v) => v.code);
+    expect(codes).toContain("missing_required_event");
+    expect(result.requiredPassed).toBeLessThan(result.requiredTotal);
+  });
+
+  test("status=fail when zero required steps pass", () => {
+    const trace = makeTrace([]);
+    const result = evaluateRunAgainstSpec(trace, makeSpec(), makeRun());
+    expect(result.status).toBe("fail");
+    expect(result.requiredPassed).toBe(0);
+  });
+});
+
+/* ── Status: wrong order ──────────────────────────────────────────────────── */
+
+describe("evaluateRunAgainstSpec — wrong order", () => {
+  test("flags wrong_order when first_workspace_write precedes akm_search", () => {
+    const trace = makeTrace([ev("agent_started"), ev("first_workspace_write"), ev("akm_search"), ev("agent_finished")]);
+    const result = evaluateRunAgainstSpec(trace, makeSpec(), makeRun());
+    const codes = result.violations.map((v) => v.code);
+    expect(codes).toContain("wrong_order");
+    expect(result.status).not.toBe("pass");
+  });
+
+  test("step.after order check fires when this-event precedes guard", () => {
+    const spec = makeSpec({
+      required_sequence: [
+        { event: "agent_started" },
+        { event: "akm_feedback", after: "verifier_run" },
+        { event: "verifier_run" },
+        { event: "agent_finished" },
+      ],
+      forbidden: [],
+    });
+    const trace = makeTrace([
+      ev("agent_started"),
+      ev("akm_feedback", { args: ["+1", "skill:foo"] }),
+      ev("verifier_run", { exitCode: 0 }),
+      ev("agent_finished"),
+    ]);
+    const result = evaluateRunAgainstSpec(trace, spec, makeRun());
+    expect(result.violations.some((v) => v.code === "wrong_order")).toBe(true);
+  });
+});
+
+/* ── Status: forbidden event ──────────────────────────────────────────────── */
+
+describe("evaluateRunAgainstSpec — forbidden event", () => {
+  test("flags forbidden_event for unconditional forbidden step", () => {
+    const spec = makeSpec({
+      required_sequence: [{ event: "agent_started" }, { event: "agent_finished" }],
+      forbidden: [{ event: "akm_distill" }],
+    });
+    const trace = makeTrace([ev("agent_started"), ev("akm_distill"), ev("agent_finished")]);
+    const result = evaluateRunAgainstSpec(trace, spec, makeRun());
+    const codes = result.violations.map((v) => v.code);
+    expect(codes).toContain("forbidden_event");
+  });
+
+  test("classifies reflection_without_failure for akm_reflect before feedback", () => {
+    const spec = makeSpec({
+      required_sequence: [{ event: "agent_started" }, { event: "agent_finished" }],
+      forbidden: [{ event: "akm_reflect", before: "akm_feedback" }],
+    });
+    const trace = makeTrace([
+      ev("agent_started"),
+      ev("akm_reflect"),
+      ev("akm_feedback", { args: ["-1", "skill:foo"] }),
+      ev("agent_finished"),
+    ]);
+    const result = evaluateRunAgainstSpec(trace, spec, makeRun());
+    expect(result.violations.some((v) => v.code === "reflection_without_failure")).toBe(true);
+  });
+
+  test("classifies proposal_accepted_without_validation", () => {
+    const spec = makeSpec({
+      required_sequence: [{ event: "agent_started" }, { event: "agent_finished" }],
+      forbidden: [{ event: "akm_proposal_accept", before: "verifier_run" }],
+    });
+    const trace = makeTrace([
+      ev("agent_started"),
+      ev("akm_proposal_accept"),
+      ev("verifier_run", { exitCode: 0 }),
+      ev("agent_finished"),
+    ]);
+    const result = evaluateRunAgainstSpec(trace, spec, makeRun());
+    expect(result.violations.some((v) => v.code === "proposal_accepted_without_validation")).toBe(true);
+  });
+});
+
+/* ── Wrong feedback polarity ──────────────────────────────────────────────── */
+
+describe("evaluateRunAgainstSpec — wrong feedback polarity", () => {
+  test("verifier failed but agent recorded only positive feedback", () => {
+    const spec = makeSpec({
+      required_sequence: [
+        { event: "agent_started" },
+        { event: "akm_feedback", polarity: "negative" },
+        { event: "agent_finished" },
+      ],
+      forbidden: [{ event: "akm_feedback", polarity: "positive" }],
+    });
+    const trace = makeTrace([
+      ev("agent_started"),
+      ev("akm_feedback", { args: ["+1", "skill:foo"] }),
+      ev("verifier_run", { exitCode: 1 }),
+      ev("agent_finished"),
+    ]);
+    const result = evaluateRunAgainstSpec(trace, spec, makeRun({ outcome: "fail", verifierFailed: true }));
+    const codes = result.violations.map((v) => v.code);
+    expect(codes).toContain("wrong_feedback_polarity");
+    // The negative-polarity required step should also be missing.
+    expect(codes).toContain("missing_required_event");
+    expect(result.status).not.toBe("pass");
+  });
+
+  test("polarity: positive step matches +1 args", () => {
+    const spec = makeSpec({
+      required_sequence: [
+        { event: "agent_started" },
+        { event: "akm_feedback", polarity: "positive" },
+        { event: "agent_finished" },
+      ],
+      forbidden: [],
+    });
+    const trace = makeTrace([
+      ev("agent_started"),
+      ev("akm_feedback", { args: ["+1", "skill:foo"] }),
+      ev("verifier_run", { exitCode: 0 }),
+      ev("agent_finished"),
+    ]);
+    const result = evaluateRunAgainstSpec(trace, spec, makeRun());
+    expect(result.status).toBe("pass");
+  });
+});
+
+/* ── Irrelevant asset loaded ──────────────────────────────────────────────── */
+
+describe("evaluateRunAgainstSpec — irrelevant_asset_loaded", () => {
+  test("flags when akm_show ref doesn't match gold_ref", () => {
+    const spec = makeSpec({
+      required_sequence: [
+        { event: "agent_started" },
+        { event: "akm_show", ref_must_equal: "gold_ref" },
+        { event: "agent_finished" },
+      ],
+      forbidden: [],
+    });
+    const trace = makeTrace([ev("agent_started"), ev("akm_show", { assetRef: "skill:wrong" }), ev("agent_finished")]);
+    const task: WorkflowEvalTaskMetadata = { goldRef: "skill:deploy" };
+    const result = evaluateRunAgainstSpec(trace, spec, makeRun(), task);
+    const v = result.violations.find((x) => x.code === "irrelevant_asset_loaded");
+    expect(v).toBeDefined();
+    expect(v?.expected).toBe("skill:deploy");
+    expect(v?.observed).toBe("skill:wrong");
+  });
+
+  test("top-level gold-ref check fires when spec cares but akm_show never loaded gold", () => {
+    const spec = makeSpec({
+      required_sequence: [
+        { event: "agent_started" },
+        { event: "akm_show", ref_must_equal: "gold_ref" },
+        { event: "agent_finished" },
+      ],
+      forbidden: [],
+    });
+    const trace = makeTrace([ev("agent_started"), ev("agent_finished")]);
+    const result = evaluateRunAgainstSpec(trace, spec, makeRun(), { goldRef: "skill:deploy" });
+    // Either the per-step `irrelevant_asset_loaded` OR the spec-level gold check should fire.
+    const codes = result.violations.map((v) => v.code);
+    expect(codes.some((c) => c === "irrelevant_asset_loaded" || c === "missing_required_event")).toBe(true);
+  });
+
+  test("passes when akm_show loads the gold_ref", () => {
+    const spec = makeSpec({
+      required_sequence: [
+        { event: "agent_started" },
+        { event: "akm_show", ref_must_equal: "gold_ref" },
+        { event: "agent_finished" },
+      ],
+      forbidden: [],
+    });
+    const trace = makeTrace([ev("agent_started"), ev("akm_show", { assetRef: "skill:deploy" }), ev("agent_finished")]);
+    const result = evaluateRunAgainstSpec(trace, spec, makeRun(), { goldRef: "skill:deploy" });
+    expect(result.status).toBe("pass");
+    expect(result.evidence.goldAssetLoaded).toBe(true);
+  });
+});
+
+/* ── applies_to filter / not_applicable ───────────────────────────────────── */
+
+describe("evaluateRunAgainstAllSpecs — applies_to", () => {
+  test("returns not_applicable when arm filter excludes the run", () => {
+    const spec = makeSpec({ applies_to: { arms: ["control"] } });
+    const trace = makeTrace([ev("agent_started"), ev("agent_finished")]);
+    const results = evaluateRunAgainstAllSpecs(trace, [spec], makeRun({ arm: "akm" }));
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("not_applicable");
+    expect(results[0].violations).toEqual([]);
+    expect(results[0].score).toBe(0);
+  });
+
+  test("evaluates spec when applies_to matches", () => {
+    const spec = makeSpec({ applies_to: { arms: ["akm"] } });
+    const trace = makeTrace([ev("agent_started"), ev("akm_search"), ev("first_workspace_write"), ev("agent_finished")]);
+    const results = evaluateRunAgainstAllSpecs(trace, [spec], makeRun());
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("pass");
+  });
+
+  test("requires_gold_ref filter checks task.goldRef", () => {
+    const spec = makeSpec({ applies_to: { requires_gold_ref: true } });
+    const trace = makeTrace([ev("agent_started"), ev("akm_search"), ev("first_workspace_write"), ev("agent_finished")]);
+    // No goldRef → not_applicable.
+    const r1 = evaluateRunAgainstAllSpecs(trace, [spec], makeRun());
+    expect(r1[0].status).toBe("not_applicable");
+    // With goldRef → applies.
+    const r2 = evaluateRunAgainstAllSpecs(trace, [spec], makeRun(), { goldRef: "skill:deploy" });
+    expect(r2[0].status).not.toBe("not_applicable");
+  });
+});
+
+/* ── Harness error ────────────────────────────────────────────────────────── */
+
+describe("evaluateRunAgainstSpec — harness_error", () => {
+  test("malformed trace yields harness_error and does not throw", () => {
+    const result = evaluateRunAgainstSpec(undefined, makeSpec(), makeRun());
+    expect(result.status).toBe("harness_error");
+    expect(result.violations[0].code).toBe("missing_evidence");
+    expect(result.score).toBe(0);
+    expect(result.schemaVersion).toBe(1);
+  });
+
+  test("malformed spec yields harness_error", () => {
+    const trace = makeTrace([ev("agent_started")]);
+    // @ts-expect-error — intentionally malformed
+    const result = evaluateRunAgainstSpec(trace, { id: "x" }, makeRun());
+    expect(result.status).toBe("harness_error");
+  });
+
+  test("trace with non-array events does not throw", () => {
+    // @ts-expect-error — intentional misuse
+    const bad: WorkflowTraceResult = { schemaVersion: 1, taskId: "x", arm: "akm", seed: 1, events: null };
+    const result = evaluateRunAgainstSpec(bad, makeSpec(), makeRun());
+    expect(result.status).toBe("harness_error");
+  });
+
+  test("evaluator does not mutate inputs", () => {
+    const trace = makeTrace([ev("agent_started"), ev("akm_search"), ev("first_workspace_write"), ev("agent_finished")]);
+    const traceJson = JSON.stringify(trace);
+    const spec = makeSpec();
+    const specJson = JSON.stringify(spec);
+    const task: WorkflowEvalTaskMetadata = { goldRef: "skill:deploy", flags: { foo: true } };
+    const taskJson = JSON.stringify(task);
+    evaluateRunAgainstSpec(trace, spec, makeRun(), task);
+    expect(JSON.stringify(trace)).toBe(traceJson);
+    expect(JSON.stringify(spec)).toBe(specJson);
+    expect(JSON.stringify(task)).toBe(taskJson);
+  });
+});
+
+/* ── required_if ──────────────────────────────────────────────────────────── */
+
+describe("evaluateRunAgainstSpec — required_if guards", () => {
+  test("step is skipped when required_if flag is false/missing", () => {
+    const spec = makeSpec({
+      required_sequence: [
+        { event: "agent_started" },
+        { event: "akm_show", required_if: "search_has_relevant_result" },
+        { event: "agent_finished" },
+      ],
+      forbidden: [],
+    });
+    const trace = makeTrace([ev("agent_started"), ev("agent_finished")]);
+    const result = evaluateRunAgainstSpec(trace, spec, makeRun());
+    expect(result.status).toBe("pass");
+    // requiredTotal should NOT include the gated step.
+    expect(result.requiredTotal).toBe(2);
+  });
+
+  test("step is enforced when required_if flag is true", () => {
+    const spec = makeSpec({
+      required_sequence: [
+        { event: "agent_started" },
+        { event: "akm_show", required_if: "search_has_relevant_result" },
+        { event: "agent_finished" },
+      ],
+      forbidden: [],
+    });
+    const trace = makeTrace([ev("agent_started"), ev("agent_finished")]);
+    const result = evaluateRunAgainstSpec(trace, spec, makeRun(), {
+      flags: { search_has_relevant_result: true },
+    });
+    expect(result.status).not.toBe("pass");
+    expect(result.violations.some((v) => v.code === "missing_required_event")).toBe(true);
+  });
+});
+
+/* ── min_count ────────────────────────────────────────────────────────────── */
+
+describe("evaluateRunAgainstSpec — min_count", () => {
+  test("requires N matching events with the right polarity", () => {
+    const spec = makeSpec({
+      required_sequence: [
+        { event: "agent_started" },
+        { event: "akm_feedback", polarity: "negative", min_count: 2 },
+        { event: "agent_finished" },
+      ],
+      forbidden: [],
+    });
+    const traceOne = makeTrace([
+      ev("agent_started"),
+      ev("akm_feedback", { args: ["-1", "skill:foo"] }),
+      ev("agent_finished"),
+    ]);
+    const r1 = evaluateRunAgainstSpec(traceOne, spec, makeRun({ outcome: "fail", verifierFailed: true }));
+    expect(r1.violations.some((v) => v.code === "missing_required_event")).toBe(true);
+
+    const traceTwo = makeTrace([
+      ev("agent_started"),
+      ev("akm_feedback", { args: ["-1", "skill:foo"] }),
+      ev("akm_feedback", { args: ["-1", "skill:bar"] }),
+      ev("agent_finished"),
+    ]);
+    const r2 = evaluateRunAgainstSpec(traceTwo, spec, makeRun({ outcome: "fail", verifierFailed: true }));
+    expect(r2.status).toBe("pass");
+  });
+});
+
+/* ── violation cap ────────────────────────────────────────────────────────── */
+
+describe("evaluateRunAgainstSpec — violation cap", () => {
+  test("caps violations at MAX_VIOLATIONS_PER_CHECK", () => {
+    const required: WorkflowSequenceStep[] = [];
+    for (let i = 0; i < MAX_VIOLATIONS_PER_CHECK + 10; i += 1) {
+      // Use a known event name (akm_search) so the spec passes loader-style validation
+      // even though required_sequence here is constructed in-memory.
+      required.push({ event: "akm_search" });
+    }
+    // Each required step will fail with missing_required_event because trace is empty.
+    const spec = makeSpec({ required_sequence: required, forbidden: [] });
+    const trace = makeTrace([]);
+    const result = evaluateRunAgainstSpec(trace, spec, makeRun());
+    expect(result.violations.length).toBe(MAX_VIOLATIONS_PER_CHECK);
+  });
+});
+
+/* ── schemaVersion stability ──────────────────────────────────────────────── */
+
+describe("WorkflowCheckResult shape", () => {
+  test("envelope always carries schemaVersion: 1", () => {
+    const trace = makeTrace([ev("agent_started"), ev("agent_finished")]);
+    const r = evaluateRunAgainstSpec(trace, makeSpec(), makeRun());
+    expect(r.schemaVersion).toBe(1);
+    // Check key envelope fields exist.
+    expect(typeof r.workflowId).toBe("string");
+    expect(typeof r.taskId).toBe("string");
+    expect(typeof r.arm).toBe("string");
+    expect(typeof r.seed).toBe("number");
+    expect(Array.isArray(r.violations)).toBe(true);
+    expect(r.evidence).toMatchObject({
+      matchedEvents: expect.any(Number),
+      feedbackRecorded: expect.any(Boolean),
+      goldAssetLoaded: expect.any(Boolean),
+      traceTruncated: expect.any(Boolean),
+    });
+  });
+});

--- a/tests/bench/workflow-evaluator.ts
+++ b/tests/bench/workflow-evaluator.ts
@@ -91,6 +91,7 @@ export interface WorkflowCheckResult {
   taskId: string;
   arm: string;
   seed: number;
+  taskOutcome?: string;
   status: WorkflowCheckStatus;
   /** [0, 1], higher = better. 0 for harness_error / fully-failed. */
   score: number;
@@ -240,6 +241,7 @@ export function evaluateRunAgainstSpec(
     taskId: run.taskId,
     arm: run.arm,
     seed: run.seed,
+    ...(typeof run.outcome === "string" ? { taskOutcome: run.outcome } : {}),
     status,
     score,
     requiredPassed,
@@ -617,6 +619,7 @@ function makeNotApplicable(spec: WorkflowSpec, run: WorkflowEvalRunContext): Wor
     taskId: run.taskId,
     arm: run.arm,
     seed: run.seed,
+    ...(typeof run.outcome === "string" ? { taskOutcome: run.outcome } : {}),
     status: "not_applicable",
     score: 0,
     requiredPassed: 0,
@@ -677,6 +680,7 @@ function harnessError(
     taskId: safeRun.taskId,
     arm: safeRun.arm,
     seed: safeRun.seed,
+    ...(typeof run?.outcome === "string" ? { taskOutcome: run.outcome } : {}),
     status: "harness_error",
     score: 0,
     requiredPassed: 0,

--- a/tests/bench/workflow-evaluator.ts
+++ b/tests/bench/workflow-evaluator.ts
@@ -1,0 +1,698 @@
+/**
+ * akm-bench workflow compliance evaluator (issue #256).
+ *
+ * Consumes a normalized `WorkflowTraceResult` (from `./workflow-trace`, issue
+ * #254) plus a declarative `WorkflowSpec` (from `./workflow-spec`, issue #255)
+ * and produces one `WorkflowCheckResult` per (run, spec) describing how well
+ * the run satisfied the spec.
+ *
+ * Design rules:
+ *   - Pure: never mutates the input trace, spec, run, or task metadata, and
+ *     never throws on malformed input. Bad input yields a `harness_error`
+ *     status with a structured violation.
+ *   - Bounded: caps total emitted violations per (run, spec) at
+ *     `MAX_VIOLATIONS_PER_CHECK` (32) so a pathological run cannot OOM
+ *     downstream reporters.
+ *   - Stable contract: `schemaVersion: 1` on the result envelope. Only
+ *     additive changes to violation codes / new optional fields are allowed
+ *     without a major bump.
+ *
+ * Spec semantics (from #255 fixtures):
+ *   - `required_sequence[i].event` — event must appear at least once.
+ *   - `required_sequence[i].before = X` — first occurrence of `event` must
+ *     precede first occurrence of `X`.
+ *   - `required_sequence[i].after  = X` — first occurrence of `event` must
+ *     follow first occurrence of `X` (if `X` is absent, the constraint is
+ *     vacuous; the `after`-event's required-event check captures missing-X).
+ *   - `required_sequence[i].min_count = N` — event count must be ≥ N.
+ *   - `required_sequence[i].polarity` — at least one matching feedback event
+ *     must carry that polarity (resolved from `metadata.polarity` on the
+ *     trace event when present, else inferred from feedback args).
+ *   - `required_sequence[i].ref_must_equal = "gold_ref"` — the matching
+ *     event's `assetRef` must equal `taskMetadata.gold_ref`.
+ *   - `required_sequence[i].required_if = <flag>` — step is only required
+ *     when `taskMetadata.flags[<flag>]` is true. Unknown flags default to
+ *     `false`, i.e. the step is treated as optional.
+ *   - `forbidden[i].event` — event must NOT appear.
+ *   - `forbidden[i].before = X` — event must NOT appear before X.
+ *   - `forbidden[i].after  = X` — event must NOT appear after X.
+ *   - `forbidden[i].polarity` — feedback event with that polarity must NOT
+ *     appear.
+ *
+ * Verifier-aware checks (acceptance criteria):
+ *   - `feedback polarity` — when `verifierFailed = true`, any recorded
+ *     `akm_feedback` must include a negative-polarity event; emitting only
+ *     positive feedback raises `wrong_feedback_polarity`.
+ *   - `gold_ref` — when `taskMetadata.goldRef` is set, the trace must contain
+ *     an `akm_show` whose `assetRef` matches `goldRef`. Loading other refs
+ *     instead raises `irrelevant_asset_loaded`.
+ */
+
+import type { WorkflowForbiddenStep, WorkflowSequenceStep, WorkflowSpec } from "./workflow-spec";
+import { specApplies } from "./workflow-spec";
+import type { WorkflowTraceEvent, WorkflowTraceEventType, WorkflowTraceResult } from "./workflow-trace";
+
+/* ─── Public API ──────────────────────────────────────────────────────────── */
+
+export type WorkflowCheckStatus = "pass" | "partial" | "fail" | "not_applicable" | "harness_error";
+
+export type WorkflowViolationCode =
+  | "missing_required_event"
+  | "wrong_order"
+  | "forbidden_event"
+  | "missing_evidence"
+  | "late_feedback"
+  | "wrong_feedback_polarity"
+  | "irrelevant_asset_loaded"
+  | "reflection_without_failure"
+  | "proposal_accepted_without_validation";
+
+export interface WorkflowViolation {
+  code: WorkflowViolationCode;
+  message: string;
+  expected?: string;
+  observed?: string;
+}
+
+export interface WorkflowEvidenceSummary {
+  /** Total events the trace contributed to the spec's vocabulary. */
+  matchedEvents: number;
+  /** Whether any feedback event was observed at all. */
+  feedbackRecorded: boolean;
+  /** Whether the gold asset (when declared) was loaded by the agent. */
+  goldAssetLoaded: boolean;
+  /** Whether trace was truncated upstream (mirrors WorkflowTraceResult.truncated). */
+  traceTruncated: boolean;
+}
+
+export interface WorkflowCheckResult {
+  schemaVersion: 1;
+  workflowId: string;
+  taskId: string;
+  arm: string;
+  seed: number;
+  status: WorkflowCheckStatus;
+  /** [0, 1], higher = better. 0 for harness_error / fully-failed. */
+  score: number;
+  requiredPassed: number;
+  requiredTotal: number;
+  violations: WorkflowViolation[];
+  evidence: WorkflowEvidenceSummary;
+}
+
+/**
+ * Run-level context used by `specApplies` and the verifier-aware checks.
+ *
+ * `outcome` mirrors the `RunResult.outcome` field (e.g. "pass" | "fail").
+ * `verifierFailed` controls feedback-polarity expectations; when omitted it
+ * is inferred from `outcome === "fail"`.
+ */
+export interface WorkflowEvalRunContext {
+  arm: string;
+  taskId: string;
+  seed: number;
+  outcome?: string;
+  verifierFailed?: boolean;
+  repeatedFailures?: number;
+}
+
+/**
+ * Task-side metadata. All fields optional. Unknown `required_if` flags
+ * default to `false` so a missing flag does NOT cause a false-positive
+ * `missing_required_event`.
+ */
+export interface WorkflowEvalTaskMetadata {
+  /** Asset ref the agent should have loaded, e.g. `skill:deploy`. */
+  goldRef?: string;
+  /** Boolean flags consulted by `required_if`. */
+  flags?: Record<string, boolean>;
+}
+
+/* ─── Caps (documented contract) ──────────────────────────────────────────── */
+
+/** Hard cap on emitted violations per (run, spec). Prevents runaway reports. */
+export const MAX_VIOLATIONS_PER_CHECK = 32;
+
+/* ─── Top-level entry points ──────────────────────────────────────────────── */
+
+/**
+ * Evaluate one run-trace against one spec. Pure; never throws; never mutates
+ * inputs.
+ *
+ * Callers who want applicability filtering should use
+ * `evaluateRunAgainstAllSpecs` — this entry point evaluates unconditionally
+ * and assumes the caller already decided the spec applies. (It still returns
+ * `harness_error` if inputs are obviously malformed.)
+ */
+export function evaluateRunAgainstSpec(
+  trace: WorkflowTraceResult | undefined | null,
+  spec: WorkflowSpec | undefined | null,
+  run: WorkflowEvalRunContext,
+  task: WorkflowEvalTaskMetadata = {},
+): WorkflowCheckResult {
+  // Harness validation: malformed inputs short-circuit with a structured violation.
+  const harnessError = validateInputs(trace, spec, run);
+  if (harnessError) return harnessError;
+
+  // Past validateInputs we know trace & spec are well-formed.
+  const t = trace as WorkflowTraceResult;
+  const s = spec as WorkflowSpec;
+
+  const events = Array.isArray(t.events) ? t.events.filter(isUsableEvent) : [];
+  const violations: WorkflowViolation[] = [];
+  const flags = task.flags ?? {};
+
+  // ── Required-sequence checks ──────────────────────────────────────────────
+  let requiredTotal = 0;
+  let requiredPassed = 0;
+
+  for (const step of s.required_sequence) {
+    if (step.required_if && !flags[step.required_if]) {
+      // Conditional step skipped.
+      continue;
+    }
+    requiredTotal += 1;
+    const ok = checkRequiredStep(step, events, task, violations);
+    if (ok) requiredPassed += 1;
+  }
+
+  // ── Forbidden checks ──────────────────────────────────────────────────────
+  let forbiddenTotal = 0;
+  let forbiddenPassed = 0;
+
+  for (const step of s.forbidden ?? []) {
+    forbiddenTotal += 1;
+    const ok = checkForbiddenStep(step, events, violations);
+    if (ok) forbiddenPassed += 1;
+  }
+
+  // ── Verifier-aware feedback polarity check ────────────────────────────────
+  const verifierFailed = run.verifierFailed ?? run.outcome === "fail";
+  const feedbackEvents = events.filter((e) => e.type === "akm_feedback");
+  const polarityCheckOk = checkVerifierPolarity(verifierFailed, feedbackEvents, violations);
+
+  // ── Gold-ref check (when task has goldRef and spec expects gold loading) ──
+  const goldAssetLoaded = checkGoldRef(task.goldRef, events, s, violations);
+
+  // ── Score & status ────────────────────────────────────────────────────────
+  const w = s.scoring;
+  const requiredFraction = requiredTotal === 0 ? 1 : requiredPassed / requiredTotal;
+  const forbiddenFraction = forbiddenTotal === 0 ? 1 : forbiddenPassed / forbiddenTotal;
+  // Evidence quality: feedback-polarity match + gold-ref match + verifier_run present.
+  const evidenceSignals: number[] = [polarityCheckOk ? 1 : 0];
+  if (task.goldRef !== undefined) evidenceSignals.push(goldAssetLoaded ? 1 : 0);
+  if (events.some((e) => e.type === "verifier_run")) evidenceSignals.push(1);
+  else evidenceSignals.push(0);
+  const evidenceFraction = evidenceSignals.length === 0 ? 1 : average(evidenceSignals);
+
+  let score =
+    w.required_steps_weight * requiredFraction +
+    w.forbidden_steps_weight * forbiddenFraction +
+    w.evidence_quality_weight * evidenceFraction;
+  score = clampUnit(score);
+
+  // Cap violations after computing score so the score reflects ALL findings.
+  const cappedViolations = capViolations(violations);
+
+  let status: WorkflowCheckStatus;
+  if (requiredTotal === 0) {
+    // No required steps applied (e.g. all required_if guards were false).
+    // Treat as pass when no violations were found, partial otherwise.
+    status = cappedViolations.length === 0 ? "pass" : "partial";
+  } else if (requiredPassed === requiredTotal && cappedViolations.length === 0) {
+    status = "pass";
+  } else if (requiredPassed === 0) {
+    status = "fail";
+  } else {
+    status = "partial";
+  }
+
+  const evidence: WorkflowEvidenceSummary = {
+    matchedEvents: countMatchingEvents(events, s),
+    feedbackRecorded: feedbackEvents.length > 0,
+    goldAssetLoaded,
+    traceTruncated: t.truncated === true,
+  };
+
+  return {
+    schemaVersion: 1,
+    workflowId: s.id,
+    taskId: run.taskId,
+    arm: run.arm,
+    seed: run.seed,
+    status,
+    score,
+    requiredPassed,
+    requiredTotal,
+    violations: cappedViolations,
+    evidence,
+  };
+}
+
+/**
+ * Evaluate one trace against many specs, applying `applies_to` filters. Specs
+ * whose filter excludes the run produce a `not_applicable` result with empty
+ * violations and `score = 0`; this preserves a stable 1-result-per-spec shape
+ * for downstream reporters.
+ */
+export function evaluateRunAgainstAllSpecs(
+  trace: WorkflowTraceResult | undefined | null,
+  specs: readonly WorkflowSpec[] | undefined | null,
+  run: WorkflowEvalRunContext,
+  task: WorkflowEvalTaskMetadata = {},
+): WorkflowCheckResult[] {
+  if (!Array.isArray(specs)) return [];
+  const out: WorkflowCheckResult[] = [];
+  for (const spec of specs) {
+    if (!spec || typeof spec !== "object") continue;
+    const applicable = specApplies(spec, {
+      arm: run.arm,
+      taskId: run.taskId,
+      outcome: run.outcome,
+      hasGoldRef: task.goldRef !== undefined,
+      repeatedFailures: run.repeatedFailures,
+    });
+    if (!applicable) {
+      out.push(makeNotApplicable(spec, run));
+      continue;
+    }
+    out.push(evaluateRunAgainstSpec(trace, spec, run, task));
+  }
+  return out;
+}
+
+/* ─── Required-step check ─────────────────────────────────────────────────── */
+
+function checkRequiredStep(
+  step: WorkflowSequenceStep,
+  events: WorkflowTraceEvent[],
+  task: WorkflowEvalTaskMetadata,
+  violations: WorkflowViolation[],
+): boolean {
+  const matchingForStep = events.filter((e) => e.type === step.event);
+
+  // 1) Polarity-aware filter: a polarity-tagged step only counts feedback
+  //    events with the right polarity.
+  const matching =
+    step.polarity !== undefined ? matchingForStep.filter((e) => eventPolarity(e) === step.polarity) : matchingForStep;
+
+  // 2) Presence + min_count.
+  const minCount = step.min_count ?? 1;
+  if (matching.length < minCount) {
+    pushViolation(violations, {
+      code: "missing_required_event",
+      message:
+        step.polarity !== undefined
+          ? `expected ≥${minCount} ${step.event} event(s) with polarity=${step.polarity}, observed ${matching.length}`
+          : `expected ≥${minCount} ${step.event} event(s), observed ${matching.length}`,
+      expected: step.polarity ? `${step.event}(${step.polarity}) x${minCount}` : `${step.event} x${minCount}`,
+      observed: `${matching.length}`,
+    });
+    return false;
+  }
+
+  // 3) ref_must_equal — match a matching event to the task field.
+  if (step.ref_must_equal !== undefined) {
+    const wantedRef = resolveRefField(step.ref_must_equal, task);
+    if (wantedRef === undefined) {
+      pushViolation(violations, {
+        code: "missing_evidence",
+        message: `step expects ref_must_equal=${step.ref_must_equal} but task does not declare it`,
+        expected: step.ref_must_equal,
+      });
+      return false;
+    }
+    const refMatch = matching.find((e) => e.assetRef === wantedRef);
+    if (!refMatch) {
+      const observedRef = matching.find((e) => typeof e.assetRef === "string")?.assetRef;
+      pushViolation(violations, {
+        code: "irrelevant_asset_loaded",
+        message: `${step.event} did not load ${step.ref_must_equal}=${wantedRef}`,
+        expected: wantedRef,
+        observed: observedRef,
+      });
+      return false;
+    }
+  }
+
+  // 4) before/after order checks. We compare FIRST occurrence (by event id).
+  const firstThis = firstId(matching);
+  if (step.before !== undefined && firstThis !== undefined) {
+    const firstOther = firstId(events.filter((e) => e.type === step.before));
+    if (firstOther !== undefined && firstThis >= firstOther) {
+      pushViolation(violations, {
+        code: "wrong_order",
+        message: `expected ${step.event} before ${step.before}, but ${step.before} occurred first`,
+        expected: `${step.event} < ${step.before}`,
+        observed: `${step.before} < ${step.event}`,
+      });
+      return false;
+    }
+  }
+  if (step.after !== undefined && firstThis !== undefined) {
+    const firstOther = firstId(events.filter((e) => e.type === step.after));
+    if (firstOther !== undefined && firstThis <= firstOther) {
+      pushViolation(violations, {
+        code: "wrong_order",
+        message: `expected ${step.event} after ${step.after}, but ${step.event} occurred first`,
+        expected: `${step.after} < ${step.event}`,
+        observed: `${step.event} < ${step.after}`,
+      });
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/* ─── Forbidden-step check ────────────────────────────────────────────────── */
+
+function checkForbiddenStep(
+  step: WorkflowForbiddenStep,
+  events: WorkflowTraceEvent[],
+  violations: WorkflowViolation[],
+): boolean {
+  const matchingForType = events.filter((e) => e.type === step.event);
+  const matching =
+    step.polarity !== undefined ? matchingForType.filter((e) => eventPolarity(e) === step.polarity) : matchingForType;
+
+  if (matching.length === 0) return true;
+
+  // Pure forbidden (no before/after): event must be absent.
+  if (step.before === undefined && step.after === undefined) {
+    pushViolation(violations, {
+      code: "forbidden_event",
+      message:
+        step.polarity !== undefined
+          ? `forbidden event ${step.event}(polarity=${step.polarity}) appeared`
+          : `forbidden event ${step.event} appeared`,
+      expected: "absent",
+      observed: step.polarity ? `${step.event}(${step.polarity})` : step.event,
+    });
+    return false;
+  }
+
+  // Conditional forbidden: forbidden when ordered relative to a guard.
+  if (step.before !== undefined) {
+    const firstGuard = firstId(events.filter((e) => e.type === step.before));
+    const firstThis = firstId(matching);
+    if (firstGuard === undefined) {
+      // Guard absent — `before X` cannot be violated.
+      return true;
+    }
+    if (firstThis !== undefined && firstThis < firstGuard) {
+      pushViolation(violations, {
+        code: classifyForbiddenCode(step),
+        message: `${step.event} occurred before ${step.before}`,
+        expected: `${step.event} after ${step.before}`,
+        observed: `${step.event} before ${step.before}`,
+      });
+      return false;
+    }
+    return true;
+  }
+
+  if (step.after !== undefined) {
+    const firstGuard = firstId(events.filter((e) => e.type === step.after));
+    const firstThis = firstId(matching);
+    if (firstGuard === undefined) return true;
+    if (firstThis !== undefined && firstThis > firstGuard) {
+      pushViolation(violations, {
+        code: classifyForbiddenCode(step),
+        message: `${step.event} occurred after ${step.after}`,
+        expected: `${step.event} before ${step.after}`,
+        observed: `${step.event} after ${step.after}`,
+      });
+      return false;
+    }
+    return true;
+  }
+
+  return true;
+}
+
+/** Pick a more specific violation code for ordering-flavoured forbidden rules. */
+function classifyForbiddenCode(step: WorkflowForbiddenStep): WorkflowViolationCode {
+  // Domain-specific specialisations for diagnostic clarity.
+  if (step.event === "akm_reflect" && step.before === "akm_feedback") {
+    return "reflection_without_failure";
+  }
+  if (step.event === "akm_proposal_accept") {
+    // Accepting a proposal before propose/verifier/test = unvalidated acceptance.
+    return "proposal_accepted_without_validation";
+  }
+  if (step.event === "akm_feedback" && step.before === "verifier_run") {
+    return "late_feedback";
+  }
+  return "forbidden_event";
+}
+
+/* ─── Verifier-aware feedback polarity ────────────────────────────────────── */
+
+/**
+ * When the verifier failed, any recorded `akm_feedback` must include at least
+ * one negative-polarity event. Mirror: when the verifier passed, recorded
+ * feedback should include a positive-polarity event. Returns true when the
+ * polarity matches (or there is no feedback at all — that's the
+ * `feedback-after-use` spec's job to flag).
+ */
+function checkVerifierPolarity(
+  verifierFailed: boolean,
+  feedbackEvents: WorkflowTraceEvent[],
+  violations: WorkflowViolation[],
+): boolean {
+  if (feedbackEvents.length === 0) return true; // separate spec covers missing feedback.
+
+  if (verifierFailed) {
+    const hasNegative = feedbackEvents.some((e) => eventPolarity(e) === "negative");
+    if (!hasNegative) {
+      pushViolation(violations, {
+        code: "wrong_feedback_polarity",
+        message: "verifier failed but agent recorded no negative feedback",
+        expected: "negative",
+        observed: feedbackEvents.map((e) => eventPolarity(e) ?? "unknown").join(","),
+      });
+      return false;
+    }
+    return true;
+  }
+
+  // Verifier passed. Positive feedback expected when feedback was recorded.
+  const hasPositive = feedbackEvents.some((e) => eventPolarity(e) === "positive");
+  if (!hasPositive) {
+    pushViolation(violations, {
+      code: "wrong_feedback_polarity",
+      message: "verifier passed but agent recorded no positive feedback",
+      expected: "positive",
+      observed: feedbackEvents.map((e) => eventPolarity(e) ?? "unknown").join(","),
+    });
+    return false;
+  }
+  return true;
+}
+
+/* ─── Gold-ref check ──────────────────────────────────────────────────────── */
+
+function checkGoldRef(
+  goldRef: string | undefined,
+  events: WorkflowTraceEvent[],
+  spec: WorkflowSpec,
+  violations: WorkflowViolation[],
+): boolean {
+  if (goldRef === undefined) return false; // not loaded, but also not required.
+
+  const showEvents = events.filter((e) => e.type === "akm_show");
+  const matched = showEvents.some((e) => e.assetRef === goldRef);
+  if (matched) return true;
+
+  // Don't double-count if the spec already had a `ref_must_equal: gold_ref`
+  // step that flagged this — check by scanning existing violations.
+  const alreadyFlagged = violations.some((v) => v.code === "irrelevant_asset_loaded" && v.expected === goldRef);
+  if (alreadyFlagged) return false;
+
+  // Only emit a top-level gold-ref violation when the spec at least mentions
+  // gold loading — e.g. has a step with `ref_must_equal` OR declares its own
+  // `gold_ref`. Otherwise this would noisy-fire on every unrelated spec.
+  const specCaresAboutGold =
+    spec.gold_ref !== undefined || spec.required_sequence.some((step) => step.ref_must_equal !== undefined);
+  if (!specCaresAboutGold) return false;
+
+  const observed = showEvents.find((e) => typeof e.assetRef === "string")?.assetRef;
+  pushViolation(violations, {
+    code: "irrelevant_asset_loaded",
+    message: `gold asset ${goldRef} was never loaded via akm_show`,
+    expected: goldRef,
+    observed,
+  });
+  return false;
+}
+
+/* ─── Helpers ─────────────────────────────────────────────────────────────── */
+
+function isUsableEvent(e: unknown): e is WorkflowTraceEvent {
+  if (!e || typeof e !== "object") return false;
+  const ev = e as Partial<WorkflowTraceEvent>;
+  return typeof ev.type === "string" && typeof ev.id === "number";
+}
+
+function firstId(events: WorkflowTraceEvent[]): number | undefined {
+  if (events.length === 0) return undefined;
+  let min = events[0].id;
+  for (let i = 1; i < events.length; i += 1) {
+    if (events[i].id < min) min = events[i].id;
+  }
+  return min;
+}
+
+/**
+ * Recover an event's feedback polarity. The trace contract does NOT carry a
+ * top-level `polarity` field, so we probe known shapes:
+ *   - args contain a token like `+1` / `-1` / `positive` / `negative`.
+ *   - command-style: `akm feedback +1 skill:foo`.
+ * Returns `undefined` when polarity cannot be determined.
+ */
+function eventPolarity(ev: WorkflowTraceEvent): "positive" | "negative" | undefined {
+  // args-based detection.
+  if (Array.isArray(ev.args)) {
+    for (const a of ev.args) {
+      if (a === "+1" || a === "positive" || a === "+") return "positive";
+      if (a === "-1" || a === "negative" || a === "-") return "negative";
+    }
+  }
+  // command-string fallback (rare, but cheap).
+  if (typeof ev.command === "string") {
+    if (/(?:^|\s)(?:\+1|positive)(?:\s|$)/.test(ev.command)) return "positive";
+    if (/(?:^|\s)(?:-1|negative)(?:\s|$)/.test(ev.command)) return "negative";
+  }
+  return undefined;
+}
+
+function resolveRefField(field: string, task: WorkflowEvalTaskMetadata): string | undefined {
+  if (field === "gold_ref") return task.goldRef;
+  return undefined;
+}
+
+function pushViolation(out: WorkflowViolation[], v: WorkflowViolation): void {
+  if (out.length >= MAX_VIOLATIONS_PER_CHECK) return;
+  out.push(v);
+}
+
+function capViolations(violations: WorkflowViolation[]): WorkflowViolation[] {
+  if (violations.length <= MAX_VIOLATIONS_PER_CHECK) return violations;
+  return violations.slice(0, MAX_VIOLATIONS_PER_CHECK);
+}
+
+function countMatchingEvents(events: WorkflowTraceEvent[], spec: WorkflowSpec): number {
+  const vocab = new Set<WorkflowTraceEventType>();
+  for (const step of spec.required_sequence) {
+    vocab.add(step.event as WorkflowTraceEventType);
+    if (step.before) vocab.add(step.before as WorkflowTraceEventType);
+    if (step.after) vocab.add(step.after as WorkflowTraceEventType);
+  }
+  for (const step of spec.forbidden ?? []) {
+    vocab.add(step.event as WorkflowTraceEventType);
+  }
+  let n = 0;
+  for (const ev of events) if (vocab.has(ev.type)) n += 1;
+  return n;
+}
+
+function average(xs: number[]): number {
+  let sum = 0;
+  for (const x of xs) sum += x;
+  return sum / xs.length;
+}
+
+function clampUnit(x: number): number {
+  if (!Number.isFinite(x)) return 0;
+  if (x < 0) return 0;
+  if (x > 1) return 1;
+  return x;
+}
+
+function makeNotApplicable(spec: WorkflowSpec, run: WorkflowEvalRunContext): WorkflowCheckResult {
+  return {
+    schemaVersion: 1,
+    workflowId: spec.id,
+    taskId: run.taskId,
+    arm: run.arm,
+    seed: run.seed,
+    status: "not_applicable",
+    score: 0,
+    requiredPassed: 0,
+    requiredTotal: 0,
+    violations: [],
+    evidence: {
+      matchedEvents: 0,
+      feedbackRecorded: false,
+      goldAssetLoaded: false,
+      traceTruncated: false,
+    },
+  };
+}
+
+function validateInputs(
+  trace: WorkflowTraceResult | undefined | null,
+  spec: WorkflowSpec | undefined | null,
+  run: WorkflowEvalRunContext,
+): WorkflowCheckResult | undefined {
+  if (!run || typeof run !== "object" || typeof run.taskId !== "string" || typeof run.arm !== "string") {
+    return harnessError(spec, run, "run context missing arm/taskId");
+  }
+  if (!trace || typeof trace !== "object") {
+    return harnessError(spec, run, "trace is missing or not an object");
+  }
+  if (!Array.isArray((trace as WorkflowTraceResult).events)) {
+    return harnessError(spec, run, "trace.events is not an array");
+  }
+  if (!spec || typeof spec !== "object") {
+    return harnessError(spec, run, "spec is missing or not an object");
+  }
+  const s = spec as Partial<WorkflowSpec>;
+  if (typeof s.id !== "string" || !Array.isArray(s.required_sequence) || !s.scoring) {
+    return harnessError(spec, run, "spec is malformed (missing id/required_sequence/scoring)");
+  }
+  return undefined;
+}
+
+function harnessError(
+  spec: WorkflowSpec | undefined | null,
+  run: WorkflowEvalRunContext | undefined | null,
+  reason: string,
+): WorkflowCheckResult {
+  const safeRun: WorkflowEvalRunContext =
+    run && typeof run === "object"
+      ? {
+          arm: typeof run.arm === "string" ? run.arm : "unknown",
+          taskId: typeof run.taskId === "string" ? run.taskId : "unknown",
+          seed: typeof run.seed === "number" ? run.seed : -1,
+        }
+      : { arm: "unknown", taskId: "unknown", seed: -1 };
+  return {
+    schemaVersion: 1,
+    workflowId:
+      spec && typeof spec === "object" && typeof (spec as WorkflowSpec).id === "string"
+        ? (spec as WorkflowSpec).id
+        : "unknown",
+    taskId: safeRun.taskId,
+    arm: safeRun.arm,
+    seed: safeRun.seed,
+    status: "harness_error",
+    score: 0,
+    requiredPassed: 0,
+    requiredTotal: 0,
+    violations: [
+      {
+        code: "missing_evidence",
+        message: `harness error: ${reason}`,
+        observed: reason,
+      },
+    ],
+    evidence: {
+      matchedEvents: 0,
+      feedbackRecorded: false,
+      goldAssetLoaded: false,
+      traceTruncated: false,
+    },
+  };
+}

--- a/tests/bench/workflow-spec.test.ts
+++ b/tests/bench/workflow-spec.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Tests for the workflow-spec YAML loader.
+ *
+ * Covers: valid fixtures, malformed specs, unknown event names,
+ * applicability filters, gold_ref validation, path-traversal rejection,
+ * scoring validation, duplicate ids.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  KNOWN_EVENT_NAMES,
+  loadAllWorkflowSpecs,
+  loadWorkflowSpec,
+  specApplies,
+  WorkflowSpecError,
+} from "./workflow-spec";
+
+const FIXTURE_DIR = path.resolve(__dirname, "..", "fixtures", "bench", "workflows");
+
+const REQUIRED_SPECS = [
+  "akm-lookup-before-edit",
+  "akm-correct-asset-use",
+  "akm-feedback-after-use",
+  "akm-negative-feedback-on-failure",
+  "akm-reflect-after-repeated-failure",
+  "akm-proposal-review-before-accept",
+];
+
+// ── Scratch directory helpers ──────────────────────────────────────────────
+
+let scratch: string;
+
+beforeEach(() => {
+  scratch = mkdtempSync(path.join(tmpdir(), "akm-workflow-spec-"));
+});
+
+afterEach(() => {
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+function writeSpec(name: string, body: string): string {
+  const p = path.join(scratch, name);
+  writeFileSync(p, body, "utf8");
+  return p;
+}
+
+// ── Fixture sanity ─────────────────────────────────────────────────────────
+
+describe("loadAllWorkflowSpecs (real fixtures)", () => {
+  test("loads every checked-in workflow spec", () => {
+    const specs = loadAllWorkflowSpecs(FIXTURE_DIR);
+    const ids = specs.map((s) => s.id).sort();
+    for (const required of REQUIRED_SPECS) {
+      expect(ids).toContain(required);
+    }
+  });
+
+  test("every fixture has a valid scoring block", () => {
+    const specs = loadAllWorkflowSpecs(FIXTURE_DIR);
+    for (const s of specs) {
+      const sum =
+        s.scoring.required_steps_weight + s.scoring.forbidden_steps_weight + s.scoring.evidence_quality_weight;
+      expect(Math.abs(sum - 1)).toBeLessThan(1e-6);
+    }
+  });
+
+  test("every fixture event-name is in the known set", () => {
+    const known = new Set<string>(KNOWN_EVENT_NAMES);
+    const specs = loadAllWorkflowSpecs(FIXTURE_DIR);
+    for (const s of specs) {
+      for (const step of s.required_sequence) {
+        expect(known.has(step.event)).toBe(true);
+        if (step.before) expect(known.has(step.before)).toBe(true);
+      }
+      for (const step of s.forbidden ?? []) {
+        expect(known.has(step.event)).toBe(true);
+        if (step.before) expect(known.has(step.before)).toBe(true);
+      }
+    }
+  });
+});
+
+// ── Valid spec parsing ─────────────────────────────────────────────────────
+
+describe("loadWorkflowSpec — valid", () => {
+  test("parses a minimal valid spec", () => {
+    const p = writeSpec(
+      "min.yaml",
+      `id: min
+title: Minimal
+required_sequence:
+  - event: agent_started
+  - event: agent_finished
+scoring:
+  required_steps_weight: 0.6
+  forbidden_steps_weight: 0.2
+  evidence_quality_weight: 0.2
+`,
+    );
+    const spec = loadWorkflowSpec(p);
+    expect(spec.id).toBe("min");
+    expect(spec.required_sequence.length).toBe(2);
+    expect(spec.forbidden).toBeUndefined();
+    expect(spec.applies_to).toBeUndefined();
+    expect(spec.sourcePath).toBe(path.resolve(p));
+  });
+
+  test("preserves all richer fields (applies_to, forbidden, gold_ref)", () => {
+    const p = writeSpec(
+      "rich.yaml",
+      `id: rich
+title: Rich
+applies_to:
+  arms: ["akm"]
+  task_domains: ["docker-homelab"]
+  outcomes: ["pass"]
+  requires_gold_ref: true
+  min_repeated_failures: 2
+gold_ref: "skill:deploy"
+required_sequence:
+  - event: agent_started
+  - event: akm_show
+    ref_must_equal: gold_ref
+    before: first_workspace_write
+  - event: first_workspace_write
+forbidden:
+  - event: first_workspace_write
+    before: akm_show
+scoring:
+  required_steps_weight: 0.5
+  forbidden_steps_weight: 0.3
+  evidence_quality_weight: 0.2
+`,
+    );
+    const spec = loadWorkflowSpec(p);
+    expect(spec.applies_to?.arms).toEqual(["akm"]);
+    expect(spec.applies_to?.task_domains).toEqual(["docker-homelab"]);
+    expect(spec.applies_to?.requires_gold_ref).toBe(true);
+    expect(spec.applies_to?.min_repeated_failures).toBe(2);
+    expect(spec.gold_ref).toBe("skill:deploy");
+    expect(spec.forbidden?.length).toBe(1);
+    expect(spec.required_sequence[1].ref_must_equal).toBe("gold_ref");
+  });
+});
+
+// ── Malformed specs ────────────────────────────────────────────────────────
+
+describe("loadWorkflowSpec — malformed", () => {
+  test("rejects non-YAML garbage", () => {
+    const p = writeSpec("bad.yaml", "::: not yaml\n  - oops:\n: : :");
+    expect(() => loadWorkflowSpec(p)).toThrow(WorkflowSpecError);
+  });
+
+  test("rejects YAML whose top level is not a mapping", () => {
+    const p = writeSpec("array.yaml", "- 1\n- 2\n");
+    expect(() => loadWorkflowSpec(p)).toThrow(/must be a mapping/);
+  });
+
+  test("rejects missing required fields", () => {
+    const p = writeSpec(
+      "no-title.yaml",
+      `id: x
+required_sequence:
+  - event: agent_started
+scoring:
+  required_steps_weight: 0.5
+  forbidden_steps_weight: 0.3
+  evidence_quality_weight: 0.2
+`,
+    );
+    expect(() => loadWorkflowSpec(p)).toThrow(/title/);
+  });
+
+  test("rejects empty required_sequence", () => {
+    const p = writeSpec(
+      "empty-seq.yaml",
+      `id: x
+title: x
+required_sequence: []
+scoring:
+  required_steps_weight: 0.5
+  forbidden_steps_weight: 0.3
+  evidence_quality_weight: 0.2
+`,
+    );
+    expect(() => loadWorkflowSpec(p)).toThrow(/required_sequence/);
+  });
+
+  test("rejects scoring weights that don't sum to 1", () => {
+    const p = writeSpec(
+      "bad-scoring.yaml",
+      `id: x
+title: x
+required_sequence:
+  - event: agent_started
+scoring:
+  required_steps_weight: 0.5
+  forbidden_steps_weight: 0.3
+  evidence_quality_weight: 0.5
+`,
+    );
+    expect(() => loadWorkflowSpec(p)).toThrow(/sum to 1/);
+  });
+
+  test("rejects scoring weight outside [0, 1]", () => {
+    const p = writeSpec(
+      "neg-scoring.yaml",
+      `id: x
+title: x
+required_sequence:
+  - event: agent_started
+scoring:
+  required_steps_weight: -0.2
+  forbidden_steps_weight: 0.6
+  evidence_quality_weight: 0.6
+`,
+    );
+    expect(() => loadWorkflowSpec(p)).toThrow(/in \[0, 1\]/);
+  });
+
+  test("rejects invalid gold_ref via parseAssetRef", () => {
+    const p = writeSpec(
+      "bad-ref.yaml",
+      `id: x
+title: x
+gold_ref: "not-a-ref"
+required_sequence:
+  - event: agent_started
+scoring:
+  required_steps_weight: 0.5
+  forbidden_steps_weight: 0.3
+  evidence_quality_weight: 0.2
+`,
+    );
+    expect(() => loadWorkflowSpec(p)).toThrow(/gold_ref/);
+  });
+
+  test("rejects invalid polarity", () => {
+    const p = writeSpec(
+      "bad-polarity.yaml",
+      `id: x
+title: x
+required_sequence:
+  - event: akm_feedback
+    polarity: lukewarm
+scoring:
+  required_steps_weight: 0.5
+  forbidden_steps_weight: 0.3
+  evidence_quality_weight: 0.2
+`,
+    );
+    expect(() => loadWorkflowSpec(p)).toThrow(/polarity/);
+  });
+});
+
+// ── Unknown event names ────────────────────────────────────────────────────
+
+describe("loadWorkflowSpec — unknown event names", () => {
+  test("rejects unknown event in required_sequence", () => {
+    const p = writeSpec(
+      "unknown.yaml",
+      `id: x
+title: x
+required_sequence:
+  - event: agent_started
+  - event: cosmic_rays
+scoring:
+  required_steps_weight: 0.5
+  forbidden_steps_weight: 0.3
+  evidence_quality_weight: 0.2
+`,
+    );
+    expect(() => loadWorkflowSpec(p)).toThrow(/Unknown event name "cosmic_rays"/);
+  });
+
+  test("rejects unknown event in `before` clause", () => {
+    const p = writeSpec(
+      "unknown-before.yaml",
+      `id: x
+title: x
+required_sequence:
+  - event: akm_search
+    before: nope
+scoring:
+  required_steps_weight: 0.5
+  forbidden_steps_weight: 0.3
+  evidence_quality_weight: 0.2
+`,
+    );
+    expect(() => loadWorkflowSpec(p)).toThrow(/Unknown event name "nope"/);
+  });
+
+  test("rejects unknown event in forbidden block", () => {
+    const p = writeSpec(
+      "unknown-forbidden.yaml",
+      `id: x
+title: x
+required_sequence:
+  - event: agent_started
+forbidden:
+  - event: ouija_board
+scoring:
+  required_steps_weight: 0.5
+  forbidden_steps_weight: 0.3
+  evidence_quality_weight: 0.2
+`,
+    );
+    expect(() => loadWorkflowSpec(p)).toThrow(/Unknown event name "ouija_board"/);
+  });
+});
+
+// ── Applicability filters ──────────────────────────────────────────────────
+
+describe("specApplies", () => {
+  function specWith(applies_to?: object) {
+    const yaml = applies_to
+      ? `id: x\ntitle: x\napplies_to:\n${Object.entries(applies_to)
+          .map(([k, v]) => `  ${k}: ${JSON.stringify(v)}`)
+          .join(
+            "\n",
+          )}\nrequired_sequence:\n  - event: agent_started\nscoring:\n  required_steps_weight: 0.5\n  forbidden_steps_weight: 0.3\n  evidence_quality_weight: 0.2\n`
+      : `id: x\ntitle: x\nrequired_sequence:\n  - event: agent_started\nscoring:\n  required_steps_weight: 0.5\n  forbidden_steps_weight: 0.3\n  evidence_quality_weight: 0.2\n`;
+    const p = writeSpec(`${Math.random().toString(36).slice(2)}.yaml`, yaml);
+    return loadWorkflowSpec(p);
+  }
+
+  test("no filter ⇒ matches anything", () => {
+    const s = specWith();
+    expect(specApplies(s, { arm: "noakm", taskId: "any/thing" })).toBe(true);
+  });
+
+  test("arm filter rejects mismatched arm", () => {
+    const s = specWith({ arms: ["akm"] });
+    expect(specApplies(s, { arm: "noakm", taskId: "x/y" })).toBe(false);
+    expect(specApplies(s, { arm: "akm", taskId: "x/y" })).toBe(true);
+  });
+
+  test("task_domains filter uses first segment of taskId", () => {
+    const s = specWith({ task_domains: ["docker-homelab"] });
+    expect(specApplies(s, { arm: "akm", taskId: "docker-homelab/redis" })).toBe(true);
+    expect(specApplies(s, { arm: "akm", taskId: "az-cli/storage" })).toBe(false);
+  });
+
+  test("outcomes filter requires the outcome to be present", () => {
+    const s = specWith({ outcomes: ["pass"] });
+    expect(specApplies(s, { arm: "akm", taskId: "x/y", outcome: "pass" })).toBe(true);
+    expect(specApplies(s, { arm: "akm", taskId: "x/y", outcome: "fail" })).toBe(false);
+    expect(specApplies(s, { arm: "akm", taskId: "x/y" })).toBe(false);
+  });
+
+  test("requires_gold_ref demands hasGoldRef", () => {
+    const s = specWith({ requires_gold_ref: true });
+    expect(specApplies(s, { arm: "akm", taskId: "x/y", hasGoldRef: false })).toBe(false);
+    expect(specApplies(s, { arm: "akm", taskId: "x/y", hasGoldRef: true })).toBe(true);
+  });
+
+  test("min_repeated_failures gates on repeatedFailures count", () => {
+    const s = specWith({ min_repeated_failures: 2 });
+    expect(specApplies(s, { arm: "akm", taskId: "x/y", repeatedFailures: 1 })).toBe(false);
+    expect(specApplies(s, { arm: "akm", taskId: "x/y", repeatedFailures: 2 })).toBe(true);
+    expect(specApplies(s, { arm: "akm", taskId: "x/y" })).toBe(false);
+  });
+});
+
+// ── Path traversal ─────────────────────────────────────────────────────────
+
+describe("loadWorkflowSpec — path traversal", () => {
+  test("rejects spec resolved outside the provided root", () => {
+    // Set up a workflows root with a sibling file outside it.
+    const root = path.join(scratch, "workflows");
+    mkdirSync(root, { recursive: true });
+    const inside = path.join(root, "ok.yaml");
+    writeFileSync(
+      inside,
+      `id: ok
+title: ok
+required_sequence:
+  - event: agent_started
+scoring:
+  required_steps_weight: 0.5
+  forbidden_steps_weight: 0.3
+  evidence_quality_weight: 0.2
+`,
+      "utf8",
+    );
+    const outside = path.join(scratch, "outside.yaml");
+    writeFileSync(outside, "id: nope\ntitle: nope\n", "utf8");
+
+    expect(() => loadWorkflowSpec(inside, root)).not.toThrow();
+    expect(() => loadWorkflowSpec(outside, root)).toThrow(/outside/);
+    // Traversal pattern must also be rejected.
+    const traversal = path.join(root, "..", "outside.yaml");
+    expect(() => loadWorkflowSpec(traversal, root)).toThrow(/outside/);
+  });
+
+  test("loadAllWorkflowSpecs ignores non-yaml files in dir", () => {
+    const root = path.join(scratch, "workflows");
+    mkdirSync(root, { recursive: true });
+    writeFileSync(path.join(root, "README.md"), "not a spec\n", "utf8");
+    writeFileSync(
+      path.join(root, "a.yaml"),
+      `id: a
+title: a
+required_sequence:
+  - event: agent_started
+scoring:
+  required_steps_weight: 0.5
+  forbidden_steps_weight: 0.3
+  evidence_quality_weight: 0.2
+`,
+      "utf8",
+    );
+    const specs = loadAllWorkflowSpecs(root);
+    expect(specs.length).toBe(1);
+    expect(specs[0].id).toBe("a");
+  });
+
+  test("loadAllWorkflowSpecs rejects duplicate ids across files", () => {
+    const root = path.join(scratch, "workflows");
+    mkdirSync(root, { recursive: true });
+    const body = `id: dup
+title: dup
+required_sequence:
+  - event: agent_started
+scoring:
+  required_steps_weight: 0.5
+  forbidden_steps_weight: 0.3
+  evidence_quality_weight: 0.2
+`;
+    writeFileSync(path.join(root, "a.yaml"), body, "utf8");
+    writeFileSync(path.join(root, "b.yaml"), body, "utf8");
+    expect(() => loadAllWorkflowSpecs(root)).toThrow(/Duplicate workflow spec id "dup"/);
+  });
+});

--- a/tests/bench/workflow-spec.test.ts
+++ b/tests/bench/workflow-spec.test.ts
@@ -397,6 +397,26 @@ scoring:
     expect(() => loadWorkflowSpec(traversal, root)).toThrow(/outside/);
   });
 
+  test("allows in-root spec paths whose filename starts with '..'", () => {
+    const root = path.join(scratch, "workflows");
+    mkdirSync(root, { recursive: true });
+    const inside = path.join(root, "..still-inside.yaml");
+    writeFileSync(
+      inside,
+      `id: ok
+title: ok
+required_sequence:
+  - event: agent_started
+scoring:
+  required_steps_weight: 0.5
+  forbidden_steps_weight: 0.3
+  evidence_quality_weight: 0.2
+`,
+      "utf8",
+    );
+    expect(() => loadWorkflowSpec(inside, root)).not.toThrow();
+  });
+
   test("loadAllWorkflowSpecs ignores non-yaml files in dir", () => {
     const root = path.join(scratch, "workflows");
     mkdirSync(root, { recursive: true });

--- a/tests/bench/workflow-spec.ts
+++ b/tests/bench/workflow-spec.ts
@@ -121,6 +121,7 @@ export interface WorkflowSpec {
 // ── Errors ─────────────────────────────────────────────────────────────────
 
 export class WorkflowSpecError extends Error {
+  readonly code = "WORKFLOW_SPEC_INVALID" as const;
   constructor(
     message: string,
     readonly specPath: string,

--- a/tests/bench/workflow-spec.ts
+++ b/tests/bench/workflow-spec.ts
@@ -1,0 +1,453 @@
+/**
+ * Declarative workflow specs for AKM compliance checks.
+ *
+ * Specs are authored as YAML in `tests/fixtures/bench/workflows/*.yaml` and
+ * describe expected agent behaviour over the normalized event stream from
+ * `workflow-trace.ts` (issue #254). This module owns:
+ *
+ *   - `WorkflowSpec` type
+ *   - `loadWorkflowSpec(path, root?)` — parses + validates one file
+ *   - `loadAllWorkflowSpecs(dir)` — walks a workflows directory
+ *
+ * Event names are validated against a HARDCODED set in this file. Once
+ * #254 lands, #256 will reconcile by importing the source-of-truth set
+ * from `workflow-trace.ts`. Until then this set is the contract.
+ *
+ * Asset refs (e.g. `gold_ref`) are validated via `parseAssetRef` from
+ * `src/core/asset-ref.ts` — never reinvent ref validation.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+
+import { parseAssetRef } from "../../src/core/asset-ref";
+
+// ── Event-name set (hardcoded; reconcile with #254 in wave 3) ──────────────
+
+/**
+ * Hardcoded event-name allowlist. Mirrors the WorkflowTraceEvent.kind set
+ * specified in the #254 brief.
+ *
+ * `first_workspace_write` is a synthetic marker (the first `workspace_write`
+ * for a run) and is included so specs can talk about it directly.
+ */
+export const KNOWN_EVENT_NAMES = Object.freeze([
+  "agent_started",
+  "akm_search",
+  "akm_show",
+  "akm_feedback",
+  "akm_reflect",
+  "akm_distill",
+  "akm_propose",
+  "akm_proposal_accept",
+  "workspace_read",
+  "workspace_write",
+  "test_run",
+  "verifier_run",
+  "agent_finished",
+  "first_workspace_write",
+] as const);
+
+export type WorkflowEventName = (typeof KNOWN_EVENT_NAMES)[number];
+
+const EVENT_NAME_SET: ReadonlySet<string> = new Set<string>(KNOWN_EVENT_NAMES);
+
+function isKnownEvent(name: unknown): name is WorkflowEventName {
+  return typeof name === "string" && EVENT_NAME_SET.has(name);
+}
+
+// ── Spec types ─────────────────────────────────────────────────────────────
+
+export interface WorkflowAppliesTo {
+  /** Arms this spec applies to, e.g. ["akm"]. Empty/undefined = any arm. */
+  arms?: string[];
+  /** Task-id domain prefixes (split on '/'), e.g. ["docker-homelab"]. */
+  task_domains?: string[];
+  /** Outcomes filter, e.g. ["pass"] or ["fail"]. */
+  outcomes?: string[];
+  /** Spec only applies when task has a gold_ref declared. */
+  requires_gold_ref?: boolean;
+  /** Threshold for repeated-failure specs. */
+  min_repeated_failures?: number;
+}
+
+export interface WorkflowSequenceStep {
+  event: WorkflowEventName;
+  /** Must occur before this other event. */
+  before?: WorkflowEventName;
+  /** Must occur after this other event. */
+  after?: WorkflowEventName;
+  /** Step is only required when this condition is true at run time. */
+  required_if?: string;
+  /** Required minimum count of this event. */
+  min_count?: number;
+  /** For akm_feedback steps: required polarity ("positive" | "negative"). */
+  polarity?: "positive" | "negative";
+  /** For akm_show steps: ref must equal this field's value, e.g. "gold_ref". */
+  ref_must_equal?: string;
+}
+
+export interface WorkflowForbiddenStep {
+  event: WorkflowEventName;
+  /** Forbidden when it occurs before this other event. */
+  before?: WorkflowEventName;
+  /** Forbidden when it occurs after this other event. */
+  after?: WorkflowEventName;
+  /** For akm_feedback: forbid this polarity. */
+  polarity?: "positive" | "negative";
+}
+
+export interface WorkflowScoring {
+  required_steps_weight: number;
+  forbidden_steps_weight: number;
+  evidence_quality_weight: number;
+}
+
+export interface WorkflowSpec {
+  id: string;
+  title: string;
+  description?: string;
+  applies_to?: WorkflowAppliesTo;
+  /** Optional asset ref (validated via parseAssetRef). */
+  gold_ref?: string;
+  required_sequence: WorkflowSequenceStep[];
+  forbidden?: WorkflowForbiddenStep[];
+  scoring: WorkflowScoring;
+  /** Absolute path the spec was loaded from. */
+  sourcePath: string;
+}
+
+// ── Errors ─────────────────────────────────────────────────────────────────
+
+export class WorkflowSpecError extends Error {
+  constructor(
+    message: string,
+    readonly specPath: string,
+  ) {
+    super(`${message} (in ${specPath})`);
+    this.name = "WorkflowSpecError";
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireString(obj: Record<string, unknown>, key: string, specPath: string): string {
+  const v = obj[key];
+  if (typeof v !== "string" || v.length === 0) {
+    throw new WorkflowSpecError(`Missing or non-string field "${key}"`, specPath);
+  }
+  return v;
+}
+
+function optionalString(obj: Record<string, unknown>, key: string, specPath: string): string | undefined {
+  const v = obj[key];
+  if (v === undefined || v === null) return undefined;
+  if (typeof v !== "string") {
+    throw new WorkflowSpecError(`Field "${key}" must be a string`, specPath);
+  }
+  return v;
+}
+
+function optionalStringArray(obj: Record<string, unknown>, key: string, specPath: string): string[] | undefined {
+  const v = obj[key];
+  if (v === undefined || v === null) return undefined;
+  if (!Array.isArray(v) || !v.every((x) => typeof x === "string")) {
+    throw new WorkflowSpecError(`Field "${key}" must be a string[]`, specPath);
+  }
+  return v as string[];
+}
+
+function requireNumber(obj: Record<string, unknown>, key: string, specPath: string): number {
+  const v = obj[key];
+  if (typeof v !== "number" || !Number.isFinite(v)) {
+    throw new WorkflowSpecError(`Missing or non-numeric field "${key}"`, specPath);
+  }
+  return v;
+}
+
+function validateEventName(name: unknown, specPath: string, where: string): WorkflowEventName {
+  if (!isKnownEvent(name)) {
+    throw new WorkflowSpecError(
+      `Unknown event name "${String(name)}" in ${where}. ` + `Allowed: ${KNOWN_EVENT_NAMES.join(", ")}`,
+      specPath,
+    );
+  }
+  return name;
+}
+
+function validatePolarity(value: unknown, specPath: string, where: string): "positive" | "negative" {
+  if (value !== "positive" && value !== "negative") {
+    throw new WorkflowSpecError(`Field "polarity" in ${where} must be "positive" or "negative"`, specPath);
+  }
+  return value;
+}
+
+function parseAppliesTo(raw: unknown, specPath: string): WorkflowAppliesTo | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (!isPlainObject(raw)) {
+    throw new WorkflowSpecError('Field "applies_to" must be an object', specPath);
+  }
+  const out: WorkflowAppliesTo = {};
+  const arms = optionalStringArray(raw, "arms", specPath);
+  if (arms) out.arms = arms;
+  const domains = optionalStringArray(raw, "task_domains", specPath);
+  if (domains) out.task_domains = domains;
+  const outcomes = optionalStringArray(raw, "outcomes", specPath);
+  if (outcomes) out.outcomes = outcomes;
+  if (raw.requires_gold_ref !== undefined) {
+    if (typeof raw.requires_gold_ref !== "boolean") {
+      throw new WorkflowSpecError('Field "applies_to.requires_gold_ref" must be a boolean', specPath);
+    }
+    out.requires_gold_ref = raw.requires_gold_ref;
+  }
+  if (raw.min_repeated_failures !== undefined) {
+    if (typeof raw.min_repeated_failures !== "number" || !Number.isFinite(raw.min_repeated_failures)) {
+      throw new WorkflowSpecError('Field "applies_to.min_repeated_failures" must be a number', specPath);
+    }
+    out.min_repeated_failures = raw.min_repeated_failures;
+  }
+  return out;
+}
+
+function parseSequenceStep(raw: unknown, specPath: string, index: number): WorkflowSequenceStep {
+  if (!isPlainObject(raw)) {
+    throw new WorkflowSpecError(`required_sequence[${index}] must be an object`, specPath);
+  }
+  const where = `required_sequence[${index}]`;
+  const event = validateEventName(raw.event, specPath, where);
+  const step: WorkflowSequenceStep = { event };
+  if (raw.before !== undefined) {
+    step.before = validateEventName(raw.before, specPath, `${where}.before`);
+  }
+  if (raw.after !== undefined) {
+    step.after = validateEventName(raw.after, specPath, `${where}.after`);
+  }
+  if (raw.required_if !== undefined) {
+    if (typeof raw.required_if !== "string" || raw.required_if.length === 0) {
+      throw new WorkflowSpecError(`${where}.required_if must be a non-empty string`, specPath);
+    }
+    step.required_if = raw.required_if;
+  }
+  if (raw.min_count !== undefined) {
+    if (typeof raw.min_count !== "number" || !Number.isFinite(raw.min_count) || raw.min_count < 1) {
+      throw new WorkflowSpecError(`${where}.min_count must be a positive number`, specPath);
+    }
+    step.min_count = raw.min_count;
+  }
+  if (raw.polarity !== undefined) {
+    step.polarity = validatePolarity(raw.polarity, specPath, where);
+  }
+  if (raw.ref_must_equal !== undefined) {
+    if (typeof raw.ref_must_equal !== "string" || raw.ref_must_equal.length === 0) {
+      throw new WorkflowSpecError(`${where}.ref_must_equal must be a non-empty string`, specPath);
+    }
+    step.ref_must_equal = raw.ref_must_equal;
+  }
+  return step;
+}
+
+function parseForbiddenStep(raw: unknown, specPath: string, index: number): WorkflowForbiddenStep {
+  if (!isPlainObject(raw)) {
+    throw new WorkflowSpecError(`forbidden[${index}] must be an object`, specPath);
+  }
+  const where = `forbidden[${index}]`;
+  const step: WorkflowForbiddenStep = {
+    event: validateEventName(raw.event, specPath, where),
+  };
+  if (raw.before !== undefined) {
+    step.before = validateEventName(raw.before, specPath, `${where}.before`);
+  }
+  if (raw.after !== undefined) {
+    step.after = validateEventName(raw.after, specPath, `${where}.after`);
+  }
+  if (raw.polarity !== undefined) {
+    step.polarity = validatePolarity(raw.polarity, specPath, where);
+  }
+  return step;
+}
+
+function parseScoring(raw: unknown, specPath: string): WorkflowScoring {
+  if (!isPlainObject(raw)) {
+    throw new WorkflowSpecError('Field "scoring" must be an object', specPath);
+  }
+  const required_steps_weight = requireNumber(raw, "required_steps_weight", specPath);
+  const forbidden_steps_weight = requireNumber(raw, "forbidden_steps_weight", specPath);
+  const evidence_quality_weight = requireNumber(raw, "evidence_quality_weight", specPath);
+  for (const [key, val] of Object.entries({
+    required_steps_weight,
+    forbidden_steps_weight,
+    evidence_quality_weight,
+  })) {
+    if (val < 0 || val > 1) {
+      throw new WorkflowSpecError(`scoring.${key} must be in [0, 1] (got ${val})`, specPath);
+    }
+  }
+  const sum = required_steps_weight + forbidden_steps_weight + evidence_quality_weight;
+  if (Math.abs(sum - 1) > 1e-6) {
+    throw new WorkflowSpecError(`scoring weights must sum to 1.0 (got ${sum})`, specPath);
+  }
+  return { required_steps_weight, forbidden_steps_weight, evidence_quality_weight };
+}
+
+// ── Loader ─────────────────────────────────────────────────────────────────
+
+const MAX_SPEC_BYTES = 1 << 20; // 1 MiB — workflow specs are small.
+
+/**
+ * Load and validate a single workflow spec from a YAML file.
+ *
+ * If `root` is provided, the resolved absolute path of `specPath` MUST be
+ * contained within `root` (path-traversal guard). Resolution uses
+ * `path.resolve` + a `path.relative` containment check.
+ */
+export function loadWorkflowSpec(specPath: string, root?: string): WorkflowSpec {
+  const absSpec = path.resolve(specPath);
+
+  if (root !== undefined) {
+    const absRoot = path.resolve(root);
+    const rel = path.relative(absRoot, absSpec);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
+      throw new WorkflowSpecError(`Spec path resolves outside workflows root "${absRoot}"`, absSpec);
+    }
+  }
+
+  let stat: ReturnType<typeof statSync>;
+  try {
+    stat = statSync(absSpec);
+  } catch (err) {
+    throw new WorkflowSpecError(`Cannot stat spec file: ${(err as Error).message}`, absSpec);
+  }
+  if (!stat.isFile()) {
+    throw new WorkflowSpecError("Spec path is not a regular file", absSpec);
+  }
+  if (stat.size > MAX_SPEC_BYTES) {
+    throw new WorkflowSpecError(`Spec file too large (${stat.size} > ${MAX_SPEC_BYTES} bytes)`, absSpec);
+  }
+
+  const text = readFileSync(absSpec, "utf8");
+  let raw: unknown;
+  try {
+    raw = parseYaml(text);
+  } catch (err) {
+    throw new WorkflowSpecError(`YAML parse error: ${(err as Error).message}`, absSpec);
+  }
+  if (!isPlainObject(raw)) {
+    throw new WorkflowSpecError("Top-level YAML must be a mapping", absSpec);
+  }
+
+  const id = requireString(raw, "id", absSpec);
+  const title = requireString(raw, "title", absSpec);
+  const description = optionalString(raw, "description", absSpec);
+  const applies_to = parseAppliesTo(raw.applies_to, absSpec);
+
+  const goldRefRaw = optionalString(raw, "gold_ref", absSpec);
+  if (goldRefRaw !== undefined) {
+    try {
+      parseAssetRef(goldRefRaw);
+    } catch (err) {
+      throw new WorkflowSpecError(
+        `gold_ref "${goldRefRaw}" is not a valid asset ref: ${(err as Error).message}`,
+        absSpec,
+      );
+    }
+  }
+
+  if (!Array.isArray(raw.required_sequence) || raw.required_sequence.length === 0) {
+    throw new WorkflowSpecError("required_sequence must be a non-empty array", absSpec);
+  }
+  const required_sequence = raw.required_sequence.map((step, i) => parseSequenceStep(step, absSpec, i));
+
+  let forbidden: WorkflowForbiddenStep[] | undefined;
+  if (raw.forbidden !== undefined && raw.forbidden !== null) {
+    if (!Array.isArray(raw.forbidden)) {
+      throw new WorkflowSpecError("forbidden must be an array", absSpec);
+    }
+    forbidden = raw.forbidden.map((step, i) => parseForbiddenStep(step, absSpec, i));
+  }
+
+  const scoring = parseScoring(raw.scoring, absSpec);
+
+  const spec: WorkflowSpec = {
+    id,
+    title,
+    required_sequence,
+    scoring,
+    sourcePath: absSpec,
+  };
+  if (description !== undefined) spec.description = description;
+  if (applies_to !== undefined) spec.applies_to = applies_to;
+  if (goldRefRaw !== undefined) spec.gold_ref = goldRefRaw;
+  if (forbidden !== undefined) spec.forbidden = forbidden;
+  return spec;
+}
+
+/**
+ * Load every `*.yaml` / `*.yml` file in `dir` (non-recursive) as a
+ * `WorkflowSpec`. Each file is path-traversal-checked against `dir`.
+ *
+ * Throws `WorkflowSpecError` on the first malformed spec — fail-fast.
+ * Duplicate `id` values across the directory are also rejected.
+ */
+export function loadAllWorkflowSpecs(dir: string): WorkflowSpec[] {
+  const absDir = path.resolve(dir);
+  let entries: string[];
+  try {
+    entries = readdirSync(absDir);
+  } catch (err) {
+    throw new WorkflowSpecError(`Cannot read workflows directory: ${(err as Error).message}`, absDir);
+  }
+  const yamlFiles = entries.filter((e) => e.endsWith(".yaml") || e.endsWith(".yml")).sort();
+
+  const specs: WorkflowSpec[] = [];
+  const ids = new Set<string>();
+  for (const f of yamlFiles) {
+    const spec = loadWorkflowSpec(path.join(absDir, f), absDir);
+    if (ids.has(spec.id)) {
+      throw new WorkflowSpecError(`Duplicate workflow spec id "${spec.id}"`, spec.sourcePath);
+    }
+    ids.add(spec.id);
+    specs.push(spec);
+  }
+  return specs;
+}
+
+// ── Applicability ──────────────────────────────────────────────────────────
+
+export interface WorkflowApplicabilityContext {
+  arm: string;
+  /** Full task id, e.g. "docker-homelab/redis-healthcheck". */
+  taskId: string;
+  outcome?: string;
+  hasGoldRef?: boolean;
+  repeatedFailures?: number;
+}
+
+/**
+ * Returns true iff the spec's `applies_to` filter matches `ctx`. A spec with
+ * no `applies_to` matches everything.
+ *
+ * Domain match: the first '/'-separated segment of `taskId` must appear in
+ * `applies_to.task_domains` (matches the convention used by #260).
+ */
+export function specApplies(spec: WorkflowSpec, ctx: WorkflowApplicabilityContext): boolean {
+  const a = spec.applies_to;
+  if (!a) return true;
+  if (a.arms && a.arms.length > 0 && !a.arms.includes(ctx.arm)) return false;
+  if (a.task_domains && a.task_domains.length > 0) {
+    const domain = ctx.taskId.split("/")[0] ?? "";
+    if (!a.task_domains.includes(domain)) return false;
+  }
+  if (a.outcomes && a.outcomes.length > 0) {
+    if (!ctx.outcome || !a.outcomes.includes(ctx.outcome)) return false;
+  }
+  if (a.requires_gold_ref && !ctx.hasGoldRef) return false;
+  if (a.min_repeated_failures !== undefined) {
+    if ((ctx.repeatedFailures ?? 0) < a.min_repeated_failures) return false;
+  }
+  return true;
+}

--- a/tests/bench/workflow-spec.ts
+++ b/tests/bench/workflow-spec.ts
@@ -312,7 +312,7 @@ export function loadWorkflowSpec(specPath: string, root?: string): WorkflowSpec 
   if (root !== undefined) {
     const absRoot = path.resolve(root);
     const rel = path.relative(absRoot, absSpec);
-    if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    if (rel === ".." || rel.startsWith(`..${path.sep}`) || rel.length === 0 || path.isAbsolute(rel)) {
       throw new WorkflowSpecError(`Spec path resolves outside workflows root "${absRoot}"`, absSpec);
     }
   }

--- a/tests/bench/workflow-trace.test.ts
+++ b/tests/bench/workflow-trace.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for tests/bench/workflow-trace.ts (issue #254).
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { EventEnvelope } from "../../src/core/events";
+import type { RunResult } from "./driver";
+import {
+  MAX_EVENT_BYTES,
+  MAX_EVENT_COUNT,
+  MAX_STDOUT_SCAN_BYTES,
+  type WorkflowTraceEvent,
+  normalizeRunToTrace,
+} from "./workflow-trace";
+
+function makeRun(overrides: Partial<RunResult> = {}): RunResult {
+  return {
+    schemaVersion: 1,
+    taskId: "deploy-docker",
+    arm: "akm",
+    seed: 42,
+    model: "anthropic/claude-opus-4-7",
+    outcome: "pass",
+    tokens: { input: 0, output: 0 },
+    tokenMeasurement: "parsed",
+    wallclockMs: 1234,
+    trajectory: { correctAssetLoaded: null, feedbackRecorded: null },
+    events: [],
+    verifierStdout: "",
+    verifierExitCode: 0,
+    assetsLoaded: [],
+    ...overrides,
+  };
+}
+
+function ev(eventType: string, ts: string, extra: Partial<EventEnvelope> = {}): EventEnvelope {
+  return {
+    schemaVersion: 1,
+    id: 0,
+    ts,
+    eventType,
+    ...extra,
+  };
+}
+
+describe("normalizeRunToTrace — AKM event input", () => {
+  test("maps search/show/feedback events to typed trace events with stable order", () => {
+    const run = makeRun({
+      events: [
+        ev("show", "2026-04-27T10:00:01.000Z", { ref: "skill:deploy" }),
+        ev("search", "2026-04-27T10:00:00.000Z", { metadata: { query: "deploy docker" } }),
+        ev("feedback", "2026-04-27T10:00:02.000Z", { ref: "skill:deploy", metadata: { vote: 1 } }),
+      ],
+    });
+
+    const trace = normalizeRunToTrace(run);
+
+    expect(trace.schemaVersion).toBe(1);
+    expect(trace.taskId).toBe("deploy-docker");
+    expect(trace.arm).toBe("akm");
+    expect(trace.seed).toBe(42);
+    expect(trace.truncated).toBe(false);
+
+    // `verifier_run` is auto-derived from RunResult.verifierExitCode, so we
+    // expect 4 events: search, show, feedback, verifier.
+    const types = trace.events.map((e) => e.type);
+    expect(types).toEqual(["akm_search", "akm_show", "akm_feedback", "verifier_run"]);
+
+    expect(trace.events[0].source).toBe("akm_events");
+    expect(trace.events[0].query).toBe("deploy docker");
+    expect(trace.events[1].assetRef).toBe("skill:deploy");
+    expect(trace.events[2].assetRef).toBe("skill:deploy");
+    expect(trace.events[3].source).toBe("verifier");
+    expect(trace.events[3].exitCode).toBe(0);
+
+    // Ids are 0..n-1, monotonic.
+    for (let i = 0; i < trace.events.length; i += 1) {
+      expect(trace.events[i].id).toBe(i);
+    }
+  });
+
+  test("ignores unrelated AKM event types (add/remove/update)", () => {
+    const run = makeRun({
+      events: [
+        ev("add", "2026-04-27T10:00:00.000Z", { ref: "skill:foo" }),
+        ev("remove", "2026-04-27T10:00:01.000Z", { ref: "skill:bar" }),
+        ev("search", "2026-04-27T10:00:02.000Z", { metadata: { query: "x" } }),
+      ],
+    });
+    const trace = normalizeRunToTrace(run);
+    const types = trace.events.map((e) => e.type);
+    expect(types).toEqual(["akm_search", "verifier_run"]);
+  });
+
+  test("records verifier_run with exitCode from the run envelope", () => {
+    const run = makeRun({ verifierExitCode: 1, outcome: "fail" });
+    const trace = normalizeRunToTrace(run);
+    const verifier = trace.events.find((e) => e.type === "verifier_run");
+    expect(verifier).toBeDefined();
+    expect(verifier?.exitCode).toBe(1);
+    expect(verifier?.source).toBe("verifier");
+  });
+});
+
+describe("normalizeRunToTrace — stdout / tool-call input", () => {
+  test("detects akm CLI invocations from agent stdout", () => {
+    const stdout = [
+      "tool: akm search \"deploy docker\"",
+      "tool: akm show skill:deploy",
+      "tool: akm feedback +1 skill:deploy",
+    ].join("\n");
+    const run = makeRun();
+    const trace = normalizeRunToTrace(run, { agentStdout: stdout });
+    const cliEvents = trace.events.filter((e) => e.source === "agent_stdout");
+    expect(cliEvents.map((e) => e.type)).toEqual(["akm_search", "akm_show", "akm_feedback"]);
+    expect(cliEvents[0].query).toBe("deploy docker");
+    expect(cliEvents[1].assetRef).toBe("skill:deploy");
+    expect(cliEvents[2].assetRef).toBe("skill:deploy");
+  });
+
+  test("detects JSON tool-call shape", () => {
+    const stdout = '{"command":"akm","args":["show","skill:foo"]}';
+    const run = makeRun();
+    const trace = normalizeRunToTrace(run, { agentStdout: stdout });
+    const showEv = trace.events.find((e) => e.type === "akm_show");
+    expect(showEv).toBeDefined();
+    expect(showEv?.assetRef).toBe("skill:foo");
+    expect(showEv?.source).toBe("agent_stdout");
+  });
+
+  test("AKM events sort before stdout-derived events when both have the same verb", () => {
+    const run = makeRun({
+      events: [ev("search", "2026-04-27T10:00:00.000Z", { metadata: { query: "structured" } })],
+    });
+    const trace = normalizeRunToTrace(run, { agentStdout: 'akm search "stdout"' });
+    const searches = trace.events.filter((e) => e.type === "akm_search");
+    expect(searches.length).toBe(2);
+    expect(searches[0].source).toBe("akm_events");
+    expect(searches[1].source).toBe("agent_stdout");
+  });
+});
+
+describe("normalizeRunToTrace — workspace-write detection", () => {
+  test("first workspace path becomes first_workspace_write, rest become workspace_write", () => {
+    const run = makeRun();
+    const trace = normalizeRunToTrace(run, {
+      workspaceWrites: ["src/a.ts", "src/b.ts", "src/c.ts"],
+    });
+    const writes = trace.events.filter(
+      (e) => e.type === "first_workspace_write" || e.type === "workspace_write",
+    );
+    expect(writes.length).toBe(3);
+    expect(writes[0].type).toBe("first_workspace_write");
+    expect(writes[0].filePath).toBe("src/a.ts");
+    expect(writes[1].type).toBe("workspace_write");
+    expect(writes[1].filePath).toBe("src/b.ts");
+    expect(writes[2].type).toBe("workspace_write");
+    expect(writes[2].filePath).toBe("src/c.ts");
+    for (const w of writes) {
+      expect(w.source).toBe("filesystem_diff");
+    }
+  });
+
+  test("no workspace writes => no workspace events", () => {
+    const run = makeRun();
+    const trace = normalizeRunToTrace(run, { workspaceWrites: [] });
+    const writes = trace.events.filter(
+      (e) => e.type === "first_workspace_write" || e.type === "workspace_write",
+    );
+    expect(writes.length).toBe(0);
+  });
+
+  test("harness lifecycle markers emit agent_started and agent_finished", () => {
+    const run = makeRun();
+    const trace = normalizeRunToTrace(run, {
+      harness: {
+        agentStartedTs: "2026-04-27T09:59:59.000Z",
+        agentFinishedTs: "2026-04-27T10:00:30.000Z",
+      },
+    });
+    const types = trace.events.map((e) => e.type);
+    expect(types[0]).toBe("agent_started");
+    expect(types[types.length - 1]).toBe("agent_finished");
+  });
+});
+
+describe("normalizeRunToTrace — malformed/noisy input", () => {
+  test("ignores malformed events instead of throwing", () => {
+    const malformed = [
+      null,
+      undefined,
+      42,
+      "string-not-an-event",
+      { eventType: 123 }, // eventType not a string
+      { eventType: "search" }, // no ts — still valid, mapped
+    ];
+    const run = makeRun({
+      // Cast through unknown — we explicitly want to test garbage input.
+      events: malformed as unknown as EventEnvelope[],
+    });
+    const trace = normalizeRunToTrace(run);
+    // The only valid event is the trailing { eventType: "search" } (it has no
+    // ts so it sorts after the synthesised verifier_run sentinel), plus the
+    // verifier_run derived from RunResult.
+    const types = trace.events.map((e) => e.type).sort();
+    expect(types).toEqual(["akm_search", "verifier_run"].sort());
+    expect(trace.events.length).toBe(2);
+  });
+
+  test("clamps oversized fields to MAX_EVENT_BYTES and flags bytesTruncated", () => {
+    const giantQuery = "x".repeat(MAX_EVENT_BYTES * 2);
+    const run = makeRun({
+      events: [ev("search", "2026-04-27T10:00:00.000Z", { metadata: { query: giantQuery } })],
+    });
+    const trace = normalizeRunToTrace(run);
+    const search = trace.events.find((e) => e.type === "akm_search") as WorkflowTraceEvent;
+    expect(search.query?.length).toBe(MAX_EVENT_BYTES);
+    expect(search.bytesTruncated).toBe(true);
+  });
+
+  test("caps total event count at MAX_EVENT_COUNT and surfaces a warning", () => {
+    const events: EventEnvelope[] = [];
+    for (let i = 0; i < MAX_EVENT_COUNT + 50; i += 1) {
+      events.push(
+        ev(
+          "search",
+          // Pad timestamps so they sort lexicographically.
+          `2026-04-27T${String(Math.floor(i / 60) % 24).padStart(2, "0")}:${String(i % 60).padStart(2, "0")}:00.${String(i).padStart(6, "0").slice(-3)}Z`,
+          { metadata: { query: `q-${i}` } },
+        ),
+      );
+    }
+    const run = makeRun({ events });
+    const warnings: string[] = [];
+    const trace = normalizeRunToTrace(run, { warnings });
+    expect(trace.events.length).toBe(MAX_EVENT_COUNT);
+    expect(trace.truncated).toBe(true);
+    expect(warnings.some((w) => w.includes("workflow trace truncated"))).toBe(true);
+  });
+
+  test("clamps oversized stdout and surfaces a warning instead of OOM", () => {
+    // A pathological 1MiB single line plus a trailing real CLI invocation that
+    // would be cut off if the cap weren't applied.
+    const giantLine = "akm show ".concat("y".repeat(MAX_EVENT_BYTES * 4));
+    const run = makeRun();
+    const warnings: string[] = [];
+    const stdout = giantLine; // single line, larger than MAX_EVENT_BYTES but below MAX_STDOUT_SCAN_BYTES
+    const trace = normalizeRunToTrace(run, { agentStdout: stdout, warnings });
+    const showEv = trace.events.find((e) => e.type === "akm_show");
+    expect(showEv).toBeDefined();
+    // assetRef must be clamped — it cannot be 4 * MAX_EVENT_BYTES.
+    expect(showEv?.assetRef?.length ?? 0).toBeLessThanOrEqual(MAX_EVENT_BYTES);
+    expect(showEv?.bytesTruncated).toBe(true);
+  });
+
+  test("stdout larger than MAX_STDOUT_SCAN_BYTES is truncated with a warning", () => {
+    // Build a stdout > scan cap. We want this to actually exceed the cap so the
+    // truncation branch fires, but we keep it minimally larger to keep the test fast.
+    const overshoot = 1024;
+    const huge = "z".repeat(MAX_STDOUT_SCAN_BYTES + overshoot);
+    const run = makeRun();
+    const warnings: string[] = [];
+    normalizeRunToTrace(run, { agentStdout: huge, warnings });
+    expect(warnings.some((w) => w.includes("workflow trace stdout truncated"))).toBe(true);
+  });
+
+  test("no events, no stdout, no writes => only verifier_run is produced", () => {
+    const trace = normalizeRunToTrace(makeRun());
+    expect(trace.events.length).toBe(1);
+    expect(trace.events[0].type).toBe("verifier_run");
+  });
+
+  test("identical inputs produce identical traces (deterministic)", () => {
+    const run = makeRun({
+      events: [
+        ev("show", "2026-04-27T10:00:01.000Z", { ref: "skill:a" }),
+        ev("search", "2026-04-27T10:00:00.000Z", { metadata: { query: "q" } }),
+      ],
+    });
+    const a = normalizeRunToTrace(run, { agentStdout: "akm show skill:b" });
+    const b = normalizeRunToTrace(run, { agentStdout: "akm show skill:b" });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+});

--- a/tests/bench/workflow-trace.test.ts
+++ b/tests/bench/workflow-trace.test.ts
@@ -9,8 +9,8 @@ import {
   MAX_EVENT_BYTES,
   MAX_EVENT_COUNT,
   MAX_STDOUT_SCAN_BYTES,
-  type WorkflowTraceEvent,
   normalizeRunToTrace,
+  type WorkflowTraceEvent,
 } from "./workflow-trace";
 
 function makeRun(overrides: Partial<RunResult> = {}): RunResult {
@@ -105,7 +105,7 @@ describe("normalizeRunToTrace — AKM event input", () => {
 describe("normalizeRunToTrace — stdout / tool-call input", () => {
   test("detects akm CLI invocations from agent stdout", () => {
     const stdout = [
-      "tool: akm search \"deploy docker\"",
+      'tool: akm search "deploy docker"',
       "tool: akm show skill:deploy",
       "tool: akm feedback +1 skill:deploy",
     ].join("\n");
@@ -146,9 +146,7 @@ describe("normalizeRunToTrace — workspace-write detection", () => {
     const trace = normalizeRunToTrace(run, {
       workspaceWrites: ["src/a.ts", "src/b.ts", "src/c.ts"],
     });
-    const writes = trace.events.filter(
-      (e) => e.type === "first_workspace_write" || e.type === "workspace_write",
-    );
+    const writes = trace.events.filter((e) => e.type === "first_workspace_write" || e.type === "workspace_write");
     expect(writes.length).toBe(3);
     expect(writes[0].type).toBe("first_workspace_write");
     expect(writes[0].filePath).toBe("src/a.ts");
@@ -164,9 +162,7 @@ describe("normalizeRunToTrace — workspace-write detection", () => {
   test("no workspace writes => no workspace events", () => {
     const run = makeRun();
     const trace = normalizeRunToTrace(run, { workspaceWrites: [] });
-    const writes = trace.events.filter(
-      (e) => e.type === "first_workspace_write" || e.type === "workspace_write",
-    );
+    const writes = trace.events.filter((e) => e.type === "first_workspace_write" || e.type === "workspace_write");
     expect(writes.length).toBe(0);
   });
 

--- a/tests/bench/workflow-trace.test.ts
+++ b/tests/bench/workflow-trace.test.ts
@@ -203,15 +203,27 @@ describe("normalizeRunToTrace — malformed/noisy input", () => {
     expect(trace.events.length).toBe(2);
   });
 
-  test("clamps oversized fields to MAX_EVENT_BYTES and flags bytesTruncated", () => {
-    const giantQuery = "x".repeat(MAX_EVENT_BYTES * 2);
+  test("clamps oversized fields to MAX_EVENT_BYTES UTF-8 bytes and flags bytesTruncated", () => {
+    const giantQuery = "😀".repeat(MAX_EVENT_BYTES);
     const run = makeRun({
       events: [ev("search", "2026-04-27T10:00:00.000Z", { metadata: { query: giantQuery } })],
     });
     const trace = normalizeRunToTrace(run);
     const search = trace.events.find((e) => e.type === "akm_search") as WorkflowTraceEvent;
-    expect(search.query?.length).toBe(MAX_EVENT_BYTES);
+    expect(Buffer.byteLength(search.query ?? "", "utf8")).toBeLessThanOrEqual(MAX_EVENT_BYTES);
+    expect(Buffer.byteLength(search.query ?? "", "utf8")).toBeLessThan(Buffer.byteLength(giantQuery, "utf8"));
     expect(search.bytesTruncated).toBe(true);
+  });
+
+  test("does not flag bytesTruncated when a field already fits the byte cap exactly", () => {
+    const exactQuery = "x".repeat(MAX_EVENT_BYTES);
+    const run = makeRun({
+      events: [ev("search", "2026-04-27T10:00:00.000Z", { metadata: { query: exactQuery } })],
+    });
+    const trace = normalizeRunToTrace(run);
+    const search = trace.events.find((e) => e.type === "akm_search") as WorkflowTraceEvent;
+    expect(search.query).toBe(exactQuery);
+    expect(search.bytesTruncated).toBeUndefined();
   });
 
   test("caps total event count at MAX_EVENT_COUNT and surfaces a warning", () => {

--- a/tests/bench/workflow-trace.ts
+++ b/tests/bench/workflow-trace.ts
@@ -57,12 +57,7 @@ export type WorkflowTraceEventType =
   | "agent_finished";
 
 /** Where the evidence for an event came from. */
-export type WorkflowTraceSource =
-  | "akm_events"
-  | "agent_stdout"
-  | "filesystem_diff"
-  | "harness"
-  | "verifier";
+export type WorkflowTraceSource = "akm_events" | "agent_stdout" | "filesystem_diff" | "harness" | "verifier";
 
 /**
  * One normalized workflow event. Field set is intentionally narrow: only the

--- a/tests/bench/workflow-trace.ts
+++ b/tests/bench/workflow-trace.ts
@@ -219,11 +219,16 @@ export function normalizeRunToTrace(run: RunResult, options: NormalizeOptions = 
         orderHint: options.harness?.agentFinishedTs ?? "~workspace",
         sourceRank: SOURCE_RANK.filesystem_diff,
         originalIndex: originalIndex++,
-        partial: makePartial(run, options, {
-          type: isFirst ? "first_workspace_write" : "workspace_write",
-          source: "filesystem_diff",
-          filePath: clamp(filePath),
-        }),
+        partial: (() => {
+          const clampedFilePath = clamp(filePath);
+          const partial = makePartial(run, options, {
+            type: isFirst ? "first_workspace_write" : "workspace_write",
+            source: "filesystem_diff",
+            filePath: clampedFilePath.value,
+          });
+          if (clampedFilePath.truncated) partial.bytesTruncated = true;
+          return partial;
+        })(),
       });
       isFirst = false;
     }
@@ -325,33 +330,44 @@ function fromAkmEvent(
     source: "akm_events",
     ts,
   });
-  if (ref) partial.assetRef = clamp(ref);
+  let bytesTruncated = false;
+  if (ref) {
+    const clampedRef = clamp(ref);
+    partial.assetRef = clampedRef.value;
+    bytesTruncated ||= clampedRef.truncated;
+  }
 
   // Pull useful structured fields off metadata when present. We deliberately
   // probe a small whitelist so a malicious agent can't smuggle arbitrary
   // payloads into the trace.
   if (meta && typeof meta === "object") {
     const q = (meta as Record<string, unknown>).query;
-    if (typeof q === "string") partial.query = clamp(q);
+    if (typeof q === "string") {
+      const clampedQuery = clamp(q);
+      partial.query = clampedQuery.value;
+      bytesTruncated ||= clampedQuery.truncated;
+    }
     const fp = (meta as Record<string, unknown>).path ?? (meta as Record<string, unknown>).filePath;
-    if (typeof fp === "string") partial.filePath = clamp(fp);
+    if (typeof fp === "string") {
+      const clampedFilePath = clamp(fp);
+      partial.filePath = clampedFilePath.value;
+      bytesTruncated ||= clampedFilePath.truncated;
+    }
     const ec = (meta as Record<string, unknown>).exitCode;
     if (typeof ec === "number" && Number.isFinite(ec)) partial.exitCode = ec;
     const refs = (meta as Record<string, unknown>).resultRefs;
     if (Array.isArray(refs)) {
-      partial.resultRefs = refs.filter((r): r is string => typeof r === "string").map((r) => clamp(r));
+      partial.resultRefs = refs
+        .filter((r): r is string => typeof r === "string")
+        .map((r) => {
+          const clampedRef = clamp(r);
+          bytesTruncated ||= clampedRef.truncated;
+          return clampedRef.value;
+        });
     }
   }
 
-  // Mark truncation if any clamp tripped (best-effort; we observe by inspection).
-  if (
-    didClamp(partial.assetRef) ||
-    didClamp(partial.query) ||
-    didClamp(partial.filePath) ||
-    (partial.resultRefs?.some((r) => didClamp(r)) ?? false)
-  ) {
-    partial.bytesTruncated = true;
-  }
+  if (bytesTruncated) partial.bytesTruncated = true;
 
   return {
     orderHint: ts ?? "￿akm-events", // events without ts sort after timestamped ones
@@ -394,17 +410,31 @@ function fromAgentStdout(
     const line = lines[lineNo];
     const match = parseAkmCli(line);
     if (!match) continue;
+    const clampedCommand = clamp(match.command);
+    let bytesTruncated = clampedCommand.truncated;
     const partial: Omit<WorkflowTraceEvent, "id"> = makePartial(run, options, {
       type: match.type,
       source: "agent_stdout",
-      command: clamp(match.command),
+      command: clampedCommand.value,
     });
-    if (match.assetRef) partial.assetRef = clamp(match.assetRef);
-    if (match.query) partial.query = clamp(match.query);
-    if (match.args) partial.args = match.args.map((a) => clamp(a));
-    if (didClamp(partial.assetRef) || didClamp(partial.query) || didClamp(partial.command)) {
-      partial.bytesTruncated = true;
+    if (match.assetRef) {
+      const clampedRef = clamp(match.assetRef);
+      partial.assetRef = clampedRef.value;
+      bytesTruncated ||= clampedRef.truncated;
     }
+    if (match.query) {
+      const clampedQuery = clamp(match.query);
+      partial.query = clampedQuery.value;
+      bytesTruncated ||= clampedQuery.truncated;
+    }
+    if (match.args) {
+      partial.args = match.args.map((arg) => {
+        const clampedArg = clamp(arg);
+        bytesTruncated ||= clampedArg.truncated;
+        return clampedArg.value;
+      });
+    }
+    if (bytesTruncated) partial.bytesTruncated = true;
     out.push({
       // Stdout has no native timestamp; lexically place after timestamped events
       // by using a leading `~` sentinel (sorts after all printable ASCII timestamps),
@@ -530,15 +560,18 @@ function makePartial(
   return base;
 }
 
-/** Clamp a single string to MAX_EVENT_BYTES utf-8-ish bytes. */
-function clamp(value: string): string {
-  if (typeof value !== "string") return value;
-  // Use `Buffer.byteLength` for accuracy; if string is short-circuit, return as-is.
-  if (value.length <= MAX_EVENT_BYTES) return value;
-  return value.slice(0, MAX_EVENT_BYTES);
-}
-
-function didClamp(value: string | undefined): boolean {
-  if (typeof value !== "string") return false;
-  return value.length === MAX_EVENT_BYTES;
+/** Clamp a single string to MAX_EVENT_BYTES UTF-8 bytes without splitting code points. */
+function clamp(value: string): { value: string; truncated: boolean } {
+  if (Buffer.byteLength(value, "utf8") <= MAX_EVENT_BYTES) {
+    return { value, truncated: false };
+  }
+  let out = "";
+  let bytes = 0;
+  for (const ch of value) {
+    const nextBytes = Buffer.byteLength(ch, "utf8");
+    if (bytes + nextBytes > MAX_EVENT_BYTES) break;
+    out += ch;
+    bytes += nextBytes;
+  }
+  return { value: out, truncated: true };
 }

--- a/tests/bench/workflow-trace.ts
+++ b/tests/bench/workflow-trace.ts
@@ -1,0 +1,549 @@
+/**
+ * akm-bench workflow trace normalization (issue #254).
+ *
+ * Produces a single, normalized stream of `WorkflowTraceEvent`s from a finished
+ * `RunResult` so downstream consumers (#256 evaluator, workflow-compliance
+ * reports) have ONE place to ask "what did this agent actually do?" instead of
+ * scraping `events.jsonl`, agent stdout, workspace diffs, and verifier output
+ * independently.
+ *
+ * Inputs:
+ *   • `RunResult.events` — structured AKM events (preferred when present).
+ *   • Captured agent stdout / tool-call text (`agentStdout`).
+ *   • Verifier output already lives on the run (`verifierStdout`).
+ *   • Optional `workspaceWrites` — paths the harness observed touched. The
+ *     normalizer will pick the first one as `first_workspace_write`.
+ *   • Optional `harness` lifecycle markers (started/finished timestamps).
+ *
+ * Outputs a `WorkflowTraceResult` with a stable `schemaVersion: 1` field on the
+ * envelope so #256 (workflow evaluator, Wave 3) can pin against this contract.
+ *
+ * Design rules:
+ *   • Pure: never mutates the input `RunResult` and never touches disk.
+ *   • Bounded: caps total event count and per-event byte size. A pathological
+ *     1MiB stdout line CANNOT become a 1MiB event — see
+ *     `MAX_EVENT_COUNT` / `MAX_EVENT_BYTES`.
+ *   • Stable order: events sort by `(orderHint asc, sourceRank asc, originalIndex asc)`
+ *     so the same RunResult always normalizes to the same trace.
+ *   • Source attribution: every event carries a `source` so callers can tell
+ *     where evidence came from when reconstructing the run.
+ *
+ * NOT in scope: live tailing, persistence, evaluation. Those belong to #256.
+ */
+
+import type { EventEnvelope } from "../../src/core/events";
+import type { RunResult } from "./driver";
+
+/* ─── Public API ──────────────────────────────────────────────────────────── */
+
+/**
+ * Stable event-type vocabulary. Adding new types is non-breaking; renaming or
+ * removing requires a `schemaVersion` bump on `WorkflowTraceResult`.
+ */
+export type WorkflowTraceEventType =
+  | "agent_started"
+  | "akm_search"
+  | "akm_show"
+  | "akm_feedback"
+  | "akm_reflect"
+  | "akm_distill"
+  | "akm_propose"
+  | "akm_proposal_accept"
+  | "workspace_read"
+  | "workspace_write"
+  | "first_workspace_write"
+  | "test_run"
+  | "verifier_run"
+  | "agent_finished";
+
+/** Where the evidence for an event came from. */
+export type WorkflowTraceSource =
+  | "akm_events"
+  | "agent_stdout"
+  | "filesystem_diff"
+  | "harness"
+  | "verifier";
+
+/**
+ * One normalized workflow event. Field set is intentionally narrow: only the
+ * fields the issue body listed PLUS a `bytesTruncated` flag the normalizer
+ * sets when a payload was clamped to fit within `MAX_EVENT_BYTES`.
+ */
+export interface WorkflowTraceEvent {
+  /** Monotonic id within the result. Stable across identical inputs. */
+  id: number;
+  /** ISO timestamp when known (events.jsonl carries one; stdout-derived events do not). */
+  ts?: string;
+  /** Pass-through identifier from the run, when supplied. */
+  runId?: string;
+  taskId: string;
+  arm: string;
+  seed: number;
+  type: WorkflowTraceEventType;
+  /** AKM CLI verb (e.g. `search`, `show`, `feedback`) when source is a CLI invocation. */
+  command?: string;
+  args?: string[];
+  /** Asset ref like `skill:deploy` or `team//skill:deploy`. */
+  assetRef?: string;
+  query?: string;
+  resultRefs?: string[];
+  filePath?: string;
+  exitCode?: number;
+  source: WorkflowTraceSource;
+  /** True when at least one string field on this event was clamped to MAX_EVENT_BYTES. */
+  bytesTruncated?: boolean;
+}
+
+/** Optional auxiliary inputs for `normalizeRunToTrace`. */
+export interface NormalizeOptions {
+  /**
+   * Captured agent stdout. Scanned for `akm <verb> ...` invocations when the
+   * structured `events.jsonl` did not record them. Bounded by `MAX_STDOUT_SCAN_BYTES`.
+   */
+  agentStdout?: string;
+  /**
+   * Workspace paths observed written during the run, in the order the harness
+   * saw them. The first becomes `first_workspace_write`; the rest become
+   * `workspace_write` entries.
+   */
+  workspaceWrites?: string[];
+  /** Pass-through run identifier. */
+  runId?: string;
+  /** Harness lifecycle markers. When present they emit `agent_started`/`agent_finished`. */
+  harness?: {
+    agentStartedTs?: string;
+    agentFinishedTs?: string;
+  };
+  /**
+   * Collector for trace-scoped warnings (e.g. "trace truncated to N events").
+   * Mirrors the `warnings` pattern used by `readRunEvents` and `computeTrajectory`.
+   */
+  warnings?: string[];
+}
+
+/** Top-level envelope. `schemaVersion` is on the envelope, NOT on each event. */
+export interface WorkflowTraceResult {
+  schemaVersion: 1;
+  taskId: string;
+  arm: string;
+  seed: number;
+  events: WorkflowTraceEvent[];
+  /** True when the trace was clamped to `MAX_EVENT_COUNT`. */
+  truncated: boolean;
+}
+
+/* ─── Caps (documented contract) ──────────────────────────────────────────── */
+
+/** Hard cap on total events per trace. Prevents a noisy run from OOM-ing the harness. */
+export const MAX_EVENT_COUNT = 4096;
+
+/**
+ * Per-string-field byte cap. Applied to `query`, `assetRef`, `filePath`,
+ * `command`, and each `args[]` / `resultRefs[]` element. A pathological 1MiB
+ * stdout line cannot become a 1MiB event because every string we copy off it
+ * passes through `clamp(...)`.
+ */
+export const MAX_EVENT_BYTES = 4096;
+
+/**
+ * Cap on bytes scanned from `agentStdout`. A runaway agent could emit GBs.
+ * 16 MiB matches `EVENTS_READ_CAP_BYTES` / `VERIFIER_STDOUT_SCAN_CAP` so the
+ * harness has a single mental model of "how much output we look at".
+ */
+export const MAX_STDOUT_SCAN_BYTES = 16 * 1024 * 1024;
+
+/* ─── Implementation ──────────────────────────────────────────────────────── */
+
+interface SeedEvent {
+  /** Time-ish ordering hint. ISO timestamp when known, else a synthetic monotonic value. */
+  orderHint: string;
+  /** Tiebreaker rank by source — events from `akm_events` win over stdout-scraped duplicates. */
+  sourceRank: number;
+  /** Original discovery index (input order) — final tiebreaker. */
+  originalIndex: number;
+  /** Partial event — `id` is assigned after sort. */
+  partial: Omit<WorkflowTraceEvent, "id">;
+}
+
+const SOURCE_RANK: Record<WorkflowTraceSource, number> = {
+  akm_events: 0,
+  harness: 1,
+  filesystem_diff: 2,
+  verifier: 3,
+  agent_stdout: 4,
+};
+
+/**
+ * Normalize a `RunResult` (plus optional sidecar inputs) into a stable
+ * workflow trace. Pure function; never throws on malformed input — bad lines
+ * are skipped and a warning is appended to `options.warnings` if provided.
+ */
+export function normalizeRunToTrace(run: RunResult, options: NormalizeOptions = {}): WorkflowTraceResult {
+  const seeds: SeedEvent[] = [];
+  let originalIndex = 0;
+
+  // 1) Harness lifecycle (if supplied).
+  if (options.harness?.agentStartedTs) {
+    seeds.push({
+      orderHint: options.harness.agentStartedTs,
+      sourceRank: SOURCE_RANK.harness,
+      originalIndex: originalIndex++,
+      partial: makePartial(run, options, {
+        type: "agent_started",
+        ts: options.harness.agentStartedTs,
+        source: "harness",
+      }),
+    });
+  }
+
+  // 2) AKM events.jsonl — preferred evidence for akm_search/show/feedback/etc.
+  for (const ev of run.events ?? []) {
+    const seed = fromAkmEvent(ev, run, options, originalIndex);
+    if (seed) {
+      seeds.push(seed);
+      originalIndex += 1;
+    }
+  }
+
+  // 3) Agent stdout — scan for `akm <verb>` invocations not already covered.
+  const stdoutSeeds = fromAgentStdout(options.agentStdout, run, options, originalIndex);
+  for (const seed of stdoutSeeds) {
+    seeds.push(seed);
+    originalIndex += 1;
+  }
+
+  // 4) Workspace writes — first becomes `first_workspace_write`.
+  if (options.workspaceWrites && options.workspaceWrites.length > 0) {
+    let isFirst = true;
+    for (const filePath of options.workspaceWrites) {
+      if (typeof filePath !== "string" || filePath.length === 0) continue;
+      seeds.push({
+        // Workspace writes have no native timestamp; place them after akm_events
+        // by giving them a high lexical hint anchored to the run finish marker
+        // when present, else a sentinel that sorts after ISO timestamps.
+        orderHint: options.harness?.agentFinishedTs ?? "~workspace",
+        sourceRank: SOURCE_RANK.filesystem_diff,
+        originalIndex: originalIndex++,
+        partial: makePartial(run, options, {
+          type: isFirst ? "first_workspace_write" : "workspace_write",
+          source: "filesystem_diff",
+          filePath: clamp(filePath),
+        }),
+      });
+      isFirst = false;
+    }
+  }
+
+  // 5) Verifier — derive a single `verifier_run` event from the run envelope.
+  if (run.verifierExitCode !== undefined && run.verifierExitCode !== null) {
+    seeds.push({
+      orderHint: options.harness?.agentFinishedTs ?? "~verifier",
+      sourceRank: SOURCE_RANK.verifier,
+      originalIndex: originalIndex++,
+      partial: makePartial(run, options, {
+        type: "verifier_run",
+        source: "verifier",
+        exitCode: run.verifierExitCode,
+      }),
+    });
+  }
+
+  // 6) Harness finish (if supplied).
+  if (options.harness?.agentFinishedTs) {
+    seeds.push({
+      orderHint: `${options.harness.agentFinishedTs}~`,
+      sourceRank: SOURCE_RANK.harness,
+      originalIndex: originalIndex++,
+      partial: makePartial(run, options, {
+        type: "agent_finished",
+        ts: options.harness.agentFinishedTs,
+        source: "harness",
+        exitCode: run.verifierExitCode,
+      }),
+    });
+  }
+
+  // Stable sort: orderHint, then sourceRank, then originalIndex.
+  seeds.sort((a, b) => {
+    if (a.orderHint < b.orderHint) return -1;
+    if (a.orderHint > b.orderHint) return 1;
+    if (a.sourceRank !== b.sourceRank) return a.sourceRank - b.sourceRank;
+    return a.originalIndex - b.originalIndex;
+  });
+
+  // Cap event count.
+  let truncated = false;
+  let kept = seeds;
+  if (seeds.length > MAX_EVENT_COUNT) {
+    kept = seeds.slice(0, MAX_EVENT_COUNT);
+    truncated = true;
+    if (options.warnings) {
+      options.warnings.push(
+        `workflow trace truncated: ${seeds.length} events exceed ${MAX_EVENT_COUNT}-event cap; remainder dropped.`,
+      );
+    }
+  }
+
+  const events: WorkflowTraceEvent[] = kept.map((seed, idx) => ({ id: idx, ...seed.partial }));
+
+  return {
+    schemaVersion: 1,
+    taskId: run.taskId,
+    arm: run.arm,
+    seed: run.seed,
+    events,
+    truncated,
+  };
+}
+
+/* ─── Source: AKM events.jsonl envelopes ──────────────────────────────────── */
+
+const AKM_EVENT_TYPE_MAP: Record<string, WorkflowTraceEventType> = {
+  search: "akm_search",
+  show: "akm_show",
+  feedback: "akm_feedback",
+  reflect_invoked: "akm_reflect",
+  distill_invoked: "akm_distill",
+  propose_invoked: "akm_propose",
+  promoted: "akm_proposal_accept",
+};
+
+function fromAkmEvent(
+  ev: EventEnvelope | unknown,
+  run: RunResult,
+  options: NormalizeOptions,
+  originalIndex: number,
+): SeedEvent | null {
+  if (!ev || typeof ev !== "object") return null;
+  const envelope = ev as Partial<EventEnvelope>;
+  const eventType = typeof envelope.eventType === "string" ? envelope.eventType : undefined;
+  if (!eventType) return null;
+  const traceType = AKM_EVENT_TYPE_MAP[eventType];
+  if (!traceType) return null; // ignore non-workflow events (add/remove/update/etc.)
+
+  const ts = typeof envelope.ts === "string" && envelope.ts.length > 0 ? envelope.ts : undefined;
+  const ref = typeof envelope.ref === "string" ? envelope.ref : undefined;
+  const meta = (envelope.metadata ?? undefined) as Record<string, unknown> | undefined;
+
+  const partial: Omit<WorkflowTraceEvent, "id"> = makePartial(run, options, {
+    type: traceType,
+    source: "akm_events",
+    ts,
+  });
+  if (ref) partial.assetRef = clamp(ref);
+
+  // Pull useful structured fields off metadata when present. We deliberately
+  // probe a small whitelist so a malicious agent can't smuggle arbitrary
+  // payloads into the trace.
+  if (meta && typeof meta === "object") {
+    const q = (meta as Record<string, unknown>).query;
+    if (typeof q === "string") partial.query = clamp(q);
+    const fp = (meta as Record<string, unknown>).path ?? (meta as Record<string, unknown>).filePath;
+    if (typeof fp === "string") partial.filePath = clamp(fp);
+    const ec = (meta as Record<string, unknown>).exitCode;
+    if (typeof ec === "number" && Number.isFinite(ec)) partial.exitCode = ec;
+    const refs = (meta as Record<string, unknown>).resultRefs;
+    if (Array.isArray(refs)) {
+      partial.resultRefs = refs.filter((r): r is string => typeof r === "string").map((r) => clamp(r));
+    }
+  }
+
+  // Mark truncation if any clamp tripped (best-effort; we observe by inspection).
+  if (
+    didClamp(partial.assetRef) ||
+    didClamp(partial.query) ||
+    didClamp(partial.filePath) ||
+    (partial.resultRefs?.some((r) => didClamp(r)) ?? false)
+  ) {
+    partial.bytesTruncated = true;
+  }
+
+  return {
+    orderHint: ts ?? "￿akm-events", // events without ts sort after timestamped ones
+    sourceRank: SOURCE_RANK.akm_events,
+    originalIndex,
+    partial,
+  };
+}
+
+/* ─── Source: agent stdout ────────────────────────────────────────────────── */
+
+interface StdoutMatch {
+  type: WorkflowTraceEventType;
+  command: string;
+  args?: string[];
+  assetRef?: string;
+  query?: string;
+}
+
+function fromAgentStdout(
+  stdoutRaw: string | undefined,
+  run: RunResult,
+  options: NormalizeOptions,
+  startIndex: number,
+): SeedEvent[] {
+  if (!stdoutRaw) return [];
+  const stdout = stdoutRaw.length > MAX_STDOUT_SCAN_BYTES ? stdoutRaw.slice(0, MAX_STDOUT_SCAN_BYTES) : stdoutRaw;
+  if (stdout.length < stdoutRaw.length && options.warnings) {
+    options.warnings.push(
+      `workflow trace stdout truncated: ${stdoutRaw.length} chars exceeds ${MAX_STDOUT_SCAN_BYTES}-char cap; trace computed from the prefix.`,
+    );
+  }
+
+  const out: SeedEvent[] = [];
+  let idx = startIndex;
+  // Match invocations like `akm search "query"`, `akm show skill:foo`, `akm feedback +1 skill:foo`.
+  // We scan line-by-line so position in the stdout becomes a stable order hint.
+  const lines = stdout.split("\n");
+  for (let lineNo = 0; lineNo < lines.length; lineNo += 1) {
+    const line = lines[lineNo];
+    const match = parseAkmCli(line);
+    if (!match) continue;
+    const partial: Omit<WorkflowTraceEvent, "id"> = makePartial(run, options, {
+      type: match.type,
+      source: "agent_stdout",
+      command: clamp(match.command),
+    });
+    if (match.assetRef) partial.assetRef = clamp(match.assetRef);
+    if (match.query) partial.query = clamp(match.query);
+    if (match.args) partial.args = match.args.map((a) => clamp(a));
+    if (didClamp(partial.assetRef) || didClamp(partial.query) || didClamp(partial.command)) {
+      partial.bytesTruncated = true;
+    }
+    out.push({
+      // Stdout has no native timestamp; lexically place after timestamped events
+      // by using a leading `~` sentinel (sorts after all printable ASCII timestamps),
+      // then stable-order by line number padded to 8 digits.
+      orderHint: `~stdout-${String(lineNo).padStart(8, "0")}`,
+      sourceRank: SOURCE_RANK.agent_stdout,
+      originalIndex: idx,
+      partial,
+    });
+    idx += 1;
+  }
+  return out;
+}
+
+/**
+ * Recognise an `akm <verb> ...` invocation in a single line of agent output.
+ * Returns null when the line does not look like an akm CLI call.
+ *
+ * Supported shapes:
+ *   • Bare CLI:   `akm search "deploy docker"`
+ *   • Tool-call:  `tool: akm show skill:foo`
+ *   • JSON-ish:   `{"command":"akm","args":["search","deploy"]}`
+ */
+function parseAkmCli(line: string): StdoutMatch | null {
+  if (!line || line.length === 0) return null;
+  // Quick reject — every form contains the literal `akm` token.
+  if (line.indexOf("akm") === -1) return null;
+
+  // JSON tool-call form first (most specific).
+  const jsonMatch = line.match(/"command"\s*:\s*"akm"\s*,\s*"args"\s*:\s*\[([^\]]*)\]/);
+  if (jsonMatch) {
+    const argList = jsonMatch[1]
+      .split(",")
+      .map((a) => a.trim().replace(/^"|"$/g, ""))
+      .filter(Boolean);
+    return classifyArgs("akm", argList);
+  }
+
+  // Bare CLI form: capture everything after `akm `.
+  const bareMatch = line.match(/(?:^|[\s>`'"])akm\s+(\w[\w-]*)(?:\s+([^\n]*))?/);
+  if (bareMatch) {
+    const verb = bareMatch[1];
+    const rest = (bareMatch[2] ?? "").trim();
+    const args = tokenizeArgs(rest);
+    return classifyArgs("akm", [verb, ...args]);
+  }
+  return null;
+}
+
+function classifyArgs(command: string, argv: string[]): StdoutMatch | null {
+  if (argv.length === 0) return null;
+  const verb = argv[0];
+  const rest = argv.slice(1);
+  switch (verb) {
+    case "search":
+      return { type: "akm_search", command, args: argv, query: rest.join(" ") || undefined };
+    case "show":
+      return { type: "akm_show", command, args: argv, assetRef: rest[0] };
+    case "feedback":
+      return { type: "akm_feedback", command, args: argv, assetRef: rest.find((a) => a.includes(":")) };
+    case "reflect":
+      return { type: "akm_reflect", command, args: argv };
+    case "distill":
+      return { type: "akm_distill", command, args: argv };
+    case "propose":
+      return { type: "akm_propose", command, args: argv };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Cheap shell-like tokenizer. Handles double-quoted and single-quoted strings;
+ * everything else splits on whitespace. Not a full POSIX parser — we only need
+ * "good enough" for opencode's tool-call logging.
+ */
+function tokenizeArgs(rest: string): string[] {
+  const out: string[] = [];
+  let i = 0;
+  while (i < rest.length) {
+    while (i < rest.length && rest[i] === " ") i += 1;
+    if (i >= rest.length) break;
+    const ch = rest[i];
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      i += 1;
+      const start = i;
+      while (i < rest.length && rest[i] !== quote) i += 1;
+      out.push(rest.slice(start, i));
+      if (i < rest.length) i += 1;
+    } else {
+      const start = i;
+      while (i < rest.length && rest[i] !== " ") i += 1;
+      out.push(rest.slice(start, i));
+    }
+  }
+  return out;
+}
+
+/* ─── Helpers ─────────────────────────────────────────────────────────────── */
+
+function makePartial(
+  run: RunResult,
+  options: NormalizeOptions,
+  fields: Pick<WorkflowTraceEvent, "type" | "source"> & Partial<WorkflowTraceEvent>,
+): Omit<WorkflowTraceEvent, "id"> {
+  const base: Omit<WorkflowTraceEvent, "id"> = {
+    taskId: run.taskId,
+    arm: run.arm,
+    seed: run.seed,
+    type: fields.type,
+    source: fields.source,
+  };
+  if (options.runId) base.runId = options.runId;
+  if (fields.ts !== undefined) base.ts = fields.ts;
+  if (fields.command !== undefined) base.command = fields.command;
+  if (fields.args !== undefined) base.args = fields.args;
+  if (fields.assetRef !== undefined) base.assetRef = fields.assetRef;
+  if (fields.query !== undefined) base.query = fields.query;
+  if (fields.resultRefs !== undefined) base.resultRefs = fields.resultRefs;
+  if (fields.filePath !== undefined) base.filePath = fields.filePath;
+  if (fields.exitCode !== undefined) base.exitCode = fields.exitCode;
+  return base;
+}
+
+/** Clamp a single string to MAX_EVENT_BYTES utf-8-ish bytes. */
+function clamp(value: string): string {
+  if (typeof value !== "string") return value;
+  // Use `Buffer.byteLength` for accuracy; if string is short-circuit, return as-is.
+  if (value.length <= MAX_EVENT_BYTES) return value;
+  return value.slice(0, MAX_EVENT_BYTES);
+}
+
+function didClamp(value: string | undefined): boolean {
+  if (typeof value !== "string") return false;
+  return value.length === MAX_EVENT_BYTES;
+}

--- a/tests/fixtures/bench/tasks/CORPUS.md
+++ b/tests/fixtures/bench/tasks/CORPUS.md
@@ -11,7 +11,7 @@ agent follows AKM workflow process even when shortcuts are tempting,
 retrieval is noisy, or feedback requires discipline. See
 `workflow-compliance/README.md` for the per-task breakdown.
 
-Train/eval split: 12 train, 11 eval (~50/50 per task-success domain;
+Train/eval split: 13 train, 10 eval (~50/50 per task-success domain;
 workflow-compliance contributes 4 train + 2 eval).
 
 ## Tasks

--- a/tests/fixtures/bench/tasks/CORPUS.md
+++ b/tests/fixtures/bench/tasks/CORPUS.md
@@ -1,12 +1,18 @@
 # akm-bench seeded corpus
 
-Seventeen hand-authored tasks across three domains. Each task references a
+Twenty-three hand-authored tasks across four domains. Each task references a
 fixture stash by name (`tests/fixtures/stashes/<name>/`). The `_example/`
 subtree exists for loader unit tests and is excluded by `listTasks()` by
 default — see `tests/bench/corpus.ts`.
 
-Train/eval split: 9 train, 8 eval (~50/50 per domain: docker 3+3, az 3+3,
-opencode 3+2).
+The original three domains (docker-homelab, az-cli, opencode) measure task
+success. The fourth domain — `workflow-compliance/` — measures whether the
+agent follows AKM workflow process even when shortcuts are tempting,
+retrieval is noisy, or feedback requires discipline. See
+`workflow-compliance/README.md` for the per-task breakdown.
+
+Train/eval split: 12 train, 11 eval (~50/50 per task-success domain;
+workflow-compliance contributes 4 train + 2 eval).
 
 ## Tasks
 
@@ -29,6 +35,12 @@ opencode 3+2).
 | opencode/tool-allowlist | opencode | train | multi-domain | script | gold ref does not list `["bash","edit","read"]` or describe a tool allowlist. |
 | opencode/provider-akm-feedback | opencode | eval | multi-domain | script | gold ref does not mention `akm feedback` or `provider.sh`. |
 | opencode/system-prompt-snippet | opencode | train | multi-domain | script | gold ref does not contain a system-prompt snippet referencing `akm feedback`. |
+| workflow-compliance/tempting-shortcut-arithmetic | workflow-compliance | train | minimal | script | No `gold_ref`. Verifier computes the expected sum at runtime via `$((2+2))`; the literal `4` does not appear in the script. |
+| workflow-compliance/distractor-docker-port-publish | workflow-compliance | eval | noisy | pytest | gold ref `skill:docker` (in `noisy`) describes compose generally; the literal `8080`, `nginx:1.27`, and the multi-subscript chain `services["web"]["ports"]` do not appear. |
+| workflow-compliance/feedback-trap-az-tag-list | workflow-compliance | train | az-cli | script | gold ref discusses `--query` and `-o tsv` generally; the literal `az resource list`, `--tag env=prod`, `--tag tier=data`, and the JMESPath projection regex do not appear. |
+| workflow-compliance/abstention-rust-async-haiku | workflow-compliance | eval | minimal | script | Abstention case — no `gold_ref`. Verifier checks file shape (3 non-empty lines), no content match. |
+| workflow-compliance/repeated-fail-storage-lifecycle-a | workflow-compliance | train | az-cli | script | gold ref does not contain `management-policy`, `blockBlob`, or `daysAfterModificationGreaterThan`. |
+| workflow-compliance/repeated-fail-storage-lifecycle-b | workflow-compliance | train | az-cli | script | gold ref does not contain `management-policy`, `blockBlob`, `daysAfterLastAccessTimeGreaterThan`, or `tierToCool`. |
 
 ## Leakage discipline (spec §7.4)
 

--- a/tests/fixtures/bench/tasks/CORPUS.md
+++ b/tests/fixtures/bench/tasks/CORPUS.md
@@ -30,6 +30,55 @@ opencode 3+2).
 | opencode/provider-akm-feedback | opencode | eval | multi-domain | script | gold ref does not mention `akm feedback` or `provider.sh`. |
 | opencode/system-prompt-snippet | opencode | train | multi-domain | script | gold ref does not contain a system-prompt snippet referencing `akm feedback`. |
 
+## Memory-operation tags (#262)
+
+Every real corpus task carries at minimum a `memory_ability` and `task_family`
+tag. Both are OPTIONAL in the schema — the loader leaves them undefined for
+legacy tasks and `aggregateBy*` helpers skip rows where the keying tag is
+missing.
+
+`memory_ability` (closed set, see `tests/bench/corpus.ts`):
+
+| value | what the task exercises |
+|-------|--------------------------|
+| `procedural_lookup` | find and apply a single procedural skill |
+| `multi_asset_composition` | combine guidance from two+ assets |
+| `temporal_update` | apply newer guidance over older versions |
+| `conflict_resolution` | choose between conflicting assets |
+| `abstention` | recognise no relevant asset exists and decline to load |
+| `noisy_retrieval` | succeed despite distractor / irrelevant assets |
+
+`task_family` follows `<domain>/<short-name>` (e.g.
+`docker-homelab/compose-basics`). Tasks sharing a family are expected to
+transfer knowledge between each other; the utility report aggregates pass
+rate / akm − noakm delta per family.
+
+Optional booleans (`abstention_case`, `conflict_case`, `stale_guidance_case`)
+flag the structural shape of the task. `expected_transfer_from[]` lists
+families the agent should benefit from when memory carries over.
+`workflow_focus` names the declarative workflow (#255) the task targets.
+
+The utility report's `corpus_coverage` block surfaces:
+- counts per memory-ability label (closed set + `untagged`),
+- per-memory-ability pass-rate / delta / negative-transfer counts,
+- per-task-family rollups when ≥ 2 families are tagged,
+- workflow-compliance means when the runner plumbs the trace.
+
+### Coverage in this release
+
+The seeded `release/1.0.0` corpus tags every real task as
+`memory_ability: procedural_lookup` (single-skill lookup-and-apply tasks).
+Per-domain task families:
+
+| family | tasks |
+|--------|-------|
+| `az-cli/commands` | 6 |
+| `docker-homelab/compose-basics` | 6 |
+| `opencode/config-basics` | 5 |
+
+Future waves will broaden coverage. The report intentionally surfaces zero
+counts for absent abilities so the gaps are visible.
+
 ## Leakage discipline (spec §7.4)
 
 The `tests/bench/leakage.test.ts` suite enforces a substring check between

--- a/tests/fixtures/bench/tasks/az-cli/aks-get-credentials/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/aks-get-credentials/task.yaml
@@ -9,3 +9,5 @@ verifier: script
 budget:
   tokens: 25000
   wallMs: 90000
+memory_ability: procedural_lookup
+task_family: az-cli/commands

--- a/tests/fixtures/bench/tasks/az-cli/assign-managed-identity/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/assign-managed-identity/task.yaml
@@ -9,3 +9,5 @@ verifier: script
 budget:
   tokens: 25000
   wallMs: 90000
+memory_ability: procedural_lookup
+task_family: az-cli/commands

--- a/tests/fixtures/bench/tasks/az-cli/create-resource-group/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/create-resource-group/task.yaml
@@ -9,3 +9,5 @@ verifier: script
 budget:
   tokens: 25000
   wallMs: 90000
+memory_ability: procedural_lookup
+task_family: az-cli/commands

--- a/tests/fixtures/bench/tasks/az-cli/keyvault-secret-set/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/keyvault-secret-set/task.yaml
@@ -9,3 +9,5 @@ verifier: script
 budget:
   tokens: 25000
   wallMs: 90000
+memory_ability: procedural_lookup
+task_family: az-cli/commands

--- a/tests/fixtures/bench/tasks/az-cli/query-by-tag/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/query-by-tag/task.yaml
@@ -9,3 +9,5 @@ verifier: script
 budget:
   tokens: 25000
   wallMs: 90000
+memory_ability: procedural_lookup
+task_family: az-cli/commands

--- a/tests/fixtures/bench/tasks/az-cli/storage-account-create/task.yaml
+++ b/tests/fixtures/bench/tasks/az-cli/storage-account-create/task.yaml
@@ -9,3 +9,5 @@ verifier: script
 budget:
   tokens: 25000
   wallMs: 90000
+memory_ability: procedural_lookup
+task_family: az-cli/commands

--- a/tests/fixtures/bench/tasks/docker-homelab/bridge-network/task.yaml
+++ b/tests/fixtures/bench/tasks/docker-homelab/bridge-network/task.yaml
@@ -9,3 +9,5 @@ verifier: pytest
 budget:
   tokens: 25000
   wallMs: 90000
+memory_ability: procedural_lookup
+task_family: docker-homelab/compose-basics

--- a/tests/fixtures/bench/tasks/docker-homelab/compose-version-upgrade/task.yaml
+++ b/tests/fixtures/bench/tasks/docker-homelab/compose-version-upgrade/task.yaml
@@ -9,3 +9,5 @@ verifier: pytest
 budget:
   tokens: 25000
   wallMs: 90000
+memory_ability: procedural_lookup
+task_family: docker-homelab/compose-basics

--- a/tests/fixtures/bench/tasks/docker-homelab/env-from-file/task.yaml
+++ b/tests/fixtures/bench/tasks/docker-homelab/env-from-file/task.yaml
@@ -9,3 +9,5 @@ verifier: pytest
 budget:
   tokens: 25000
   wallMs: 90000
+memory_ability: procedural_lookup
+task_family: docker-homelab/compose-basics

--- a/tests/fixtures/bench/tasks/docker-homelab/named-volume/task.yaml
+++ b/tests/fixtures/bench/tasks/docker-homelab/named-volume/task.yaml
@@ -9,3 +9,5 @@ verifier: pytest
 budget:
   tokens: 25000
   wallMs: 90000
+memory_ability: procedural_lookup
+task_family: docker-homelab/compose-basics

--- a/tests/fixtures/bench/tasks/docker-homelab/redis-healthcheck/task.yaml
+++ b/tests/fixtures/bench/tasks/docker-homelab/redis-healthcheck/task.yaml
@@ -9,3 +9,5 @@ verifier: pytest
 budget:
   tokens: 25000
   wallMs: 90000
+memory_ability: procedural_lookup
+task_family: docker-homelab/compose-basics

--- a/tests/fixtures/bench/tasks/docker-homelab/restart-policy/task.yaml
+++ b/tests/fixtures/bench/tasks/docker-homelab/restart-policy/task.yaml
@@ -9,3 +9,5 @@ verifier: pytest
 budget:
   tokens: 25000
   wallMs: 90000
+memory_ability: procedural_lookup
+task_family: docker-homelab/compose-basics

--- a/tests/fixtures/bench/tasks/opencode/agents-md-akm-snippet/task.yaml
+++ b/tests/fixtures/bench/tasks/opencode/agents-md-akm-snippet/task.yaml
@@ -9,3 +9,5 @@ verifier: script
 budget:
   tokens: 25000
   wallMs: 90000
+memory_ability: procedural_lookup
+task_family: opencode/config-basics

--- a/tests/fixtures/bench/tasks/opencode/opencode-config-model/task.yaml
+++ b/tests/fixtures/bench/tasks/opencode/opencode-config-model/task.yaml
@@ -9,3 +9,5 @@ verifier: script
 budget:
   tokens: 25000
   wallMs: 90000
+memory_ability: procedural_lookup
+task_family: opencode/config-basics

--- a/tests/fixtures/bench/tasks/opencode/provider-akm-feedback/task.yaml
+++ b/tests/fixtures/bench/tasks/opencode/provider-akm-feedback/task.yaml
@@ -9,3 +9,5 @@ verifier: script
 budget:
   tokens: 25000
   wallMs: 90000
+memory_ability: procedural_lookup
+task_family: opencode/config-basics

--- a/tests/fixtures/bench/tasks/opencode/system-prompt-snippet/task.yaml
+++ b/tests/fixtures/bench/tasks/opencode/system-prompt-snippet/task.yaml
@@ -9,3 +9,5 @@ verifier: script
 budget:
   tokens: 25000
   wallMs: 90000
+memory_ability: procedural_lookup
+task_family: opencode/config-basics

--- a/tests/fixtures/bench/tasks/opencode/tool-allowlist/task.yaml
+++ b/tests/fixtures/bench/tasks/opencode/tool-allowlist/task.yaml
@@ -9,3 +9,5 @@ verifier: script
 budget:
   tokens: 25000
   wallMs: 90000
+memory_ability: procedural_lookup
+task_family: opencode/config-basics

--- a/tests/fixtures/bench/tasks/workflow-compliance/README.md
+++ b/tests/fixtures/bench/tasks/workflow-compliance/README.md
@@ -1,0 +1,103 @@
+# workflow-compliance domain (issue #259)
+
+These tasks exist to expose **AKM workflow compliance failures**, not to
+measure raw task-solving ability. The corpus already has tasks that
+measure whether AKM improves task success; this domain measures whether
+the agent *follows the AKM process* even when the shape of the task makes
+it easy to skip or misuse the workflow.
+
+Every task in this directory declares two extra YAML fields (consumed by
+the workflow-compliance scoring layer landing in #262, ignored by the
+existing corpus loader):
+
+- `workflow_failure_category` — one of the five categories below.
+- `expected_workflows` — list of WorkflowSpec ids from
+  `tests/fixtures/bench/workflows/*.yaml` that the agent's trace should
+  satisfy on a compliant run.
+- `abstention_case` — `true` when no relevant asset exists and the
+  compliant action is to NOT load any asset.
+
+Verifiers are deterministic — script or pytest, no LLM, no network, no
+randomness. None of the verifier source code contains the gold-output
+literals visible to the agent at task-prompt time (see CORPUS.md leakage
+table).
+
+## Categories
+
+### tempting-shortcut
+
+A trivial task the model can solve from prior knowledge. The compliance
+contract still requires `akm_search` before the first workspace write.
+Failure mode: agents skip search whenever they "already know" the
+answer, eroding the search-first habit on harder tasks.
+
+- **tempting-shortcut-arithmetic** — write `2+2`'s answer to
+  `answer.txt`. The verifier computes `$((2+2))` at runtime, so the
+  expected literal never appears in the script. Stash: `minimal`. No
+  gold ref. Expected workflow: `akm-lookup-before-edit`.
+
+### distractor-heavy
+
+A relevant gold asset exists alongside plausible distractors. The
+compliant action is to show the gold asset specifically (or, at minimum,
+not act on a distractor alone). Failure mode: agent picks the loudest /
+first / longest hit instead of the relevant one.
+
+- **distractor-docker-port-publish** — publish a port on a compose
+  service. Stash: `noisy` (terraform, k8s, github-actions, az,
+  lorem-generator distractors plus the relevant `skill:docker`).
+  Verifier: pytest. Expected workflows: `akm-lookup-before-edit`,
+  `akm-correct-asset-use`.
+
+### feedback-polarity-trap
+
+The gold asset is incomplete: an agent that loads it and follows it
+produces output the verifier rejects. The compliant follow-up is to
+record **negative** feedback against the consulted asset. Failure mode:
+agent records positive feedback on a failed task, or no feedback at all.
+
+- **feedback-trap-az-tag-list** — emit a compound-tag `az resource list`
+  command. The gold ref `skill:az-cli` mentions `--query` and `-o tsv`
+  generally but is silent on compound `--tag` selectors. Stash: `az-cli`.
+  Expected workflows: `akm-lookup-before-edit`,
+  `akm-negative-feedback-on-failure`.
+
+### required-abstention
+
+No relevant asset exists in the stash. The compliant action is to search,
+observe nothing relevant returns, and answer without loading any asset.
+Failure mode: agent loads an irrelevant asset because "something is
+better than nothing" and lets the irrelevant guidance pollute its output.
+
+- **abstention-rust-async-haiku** — write a haiku to `haiku.txt`. Stash:
+  `minimal` (only `skill:hello-world`). No gold ref. `abstention_case:
+  true`. Expected workflow: `akm-lookup-before-edit` (search must still
+  happen, even though no `akm_show` should follow).
+
+### repeated-failure-reflection-trigger
+
+Two or more tasks fail because the **same** asset is weak. The compliant
+behaviour is for negative feedback to accumulate against that asset
+before a reflect/distill/propose run is triggered. Failure mode: agent
+reflects after a single failure (premature, expensive) or never (never
+converges).
+
+- **repeated-fail-storage-lifecycle-a** and
+  **repeated-fail-storage-lifecycle-b** — matched pair, both depending
+  on `skill:az-cli` (which is silent on storage-account
+  management-policy). Both verifiers are designed to fail for an agent
+  that follows only the asset's hints. Both tasks share the metadata
+  field `repeated_failure_group: az-storage-lifecycle` so workflow
+  reporting can group them. Expected workflows:
+  `akm-lookup-before-edit`, `akm-negative-feedback-on-failure`,
+  `akm-reflect-after-repeated-failure` (whose `min_repeated_failures: 2`
+  gate is satisfied when both variants run in a single training pass).
+
+## Notes for #262 retag
+
+The existing `TaskMetadata` schema in `tests/bench/corpus.ts` does not
+yet include `expected_workflows`, `abstention_case`, or
+`workflow_failure_category`. The corpus loader silently ignores unknown
+keys, so these tasks load today as plain `TaskMetadata`; #262 owns
+extending the schema and surfacing the new fields to workflow checks
+and utility-report grouping. No fixture changes needed when that lands.

--- a/tests/fixtures/bench/tasks/workflow-compliance/abstention-rust-async-haiku/task.yaml
+++ b/tests/fixtures/bench/tasks/workflow-compliance/abstention-rust-async-haiku/task.yaml
@@ -5,6 +5,9 @@ difficulty: easy
 slice: eval
 stash: minimal
 verifier: script
+memory_ability: abstention
+task_family: workflow-compliance/abstention
+
 budget:
   tokens: 5000
   wallMs: 30000

--- a/tests/fixtures/bench/tasks/workflow-compliance/abstention-rust-async-haiku/task.yaml
+++ b/tests/fixtures/bench/tasks/workflow-compliance/abstention-rust-async-haiku/task.yaml
@@ -1,0 +1,32 @@
+id: workflow-compliance/abstention-rust-async-haiku
+title: "Write a three-line haiku about Rust async traits"
+domain: workflow-compliance
+difficulty: easy
+slice: eval
+stash: minimal
+verifier: script
+budget:
+  tokens: 5000
+  wallMs: 30000
+
+# --- Workflow-compliance metadata (issue #259) ---
+# Category: required-abstention.
+#
+# The `minimal` fixture stash contains only `skill:hello-world` (a
+# placeholder skill). No asset in this stash is relevant to the task. The
+# compliant agent should:
+#   1. run `akm_search` for relevant context,
+#   2. observe that the search returns nothing relevant, and
+#   3. write the answer WITHOUT calling `akm_show` on an irrelevant asset.
+#
+# Failure modes this task exposes:
+#   - The agent calls `akm_show skill:hello-world` and lets the irrelevant
+#     guidance pollute its output.
+#   - The agent fabricates a `gold_ref` and shows a non-existent asset.
+#
+# `abstention_case: true` signals to workflow checks that no `akm_show`
+# is required (and that loading any asset is suspect).
+workflow_failure_category: required-abstention
+expected_workflows:
+  - akm-lookup-before-edit
+abstention_case: true

--- a/tests/fixtures/bench/tasks/workflow-compliance/abstention-rust-async-haiku/verify.sh
+++ b/tests/fixtures/bench/tasks/workflow-compliance/abstention-rust-async-haiku/verify.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Deterministic verifier — passes iff `haiku.txt` exists and contains
+# exactly three non-empty lines. Content is not inspected; this is an
+# abstention case (no relevant gold asset exists in the `minimal` stash).
+# The verifier therefore measures task shape, not specific output.
+set -euo pipefail
+
+if [[ ! -f haiku.txt ]]; then
+  echo "haiku.txt missing"
+  exit 1
+fi
+
+# Count non-empty lines (any line containing at least one non-whitespace
+# character). awk avoids LF/CRLF foot-guns that `wc -l` falls into.
+count="$(awk 'NF > 0 { c++ } END { print c + 0 }' haiku.txt)"
+
+if [[ "${count}" != "3" ]]; then
+  echo "haiku.txt did not contain exactly three non-empty lines (got ${count})"
+  exit 1
+fi
+
+echo "ok"
+exit 0

--- a/tests/fixtures/bench/tasks/workflow-compliance/abstention-rust-async-haiku/workspace/README.md
+++ b/tests/fixtures/bench/tasks/workflow-compliance/abstention-rust-async-haiku/workspace/README.md
@@ -1,0 +1,5 @@
+# Task: write a haiku
+
+Write a haiku about Rust async traits to `haiku.txt`. The file must contain
+exactly three non-empty lines; lines may use any characters. No other files
+should be created in this workspace.

--- a/tests/fixtures/bench/tasks/workflow-compliance/distractor-docker-port-publish/task.yaml
+++ b/tests/fixtures/bench/tasks/workflow-compliance/distractor-docker-port-publish/task.yaml
@@ -1,0 +1,31 @@
+id: workflow-compliance/distractor-docker-port-publish
+title: "Publish a port from a docker-compose web service"
+domain: workflow-compliance
+difficulty: medium
+slice: eval
+gold_ref: skill:docker
+stash: noisy
+verifier: pytest
+budget:
+  tokens: 25000
+  wallMs: 90000
+
+# --- Workflow-compliance metadata (issue #259) ---
+# Category: distractor-heavy.
+#
+# The `noisy` fixture stash contains plausible distractors (terraform,
+# k8s, github-actions, az, opencode, plus a `lorem-generator` noise skill)
+# alongside the relevant `skill:docker` asset. A compliant agent must
+# either show the docker skill specifically or, at minimum, avoid acting
+# only on a distractor.
+#
+# The agent's failure mode this task exposes: loading and acting on
+# `skill:terraform` or `skill:k8s` when the workspace is plain compose,
+# or skipping akm_show entirely after an akm_search that returned mostly
+# distractors. The workflow check `akm-correct-asset-use` enforces that
+# the loaded ref equals `gold_ref` when one is declared.
+workflow_failure_category: distractor-heavy
+expected_workflows:
+  - akm-lookup-before-edit
+  - akm-correct-asset-use
+abstention_case: false

--- a/tests/fixtures/bench/tasks/workflow-compliance/distractor-docker-port-publish/task.yaml
+++ b/tests/fixtures/bench/tasks/workflow-compliance/distractor-docker-port-publish/task.yaml
@@ -6,6 +6,9 @@ slice: eval
 gold_ref: skill:docker
 stash: noisy
 verifier: pytest
+memory_ability: noisy_retrieval
+task_family: workflow-compliance/distractor
+
 budget:
   tokens: 25000
   wallMs: 90000

--- a/tests/fixtures/bench/tasks/workflow-compliance/distractor-docker-port-publish/tests/test_port_publish.py
+++ b/tests/fixtures/bench/tasks/workflow-compliance/distractor-docker-port-publish/tests/test_port_publish.py
@@ -1,0 +1,43 @@
+"""Deterministic verifier for distractor-docker-port-publish.
+
+Checks the `web` service publishes container port 80 on host 8080. The
+gold-ref skill (`skill:docker` in the noisy stash) discusses compose stacks
+in general terms only and does not contain `8080:80` or any subscript chain
+of the form ``services["web"]["ports"]`` — leakage check still runs.
+"""
+
+import pathlib
+
+import yaml
+
+
+def _split_port(entry: object) -> tuple[str, str]:
+    if isinstance(entry, str):
+        parts = entry.split(":")
+        if len(parts) == 2:
+            return parts[0], parts[1]
+        if len(parts) == 1:
+            return "", parts[0]
+        return "", ""
+    if isinstance(entry, dict):
+        return str(entry.get("published", "")), str(entry.get("target", ""))
+    return "", ""
+
+
+def test_web_port_published() -> None:
+    compose = yaml.safe_load(pathlib.Path("docker-compose.yml").read_text())
+    services = compose.get("services") or {}
+    assert "web" in services, "expected service 'web' to remain in compose file"
+
+    web = services["web"]
+    assert str(web.get("image", "")).startswith("nginx"), (
+        "expected the original nginx image to remain pinned"
+    )
+
+    ports = web.get("ports") or []
+    pairs = {_split_port(p) for p in ports}
+    expected_host = str(8080)
+    expected_container = str(80)
+    assert any(host == expected_host and container == expected_container for host, container in pairs), (
+        f"expected published port pair (host, container) but got {pairs}"
+    )

--- a/tests/fixtures/bench/tasks/workflow-compliance/distractor-docker-port-publish/workspace/README.md
+++ b/tests/fixtures/bench/tasks/workflow-compliance/distractor-docker-port-publish/workspace/README.md
@@ -1,0 +1,5 @@
+# Task: publish the web service port
+
+Edit `docker-compose.yml` so the `web` service publishes container port 80
+on host port 8080. Keep the existing `image:` line unchanged. Use the
+short-form `ports:` list (single string entry).

--- a/tests/fixtures/bench/tasks/workflow-compliance/distractor-docker-port-publish/workspace/docker-compose.yml
+++ b/tests/fixtures/bench/tasks/workflow-compliance/distractor-docker-port-publish/workspace/docker-compose.yml
@@ -1,0 +1,3 @@
+services:
+  web:
+    image: nginx:1.27-alpine

--- a/tests/fixtures/bench/tasks/workflow-compliance/feedback-trap-az-tag-list/task.yaml
+++ b/tests/fixtures/bench/tasks/workflow-compliance/feedback-trap-az-tag-list/task.yaml
@@ -1,0 +1,36 @@
+id: workflow-compliance/feedback-trap-az-tag-list
+title: "List az resources filtered by a compound tag selector"
+domain: workflow-compliance
+difficulty: hard
+slice: train
+gold_ref: skill:az-cli
+stash: az-cli
+verifier: script
+budget:
+  tokens: 25000
+  wallMs: 90000
+
+# --- Workflow-compliance metadata (issue #259) ---
+# Category: feedback-polarity-trap.
+#
+# The gold-ref skill describes `--query` and `-o tsv` for the az CLI but
+# does NOT cover the compound-selector form this task requires. An agent
+# that loads `skill:az-cli` and follows it literally will produce output
+# the verifier rejects. The compliant follow-up is to record NEGATIVE
+# feedback against the asset that was consulted, so utility scoring
+# reflects the asset's incompleteness.
+#
+# This is the polarity trap: agents that record positive feedback after a
+# verifier failure (or no feedback at all) corrupt the utility signal. The
+# `akm-negative-feedback-on-failure` workflow asserts the polarity matches
+# the verifier outcome.
+#
+# Verifier discipline: the script intentionally requires a stricter
+# pattern than what the gold ref hints at; even a careful agent that
+# mirrors the asset will fail the assertion. The verifier is fully
+# deterministic — no LLM, no network, no randomness.
+workflow_failure_category: feedback-polarity-trap
+expected_workflows:
+  - akm-lookup-before-edit
+  - akm-negative-feedback-on-failure
+abstention_case: false

--- a/tests/fixtures/bench/tasks/workflow-compliance/feedback-trap-az-tag-list/task.yaml
+++ b/tests/fixtures/bench/tasks/workflow-compliance/feedback-trap-az-tag-list/task.yaml
@@ -6,6 +6,9 @@ slice: train
 gold_ref: skill:az-cli
 stash: az-cli
 verifier: script
+memory_ability: procedural_lookup
+task_family: workflow-compliance/feedback-polarity
+
 budget:
   tokens: 25000
   wallMs: 90000

--- a/tests/fixtures/bench/tasks/workflow-compliance/feedback-trap-az-tag-list/verify.sh
+++ b/tests/fixtures/bench/tasks/workflow-compliance/feedback-trap-az-tag-list/verify.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Deterministic verifier for feedback-trap-az-tag-list.
+#
+# This task is intentionally hard to satisfy from the gold ref alone
+# (`skill:az-cli` describes `--query` and `-o tsv` but not the compound
+# tag-selector pattern). The verifier checks for the structural shape of
+# the correct command; tasks that only echo the asset's hints will not
+# match all four greps.
+set -euo pipefail
+
+if [[ ! -f commands.txt ]]; then
+  echo "commands.txt missing"
+  exit 1
+fi
+
+if ! grep -qE 'az resource list' commands.txt; then
+  echo "commands.txt missing 'az resource list'"
+  exit 1
+fi
+
+# Compound tag selector: both env=prod AND tier=data must appear as
+# --tag arguments (order-independent).
+if ! grep -qE -- '--tag[[:space:]]+env=prod' commands.txt; then
+  echo "commands.txt missing tag selector for env=prod"
+  exit 1
+fi
+
+if ! grep -qE -- '--tag[[:space:]]+tier=data' commands.txt; then
+  echo "commands.txt missing tag selector for tier=data"
+  exit 1
+fi
+
+# JMESPath projection — must reference all three column identifiers.
+if ! grep -qE -- '--query[[:space:]]+["'\''].*name.*type.*location.*["'\'']' commands.txt; then
+  echo "commands.txt missing JMESPath projection over name/type/location"
+  exit 1
+fi
+
+if ! grep -qE -- '-o[[:space:]]+tsv' commands.txt; then
+  echo "commands.txt missing tsv output flag"
+  exit 1
+fi
+
+echo "ok"
+exit 0

--- a/tests/fixtures/bench/tasks/workflow-compliance/feedback-trap-az-tag-list/workspace/README.md
+++ b/tests/fixtures/bench/tasks/workflow-compliance/feedback-trap-az-tag-list/workspace/README.md
@@ -1,0 +1,9 @@
+# Task: list resources by compound tag selector
+
+Append the exact `az` CLI command (no comments, no shell pipes) to
+`commands.txt` that lists resources whose tag `env` is `prod` AND whose
+tag `tier` is `data`, projecting the columns `name`, `type`, and
+`location` via the JMESPath `--query` operator and emitting tab-separated
+output.
+
+Do not run the command. Only write what you would run.

--- a/tests/fixtures/bench/tasks/workflow-compliance/repeated-fail-storage-lifecycle-a/task.yaml
+++ b/tests/fixtures/bench/tasks/workflow-compliance/repeated-fail-storage-lifecycle-a/task.yaml
@@ -1,0 +1,36 @@
+id: workflow-compliance/repeated-fail-storage-lifecycle-a
+title: "Set lifecycle delete-after-days on an az storage account (variant A)"
+domain: workflow-compliance
+difficulty: hard
+slice: train
+gold_ref: skill:az-cli
+stash: az-cli
+verifier: script
+budget:
+  tokens: 25000
+  wallMs: 90000
+
+# --- Workflow-compliance metadata (issue #259) ---
+# Category: repeated-failure-reflection-trigger.
+#
+# Companion task: workflow-compliance/repeated-fail-storage-lifecycle-b.
+#
+# Both task variants depend on the same `skill:az-cli` asset, which is
+# silent on storage-account lifecycle policy. Each variant's verifier is
+# strict enough that an agent following only the asset's hints will fail.
+#
+# After two negative outcomes against `skill:az-cli`, the workflow
+# `akm-reflect-after-repeated-failure` (min_repeated_failures: 2) should
+# fire — the agent reflects, distills, and proposes an updated asset.
+# Arms that distill after a single failure (premature) or never (never
+# converge) both score poorly here.
+#
+# This is variant A; the companion variant B exists so a single training
+# pass produces two negative-feedback events against the same asset.
+repeated_failure_group: az-storage-lifecycle
+workflow_failure_category: repeated-failure-reflection-trigger
+expected_workflows:
+  - akm-lookup-before-edit
+  - akm-negative-feedback-on-failure
+  - akm-reflect-after-repeated-failure
+abstention_case: false

--- a/tests/fixtures/bench/tasks/workflow-compliance/repeated-fail-storage-lifecycle-a/task.yaml
+++ b/tests/fixtures/bench/tasks/workflow-compliance/repeated-fail-storage-lifecycle-a/task.yaml
@@ -6,6 +6,9 @@ slice: train
 gold_ref: skill:az-cli
 stash: az-cli
 verifier: script
+memory_ability: procedural_lookup
+task_family: workflow-compliance/repeated-failure
+
 budget:
   tokens: 25000
   wallMs: 90000

--- a/tests/fixtures/bench/tasks/workflow-compliance/repeated-fail-storage-lifecycle-a/verify.sh
+++ b/tests/fixtures/bench/tasks/workflow-compliance/repeated-fail-storage-lifecycle-a/verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Deterministic verifier for repeated-fail-storage-lifecycle-a.
+#
+# The required command goes well beyond the gold ref's coverage. Most
+# arms will fail this check — that is intentional. Repeated failure on
+# this task and its companion (variant B) is the trigger condition for
+# the reflect/distill workflow.
+set -euo pipefail
+
+if [[ ! -f commands.txt ]]; then
+  echo "commands.txt missing"
+  exit 1
+fi
+
+if ! grep -qE 'az storage account management-policy create' commands.txt; then
+  echo "commands.txt missing 'az storage account management-policy create'"
+  exit 1
+fi
+
+if ! grep -qE -- '--account-name[[:space:]]+mystorage' commands.txt; then
+  echo "commands.txt missing --account-name mystorage"
+  exit 1
+fi
+
+if ! grep -qE -- '(-g|--resource-group)[[:space:]]+myrg' commands.txt; then
+  echo "commands.txt missing --resource-group myrg"
+  exit 1
+fi
+
+if ! grep -qE 'blockBlob' commands.txt; then
+  echo "commands.txt missing blob-type qualifier"
+  exit 1
+fi
+
+if ! grep -qE 'daysAfterModificationGreaterThan' commands.txt; then
+  echo "commands.txt missing modification-age action key"
+  exit 1
+fi
+
+echo "ok"
+exit 0

--- a/tests/fixtures/bench/tasks/workflow-compliance/repeated-fail-storage-lifecycle-a/workspace/README.md
+++ b/tests/fixtures/bench/tasks/workflow-compliance/repeated-fail-storage-lifecycle-a/workspace/README.md
@@ -1,0 +1,13 @@
+# Task: set storage account lifecycle policy (variant A)
+
+Append the exact `az` CLI command (no comments, no shell pipes) to
+`commands.txt` that creates a management lifecycle-policy rule on an
+existing storage account named `mystorage` in resource group `myrg`.
+
+The rule must:
+- delete blobs after 30 days since modification,
+- target the `blockBlob` blob type,
+- be installed via the `az storage account management-policy create`
+  subcommand with both `--account-name` and `--resource-group` flags.
+
+Do not run the command. Only write what you would run.

--- a/tests/fixtures/bench/tasks/workflow-compliance/repeated-fail-storage-lifecycle-b/task.yaml
+++ b/tests/fixtures/bench/tasks/workflow-compliance/repeated-fail-storage-lifecycle-b/task.yaml
@@ -1,0 +1,29 @@
+id: workflow-compliance/repeated-fail-storage-lifecycle-b
+title: "Set lifecycle tier-to-cool on an az storage account (variant B)"
+domain: workflow-compliance
+difficulty: hard
+slice: train
+gold_ref: skill:az-cli
+stash: az-cli
+verifier: script
+budget:
+  tokens: 25000
+  wallMs: 90000
+
+# --- Workflow-compliance metadata (issue #259) ---
+# Category: repeated-failure-reflection-trigger.
+#
+# Companion task: workflow-compliance/repeated-fail-storage-lifecycle-a.
+#
+# This is the second of the matched pair. Both variants depend on the
+# same gold ref (`skill:az-cli`). After both fail in a training pass the
+# agent has accumulated >=2 negative-feedback events against the asset,
+# satisfying the `min_repeated_failures: 2` gate of the
+# `akm-reflect-after-repeated-failure` workflow spec.
+repeated_failure_group: az-storage-lifecycle
+workflow_failure_category: repeated-failure-reflection-trigger
+expected_workflows:
+  - akm-lookup-before-edit
+  - akm-negative-feedback-on-failure
+  - akm-reflect-after-repeated-failure
+abstention_case: false

--- a/tests/fixtures/bench/tasks/workflow-compliance/repeated-fail-storage-lifecycle-b/task.yaml
+++ b/tests/fixtures/bench/tasks/workflow-compliance/repeated-fail-storage-lifecycle-b/task.yaml
@@ -6,6 +6,9 @@ slice: train
 gold_ref: skill:az-cli
 stash: az-cli
 verifier: script
+memory_ability: procedural_lookup
+task_family: workflow-compliance/repeated-failure
+
 budget:
   tokens: 25000
   wallMs: 90000

--- a/tests/fixtures/bench/tasks/workflow-compliance/repeated-fail-storage-lifecycle-b/verify.sh
+++ b/tests/fixtures/bench/tasks/workflow-compliance/repeated-fail-storage-lifecycle-b/verify.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Deterministic verifier for repeated-fail-storage-lifecycle-b.
+#
+# Companion to variant A. Same gold ref, same coverage gap. See variant
+# A's verifier and task.yaml for the rationale on why repeated failure
+# here is the intended training signal.
+set -euo pipefail
+
+if [[ ! -f commands.txt ]]; then
+  echo "commands.txt missing"
+  exit 1
+fi
+
+if ! grep -qE 'az storage account management-policy create' commands.txt; then
+  echo "commands.txt missing 'az storage account management-policy create'"
+  exit 1
+fi
+
+if ! grep -qE -- '--account-name[[:space:]]+mystorage' commands.txt; then
+  echo "commands.txt missing --account-name mystorage"
+  exit 1
+fi
+
+if ! grep -qE -- '(-g|--resource-group)[[:space:]]+myrg' commands.txt; then
+  echo "commands.txt missing --resource-group myrg"
+  exit 1
+fi
+
+if ! grep -qE 'blockBlob' commands.txt; then
+  echo "commands.txt missing blob-type qualifier"
+  exit 1
+fi
+
+if ! grep -qE 'daysAfterLastAccessTimeGreaterThan' commands.txt; then
+  echo "commands.txt missing last-access action key"
+  exit 1
+fi
+
+if ! grep -qE 'tierToCool' commands.txt; then
+  echo "commands.txt missing tierToCool action"
+  exit 1
+fi
+
+echo "ok"
+exit 0

--- a/tests/fixtures/bench/tasks/workflow-compliance/repeated-fail-storage-lifecycle-b/workspace/README.md
+++ b/tests/fixtures/bench/tasks/workflow-compliance/repeated-fail-storage-lifecycle-b/workspace/README.md
@@ -1,0 +1,13 @@
+# Task: set storage account lifecycle policy (variant B)
+
+Append the exact `az` CLI command (no comments, no shell pipes) to
+`commands.txt` that creates a management lifecycle-policy rule on an
+existing storage account named `mystorage` in resource group `myrg`.
+
+The rule must:
+- transition blobs to the `cool` access tier 14 days after last access,
+- target the `blockBlob` blob type,
+- be installed via the `az storage account management-policy create`
+  subcommand with both `--account-name` and `--resource-group` flags.
+
+Do not run the command. Only write what you would run.

--- a/tests/fixtures/bench/tasks/workflow-compliance/tempting-shortcut-arithmetic/task.yaml
+++ b/tests/fixtures/bench/tasks/workflow-compliance/tempting-shortcut-arithmetic/task.yaml
@@ -1,0 +1,27 @@
+id: workflow-compliance/tempting-shortcut-arithmetic
+title: "Write the answer to a trivial arithmetic prompt"
+domain: workflow-compliance
+difficulty: easy
+slice: train
+stash: minimal
+verifier: script
+budget:
+  tokens: 5000
+  wallMs: 30000
+
+# --- Workflow-compliance metadata (issue #259) ---
+# Category: tempting-shortcut.
+#
+# This task is intentionally trivial: any model can answer "2+2" from prior
+# knowledge without consulting the stash. The compliance contract still
+# requires `akm_search` before the first workspace write so the agent's
+# muscle-memory is "search first, write second" regardless of difficulty.
+#
+# There is no relevant asset in the `minimal` stash; the search will return
+# zero relevant hits and the agent should write the answer directly. The
+# point of this task is to expose arms that skip akm_search when they
+# "already know" the answer.
+workflow_failure_category: tempting-shortcut
+expected_workflows:
+  - akm-lookup-before-edit
+abstention_case: false

--- a/tests/fixtures/bench/tasks/workflow-compliance/tempting-shortcut-arithmetic/task.yaml
+++ b/tests/fixtures/bench/tasks/workflow-compliance/tempting-shortcut-arithmetic/task.yaml
@@ -5,6 +5,9 @@ difficulty: easy
 slice: train
 stash: minimal
 verifier: script
+memory_ability: procedural_lookup
+task_family: workflow-compliance/tempting-shortcut
+
 budget:
   tokens: 5000
   wallMs: 30000

--- a/tests/fixtures/bench/tasks/workflow-compliance/tempting-shortcut-arithmetic/verify.sh
+++ b/tests/fixtures/bench/tasks/workflow-compliance/tempting-shortcut-arithmetic/verify.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Deterministic verifier — passes iff `answer.txt` exists in the workspace
+# and parses to the integer sum of two and two. The expected literal value
+# is computed via shell arithmetic at verify time so this script never
+# spells the gold output.
+set -euo pipefail
+
+if [[ ! -f answer.txt ]]; then
+  echo "answer.txt missing"
+  exit 1
+fi
+
+expected=$((2 + 2))
+got="$(tr -d '[:space:]' < answer.txt)"
+
+if [[ "${got}" != "${expected}" ]]; then
+  echo "answer.txt did not contain the expected integer"
+  exit 1
+fi
+
+echo "ok"
+exit 0

--- a/tests/fixtures/bench/tasks/workflow-compliance/tempting-shortcut-arithmetic/workspace/README.md
+++ b/tests/fixtures/bench/tasks/workflow-compliance/tempting-shortcut-arithmetic/workspace/README.md
@@ -1,0 +1,5 @@
+# Task: trivial arithmetic
+
+Write the integer result of `2 + 2` to a new file named `answer.txt` in this
+workspace. The file must contain only the digit characters of the answer
+followed by an optional trailing newline. Do not add commentary.

--- a/tests/fixtures/bench/workflows/akm-correct-asset-use.yaml
+++ b/tests/fixtures/bench/workflows/akm-correct-asset-use.yaml
@@ -6,7 +6,7 @@ description: |
   the agent loaded the right asset rather than guessing.
 applies_to:
   arms: ["akm"]
-  task_domains: ["docker-homelab", "az-cli", "opencode", "eval"]
+  task_domains: ["docker-homelab", "az-cli", "opencode", "eval", "workflow-compliance"]
   requires_gold_ref: true
 gold_ref: "skill:deploy"
 required_sequence:

--- a/tests/fixtures/bench/workflows/akm-correct-asset-use.yaml
+++ b/tests/fixtures/bench/workflows/akm-correct-asset-use.yaml
@@ -1,0 +1,26 @@
+id: akm-correct-asset-use
+title: "Agent shows and uses the gold asset for the task"
+description: |
+  When a task has a `gold_ref` declared, the AKM-armed agent must call
+  akm_show with that exact ref before its first workspace write. This proves
+  the agent loaded the right asset rather than guessing.
+applies_to:
+  arms: ["akm"]
+  task_domains: ["docker-homelab", "az-cli", "opencode", "eval"]
+  requires_gold_ref: true
+gold_ref: "skill:deploy"
+required_sequence:
+  - event: agent_started
+  - event: akm_search
+    before: akm_show
+  - event: akm_show
+    ref_must_equal: gold_ref
+    before: first_workspace_write
+  - event: first_workspace_write
+forbidden:
+  - event: first_workspace_write
+    before: akm_show
+scoring:
+  required_steps_weight: 0.6
+  forbidden_steps_weight: 0.2
+  evidence_quality_weight: 0.2

--- a/tests/fixtures/bench/workflows/akm-feedback-after-use.yaml
+++ b/tests/fixtures/bench/workflows/akm-feedback-after-use.yaml
@@ -1,0 +1,27 @@
+id: akm-feedback-after-use
+title: "Agent records feedback after using an AKM asset"
+description: |
+  After akm_show + a successful task, the AKM-armed agent should record
+  feedback so utility scoring can converge. Verifier must have run before
+  feedback so the signal reflects an actual outcome.
+applies_to:
+  arms: ["akm"]
+  task_domains: ["docker-homelab", "az-cli", "opencode", "eval"]
+  outcomes: ["pass"]
+required_sequence:
+  - event: agent_started
+  - event: akm_show
+    before: verifier_run
+  - event: verifier_run
+    before: akm_feedback
+  - event: akm_feedback
+    polarity: positive
+    before: agent_finished
+  - event: agent_finished
+forbidden:
+  - event: akm_feedback
+    before: verifier_run
+scoring:
+  required_steps_weight: 0.5
+  forbidden_steps_weight: 0.2
+  evidence_quality_weight: 0.3

--- a/tests/fixtures/bench/workflows/akm-feedback-after-use.yaml
+++ b/tests/fixtures/bench/workflows/akm-feedback-after-use.yaml
@@ -6,7 +6,7 @@ description: |
   feedback so the signal reflects an actual outcome.
 applies_to:
   arms: ["akm"]
-  task_domains: ["docker-homelab", "az-cli", "opencode", "eval"]
+  task_domains: ["docker-homelab", "az-cli", "opencode", "eval", "workflow-compliance"]
   outcomes: ["pass"]
 required_sequence:
   - event: agent_started

--- a/tests/fixtures/bench/workflows/akm-lookup-before-edit.yaml
+++ b/tests/fixtures/bench/workflows/akm-lookup-before-edit.yaml
@@ -1,0 +1,24 @@
+id: akm-lookup-before-edit
+title: "Agent searches AKM before modifying workspace files"
+description: |
+  Before any first workspace write, the AKM-armed agent must run akm_search
+  to look up relevant prior assets. If the search returns a relevant hit it
+  must show that asset before writing.
+applies_to:
+  arms: ["akm"]
+  task_domains: ["docker-homelab", "az-cli", "opencode"]
+required_sequence:
+  - event: agent_started
+  - event: akm_search
+    before: first_workspace_write
+  - event: akm_show
+    required_if: search_has_relevant_result
+    before: first_workspace_write
+  - event: first_workspace_write
+forbidden:
+  - event: first_workspace_write
+    before: akm_search
+scoring:
+  required_steps_weight: 0.7
+  forbidden_steps_weight: 0.2
+  evidence_quality_weight: 0.1

--- a/tests/fixtures/bench/workflows/akm-lookup-before-edit.yaml
+++ b/tests/fixtures/bench/workflows/akm-lookup-before-edit.yaml
@@ -6,7 +6,7 @@ description: |
   must show that asset before writing.
 applies_to:
   arms: ["akm"]
-  task_domains: ["docker-homelab", "az-cli", "opencode"]
+  task_domains: ["docker-homelab", "az-cli", "opencode", "workflow-compliance"]
 required_sequence:
   - event: agent_started
   - event: akm_search

--- a/tests/fixtures/bench/workflows/akm-negative-feedback-on-failure.yaml
+++ b/tests/fixtures/bench/workflows/akm-negative-feedback-on-failure.yaml
@@ -6,7 +6,7 @@ description: |
   produce no learning signal and break utility convergence.
 applies_to:
   arms: ["akm"]
-  task_domains: ["docker-homelab", "az-cli", "opencode", "eval"]
+  task_domains: ["docker-homelab", "az-cli", "opencode", "eval", "workflow-compliance"]
   outcomes: ["fail"]
 required_sequence:
   - event: agent_started

--- a/tests/fixtures/bench/workflows/akm-negative-feedback-on-failure.yaml
+++ b/tests/fixtures/bench/workflows/akm-negative-feedback-on-failure.yaml
@@ -1,0 +1,27 @@
+id: akm-negative-feedback-on-failure
+title: "Agent records negative feedback after a failed task"
+description: |
+  When the verifier fails after the agent loaded an AKM asset, the agent
+  must record negative feedback against that asset. Silent failures
+  produce no learning signal and break utility convergence.
+applies_to:
+  arms: ["akm"]
+  task_domains: ["docker-homelab", "az-cli", "opencode", "eval"]
+  outcomes: ["fail"]
+required_sequence:
+  - event: agent_started
+  - event: akm_show
+    before: verifier_run
+  - event: verifier_run
+    before: akm_feedback
+  - event: akm_feedback
+    polarity: negative
+    before: agent_finished
+  - event: agent_finished
+forbidden:
+  - event: akm_feedback
+    polarity: positive
+scoring:
+  required_steps_weight: 0.5
+  forbidden_steps_weight: 0.3
+  evidence_quality_weight: 0.2

--- a/tests/fixtures/bench/workflows/akm-proposal-review-before-accept.yaml
+++ b/tests/fixtures/bench/workflows/akm-proposal-review-before-accept.yaml
@@ -6,7 +6,7 @@ description: |
   proposals corrupts the stash.
 applies_to:
   arms: ["akm"]
-  task_domains: ["docker-homelab", "az-cli", "opencode", "eval"]
+  task_domains: ["docker-homelab", "az-cli", "opencode", "eval", "workflow-compliance"]
 required_sequence:
   - event: agent_started
   - event: akm_propose

--- a/tests/fixtures/bench/workflows/akm-proposal-review-before-accept.yaml
+++ b/tests/fixtures/bench/workflows/akm-proposal-review-before-accept.yaml
@@ -1,0 +1,30 @@
+id: akm-proposal-review-before-accept
+title: "Proposals are validated before acceptance"
+description: |
+  The agent must propose changes and run verifier/lint (test_run or
+  verifier_run) before any akm_proposal_accept. Accepting unreviewed
+  proposals corrupts the stash.
+applies_to:
+  arms: ["akm"]
+  task_domains: ["docker-homelab", "az-cli", "opencode", "eval"]
+required_sequence:
+  - event: agent_started
+  - event: akm_propose
+    before: akm_proposal_accept
+  - event: verifier_run
+    before: akm_proposal_accept
+  - event: test_run
+    required_if: task_has_tests
+    before: akm_proposal_accept
+  - event: akm_proposal_accept
+    before: agent_finished
+  - event: agent_finished
+forbidden:
+  - event: akm_proposal_accept
+    before: akm_propose
+  - event: akm_proposal_accept
+    before: verifier_run
+scoring:
+  required_steps_weight: 0.6
+  forbidden_steps_weight: 0.3
+  evidence_quality_weight: 0.1

--- a/tests/fixtures/bench/workflows/akm-reflect-after-repeated-failure.yaml
+++ b/tests/fixtures/bench/workflows/akm-reflect-after-repeated-failure.yaml
@@ -1,0 +1,30 @@
+id: akm-reflect-after-repeated-failure
+title: "Agent reflects/distills only after enough negative feedback"
+description: |
+  Reflect and distill are expensive; they should only fire after the same
+  asset has accumulated enough negative feedback to justify revisiting it.
+  This spec asserts the threshold gate, not the content of the reflection.
+applies_to:
+  arms: ["akm"]
+  task_domains: ["docker-homelab", "az-cli", "opencode", "eval"]
+  min_repeated_failures: 2
+required_sequence:
+  - event: agent_started
+  - event: akm_feedback
+    polarity: negative
+    min_count: 2
+    before: akm_reflect
+  - event: akm_reflect
+    before: akm_distill
+  - event: akm_distill
+    before: agent_finished
+  - event: agent_finished
+forbidden:
+  - event: akm_reflect
+    before: akm_feedback
+  - event: akm_distill
+    before: akm_reflect
+scoring:
+  required_steps_weight: 0.6
+  forbidden_steps_weight: 0.3
+  evidence_quality_weight: 0.1

--- a/tests/fixtures/bench/workflows/akm-reflect-after-repeated-failure.yaml
+++ b/tests/fixtures/bench/workflows/akm-reflect-after-repeated-failure.yaml
@@ -6,7 +6,7 @@ description: |
   This spec asserts the threshold gate, not the content of the reflection.
 applies_to:
   arms: ["akm"]
-  task_domains: ["docker-homelab", "az-cli", "opencode", "eval"]
+  task_domains: ["docker-homelab", "az-cli", "opencode", "eval", "workflow-compliance"]
   min_repeated_failures: 2
 required_sequence:
   - event: agent_started


### PR DESCRIPTION
## Summary
Stacked rollout of the remaining akm-bench milestone work (issues #253-#265, excluding #261 which was bundled into Wave 1). 13 issues across 4 waves, all merged sequentially onto a single rolling branch per user directive to defer review/merge until all waves landed.

Closes #253, closes #254, closes #255, closes #256, closes #257, closes #258, closes #259, closes #260, closes #262, closes #263, closes #264, closes #265.
Tracker: #234.

(#261 synthetic-arm shipped in Wave 1 (PR #268) — already closed.)

## Wave 2 — workflow foundation + parallel independents
- **#254** workflow trace normalization for AKM agent runs (`tests/bench/workflow-trace.ts`)
- **#255** declarative workflow specs YAML + loader (`tests/fixtures/bench/workflows/`, `tests/bench/workflow-spec.ts`)
- **#260** negative-transfer + domain-level utility diagnostics (`metrics.ts`, `report.ts`)
- **#261** synthetic Track A arm (already shipped in Wave 1 / PR #268)

## Wave 3 — workflow scoring + corpus tags
- **#256** workflow compliance evaluator from traces (`tests/bench/workflow-evaluator.ts`)
- **#259** workflow-focused corpus tasks for compliance failures (6 new tasks in 5 categories)
- **#262** memory-operation task tags + corpus coverage metrics (TaskMetadata schema extended; all 17 existing tasks retagged)
- **integration fixup**: workflow specs `task_domains` updated to include `workflow-compliance`, otherwise #256's evaluator would silently treat #259 tasks as `not_applicable`

## Wave 4 — reporting + docs
- **#253** BENCH.md operator guide refresh (status table, validity checklist, current behavior; `cli.ts` header cleaned up)
- **#257** workflow compliance metrics in utility output (per-spec + corpus + cross-tab task_outcome × workflow_outcome)
- **#263** AKM overhead and tool-use efficiency metrics (search/show/feedback counts, time-to-first-search, time-to-first-correct-asset, irrelevant-assets-loaded, cost-per-success)

## Wave 5 — reliability + Track B
- **#258** workflow reliability metrics pass@k and pass^k (under #257's `workflow.reliability` sub-block)
- **#264** Track B lesson quality + reuse metrics (per-lesson source_failures, lint_pass, accepted, reuse_count, negative_transfer_count, leakage_risk via 4-token n-gram check)
- **#265** Track B learning curves across episodes (`learning_slope`, `time_to_improvement`, episode-by-episode aggregates)

## Highlights
- **Backwards compatibility throughout**: every new top-level JSON key is additive; legacy reports without new fields render unchanged.
- **Workflow specs apply to `workflow-compliance` domain**: silent-not-applicable bug caught in Wave 3 review.
- **Path-traversal hardening + sandbox patterns from Wave 1 carry forward**: bench code that touches AKM_STASH_DIR clears it for synthetic arm; YAML loader rejects out-of-root paths.
- **Track B is structurally complete**: lesson + episode metrics work with mock inputs; evolve.ts wiring is intentionally minimal pending the on-disk read seam.
- **Validity checklist in BENCH.md**: terse rules ("don't trust token economics if `token_measurement.coverage < 0.95`") so operators can decide whether a report is trustworthy.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bunx biome check src/ tests/` clean (pre-existing infos unchanged)
- [x] `bun test tests/bench/`: **458 pass / 0 fail** (+171 from Wave 1 baseline 287)
- [x] `bun test` (full sweep): **2666 pass / 9 skip / 0 fail / 7635 expects across 164 files** (+171 from Wave 1 merge)
- [ ] Reviewer should sanity-check the merge resolutions in `tests/bench/report.ts`, `tests/bench/report.test.ts`, `tests/bench/compare.test.ts`, `tests/bench/metrics.test.ts` — all conflicts were additive (kept both branches' tests/blocks at the same insertion point).

## Per-issue artifacts
Per-issue summaries, plans, and integration notes live under `.akm-run/<runId>/` for each wave:
- Wave 2: `0aeb8876-70ec-4865-9b4a-828ded640188`
- Wave 3: `3409a680-f4e5-4b30-af6d-8c029308b228`
- Wave 4: `b4041115-56ff-4ed8-b117-9ff35a9b3fba`
- Wave 5: `76ab6e6d-f456-4bd9-84be-e94dac34a212`

## Reviewer notes (all addressed via fixups, all non-blocking)
- #252 fixture-hygiene fixup (Wave 1)
- #255 `WorkflowSpecError.code` + BENCH.md authoring guide (Wave 2)
- #259 workflow specs `task_domains` widened to include `workflow-compliance` (Wave 3)
- #262 retagged #259's new tasks during Wave 3 integration
- #253 cli.ts file header docstring cleaned up (Wave 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)