### PR TITLE
add example workflows for common engineering tasks

### DIFF
--- a/docs/example-stash/README.md
+++ b/docs/example-stash/README.md
@@ -27,6 +27,41 @@ In this example stash:
 - `workflows/topic-swarm-select-and-deep-research.md` is the broader workflow
   that explores many candidate topics, selects the best one, and then transitions
   into deep research.
+- `workflows/blog-publish-article.md` is a long-form editorial workflow with
+  multi-reviewer gates.
+- `workflows/github-issues-parallel-implementer.md` shows multi-agent parallel
+  implementation across isolated worktrees.
+
+### Common-task workflows
+
+Smaller, repeatable workflows that double as templates for everyday
+engineering work:
+
+- `workflows/triage-bug-report.md` — intake, reproduce, localize, propose a
+  fix, and promote durable lessons back into the stash and a knowledge wiki.
+- `workflows/weekly-dependency-audit.md` — recurring lockfile audit that
+  ships safe upgrades and queues the rest, demonstrating `akm vault` for
+  registry credentials.
+- `workflows/code-review-pr.md` — structured PR review against the project's
+  own conventions, demonstrating `akm search` for prior art and
+  `akm feedback` to signal reviewer-persona quality.
+- `workflows/ship-feature-from-spec.md` — spec-to-PR delivery loop with
+  test-first discipline and ADR-style decision capture.
+
+### Nested workflow example
+
+- `workflows/release-train.md` is an **orchestrator** that delegates to
+  other workflows in this stash as nested runs:
+  - `workflow:weekly-dependency-audit` for pre-flight maintenance
+  - `workflow:code-review-pr` once per release-blocker PR
+  - `workflow:release-retrospective` (sibling, to be created) for the
+    post-release learning loop
+
+  Each nested run has its own `runId`, can be inspected with
+  `akm workflow status`, and can be resumed independently if interrupted.
+  The orchestrator only owns the cross-cutting artefacts (release book,
+  changelog, tag, deploy, announcement) — the heavy lifting lives in
+  small, individually testable workflows.
 
 ## Suggested Flow
 
@@ -35,6 +70,11 @@ In this example stash:
 2. That command creates or starts the combined workflow in `workflows/`.
 3. If the topic is already known, skip the swarm and start the standalone
    deep-research workflow directly.
+4. For routine engineering work, pick the common-task workflow that matches
+   the job — bug, dep audit, review, feature — instead of running the
+   full research stack.
+5. For a release, run `workflow:release-train` and let it spawn the nested
+   runs it needs.
 
 As this example stash grows, it can hold more asset types without overloading
 the generic `docs/examples/` namespace.

--- a/docs/example-stash/workflows/code-review-pr.md
+++ b/docs/example-stash/workflows/code-review-pr.md
@@ -1,0 +1,196 @@
+---
+description: Review a single pull request against the project's actual conventions and prior decisions, leaving structured feedback that an author can act on without a follow-up call. Doubles as a way to capture review heuristics back into the stash.
+tags:
+  - example
+  - code-review
+  - pull-requests
+  - feedback
+  - memory
+params:
+  pr_ref: "Pull request reference (e.g. `gh:itlackey/akm#214`, or a freeform PR ID for non-GitHub forges)."
+  reviewer_persona: "Optional persona ref to bias the review (e.g. `skill:senior-typescript-reviewer`, `skill:security-reviewer`). Defaults to a generalist reviewer."
+  workspace_dir: "Directory for run artefacts. Defaults to `.akm-run/{{ runId }}`."
+  conventions_query: "Search query used to discover project conventions in the stash (e.g. `error handling conventions`, `react component style`). Defaults to the PR title."
+  knowledge_wiki: "AKM wiki to consult for prior architectural decisions and to update with new heuristics. Defaults to `engineering`."
+---
+
+# Workflow: Code Review PR
+
+A repeatable structure for high-signal PR review. The goal is to give the
+author the smallest set of changes that materially improve the patch — not to
+relitigate the architecture and not to nit-pick. The workflow also captures
+durable lessons so the next reviewer benefits from this one's effort.
+
+## Step: Load the PR and surface relevant prior art
+Step ID: load-context
+
+### Instructions
+A review starts with context the author already had, not a blank slate.
+
+1. Pull the PR metadata and diff:
+
+   ```sh
+   gh pr view {{ pr_ref }} --json title,body,author,headRefName,baseRefName,additions,deletions,files,labels
+   gh pr diff {{ pr_ref }} > {{ workspace_dir }}/pr.diff
+   ```
+
+   Cache the JSON in `{{ workspace_dir }}/pr-meta.json`.
+2. Discover project conventions relevant to the changed surfaces:
+
+   ```sh
+   akm search "{{ conventions_query }}"
+   akm wiki search {{ knowledge_wiki }} "{{ conventions_query }}"
+   ```
+
+   Record the top 5 hits in `{{ workspace_dir }}/conventions.md` with a
+   one-line note on whether each applies to this PR.
+3. If `reviewer_persona` is set, load it and treat its review rubric as the
+   authoritative checklist:
+
+   ```sh
+   akm show {{ reviewer_persona }}
+   ```
+
+### Completion Criteria
+- `pr-meta.json` and `pr.diff` are saved to disk for offline re-reading.
+- `conventions.md` lists relevant stash and wiki hits with applicability
+  notes.
+- The reviewer persona (if any) is loaded; otherwise the run notes
+  explicitly state the generalist rubric is in use.
+
+## Step: Read the change with intent
+Step ID: read-with-intent
+
+### Instructions
+Three passes, in order. Do not skip ahead.
+
+1. **What is the PR trying to do?** Read the description and the linked
+   issue. Write a one-paragraph summary in
+   `{{ workspace_dir }}/intent.md`. If you cannot articulate the intent
+   from the description, that is itself review feedback — record it.
+2. **Does the diff implement the stated intent?** Walk the files in the
+   order the author put them in the PR. For each file, note in
+   `{{ workspace_dir }}/walkthrough.md`:
+   - what changed in this file
+   - whether it serves the intent or seems orthogonal
+   - any callers/tests it implies but does not include
+3. **What did the diff *not* change that you expected?** Missing test
+   coverage, missing migration, missing changelog entry, missing
+   documentation. Record those gaps separately under a `## Gaps` section
+   in `walkthrough.md`.
+
+### Completion Criteria
+- `intent.md` summarises the goal in your own words.
+- `walkthrough.md` covers every file in the diff and lists expected-but-
+  missing changes under `Gaps`.
+- Off-topic refactors are flagged for the author to split out, not
+  silently approved.
+
+## Step: Apply the rubric
+Step ID: apply-rubric
+
+### Instructions
+Score the PR against an explicit rubric so feedback is calibrated, not
+vibes-based.
+
+For each rubric item, write a verdict in
+`{{ workspace_dir }}/rubric.md`: `pass`, `concern`, `block`, with one
+line of justification.
+
+Default rubric (extend per `reviewer_persona`):
+
+1. **Correctness** — does it implement the stated intent and only that?
+2. **Tests** — is the new behaviour covered, including edge cases the diff
+   itself implies (boundary conditions, error paths, concurrency)?
+3. **Conventions** — does it match the patterns in `conventions.md`, or
+   if it diverges, is the divergence justified in the PR body?
+4. **Security and data integrity** — any new input is validated, secrets
+   never logged, no obvious injection or auth bypass.
+5. **Reversibility** — can this be reverted cleanly? Database migrations
+   and feature flag flips are called out.
+6. **Diff hygiene** — no unrelated formatting, no dead code, no debug
+   logging, commit messages explain the *why*.
+
+Promote a `block` verdict only when the issue would harm production or
+permanently regress a contract. A code style preference is a `concern`,
+not a `block`.
+
+### Completion Criteria
+- Every rubric item has a verdict and a one-line justification.
+- `block` verdicts cite a concrete production or contract harm.
+- Style preferences are filed as `concern`, not `block`.
+
+## Step: Post the review
+Step ID: post-review
+
+### Instructions
+A good review reads as a single coherent message, not 14 separate inline
+comments that contradict each other.
+
+1. Draft `{{ workspace_dir }}/review.md` with this structure:
+   - **Summary**: 2–3 sentences on what this PR does and overall verdict.
+   - **Required to merge** (`block` items): each one tied to a file/line
+     and the rubric item it failed.
+   - **Strongly suggested** (`concern` items): same structure, but
+     explicitly optional.
+   - **Optional / nits**: clearly labelled, never promoted.
+   - **What worked well**: at least one specific thing — calibration
+     matters as much for praise as for criticism.
+2. Post the review:
+
+   ```sh
+   gh pr review {{ pr_ref }} --request-changes -F {{ workspace_dir }}/review.md
+   ```
+
+   (Use `--approve` or `--comment` instead if there are no `block`
+   items.)
+3. Record inline comments only for items that need to point to a specific
+   line and would be ambiguous in the summary.
+
+### Completion Criteria
+- A single review is posted with `block`, `concern`, and nit sections
+  clearly separated.
+- Inline comments exist only where a line reference is necessary.
+- The review includes at least one specific positive observation.
+
+## Step: Capture durable heuristics
+Step ID: capture-heuristics
+
+### Instructions
+A review that taught you something should leave a trace beyond the PR
+thread.
+
+1. If a recurring pattern surfaced (good or bad) that future reviews
+   should look for, add or update a page under `wiki:{{ knowledge_wiki }}`
+   describing it. One page per pattern, not one mega-page.
+2. Save personal review heuristics with `akm remember`:
+
+   ```sh
+   akm remember "When reviewing PRs that touch the FTS5 indexer, always
+   check that schema-version bumps are handled in db.ts and not just in
+   schema.ts."
+   ```
+
+3. If you used a reviewer persona and it surfaced a useful prompt or
+   missed something important, signal that with `akm feedback`:
+
+   ```sh
+   akm feedback {{ reviewer_persona }} --positive --note "Caught an
+   auth-bypass pattern I would have missed."
+   # or
+   akm feedback {{ reviewer_persona }} --negative --note "Missed an
+   obvious test gap; rubric needs a coverage step."
+   ```
+
+4. Re-index so future reviews find the new material:
+
+   ```sh
+   akm wiki ingest {{ knowledge_wiki }}
+   akm index
+   ```
+
+### Completion Criteria
+- At least one of: a wiki page added/updated, a memory recorded, or an
+  explicit note that this PR carried no durable lesson.
+- If `reviewer_persona` was used, a feedback signal is recorded.
+- `akm index` and `akm wiki ingest` complete cleanly.

--- a/docs/example-stash/workflows/release-train.md
+++ b/docs/example-stash/workflows/release-train.md
@@ -1,0 +1,310 @@
+---
+description: Drive a recurring release from a quiet base branch to a tagged, deployed, retrospected release. Composes other workflows as nested runs — `weekly-dependency-audit`, `code-review-pr` (per release-blocker PR), and a final retrospective — so the orchestrator stays small and the heavy lifting lives in dedicated, individually testable workflows.
+tags:
+  - example
+  - release
+  - nested-workflows
+  - orchestration
+  - vault
+params:
+  release_version: "Semver version being released (e.g. `1.4.0`). The workflow validates this against the changelog and tags."
+  base_branch: "Branch the release is cut from. Defaults to `main`."
+  release_branch: "Optional release branch (e.g. `release/1.4.x`). Defaults to `release/{{ release_version }}` when omitted."
+  release_pr_query: "GitHub search query that selects the PRs in scope for this release (e.g. `is:open milestone:1.4.0 label:release-blocker`). The orchestrator iterates this list."
+  deploy_vault: "Vault ref with deploy credentials (e.g. `vault:production`). Loaded only at the shell level, never echoed."
+  workspace_dir: "Directory for run artefacts. Defaults to `.akm-run/{{ runId }}`."
+  knowledge_wiki: "AKM wiki for release notes and retrospectives. Defaults to `engineering`."
+  skip_dependency_audit: "Set to `true` to skip the nested dependency audit (e.g. for hotfixes). Defaults to `false`."
+---
+
+# Workflow: Release Train
+
+This workflow is an **orchestrator**. It does very little real work itself.
+Each major phase delegates to a *nested run* of another workflow in this
+stash:
+
+- pre-flight maintenance → `workflow:weekly-dependency-audit`
+- per-PR sign-off → one `workflow:code-review-pr` run per blocker
+- post-release learning → `workflow:release-retrospective` (defined inline
+  below as a sibling workflow you can split out)
+
+The pattern is intentional. Each nested workflow is *individually*
+runnable, testable, and resumable. The orchestrator's only job is to
+sequence them, stitch their outputs together, and own the cross-cutting
+release artefacts (changelog, tag, deploy, announcement). Because every
+nested run gets its own `runId`, an interrupted release can resume by
+asking `akm workflow status` of the orchestrator and walking down to the
+nested runs it spawned.
+
+## Step: Open the release book
+Step ID: open-release-book
+
+### Instructions
+Establish a single durable index of every artefact this release will
+produce, including the IDs of nested runs.
+
+1. Validate `release_version` is semver. Resolve `release_branch` to its
+   default if omitted.
+2. Create `{{ workspace_dir }}/release-book.md` with these sections, all
+   initially empty:
+   - `Inputs` — params, base SHA, expected scope from `release_pr_query`.
+   - `Nested runs` — IDs of each nested workflow run, with state.
+   - `Artefacts` — changelog path, tag, deploy log, announcement.
+   - `Anomalies` — anything that needed manual override.
+3. Snapshot the current state of `{{ release_pr_query }}`:
+
+   ```sh
+   gh pr list --search "{{ release_pr_query }}" \
+     --json number,title,author,labels,headRefName,statusCheckRollup \
+     > {{ workspace_dir }}/in-scope-prs.json
+   ```
+
+   Block the run with a clear message if the list is empty *and*
+   `skip_dependency_audit` is `true` — there is nothing to release.
+
+### Completion Criteria
+- `release-book.md` exists and is the canonical index for this release.
+- `in-scope-prs.json` lists every PR matched by `release_pr_query` at the
+  point the release started.
+- `release_branch` is resolved and recorded in `release-book.md`.
+
+## Step: Run the dependency audit as a nested workflow
+Step ID: nested-dependency-audit
+
+### Instructions
+Unless `skip_dependency_audit` is `true`, every release passes through
+the same weekly dependency audit before opening the release branch. We
+do not duplicate that logic here — we *call* it.
+
+1. If `skip_dependency_audit` is `true`, mark this step
+   `--state skipped --notes "hotfix release"` and continue. Otherwise:
+2. Start the nested run, passing through the parameters it needs:
+
+   ```sh
+   akm workflow start workflow:weekly-dependency-audit \
+     --params '{"package_manager":"bun","base_branch":"{{ base_branch }}",
+                "freeze_list":[]}'
+   ```
+
+   Capture the returned run ID — call it `DEP_RUN_ID` — and append it to
+   the `Nested runs` section of `release-book.md`.
+3. Drive the nested run to completion exactly as a human would. Each
+   call returns the next actionable step:
+
+   ```sh
+   akm workflow next $DEP_RUN_ID
+   # ... do the work for that step ...
+   akm workflow complete $DEP_RUN_ID --step <step-id> --state completed \
+     --notes "..." --evidence '{"artefact":"path/to/output"}'
+   ```
+
+   Repeat until `akm workflow status $DEP_RUN_ID` reports the run as
+   `completed`.
+4. Read the nested run's `handoff.md` artefact. If it produced a
+   green-band PR, add that PR to `in-scope-prs.json` for this release.
+   If it produced any red-band issues, link them in `release-book.md`
+   under `Anomalies` so the retrospective can pick them up.
+5. If the nested run finishes in `blocked` or `failed`, do not paper
+   over it. Block this orchestrator step with the nested run ID in the
+   notes — the release does not advance until the dependency audit is
+   resolved (which may itself need `akm workflow resume`).
+
+### Completion Criteria
+- Either the dep-audit run is in state `completed` and its outputs are
+  reflected in this release's book, or this step is `skipped` for a
+  hotfix with an explicit note.
+- The nested run ID is recorded in `release-book.md` so the audit trail
+  is recoverable from the orchestrator alone.
+- A failed nested run blocks the orchestrator instead of being silently
+  ignored.
+
+## Step: Cut the release branch and lock scope
+Step ID: cut-release-branch
+
+### Instructions
+With dependencies green, lock the scope of what this release contains.
+
+1. Cut `release_branch` from `base_branch`:
+
+   ```sh
+   git fetch origin {{ base_branch }}
+   git switch -c {{ release_branch }} origin/{{ base_branch }}
+   git push -u origin {{ release_branch }}
+   ```
+
+2. Re-run the PR query and diff it against `in-scope-prs.json`. New PRs
+   matching the query after the release started are *not* automatically
+   included — append them to `Anomalies` in `release-book.md` and require
+   an explicit decision before adding them to scope.
+3. Generate a changelog draft at `{{ workspace_dir }}/CHANGELOG.draft.md`
+   using PR titles, labels, and bodies from `in-scope-prs.json`. Group
+   into `Features`, `Fixes`, `Internal`, `Breaking`. Mark anything
+   `Breaking` for explicit reviewer attention in the next step.
+
+### Completion Criteria
+- `release_branch` exists on the remote and is based on a known
+  `base_branch` SHA recorded in `release-book.md`.
+- `CHANGELOG.draft.md` covers every PR in `in-scope-prs.json`, grouped
+  and with `Breaking` items flagged.
+- Late-arriving PRs are surfaced in `Anomalies`, never silently merged.
+
+## Step: Review every release-blocker PR as a nested workflow
+Step ID: nested-pr-reviews
+
+### Instructions
+For each PR in `in-scope-prs.json` that is not already approved by a
+human reviewer, drive it through the standard review workflow as a
+nested run. The orchestrator tracks the per-PR run IDs and aggregates
+the verdicts.
+
+1. Build a worklist file `{{ workspace_dir }}/review-worklist.md` from
+   `in-scope-prs.json`. For each PR, record `pr_ref`, current review
+   state, and the nested run ID once started.
+2. For each unreviewed PR (process up to 3 in parallel — see the
+   `github-issues-parallel-implementer.md` example for the worktree
+   pattern):
+
+   ```sh
+   akm workflow start workflow:code-review-pr \
+     --params '{"pr_ref":"gh:itlackey/akm#<num>","conventions_query":"<title>",
+                "knowledge_wiki":"{{ knowledge_wiki }}"}'
+   ```
+
+   Append the returned run ID to the worklist, then drive it via
+   `akm workflow next` / `akm workflow complete` until the nested run
+   reports `completed`.
+3. After each nested run finishes, re-read its
+   `rubric.md` artefact:
+   - If every rubric item is `pass` or `concern`, mark the PR
+     reviewed in the worklist.
+   - If any rubric item is `block`, the PR is *not* releasable. Either
+     wait for a fix and re-run the nested workflow on the new commit,
+     or remove the PR from scope and update `Anomalies`.
+4. When all PRs in the worklist are either reviewed-and-merged or
+   removed-from-scope, regenerate `CHANGELOG.draft.md` against the
+   actual merged set and promote it to `CHANGELOG.md` on the release
+   branch.
+
+### Completion Criteria
+- Every in-scope PR has a corresponding nested `code-review-pr` run ID
+  in `review-worklist.md`, or a recorded reason it was excluded.
+- No PR with a `block` rubric verdict is in the merged release set.
+- `CHANGELOG.md` on the release branch matches the actual merged PRs,
+  not the original projection.
+
+## Step: Tag, deploy, and announce
+Step ID: tag-deploy-announce
+
+### Instructions
+The orchestrator owns these cross-cutting steps directly — they are not
+themselves multi-step procedures and do not need a nested workflow.
+
+1. Verify all CI on `release_branch` is green:
+
+   ```sh
+   gh pr checks {{ release_branch }}
+   ```
+
+2. Tag and push:
+
+   ```sh
+   git tag -a v{{ release_version }} -m "Release {{ release_version }}"
+   git push origin v{{ release_version }}
+   ```
+
+3. Load deploy credentials only into the deploy shell:
+
+   ```sh
+   source <(akm vault load {{ deploy_vault }})
+   ./scripts/deploy.sh {{ release_version }} | tee {{ workspace_dir }}/deploy.log
+   ```
+
+   Verify the deploy health check passes before continuing. If it
+   fails, mark this step `--state failed` and let the retrospective run
+   pick up the incident — do not attempt to clean up the partial deploy
+   here.
+4. Post the release announcement using `CHANGELOG.md` as the body. Link
+   to the orchestrator run ID and to each nested run ID so reviewers can
+   audit the path the release took.
+
+### Completion Criteria
+- `v{{ release_version }}` tag exists on the remote and points at the
+  release branch's tip SHA.
+- `deploy.log` shows a successful deploy and a passing health check.
+- The announcement links to the orchestrator's run ID for full audit
+  traceability.
+
+## Step: Run the retrospective as a nested workflow
+Step ID: nested-retrospective
+
+### Instructions
+Every release ends with a small retrospective so the *next* release
+inherits this one's lessons. We delegate to a focused workflow rather
+than burying the retro inside the orchestrator.
+
+1. Start the nested retrospective run:
+
+   ```sh
+   akm workflow start workflow:release-retrospective \
+     --params '{"release_version":"{{ release_version }}",
+                "orchestrator_run_id":"{{ runId }}",
+                "knowledge_wiki":"{{ knowledge_wiki }}"}'
+   ```
+
+   Append the run ID to `release-book.md` under `Nested runs`.
+2. Drive the nested run to completion. Its responsibilities (defined in
+   that workflow, not here) are:
+   - read `release-book.md` and every nested run's notes
+   - extract patterns: which steps blocked, which `Anomalies` recurred
+     across releases, which nested workflows themselves need updates
+   - publish a retrospective page under
+     `wiki:{{ knowledge_wiki }}/releases/{{ release_version }}.md`
+   - file follow-up issues for each actionable lesson
+3. When the retro finishes, link its wiki page from `release-book.md`
+   under `Artefacts`.
+
+If `workflow:release-retrospective` does not yet exist in the stash,
+this step blocks with a note pointing the next agent to create it —
+that creation work is itself a small `ship-feature-from-spec` run, and
+recording the gap in the run is more valuable than papering it over with
+ad-hoc notes here.
+
+### Completion Criteria
+- A nested retro run is started, completed, and its run ID is recorded.
+- A retrospective wiki page exists at
+  `wiki:{{ knowledge_wiki }}/releases/{{ release_version }}.md` and is
+  linked from `release-book.md`.
+- Every actionable lesson is filed as a tracked issue, not left as a
+  bullet in the wiki page.
+
+## Step: Close the release book
+Step ID: close-release-book
+
+### Instructions
+Make the orchestrator's audit trail self-contained.
+
+1. Update `release-book.md` so every section has a real value:
+   `Inputs`, `Nested runs` (with each ID and final state), `Artefacts`
+   (changelog, tag, deploy log, retro), `Anomalies`.
+2. Save the orchestrator's `runId` and the release version as a memory
+   so future releases can pattern-match:
+
+   ```sh
+   akm remember "Release {{ release_version }} ran via orchestrator
+   run {{ runId }}; deploy succeeded on first attempt; nested
+   dependency audit produced 2 follow-up issues."
+   ```
+
+3. Refresh the wiki and stash indexes:
+
+   ```sh
+   akm wiki ingest {{ knowledge_wiki }}
+   akm index
+   akm wiki lint {{ knowledge_wiki }}
+   ```
+
+### Completion Criteria
+- `release-book.md` has no empty sections.
+- A memory linking this orchestrator run to its release version is
+  stored.
+- `akm index` and `akm wiki lint {{ knowledge_wiki }}` complete cleanly.

--- a/docs/example-stash/workflows/ship-feature-from-spec.md
+++ b/docs/example-stash/workflows/ship-feature-from-spec.md
@@ -1,0 +1,212 @@
+---
+description: Take a written spec or issue from "agreed on the shape" to a merged, deployed change. Optimised for the case where the work is too small to need full release-train ceremony but too important to YOLO straight into main.
+tags:
+  - example
+  - features
+  - delivery
+  - tdd
+  - vault
+params:
+  spec_ref: "Reference to the agreed spec — a stash asset (e.g. `wiki:engineering/spec-foo`), an issue (`gh:itlackey/akm#214`), or a path under the run workspace."
+  base_branch: "Branch to cut the feature branch from. Defaults to `main`."
+  feature_slug: "Short kebab-case slug used in branch and PR names (e.g. `fts5-tokenizer-v2`)."
+  workspace_dir: "Directory for run artefacts. Defaults to `.akm-run/{{ runId }}`."
+  vault: "Optional vault ref for any credentials the test or deploy needs (e.g. `vault:integration-tests`)."
+  knowledge_wiki: "AKM wiki to consult for prior decisions and update with new ones. Defaults to `engineering`."
+---
+
+# Workflow: Ship Feature From Spec
+
+A pragmatic delivery loop: read the spec, write the test first, make it
+pass, leave the codebase a little better than you found it, and document
+the decision so the next person who touches this code finds your reasoning
+instead of guessing it.
+
+## Step: Anchor the spec and decision context
+Step ID: anchor-spec
+
+### Instructions
+Before writing any code, make sure you actually understand the spec the same
+way the person who wrote it does.
+
+1. Resolve `spec_ref` and copy its content into
+   `{{ workspace_dir }}/spec.md`. If the spec lives in the wiki:
+
+   ```sh
+   akm show {{ spec_ref }} > {{ workspace_dir }}/spec.md
+   ```
+
+2. Search for related decisions and prior implementations:
+
+   ```sh
+   akm search "{{ feature_slug }}"
+   akm wiki search {{ knowledge_wiki }} "{{ feature_slug }}"
+   ```
+
+   Capture relevant hits in `{{ workspace_dir }}/related.md` with one line on
+   why each matters.
+3. Write `{{ workspace_dir }}/understanding.md` in your own words: what is
+   in scope, what is explicitly out of scope, what the success criteria are,
+   and any open questions. If there are open questions, block the run and
+   ask them — do not guess.
+
+### Completion Criteria
+- `spec.md` is a verbatim copy of the agreed spec.
+- `related.md` lists prior art and notes whether each constrains this work.
+- `understanding.md` states scope, non-goals, and success criteria; open
+  questions either resolved or surfaced as blockers.
+
+## Step: Cut the branch and the failing test
+Step ID: failing-test
+
+### Instructions
+Test-first is non-negotiable here. The test encodes the spec; the test
+passing is the definition of done.
+
+1. Cut the branch from a fresh base:
+
+   ```sh
+   git fetch origin {{ base_branch }}
+   git switch -c feat/{{ feature_slug }} origin/{{ base_branch }}
+   ```
+
+2. Write the smallest test that demonstrates the new behaviour, named to
+   match the spec's success criterion. Place it next to the existing tests
+   for the affected module.
+3. Run the test and capture the failing output to
+   `{{ workspace_dir }}/red.log`. The failure must be for the *right*
+   reason — a missing implementation, not a typo or import error.
+4. If the spec implies multiple behaviours, write the failing test for the
+   most important one first. Stash the rest as `## Pending tests` in
+   `{{ workspace_dir }}/test-plan.md`.
+
+### Completion Criteria
+- A feature branch `feat/{{ feature_slug }}` exists from a fresh base.
+- A failing test exists and is committed; `red.log` shows it failing for
+  the intended reason.
+- `test-plan.md` lists the remaining tests to add as the implementation
+  progresses.
+
+## Step: Implement the smallest change that makes it green
+Step ID: implement
+
+### Instructions
+Resist the urge to refactor while implementing. Make it work first; tidy
+in a separate step.
+
+1. Implement the smallest change that turns `red.log` into a passing run.
+   Avoid touching files unrelated to the failing test.
+2. Run the project's gates after each meaningful edit:
+
+   ```sh
+   bunx biome check --write src/ tests/
+   bunx tsc --noEmit
+   bun test
+   ```
+
+3. As each pending test from `test-plan.md` becomes relevant, add it,
+   watch it fail, then make it pass. Commit per logical change with a
+   message that explains *why*, not what.
+4. If a planned approach hits a wall, do not silently change the spec.
+   Stop, document the wall in `{{ workspace_dir }}/blockers.md`, and
+   either revise `understanding.md` (if the user agrees) or block the
+   run.
+
+### Completion Criteria
+- All tests in `test-plan.md` are added and passing.
+- Lint, typecheck, and test gates pass cleanly on the branch.
+- Every commit message names the *why*, not just the *what*.
+
+## Step: Tidy and harden
+Step ID: tidy
+
+### Instructions
+Now you are allowed to refactor — but only what you touched, and only what
+the diff already justifies.
+
+1. Re-read the diff (`git diff origin/{{ base_branch }}...HEAD`) as if
+   you were the reviewer:
+   - Are there obvious naming improvements in code you already changed?
+   - Is there a comment explaining a non-obvious invariant where it would
+     genuinely help?
+   - Is there dead code, debug logging, or commented-out blocks?
+2. Apply only changes that the existing diff already justifies. Resist
+   sweeping refactors; file them as follow-up issues instead.
+3. Re-run gates. If anything regresses, the tidy was too aggressive —
+   revert and try a smaller pass.
+
+### Completion Criteria
+- The diff contains no dead code, debug prints, or unrelated formatting.
+- Refactors are confined to files the feature already touched.
+- Out-of-scope cleanups are filed as follow-up issues, not bundled in.
+
+## Step: Verify in an integration-like environment
+Step ID: verify-integration
+
+### Instructions
+Unit tests are necessary, not sufficient. Exercise the change through the
+real entry points before opening the PR.
+
+1. If the change has a CLI surface, run it end-to-end with realistic
+   inputs and capture the transcripts to
+   `{{ workspace_dir }}/integration.log`.
+2. If the change has a UI surface, run it in the dev server and verify the
+   golden path *and* the most plausible edge cases. Note explicitly in
+   `integration.log` if you could not exercise the UI.
+3. If integration requires credentials, load them only into the test
+   shell:
+
+   ```sh
+   source <(akm vault load {{ vault }})
+   ```
+
+   The credentials must never appear in `integration.log`.
+4. If integration uncovers a gap, return to `failing-test` with a new test
+   that catches it.
+
+### Completion Criteria
+- `integration.log` shows the change exercised through realistic entry
+  points.
+- Any UI changes were verified manually and that verification is recorded.
+- Credentials never appear in any artefact written to the workspace.
+
+## Step: Open the PR and document the decision
+Step ID: open-pr-and-document
+
+### Instructions
+The PR is the durable artefact. Make it readable.
+
+1. Push the branch and open the PR:
+
+   ```sh
+   git push -u origin feat/{{ feature_slug }}
+   gh pr create --base {{ base_branch }} --title "feat: {{ feature_slug }}" \
+     --body-file {{ workspace_dir }}/pr-body.md
+   ```
+
+   Build `pr-body.md` from `understanding.md` (intent and scope),
+   `test-plan.md` (verification), and a manual test plan derived from
+   `integration.log`.
+2. If the spec implied a non-trivial architectural choice, write or
+   update an ADR-style page under `wiki:{{ knowledge_wiki }}/decisions/`
+   recording the choice, the rejected alternatives, and the reasoning.
+3. Re-index so the new decision is searchable:
+
+   ```sh
+   akm wiki ingest {{ knowledge_wiki }}
+   akm index
+   ```
+
+4. Record any heuristics you'd want next time:
+
+   ```sh
+   akm remember "When implementing tokenizer features, write the FTS5
+   round-trip test before touching the parser — saved an afternoon."
+   ```
+
+### Completion Criteria
+- A PR is open with a body that summarises intent, verification, and
+  manual test plan.
+- Architectural decisions implied by the spec are recorded as a wiki
+  page under `decisions/`.
+- The knowledge wiki and stash index are refreshed.

--- a/docs/example-stash/workflows/triage-bug-report.md
+++ b/docs/example-stash/workflows/triage-bug-report.md
@@ -1,0 +1,181 @@
+---
+description: Triage a single bug report from intake to a reproducible failing test, a documented root cause, and a fix proposal — recording durable patterns to the knowledge base so the next similar bug is faster.
+tags:
+  - example
+  - bugs
+  - triage
+  - wiki
+  - memory
+params:
+  bug_ref: "Issue link or identifier for the bug being triaged (e.g. `gh:itlackey/akm#142`, `JIRA-1408`, or a freeform ID)."
+  repro_env: "Environment where the bug must be reproduced (e.g. `node@20 + bun@1.1`, `staging`, `local-docker`)."
+  severity_hint: "Reporter-provided severity hint (`low`, `medium`, `high`, `critical`). The triage step may revise this."
+  workspace_dir: "Directory for run artefacts. Defaults to `.akm-run/{{ runId }}`."
+  knowledge_wiki: "AKM wiki to consult and update with durable patterns. Defaults to `engineering`."
+---
+
+# Workflow: Triage Bug Report
+
+Bug triage is one of the most repetitive jobs an engineer does, and most of the
+variance is friction: hunting for the last time we saw something similar,
+reconstructing the reporter's environment, and forgetting to write down the
+heuristic that finally cracked it. This workflow turns the work into a
+checklist and writes its outputs back into the stash so the next triage
+benefits.
+
+## Step: Capture the report and prior art
+Step ID: capture
+
+### Instructions
+Pull the bug into the workspace before doing any analysis.
+
+1. Create `{{ workspace_dir }}/report.md` with the verbatim bug body, reporter,
+   timestamps, attachments, and any reproduction steps the reporter offered.
+2. Search the local stash for prior incidents that look related:
+
+   ```sh
+   akm search "<symptom keywords from {{ bug_ref }}>"
+   akm wiki search {{ knowledge_wiki }} "<symptom keywords>"
+   ```
+
+3. Record the top 5 hits in `{{ workspace_dir }}/prior-art.md` with one line of
+   why each is relevant or why it was discarded. If a known-issue wiki page
+   already documents the same root cause, link it and stop the workflow with
+   `--state skipped --notes "duplicate of <wiki ref>"`.
+
+### Completion Criteria
+- `report.md` captures the original report verbatim.
+- `prior-art.md` lists the top stash and wiki hits with a relevance verdict.
+- Duplicates are marked `skipped` with a pointer to the existing record.
+
+## Step: Reproduce in a clean environment
+Step ID: reproduce
+
+### Instructions
+A bug report you cannot reproduce is a bug report you cannot fix. Build the
+smallest reliable repro before forming any hypotheses.
+
+1. Stand up `repro_env` from scratch — do not reuse a dirty local checkout.
+2. Translate the reporter's steps into an executable script at
+   `{{ workspace_dir }}/repro.sh` (or `repro.test.ts` if the bug surfaces in a
+   test). Failing fast and noisily is the goal.
+3. Run the script and capture stdout, stderr, and any relevant logs into
+   `{{ workspace_dir }}/repro.log`.
+4. If the bug does not reproduce, branch:
+   - Add the missing details you needed (data fixtures, env vars, timing) to
+     `report.md`.
+   - Block the workflow with `--state blocked --notes "needs <missing detail>"`
+     and request them from the reporter.
+
+### Completion Criteria
+- `repro.sh` (or equivalent) reproduces the bug deterministically on a clean
+  `repro_env`.
+- `repro.log` shows the failing signal with timestamps.
+- A non-reproducible report is blocked with a concrete information request,
+  not silently closed.
+
+## Step: Localize the root cause
+Step ID: localize
+
+### Instructions
+Move from "it fails" to "this line, for this reason."
+
+1. Bisect or trace through the failing path. Record each hypothesis you
+   eliminate in `{{ workspace_dir }}/investigation.md` with a one-line note on
+   why it was wrong — future-you needs the dead ends almost as much as the
+   live ones.
+2. When the failing site is identified, write a short root-cause explanation
+   in `{{ workspace_dir }}/rootcause.md`:
+   - the file and line range
+   - the invariant that was violated
+   - which inputs trigger it
+   - which inputs do *not* trigger it (so the fix is not over-broad)
+3. Re-rate severity using the impact you just measured. Update
+   `report.md` if it differs from `severity_hint`.
+
+### Completion Criteria
+- `investigation.md` documents the eliminated hypotheses, not just the winning
+  one.
+- `rootcause.md` names a specific file, line range, and violated invariant.
+- Severity is re-rated against measured impact, not the reporter's guess.
+
+## Step: Propose a fix and a regression test
+Step ID: propose-fix
+
+### Instructions
+Triage ends with a *proposal*, not a merged fix. The point is to hand a
+reviewer a clean package.
+
+1. Add a regression test that fails today and will pass after the fix.
+   Place it next to existing tests for the affected module.
+2. Sketch the smallest change that satisfies the failing test in
+   `{{ workspace_dir }}/fix-proposal.md`:
+   - the diff, or a precise description of the diff
+   - why this is the minimal correct change
+   - rejected alternatives and why
+   - any follow-ups that should be tracked separately rather than bundled in
+3. If the fix is mechanical and low-risk, you may also open a draft PR. If
+   it is architecturally meaningful, stop here and let the regular feature
+   workflow take over.
+
+### Completion Criteria
+- A failing regression test exists and is committed to a feature branch.
+- `fix-proposal.md` contains the minimal change, alternatives considered, and
+  scope boundary.
+- Larger refactors are explicitly *not* bundled into the fix.
+
+## Step: Promote durable lessons
+Step ID: promote-lessons
+
+### Instructions
+The point of doing triage inside a workflow is that the *next* triage gets
+faster. This step makes that real.
+
+1. Decide what about this bug is worth keeping:
+   - Is the root cause an instance of a recurring pattern? If so, add or
+     update a page in `wiki:{{ knowledge_wiki }}` describing the pattern,
+     symptoms, and fix shape.
+   - Is the diagnostic technique you used reusable? Add it to the same wiki
+     under a `techniques/` page.
+2. Save personal heuristics that are not team-shareable (style preferences,
+   intuitions, "always check this first") with `akm remember`:
+
+   ```sh
+   akm remember "When triaging FTS5 ranking bugs, always inspect the tokenizer
+   config before the query parser."
+   ```
+
+3. Refresh the knowledge wiki index so the new pages are searchable:
+
+   ```sh
+   akm wiki ingest {{ knowledge_wiki }}
+   akm index
+   akm wiki lint {{ knowledge_wiki }}
+   ```
+
+### Completion Criteria
+- At least one of: a new/updated wiki page, a stored memory, or an explicit
+  note that the bug carried no durable lesson.
+- `akm wiki lint` runs cleanly on `{{ knowledge_wiki }}`.
+- `akm wiki search {{ knowledge_wiki }} "<symptom>"` now returns the new page.
+
+## Step: Hand off
+Step ID: handoff
+
+### Instructions
+Close the loop with the reporter and the team.
+
+1. Post a triage summary on the bug ticket linking to:
+   - `rootcause.md`
+   - the regression test
+   - `fix-proposal.md`
+   - any wiki pages added in `promote-lessons`
+2. Mark the ticket with the revised severity and assign the fix owner if it
+   is not you.
+3. Record the run ID and final state on the ticket so a later reader can find
+   `akm workflow status {{ runId }}` for the audit trail.
+
+### Completion Criteria
+- The bug ticket links to the rootcause, fix proposal, and regression test.
+- Severity, owner, and next action are explicit.
+- The run ID is referenced on the ticket so the artefact trail is recoverable.

--- a/docs/example-stash/workflows/weekly-dependency-audit.md
+++ b/docs/example-stash/workflows/weekly-dependency-audit.md
@@ -1,0 +1,171 @@
+---
+description: Run a focused weekly dependency audit — surface outdated and vulnerable packages, classify them by upgrade risk, land safe upgrades behind tests, and queue the rest for review without bundling unrelated work into one giant PR.
+tags:
+  - example
+  - maintenance
+  - dependencies
+  - vault
+  - weekly
+params:
+  package_manager: "Package manager in use (`bun`, `pnpm`, `npm`, `yarn`, or `cargo`). Defaults to `bun`."
+  base_branch: "Branch to cut the audit branch from. Defaults to `main`."
+  vault: "Optional vault ref with private-registry credentials (e.g. `vault:npm-readonly`). Loaded only at the shell level, never echoed."
+  workspace_dir: "Directory for run artefacts. Defaults to `.akm-run/{{ runId }}`."
+  max_pr_size: "Soft cap on the number of packages bundled into a single PR. Defaults to `8`."
+  freeze_list: "Optional JSON array of package names that must not be upgraded this week (e.g. `[\"react\", \"vite\"]`)."
+---
+
+# Workflow: Weekly Dependency Audit
+
+A short, repeatable workflow for the recurring "is anything dangerous in our
+lockfile this week?" question. Run it on a schedule, hand the output to
+review, move on. Optimised for *not* drifting into a half-finished migration
+or accidentally importing a sketchy postinstall script.
+
+## Step: Prepare a clean audit branch
+Step ID: prepare-branch
+
+### Instructions
+Set up an isolated workspace before touching the lockfile.
+
+1. Confirm `base_branch` is up to date:
+
+   ```sh
+   git fetch origin {{ base_branch }}
+   git switch -c chore/dep-audit-{{ runId }} origin/{{ base_branch }}
+   ```
+
+2. If `vault` is provided, verify the keys it declares without surfacing
+   values:
+
+   ```sh
+   akm vault show {{ vault }}
+   ```
+
+   Block the run if any key the registry needs is missing.
+3. Create `{{ workspace_dir }}/audit-context.md` with the run timestamp,
+   `package_manager`, `base_branch` HEAD SHA, and the contents of
+   `freeze_list` (if any).
+
+### Completion Criteria
+- A clean branch `chore/dep-audit-{{ runId }}` exists from a fresh
+  `base_branch`.
+- `vault` keys are confirmed present (or `vault` was omitted intentionally).
+- `audit-context.md` records the starting state for reproducibility.
+
+## Step: Inventory outdated and vulnerable packages
+Step ID: inventory
+
+### Instructions
+Produce one canonical list of candidates. Do not start upgrading yet.
+
+1. Load registry credentials only into the shell that runs the audit
+   commands, never into agent context:
+
+   ```sh
+   source <(akm vault load {{ vault }})
+   ```
+
+2. Run the package-manager-native commands and capture full output to disk:
+
+   - `bun`: `bun outdated --json` and `bun audit --json`
+   - `pnpm`: `pnpm outdated --json` and `pnpm audit --json`
+   - `npm`: `npm outdated --json` and `npm audit --json`
+   - `yarn`: `yarn outdated --json` and `yarn npm audit --json`
+
+   Save raw output to `{{ workspace_dir }}/outdated.json` and
+   `{{ workspace_dir }}/audit.json`.
+3. Build `{{ workspace_dir }}/candidates.md` with one row per package:
+   `name`, `current`, `wanted`, `latest`, `severity` (from audit, if any),
+   `direct_dep` (yes/no), `notes`. Strip out anything in `freeze_list`.
+
+### Completion Criteria
+- `outdated.json` and `audit.json` exist with raw tool output.
+- `candidates.md` lists every upgrade candidate with version deltas and
+  severity.
+- Packages in `freeze_list` are excluded from `candidates.md` and the reason
+  is recorded.
+
+## Step: Classify by upgrade risk
+Step ID: classify
+
+### Instructions
+Sort candidates into bands so that the safe ones can ship today and the rest
+can be triaged separately.
+
+For each row in `candidates.md`, assign one of:
+
+- **green** — patch bumps, lockfile-only changes, dev-only tools with
+  passing tests, or transitive deps with no API surface change.
+- **yellow** — minor bumps, anything that touches a build pipeline, or
+  packages with a non-trivial changelog.
+- **red** — major bumps, anything in audit with `high` or `critical`
+  severity, packages whose changelog mentions breaking changes or runtime
+  behaviour changes, and anything with fewer than two weeks since release.
+
+Write `{{ workspace_dir }}/classified.md` with three sections (`green`,
+`yellow`, `red`) and a one-line justification per package. If a package's
+changelog cannot be located, default it to `yellow` and record the gap.
+
+### Completion Criteria
+- Every candidate has exactly one band assigned.
+- Each classification has a one-line justification (changelog, severity, age).
+- Packages with missing changelog provenance are not silently promoted to
+  `green`.
+
+## Step: Land the green band
+Step ID: land-green
+
+### Instructions
+Apply the safe upgrades and prove they did not regress.
+
+1. Apply only the green-band upgrades. Stay under `max_pr_size`; if there
+   are more, split into multiple PRs by domain (testing tools, types,
+   runtime, etc.).
+2. Run the project's verification gates and save outputs:
+
+   ```sh
+   bunx biome check --write src/ tests/
+   bunx tsc --noEmit
+   bun test
+   ```
+
+3. Commit with the convention `chore(deps): bump <list>` and push the
+   branch. Open a PR titled `chore(deps): weekly green-band audit
+   {{ runId }}` whose body links to `classified.md` and lists every package
+   bumped with `current → new`.
+4. If any gate fails, do not push a partially working batch. Bisect the
+   failing package, demote it from `green` to `yellow` with a note, and
+   retry.
+
+### Completion Criteria
+- A PR exists for the green band, gates passing, body linking to
+  `classified.md`.
+- No green-band package is shipped without a clean lint, typecheck, and
+  test run.
+- Demotions from green to yellow are recorded with the failing evidence.
+
+## Step: Queue yellow and red for review
+Step ID: queue-review
+
+### Instructions
+The point of this workflow is to *not* try to land the hard cases on a
+schedule. Hand them off cleanly instead.
+
+1. For each yellow-band package, file a follow-up issue with:
+   - the version delta and changelog link
+   - the test surfaces likely to be affected
+   - a one-paragraph upgrade plan
+2. For each red-band package, file an issue tagged `dep-upgrade` and
+   `needs-design` linking to the changelog and to any audit advisory. Do
+   *not* attempt the upgrade in this run.
+3. Update `{{ workspace_dir }}/handoff.md` listing every issue filed, the
+   green-band PR link, and any package that was deferred without an issue
+   (with reason).
+
+### Completion Criteria
+- Every yellow and red package is either in a filed issue or explicitly
+  deferred with a reason in `handoff.md`.
+- The green-band PR is linked from `handoff.md`.
+- No "I'll do it next week" items are left in the workflow run notes
+  without a corresponding tracked issue.


### PR DESCRIPTION
Adds five workflows under docs/example-stash/workflows/ that double as templates for everyday engineering work and exercise the akm feature surface (search, wiki, vault, remember, feedback):

- triage-bug-report
- weekly-dependency-audit
- code-review-pr
- ship-feature-from-spec
- release-train (orchestrator that drives the dep-audit, code-review, and a release-retrospective workflow as nested runs)

All five validate cleanly via `akm workflow validate`. README updated to describe the common-task and nested-workflow groupings.

