### PR TITLE
docs(reviews): align review docs with 0.7.0 ship + 1.0 GA framing (#280)

### DIFF
--- a/docs/reviews/0.6.0-architecture-critique.md
+++ b/docs/reviews/0.6.0-architecture-critique.md
@@ -1,5 +1,7 @@
 # akm 0.6.0 — Critical architecture & clean-code review
 
+> _Historical review captured at 0.6.x. References to "v1.0" in this document describe intent at that time. See [`docs/migration/release-notes/0.7.0.md`](../migration/release-notes/0.7.0.md) for what actually shipped, and [`docs/migration/v1.md`](../migration/v1.md) for the path to the future 1.0 GA freeze._
+
 **Branch reviewed:** `release/0.6.0` at `563542e` (version `0.6.0-rc1`)
 **Review angle:** architecture, clean code, maintainability, extendability
 **Method:** independent read-through of `src/` and `docs/technical/architecture.md`, cross-checked against the rules in `CLAUDE.md`. This is a second opinion; it deliberately does **not** duplicate `docs/reviews/0.6.0-e2e-review.md` (CLI ergonomics, security, performance hotspots). Read this alongside that document.
@@ -110,6 +112,8 @@ Still missing dedicated unit coverage for `src/renderers.ts`, `src/search-source
 ---
 
 ## What I would fix before v1, in priority order
+
+> _Update (0.7.0): items 1, 3, and 4 below have shipped on the path to the future 1.0 GA freeze — see `CLAUDE.md` for the locked rules ("One scoring pipeline", "Output shape registry is exhaustive", "Error classes own `.code`. No regex-on-message hint chain") and [`docs/migration/release-notes/0.7.0.md`](../migration/release-notes/0.7.0.md) for the 0.7.0 ship summary. Items 2 and 5 remain on the v1.0 GA agenda._
 
 1. **Collapse the provider-type `if`-ladders** at `stash-search.ts:58–60`, `stash-show.ts:142`, `search-source.ts:100–130` into polymorphic calls on the provider interface. Deletes code, makes `npm`-style providers pluggable, stops "new provider" from being a cross-cutting refactor.
 2. **Normalize scores at the provider boundary, not the merge.** Replace the current `mergeStashHits` sort by a single normalized score range written into `LiveStashProvider`.

--- a/docs/reviews/0.6.0-e2e-review.md
+++ b/docs/reviews/0.6.0-e2e-review.md
@@ -1,5 +1,7 @@
 # akm 0.6.0 — End-to-End Code Review
 
+> _Historical review captured at 0.6.x. References to "v1.0" in this document describe intent at that time. See [`docs/migration/release-notes/0.7.0.md`](../migration/release-notes/0.7.0.md) for what actually shipped, and [`docs/migration/v1.md`](../migration/v1.md) for the path to the future 1.0 GA freeze._
+
 **Branch:** `release/0.6.0` at HEAD `bae45e7`
 **Review date:** 2026-04-24
 **Scope:** CLI ergonomics · architecture & complexity · security · performance · maintainability

--- a/docs/reviews/v1-agent-reflection-issues.md
+++ b/docs/reviews/v1-agent-reflection-issues.md
@@ -1,13 +1,15 @@
 # GitHub Issue Set: v1 Agent Reflection & Self-Evolution
 
-**Status:** Draft backlog for aggressive pre-release implementation.
+**Status:** Forward-looking design backlog. Wave 1 shipped in 0.7.0; Waves 2-3 remain on the path to the future 1.0 GA freeze.
 **Source proposal:** "Agent Reflection and Self-Evolution for akm" (2026-04-26).
-**Target milestone:** `v1.0` (current train: `v0.6.x` pre-release).
+**Target milestone:** `1.0` GA freeze (current train: 0.7.x pre-release on the path to 1.0).
 
 This document translates the proposal into a smaller, more aggressive GitHub issue set.
 Compared to the earlier draft, it deliberately combines related work, moves contract/doc
-sync to the front of the queue, and removes sequencing traps that only matter once v1 is
-already frozen.
+sync to the front of the queue, and removes sequencing traps that only matter once the
+1.0 GA contract is already frozen.
+
+> _Cross-links: see [`docs/migration/release-notes/0.7.0.md`](../migration/release-notes/0.7.0.md) for what actually shipped in the 0.7.0 pre-release toward the future 1.0 GA freeze, and [`docs/migration/v1.md`](../migration/v1.md) for the per-surface delta from 0.6.x. The 1.0 GA contract surface (locked at 1.0.0) is described in [`docs/technical/v1-architecture-spec.md`](../technical/v1-architecture-spec.md) §9._
 
 ## Planning principles
 
@@ -18,20 +20,22 @@ already frozen.
 
 ---
 
-## Wave 1 — Contract Sync + Agent Foundations (`v0.7`)
+## Wave 1 — Contract Sync + Agent Foundations (`0.7.0`, shipped)
 
-### Issue 1 — Rewrite the v1 contract baseline
+> _Status: Wave 1 shipped in 0.7.0. The surfaces below are committed to but are not contractually frozen until 1.0 GA. See [`docs/migration/release-notes/0.7.0.md`](../migration/release-notes/0.7.0.md)._
+
+### Issue 1 — Rewrite the v1 contract baseline (shipped in 0.7.0 via PR #233)
 - **Title:** `docs(contract): rewrite v1 lock sections for agent/proposal/lesson surfaces`
 - **Labels:** `area:docs`, `area:test`, `v0.7`, `type:chore`
-- **Summary:** Update the architecture spec, CLI/config references, and migration baseline early so implementation proceeds against the intended v1 surface instead of stale `v0.6` refactor docs.
+- **Summary:** Update the architecture spec, CLI/config references, and migration baseline early so 0.7.0 implementation proceeds against the intended 1.0 GA surface instead of stale `v0.6` refactor docs.
 - **Acceptance criteria:**
-  - `docs/technical/v1-architecture-spec.md` reflects proposal queue, agent CLI integration, open quality/type rules, `lesson`, and `llm.features.*` as intended v1 surfaces.
-  - `docs/cli.md` and `docs/configuration.md` clearly distinguish shipped pre-release behavior from planned v1 additions.
-  - `docs/migration/v1.md` is updated to the new pre-release migration baseline instead of implying the earlier refactor is the final v1 story.
-  - Contract tests cover the locked sections that are actually being carried into implementation.
+  - `docs/technical/v1-architecture-spec.md` reflects proposal queue, agent CLI integration, open quality/type rules, `lesson`, and `llm.features.*` as the surfaces 0.7.0 ships toward the future 1.0 GA freeze.
+  - `docs/cli.md` and `docs/configuration.md` clearly distinguish 0.7.0-shipped behavior from surfaces still pending before 1.0 GA.
+  - `docs/migration/v1.md` is updated to the 0.7.0 pre-release migration baseline instead of implying the earlier refactor is the final 1.0 GA story.
+  - Contract tests cover the sections committed-but-not-frozen-until-1.0 that are actually being carried into implementation.
 - **Depends on:** none.
 
-### Issue 2 — Add agent runtime foundations
+### Issue 2 — Add agent runtime foundations (shipped in 0.7.0 via PR #234)
 - **Title:** `feat(agent): add config, profiles, spawn wrapper, and setup detection`
 - **Labels:** `area:agent`, `area:config`, `area:setup`, `v0.7`, `type:feature`
 - **Summary:** Combine the agent config schema, built-in profile registry, CLI spawn wrapper, and setup UX into one foundation issue.
@@ -45,7 +49,7 @@ already frozen.
   - Tests cover config parsing, profile command construction, timeout handling, malformed output, and setup detection branches.
 - **Depends on:** #1.
 
-### Issue 3 — Lock bounded LLM/agent architecture rules
+### Issue 3 — Lock bounded LLM/agent architecture rules (shipped in 0.7.0)
 - **Title:** `docs(test): enforce stateless in-tree LLM and shell-out-only agent invariants`
 - **Labels:** `area:docs`, `area:test`, `v0.7`, `type:chore`
 - **Summary:** Document and test the intended boundary: in-tree LLM helpers stay bounded and stateless; external agents are invoked via CLI shell-out only.
@@ -55,7 +59,7 @@ already frozen.
   - The rules are narrow enough to be maintained without brittle grep-only enforcement.
 - **Depends on:** #1.
 
-### Issue 4 — Clean up registry/search naming before proposal semantics land
+### Issue 4 — Clean up registry/search naming before proposal semantics land (shipped in 0.7.0)
 - **Title:** `feat(search): remove registry curated field and align search hit projections`
 - **Labels:** `area:search`, `area:registry`, `v0.7`, `type:feature`
 - **Summary:** Remove the vestigial registry `curated` boolean and align hit projections before new `quality` semantics are introduced elsewhere.
@@ -68,7 +72,9 @@ already frozen.
 
 ---
 
-## Wave 2 — Proposal Workflow + Search Semantics (`v0.8`)
+## Wave 2 — Proposal Workflow + Search Semantics (`0.8.0` pre-release toward 1.0 GA)
+
+> _Status: planned. The proposal queue scaffolding shipped in 0.7.0 ([`docs/migration/release-notes/0.7.0.md`](../migration/release-notes/0.7.0.md)); the surfaces below remain committed-but-not-frozen until the future 1.0 GA freeze._
 
 ### Issue 5 — Add quality/proposal semantics
 - **Title:** `feat(search): add proposed quality semantics and filtering`
@@ -99,7 +105,9 @@ already frozen.
 
 ---
 
-## Wave 3 — Reflection, Generation, Distillation, and v1 Lock (`v0.9 -> v1.0`)
+## Wave 3 — Reflection, Generation, Distillation, and 1.0 GA Lock (`0.9.x -> 1.0` GA)
+
+> _Status: planned. This is the wave that drives toward the 1.0 GA contract freeze (spec §9). Surfaces are committed but not frozen until 1.0 GA. See [`docs/migration/v1.md`](../migration/v1.md) for the path-to-1.0 narrative._
 
 ### Issue 7 — Implement `akm reflect` and `akm propose`
 - **Title:** `feat(agent): implement reflect/propose commands on top of the proposal queue`
@@ -138,25 +146,25 @@ already frozen.
   - Failures degrade cleanly when the feature is disabled or the LLM call fails.
 - **Depends on:** #6, #8.
 
-### Issue 10 — Finalize v1 docs, migration notes, and contract locks
-- **Title:** `test(docs): finalize v1 contract suite, migration docs, and release notes`
+### Issue 10 — Finalize 1.0 GA docs, migration notes, and contract locks
+- **Title:** `test(docs): finalize 1.0 GA contract suite, migration docs, and release notes`
 - **Labels:** `area:test`, `area:docs`, `v1.0`, `type:chore`
-- **Summary:** Finish the lock phase by ensuring the shipped docs, migration notes, and contract tests all describe the same surfaces that the code now implements.
+- **Summary:** Finish the lock phase by ensuring the shipped docs, migration notes, and contract tests all describe the same surfaces that the code now implements at the 1.0 GA freeze.
 - **Acceptance criteria:**
   - One test file exists per locked contract section.
   - Locked docs reflect proposal-backed workflows, new quality/type semantics, and final config/CLI surfaces.
   - Migration guidance explains proposal queue, `quality` extensions, `lesson`, `llm.features.*`, and any removed legacy fields such as registry `curated`.
-  - Release notes call out the major pre-v1 behavioral changes.
+  - Release notes call out the major behavioral changes between 0.6.x and the 1.0 GA freeze.
 - **Depends on:** #5, #7, #9.
 
 ---
 
 ## Suggested Milestones
-- **v0.7:** #1-#4
-- **v0.8:** #5-#6
-- **v0.9:** #7-#8
-- **v0.10:** #9
-- **v1.0 lock + docs:** #10
+- **0.7.0** (shipped): #1-#4
+- **0.8.0** (pre-release toward 1.0 GA): #5-#6
+- **0.9.0** (pre-release toward 1.0 GA): #7-#8
+- **0.10.0** (pre-release toward 1.0 GA): #9
+- **1.0 GA lock + docs:** #10
 
 ## Suggested Tracking Labels
 - `wave:contract-foundations`

--- a/docs/reviews/v1-gap-analysis.md
+++ b/docs/reviews/v1-gap-analysis.md
@@ -2,11 +2,13 @@
 
 **Status:** Archived on 2026-04-27.
 
-This analysis focused on early v0.6 architectural debt (provider split, OpenViking removal, stash/source terminology migration). Those findings were useful for the refactor era but do **not** define the current v1 feature contract.
+This analysis focused on early 0.6 architectural debt (provider split, OpenViking removal, stash/source terminology migration). Those findings were useful for the refactor era but do **not** define the surface 0.7.0 ships toward the future 1.0 GA freeze.
 
 ## Current planning baseline
 Use the new issue set derived from the 2026-04-26 proposal:
-- `docs/reviews/v1-agent-reflection-issues.md`
+- [`docs/reviews/v1-agent-reflection-issues.md`](v1-agent-reflection-issues.md) — forward-looking design backlog targeting the 1.0 GA contract.
+- [`docs/migration/release-notes/0.7.0.md`](../migration/release-notes/0.7.0.md) — what 0.7.0 actually shipped toward the 1.0 GA freeze.
+- [`docs/migration/v1.md`](../migration/v1.md) — per-surface migration delta from 0.6.x.
 
 ## Scope clarification
 Any statements here that conflict with:
@@ -15,4 +17,4 @@ Any statements here that conflict with:
 - `quality`/`type` open contract behavior,
 - lesson/distill additions,
 
-should be considered obsolete.
+should be considered obsolete. The locked 1.0 GA contract surface lives in [`docs/technical/v1-architecture-spec.md`](../technical/v1-architecture-spec.md) §9.

--- a/docs/reviews/v1-implementation-plan.md
+++ b/docs/reviews/v1-implementation-plan.md
@@ -1,9 +1,11 @@
 # akm v1 — Consolidated Implementation Plan
 
-**Status:** Current pre-release implementation plan (2026-04-27).
+**Status:** Forward-looking implementation plan toward the future 1.0 GA freeze. Wave 1 shipped in 0.7.0; Waves 2-3 remain in flight.
 
 This document summarizes the implementation strategy behind the detailed issue backlog in
 `docs/reviews/v1-agent-reflection-issues.md`.
+
+> _Cross-links: see [`docs/migration/release-notes/0.7.0.md`](../migration/release-notes/0.7.0.md) for what 0.7.0 actually shipped on the path to the 1.0 GA freeze, and [`docs/migration/v1.md`](../migration/v1.md) for the per-surface delta from 0.6.x. The 1.0 GA contract surface (locked at 1.0.0) is described in [`docs/technical/v1-architecture-spec.md`](../technical/v1-architecture-spec.md) §9._
 
 ## What changed
 
@@ -24,7 +26,7 @@ This plan is intentionally more aggressive:
 1. Contract docs move first.
 The architecture spec, CLI/config references, migration guide, and contract tests need to be
 updated before most of the new work lands, not after. That keeps implementation aligned with the
- intended v1 surface.
+ surface 0.7.0 ships toward the future 1.0 GA freeze.
 
 2. Agent foundations land as one slice.
 Config schema, built-in profiles, process spawning, and setup detection are all parts of the same
@@ -44,25 +46,26 @@ quality metadata are introduced more broadly.
 
 ## Execution waves
 
-### Wave 1 — Contract Sync + Agent Foundations (`v0.7`)
+### Wave 1 — Contract Sync + Agent Foundations (`0.7.0`, shipped)
 
-- Rewrite the v1 contract baseline.
-- Add agent runtime foundations.
-- Lock bounded LLM/agent architecture rules.
-- Remove the vestigial registry `curated` field and align registry/search projections.
+- Rewrite the v1 contract baseline. _(shipped in 0.7.0 via PR #233)_
+- Add agent runtime foundations. _(shipped in 0.7.0 via PR #234)_
+- Lock bounded LLM/agent architecture rules. _(shipped in 0.7.0)_
+- Remove the vestigial registry `curated` field and align registry/search projections. _(shipped in 0.7.0)_
 
-Deliverable: the docs and tests define the intended v1 surface early, and the codebase has a real
-agent runtime foundation to build on.
+Deliverable: 0.7.0 ships docs and tests that define the surface targeted toward the future 1.0 GA
+freeze, and the codebase has a real agent runtime foundation to build on. The surfaces are
+committed to but not contractually frozen until 1.0 GA.
 
-### Wave 2 — Proposal Workflow + Search Semantics (`v0.8`)
+### Wave 2 — Proposal Workflow + Search Semantics (`0.8.0` pre-release toward 1.0 GA)
 
 - Add `quality: "proposed"` and search filtering.
 - Build the durable proposal queue and `akm proposal *` review flow.
 
 Deliverable: one stable proposal and review pipeline that later commands can reuse without special
-cases.
+cases. Committed but not frozen until 1.0 GA.
 
-### Wave 3 — Reflection, Generation, Distillation, and v1 Lock (`v0.9 -> v1.0`)
+### Wave 3 — Reflection, Generation, Distillation, and 1.0 GA Lock (`0.9.x -> 1.0` GA)
 
 - Implement `akm reflect` and `akm propose` on top of the shared queue.
 - Add `lesson` and `llm.features.*` together.
@@ -70,7 +73,7 @@ cases.
 - Finalize docs, migration notes, release notes, and contract locks.
 
 Deliverable: the full reflection/proposal loop is present, feature-gated where needed, and backed
-by final v1 docs/tests.
+by the final 1.0 GA docs/tests at the contract freeze.
 
 ## Source documents
 


### PR DESCRIPTION
## Summary
Surgically updates the 5 docs in `docs/reviews/` to reflect 0.7.0 actually shipping the v1 surfaces while the 1.0 GA freeze remains in the future. Companion to PR #275 + #279.

Closes #280.

## Per-file
- **`0.6.0-architecture-critique.md`** (+4): added historical-stamp blockquote header. Body preserved as point-in-time record. Added an `Update (0.7.0)` blockquote noting items 1, 3, 4 from the priority list shipped (cross-links to CLAUDE.md + 0.7.0 release notes).
- **`0.6.0-e2e-review.md`** (+2): historical-stamp header only. Body preserved.
- **`v1-agent-reflection-issues.md`** (+33 / -25): reframed status, target milestone, all 3 wave headers, milestones list. Issues 1-4 stamped "(shipped in 0.7.0)" with PR #233 / #234 references. Issue 10 + acceptance criteria reworded around "1.0 GA freeze" instead of "v1 lock". Cross-links block at top.
- **`v1-gap-analysis.md`** (+5 / -3): reworded archived-status paragraph; expanded "Current planning baseline" with cross-links to 0.7.0 release notes + `docs/migration/v1.md`.
- **`v1-implementation-plan.md`** (+17 / -12): reworded status, guiding-decision #1, all 3 wave headers/deliverables. Wave 1 bullets stamped shipped + PR refs.

## What was deliberately NOT changed
- File names — the `v1-` prefix correctly identifies these as v1.0-GA-targeting design docs; renaming them would lose the contract-target signal.
- Body of historical 0.6.0 reviews — preserved as point-in-time records.
- Genuine "1.0 GA contract" / "v1 freeze" language describing the future contract freeze.

## Verification
- `git grep -n "release/1\.0" docs/reviews/` → 0 hits.
- biome clean (no formatting changes — markdown unchanged).
- No source/test files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)