### PR TITLE
fix(ux): Wave C UX + CLI surface polish — formatPlain coverage + hints + arity + --verbose declaration (#284)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -239,6 +239,7 @@ const searchCommand = defineCommand({
         throw new UsageError(
           'A search query is required. Usage: akm search "<query>" [--type <type>] [--limit <n>]',
           "MISSING_REQUIRED_ARGUMENT",
+          "Provide a query string. Filter by type with --type skill|command|...; limit results with --limit N.",
         );
       }
       const type = args.type as string | undefined;
@@ -262,7 +263,10 @@ const searchCommand = defineCommand({
 const curateCommand = defineCommand({
   meta: { name: "curate", description: "Curate the best matching assets for a task or prompt" },
   args: {
-    query: { type: "positional", description: "Task or prompt to curate assets for", required: true },
+    // Optional in citty so run() is invoked when omitted; we re-validate
+    // below to surface a structured UsageError (exit 2) instead of citty's
+    // default help-banner exit-0.
+    query: { type: "positional", description: "Task or prompt to curate assets for", required: false },
     type: {
       type: "string",
       description:
@@ -273,6 +277,13 @@ const curateCommand = defineCommand({
   },
   async run({ args }) {
     await runWithJsonErrors(async () => {
+      if (!args.query || !String(args.query).trim()) {
+        throw new UsageError(
+          'A curate query is required. Usage: akm curate "<task or prompt>" [--type <type>] [--limit <n>]',
+          "MISSING_REQUIRED_ARGUMENT",
+          'Describe the task you want assets for, e.g. `akm curate "deploy to prod"`.',
+        );
+      }
       const type = args.type as string | undefined;
       const limitRaw = args.limit ? parseInt(args.limit, 10) : undefined;
       if (limitRaw !== undefined && Number.isNaN(limitRaw)) {
@@ -316,16 +327,30 @@ const addCommand = defineCommand({
     },
     "max-pages": { type: "string", description: "Maximum pages to crawl for website sources (default: 50)" },
     "max-depth": { type: "string", description: "Maximum crawl depth for website sources (default: 3)" },
+    "allow-insecure": {
+      type: "boolean",
+      description: "Allow a plain HTTP source URL (otherwise rejected for non-localhost hosts)",
+      default: false,
+    },
   },
   async run({ args }) {
     await runWithJsonErrors(async () => {
       const ref = args.ref.trim();
+      const allowInsecure = getHyphenatedBoolean(args, "allow-insecure");
 
       // URL with --provider → stash source (remote or git provider)
       if (args.provider) {
         if (shouldWarnOnPlainHttp(ref)) {
+          if (!allowInsecure) {
+            throw new UsageError(
+              "Source URL uses plain HTTP (not HTTPS). An on-path attacker could substitute a malicious payload. " +
+                "Use https:// or pass --allow-insecure if you have explicitly accepted the risk.",
+              "INVALID_FLAG_VALUE",
+              "Re-run with `--allow-insecure` only after confirming the URL is trusted.",
+            );
+          }
           warn(
-            "Warning: source URL uses plain HTTP (not HTTPS). For security, prefer https:// to protect against eavesdropping and tampering.",
+            "Warning: source URL uses plain HTTP (not HTTPS). --allow-insecure was set; an on-path attacker could substitute a malicious payload.",
           );
         }
         let parsedOptions: Record<string, unknown> | undefined;
@@ -357,8 +382,16 @@ const addCommand = defineCommand({
       }
 
       if (shouldWarnOnPlainHttp(ref)) {
+        if (!allowInsecure) {
+          throw new UsageError(
+            "Source URL uses plain HTTP (not HTTPS). An on-path attacker could substitute a malicious payload. " +
+              "Use https:// or pass --allow-insecure if you have explicitly accepted the risk.",
+            "INVALID_FLAG_VALUE",
+            "Re-run with `--allow-insecure` only after confirming the URL is trusted.",
+          );
+        }
         warn(
-          "Warning: source URL uses plain HTTP (not HTTPS). For security, prefer https:// to protect against eavesdropping and tampering.",
+          "Warning: source URL uses plain HTTP (not HTTPS). --allow-insecure was set; an on-path attacker could substitute a malicious payload.",
         );
       }
       const websiteOptions = buildWebsiteOptions(args);
@@ -541,7 +574,12 @@ const showCommand = defineCommand({
       "Show a stash asset by ref (e.g. akm show knowledge:guide.md toc, akm show knowledge:guide.md section 'Auth')",
   },
   args: {
-    ref: { type: "positional", description: "Asset ref (type:name)", required: true },
+    ref: {
+      type: "positional",
+      description:
+        'Asset ref ([origin//]type:name) optionally followed by a view mode. View modes: `toc` (table of contents), `section "Heading"` (extract one section), `lines <start> <end>` (line range), `frontmatter` (YAML metadata only), `full` (raw file). Example: `akm show knowledge:guide.md section "Auth"`.',
+      required: true,
+    },
     format: { type: "string", description: "Output format (json|jsonl|text|yaml)" },
     detail: { type: "string", description: "Detail level (brief|normal|full|summary|agent)" },
     scope: {
@@ -956,16 +994,23 @@ const feedbackCommand = defineCommand({
     description: "Record positive or negative feedback for any indexed stash asset",
   },
   args: {
-    ref: { type: "positional", description: "Asset ref (type:name)", required: true },
+    // Optional in citty so run() is invoked even when omitted; we re-validate
+    // and throw a structured UsageError below so exit code is 2 (USAGE) rather
+    // than citty's default 0 (help banner).
+    ref: { type: "positional", description: "Asset ref (type:name)", required: false },
     positive: { type: "boolean", description: "Record positive feedback", default: false },
     negative: { type: "boolean", description: "Record negative feedback", default: false },
     note: { type: "string", description: "Optional note to attach to the feedback" },
   },
   run({ args }) {
     return runWithJsonErrors(() => {
-      const ref = args.ref.trim();
+      const ref = (args.ref ?? "").trim();
       if (!ref) {
-        throw new UsageError("Asset ref is required. Usage: akm feedback <ref> --positive|--negative");
+        throw new UsageError(
+          "Asset ref is required. Usage: akm feedback <ref> --positive|--negative",
+          "MISSING_REQUIRED_ARGUMENT",
+          "Pass a ref like `skill:deploy` and either --positive or --negative.",
+        );
       }
       parseAssetRef(ref);
       if (args.positive && args.negative) {
@@ -1162,11 +1207,41 @@ const workflowNextCommand = defineCommand({
   async run({ args }) {
     await runWithJsonErrors(async () => {
       const parsedParams = args.params ? parseWorkflowJsonObject(args.params, "--params") : undefined;
+      // If the target looks like a UUID-style run id (no `:` and matches the
+      // run-id shape), short-circuit with a structured WORKFLOW_NOT_FOUND
+      // error before parseAssetRef gets to throw an unhelpful ref-parse error.
+      if (looksLikeWorkflowRunId(args.target)) {
+        const { listWorkflowRuns: listRuns } = await import("./workflows/runs.js");
+        const { runs: existingRuns } = listRuns({});
+        if (!existingRuns.some((r) => r.id === args.target)) {
+          throw new NotFoundError(
+            `Workflow run "${args.target}" not found.`,
+            "WORKFLOW_NOT_FOUND",
+            "Run `akm workflow list --active` to see runs.",
+          );
+        }
+      }
       const result = await getNextWorkflowStep(args.target, parsedParams);
       output("workflow-next", result);
     });
   },
 });
+
+/**
+ * Heuristic: a workflow run id is a UUID-shaped or hex-id-shaped string with
+ * no `:` separator (refs always contain a colon: `workflow:<name>` or
+ * `<origin>//workflow:<name>`). When this matches we can give a much better
+ * error than parseAssetRef's "Invalid asset type" failure.
+ */
+function looksLikeWorkflowRunId(target: string): boolean {
+  if (target.includes(":")) return false;
+  if (target.includes("/")) return false;
+  // UUID v4-ish: 8-4-4-4-12 hex digits separated by dashes.
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(target)) return true;
+  // Bare hex/alphanumeric run ids of >=8 chars (covers shortened ids).
+  if (/^[0-9a-z][0-9a-z_-]{7,}$/i.test(target) && /[0-9]/.test(target)) return true;
+  return false;
+}
 
 const workflowCompleteCommand = defineCommand({
   meta: {
@@ -1651,7 +1726,12 @@ const hintsCommand = defineCommand({
     description: "Print agent instructions on how to use akm, use --detail full for a complete guide",
   },
   args: {
-    detail: { type: "string", description: "Detail level (normal|full)", default: "normal" },
+    detail: {
+      type: "string",
+      description:
+        "Hints detail level — accepts only `normal` or `full`. Differs from the global --detail flag (brief|normal|full|summary|agent); other values are rejected with INVALID_DETAIL_VALUE.",
+      default: "normal",
+    },
   },
   run({ args }) {
     if (args.detail !== "normal" && args.detail !== "full") {
@@ -1677,14 +1757,26 @@ const helpCommand = defineCommand({
           "Print release notes and migration guidance for a version. Bundled notes live in docs/migration/release-notes/<version>.md; an unknown version lists what's available.",
       },
       args: {
+        // Optional in citty so run() is invoked even when omitted; we
+        // re-validate below to surface a structured UsageError (exit 2)
+        // instead of citty's default help-banner exit-0.
         version: {
           type: "positional",
           description: "Version to review (for example 0.6.0, v0.6.0, 0.6.0-rc1, or latest)",
-          required: true,
+          required: false,
         },
       },
       run({ args }) {
-        process.stdout.write(renderMigrationHelp(args.version));
+        return runWithJsonErrors(() => {
+          if (!args.version || !String(args.version).trim()) {
+            throw new UsageError(
+              "Usage: akm help migrate <version>.",
+              "MISSING_REQUIRED_ARGUMENT",
+              "Pass a version like `0.6.0`, `v0.6.0`, `0.6.0-rc1`, or `latest`.",
+            );
+          }
+          process.stdout.write(renderMigrationHelp(args.version));
+        });
       },
     }),
   },
@@ -2676,14 +2768,27 @@ const proposeCommand = defineCommand({
     description: "Ask the configured agent CLI to author a brand-new asset and queue it as a proposal",
   },
   args: {
-    type: { type: "positional", description: "Asset type (skill, command, knowledge, lesson, ...)", required: true },
-    name: { type: "positional", description: "Asset name (slug or path under the type dir)", required: true },
-    task: { type: "string", description: "Task description for the agent (what should the asset do?)", required: true },
+    // Optional in citty so run() is invoked when omitted; we re-validate
+    // below to surface a structured UsageError (exit 2) instead of citty's
+    // default help-banner exit-0.
+    type: { type: "positional", description: "Asset type (skill, command, knowledge, lesson, ...)", required: false },
+    name: { type: "positional", description: "Asset name (slug or path under the type dir)", required: false },
+    task: { type: "string", description: "Task description for the agent (what should the asset do?)" },
     profile: { type: "string", description: "Override the agent profile (defaults to agent.default)" },
     "timeout-ms": { type: "string", description: "Override the agent CLI timeout in milliseconds" },
   },
   async run({ args }) {
     await runWithJsonErrors(async () => {
+      // citty silently shows help and exits 0 when required positionals are
+      // omitted. Re-validate explicitly so the exit code is 2 (USAGE) and a
+      // structured JSON error reaches scripted callers.
+      if (!args.type || !args.name || !args.task) {
+        throw new UsageError(
+          "Usage: akm propose <type> <name> --task '<task>'.",
+          "MISSING_REQUIRED_ARGUMENT",
+          "Provide the asset type, name, and a --task description, e.g. `akm propose skill deploy --task 'Deploy a service'`.",
+        );
+      }
       const timeoutRaw = (args as Record<string, unknown>)["timeout-ms"];
       const timeoutMs =
         typeof timeoutRaw === "string" && timeoutRaw.trim() ? Number.parseInt(timeoutRaw, 10) : undefined;
@@ -2709,9 +2814,14 @@ const main = defineCommand({
     description: "Agent Kit Manager — search, show, and manage assets from your stash.",
   },
   args: {
-    format: { type: "string", description: "Output format (json|jsonl|text|yaml)" },
-    detail: { type: "string", description: "Detail level (brief|normal|full|summary|agent)" },
+    format: { type: "string", description: "Output format (json|jsonl|text|yaml)", default: "json" },
+    detail: { type: "string", description: "Detail level (brief|normal|full|summary|agent)", default: "brief" },
     quiet: { type: "boolean", alias: "q", description: "Suppress stderr warnings", default: false },
+    verbose: {
+      type: "boolean",
+      description: "Print per-spec diagnostics to stderr (also honours AKM_VERBOSE env var)",
+      default: false,
+    },
   },
   subCommands: {
     setup: setupCommand,

--- a/src/commands/config-cli.ts
+++ b/src/commands/config-cli.ts
@@ -77,9 +77,12 @@ export function parseConfigValue(key: string, value: string): Partial<AkmConfig>
     case "security.installAudit.allowedFindings":
       return { security: { installAudit: { allowedFindings: parseAllowedFindingsValue(value, key) } } };
     default:
-      throw new UsageError(`Unknown config key: ${key}`);
+      throw new UsageError(`Unknown config key: ${key}`, "INVALID_FLAG_VALUE", UNKNOWN_CONFIG_KEY_HINT);
   }
 }
+
+const UNKNOWN_CONFIG_KEY_HINT =
+  "Valid top-level keys: stashDir, embedding, llm, registries, sources, agent, output, semanticSearchMode. Use dotted paths like `embedding.endpoint` or `output.format` for nested values.";
 
 export function getConfigValue(config: AkmConfig, key: string): unknown {
   switch (key) {
@@ -130,7 +133,7 @@ export function getConfigValue(config: AkmConfig, key: string): unknown {
     case "security.installAudit.allowedFindings":
       return config.security?.installAudit?.allowedFindings ?? null;
     default:
-      throw new UsageError(`Unknown config key: ${key}`);
+      throw new UsageError(`Unknown config key: ${key}`, "INVALID_FLAG_VALUE", UNKNOWN_CONFIG_KEY_HINT);
   }
 }
 
@@ -187,7 +190,7 @@ export function setConfigValue(config: AkmConfig, key: string, rawValue: string)
       return { ...config, defaultWriteTarget: name };
     }
     default:
-      throw new UsageError(`Unknown config key: ${key}`);
+      throw new UsageError(`Unknown config key: ${key}`, "INVALID_FLAG_VALUE", UNKNOWN_CONFIG_KEY_HINT);
   }
 }
 
@@ -259,7 +262,7 @@ export function unsetConfigValue(config: AkmConfig, key: string): AkmConfig {
         }),
       };
     default:
-      throw new UsageError(`Unknown or unsupported unset key: ${key}`);
+      throw new UsageError(`Unknown or unsupported unset key: ${key}`, "INVALID_FLAG_VALUE", UNKNOWN_CONFIG_KEY_HINT);
   }
 }
 

--- a/src/commands/installed-stashes.ts
+++ b/src/commands/installed-stashes.ts
@@ -378,7 +378,7 @@ function selectTargets(
     );
   }
 
-  throw new NotFoundError(`No matching source for target: ${target}`);
+  throw new NotFoundError(`No matching source for target: ${target}`, "SOURCE_NOT_FOUND");
 }
 
 function tryResolveInstalledTarget(installed: InstalledStashEntry[], target: string): InstalledStashEntry | undefined {

--- a/src/core/asset-ref.ts
+++ b/src/core/asset-ref.ts
@@ -83,14 +83,15 @@ export function parseAssetRef(ref: string): AssetRef {
 // ── Validation ──────────────────────────────────────────────────────────────
 
 function validateName(name: string): void {
-  if (!name) throw new UsageError("Empty asset name.");
-  if (name.includes("\0")) throw new UsageError("Null byte in asset name.");
-  if (/^[A-Za-z]:/.test(name)) throw new UsageError("Windows drive path in asset name.");
+  if (!name) throw new UsageError("Empty asset name.", "MISSING_REQUIRED_ARGUMENT");
+  if (name.includes("\0")) throw new UsageError("Null byte in asset name.", "MISSING_REQUIRED_ARGUMENT");
+  if (/^[A-Za-z]:/.test(name)) throw new UsageError("Windows drive path in asset name.", "MISSING_REQUIRED_ARGUMENT");
 
   const normalized = path.posix.normalize(name.replace(/\\/g, "/"));
-  if (path.posix.isAbsolute(normalized)) throw new UsageError("Absolute path in asset name.");
+  if (path.posix.isAbsolute(normalized))
+    throw new UsageError("Absolute path in asset name.", "MISSING_REQUIRED_ARGUMENT");
   if (normalized === ".." || normalized.startsWith("../")) {
-    throw new UsageError("Path traversal in asset name.");
+    throw new UsageError("Path traversal in asset name.", "MISSING_REQUIRED_ARGUMENT");
   }
 }
 

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -64,6 +64,7 @@ const CONFIG_HINTS: Partial<Record<ConfigErrorCode, string>> = {
 
 /** Default hint for each UsageError code. */
 const USAGE_HINTS: Partial<Record<UsageErrorCode, string>> = {
+  INVALID_FLAG_VALUE: "Run `akm <command> --help` to see accepted values.",
   INVALID_SOURCE_VALUE: "Pick one of: stash, registry, both.",
   INVALID_FORMAT_VALUE: "Pick one of: json, jsonl, text, yaml.",
   INVALID_DETAIL_VALUE: "Pick one of: brief, normal, full, summary, agent.",
@@ -77,7 +78,10 @@ const USAGE_HINTS: Partial<Record<UsageErrorCode, string>> = {
 
 /** Default hint for each NotFoundError code. */
 const NOT_FOUND_HINTS: Partial<Record<NotFoundErrorCode, string>> = {
+  ASSET_NOT_FOUND: "Run `akm search <query>` or `akm index` to refresh the index.",
   SOURCE_NOT_FOUND: "Run `akm list` to view your sources, then retry with one of those values.",
+  WORKFLOW_NOT_FOUND: "Run `akm workflow list --active` to see runs.",
+  FILE_NOT_FOUND: "Check the path exists and is readable.",
 };
 
 /** Raised when configuration or environment is invalid or missing. */

--- a/src/output/text.ts
+++ b/src/output/text.ts
@@ -216,9 +216,233 @@ export function formatPlain(command: string, result: unknown, detail: DetailLeve
     case "distill": {
       return formatDistillPlain(r);
     }
+    case "info":
+      return formatInfoPlain(r);
+    case "config":
+      return formatConfigPlain(r);
+    case "feedback":
+      return formatFeedbackPlain(r);
+    case "remember":
+      return formatRememberPlain(r);
+    case "import":
+      return formatImportPlain(r);
+    case "save":
+      return formatSavePlain(r);
+    case "enable":
+    case "disable":
+      return formatToggleComponentPlain(command, r);
+    case "registry-list":
+      return formatRegistryListPlain(r);
+    case "registry-add":
+      return formatRegistryAddPlain(r);
+    case "registry-remove":
+      return formatRegistryRemovePlain(r);
+    case "registry-search":
+      return formatRegistrySearchPlain(r, detail);
+    case "registry-build-index":
+      return formatRegistryBuildIndexPlain(r);
+    case "vault-list":
+      return formatVaultListPlain(r);
+    case "vault-create":
+      return `Created vault ${String(r.ref ?? "?")} at ${String(r.path ?? "?")}`;
+    case "vault-set":
+      return `Set ${String(r.key ?? "?")} in ${String(r.ref ?? "?")} (value not displayed)`;
+    case "vault-unset": {
+      const removed = r.removed === true;
+      const head = removed
+        ? `Removed ${String(r.key ?? "?")} from ${String(r.ref ?? "?")}`
+        : `Key ${String(r.key ?? "?")} was not present in ${String(r.ref ?? "?")}`;
+      return head;
+    }
+    case "wiki-register":
+      return formatWikiRegisterPlain(r);
+    case "workflow-resume":
+      return formatWorkflowStatusPlain(r) ?? `Resumed workflow run ${String(r.id ?? r.runId ?? "?")}`;
+    case "workflow-validate":
+      return formatWorkflowValidatePlain(r);
     default:
       return null; // fall through to YAML
   }
+}
+
+export function formatInfoPlain(r: Record<string, unknown>): string {
+  const lines: string[] = [];
+  if (r.version) lines.push(`version: ${String(r.version)}`);
+  if (r.stashDir) lines.push(`stashDir: ${String(r.stashDir)}`);
+  if (r.configPath) lines.push(`configPath: ${String(r.configPath)}`);
+  if (r.cacheDir) lines.push(`cacheDir: ${String(r.cacheDir)}`);
+  if (r.dbPath) lines.push(`dbPath: ${String(r.dbPath)}`);
+  const capabilities = r.capabilities as Record<string, unknown> | undefined;
+  if (capabilities) {
+    lines.push("capabilities:");
+    for (const [k, v] of Object.entries(capabilities)) {
+      lines.push(`  ${k}: ${typeof v === "object" ? JSON.stringify(v) : String(v)}`);
+    }
+  }
+  const indexStats = r.index as Record<string, unknown> | undefined;
+  if (indexStats) {
+    lines.push("index:");
+    for (const [k, v] of Object.entries(indexStats)) {
+      lines.push(`  ${k}: ${typeof v === "object" ? JSON.stringify(v) : String(v)}`);
+    }
+  }
+  if (lines.length === 0) return JSON.stringify(r, null, 2);
+  return lines.join("\n");
+}
+
+export function formatConfigPlain(r: Record<string, unknown>): string {
+  // Recursive flattener: prints `key=value` lines, and nested objects as
+  // `parent.child=value`. Arrays render as JSON for compactness.
+  const lines: string[] = [];
+  const walk = (obj: Record<string, unknown>, prefix: string): void => {
+    for (const [k, v] of Object.entries(obj)) {
+      const path = prefix ? `${prefix}.${k}` : k;
+      if (v === null || v === undefined) {
+        lines.push(`${path}=`);
+      } else if (Array.isArray(v)) {
+        lines.push(`${path}=${JSON.stringify(v)}`);
+      } else if (typeof v === "object") {
+        walk(v as Record<string, unknown>, path);
+      } else {
+        lines.push(`${path}=${String(v)}`);
+      }
+    }
+  };
+  walk(r, "");
+  if (lines.length === 0) return "(empty config)";
+  return lines.join("\n");
+}
+
+export function formatFeedbackPlain(r: Record<string, unknown>): string {
+  const ref = String(r.ref ?? "?");
+  const signal = String(r.signal ?? "?");
+  const note = typeof r.note === "string" && r.note ? ` — ${r.note}` : "";
+  return `Recorded ${signal} feedback for ${ref}${note}`;
+}
+
+export function formatRememberPlain(r: Record<string, unknown>): string {
+  const ref = String(r.ref ?? "?");
+  const pathValue = String(r.path ?? "?");
+  return `Saved ${ref} at ${pathValue}`;
+}
+
+export function formatImportPlain(r: Record<string, unknown>): string {
+  const ref = String(r.ref ?? "?");
+  const source = String(r.source ?? "?");
+  const pathValue = String(r.path ?? "?");
+  return `Imported ${source} → ${ref} at ${pathValue}`;
+}
+
+export function formatSavePlain(r: Record<string, unknown>): string {
+  if (r.ok === false) {
+    const reason = typeof r.reason === "string" ? r.reason : "unknown";
+    return `save: failed (${reason})`;
+  }
+  const name = typeof r.name === "string" ? r.name : "primary stash";
+  const committed = r.committed === true;
+  const pushed = r.pushed === true;
+  const parts = [`save: ${name}`];
+  parts.push(committed ? "committed" : "no changes");
+  if (pushed) parts.push("pushed");
+  return parts.join(" — ");
+}
+
+export function formatToggleComponentPlain(command: string, r: Record<string, unknown>): string {
+  const verb = command === "enable" ? "Enabled" : "Disabled";
+  const component = String(r.component ?? "?");
+  const changed = r.changed === true;
+  return changed ? `${verb} ${component}` : `${component} was already ${command}d`;
+}
+
+export function formatRegistryListPlain(r: Record<string, unknown>): string {
+  const registries = Array.isArray(r.registries) ? (r.registries as Array<Record<string, unknown>>) : [];
+  if (registries.length === 0) {
+    return "No registries configured. Add one with `akm registry add <url>`.";
+  }
+  const lines: string[] = [];
+  for (const reg of registries) {
+    const url = String(reg.url ?? "?");
+    const name = typeof reg.name === "string" ? reg.name : "";
+    const provider = typeof reg.provider === "string" ? ` (${reg.provider})` : "";
+    const enabled = reg.enabled === false ? " [disabled]" : "";
+    const head = name ? `${name}: ${url}` : url;
+    lines.push(`${head}${provider}${enabled}`);
+  }
+  return lines.join("\n");
+}
+
+export function formatRegistryAddPlain(r: Record<string, unknown>): string {
+  if (r.added === false) {
+    return typeof r.message === "string" ? r.message : "Registry already configured.";
+  }
+  const registries = Array.isArray(r.registries) ? r.registries.length : 0;
+  return `Registry added (${registries} total).`;
+}
+
+export function formatRegistryRemovePlain(r: Record<string, unknown>): string {
+  if (r.removed === false) {
+    return typeof r.message === "string" ? r.message : "No matching registry found.";
+  }
+  const entry = r.entry as Record<string, unknown> | undefined;
+  const url = entry ? String(entry.url ?? entry.name ?? "?") : "?";
+  return `Removed registry ${url}`;
+}
+
+export function formatRegistrySearchPlain(r: Record<string, unknown>, detail: DetailLevel): string {
+  // Reuse the same renderer as `search` — both share `hits` / `registryHits`.
+  return formatSearchPlain(r, detail);
+}
+
+export function formatRegistryBuildIndexPlain(r: Record<string, unknown>): string {
+  const outPath = String(r.outPath ?? "?");
+  const total = typeof r.totalKits === "number" ? r.totalKits : 0;
+  const version = typeof r.version === "number" ? `v${r.version}` : "";
+  return `Wrote registry index ${version} (${total} kits) → ${outPath}`.replace(/\s+/g, " ").trim();
+}
+
+export function formatVaultListPlain(r: Record<string, unknown>): string {
+  // Single-vault listing: { ref, path, entries: [{ key, comment? }, ...] }
+  if (typeof r.ref === "string" && Array.isArray(r.entries)) {
+    const ref = r.ref;
+    const entries = r.entries as Array<Record<string, unknown>>;
+    if (entries.length === 0) {
+      return `No keys in ${ref}. Set one with \`akm vault set ${ref} KEY=VALUE\`.`;
+    }
+    const lines = [ref];
+    for (const e of entries) {
+      const key = String(e.key ?? "?");
+      const comment = typeof e.comment === "string" && e.comment ? `  # ${e.comment}` : "";
+      lines.push(`  ${key}${comment}`);
+    }
+    return lines.join("\n");
+  }
+  // Multi-vault listing: { vaults: [{ ref, path, keyCount }, ...] }
+  const vaults = Array.isArray(r.vaults) ? (r.vaults as Array<Record<string, unknown>>) : [];
+  if (vaults.length === 0) {
+    return "No vaults. Create one with `akm vault create <name>` then `akm vault set vault:<name> KEY=VALUE`.";
+  }
+  const lines: string[] = [];
+  for (const v of vaults) {
+    const ref = String(v.ref ?? "?");
+    const keyCount = typeof v.keyCount === "number" ? v.keyCount : 0;
+    lines.push(`${ref}\t${keyCount} key(s)`);
+  }
+  return lines.join("\n");
+}
+
+export function formatWikiRegisterPlain(r: Record<string, unknown>): string {
+  const name = String(r.name ?? r.wiki ?? "?");
+  const ref = String(r.ref ?? r.path ?? r.url ?? "?");
+  return `Registered wiki ${name} → ${ref}`;
+}
+
+export function formatWorkflowValidatePlain(r: Record<string, unknown>): string {
+  const ok = r.ok !== false;
+  const pathValue = String(r.path ?? "?");
+  if (!ok) return `workflow validate: failed (${pathValue})`;
+  const title = typeof r.title === "string" ? r.title : "";
+  const stepCount = typeof r.stepCount === "number" ? r.stepCount : 0;
+  return `workflow validate: ok — ${title || pathValue} (${stepCount} step(s))`;
 }
 
 export function formatProposalProducerPlain(command: string, r: Record<string, unknown>): string {
@@ -243,7 +467,9 @@ export function formatProposalProducerPlain(command: string, r: Record<string, u
 export function formatProposalListPlain(r: Record<string, unknown>): string {
   const proposals = Array.isArray(r.proposals) ? (r.proposals as Array<Record<string, unknown>>) : [];
   const total = typeof r.totalCount === "number" ? r.totalCount : proposals.length;
-  if (proposals.length === 0) return `${total} proposal(s).\nNo proposals.`;
+  if (proposals.length === 0) {
+    return `${total} proposal(s).\nNo proposals.\nGenerate one with \`akm reflect <ref>\`, \`akm propose <type> <name> --task ...\`, or \`akm distill <ref>\`.`;
+  }
   const lines = [`${total} proposal(s)`, ""];
   for (const p of proposals) {
     const id = String(p.id ?? "?");
@@ -454,7 +680,9 @@ function formatShowPlain(r: Record<string, unknown>, detail: DetailLevel): strin
 
 export function formatWorkflowListPlain(result: Record<string, unknown>): string {
   const runs = Array.isArray(result.runs) ? (result.runs as Array<Record<string, unknown>>) : [];
-  if (runs.length === 0) return "No workflow runs found.";
+  if (runs.length === 0) {
+    return "No workflow runs. Start one with `akm workflow next workflow:<name>` or author one with `akm workflow create <name>`.";
+  }
 
   return runs
     .map((run) => {

--- a/src/registry/resolve.ts
+++ b/src/registry/resolve.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { fetchWithRetry, jsonWithByteCap } from "../core/common";
-import { UsageError } from "../core/errors";
+import { NotFoundError, UsageError } from "../core/errors";
 import { asRecord, asString, GITHUB_API_BASE, githubHeaders } from "../integrations/github";
 import type {
   ParsedGithubRef,
@@ -236,7 +236,11 @@ function tryParseLocalRef(rawRef: string, explicitPath: boolean): ParsedLocalRef
   } catch {
     // Explicit paths (./foo, ../bar, /abs) should throw on missing
     if (explicitPath) {
-      throw new Error(`Local path not found: ${resolvedPath}`);
+      throw new NotFoundError(
+        `Local path not found: ${resolvedPath}`,
+        "FILE_NOT_FOUND",
+        "Check the path exists and is readable.",
+      );
     }
     // Bare names that don't exist on disk — let caller fall through to npm/github
     return undefined;

--- a/src/setup/setup.ts
+++ b/src/setup/setup.ts
@@ -378,6 +378,10 @@ async function stepOllama(current: AkmConfig): Promise<OllamaChoices> {
       bge: 384,
     };
     const guessedDim = Object.entries(knownDims).find(([k]) => embChoice.includes(k))?.[1] ?? 384;
+    p.note(
+      "Embedding dimension must match the model. Common values: 384 (BGE small), 768 (BGE base), 1024 (BGE large). Press Enter to accept the detected default.",
+      "Embedding dimension",
+    );
     const dimChoice = await prompt(() =>
       p.text({
         message: `Embedding dimension for ${embChoice}:`,
@@ -1017,7 +1021,7 @@ export async function runSetupWizard(): Promise<void> {
   const embedding = newConfig.embedding;
   const llm = newConfig.llm;
   const registries = newConfig.registries;
-  const allStashes = newConfig.stashes ?? [];
+  const allStashes = newConfig.sources ?? newConfig.stashes ?? [];
 
   // Confirm before saving
   const effectiveRegistries = registries ?? DEFAULT_CONFIG.registries ?? [];

--- a/tests/cli-errors.test.ts
+++ b/tests/cli-errors.test.ts
@@ -161,19 +161,18 @@ describe("error class hints", () => {
   });
 
   test("UsageError without a code-mapped hint returns undefined", () => {
-    expect(new UsageError("bad flag", "INVALID_FLAG_VALUE").hint()).toBeUndefined();
+    // INVALID_FLAG_VALUE is intentionally a generic fallback — points at --help.
+    expect(new UsageError("bad flag", "INVALID_FLAG_VALUE").hint()).toContain("akm <command> --help");
     expect(new UsageError("unknown key", "UNKNOWN_CONFIG_KEY").hint()).toBeUndefined();
     expect(new UsageError("bad json arg", "INVALID_JSON_ARGUMENT").hint()).toBeUndefined();
   });
 
   test("NotFoundError derives hint from code by default", () => {
+    // Wave C #284 added canned hints for the remaining codes.
     expect(new NotFoundError("missing source", "SOURCE_NOT_FOUND").hint()).toContain("akm list");
-  });
-
-  test("NotFoundError without a code-mapped hint returns undefined", () => {
-    expect(new NotFoundError("missing asset", "ASSET_NOT_FOUND").hint()).toBeUndefined();
-    expect(new NotFoundError("missing wf", "WORKFLOW_NOT_FOUND").hint()).toBeUndefined();
-    expect(new NotFoundError("missing file", "FILE_NOT_FOUND").hint()).toBeUndefined();
+    expect(new NotFoundError("missing asset", "ASSET_NOT_FOUND").hint()).toContain("akm search");
+    expect(new NotFoundError("missing wf", "WORKFLOW_NOT_FOUND").hint()).toContain("akm workflow list");
+    expect(new NotFoundError("missing file", "FILE_NOT_FOUND").hint()).toContain("path exists");
   });
 
   test("explicit hint at construction overrides the code-derived default", () => {

--- a/tests/wave2-cluster-d.test.ts
+++ b/tests/wave2-cluster-d.test.ts
@@ -112,10 +112,10 @@ describe("error hint rendering (#8)", () => {
     expect(err.hint()).toContain("stash");
   });
 
-  test("NotFoundError with ASSET_NOT_FOUND has no default hint (expected)", () => {
+  test("NotFoundError with ASSET_NOT_FOUND has a canned hint (Wave C #284)", () => {
     const err = new NotFoundError("not found");
-    // ASSET_NOT_FOUND is not in NOT_FOUND_HINTS by design
-    expect(err.hint()).toBeUndefined();
+    // Wave C added a default hint for ASSET_NOT_FOUND pointing at search/index.
+    expect(err.hint()).toContain("akm search");
   });
 
   test("NotFoundError with explicit hint returns it", () => {


### PR DESCRIPTION
## Summary
Wave C of issue #284 — operator-UX hardening across `src/cli.ts`, `src/output/text.ts`, `src/core/errors.ts`, `src/setup/setup.ts`, plus surgical fixes in `src/registry/resolve.ts`, `src/commands/installed-stashes.ts`, `src/commands/config-cli.ts`, `src/core/asset-ref.ts`. Sequenced after Wave A merged (#285) so `src/cli.ts` could be touched safely.

Closes #284 (final wave — supersedes the partial close from PR #285).

## UX-CRIT (6) — operator hits a wall
- **CRIT-1** `formatPlain()` null fallback (CLAUDE.md violation): added textRenderers for all 56 commands that call `output("…")`. No more silent JSON fallback when operator picks `--format text`.
- **CRIT-2** `akm search` no-query: error hint now mentions `--type`/`--limit` instead of show-style ref grammar.
- **CRIT-3** `akm workflow next bogus-id`: UUID-shape detection up-front; emits `NotFoundError("WORKFLOW_NOT_FOUND")` with `Run \`akm workflow list --active\`` hint instead of cryptic ref-parse error.
- **CRIT-4** `akm add /missing/path`: `NotFoundError("FILE_NOT_FOUND")` with hint, replacing bare `Error`.
- **CRIT-5** Setup wizard embedding-dimension prompt: added `p.note(...)` explaining 384/768/1024 + detected default.
- **CRIT-6** `akm update bogus`: passes `"SOURCE_NOT_FOUND"` code, matching the working pattern at line 157.

## UX-HIGH (10)
- **HIGH-1/2/3** Empty-state hints for `proposal list`, `workflow list`, `vault list` — point operator at how to create the first one.
- **HIGH-4** `akm show --help` now lists view modes (`toc`, `section "Auth"`, `lines 1 50`, `frontmatter`, `full`).
- **HIGH-5** `add` HTTP gating now matches `registry add` — both reject without `--allow-insecure`.
- **HIGH-6** Arity guards on `propose`, `feedback`, `curate`, `help migrate` — no more silent exit-0-with-help when required positionals missing. Now exit 2 with `MISSING_REQUIRED_ARGUMENT`.
- **HIGH-7** `--verbose` declared in `main.args` so it shows in `--help` (was honoured at runtime but invisible).
- **HIGH-8** Default-value annotations rendered in `--help` for `--format` / `--detail`.
- **HIGH-9** Config get/set/unset unknown-key error now lists valid top-level keys.
- **HIGH-10** Same as CRIT-6 (overlap intentional).

## Error hint coverage (UX-MED)
Canned hints added in `src/core/errors.ts` for previously-empty codes:
- `INVALID_FLAG_VALUE` → "Run `akm <command> --help` to see accepted values."
- `ASSET_NOT_FOUND` → "Run `akm search <query>` or `akm index` to refresh the index."
- `WORKFLOW_NOT_FOUND` → "Run `akm workflow list --active` to see runs."
- `FILE_NOT_FOUND` → "Check the path exists and is readable."

`src/core/asset-ref.ts:86-93` throws now use `MISSING_REQUIRED_ARGUMENT` consistent with peer throws.

## Cross-cutting
- Setup wizard reads `newConfig.sources ?? newConfig.stashes ?? []` (post-Wave-B `stashes[]` shim removal).
- `hints` command's `--detail` accepted-values documented in description.

## Test plan
- [x] `bunx tsc --noEmit` clean.
- [x] `bunx biome check src/ tests/` clean.
- [x] `bun test`: **2803 pass / 9 skip / 0 fail / 8020 expects across 171 files**.
- [x] All grep contracts independently verified per `feedback_verify_dont_trust_agent_done.md`.
- [x] Smoke: `bun run src/cli.ts proposal list --format text` against empty stash → ends with `Generate one with \`akm reflect <ref>\` ...`.

## Verify-grep results (real output)
- `grep -n "verbose: {" src/cli.ts` → `2820:    verbose: { ... }` (declared in main.args)
- `grep -n "newConfig.sources ?? newConfig.stashes" src/setup/setup.ts` → 1 hit
- `errors.ts` canned hints present for all 4 codes.
- `registry/resolve.ts:239` is now `NotFoundError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)