### PR TITLE
feat(tasks): cross-platform `akm tasks` scheduler (cron / launchd / schtasks)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,374 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under the name "LEGAL", with additions for new restrictions
+placed at the end of the file. Except to the extent prohibited by
+statute or regulation, such description must be sufficiently detailed
+for a recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/docs/technical/v1-architecture-spec.md
+++ b/docs/technical/v1-architecture-spec.md
@@ -328,7 +328,10 @@ union. The v1 contract is:
 - **Well-known types**, each with a renderer, a directory under the working
   stash, and frontmatter expectations:
   `skill`, `command`, `agent`, `knowledge`, `script`, `memory`, `workflow`,
-  `vault`, `wiki`, and (Planned for v1) `lesson`. See §13.
+  `vault`, `wiki`, `task`, and (Planned for v1) `lesson`. See §13. The
+  `task` type stores cron-style scheduled invocations of workflows or
+  prompts; `akm tasks` registers them with the OS-native scheduler (cron /
+  launchd / schtasks).
 - **Plugin-registered types** are allowed via `registerAssetType()` (see
   `src/core/asset-spec.ts`) and behave like well-known types as long as they
   register a renderer. Unknown types parse, index, and search; they render as

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,18 @@ import { akmShowUnified } from "./commands/show";
 import { akmAdd } from "./commands/source-add";
 import { akmClone } from "./commands/source-clone";
 import { addStash } from "./commands/source-manage";
+import {
+  akmTasksAdd,
+  akmTasksDoctor,
+  akmTasksHistory,
+  akmTasksList,
+  akmTasksRemove,
+  akmTasksRun,
+  akmTasksSetEnabled,
+  akmTasksShow,
+  akmTasksSync,
+  parseTaskRef,
+} from "./commands/tasks";
 import { parseAssetRef } from "./core/asset-ref";
 import { deriveCanonicalAssetName, resolveAssetPathFromName } from "./core/asset-spec";
 import { isHttpUrl, isWithin, resolveStashDir, tryReadStdinText } from "./core/common";
@@ -3030,6 +3042,209 @@ const proposeCommand = defineCommand({
   },
 });
 
+const TASKS_SUBCOMMAND_SET = new Set([
+  "add",
+  "list",
+  "show",
+  "remove",
+  "enable",
+  "disable",
+  "run",
+  "history",
+  "sync",
+  "doctor",
+]);
+
+function hasTasksSubcommand(args: Record<string, unknown>): boolean {
+  const command = Array.isArray(args._) ? args._[0] : undefined;
+  return typeof command === "string" && TASKS_SUBCOMMAND_SET.has(command);
+}
+
+const tasksAddCommand = defineCommand({
+  meta: { name: "add", description: "Register a new scheduled task and install it in the OS scheduler" },
+  args: {
+    id: { type: "positional", description: "Task id (used as filename and scheduler entry)", required: true },
+    schedule: { type: "string", description: 'Cron-style schedule, e.g. "0 9 * * *" or "@daily"', required: true },
+    workflow: { type: "string", description: "Workflow ref to invoke (e.g. workflow:my-flow)" },
+    prompt: {
+      type: "string",
+      description: "Prompt for the configured agent harness — inline text, an asset ref like agent:foo, or ./path.md",
+    },
+    profile: { type: "string", description: "Agent profile to use for prompt targets (default: config.agent.default)" },
+    params: { type: "string", description: "Workflow params as a JSON object" },
+    description: { type: "string", description: "Human-readable description" },
+    tags: { type: "string", description: "Comma-separated tags" },
+    disabled: { type: "boolean", description: "Register but leave disabled in the OS scheduler", default: false },
+    force: { type: "boolean", description: "Overwrite an existing task with the same id", default: false },
+  },
+  async run({ args }) {
+    await runWithJsonErrors(async () => {
+      const result = await akmTasksAdd({
+        id: args.id,
+        schedule: args.schedule,
+        workflow: args.workflow,
+        prompt: args.prompt,
+        profile: args.profile,
+        params: args.params,
+        description: args.description,
+        tags: args.tags
+          ? args.tags
+              .split(/[\s,]+/)
+              .map((s) => s.trim())
+              .filter(Boolean)
+          : undefined,
+        disabled: args.disabled === true,
+        force: args.force === true,
+      });
+      output("tasks-add", result);
+    });
+  },
+});
+
+const tasksListCommand = defineCommand({
+  meta: { name: "list", description: "List scheduled tasks in the stash" },
+  async run() {
+    await runWithJsonErrors(async () => {
+      const result = await akmTasksList();
+      output("tasks-list", result);
+    });
+  },
+});
+
+const tasksShowCommand = defineCommand({
+  meta: { name: "show", description: "Show a parsed task definition" },
+  args: { id: { type: "positional", description: "Task id or task:<id>", required: true } },
+  async run({ args }) {
+    await runWithJsonErrors(async () => {
+      const { id } = parseTaskRef(args.id);
+      const result = await akmTasksShow(id);
+      output("tasks-show", result);
+    });
+  },
+});
+
+const tasksRemoveCommand = defineCommand({
+  meta: { name: "remove", description: "Delete a task file and uninstall it from the OS scheduler" },
+  args: { id: { type: "positional", description: "Task id", required: true } },
+  async run({ args }) {
+    await runWithJsonErrors(async () => {
+      const { id } = parseTaskRef(args.id);
+      const result = await akmTasksRemove(id);
+      output("tasks-remove", result);
+    });
+  },
+});
+
+const tasksEnableCommand = defineCommand({
+  meta: { name: "enable", description: "Enable a previously-disabled task" },
+  args: { id: { type: "positional", description: "Task id", required: true } },
+  async run({ args }) {
+    await runWithJsonErrors(async () => {
+      const { id } = parseTaskRef(args.id);
+      const result = await akmTasksSetEnabled(id, true);
+      output("tasks-enable", result);
+    });
+  },
+});
+
+const tasksDisableCommand = defineCommand({
+  meta: { name: "disable", description: "Disable a task in the OS scheduler without removing the file" },
+  args: { id: { type: "positional", description: "Task id", required: true } },
+  async run({ args }) {
+    await runWithJsonErrors(async () => {
+      const { id } = parseTaskRef(args.id);
+      const result = await akmTasksSetEnabled(id, false);
+      output("tasks-disable", result);
+    });
+  },
+});
+
+const tasksRunCommand = defineCommand({
+  meta: {
+    name: "run",
+    description: "Execute a task now (this is what cron / launchd / schtasks invoke at the scheduled time)",
+  },
+  args: { id: { type: "positional", description: "Task id", required: true } },
+  async run({ args }) {
+    await runWithJsonErrors(async () => {
+      const { id } = parseTaskRef(args.id);
+      const envelope = await akmTasksRun(id);
+      output("tasks-run", envelope);
+      if (envelope.exitCode !== 0) process.exit(envelope.exitCode);
+    });
+  },
+});
+
+const tasksHistoryCommand = defineCommand({
+  meta: { name: "history", description: "Show recent task run history" },
+  args: {
+    id: { type: "string", description: "Filter to one task id" },
+    limit: { type: "string", description: "Maximum rows to return (default 50)" },
+  },
+  async run({ args }) {
+    await runWithJsonErrors(async () => {
+      const limit = args.limit ? Number(args.limit) : undefined;
+      if (limit !== undefined && (!Number.isFinite(limit) || limit <= 0)) {
+        throw new UsageError("--limit must be a positive integer.", "INVALID_FLAG_VALUE");
+      }
+      const result = await akmTasksHistory({ id: args.id, limit });
+      output("tasks-history", result);
+    });
+  },
+});
+
+const tasksSyncCommand = defineCommand({
+  meta: {
+    name: "sync",
+    description: "Reconcile the on-disk task files with the OS scheduler",
+  },
+  async run() {
+    await runWithJsonErrors(async () => {
+      const result = await akmTasksSync();
+      output("tasks-sync", result);
+    });
+  },
+});
+
+const tasksDoctorCommand = defineCommand({
+  meta: {
+    name: "doctor",
+    description: "Report the active scheduler backend, akm bin path, log dir, and supported schedule subset",
+  },
+  async run() {
+    await runWithJsonErrors(async () => {
+      const result = await akmTasksDoctor();
+      output("tasks-doctor", result);
+    });
+  },
+});
+
+const tasksCommand = defineCommand({
+  meta: {
+    name: "tasks",
+    description: "Schedule workflows or prompts via the OS-native scheduler (cron / launchd / schtasks)",
+  },
+  subCommands: {
+    add: tasksAddCommand,
+    list: tasksListCommand,
+    show: tasksShowCommand,
+    remove: tasksRemoveCommand,
+    enable: tasksEnableCommand,
+    disable: tasksDisableCommand,
+    run: tasksRunCommand,
+    history: tasksHistoryCommand,
+    sync: tasksSyncCommand,
+    doctor: tasksDoctorCommand,
+  },
+  run({ args }) {
+    return runWithJsonErrors(async () => {
+      if (hasTasksSubcommand(args)) return;
+      const result = await akmTasksList();
+      output("tasks-list", result);
+    });
+  },
+});
+
 const main = defineCommand({
   meta: {
     name: "akm",
@@ -3080,6 +3295,7 @@ const main = defineCommand({
     completions: completionsCommand,
     vault: vaultCommand,
     wiki: wikiCommand,
+    tasks: tasksCommand,
   },
 });
 

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -253,12 +253,14 @@ export interface TasksSyncResult {
   installed: string[];
   removed: string[];
   unchanged: string[];
+  skipped: { id: string; reason: string }[];
   backend: string;
 }
 
 /**
  * Reconcile the on-disk task files with the OS scheduler.
- *   • install missing tasks
+ *   • install missing tasks (after validating them — invalid files are
+ *     skipped with a per-task reason rather than aborting the whole sync)
  *   • remove orphan scheduler entries that no longer have a backing file
  */
 export async function akmTasksSync(): Promise<TasksSyncResult> {
@@ -271,16 +273,25 @@ export async function akmTasksSync(): Promise<TasksSyncResult> {
         .map((f) => f.slice(0, -3))
     : [];
   const sched = selectBackend();
+  const backend = backendNameForPlatform();
   const present = new Set((await sched.list()).map((t) => t.id));
   const installed: string[] = [];
   const unchanged: string[] = [];
+  const skipped: { id: string; reason: string }[] = [];
 
   for (const id of fileIds) {
     const filePath = path.join(typeRoot, `${id}.md`);
     let task: TaskDocument;
     try {
       task = parseTaskDocument({ markdown: fs.readFileSync(filePath, "utf8"), filePath, id });
-    } catch {
+    } catch (err) {
+      skipped.push({ id, reason: err instanceof Error ? err.message : String(err) });
+      continue;
+    }
+    try {
+      await validateTaskDocument(task, { backend, stashDir });
+    } catch (err) {
+      skipped.push({ id, reason: err instanceof Error ? err.message : String(err) });
       continue;
     }
     if (present.has(id)) {
@@ -298,7 +309,7 @@ export async function akmTasksSync(): Promise<TasksSyncResult> {
       removed.push(installedId);
     }
   }
-  return { installed, removed, unchanged, backend: sched.name };
+  return { installed, removed, unchanged, skipped, backend: sched.name };
 }
 
 export interface TasksDoctorResult {

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -219,7 +219,14 @@ export async function akmTasksSetEnabled(
   const updated = setEnabledInMarkdown(markdown, enabled);
   fs.writeFileSync(filePath, updated, "utf8");
   const sched = selectBackend();
-  await sched.setEnabled(normalised, enabled);
+  try {
+    await sched.setEnabled(normalised, enabled);
+  } catch (err) {
+    // Roll the file back so the markdown source-of-truth and the OS
+    // scheduler don't diverge silently when the backend call fails.
+    fs.writeFileSync(filePath, markdown, "utf8");
+    throw err;
+  }
   return { id: normalised, enabled, backend: sched.name };
 }
 

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -1,0 +1,481 @@
+/**
+ * `akm tasks` — register, inspect, run, and remove scheduled task assets.
+ *
+ * Each handler exported here is a pure function that performs the real work;
+ * `src/cli.ts` wraps these in citty `defineCommand`s and shapes their return
+ * values via `output()`.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { parseAssetRef } from "../core/asset-ref";
+import { resolveAssetPathFromName } from "../core/asset-spec";
+import { isWithin, resolveStashDir } from "../core/common";
+import { loadConfig } from "../core/config";
+import { ConfigError, NotFoundError, UsageError } from "../core/errors";
+import { getTaskHistoryDir, getTaskLogDir } from "../core/paths";
+import { listAgentProfileNames } from "../integrations/agent";
+import { resolveAssetPath } from "../sources/resolve";
+import { backendNameForPlatform, selectBackend } from "../tasks/backends";
+import { parseTaskDocument } from "../tasks/parser";
+import { resolveAkmInvocation } from "../tasks/resolveAkmBin";
+import { exitCodeForStatus, readTaskHistory, runTask, type TaskRunResult } from "../tasks/runner";
+import { parseSchedule, SCHEDULE_SUPPORTED_SUBSET_HINT, translateToCron } from "../tasks/schedule";
+import type { TaskDocument } from "../tasks/schema";
+import { validateTaskDocument } from "../tasks/validator";
+
+export interface TasksAddInput {
+  id: string;
+  schedule: string;
+  workflow?: string;
+  prompt?: string;
+  profile?: string;
+  params?: string;
+  description?: string;
+  tags?: string[];
+  disabled?: boolean;
+  force?: boolean;
+}
+
+export interface TasksAddResult {
+  id: string;
+  ref: string;
+  path: string;
+  stashDir: string;
+  schedule: string;
+  enabled: boolean;
+  backend: string;
+  target: TaskDocument["target"];
+}
+
+export async function akmTasksAdd(input: TasksAddInput): Promise<TasksAddResult> {
+  const id = normaliseTaskId(input.id);
+  if ((input.workflow && input.prompt) || (!input.workflow && !input.prompt)) {
+    throw new UsageError(
+      "Pass exactly one of --workflow <ref> or --prompt <inline|asset-ref|./file.md>.",
+      "INVALID_FLAG_VALUE",
+    );
+  }
+
+  // Validate the schedule for the active backend before writing anything.
+  const backend = backendNameForPlatform();
+  parseSchedule(input.schedule, backend);
+
+  const stashDir = resolveStashDir();
+  const typeRoot = path.join(stashDir, "tasks");
+  fs.mkdirSync(typeRoot, { recursive: true });
+
+  const assetPath = resolveAssetPathFromName("task", typeRoot, id);
+  if (!isWithin(assetPath, typeRoot)) {
+    throw new UsageError(`Resolved task path escapes the stash: "${id}".`, "PATH_ESCAPE_VIOLATION");
+  }
+  if (fs.existsSync(assetPath) && !input.force) {
+    throw new UsageError(
+      `Task "${id}" already exists. Pass --force to overwrite, or use \`akm tasks remove ${id}\` first.`,
+      "RESOURCE_ALREADY_EXISTS",
+    );
+  }
+
+  const markdown = renderTaskMarkdown({
+    id,
+    schedule: input.schedule,
+    workflow: input.workflow,
+    prompt: input.prompt,
+    profile: input.profile,
+    params: input.params,
+    description: input.description,
+    tags: input.tags,
+    enabled: input.disabled !== true,
+  });
+
+  const task = parseTaskDocument({ markdown, filePath: assetPath, id });
+  await validateTaskDocument(task, { backend, stashDir });
+
+  fs.writeFileSync(assetPath, markdown.endsWith("\n") ? markdown : `${markdown}\n`, "utf8");
+
+  // Install in the OS scheduler. If install fails after the file was written,
+  // delete the file so the on-disk state never claims a task is registered
+  // when it isn't.
+  try {
+    const sched = selectBackend();
+    await sched.install(task);
+  } catch (err) {
+    try {
+      fs.rmSync(assetPath, { force: true });
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  }
+
+  return {
+    id,
+    ref: `task:${id}`,
+    path: assetPath,
+    stashDir,
+    schedule: task.schedule,
+    enabled: task.enabled,
+    backend,
+    target: task.target,
+  };
+}
+
+export interface TasksListResult {
+  tasks: Array<{
+    id: string;
+    ref: string;
+    path: string;
+    schedule: string;
+    enabled: boolean;
+    target: TaskDocument["target"];
+    description?: string;
+    tags?: string[];
+  }>;
+}
+
+export async function akmTasksList(): Promise<TasksListResult> {
+  const stashDir = resolveStashDir();
+  const typeRoot = path.join(stashDir, "tasks");
+  if (!fs.existsSync(typeRoot)) return { tasks: [] };
+  const files = fs.readdirSync(typeRoot).filter((f) => f.endsWith(".md"));
+  const tasks: TasksListResult["tasks"] = [];
+  for (const file of files) {
+    const id = file.slice(0, -3);
+    const filePath = path.join(typeRoot, file);
+    let task: TaskDocument;
+    try {
+      task = parseTaskDocument({ markdown: fs.readFileSync(filePath, "utf8"), filePath, id });
+    } catch {
+      continue; // skip malformed files; `akm tasks show <id>` will surface the error
+    }
+    tasks.push({
+      id: task.id,
+      ref: `task:${task.id}`,
+      path: filePath,
+      schedule: task.schedule,
+      enabled: task.enabled,
+      target: task.target,
+      description: task.description,
+      tags: task.tags,
+    });
+  }
+  return { tasks };
+}
+
+export async function akmTasksShow(id: string): Promise<{
+  id: string;
+  ref: string;
+  path: string;
+  schedule: string;
+  cron: string;
+  enabled: boolean;
+  target: TaskDocument["target"];
+  description?: string;
+  tags?: string[];
+}> {
+  const normalised = normaliseTaskId(id);
+  const stashDir = resolveStashDir();
+  const filePath = await resolveAssetPath(stashDir, "task", normalised);
+  const task = parseTaskDocument({
+    markdown: fs.readFileSync(filePath, "utf8"),
+    filePath,
+    id: normalised,
+  });
+  const spec = parseSchedule(task.schedule, backendNameForPlatform());
+  return {
+    id: task.id,
+    ref: `task:${task.id}`,
+    path: filePath,
+    schedule: task.schedule,
+    cron: translateToCron(spec),
+    enabled: task.enabled,
+    target: task.target,
+    description: task.description,
+    tags: task.tags,
+  };
+}
+
+export async function akmTasksRemove(id: string): Promise<{ id: string; removed: true; backend: string }> {
+  const normalised = normaliseTaskId(id);
+  const stashDir = resolveStashDir();
+  const filePath = await resolveAssetPath(stashDir, "task", normalised);
+  const sched = selectBackend();
+  try {
+    await sched.uninstall(normalised);
+  } finally {
+    fs.rmSync(filePath, { force: true });
+  }
+  return { id: normalised, removed: true, backend: sched.name };
+}
+
+export async function akmTasksSetEnabled(
+  id: string,
+  enabled: boolean,
+): Promise<{ id: string; enabled: boolean; backend: string }> {
+  const normalised = normaliseTaskId(id);
+  const stashDir = resolveStashDir();
+  const filePath = await resolveAssetPath(stashDir, "task", normalised);
+  const markdown = fs.readFileSync(filePath, "utf8");
+  const updated = setEnabledInMarkdown(markdown, enabled);
+  fs.writeFileSync(filePath, updated, "utf8");
+  const sched = selectBackend();
+  await sched.setEnabled(normalised, enabled);
+  return { id: normalised, enabled, backend: sched.name };
+}
+
+export interface TasksRunResultEnvelope {
+  ok: boolean;
+  result: TaskRunResult;
+  exitCode: number;
+}
+
+export async function akmTasksRun(id: string): Promise<TasksRunResultEnvelope> {
+  const normalised = normaliseTaskId(id);
+  const result = await runTask(normalised);
+  return {
+    ok: result.status === "completed" || result.status === "disabled",
+    result,
+    exitCode: exitCodeForStatus(result.status),
+  };
+}
+
+export interface TasksHistoryResult {
+  rows: TaskRunResult[];
+}
+
+export async function akmTasksHistory(input: { id?: string; limit?: number }): Promise<TasksHistoryResult> {
+  const limit = input.limit !== undefined && input.limit > 0 ? input.limit : 50;
+  const id = input.id ? normaliseTaskId(input.id) : undefined;
+  return { rows: readTaskHistory({ id, limit }) };
+}
+
+export interface TasksSyncResult {
+  installed: string[];
+  removed: string[];
+  unchanged: string[];
+  backend: string;
+}
+
+/**
+ * Reconcile the on-disk task files with the OS scheduler.
+ *   • install missing tasks
+ *   • remove orphan scheduler entries that no longer have a backing file
+ */
+export async function akmTasksSync(): Promise<TasksSyncResult> {
+  const stashDir = resolveStashDir();
+  const typeRoot = path.join(stashDir, "tasks");
+  const fileIds = fs.existsSync(typeRoot)
+    ? fs
+        .readdirSync(typeRoot)
+        .filter((f) => f.endsWith(".md"))
+        .map((f) => f.slice(0, -3))
+    : [];
+  const sched = selectBackend();
+  const present = new Set((await sched.list()).map((t) => t.id));
+  const installed: string[] = [];
+  const unchanged: string[] = [];
+
+  for (const id of fileIds) {
+    const filePath = path.join(typeRoot, `${id}.md`);
+    let task: TaskDocument;
+    try {
+      task = parseTaskDocument({ markdown: fs.readFileSync(filePath, "utf8"), filePath, id });
+    } catch {
+      continue;
+    }
+    if (present.has(id)) {
+      unchanged.push(id);
+    } else {
+      await sched.install(task);
+      installed.push(id);
+    }
+  }
+
+  const removed: string[] = [];
+  for (const installedId of present) {
+    if (!fileIds.includes(installedId)) {
+      await sched.uninstall(installedId);
+      removed.push(installedId);
+    }
+  }
+  return { installed, removed, unchanged, backend: sched.name };
+}
+
+export interface TasksDoctorResult {
+  backend: string;
+  akm: { argv: string[]; via: string };
+  logDir: string;
+  historyDir: string;
+  agent: { defaultProfile?: string; available: string[] };
+  scheduleSubset: string;
+  warnings: string[];
+}
+
+export async function akmTasksDoctor(): Promise<TasksDoctorResult> {
+  const warnings: string[] = [];
+  let invocation: { argv: string[]; via: string } = { argv: [], via: "unresolved" };
+  try {
+    const r = resolveAkmInvocation();
+    invocation = { argv: r.argv, via: r.via };
+  } catch (err) {
+    warnings.push(err instanceof Error ? err.message : String(err));
+  }
+  const backend = backendNameForPlatform();
+  const config = loadConfig();
+  const defaultProfile = config.agent?.default;
+  const profiles = listAgentProfileNames(config.agent);
+
+  return {
+    backend,
+    akm: invocation,
+    logDir: getTaskLogDir(),
+    historyDir: getTaskHistoryDir(),
+    agent: { defaultProfile, available: profiles },
+    scheduleSubset: SCHEDULE_SUPPORTED_SUBSET_HINT,
+    warnings,
+  };
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+const VALID_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+function normaliseTaskId(raw: string): string {
+  const id = raw.trim().replace(/\.md$/, "");
+  if (!id) {
+    throw new UsageError("Task id must be non-empty.", "MISSING_REQUIRED_ARGUMENT");
+  }
+  if (!VALID_ID_RE.test(id)) {
+    throw new UsageError(
+      `Task id "${id}" is invalid. Use letters, digits, dots, underscores, and dashes only.`,
+      "INVALID_FLAG_VALUE",
+    );
+  }
+  return id;
+}
+
+interface RenderInput {
+  id: string;
+  schedule: string;
+  workflow?: string;
+  prompt?: string;
+  profile?: string;
+  params?: string;
+  description?: string;
+  tags?: string[];
+  enabled: boolean;
+}
+
+function renderTaskMarkdown(input: RenderInput): string {
+  const lines: string[] = ["---"];
+  lines.push(`schedule: ${yamlQuote(input.schedule)}`);
+  if (input.workflow) {
+    lines.push(`workflow: ${yamlQuote(input.workflow)}`);
+    if (input.params) {
+      const parsed = parseJsonObjectArg(input.params);
+      lines.push("params:");
+      for (const [k, v] of Object.entries(parsed)) {
+        lines.push(`  ${k}: ${yamlScalarValue(v)}`);
+      }
+    }
+  } else if (input.prompt) {
+    if (looksLikeAssetRef(input.prompt) || isFilePath(input.prompt) || input.prompt === "inline") {
+      lines.push(`prompt: ${yamlQuote(input.prompt)}`);
+    } else {
+      lines.push(`prompt: inline`);
+    }
+    if (input.profile) lines.push(`profile: ${yamlQuote(input.profile)}`);
+  }
+  lines.push(`enabled: ${input.enabled}`);
+  if (input.description) lines.push(`description: ${yamlQuote(input.description)}`);
+  if (input.tags && input.tags.length > 0) {
+    lines.push(`tags: [${input.tags.map((t) => yamlQuote(t)).join(", ")}]`);
+  }
+  lines.push("---", "");
+
+  if (input.workflow) {
+    lines.push(`# Task: ${humanise(input.id)}`, "");
+  } else if (input.prompt) {
+    if (looksLikeAssetRef(input.prompt) || isFilePath(input.prompt) || input.prompt === "inline") {
+      lines.push(`# Task: ${humanise(input.id)}`, "");
+    } else {
+      // Raw inline prompt — use the body itself.
+      lines.push(input.prompt.trim(), "");
+    }
+  }
+  return lines.join("\n");
+}
+
+function yamlQuote(value: string): string {
+  if (/^[A-Za-z_][A-Za-z0-9_.\-/:]*$/.test(value)) return value;
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function yamlScalarValue(v: unknown): string {
+  if (typeof v === "string") return yamlQuote(v);
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  if (v === null) return "null";
+  return JSON.stringify(v);
+}
+
+function parseJsonObjectArg(raw: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new UsageError("--params must be valid JSON.", "INVALID_JSON_ARGUMENT");
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new UsageError("--params must be a JSON object.", "INVALID_JSON_ARGUMENT");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function looksLikeAssetRef(s: string): boolean {
+  return /^[a-z][a-z0-9_-]*:[^\s]/i.test(s) && !s.startsWith("./") && !s.startsWith("/");
+}
+
+function isFilePath(s: string): boolean {
+  return s.startsWith("./") || s.startsWith("../") || path.isAbsolute(s);
+}
+
+function humanise(id: string): string {
+  return id.replace(/[-_]+/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/**
+ * Toggle the `enabled:` value in a task markdown's frontmatter without doing
+ * a round-trip through the parser+renderer (which would lose comments and
+ * formatting choices). Inserts the key right before the closing `---` if
+ * absent.
+ */
+export function setEnabledInMarkdown(markdown: string, enabled: boolean): string {
+  const m = markdown.match(/^(---\r?\n)([\s\S]*?)(\r?\n---(?:\r\n|\r|\n|$))([\s\S]*)$/);
+  if (!m) {
+    throw new UsageError("Task markdown is missing frontmatter; cannot toggle enabled.", "INVALID_FLAG_VALUE");
+  }
+  const [, openFence, fmBody, closeFence, body] = m;
+  const replaced = fmBody.match(/(^|\r?\n)enabled:\s*[^\r\n]*/i)
+    ? fmBody.replace(/(^|\r?\n)enabled:\s*[^\r\n]*/i, `$1enabled: ${enabled}`)
+    : `${fmBody}\nenabled: ${enabled}`;
+  return `${openFence}${replaced}${closeFence}${body}`;
+}
+
+// Re-exported so tests can verify the validator path directly.
+// Re-export error classes consumed by callers that want to instanceof-check.
+// Re-export this so the CLI can decide what process exit code to use after
+// `akm tasks run` completes.
+export { ConfigError, exitCodeForStatus, NotFoundError, parseTaskDocument, UsageError };
+
+// Helper: ensure the asset-spec resolver agrees with our id rules. If the
+// user passes a ref, we accept the bare name part too.
+export function parseTaskRef(input: string): { id: string } {
+  if (input.includes(":")) {
+    const ref = parseAssetRef(input);
+    if (ref.type !== "task") {
+      throw new UsageError(`Expected a task id or task:<id> ref, got "${input}".`, "INVALID_FLAG_VALUE");
+    }
+    return { id: normaliseTaskId(ref.name) };
+  }
+  return { id: normaliseTaskId(input) };
+}

--- a/src/core/asset-registry.ts
+++ b/src/core/asset-registry.ts
@@ -24,6 +24,7 @@ export const TYPE_TO_RENDERER: Record<string, string> = {
   workflow: "workflow-md",
   vault: "vault-env",
   wiki: "wiki-md",
+  task: "task-md",
 };
 
 /** Map asset types to action builder functions for search results. */
@@ -38,6 +39,8 @@ export const ACTION_BUILDERS: Record<string, (ref: string) => string> = {
   vault: (ref) =>
     `akm show ${ref} -> inspect keys; source "$(akm vault path ${ref})" -> load values; akm vault run ${ref} -- <command> -> run with injected env`,
   wiki: (ref) => `akm show ${ref} -> read the wiki page`,
+  task: (ref) =>
+    `akm tasks show ${ref.replace(/^task:/, "")} -> inspect; akm tasks run <id> -> run now; akm tasks remove <id> -> unschedule`,
 };
 
 /**

--- a/src/core/asset-spec.ts
+++ b/src/core/asset-spec.ts
@@ -3,6 +3,9 @@ import { buildWorkflowAction } from "../output/renderers";
 import { registerActionBuilder, registerTypeRenderer } from "./asset-registry";
 import { toPosix } from "./common";
 
+const buildTaskAction = (ref: string): string =>
+  `akm tasks show ${ref.replace(/^task:/, "")} -> inspect; akm tasks run <id> -> run now; akm tasks remove <id> -> unschedule`;
+
 export interface AssetSpec {
   stashDir: string;
   isRelevantFile: (fileName: string) => boolean;
@@ -123,6 +126,15 @@ const ASSET_SPECS_INTERNAL: Record<string, AssetSpec> = {
     ...markdownSpec,
     rendererName: "lesson-md",
     actionBuilder: (ref) => `akm show ${ref} -> read the lesson and apply when_to_use`,
+  },
+  // Scheduled tasks. A task file pairs a cron-style schedule with a target
+  // (workflow ref or prompt) that `akm tasks` registers with the OS-native
+  // scheduler (cron / launchd / schtasks). Stored under <stash>/tasks/<id>.md.
+  task: {
+    stashDir: "tasks",
+    ...markdownSpec,
+    rendererName: "task-md",
+    actionBuilder: buildTaskAction,
   },
 };
 

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -108,6 +108,16 @@ export function getBinDir(): string {
   return path.join(getCacheDir(), "bin");
 }
 
+// ── Scheduled-task runtime directories (logs + history) ──────────────────────
+
+export function getTaskLogDir(): string {
+  return path.join(getCacheDir(), "tasks", "logs");
+}
+
+export function getTaskHistoryDir(): string {
+  return path.join(getCacheDir(), "tasks", "history");
+}
+
 // ── Default stash directory ──────────────────────────────────────────────────
 
 export function getDefaultStashDir(): string {

--- a/src/indexer/matchers.ts
+++ b/src/indexer/matchers.ts
@@ -98,6 +98,10 @@ export function directoryMatcher(ctx: FileContext): MatchResult | null {
     if (dir === "vaults" && (ctx.fileName === ".env" || ctx.fileName.endsWith(".env"))) {
       return { type: "vault", specificity: 10, renderer: "vault-env" };
     }
+
+    if (dir === "tasks" && ext === ".md") {
+      return { type: "task", specificity: 10, renderer: "task-md" };
+    }
   }
 
   return null;
@@ -144,6 +148,10 @@ export function parentDirHintMatcher(ctx: FileContext): MatchResult | null {
 
   if (parentDir === "vaults" && (fileName === ".env" || fileName.endsWith(".env"))) {
     return { type: "vault", specificity: 15, renderer: "vault-env" };
+  }
+
+  if (parentDir === "tasks" && ext === ".md") {
+    return { type: "task", specificity: 15, renderer: "task-md" };
   }
 
   return null;

--- a/src/output/renderers.ts
+++ b/src/output/renderers.ts
@@ -667,6 +667,59 @@ const vaultEnvRenderer: AssetRenderer = {
   },
 };
 
+// ── 7. task-md ───────────────────────────────────────────────────────────────
+
+const TASK_PAGE_ACTION =
+  "Scheduled task — `akm tasks show <id>` for parsed details, `akm tasks run <id>` to invoke now.";
+
+const taskMdRenderer: AssetRenderer = {
+  name: "task-md",
+
+  buildShowResponse(ctx: RenderContext): ShowResponse {
+    const name = deriveName(ctx);
+    return {
+      type: "task",
+      name,
+      path: ctx.absPath,
+      action: TASK_PAGE_ACTION,
+      content: ctx.content(),
+    };
+  },
+
+  extractMetadata(entry: StashEntry, ctx: RenderContext): void {
+    try {
+      const parsed = parseFrontmatter(ctx.content());
+      const fm = parsed.data;
+
+      const desc = toStringOrUndefined(fm.description);
+      if (desc && !entry.description) {
+        entry.description = desc;
+        entry.source = "frontmatter";
+        entry.confidence = 0.9;
+      }
+
+      if (Array.isArray(fm.tags)) {
+        const fmTags = fm.tags.filter((t): t is string => typeof t === "string" && t.trim().length > 0);
+        if (fmTags.length > 0) {
+          entry.tags = Array.from(new Set([...(entry.tags ?? []), ...fmTags]));
+        }
+      }
+      entry.tags = Array.from(new Set([...(entry.tags ?? []), "task", "scheduled"]));
+
+      const hints = new Set<string>(entry.searchHints ?? []);
+      const schedule = toStringOrUndefined(fm.schedule);
+      if (schedule) hints.add(`schedule:${schedule}`);
+      const workflow = toStringOrUndefined(fm.workflow);
+      if (workflow) hints.add(`workflow:${workflow}`);
+      const prompt = toStringOrUndefined(fm.prompt);
+      if (prompt) hints.add(`prompt:${prompt}`);
+      if (hints.size > 0) entry.searchHints = Array.from(hints).filter(Boolean);
+    } catch {
+      // Non-fatal: skip metadata extraction on error
+    }
+  },
+};
+
 // ── Registration ─────────────────────────────────────────────────────────────
 
 /** All built-in renderers. */
@@ -681,6 +734,7 @@ const builtinRenderers: AssetRenderer[] = [
   workflowMdRenderer,
   scriptSourceRenderer,
   vaultEnvRenderer,
+  taskMdRenderer,
 ];
 
 /**

--- a/src/output/shapes.ts
+++ b/src/output/shapes.ts
@@ -101,6 +101,16 @@ export function shapeForCommand(command: string, result: unknown, detail: Detail
     case "workflow-start":
     case "workflow-status":
     case "workflow-validate":
+    case "tasks-add":
+    case "tasks-list":
+    case "tasks-show":
+    case "tasks-remove":
+    case "tasks-enable":
+    case "tasks-disable":
+    case "tasks-run":
+    case "tasks-history":
+    case "tasks-sync":
+    case "tasks-doctor":
       return result;
     default:
       // v1 spec §9 (output-shape registry exhaustive): no silent JSON.stringify

--- a/src/tasks/backends/cron.ts
+++ b/src/tasks/backends/cron.ts
@@ -1,0 +1,207 @@
+// crontab backend for `akm tasks` (Linux default).
+//
+// Each akm-owned entry is wrapped in markers so a hand-edited crontab keeps
+// its other lines untouched:
+//
+//     # akm:task <id> BEGIN
+//     [SCHED] /abs/akm tasks run <id> >> /home/.../tasks/logs/<id>.log 2>&1
+//     # akm:task <id> END
+//
+// The backend reads/writes the user's crontab via `crontab -l` and
+// `crontab -`. Tests inject a fake exec so unit tests don't touch the real
+// crontab.
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { ConfigError } from "../../core/errors";
+import { getTaskLogDir } from "../../core/paths";
+import { resolveAkmInvocation } from "../resolveAkmBin";
+import { parseSchedule, translateToCron } from "../schedule";
+import type { TaskDocument } from "../schema";
+import type { InstalledTaskRef, TaskBackend } from "./index";
+
+export type CronExecResult = { status: number; stdout: string; stderr: string };
+
+export interface CronExec {
+  /** Read the user's current crontab. Empty string when none is installed. */
+  read(): CronExecResult;
+  /** Replace the user's crontab with the given content. */
+  write(content: string): CronExecResult;
+}
+
+export interface CronBackendOptions {
+  exec?: CronExec;
+  /** Override the absolute log directory. Defaults to {@link getTaskLogDir}. */
+  logDir?: string;
+  /** Override the akm invocation argv. Tests use this to skip resolution. */
+  akmArgv?: string[];
+}
+
+const BEGIN = (id: string) => `# akm:task ${id} BEGIN`;
+const END = (id: string) => `# akm:task ${id} END`;
+const DISABLED_PREFIX = "# akm:disabled ";
+const BLOCK_RE = /^# akm:task ([\w.@:_-]+) BEGIN$/;
+
+export function CRON_BACKEND(options: CronBackendOptions = {}): TaskBackend {
+  const exec = options.exec ?? defaultCronExec();
+  const logDir = options.logDir ?? getTaskLogDir();
+  const akmArgv = options.akmArgv ?? resolveAkmInvocation().argv;
+
+  return {
+    name: "cron",
+    install(task: TaskDocument) {
+      const cronLine = buildCronLine(task, akmArgv, logDir);
+      const existing = readCrontab(exec);
+      const block = renderBlock(task.id, cronLine, task.enabled);
+      const next = upsertBlock(existing, task.id, block);
+      writeCrontab(exec, next);
+    },
+    uninstall(id: string) {
+      const existing = readCrontab(exec);
+      const next = removeBlock(existing, id);
+      writeCrontab(exec, next);
+    },
+    setEnabled(id: string, enabled: boolean) {
+      const existing = readCrontab(exec);
+      const next = toggleBlock(existing, id, enabled);
+      writeCrontab(exec, next);
+    },
+    list(): InstalledTaskRef[] {
+      const existing = readCrontab(exec);
+      const ids: string[] = [];
+      for (const line of existing.split(/\r?\n/)) {
+        const m = line.match(BLOCK_RE);
+        if (m) ids.push(m[1]);
+      }
+      return ids.map((id) => ({ id }));
+    },
+  };
+}
+
+// ── helpers (exported for tests) ────────────────────────────────────────────
+
+export function buildCronLine(task: TaskDocument, akmArgv: string[], logDir: string): string {
+  const spec = parseSchedule(task.schedule, "cron");
+  const cronExpr = translateToCron(spec);
+  const logPath = path.join(logDir, `${task.id}.log`);
+  const cmd = [...akmArgv, "tasks", "run", task.id].map((part) => quoteForCron(part)).join(" ");
+  return `${cronExpr} ${cmd} >> ${quoteForCron(logPath)} 2>&1`;
+}
+
+export function renderBlock(id: string, cronLine: string, enabled: boolean): string {
+  const body = enabled ? cronLine : `${DISABLED_PREFIX}${cronLine}`;
+  return [BEGIN(id), body, END(id)].join("\n");
+}
+
+export function upsertBlock(existing: string, id: string, block: string): string {
+  const trimmed = existing.replace(/\s+$/g, "");
+  const removed = removeBlock(trimmed, id);
+  const sep = removed.length === 0 ? "" : "\n";
+  return `${removed}${sep}${block}\n`;
+}
+
+export function removeBlock(existing: string, id: string): string {
+  const lines = existing.split(/\r?\n/);
+  const out: string[] = [];
+  let inBlock = false;
+  for (const line of lines) {
+    if (!inBlock && line === BEGIN(id)) {
+      inBlock = true;
+      continue;
+    }
+    if (inBlock && line === END(id)) {
+      inBlock = false;
+      continue;
+    }
+    if (inBlock) continue;
+    out.push(line);
+  }
+  // Collapse trailing blank lines.
+  while (out.length > 0 && out[out.length - 1] === "") out.pop();
+  return out.join("\n");
+}
+
+export function toggleBlock(existing: string, id: string, enabled: boolean): string {
+  const lines = existing.split(/\r?\n/);
+  const out: string[] = [];
+  let inBlock = false;
+  for (const line of lines) {
+    if (!inBlock && line === BEGIN(id)) {
+      inBlock = true;
+      out.push(line);
+      continue;
+    }
+    if (inBlock && line === END(id)) {
+      inBlock = false;
+      out.push(line);
+      continue;
+    }
+    if (inBlock) {
+      const isComment = line.startsWith(DISABLED_PREFIX);
+      if (enabled && isComment) {
+        out.push(line.slice(DISABLED_PREFIX.length));
+      } else if (!enabled && !isComment) {
+        out.push(`${DISABLED_PREFIX}${line}`);
+      } else {
+        out.push(line);
+      }
+      continue;
+    }
+    out.push(line);
+  }
+  return out.join("\n");
+}
+
+function quoteForCron(part: string): string {
+  // crontab passes the rest of the line to /bin/sh -c, so quote anything that
+  // isn't a plain shell-safe token. Single-quote and escape embedded single
+  // quotes via the standard shell idiom: `'foo'\''bar'`.
+  if (/^[A-Za-z0-9_\-./@:%=+,]+$/.test(part)) return part;
+  return `'${part.replace(/'/g, `'\\''`)}'`;
+}
+
+function readCrontab(exec: CronExec): string {
+  const result = exec.read();
+  if (result.status === 0) return result.stdout ?? "";
+  // BSD crontab returns 1 with "no crontab for <user>" on stderr — treat as empty.
+  if (/no crontab for/i.test(result.stderr ?? "")) return "";
+  if (/no crontab/i.test(result.stdout ?? "")) return "";
+  throw new ConfigError(
+    `crontab -l failed (exit ${result.status}): ${result.stderr || result.stdout || "no output"}.`,
+    "INVALID_CONFIG_FILE",
+    "Ensure the `crontab` binary is on PATH and your shell can read the user crontab.",
+  );
+}
+
+function writeCrontab(exec: CronExec, content: string): void {
+  const normalised = content.endsWith("\n") || content.length === 0 ? content : `${content}\n`;
+  const result = exec.write(normalised);
+  if (result.status !== 0) {
+    throw new ConfigError(
+      `crontab - failed (exit ${result.status}): ${result.stderr || result.stdout || "no output"}.`,
+      "INVALID_CONFIG_FILE",
+      "Ensure the `crontab` binary is on PATH and your shell can write the user crontab.",
+    );
+  }
+}
+
+function defaultCronExec(): CronExec {
+  return {
+    read(): CronExecResult {
+      const r = spawnSync("crontab", ["-l"], { encoding: "utf8" });
+      return {
+        status: r.status ?? 1,
+        stdout: r.stdout ?? "",
+        stderr: r.stderr ?? "",
+      };
+    },
+    write(content: string): CronExecResult {
+      const r = spawnSync("crontab", ["-"], { encoding: "utf8", input: content });
+      return {
+        status: r.status ?? 1,
+        stdout: r.stdout ?? "",
+        stderr: r.stderr ?? "",
+      };
+    },
+  };
+}

--- a/src/tasks/backends/cron.ts
+++ b/src/tasks/backends/cron.ts
@@ -12,6 +12,7 @@
 // crontab.
 
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import { ConfigError } from "../../core/errors";
 import { getTaskLogDir } from "../../core/paths";
@@ -50,6 +51,10 @@ export function CRON_BACKEND(options: CronBackendOptions = {}): TaskBackend {
   return {
     name: "cron",
     install(task: TaskDocument) {
+      // Create the log directory before writing the crontab line — cron
+      // appends with `>>` and the surrounding shell will fail the entire
+      // entry if the parent directory doesn't exist.
+      ensureDir(logDir);
       const cronLine = buildCronLine(task, akmArgv, logDir);
       const existing = readCrontab(exec);
       const block = renderBlock(task.id, cronLine, task.enabled);
@@ -182,6 +187,15 @@ function writeCrontab(exec: CronExec, content: string): void {
       "INVALID_CONFIG_FILE",
       "Ensure the `crontab` binary is on PATH and your shell can write the user crontab.",
     );
+  }
+}
+
+function ensureDir(dir: string): void {
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch {
+    // Best-effort: the install will surface a clearer error if the cron
+    // line later fails at runtime due to a missing redirection target.
   }
 }
 

--- a/src/tasks/backends/cron.ts
+++ b/src/tasks/backends/cron.ts
@@ -8,8 +8,19 @@
 //     # akm:task <id> END
 //
 // The backend reads/writes the user's crontab via `crontab -l` and
-// `crontab -`. Tests inject a fake exec so unit tests don't touch the real
-// crontab.
+// `crontab -`. Disabling a task comments the entry with `# akm:disabled `
+// rather than removing it, so re-enabling preserves the original schedule.
+//
+// Platform notes:
+//   • Operates on the *per-user* crontab — system-wide /etc/cron.d entries
+//     are out of scope.
+//   • Cron runs jobs with a stripped environment (`SHELL`, `PATH`, `HOME`,
+//     `LOGNAME`/`USER` only). The cron line uses an absolute akm path
+//     resolved at install time so it doesn't rely on the inherited PATH.
+//   • BSD `crontab -l` returns exit 1 with "no crontab for <user>" on a
+//     fresh user; we treat that as an empty crontab rather than an error.
+//
+// Tests inject a fake exec so unit tests don't touch the real crontab.
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";

--- a/src/tasks/backends/index.ts
+++ b/src/tasks/backends/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Backend selection for the OS-native scheduler.
+ *
+ *   • Linux   → crontab
+ *   • macOS   → launchd (per-user LaunchAgent)
+ *   • Windows → schtasks.exe / Task Scheduler
+ *
+ * Each backend implements {@link TaskBackend}; selection is a one-line
+ * platform check. Tests inject a fake `platform` to exercise non-host
+ * code paths.
+ */
+
+import type { ScheduleBackend } from "../schedule";
+import type { TaskDocument } from "../schema";
+import { CRON_BACKEND, type CronBackendOptions } from "./cron";
+import { LAUNCHD_BACKEND, type LaunchdBackendOptions } from "./launchd";
+import { SCHTASKS_BACKEND, type SchtasksBackendOptions } from "./schtasks";
+
+export interface InstalledTaskRef {
+  id: string;
+}
+
+export interface TaskBackend {
+  /** Stable name surfaced by `tasks doctor`. */
+  readonly name: ScheduleBackend;
+  install(task: TaskDocument): Promise<void> | void;
+  uninstall(id: string): Promise<void> | void;
+  setEnabled(id: string, enabled: boolean): Promise<void> | void;
+  list(): Promise<InstalledTaskRef[]> | InstalledTaskRef[];
+}
+
+export type SelectBackendOptions =
+  | { platform?: NodeJS.Platform; cron?: CronBackendOptions }
+  | { platform?: NodeJS.Platform; launchd?: LaunchdBackendOptions }
+  | { platform?: NodeJS.Platform; schtasks?: SchtasksBackendOptions };
+
+export function selectBackend(options: SelectBackendOptions = {}): TaskBackend {
+  const platform = (options as { platform?: NodeJS.Platform }).platform ?? process.platform;
+  switch (platform) {
+    case "win32":
+      return SCHTASKS_BACKEND((options as { schtasks?: SchtasksBackendOptions }).schtasks);
+    case "darwin":
+      return LAUNCHD_BACKEND((options as { launchd?: LaunchdBackendOptions }).launchd);
+    default:
+      return CRON_BACKEND((options as { cron?: CronBackendOptions }).cron);
+  }
+}
+
+export function backendNameForPlatform(platform: NodeJS.Platform = process.platform): ScheduleBackend {
+  if (platform === "win32") return "schtasks";
+  if (platform === "darwin") return "launchd";
+  return "cron";
+}

--- a/src/tasks/backends/launchd.ts
+++ b/src/tasks/backends/launchd.ts
@@ -1,0 +1,215 @@
+/**
+ * launchd backend for `akm tasks` (macOS default).
+ *
+ * Each task is written as a per-user LaunchAgent plist at
+ * `~/Library/LaunchAgents/com.akm.task.<id>.plist` and registered via
+ * `launchctl bootstrap gui/<uid> <plist>`. Disabling uses
+ * `launchctl disable gui/<uid>/<label>` and re-enabling uses `enable`.
+ *
+ * Tests inject a fake exec + filesystem so the backend can be unit-tested
+ * without touching the host launchctl.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ConfigError } from "../../core/errors";
+import { getTaskLogDir } from "../../core/paths";
+import { resolveAkmInvocation } from "../resolveAkmBin";
+import { type LaunchdTrigger, parseSchedule, translateToLaunchd } from "../schedule";
+import type { TaskDocument } from "../schema";
+import type { InstalledTaskRef, TaskBackend } from "./index";
+
+export interface LaunchdExec {
+  run(args: string[]): { status: number; stdout: string; stderr: string };
+  uid(): number;
+}
+
+export interface LaunchdFs {
+  writeFile(file: string, content: string): void;
+  removeFile(file: string): void;
+  ensureDir(dir: string): void;
+  list(dir: string): string[];
+  exists(file: string): boolean;
+}
+
+export interface LaunchdBackendOptions {
+  exec?: LaunchdExec;
+  fs?: LaunchdFs;
+  /** Override the LaunchAgents directory. Defaults to `~/Library/LaunchAgents`. */
+  agentsDir?: string;
+  /** Override the absolute log directory. */
+  logDir?: string;
+  /** Override the akm invocation argv. */
+  akmArgv?: string[];
+}
+
+export const LAUNCHD_LABEL_PREFIX = "com.akm.task.";
+const PLIST_PREFIX = "com.akm.task.";
+
+export function LAUNCHD_BACKEND(options: LaunchdBackendOptions = {}): TaskBackend {
+  const exec = options.exec ?? defaultLaunchdExec();
+  const fsLike = options.fs ?? defaultLaunchdFs();
+  const agentsDir = options.agentsDir ?? path.join(os.homedir() ?? "", "Library", "LaunchAgents");
+  const logDir = options.logDir ?? getTaskLogDir();
+  const akmArgv = options.akmArgv ?? resolveAkmInvocation().argv;
+
+  const plistPath = (id: string) => path.join(agentsDir, `${PLIST_PREFIX}${id}.plist`);
+  const label = (id: string) => `${LAUNCHD_LABEL_PREFIX}${id}`;
+  const target = (id: string) => `gui/${exec.uid()}/${label(id)}`;
+
+  return {
+    name: "launchd",
+    install(task: TaskDocument) {
+      const xml = buildPlistXml(task, akmArgv, logDir);
+      fsLike.ensureDir(agentsDir);
+      fsLike.writeFile(plistPath(task.id), xml);
+      const bootout = exec.run(["launchctl", "bootout", target(task.id)]);
+      // bootout returning non-zero is fine — agent might not be loaded.
+      void bootout;
+      const bootstrap = exec.run(["launchctl", "bootstrap", `gui/${exec.uid()}`, plistPath(task.id)]);
+      if (bootstrap.status !== 0) {
+        throw new ConfigError(
+          `launchctl bootstrap failed (exit ${bootstrap.status}): ${bootstrap.stderr || bootstrap.stdout || "no output"}.`,
+          "INVALID_CONFIG_FILE",
+          "Ensure `launchctl` is available; on macOS it is part of the base system.",
+        );
+      }
+      if (!task.enabled) {
+        const disable = exec.run(["launchctl", "disable", target(task.id)]);
+        if (disable.status !== 0) {
+          throw new ConfigError(
+            `launchctl disable failed: ${disable.stderr || disable.stdout || "no output"}.`,
+            "INVALID_CONFIG_FILE",
+          );
+        }
+      }
+    },
+    uninstall(id: string) {
+      // Bootout first (may fail if agent never loaded — that's fine).
+      exec.run(["launchctl", "bootout", target(id)]);
+      const file = plistPath(id);
+      if (fsLike.exists(file)) fsLike.removeFile(file);
+    },
+    setEnabled(id: string, enabled: boolean) {
+      const verb = enabled ? "enable" : "disable";
+      const r = exec.run(["launchctl", verb, target(id)]);
+      if (r.status !== 0) {
+        throw new ConfigError(
+          `launchctl ${verb} failed: ${r.stderr || r.stdout || "no output"}.`,
+          "INVALID_CONFIG_FILE",
+        );
+      }
+    },
+    list(): InstalledTaskRef[] {
+      if (!fsLike.exists(agentsDir)) return [];
+      const ids: string[] = [];
+      for (const file of fsLike.list(agentsDir)) {
+        if (file.startsWith(PLIST_PREFIX) && file.endsWith(".plist")) {
+          ids.push(file.slice(PLIST_PREFIX.length, -".plist".length));
+        }
+      }
+      return ids.map((id) => ({ id }));
+    },
+  };
+}
+
+// ── XML builder (exported for tests) ────────────────────────────────────────
+
+export function buildPlistXml(task: TaskDocument, akmArgv: string[], logDir: string): string {
+  const spec = parseSchedule(task.schedule, "launchd");
+  const trigger = translateToLaunchd(spec);
+  const argv = [...akmArgv, "tasks", "run", task.id];
+  const programArgs = argv.map((a) => `      <string>${escapeXml(a)}</string>`).join("\n");
+  const logPath = path.join(logDir, `${task.id}.log`);
+  const triggerXml = renderLaunchdTrigger(trigger);
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LAUNCHD_LABEL_PREFIX}${escapeXml(task.id)}</string>
+  <key>ProgramArguments</key>
+  <array>
+${programArgs}
+  </array>
+  <key>StandardOutPath</key>
+  <string>${escapeXml(logPath)}</string>
+  <key>StandardErrorPath</key>
+  <string>${escapeXml(logPath)}</string>
+  <key>RunAtLoad</key>
+  <false/>
+${triggerXml}
+</dict>
+</plist>
+`;
+}
+
+function renderLaunchdTrigger(trigger: LaunchdTrigger): string {
+  if (trigger.intervalSeconds !== undefined) {
+    return `  <key>StartInterval</key>
+  <integer>${trigger.intervalSeconds}</integer>`;
+  }
+  const cal = trigger.calendar ?? {};
+  const lines = ["  <key>StartCalendarInterval</key>", "  <dict>"];
+  if (cal.Minute !== undefined) lines.push(`    <key>Minute</key><integer>${cal.Minute}</integer>`);
+  if (cal.Hour !== undefined) lines.push(`    <key>Hour</key><integer>${cal.Hour}</integer>`);
+  if (cal.Day !== undefined) lines.push(`    <key>Day</key><integer>${cal.Day}</integer>`);
+  if (cal.Month !== undefined) lines.push(`    <key>Month</key><integer>${cal.Month}</integer>`);
+  if (cal.Weekday !== undefined) lines.push(`    <key>Weekday</key><integer>${cal.Weekday}</integer>`);
+  lines.push("  </dict>");
+  return lines.join("\n");
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function defaultLaunchdExec(): LaunchdExec {
+  return {
+    run(args: string[]) {
+      const [bin, ...rest] = args;
+      const r = spawnSync(bin, rest, { encoding: "utf8" });
+      return {
+        status: r.status ?? 1,
+        stdout: r.stdout ?? "",
+        stderr: r.stderr ?? "",
+      };
+    },
+    uid() {
+      const fn = (process as { getuid?: () => number }).getuid;
+      return typeof fn === "function" ? fn.call(process) : 0;
+    },
+  };
+}
+
+function defaultLaunchdFs(): LaunchdFs {
+  return {
+    writeFile(file, content) {
+      fs.writeFileSync(file, content, { encoding: "utf8" });
+    },
+    removeFile(file) {
+      fs.rmSync(file, { force: true });
+    },
+    ensureDir(dir) {
+      fs.mkdirSync(dir, { recursive: true });
+    },
+    list(dir) {
+      try {
+        return fs.readdirSync(dir);
+      } catch {
+        return [];
+      }
+    },
+    exists(file) {
+      return fs.existsSync(file);
+    },
+  };
+}

--- a/src/tasks/backends/launchd.ts
+++ b/src/tasks/backends/launchd.ts
@@ -64,6 +64,9 @@ export function LAUNCHD_BACKEND(options: LaunchdBackendOptions = {}): TaskBacken
     install(task: TaskDocument) {
       const xml = buildPlistXml(task, akmArgv, logDir);
       fsLike.ensureDir(agentsDir);
+      // launchd refuses to start a job when StandardOutPath/StandardErrorPath
+      // points at a non-existent directory; create it before bootstrap.
+      fsLike.ensureDir(logDir);
       fsLike.writeFile(plistPath(task.id), xml);
       const bootout = exec.run(["launchctl", "bootout", target(task.id)]);
       // bootout returning non-zero is fine — agent might not be loaded.

--- a/src/tasks/backends/launchd.ts
+++ b/src/tasks/backends/launchd.ts
@@ -6,6 +6,15 @@
  * `launchctl bootstrap gui/<uid> <plist>`. Disabling uses
  * `launchctl disable gui/<uid>/<label>` and re-enabling uses `enable`.
  *
+ * Platform notes:
+ *   • The `bootstrap` / `bootout` / `enable` / `disable` subcommands require
+ *     macOS 10.10 (Yosemite) or newer. On older systems the equivalents
+ *     are `launchctl load -w` / `unload -w`. We only target modern macOS.
+ *   • `gui/<uid>` is the per-user GUI launchd domain — agents in this
+ *     domain only run while the user is logged in (no background runs at
+ *     the loginwindow). Tasks that need to run when the user is logged
+ *     out should be installed as system Daemons, which is out of scope.
+ *
  * Tests inject a fake exec + filesystem so the backend can be unit-tested
  * without touching the host launchctl.
  */
@@ -51,7 +60,7 @@ const PLIST_PREFIX = "com.akm.task.";
 export function LAUNCHD_BACKEND(options: LaunchdBackendOptions = {}): TaskBackend {
   const exec = options.exec ?? defaultLaunchdExec();
   const fsLike = options.fs ?? defaultLaunchdFs();
-  const agentsDir = options.agentsDir ?? path.join(os.homedir() ?? "", "Library", "LaunchAgents");
+  const agentsDir = options.agentsDir ?? defaultAgentsDir();
   const logDir = options.logDir ?? getTaskLogDir();
   const akmArgv = options.akmArgv ?? resolveAkmInvocation().argv;
 
@@ -173,6 +182,21 @@ function escapeXml(s: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;");
+}
+
+function defaultAgentsDir(): string {
+  // launchd's per-user LaunchAgents live under the user's home directory.
+  // If we can't determine HOME, refuse rather than silently producing a
+  // relative path that would write somewhere unexpected.
+  const home = os.homedir();
+  if (!home) {
+    throw new ConfigError(
+      "Cannot determine user home directory; launchd backend requires HOME to locate ~/Library/LaunchAgents.",
+      "INVALID_CONFIG_FILE",
+      "Set $HOME (POSIX) or the equivalent before running `akm tasks` on macOS.",
+    );
+  }
+  return path.join(home, "Library", "LaunchAgents");
 }
 
 function defaultLaunchdExec(): LaunchdExec {

--- a/src/tasks/backends/schtasks.ts
+++ b/src/tasks/backends/schtasks.ts
@@ -28,6 +28,7 @@ export interface SchtasksFs {
   writeFile(file: string, content: string): void;
   removeFile(file: string): void;
   tmpdir(): string;
+  ensureDir(dir: string): void;
 }
 
 export interface SchtasksBackendOptions {
@@ -54,7 +55,10 @@ export function SCHTASKS_BACKEND(options: SchtasksBackendOptions = {}): TaskBack
   return {
     name: "schtasks",
     install(task: TaskDocument) {
-      const xml = buildSchtasksXml(task, akmArgv, logDir);
+      // The generated XML sets <WorkingDirectory> to logDir; create it
+      // before registering so the scheduler doesn't fail to launch the job.
+      fsLike.ensureDir(logDir);
+      const xml = buildSchtasksXml(task, akmArgv, logDir, { folderPrefix: folder });
       const tmpFile = path.join(fsLike.tmpdir(), `akm-task-${task.id}-${Date.now()}.xml`);
       fsLike.writeFile(tmpFile, xml);
       try {
@@ -117,19 +121,34 @@ export function SCHTASKS_BACKEND(options: SchtasksBackendOptions = {}): TaskBack
 
 // ── XML builder (exported for tests) ────────────────────────────────────────
 
-export function buildSchtasksXml(task: TaskDocument, akmArgv: string[], logDir: string): string {
+export interface BuildSchtasksXmlOptions {
+  /** Task folder prefix (e.g. `\\akm\\`). Used to build the <URI>. */
+  folderPrefix?: string;
+  /** Override the StartBoundary timestamp (tests). Defaults to install time. */
+  now?: () => Date;
+}
+
+export function buildSchtasksXml(
+  task: TaskDocument,
+  akmArgv: string[],
+  logDir: string,
+  options: BuildSchtasksXmlOptions = {},
+): string {
+  const folder = options.folderPrefix ?? DEFAULT_FOLDER_PREFIX;
+  const now = options.now ? options.now() : new Date();
+  const startBoundary = formatStartBoundary(now);
   const spec = parseSchedule(task.schedule, "schtasks");
   const trigger = translateToSchtasks(spec);
   const command = akmArgv[0];
   const args = [...akmArgv.slice(1), "tasks", "run", task.id].map((a) => quoteArg(a)).join(" ");
-  const triggerXml = renderSchtasksTrigger(trigger);
+  const triggerXml = renderSchtasksTrigger(trigger, startBoundary);
   const logPath = path.join(logDir, `${task.id}.log`);
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <RegistrationInfo>
     <Description>akm scheduled task: ${escapeXml(task.id)}</Description>
-    <URI>\\akm\\${escapeXml(task.id)}</URI>
+    <URI>${escapeXml(folder)}${escapeXml(task.id)}</URI>
   </RegistrationInfo>
   <Triggers>
 ${triggerXml}
@@ -158,8 +177,7 @@ ${triggerXml}
 `;
 }
 
-function renderSchtasksTrigger(trigger: SchtasksTrigger): string {
-  const startBoundary = "2025-01-01T00:00:00";
+function renderSchtasksTrigger(trigger: SchtasksTrigger, startBoundary: string): string {
   switch (trigger.kind) {
     case "minute":
       return `    <TimeTrigger>
@@ -201,10 +219,25 @@ ${days}
 }
 
 function pad(base: string, hour: number, minute: number): string {
-  // Replace HH:MM in `2025-01-01T00:00:00` with the configured time.
+  // Rewrite the time component of an ISO-8601 boundary while preserving
+  // the date so daily/weekly triggers fire at the configured wall-clock
+  // time rather than the install instant.
   const hh = String(hour).padStart(2, "0");
   const mm = String(minute).padStart(2, "0");
   return base.replace(/T\d\d:\d\d:\d\d$/, `T${hh}:${mm}:00`);
+}
+
+function formatStartBoundary(d: Date): string {
+  // Local-time ISO-8601 (no zone suffix) — Task Scheduler interprets a
+  // bare boundary in the registering user's timezone, which matches what
+  // a user typing "0 9 * * *" intuitively means ("9am local").
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mi = String(d.getMinutes()).padStart(2, "0");
+  const ss = String(d.getSeconds()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}T${hh}:${mi}:${ss}`;
 }
 
 function quoteArg(s: string): string {
@@ -246,6 +279,9 @@ function defaultSchtasksFs(): SchtasksFs {
       } catch {
         /* ignore */
       }
+    },
+    ensureDir(dir) {
+      fs.mkdirSync(dir, { recursive: true });
     },
     tmpdir() {
       return os.tmpdir();

--- a/src/tasks/backends/schtasks.ts
+++ b/src/tasks/backends/schtasks.ts
@@ -1,0 +1,254 @@
+/**
+ * schtasks.exe backend for `akm tasks` (Windows default).
+ *
+ * Each task is registered under the `\akm\` Task Scheduler folder so the
+ * backend never touches user-managed tasks. The full task definition is
+ * sent through `schtasks /Create /TN \akm\<id> /XML <path>` so we can
+ * express triggers/principals/actions without quoting hell.
+ *
+ * Tests inject a fake exec + filesystem.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ConfigError } from "../../core/errors";
+import { getTaskLogDir } from "../../core/paths";
+import { resolveAkmInvocation } from "../resolveAkmBin";
+import { parseSchedule, type SchtasksTrigger, translateToSchtasks } from "../schedule";
+import type { TaskDocument } from "../schema";
+import type { InstalledTaskRef, TaskBackend } from "./index";
+
+export interface SchtasksExec {
+  run(args: string[]): { status: number; stdout: string; stderr: string };
+}
+
+export interface SchtasksFs {
+  writeFile(file: string, content: string): void;
+  removeFile(file: string): void;
+  tmpdir(): string;
+}
+
+export interface SchtasksBackendOptions {
+  exec?: SchtasksExec;
+  fs?: SchtasksFs;
+  /** Override the akm invocation argv. */
+  akmArgv?: string[];
+  /** Override the absolute log directory. */
+  logDir?: string;
+  /** Folder prefix for task names. Default `\akm\`. */
+  folderPrefix?: string;
+}
+
+export const DEFAULT_FOLDER_PREFIX = "\\akm\\";
+
+export function SCHTASKS_BACKEND(options: SchtasksBackendOptions = {}): TaskBackend {
+  const exec = options.exec ?? defaultSchtasksExec();
+  const fsLike = options.fs ?? defaultSchtasksFs();
+  const akmArgv = options.akmArgv ?? resolveAkmInvocation().argv;
+  const logDir = options.logDir ?? getTaskLogDir();
+  const folder = options.folderPrefix ?? DEFAULT_FOLDER_PREFIX;
+  const taskName = (id: string) => `${folder}${id}`;
+
+  return {
+    name: "schtasks",
+    install(task: TaskDocument) {
+      const xml = buildSchtasksXml(task, akmArgv, logDir);
+      const tmpFile = path.join(fsLike.tmpdir(), `akm-task-${task.id}-${Date.now()}.xml`);
+      fsLike.writeFile(tmpFile, xml);
+      try {
+        // /F forces overwrite if a task with the same name exists.
+        const r = exec.run(["schtasks", "/Create", "/TN", taskName(task.id), "/XML", tmpFile, "/F"]);
+        if (r.status !== 0) {
+          throw new ConfigError(
+            `schtasks /Create failed (exit ${r.status}): ${r.stderr || r.stdout || "no output"}.`,
+            "INVALID_CONFIG_FILE",
+          );
+        }
+        if (!task.enabled) {
+          const dis = exec.run(["schtasks", "/Change", "/TN", taskName(task.id), "/DISABLE"]);
+          if (dis.status !== 0) {
+            throw new ConfigError(
+              `schtasks /Change /DISABLE failed: ${dis.stderr || dis.stdout || "no output"}.`,
+              "INVALID_CONFIG_FILE",
+            );
+          }
+        }
+      } finally {
+        fsLike.removeFile(tmpFile);
+      }
+    },
+    uninstall(id: string) {
+      const r = exec.run(["schtasks", "/Delete", "/TN", taskName(id), "/F"]);
+      if (r.status !== 0 && !/cannot find/i.test(r.stderr ?? "")) {
+        throw new ConfigError(
+          `schtasks /Delete failed: ${r.stderr || r.stdout || "no output"}.`,
+          "INVALID_CONFIG_FILE",
+        );
+      }
+    },
+    setEnabled(id: string, enabled: boolean) {
+      const flag = enabled ? "/ENABLE" : "/DISABLE";
+      const r = exec.run(["schtasks", "/Change", "/TN", taskName(id), flag]);
+      if (r.status !== 0) {
+        throw new ConfigError(
+          `schtasks /Change ${flag} failed: ${r.stderr || r.stdout || "no output"}.`,
+          "INVALID_CONFIG_FILE",
+        );
+      }
+    },
+    list(): InstalledTaskRef[] {
+      const r = exec.run(["schtasks", "/Query", "/FO", "CSV", "/NH"]);
+      if (r.status !== 0) return [];
+      const ids: string[] = [];
+      for (const line of (r.stdout ?? "").split(/\r?\n/)) {
+        const m = line.match(/^"([^"]+)",/);
+        if (!m) continue;
+        const name = m[1];
+        if (name.startsWith(folder)) {
+          ids.push(name.slice(folder.length));
+        }
+      }
+      return ids.map((id) => ({ id }));
+    },
+  };
+}
+
+// ── XML builder (exported for tests) ────────────────────────────────────────
+
+export function buildSchtasksXml(task: TaskDocument, akmArgv: string[], logDir: string): string {
+  const spec = parseSchedule(task.schedule, "schtasks");
+  const trigger = translateToSchtasks(spec);
+  const command = akmArgv[0];
+  const args = [...akmArgv.slice(1), "tasks", "run", task.id].map((a) => quoteArg(a)).join(" ");
+  const triggerXml = renderSchtasksTrigger(trigger);
+  const logPath = path.join(logDir, `${task.id}.log`);
+
+  return `<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>akm scheduled task: ${escapeXml(task.id)}</Description>
+    <URI>\\akm\\${escapeXml(task.id)}</URI>
+  </RegistrationInfo>
+  <Triggers>
+${triggerXml}
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <Enabled>${task.enabled ? "true" : "false"}</Enabled>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>${escapeXml(command)}</Command>
+      <Arguments>${escapeXml(args)}</Arguments>
+      <WorkingDirectory>${escapeXml(logDir)}</WorkingDirectory>
+    </Exec>
+  </Actions>
+  <!-- Log target (informational only; schtasks doesn't redirect): ${escapeXml(logPath)} -->
+</Task>
+`;
+}
+
+function renderSchtasksTrigger(trigger: SchtasksTrigger): string {
+  const startBoundary = "2025-01-01T00:00:00";
+  switch (trigger.kind) {
+    case "minute":
+      return `    <TimeTrigger>
+      <Repetition>
+        <Interval>PT${trigger.everyMinutes}M</Interval>
+      </Repetition>
+      <StartBoundary>${startBoundary}</StartBoundary>
+      <Enabled>true</Enabled>
+    </TimeTrigger>`;
+    case "hour":
+      return `    <TimeTrigger>
+      <Repetition>
+        <Interval>PT${trigger.everyHours}H</Interval>
+      </Repetition>
+      <StartBoundary>${startBoundary}</StartBoundary>
+      <Enabled>true</Enabled>
+    </TimeTrigger>`;
+    case "daily":
+      return `    <CalendarTrigger>
+      <StartBoundary>${pad(startBoundary, trigger.atHour, trigger.atMinute)}</StartBoundary>
+      <Enabled>true</Enabled>
+      <ScheduleByDay><DaysInterval>1</DaysInterval></ScheduleByDay>
+    </CalendarTrigger>`;
+    case "weekly": {
+      const dayMap = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+      const days = trigger.daysOfWeek.map((d) => `        <${dayMap[d]} />`).join("\n");
+      return `    <CalendarTrigger>
+      <StartBoundary>${pad(startBoundary, trigger.atHour, trigger.atMinute)}</StartBoundary>
+      <Enabled>true</Enabled>
+      <ScheduleByWeek>
+        <DaysOfWeek>
+${days}
+        </DaysOfWeek>
+        <WeeksInterval>1</WeeksInterval>
+      </ScheduleByWeek>
+    </CalendarTrigger>`;
+    }
+  }
+}
+
+function pad(base: string, hour: number, minute: number): string {
+  // Replace HH:MM in `2025-01-01T00:00:00` with the configured time.
+  const hh = String(hour).padStart(2, "0");
+  const mm = String(minute).padStart(2, "0");
+  return base.replace(/T\d\d:\d\d:\d\d$/, `T${hh}:${mm}:00`);
+}
+
+function quoteArg(s: string): string {
+  if (/^[A-Za-z0-9_\-./@:%=+,\\]+$/.test(s)) return s;
+  return `"${s.replace(/"/g, '\\"')}"`;
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function defaultSchtasksExec(): SchtasksExec {
+  return {
+    run(args: string[]) {
+      const [bin, ...rest] = args;
+      const r = spawnSync(bin, rest, { encoding: "utf8" });
+      return {
+        status: r.status ?? 1,
+        stdout: r.stdout ?? "",
+        stderr: r.stderr ?? "",
+      };
+    },
+  };
+}
+
+function defaultSchtasksFs(): SchtasksFs {
+  return {
+    writeFile(file, content) {
+      fs.writeFileSync(file, content, { encoding: "utf8" });
+    },
+    removeFile(file) {
+      try {
+        fs.rmSync(file, { force: true });
+      } catch {
+        /* ignore */
+      }
+    },
+    tmpdir() {
+      return os.tmpdir();
+    },
+  };
+}

--- a/src/tasks/backends/schtasks.ts
+++ b/src/tasks/backends/schtasks.ts
@@ -6,6 +6,24 @@
  * sent through `schtasks /Create /TN \akm\<id> /XML <path>` so we can
  * express triggers/principals/actions without quoting hell.
  *
+ * Platform notes:
+ *   • `LogonType=InteractiveToken` means the task runs in the context of
+ *     the registering user only when they are logged in — there is no
+ *     stored password and the task will not fire at the lock screen.
+ *   • `<Principal>` deliberately omits `<UserId>`; per the Task Scheduler
+ *     2.0 schema (`principalType.UserId` minOccurs=0) this is valid and
+ *     defaults to the registering user.
+ *   • `<DisallowStartIfOnBatteries>false</…>` and `<StopIfGoingOnBatteries>
+ *     false</…>` allow the task to run on battery — utility tasks would
+ *     otherwise be silently skipped on laptops.
+ *   • `MultipleInstancesPolicy=IgnoreNew` makes overlapping triggers safe:
+ *     while a task is still running, a new fire is dropped rather than
+ *     queued or run in parallel.
+ *   • `/Query /FO CSV /NH` (without `/V`) outputs three columns:
+ *     `TaskName,Next Run Time,Status` — so the regex anchors on the task
+ *     name as the leading quoted field. Adding `/V` would shift HostName
+ *     into column 0; we deliberately don't.
+ *
  * Tests inject a fake exec + filesystem.
  */
 

--- a/src/tasks/backends/schtasks.ts
+++ b/src/tasks/backends/schtasks.ts
@@ -125,7 +125,7 @@ export function buildSchtasksXml(task: TaskDocument, akmArgv: string[], logDir: 
   const triggerXml = renderSchtasksTrigger(trigger);
   const logPath = path.join(logDir, `${task.id}.log`);
 
-  return `<?xml version="1.0" encoding="UTF-16"?>
+  return `<?xml version="1.0" encoding="UTF-8"?>
 <Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <RegistrationInfo>
     <Description>akm scheduled task: ${escapeXml(task.id)}</Description>

--- a/src/tasks/parser.ts
+++ b/src/tasks/parser.ts
@@ -1,0 +1,194 @@
+/**
+ * Parse a task markdown file (frontmatter + body) into a {@link TaskDocument}.
+ *
+ * The on-disk shape is:
+ *
+ * ```markdown
+ * ---
+ * schedule: "0 9 * * *"
+ * # one of:
+ * workflow: workflow:daily-backup
+ * params:
+ *   region: us-east-1
+ * # ...or:
+ * prompt: inline                    # body is the prompt
+ * profile: opencode                 # optional
+ * # ...or:
+ * prompt: agent:my-agent            # asset ref
+ * # ...or:
+ * prompt: ./prompts/my-prompt.md    # relative file path
+ * enabled: true                     # default true
+ * description: …
+ * tags: [scheduled, backup]
+ * ---
+ *
+ * # Task: Daily backup           (optional notes; for prompt:inline this is the prompt)
+ * ```
+ *
+ * Validation lives in {@link validateTaskDocument}. The parser only enforces
+ * shape; cron syntax, target reachability, and profile availability are
+ * checked separately so callers can choose how strictly to surface errors.
+ */
+
+import path from "node:path";
+import { UsageError } from "../core/errors";
+import { parseFrontmatter } from "../core/frontmatter";
+import { TASK_SCHEMA_VERSION, type TaskDocument, type TaskTarget } from "./schema";
+
+export interface ParseTaskInput {
+  /** The full markdown contents of the task file. */
+  markdown: string;
+  /** Absolute or relative path used in error messages and `source.path`. */
+  filePath: string;
+  /** Filename-derived id; usually `path.basename(filePath, ".md")`. */
+  id: string;
+}
+
+export function parseTaskDocument(input: ParseTaskInput): TaskDocument {
+  const { markdown, filePath, id } = input;
+  const fm = parseFrontmatter(markdown);
+  const data = fm.data;
+
+  const schedule = readString(data.schedule, "schedule", filePath);
+  if (!schedule) {
+    throw new UsageError(
+      `Task "${id}" is missing a schedule (frontmatter key "schedule"). File: ${filePath}`,
+      "MISSING_REQUIRED_ARGUMENT",
+    );
+  }
+
+  const enabled = data.enabled === undefined ? true : data.enabled === true;
+  const description = readString(data.description, "description", filePath);
+  const tags = readStringArray(data.tags);
+
+  const hasWorkflow = "workflow" in data && data.workflow !== "";
+  const hasPrompt = "prompt" in data && data.prompt !== "";
+  if (hasWorkflow && hasPrompt) {
+    throw new UsageError(
+      `Task "${id}" sets both \`workflow\` and \`prompt\`; pick exactly one. File: ${filePath}`,
+      "INVALID_FLAG_VALUE",
+    );
+  }
+  if (!hasWorkflow && !hasPrompt) {
+    throw new UsageError(
+      `Task "${id}" must set either \`workflow\` or \`prompt\` in frontmatter. File: ${filePath}`,
+      "MISSING_REQUIRED_ARGUMENT",
+    );
+  }
+
+  let target: TaskTarget;
+  if (hasWorkflow) {
+    const ref = readString(data.workflow, "workflow", filePath);
+    if (!ref) {
+      throw new UsageError(`Task "${id}" has empty \`workflow\`. File: ${filePath}`, "INVALID_FLAG_VALUE");
+    }
+    target = {
+      kind: "workflow",
+      ref,
+      params: readParams(data.params, filePath),
+    };
+  } else {
+    const promptRaw = readString(data.prompt, "prompt", filePath);
+    if (!promptRaw) {
+      throw new UsageError(`Task "${id}" has empty \`prompt\`. File: ${filePath}`, "INVALID_FLAG_VALUE");
+    }
+    const profile = readString(data.profile, "profile", filePath);
+    target = {
+      kind: "prompt",
+      source: resolvePromptSource(promptRaw, fm.content, filePath, id),
+      profile: profile && profile.length > 0 ? profile : undefined,
+    };
+  }
+
+  return {
+    schemaVersion: TASK_SCHEMA_VERSION,
+    id,
+    schedule,
+    enabled,
+    target,
+    description: description && description.length > 0 ? description : undefined,
+    tags: tags && tags.length > 0 ? tags : undefined,
+    source: { path: filePath },
+  };
+}
+
+/**
+ * Split `prompt:` frontmatter into one of {@link TaskPromptSource} variants.
+ *
+ *   • "inline"                          → body is the prompt
+ *   • "<type>:<name>" (asset ref)       → asset
+ *   • "./foo.md", "../foo.md", "/abs"   → file
+ *   • anything else                     → treated as inline prompt text
+ *     (the value itself is the prompt)
+ */
+function resolvePromptSource(
+  raw: string,
+  body: string,
+  filePath: string,
+  id: string,
+): import("./schema").TaskPromptSource {
+  const trimmed = raw.trim();
+  if (trimmed === "inline") {
+    const text = body.trim();
+    if (!text) {
+      throw new UsageError(
+        `Task "${id}" sets \`prompt: inline\` but the markdown body is empty. File: ${filePath}`,
+        "MISSING_REQUIRED_ARGUMENT",
+      );
+    }
+    return { kind: "inline", text };
+  }
+
+  if (trimmed.startsWith("./") || trimmed.startsWith("../") || path.isAbsolute(trimmed)) {
+    return { kind: "file", path: trimmed };
+  }
+
+  if (/^[a-z][a-z0-9_-]*:[^\s]/i.test(trimmed)) {
+    return { kind: "asset", ref: trimmed };
+  }
+
+  // Fallback: treat the literal value as the prompt text.
+  return { kind: "inline", text: trimmed };
+}
+
+function readString(value: unknown, key: string, filePath: string): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "string") return value.trim();
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  throw new UsageError(`Frontmatter key "${key}" must be a string. File: ${filePath}`, "INVALID_FLAG_VALUE");
+}
+
+function readStringArray(value: unknown): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "string") {
+    return value
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === "string" && v.trim().length > 0);
+  }
+  return undefined;
+}
+
+function readParams(value: unknown, filePath: string): Record<string, unknown> {
+  if (value === undefined || value === null) return {};
+  if (typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value === "string" && value.trim()) {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // fall through
+    }
+  }
+  throw new UsageError(
+    `Frontmatter key "params" must be a mapping or a JSON object. File: ${filePath}`,
+    "INVALID_FLAG_VALUE",
+  );
+}

--- a/src/tasks/resolveAkmBin.ts
+++ b/src/tasks/resolveAkmBin.ts
@@ -1,0 +1,100 @@
+/**
+ * Resolve the absolute invocation that the OS scheduler should run.
+ *
+ * cron / launchd / schtasks all execute jobs with a stripped environment and
+ * a minimal PATH, so the registered command must be an absolute path.
+ *
+ * Resolution order:
+ *
+ *   1. `$AKM_BIN` (explicit override; takes precedence everywhere).
+ *   2. `process.execPath` + the resolved CLI script — works when running
+ *      from a development checkout (`bun /repo/src/cli.ts`) and from a
+ *      compiled install (`bun /opt/akm/dist/cli.js`).
+ *   3. `which akm` / `where akm` — last resort when the binary is on PATH
+ *      but neither override applies.
+ *
+ * Returns the argv array the scheduler should execute (e.g.
+ * `["/usr/local/bin/bun", "/repo/dist/cli.js"]`). The caller appends
+ * subcommand args (`"tasks", "run", "<id>"`).
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { ConfigError } from "../core/errors";
+
+export interface ResolvedAkmInvocation {
+  /** Argv prefix the OS scheduler should execute (one shell-safe path per element). */
+  argv: string[];
+  /** Source of the resolution, surfaced by `tasks doctor`. */
+  via: "AKM_BIN" | "execPath" | "which";
+}
+
+export function resolveAkmInvocation(
+  options: { env?: NodeJS.ProcessEnv; cliEntryUrl?: string } = {},
+): ResolvedAkmInvocation {
+  const env = options.env ?? process.env;
+
+  const override = env.AKM_BIN?.trim();
+  if (override) {
+    return { argv: [override], via: "AKM_BIN" };
+  }
+
+  const cliPath = resolveCliEntry(options.cliEntryUrl ?? import.meta.url);
+  if (cliPath && process.execPath) {
+    return { argv: [process.execPath, cliPath], via: "execPath" };
+  }
+
+  const whichBin = findOnPath("akm", env);
+  if (whichBin) {
+    return { argv: [whichBin], via: "which" };
+  }
+
+  throw new ConfigError(
+    "Cannot resolve absolute path to the akm binary for scheduler registration.",
+    "INVALID_CONFIG_FILE",
+    "Set AKM_BIN to the absolute path of the akm binary, or ensure `akm` is on PATH.",
+  );
+}
+
+/**
+ * From the URL of a module inside `src/tasks/` figure out the CLI entry.
+ *
+ *   • dev      `…/src/tasks/resolveAkmBin.ts`   → `…/src/cli.ts`
+ *   • build    `…/dist/tasks/resolveAkmBin.js`  → `…/dist/cli.js`
+ */
+function resolveCliEntry(moduleUrl: string): string | undefined {
+  let modulePath: string;
+  try {
+    modulePath = fileURLToPath(moduleUrl);
+  } catch {
+    return undefined;
+  }
+  const dir = path.dirname(modulePath); // .../tasks
+  const parent = path.dirname(dir); // .../src or .../dist
+  const ext = path.extname(modulePath); // .ts | .js
+  const candidate = path.join(parent, `cli${ext}`);
+  if (fs.existsSync(candidate)) return candidate;
+  // Fallback: try the other extension.
+  const alt = path.join(parent, ext === ".ts" ? "cli.js" : "cli.ts");
+  if (fs.existsSync(alt)) return alt;
+  return undefined;
+}
+
+function findOnPath(bin: string, env: NodeJS.ProcessEnv): string | undefined {
+  const tool = process.platform === "win32" ? "where" : "which";
+  try {
+    const out = spawnSync(tool, [bin], { encoding: "utf8", env });
+    if (out.status === 0 && typeof out.stdout === "string") {
+      const first = out.stdout
+        .split(/\r?\n/)
+        .map((s) => s.trim())
+        .find(Boolean);
+      if (first && fs.existsSync(first)) return first;
+    }
+  } catch {
+    // ignore — caller will throw a ConfigError
+  }
+  return undefined;
+}

--- a/src/tasks/runner.ts
+++ b/src/tasks/runner.ts
@@ -25,7 +25,7 @@ import path from "node:path";
 import { parseAssetRef } from "../core/asset-ref";
 import { resolveStashDir } from "../core/common";
 import { loadConfig } from "../core/config";
-import { NotFoundError, UsageError } from "../core/errors";
+import { NotFoundError } from "../core/errors";
 import { getTaskHistoryDir, getTaskLogDir } from "../core/paths";
 import { type AgentRunResult, type RunAgentOptions, requireAgentProfile, runAgent } from "../integrations/agent";
 import { resolveAssetPath } from "../sources/resolve";
@@ -110,7 +110,6 @@ export async function runTask(id: string, options: RunTaskOptions = {}): Promise
   if (task.target.kind === "workflow") {
     return await runWorkflowTask({
       task,
-      stashDir,
       logPath,
       historyDir,
       startedAt,
@@ -134,7 +133,6 @@ export async function runTask(id: string, options: RunTaskOptions = {}): Promise
 
 async function runWorkflowTask(input: {
   task: TaskDocument;
-  stashDir: string;
   logPath: string;
   historyDir: string;
   startedAt: Date;
@@ -368,6 +366,3 @@ export function exitCodeForStatus(status: TaskRunStatus): number {
       return 0;
   }
 }
-
-// ── Re-export so the CLI can avoid double-imports ───────────────────────────
-export { UsageError };

--- a/src/tasks/runner.ts
+++ b/src/tasks/runner.ts
@@ -5,7 +5,10 @@
  * Responsibilities:
  *
  *   1. Resolve the task file via `resolveAssetPath(stashDir, "task", id)`.
- *   2. Parse + validate the task document.
+ *   2. Parse the task document. (Validation runs at `tasks add` /
+ *      `tasks sync` time, not here — at run time we still want to attempt
+ *      execution and surface the actual failure rather than re-fail on a
+ *      validation error that the user already knows about.)
  *   3. Refuse to run when `enabled === false` (defense-in-depth).
  *   4. Dispatch by target kind:
  *        • workflow → `startWorkflowRun(ref, params)`
@@ -31,7 +34,7 @@ import { startWorkflowRun } from "../workflows/runs";
 import { parseTaskDocument } from "./parser";
 import type { TaskDocument } from "./schema";
 
-export type TaskRunStatus = "completed" | "blocked" | "failed" | "disabled";
+export type TaskRunStatus = "completed" | "blocked" | "failed" | "disabled" | "active";
 
 export interface TaskRunResult {
   id: string;
@@ -157,13 +160,13 @@ async function runWorkflowTask(input: {
   }
 
   const finishedAt = now();
-  const status: TaskRunStatus = error ? "failed" : ((detail?.run.status as TaskRunStatus | undefined) ?? "completed");
+  const status: TaskRunStatus = error ? "failed" : mapWorkflowStatus(detail?.run.status);
   const log = renderWorkflowLog({ task, detail, error });
   fs.writeFileSync(logPath, log);
 
   const result: TaskRunResult = {
     id: task.id,
-    status: status === "completed" || status === "blocked" || status === "failed" ? status : "completed",
+    status,
     startedAt: startedAt.toISOString(),
     finishedAt: finishedAt.toISOString(),
     durationMs: finishedAt.getTime() - startedAt.getTime(),
@@ -177,6 +180,25 @@ async function runWorkflowTask(input: {
   appendHistory(historyDir, task.id, result);
   if (error) throw error;
   return result;
+}
+
+/**
+ * Map the workflow runtime's status into the task-runner status space.
+ * Workflows can legitimately remain `active` after `startWorkflowRun`
+ * returns (multi-step workflows pause for user input); recording them as
+ * "completed" would be misleading. We preserve "active" as a first-class
+ * task status with exit code 0 — the OS scheduler treats it as success.
+ */
+function mapWorkflowStatus(status: string | undefined): TaskRunStatus {
+  switch (status) {
+    case "completed":
+    case "blocked":
+    case "failed":
+    case "active":
+      return status;
+    default:
+      return "completed";
+  }
 }
 
 function renderWorkflowLog(input: { task: TaskDocument; detail?: WorkflowRunDetail; error?: Error }): string {
@@ -331,6 +353,8 @@ export function readTaskHistory(options: ReadHistoryOptions = {}): TaskRunResult
 export function exitCodeForStatus(status: TaskRunStatus): number {
   switch (status) {
     case "completed":
+      return 0;
+    case "active":
       return 0;
     case "blocked":
       return 1;

--- a/src/tasks/runner.ts
+++ b/src/tasks/runner.ts
@@ -1,0 +1,345 @@
+/**
+ * `akm tasks run <id>` — what cron / launchd / schtasks invoke at the
+ * scheduled moment.
+ *
+ * Responsibilities:
+ *
+ *   1. Resolve the task file via `resolveAssetPath(stashDir, "task", id)`.
+ *   2. Parse + validate the task document.
+ *   3. Refuse to run when `enabled === false` (defense-in-depth).
+ *   4. Dispatch by target kind:
+ *        • workflow → `startWorkflowRun(ref, params)`
+ *        • prompt   → `runAgent(profile, prompt, { stdio: "captured" })`
+ *   5. Capture stdout / stderr to `<cacheDir>/tasks/logs/<id>/<ts>.log`.
+ *   6. Append a JSONL row to `<cacheDir>/tasks/history/<id>.jsonl`.
+ *
+ * Returns a structured result so the CLI handler can shape it for `output()`
+ * and so tests can assert against it without scraping stdout.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { parseAssetRef } from "../core/asset-ref";
+import { resolveStashDir } from "../core/common";
+import { loadConfig } from "../core/config";
+import { NotFoundError, UsageError } from "../core/errors";
+import { getTaskHistoryDir, getTaskLogDir } from "../core/paths";
+import { type AgentRunResult, type RunAgentOptions, requireAgentProfile, runAgent } from "../integrations/agent";
+import { resolveAssetPath } from "../sources/resolve";
+import type { WorkflowRunDetail } from "../workflows/runs";
+import { startWorkflowRun } from "../workflows/runs";
+import { parseTaskDocument } from "./parser";
+import type { TaskDocument } from "./schema";
+
+export type TaskRunStatus = "completed" | "blocked" | "failed" | "disabled";
+
+export interface TaskRunResult {
+  id: string;
+  status: TaskRunStatus;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  log: string;
+  target: { kind: "workflow"; ref: string } | { kind: "prompt"; profile?: string };
+  /** Workflow run id (for workflow targets) or agent reason/error (for prompt targets). */
+  detail?: { runId?: string; reason?: string; error?: string; exitCode?: number | null };
+}
+
+export interface RunTaskOptions {
+  /** Override stash dir resolution (tests). */
+  stashDir?: string;
+  /** Override the agent runner (tests). Defaults to {@link runAgent}. */
+  runAgentImpl?: (...args: Parameters<typeof runAgent>) => Promise<AgentRunResult>;
+  /**
+   * Override the workflow runner (tests). Defaults to
+   * {@link startWorkflowRun}.
+   */
+  startWorkflowRunImpl?: typeof startWorkflowRun;
+  /** Override clock (tests). */
+  now?: () => Date;
+  /** Override log dir (tests). */
+  logDir?: string;
+  /** Override history dir (tests). */
+  historyDir?: string;
+  /** Extra args/env to pass through to runAgent (tests). */
+  agentOptions?: Partial<RunAgentOptions>;
+}
+
+export async function runTask(id: string, options: RunTaskOptions = {}): Promise<TaskRunResult> {
+  const stashDir = options.stashDir ?? resolveStashDir();
+  const runAgentImpl = options.runAgentImpl ?? runAgent;
+  const startWorkflowRunImpl = options.startWorkflowRunImpl ?? startWorkflowRun;
+  const now = options.now ?? (() => new Date());
+  const logDir = options.logDir ?? getTaskLogDir();
+  const historyDir = options.historyDir ?? getTaskHistoryDir();
+
+  const filePath = await resolveAssetPath(stashDir, "task", id);
+  const markdown = fs.readFileSync(filePath, "utf8");
+  const task = parseTaskDocument({ markdown, filePath, id });
+
+  const startedAt = now();
+  const startedIso = startedAt.toISOString();
+  const tsSlug = startedIso.replace(/[:.]/g, "-");
+  const taskLogDir = path.join(logDir, id);
+  fs.mkdirSync(taskLogDir, { recursive: true });
+  fs.mkdirSync(historyDir, { recursive: true });
+  const logPath = path.join(taskLogDir, `${tsSlug}.log`);
+
+  if (!task.enabled) {
+    const finishedAt = now();
+    const result: TaskRunResult = {
+      id,
+      status: "disabled",
+      startedAt: startedIso,
+      finishedAt: finishedAt.toISOString(),
+      durationMs: finishedAt.getTime() - startedAt.getTime(),
+      log: logPath,
+      target:
+        task.target.kind === "workflow"
+          ? { kind: "workflow", ref: task.target.ref }
+          : { kind: "prompt", profile: task.target.profile },
+    };
+    fs.writeFileSync(logPath, `[akm tasks] task "${id}" is disabled — skipping run.\n`);
+    appendHistory(historyDir, id, result);
+    return result;
+  }
+
+  if (task.target.kind === "workflow") {
+    return await runWorkflowTask({
+      task,
+      stashDir,
+      logPath,
+      historyDir,
+      startedAt,
+      now,
+      startWorkflowRunImpl,
+    });
+  }
+  return await runPromptTask({
+    task,
+    stashDir,
+    logPath,
+    historyDir,
+    startedAt,
+    now,
+    runAgentImpl,
+    agentOptions: options.agentOptions,
+  });
+}
+
+// ── workflow target ─────────────────────────────────────────────────────────
+
+async function runWorkflowTask(input: {
+  task: TaskDocument;
+  stashDir: string;
+  logPath: string;
+  historyDir: string;
+  startedAt: Date;
+  now: () => Date;
+  startWorkflowRunImpl: typeof startWorkflowRun;
+}): Promise<TaskRunResult> {
+  const { task, logPath, historyDir, startedAt, now, startWorkflowRunImpl } = input;
+  if (task.target.kind !== "workflow") throw new Error("invariant: workflow target");
+  const ref = parseAssetRef(task.target.ref);
+  if (ref.type !== "workflow") {
+    throw new NotFoundError(
+      `Task "${task.id}" workflow target must be a workflow ref (got "${task.target.ref}").`,
+      "WORKFLOW_NOT_FOUND",
+    );
+  }
+
+  let detail: WorkflowRunDetail | undefined;
+  let error: Error | undefined;
+  try {
+    detail = await startWorkflowRunImpl(task.target.ref, task.target.params);
+  } catch (e) {
+    error = e instanceof Error ? e : new Error(String(e));
+  }
+
+  const finishedAt = now();
+  const status: TaskRunStatus = error ? "failed" : ((detail?.run.status as TaskRunStatus | undefined) ?? "completed");
+  const log = renderWorkflowLog({ task, detail, error });
+  fs.writeFileSync(logPath, log);
+
+  const result: TaskRunResult = {
+    id: task.id,
+    status: status === "completed" || status === "blocked" || status === "failed" ? status : "completed",
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+    durationMs: finishedAt.getTime() - startedAt.getTime(),
+    log: logPath,
+    target: { kind: "workflow", ref: task.target.ref },
+    detail: {
+      runId: detail?.run.id,
+      ...(error ? { error: error.message } : {}),
+    },
+  };
+  appendHistory(historyDir, task.id, result);
+  if (error) throw error;
+  return result;
+}
+
+function renderWorkflowLog(input: { task: TaskDocument; detail?: WorkflowRunDetail; error?: Error }): string {
+  const lines: string[] = [];
+  lines.push(`[akm tasks] task=${input.task.id} kind=workflow ref=${(input.task.target as { ref: string }).ref}`);
+  if (input.detail) {
+    lines.push(`run_id=${input.detail.run.id} status=${input.detail.run.status}`);
+    lines.push(`workflow_title=${input.detail.run.workflowTitle}`);
+  }
+  if (input.error) {
+    lines.push(`error=${input.error.message}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+// ── prompt target ───────────────────────────────────────────────────────────
+
+async function runPromptTask(input: {
+  task: TaskDocument;
+  stashDir: string;
+  logPath: string;
+  historyDir: string;
+  startedAt: Date;
+  now: () => Date;
+  runAgentImpl: (...args: Parameters<typeof runAgent>) => Promise<AgentRunResult>;
+  agentOptions?: Partial<RunAgentOptions>;
+}): Promise<TaskRunResult> {
+  const { task, stashDir, logPath, historyDir, startedAt, now, runAgentImpl, agentOptions } = input;
+  if (task.target.kind !== "prompt") throw new Error("invariant: prompt target");
+
+  const config = loadConfig();
+  const profile = requireAgentProfile(config.agent, task.target.profile);
+  const promptText = await resolvePromptText(task, stashDir);
+
+  const result = await runAgentImpl(profile, promptText, {
+    stdio: "captured",
+    timeoutMs: config.agent?.timeoutMs,
+    cwd: stashDir,
+    ...agentOptions,
+  });
+
+  const finishedAt = now();
+  const log = renderPromptLog({ task, profileName: profile.name, result });
+  fs.writeFileSync(logPath, log);
+
+  const status: TaskRunStatus = result.ok ? "completed" : "failed";
+  const out: TaskRunResult = {
+    id: task.id,
+    status,
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+    durationMs: finishedAt.getTime() - startedAt.getTime(),
+    log: logPath,
+    target: { kind: "prompt", profile: profile.name },
+    detail: result.ok
+      ? { exitCode: result.exitCode }
+      : { reason: result.reason, error: result.error, exitCode: result.exitCode },
+  };
+  appendHistory(historyDir, task.id, out);
+  return out;
+}
+
+async function resolvePromptText(task: TaskDocument, stashDir: string): Promise<string> {
+  if (task.target.kind !== "prompt") throw new Error("invariant: prompt target");
+  const src = task.target.source;
+  if (src.kind === "inline") return src.text;
+  if (src.kind === "file") {
+    const taskDir = path.dirname(task.source.path);
+    const filePath = path.isAbsolute(src.path) ? src.path : path.resolve(taskDir, src.path);
+    if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+      throw new NotFoundError(`Prompt file not found: ${filePath}`, "FILE_NOT_FOUND");
+    }
+    return fs.readFileSync(filePath, "utf8");
+  }
+  // asset
+  const ref = parseAssetRef(src.ref);
+  const assetPath = await resolveAssetPath(stashDir, ref.type, ref.name);
+  return fs.readFileSync(assetPath, "utf8");
+}
+
+function renderPromptLog(input: { task: TaskDocument; profileName: string; result: AgentRunResult }): string {
+  const lines: string[] = [];
+  lines.push(`[akm tasks] task=${input.task.id} kind=prompt profile=${input.profileName}`);
+  lines.push(
+    `ok=${input.result.ok} exit_code=${input.result.exitCode ?? "null"} duration_ms=${input.result.durationMs}`,
+  );
+  if (!input.result.ok) {
+    lines.push(`reason=${input.result.reason ?? ""} error=${input.result.error ?? ""}`);
+  }
+  if (input.result.stdout) {
+    lines.push("--- agent stdout ---");
+    lines.push(input.result.stdout);
+  }
+  if (input.result.stderr) {
+    lines.push("--- agent stderr ---");
+    lines.push(input.result.stderr);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+// ── history ─────────────────────────────────────────────────────────────────
+
+function appendHistory(historyDir: string, id: string, result: TaskRunResult): void {
+  const file = path.join(historyDir, `${id}.jsonl`);
+  fs.mkdirSync(historyDir, { recursive: true });
+  fs.appendFileSync(file, `${JSON.stringify(result)}\n`);
+}
+
+/**
+ * Read recent history rows for one or all tasks.
+ *
+ * Returns rows in reverse-chronological order, optionally limited.
+ */
+export interface ReadHistoryOptions {
+  id?: string;
+  limit?: number;
+  historyDir?: string;
+}
+
+export function readTaskHistory(options: ReadHistoryOptions = {}): TaskRunResult[] {
+  const dir = options.historyDir ?? getTaskHistoryDir();
+  if (!fs.existsSync(dir)) return [];
+  const files = options.id
+    ? [path.join(dir, `${options.id}.jsonl`)].filter((f) => fs.existsSync(f))
+    : fs
+        .readdirSync(dir)
+        .filter((f) => f.endsWith(".jsonl"))
+        .map((f) => path.join(dir, f));
+  const rows: TaskRunResult[] = [];
+  for (const file of files) {
+    const text = fs.readFileSync(file, "utf8");
+    for (const line of text.split(/\r?\n/)) {
+      if (!line.trim()) continue;
+      try {
+        rows.push(JSON.parse(line) as TaskRunResult);
+      } catch {
+        // skip malformed lines
+      }
+    }
+  }
+  rows.sort((a, b) => (a.startedAt < b.startedAt ? 1 : -1));
+  if (options.limit !== undefined && options.limit >= 0) {
+    return rows.slice(0, options.limit);
+  }
+  return rows;
+}
+
+/**
+ * The exit code surfaced to the OS scheduler. Mapped from {@link TaskRunStatus}
+ * so cron / launchd / schtasks see a useful return value.
+ */
+export function exitCodeForStatus(status: TaskRunStatus): number {
+  switch (status) {
+    case "completed":
+      return 0;
+    case "blocked":
+      return 1;
+    case "failed":
+      return 1;
+    case "disabled":
+      return 0;
+  }
+}
+
+// ── Re-export so the CLI can avoid double-imports ───────────────────────────
+export { UsageError };

--- a/src/tasks/runner.ts
+++ b/src/tasks/runner.ts
@@ -178,7 +178,11 @@ async function runWorkflowTask(input: {
     },
   };
   appendHistory(historyDir, task.id, result);
-  if (error) throw error;
+  // Don't re-throw on workflow failure: the OS scheduler reads exit codes,
+  // not exceptions, and the CLI maps `status: "failed"` to a non-zero exit
+  // via exitCodeForStatus(). Throwing here would route through the generic
+  // runWithJsonErrors path and lose the structured result/history we just
+  // recorded.
   return result;
 }
 

--- a/src/tasks/schedule.ts
+++ b/src/tasks/schedule.ts
@@ -1,0 +1,310 @@
+/**
+ * Cross-platform schedule parsing and translation.
+ *
+ * Users always type cron-style expressions:
+ *
+ *   • `m h dom mon dow`   — five-field cron (UNIX minute/hour/dom/mon/dow)
+ *   • `@hourly` `@daily` `@weekly` `@monthly`
+ *
+ * Each {@link ScheduleSpec} can then be translated to:
+ *
+ *   • a verbatim cron line (Linux backend),
+ *   • a launchd plist `<StartCalendarInterval>` / `<StartInterval>` (macOS),
+ *   • Task Scheduler XML triggers (Windows).
+ *
+ * The supported subset is the intersection of patterns the three OS
+ * schedulers can express without ambiguity. Patterns outside the subset
+ * (multi-value lists, ranges, step values other than `*\/N`, day-of-month
+ * AND day-of-week combinations) are rejected with a
+ * {@link UsageError} and a hint listing accepted forms.
+ */
+
+import { UsageError } from "../core/errors";
+
+export type ScheduleBackend = "cron" | "launchd" | "schtasks";
+
+/** Parsed shape, before backend translation. */
+export interface ScheduleSpec {
+  /** Original input as the user typed it (for error messages and storage). */
+  raw: string;
+  /** Cron-style five-field representation, alias-expanded. */
+  cron: string;
+  /** Structured fields. */
+  fields: ScheduleFields;
+}
+
+export interface ScheduleFields {
+  minute: ScheduleField;
+  hour: ScheduleField;
+  dom: ScheduleField; // day of month
+  month: ScheduleField;
+  dow: ScheduleField; // day of week (0-6, Sunday = 0)
+}
+
+/**
+ * Parsed value of a single cron field. The supported subset is:
+ *
+ *   • star          `*`
+ *   • single value  `5`
+ *   • step on star  `*\/15`
+ */
+export type ScheduleField = { kind: "star" } | { kind: "value"; value: number } | { kind: "step"; step: number };
+
+const ALIAS_TO_CRON: Record<string, string> = {
+  "@hourly": "0 * * * *",
+  "@daily": "0 0 * * *",
+  "@midnight": "0 0 * * *",
+  "@weekly": "0 0 * * 0",
+  "@monthly": "0 0 1 * *",
+};
+
+const FIELD_LIMITS = {
+  minute: { min: 0, max: 59 },
+  hour: { min: 0, max: 23 },
+  dom: { min: 1, max: 31 },
+  month: { min: 1, max: 12 },
+  dow: { min: 0, max: 6 },
+} as const;
+
+const SUPPORTED_HINT =
+  "Supported subset: `*`, single integers (`5`), and step-on-star (`*/N`). " +
+  "Aliases: `@hourly`, `@daily`, `@weekly`, `@monthly`. " +
+  "Lists, ranges, and named days/months are not supported.";
+
+export function parseSchedule(input: string, backend: ScheduleBackend): ScheduleSpec {
+  const cron = expandAlias(input);
+  const fields = parseCronFields(cron, input);
+  const spec: ScheduleSpec = { raw: input, cron, fields };
+  // Eagerly validate translatability so the caller does not silently accept
+  // expressions that work for crontab but cannot be expressed on launchd /
+  // schtasks. The translator throws on unsupported combinations.
+  if (backend === "launchd") translateToLaunchd(spec);
+  if (backend === "schtasks") translateToSchtasks(spec);
+  return spec;
+}
+
+function expandAlias(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new UsageError("Schedule is empty.", "MISSING_REQUIRED_ARGUMENT");
+  }
+  const lower = trimmed.toLowerCase();
+  if (lower in ALIAS_TO_CRON) return ALIAS_TO_CRON[lower];
+  return trimmed;
+}
+
+function parseCronFields(cron: string, original: string): ScheduleFields {
+  const parts = cron.split(/\s+/);
+  if (parts.length !== 5) {
+    throw new UsageError(
+      `Invalid schedule "${original}": expected 5 fields, got ${parts.length}. ${SUPPORTED_HINT}`,
+      "INVALID_FLAG_VALUE",
+    );
+  }
+  const [m, h, dom, mon, dow] = parts;
+  return {
+    minute: parseField(m, "minute", FIELD_LIMITS.minute, original),
+    hour: parseField(h, "hour", FIELD_LIMITS.hour, original),
+    dom: parseField(dom, "day-of-month", FIELD_LIMITS.dom, original),
+    month: parseField(mon, "month", FIELD_LIMITS.month, original),
+    dow: parseField(dow, "day-of-week", FIELD_LIMITS.dow, original),
+  };
+}
+
+function parseField(raw: string, name: string, limit: { min: number; max: number }, original: string): ScheduleField {
+  if (raw === "*") return { kind: "star" };
+
+  const stepMatch = raw.match(/^\*\/(\d+)$/);
+  if (stepMatch) {
+    const step = Number(stepMatch[1]);
+    if (!Number.isInteger(step) || step <= 0 || step > limit.max + 1) {
+      throw new UsageError(
+        `Invalid ${name} step "${raw}" in schedule "${original}". ${SUPPORTED_HINT}`,
+        "INVALID_FLAG_VALUE",
+      );
+    }
+    return { kind: "step", step };
+  }
+
+  if (/^\d+$/.test(raw)) {
+    const value = Number(raw);
+    if (value < limit.min || value > limit.max) {
+      throw new UsageError(
+        `Invalid ${name} value "${raw}" in schedule "${original}" (allowed ${limit.min}-${limit.max}).`,
+        "INVALID_FLAG_VALUE",
+      );
+    }
+    return { kind: "value", value };
+  }
+
+  throw new UsageError(
+    `Unsupported ${name} expression "${raw}" in schedule "${original}". ${SUPPORTED_HINT}`,
+    "INVALID_FLAG_VALUE",
+  );
+}
+
+// ── Backend translators ─────────────────────────────────────────────────────
+
+/** Verbatim cron line, alias-expanded. */
+export function translateToCron(spec: ScheduleSpec): string {
+  return spec.cron;
+}
+
+/**
+ * Build the inner XML for the `Triggers` of a launchd plist's
+ * `StartCalendarInterval` array, OR a single `StartInterval` integer when the
+ * schedule is a single `*\/N` minute step (the simpler launchd primitive).
+ */
+export interface LaunchdTrigger {
+  /** Use `<integer>N</integer>` under `<key>StartInterval</key>`. */
+  intervalSeconds?: number;
+  /** Use `<dict>…</dict>` under `<key>StartCalendarInterval</key>`. */
+  calendar?: LaunchdCalendar;
+}
+
+export interface LaunchdCalendar {
+  Minute?: number;
+  Hour?: number;
+  Day?: number; // day of month
+  Month?: number;
+  Weekday?: number; // 0 = Sunday
+}
+
+export function translateToLaunchd(spec: ScheduleSpec): LaunchdTrigger {
+  const f = spec.fields;
+
+  // `*/N` minute (everything else `*`) → StartInterval = N*60 seconds.
+  if (
+    f.minute.kind === "step" &&
+    f.hour.kind === "star" &&
+    f.dom.kind === "star" &&
+    f.month.kind === "star" &&
+    f.dow.kind === "star"
+  ) {
+    return { intervalSeconds: f.minute.step * 60 };
+  }
+
+  // `*/N` hour → StartInterval = N*3600.
+  if (
+    f.minute.kind === "value" &&
+    f.minute.value === 0 &&
+    f.hour.kind === "step" &&
+    f.dom.kind === "star" &&
+    f.month.kind === "star" &&
+    f.dow.kind === "star"
+  ) {
+    return { intervalSeconds: f.hour.step * 3600 };
+  }
+
+  // Otherwise build a calendar dict from concrete values. launchd treats any
+  // omitted key as "every value", so a `*` field translates to "no key".
+  // Exception: launchd does not support arbitrary step values inside a
+  // calendar dict — reject those.
+  const calendar: LaunchdCalendar = {};
+  rejectStepInsideCalendar(f.minute, "minute", spec);
+  rejectStepInsideCalendar(f.hour, "hour", spec);
+  rejectStepInsideCalendar(f.dom, "day-of-month", spec);
+  rejectStepInsideCalendar(f.month, "month", spec);
+  rejectStepInsideCalendar(f.dow, "day-of-week", spec);
+
+  if (f.minute.kind === "value") calendar.Minute = f.minute.value;
+  if (f.hour.kind === "value") calendar.Hour = f.hour.value;
+  if (f.dom.kind === "value") calendar.Day = f.dom.value;
+  if (f.month.kind === "value") calendar.Month = f.month.value;
+  if (f.dow.kind === "value") calendar.Weekday = f.dow.value;
+
+  // launchd's CalendarInterval requires at least one specific key. If every
+  // field is `*` the schedule has no anchor and we'd need a StartInterval
+  // instead — treat this as "every minute".
+  if (Object.keys(calendar).length === 0) {
+    return { intervalSeconds: 60 };
+  }
+  return { calendar };
+}
+
+function rejectStepInsideCalendar(field: ScheduleField, name: string, spec: ScheduleSpec): void {
+  if (field.kind === "step") {
+    throw new UsageError(
+      `Schedule "${spec.raw}" uses step (${name} = */N) in a position macOS launchd cannot express. ${SUPPORTED_HINT}`,
+      "INVALID_FLAG_VALUE",
+      "Either restrict the step to the minute or hour field only, or rewrite the schedule with concrete values.",
+    );
+  }
+}
+
+/**
+ * Translate to Windows Task Scheduler XML trigger fragment.
+ *
+ * The shape returned is consumed by `backends/schtasks.ts` to build the full
+ * Task Scheduler XML. We deliberately return a simple union rather than a raw
+ * XML string so the backend can compose it with the other XML elements
+ * (Principal, Actions, Settings).
+ */
+export type SchtasksTrigger =
+  | { kind: "minute"; everyMinutes: number }
+  | { kind: "hour"; everyHours: number }
+  | { kind: "daily"; atHour: number; atMinute: number }
+  | { kind: "weekly"; atHour: number; atMinute: number; daysOfWeek: number[] };
+
+export function translateToSchtasks(spec: ScheduleSpec): SchtasksTrigger {
+  const f = spec.fields;
+
+  // `*/N` minute → MINUTE, every N.
+  if (
+    f.minute.kind === "step" &&
+    f.hour.kind === "star" &&
+    f.dom.kind === "star" &&
+    f.month.kind === "star" &&
+    f.dow.kind === "star"
+  ) {
+    return { kind: "minute", everyMinutes: f.minute.step };
+  }
+
+  // `0 */N * * *` → HOURLY, every N.
+  if (
+    f.minute.kind === "value" &&
+    f.minute.value === 0 &&
+    f.hour.kind === "step" &&
+    f.dom.kind === "star" &&
+    f.month.kind === "star" &&
+    f.dow.kind === "star"
+  ) {
+    return { kind: "hour", everyHours: f.hour.step };
+  }
+
+  // `M H * * *` → DAILY at H:M.
+  if (
+    f.minute.kind === "value" &&
+    f.hour.kind === "value" &&
+    f.dom.kind === "star" &&
+    f.month.kind === "star" &&
+    f.dow.kind === "star"
+  ) {
+    return { kind: "daily", atHour: f.hour.value, atMinute: f.minute.value };
+  }
+
+  // `M H * * D` → WEEKLY at H:M on day D.
+  if (
+    f.minute.kind === "value" &&
+    f.hour.kind === "value" &&
+    f.dom.kind === "star" &&
+    f.month.kind === "star" &&
+    f.dow.kind === "value"
+  ) {
+    return {
+      kind: "weekly",
+      atHour: f.hour.value,
+      atMinute: f.minute.value,
+      daysOfWeek: [f.dow.value],
+    };
+  }
+
+  throw new UsageError(
+    `Schedule "${spec.raw}" cannot be expressed as a Windows Task Scheduler trigger. ${SUPPORTED_HINT}`,
+    "INVALID_FLAG_VALUE",
+    "Use one of: */N minutes, every N hours (0 */N * * *), daily at HH:MM, or weekly on a single weekday.",
+  );
+}
+
+/** Human-readable summary used by `tasks doctor`. */
+export const SCHEDULE_SUPPORTED_SUBSET_HINT = SUPPORTED_HINT;

--- a/src/tasks/schedule.ts
+++ b/src/tasks/schedule.ts
@@ -12,11 +12,16 @@
  *   • a launchd plist `<StartCalendarInterval>` / `<StartInterval>` (macOS),
  *   • Task Scheduler XML triggers (Windows).
  *
- * The supported subset is the intersection of patterns the three OS
- * schedulers can express without ambiguity. Patterns outside the subset
- * (multi-value lists, ranges, step values other than `*\/N`, day-of-month
- * AND day-of-week combinations) are rejected with a
- * {@link UsageError} and a hint listing accepted forms.
+ * The shared subset is `*`, single integers, `*\/N`, plus the `@hourly /
+ * @daily / @weekly / @monthly` aliases. Patterns outside that — multi-value
+ * lists, ranges, step values other than `*\/N`, day-of-month AND
+ * day-of-week combinations — are rejected with a {@link UsageError}.
+ *
+ * Cron is the most permissive of the three backends; some patterns it
+ * accepts (e.g. `@hourly` = `0 * * * *`) have no clean schtasks primitive.
+ * Validation runs against the *active* backend, so a task authored on
+ * Linux may fail to translate when copied to macOS/Windows. `tasks sync`
+ * re-validates against the local backend and surfaces any incompatibility.
  */
 
 import { UsageError } from "../core/errors";
@@ -75,9 +80,12 @@ export function parseSchedule(input: string, backend: ScheduleBackend): Schedule
   const cron = expandAlias(input);
   const fields = parseCronFields(cron, input);
   const spec: ScheduleSpec = { raw: input, cron, fields };
-  // Eagerly validate translatability so the caller does not silently accept
-  // expressions that work for crontab but cannot be expressed on launchd /
-  // schtasks. The translator throws on unsupported combinations.
+  // Validate translatability for the active backend so the caller does not
+  // silently accept expressions that backend cannot run. Note: cron is the
+  // most permissive of the three (e.g. `@hourly` is `0 * * * *` which has
+  // no clean schtasks primitive), so a task authored on Linux may not be
+  // portable to macOS/Windows. `tasks sync` on the destination platform
+  // re-runs this with the local backend and will surface any incompatibility.
   if (backend === "launchd") translateToLaunchd(spec);
   if (backend === "schtasks") translateToSchtasks(spec);
   return spec;

--- a/src/tasks/schedule.ts
+++ b/src/tasks/schedule.ts
@@ -125,7 +125,11 @@ function parseField(raw: string, name: string, limit: { min: number; max: number
   const stepMatch = raw.match(/^\*\/(\d+)$/);
   if (stepMatch) {
     const step = Number(stepMatch[1]);
-    if (!Number.isInteger(step) || step <= 0 || step > limit.max + 1) {
+    // Step must be ≥1 and ≤ the field's range size, not just `max`. For
+    // 1-based fields like day-of-month (1-31) and month (1-12) the previous
+    // `max + 1` bound let invalid steps like `*/32` or `*/13` slip through.
+    const range = limit.max - limit.min + 1;
+    if (!Number.isInteger(step) || step <= 0 || step > range) {
       throw new UsageError(
         `Invalid ${name} step "${raw}" in schedule "${original}". ${SUPPORTED_HINT}`,
         "INVALID_FLAG_VALUE",

--- a/src/tasks/schema.ts
+++ b/src/tasks/schema.ts
@@ -1,0 +1,49 @@
+/**
+ * Task asset schema. A task pairs a cron-style schedule with exactly one of:
+ *
+ *   • a workflow target  — invoked via `startWorkflowRun()`
+ *   • a prompt target    — invoked via `runAgent()` against the configured
+ *                          agent harness (e.g. `opencode run`)
+ *
+ * Tasks are stored as markdown files at `<stash>/tasks/<id>.md`. The
+ * frontmatter holds the schedule and target; for inline-prompt tasks the
+ * markdown body is the prompt text.
+ */
+
+export const TASK_SCHEMA_VERSION = 1;
+
+export interface TaskWorkflowTarget {
+  kind: "workflow";
+  /** A workflow ref, e.g. `workflow:daily-backup`. */
+  ref: string;
+  params: Record<string, unknown>;
+}
+
+export type TaskPromptSource =
+  | { kind: "inline"; text: string }
+  /** A stash asset ref like `agent:my-agent` or `command:foo`. */
+  | { kind: "asset"; ref: string }
+  /** A path resolved relative to the task file's directory. */
+  | { kind: "file"; path: string };
+
+export interface TaskPromptTarget {
+  kind: "prompt";
+  source: TaskPromptSource;
+  /** Agent profile name; defaults to `config.agent.default` when undefined. */
+  profile?: string;
+}
+
+export type TaskTarget = TaskWorkflowTarget | TaskPromptTarget;
+
+export interface TaskDocument {
+  schemaVersion: typeof TASK_SCHEMA_VERSION;
+  /** Filesystem-derived id (basename without `.md`). */
+  id: string;
+  /** Cron-style expression, possibly an `@`-alias. */
+  schedule: string;
+  enabled: boolean;
+  target: TaskTarget;
+  description?: string;
+  tags?: string[];
+  source: { path: string };
+}

--- a/src/tasks/validator.ts
+++ b/src/tasks/validator.ts
@@ -1,0 +1,72 @@
+/**
+ * Validate a parsed {@link TaskDocument} for runnability.
+ *
+ * Enforces:
+ *   • the schedule is parseable and translates to the active backend
+ *   • the workflow ref resolves (workflow targets)
+ *   • the asset/file source exists (prompt targets)
+ *   • the agent profile resolves (prompt targets)
+ *
+ * Validation is deliberately split from parsing: callers that only want to
+ * read frontmatter (e.g. `tasks list`) can skip these checks, while
+ * `tasks add` and `tasks run` should always run them.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { parseAssetRef } from "../core/asset-ref";
+import { resolveStashDir } from "../core/common";
+import { loadConfig } from "../core/config";
+import { NotFoundError } from "../core/errors";
+import { requireAgentProfile } from "../integrations/agent";
+import { resolveAssetPath } from "../sources/resolve";
+import { parseSchedule, type ScheduleBackend } from "./schedule";
+import type { TaskDocument } from "./schema";
+
+export interface ValidateTaskOptions {
+  /** Which backend the schedule must translate to. */
+  backend: ScheduleBackend;
+  /** Override stashDir; defaults to {@link resolveStashDir}. */
+  stashDir?: string;
+}
+
+export async function validateTaskDocument(task: TaskDocument, options: ValidateTaskOptions): Promise<void> {
+  // Schedule must parse and translate.
+  parseSchedule(task.schedule, options.backend);
+
+  if (task.target.kind === "workflow") {
+    const stashDir = options.stashDir ?? resolveStashDir();
+    const ref = parseAssetRef(task.target.ref);
+    if (ref.type !== "workflow") {
+      throw new NotFoundError(
+        `Task "${task.id}" workflow target must be a workflow ref (got "${task.target.ref}").`,
+        "WORKFLOW_NOT_FOUND",
+      );
+    }
+    await resolveAssetPath(stashDir, "workflow", ref.name);
+    return;
+  }
+
+  // Prompt target.
+  if (task.target.profile) {
+    const config = loadConfig();
+    requireAgentProfile(config.agent, task.target.profile);
+  }
+
+  const src = task.target.source;
+  if (src.kind === "asset") {
+    const stashDir = options.stashDir ?? resolveStashDir();
+    const ref = parseAssetRef(src.ref);
+    await resolveAssetPath(stashDir, ref.type, ref.name);
+  } else if (src.kind === "file") {
+    const taskDir = path.dirname(task.source.path);
+    const resolved = path.isAbsolute(src.path) ? src.path : path.resolve(taskDir, src.path);
+    if (!fs.existsSync(resolved) || !fs.statSync(resolved).isFile()) {
+      throw new NotFoundError(
+        `Prompt file not found for task "${task.id}": ${src.path} (resolved to ${resolved}).`,
+        "FILE_NOT_FOUND",
+      );
+    }
+  }
+  // inline source is always valid post-parse.
+}

--- a/src/tasks/validator.ts
+++ b/src/tasks/validator.ts
@@ -47,11 +47,13 @@ export async function validateTaskDocument(task: TaskDocument, options: Validate
     return;
   }
 
-  // Prompt target.
-  if (task.target.profile) {
-    const config = loadConfig();
-    requireAgentProfile(config.agent, task.target.profile);
-  }
+  // Prompt target. Resolve the profile unconditionally — when no profile is
+  // set on the task, requireAgentProfile falls back to config.agent.default
+  // and throws a clear error if neither is configured. Catching this at
+  // `tasks add` / `tasks sync` time is much more useful than failing only
+  // when the OS scheduler fires.
+  const config = loadConfig();
+  requireAgentProfile(config.agent, task.target.profile);
 
   const src = task.target.source;
   if (src.kind === "asset") {

--- a/tests/asset-spec.test.ts
+++ b/tests/asset-spec.test.ts
@@ -42,7 +42,8 @@ describe("getAssetTypes", () => {
     expect(types).toContain("vault");
     expect(types).toContain("wiki");
     expect(types).toContain("lesson");
-    expect(types).toHaveLength(10);
+    expect(types).toContain("task");
+    expect(types).toHaveLength(11);
   });
 });
 

--- a/tests/completions.test.ts
+++ b/tests/completions.test.ts
@@ -115,7 +115,7 @@ describe("completions command", () => {
 
   test("contains flag value completions for --type", () => {
     expect(script).toContain("--type)");
-    expect(script).toContain("skill command agent knowledge workflow script memory vault wiki lesson any");
+    expect(script).toContain("skill command agent knowledge workflow script memory vault wiki lesson task any");
   });
 
   test("contains flag value completions for --source", () => {

--- a/tests/file-context.test.ts
+++ b/tests/file-context.test.ts
@@ -558,9 +558,9 @@ describe("Renderer", () => {
     expect(response.content).not.toContain("Setup");
   });
 
-  test("getAllRenderers() returns all 10 built-in renderers", async () => {
+  test("getAllRenderers() returns all 11 built-in renderers", async () => {
     const all = await getAllRenderers();
-    expect(all).toHaveLength(10);
+    expect(all).toHaveLength(11);
 
     const names = all.map((r) => r.name).sort();
     expect(names).toEqual([
@@ -571,6 +571,7 @@ describe("Renderer", () => {
       "memory-md",
       "script-source",
       "skill-md",
+      "task-md",
       "vault-env",
       "wiki-md",
       "workflow-md",

--- a/tests/tasks-cron-backend.test.ts
+++ b/tests/tasks-cron-backend.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { buildCronLine, removeBlock, renderBlock, toggleBlock, upsertBlock } from "../src/tasks/backends/cron";
+import type { TaskDocument } from "../src/tasks/schema";
+
+const TASK: TaskDocument = {
+  schemaVersion: 1,
+  id: "ping",
+  schedule: "*/15 * * * *",
+  enabled: true,
+  target: { kind: "workflow", ref: "workflow:noop", params: {} },
+  source: { path: "/stash/tasks/ping.md" },
+};
+
+describe("cron backend helpers", () => {
+  test("buildCronLine emits absolute akm path", () => {
+    const line = buildCronLine(TASK, ["/usr/local/bin/akm"], "/var/log/akm");
+    expect(line).toBe("*/15 * * * * /usr/local/bin/akm tasks run ping >> /var/log/akm/ping.log 2>&1");
+  });
+
+  test("buildCronLine quotes paths containing spaces", () => {
+    const line = buildCronLine(TASK, ["/Applications/My Stuff/akm"], "/var/log");
+    expect(line).toContain("'/Applications/My Stuff/akm'");
+  });
+
+  test("renderBlock wraps the cron line in begin/end markers", () => {
+    const block = renderBlock("ping", "* * * * * /bin/akm tasks run ping", true);
+    expect(block.split("\n")).toEqual([
+      "# akm:task ping BEGIN",
+      "* * * * * /bin/akm tasks run ping",
+      "# akm:task ping END",
+    ]);
+  });
+
+  test("renderBlock with enabled=false comments the cron line", () => {
+    const block = renderBlock("ping", "* * * * * /bin/akm tasks run ping", false);
+    const middle = block.split("\n")[1];
+    expect(middle.startsWith("# akm:disabled ")).toBe(true);
+  });
+
+  test("upsertBlock inserts when absent", () => {
+    const next = upsertBlock("# user line\n0 * * * * other-job\n", "ping", renderBlock("ping", "X", true));
+    expect(next).toContain("# user line");
+    expect(next).toContain("0 * * * * other-job");
+    expect(next).toContain("# akm:task ping BEGIN");
+    expect(next).toContain("# akm:task ping END");
+  });
+
+  test("upsertBlock replaces when present, leaves other lines untouched", () => {
+    const initial = [
+      "# user line",
+      "0 * * * * other-job",
+      "# akm:task ping BEGIN",
+      "* * * * * old-cmd",
+      "# akm:task ping END",
+      "# trailing user line",
+    ].join("\n");
+    const next = upsertBlock(initial, "ping", renderBlock("ping", "* * * * * NEW", true));
+    expect(next).toContain("0 * * * * other-job");
+    expect(next).toContain("# trailing user line");
+    expect(next).toContain("* * * * * NEW");
+    expect(next).not.toContain("old-cmd");
+  });
+
+  test("removeBlock leaves untouched when block absent", () => {
+    const initial = "0 * * * * other-job";
+    expect(removeBlock(initial, "ping")).toBe(initial);
+  });
+
+  test("removeBlock removes only the named block", () => {
+    const initial = [
+      "0 * * * * other-job",
+      "# akm:task other BEGIN",
+      "0 0 * * * /bin/akm tasks run other",
+      "# akm:task other END",
+      "# akm:task ping BEGIN",
+      "* * * * * /bin/akm tasks run ping",
+      "# akm:task ping END",
+    ].join("\n");
+    const next = removeBlock(initial, "ping");
+    expect(next).toContain("# akm:task other BEGIN");
+    expect(next).not.toContain("# akm:task ping BEGIN");
+    expect(next).toContain("0 * * * * other-job");
+  });
+
+  test("toggleBlock comments and uncomments the body", () => {
+    const enabled = renderBlock("ping", "* * * * * X", true);
+    const disabled = toggleBlock(enabled, "ping", false);
+    expect(disabled).toContain("# akm:disabled * * * * * X");
+    const reenabled = toggleBlock(disabled, "ping", true);
+    expect(reenabled).toContain("* * * * * X");
+    expect(reenabled).not.toContain("akm:disabled");
+  });
+});

--- a/tests/tasks-launchd-backend.test.ts
+++ b/tests/tasks-launchd-backend.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { buildPlistXml } from "../src/tasks/backends/launchd";
+import type { TaskDocument } from "../src/tasks/schema";
+
+function makeTask(schedule: string): TaskDocument {
+  return {
+    schemaVersion: 1,
+    id: "ping",
+    schedule,
+    enabled: true,
+    target: { kind: "workflow", ref: "workflow:noop", params: {} },
+    source: { path: "/stash/tasks/ping.md" },
+  };
+}
+
+describe("buildPlistXml", () => {
+  test("step minutes -> StartInterval", () => {
+    const xml = buildPlistXml(makeTask("*/15 * * * *"), ["/abs/akm"], "/var/log/akm");
+    expect(xml).toContain("<key>Label</key>");
+    expect(xml).toContain("<string>com.akm.task.ping</string>");
+    expect(xml).toContain("<key>StartInterval</key>");
+    expect(xml).toContain("<integer>900</integer>");
+    expect(xml).toContain("<string>/abs/akm</string>");
+    expect(xml).toContain("<string>tasks</string>");
+    expect(xml).toContain("<string>run</string>");
+    expect(xml).toContain("<string>ping</string>");
+    expect(xml).toContain("<string>/var/log/akm/ping.log</string>");
+  });
+
+  test("daily at HH:MM -> StartCalendarInterval", () => {
+    const xml = buildPlistXml(makeTask("30 9 * * *"), ["/abs/akm"], "/var/log/akm");
+    expect(xml).toContain("<key>StartCalendarInterval</key>");
+    expect(xml).toContain("<key>Hour</key><integer>9</integer>");
+    expect(xml).toContain("<key>Minute</key><integer>30</integer>");
+  });
+
+  test("weekly on Mon -> Weekday=1", () => {
+    const xml = buildPlistXml(makeTask("0 8 * * 1"), ["/abs/akm"], "/var/log/akm");
+    expect(xml).toContain("<key>Weekday</key><integer>1</integer>");
+  });
+});

--- a/tests/tasks-parser.test.ts
+++ b/tests/tasks-parser.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { UsageError } from "../src/core/errors";
+import { parseTaskDocument } from "../src/tasks/parser";
+
+describe("parseTaskDocument", () => {
+  test("workflow target with params", () => {
+    const md = [
+      "---",
+      'schedule: "0 9 * * *"',
+      "workflow: workflow:daily-backup",
+      "params:",
+      "  region: us-east-1",
+      "enabled: true",
+      "tags: [scheduled, backup]",
+      "---",
+      "",
+      "# Task: Daily backup",
+      "",
+    ].join("\n");
+    const task = parseTaskDocument({ markdown: md, filePath: "/stash/tasks/daily.md", id: "daily" });
+    expect(task.id).toBe("daily");
+    expect(task.schedule).toBe("0 9 * * *");
+    expect(task.enabled).toBe(true);
+    expect(task.target.kind).toBe("workflow");
+    if (task.target.kind === "workflow") {
+      expect(task.target.ref).toBe("workflow:daily-backup");
+      expect(task.target.params).toEqual({ region: "us-east-1" });
+    }
+    expect(task.tags).toEqual(["scheduled", "backup"]);
+  });
+
+  test("inline prompt target uses the body", () => {
+    const md = [
+      "---",
+      'schedule: "@daily"',
+      "prompt: inline",
+      "profile: opencode",
+      "---",
+      "",
+      "Summarise today's git activity.",
+      "",
+    ].join("\n");
+    const task = parseTaskDocument({ markdown: md, filePath: "/stash/tasks/digest.md", id: "digest" });
+    expect(task.target.kind).toBe("prompt");
+    if (task.target.kind === "prompt") {
+      expect(task.target.profile).toBe("opencode");
+      expect(task.target.source.kind).toBe("inline");
+      if (task.target.source.kind === "inline") {
+        expect(task.target.source.text).toBe("Summarise today's git activity.");
+      }
+    }
+  });
+
+  test("asset-ref prompt target", () => {
+    const md = ["---", 'schedule: "0 8 * * 1"', "prompt: agent:standup-bot", "profile: claude", "---"].join("\n");
+    const task = parseTaskDocument({ markdown: md, filePath: "/stash/tasks/standup.md", id: "standup" });
+    if (task.target.kind === "prompt" && task.target.source.kind === "asset") {
+      expect(task.target.source.ref).toBe("agent:standup-bot");
+    } else {
+      throw new Error("expected asset prompt target");
+    }
+  });
+
+  test("file-path prompt target", () => {
+    const md = ["---", 'schedule: "@hourly"', "prompt: ./prompts/triage.md", "---"].join("\n");
+    const task = parseTaskDocument({ markdown: md, filePath: "/stash/tasks/triage.md", id: "triage" });
+    if (task.target.kind === "prompt" && task.target.source.kind === "file") {
+      expect(task.target.source.path).toBe("./prompts/triage.md");
+    } else {
+      throw new Error("expected file prompt target");
+    }
+  });
+
+  test("rejects task with both workflow and prompt", () => {
+    const md = ["---", 'schedule: "@daily"', "workflow: workflow:foo", "prompt: inline", "---", "", "body", ""].join(
+      "\n",
+    );
+    expect(() => parseTaskDocument({ markdown: md, filePath: "/stash/tasks/x.md", id: "x" })).toThrow(UsageError);
+  });
+
+  test("rejects task with neither workflow nor prompt", () => {
+    const md = ["---", 'schedule: "@daily"', "---"].join("\n");
+    expect(() => parseTaskDocument({ markdown: md, filePath: "/stash/tasks/x.md", id: "x" })).toThrow(UsageError);
+  });
+
+  test("rejects missing schedule", () => {
+    const md = ["---", "workflow: workflow:foo", "---"].join("\n");
+    expect(() => parseTaskDocument({ markdown: md, filePath: "/stash/tasks/x.md", id: "x" })).toThrow(UsageError);
+  });
+
+  test("rejects prompt: inline with empty body", () => {
+    const md = ["---", 'schedule: "@daily"', "prompt: inline", "---", ""].join("\n");
+    expect(() => parseTaskDocument({ markdown: md, filePath: "/stash/tasks/x.md", id: "x" })).toThrow(UsageError);
+  });
+
+  test("default enabled is true when omitted", () => {
+    const md = ["---", 'schedule: "@daily"', "workflow: workflow:foo", "---", "", "body", ""].join("\n");
+    const task = parseTaskDocument({ markdown: md, filePath: "/stash/tasks/x.md", id: "x" });
+    expect(task.enabled).toBe(true);
+  });
+
+  test("enabled: false honored", () => {
+    const md = ["---", 'schedule: "@daily"', "workflow: workflow:foo", "enabled: false", "---", "", "body", ""].join(
+      "\n",
+    );
+    const task = parseTaskDocument({ markdown: md, filePath: "/stash/tasks/x.md", id: "x" });
+    expect(task.enabled).toBe(false);
+  });
+});

--- a/tests/tasks-runner.test.ts
+++ b/tests/tasks-runner.test.ts
@@ -1,0 +1,217 @@
+import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { AgentRunResult } from "../src/integrations/agent";
+import { resolveAkmInvocation } from "../src/tasks/resolveAkmBin";
+import { exitCodeForStatus, readTaskHistory, runTask } from "../src/tasks/runner";
+
+type FakeWorkflowRunner = (
+  ref: string,
+  params?: Record<string, unknown>,
+) => Promise<{
+  run: {
+    id: string;
+    workflowRef: string;
+    workflowTitle: string;
+    status: "active" | "completed" | "blocked" | "failed";
+    params: Record<string, unknown>;
+    createdAt: string;
+    updatedAt: string;
+    completedAt: string | null;
+    currentStepId: string | null;
+  };
+  workflow: { ref: string; title: string; steps: [] };
+}>;
+
+type FakeRunAgent = (...args: unknown[]) => Promise<AgentRunResult>;
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "akm-tasks-runner-"));
+const stashDir = path.join(tmpRoot, "stash");
+const cacheDir = path.join(tmpRoot, "cache");
+const logDir = path.join(cacheDir, "tasks", "logs");
+const historyDir = path.join(cacheDir, "tasks", "history");
+const tasksDir = path.join(stashDir, "tasks");
+const configDir = path.join(tmpRoot, "cfg");
+
+const TRACKED_ENV_KEYS = ["AKM_CONFIG_DIR", "AKM_CACHE_DIR", "AKM_STASH_DIR"];
+const PRESERVED_ENV: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of TRACKED_ENV_KEYS) PRESERVED_ENV[key] = process.env[key];
+  fs.rmSync(stashDir, { recursive: true, force: true });
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+  fs.rmSync(configDir, { recursive: true, force: true });
+  fs.mkdirSync(tasksDir, { recursive: true });
+  // Workflows directory needs to exist so resolveAssetPath can stat the type root.
+  fs.mkdirSync(path.join(stashDir, "workflows"), { recursive: true });
+});
+
+afterEach(() => {
+  for (const key of TRACKED_ENV_KEYS) {
+    if (PRESERVED_ENV[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = PRESERVED_ENV[key];
+    }
+  }
+});
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function writeTask(id: string, body: string): void {
+  fs.writeFileSync(path.join(tasksDir, `${id}.md`), body, "utf8");
+}
+
+describe("runTask — workflow target", () => {
+  test("dispatches to startWorkflowRun and writes log + history JSONL", async () => {
+    writeTask("wf", ["---", 'schedule: "@daily"', "workflow: workflow:noop", "---", "", "# Task: noop", ""].join("\n"));
+    const calls: Array<{ ref: string; params: Record<string, unknown> }> = [];
+    const fakeWf: FakeWorkflowRunner = async (ref, params = {}) => {
+      calls.push({ ref, params });
+      return {
+        run: {
+          id: "run-id-1",
+          workflowRef: ref,
+          workflowTitle: "Noop",
+          status: "completed",
+          params,
+          createdAt: "2025-01-01T00:00:00Z",
+          updatedAt: "2025-01-01T00:00:00Z",
+          completedAt: "2025-01-01T00:00:00Z",
+          currentStepId: null,
+        },
+        workflow: { ref, title: "Noop", steps: [] },
+      };
+    };
+
+    const result = await runTask("wf", {
+      stashDir,
+      logDir,
+      historyDir,
+      startWorkflowRunImpl: fakeWf as never,
+      now: () => new Date("2025-01-01T00:00:00Z"),
+    });
+
+    expect(calls).toEqual([{ ref: "workflow:noop", params: {} }]);
+    expect(result.status).toBe("completed");
+    expect(result.target).toEqual({ kind: "workflow", ref: "workflow:noop" });
+    expect(result.detail?.runId).toBe("run-id-1");
+
+    const logExists = fs.existsSync(result.log);
+    expect(logExists).toBe(true);
+
+    const rows = readTaskHistory({ id: "wf", historyDir });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe("wf");
+    expect(rows[0].status).toBe("completed");
+  });
+});
+
+describe("runTask — prompt target", () => {
+  test("dispatches to runAgent (mocked) and writes captured stdout to the log", async () => {
+    writeTask(
+      "prompt",
+      ["---", 'schedule: "@daily"', "prompt: inline", "profile: opencode", "---", "", "say hello", ""].join("\n"),
+    );
+
+    const fakeRunAgent: FakeRunAgent = async (...args) => {
+      const prompt = args[1] as string;
+      return {
+        ok: true,
+        exitCode: 0,
+        stdout: `agent received: ${prompt}`,
+        stderr: "",
+        durationMs: 12,
+      };
+    };
+
+    // We need a config with an agent block so requireAgentProfile succeeds.
+    process.env.AKM_CONFIG_DIR = configDir;
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ agent: { default: "opencode" } }));
+
+    const result = await runTask("prompt", {
+      stashDir,
+      logDir,
+      historyDir,
+      runAgentImpl: fakeRunAgent,
+      now: () => new Date("2025-01-01T00:00:00Z"),
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.target).toEqual({ kind: "prompt", profile: "opencode" });
+    expect(fs.readFileSync(result.log, "utf8")).toContain("agent received: say hello");
+
+    const rows = readTaskHistory({ id: "prompt", historyDir });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].target).toEqual({ kind: "prompt", profile: "opencode" });
+  });
+
+  test("agent failure surfaces as failed status with reason", async () => {
+    writeTask(
+      "fail",
+      ["---", 'schedule: "@daily"', "prompt: inline", "profile: opencode", "---", "", "boom", ""].join("\n"),
+    );
+
+    process.env.AKM_CONFIG_DIR = configDir;
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ agent: { default: "opencode" } }));
+
+    const fakeRunAgent: FakeRunAgent = async () => {
+      return {
+        ok: false,
+        exitCode: 2,
+        stdout: "",
+        stderr: "boom",
+        durationMs: 12,
+        reason: "non_zero_exit",
+        error: "agent CLI exited with code 2",
+      };
+    };
+
+    const result = await runTask("fail", {
+      stashDir,
+      logDir,
+      historyDir,
+      runAgentImpl: fakeRunAgent,
+      now: () => new Date("2025-01-01T00:00:00Z"),
+    });
+    expect(result.status).toBe("failed");
+    expect(result.detail?.reason).toBe("non_zero_exit");
+    expect(exitCodeForStatus(result.status)).toBe(1);
+  });
+});
+
+describe("runTask — disabled tasks no-op", () => {
+  test("disabled task is recorded but not dispatched", async () => {
+    writeTask(
+      "off",
+      ["---", 'schedule: "@daily"', "workflow: workflow:noop", "enabled: false", "---", "", "body", ""].join("\n"),
+    );
+    let called = false;
+    const fakeWf = async () => {
+      called = true;
+      throw new Error("should not be called");
+    };
+    const result = await runTask("off", {
+      stashDir,
+      logDir,
+      historyDir,
+      startWorkflowRunImpl: fakeWf as never,
+      now: () => new Date("2025-01-01T00:00:00Z"),
+    });
+    expect(called).toBe(false);
+    expect(result.status).toBe("disabled");
+    expect(exitCodeForStatus(result.status)).toBe(0);
+  });
+});
+
+describe("resolveAkmInvocation", () => {
+  test("AKM_BIN takes precedence", () => {
+    const r = resolveAkmInvocation({ env: { AKM_BIN: "/abs/akm" } });
+    expect(r).toEqual({ argv: ["/abs/akm"], via: "AKM_BIN" });
+  });
+});

--- a/tests/tasks-schedule.test.ts
+++ b/tests/tasks-schedule.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { UsageError } from "../src/core/errors";
+import { parseSchedule, translateToCron, translateToLaunchd, translateToSchtasks } from "../src/tasks/schedule";
+
+describe("parseSchedule", () => {
+  test("expands aliases", () => {
+    expect(parseSchedule("@daily", "cron").cron).toBe("0 0 * * *");
+    expect(parseSchedule("@hourly", "cron").cron).toBe("0 * * * *");
+    expect(parseSchedule("@weekly", "cron").cron).toBe("0 0 * * 0");
+    expect(parseSchedule("@monthly", "cron").cron).toBe("0 0 1 * *");
+  });
+
+  test("accepts plain cron", () => {
+    const spec = parseSchedule("*/15 * * * *", "cron");
+    expect(spec.fields.minute.kind).toBe("step");
+    if (spec.fields.minute.kind === "step") expect(spec.fields.minute.step).toBe(15);
+    expect(spec.fields.hour.kind).toBe("star");
+  });
+
+  test("rejects too-many fields", () => {
+    expect(() => parseSchedule("0 0 0 0 0 0", "cron")).toThrow(UsageError);
+  });
+
+  test("rejects out-of-range value", () => {
+    expect(() => parseSchedule("0 25 * * *", "cron")).toThrow(UsageError);
+  });
+
+  test("rejects unsupported list/range syntax", () => {
+    expect(() => parseSchedule("0,15 * * * *", "cron")).toThrow(UsageError);
+    expect(() => parseSchedule("0-30 * * * *", "cron")).toThrow(UsageError);
+  });
+});
+
+describe("translateToCron", () => {
+  test("emits the cron expression verbatim", () => {
+    expect(translateToCron(parseSchedule("0 9 * * *", "cron"))).toBe("0 9 * * *");
+  });
+});
+
+describe("translateToLaunchd", () => {
+  test("*/15 minutes -> StartInterval", () => {
+    const t = translateToLaunchd(parseSchedule("*/15 * * * *", "launchd"));
+    expect(t.intervalSeconds).toBe(15 * 60);
+  });
+
+  test("0 */2 * * * -> StartInterval (hourly step)", () => {
+    const t = translateToLaunchd(parseSchedule("0 */2 * * *", "launchd"));
+    expect(t.intervalSeconds).toBe(2 * 3600);
+  });
+
+  test("daily at 09:30 -> calendar", () => {
+    const t = translateToLaunchd(parseSchedule("30 9 * * *", "launchd"));
+    expect(t.calendar).toEqual({ Minute: 30, Hour: 9 });
+  });
+
+  test("weekly at 08:00 mon -> calendar", () => {
+    const t = translateToLaunchd(parseSchedule("0 8 * * 1", "launchd"));
+    expect(t.calendar).toEqual({ Minute: 0, Hour: 8, Weekday: 1 });
+  });
+
+  test("rejects step in non-minute/hour position", () => {
+    // No realistic path produces this from cron syntax we accept; force the shape.
+    expect(() => parseSchedule("*/5 */5 * * *", "launchd")).toThrow(UsageError);
+  });
+});
+
+describe("translateToSchtasks", () => {
+  test("*/30 minutes -> minute trigger", () => {
+    const t = translateToSchtasks(parseSchedule("*/30 * * * *", "schtasks"));
+    expect(t).toEqual({ kind: "minute", everyMinutes: 30 });
+  });
+
+  test("0 */3 * * * -> hour trigger", () => {
+    const t = translateToSchtasks(parseSchedule("0 */3 * * *", "schtasks"));
+    expect(t).toEqual({ kind: "hour", everyHours: 3 });
+  });
+
+  test("M H * * * -> daily", () => {
+    const t = translateToSchtasks(parseSchedule("15 9 * * *", "schtasks"));
+    expect(t).toEqual({ kind: "daily", atHour: 9, atMinute: 15 });
+  });
+
+  test("M H * * D -> weekly", () => {
+    const t = translateToSchtasks(parseSchedule("0 8 * * 1", "schtasks"));
+    expect(t).toEqual({ kind: "weekly", atHour: 8, atMinute: 0, daysOfWeek: [1] });
+  });
+
+  test("rejects unsupported combinations", () => {
+    expect(() => parseSchedule("0 0 1 * *", "schtasks")).toThrow(UsageError);
+  });
+});

--- a/tests/tasks-schtasks-backend.test.ts
+++ b/tests/tasks-schtasks-backend.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { buildSchtasksXml } from "../src/tasks/backends/schtasks";
+import type { TaskDocument } from "../src/tasks/schema";
+
+function makeTask(schedule: string): TaskDocument {
+  return {
+    schemaVersion: 1,
+    id: "ping",
+    schedule,
+    enabled: true,
+    target: { kind: "workflow", ref: "workflow:noop", params: {} },
+    source: { path: "/stash/tasks/ping.md" },
+  };
+}
+
+describe("buildSchtasksXml", () => {
+  test("step minutes -> TimeTrigger PT5M", () => {
+    const xml = buildSchtasksXml(makeTask("*/5 * * * *"), ["C:/akm/akm.exe"], "C:/log");
+    expect(xml).toContain("<TimeTrigger>");
+    expect(xml).toContain("<Interval>PT5M</Interval>");
+    expect(xml).toContain("<URI>\\akm\\ping</URI>");
+    expect(xml).toContain("<Command>C:/akm/akm.exe</Command>");
+    expect(xml).toContain("<Arguments>tasks run ping</Arguments>");
+    expect(xml).toContain("<Enabled>true</Enabled>");
+  });
+
+  test("daily at 09:30 -> CalendarTrigger ScheduleByDay", () => {
+    const xml = buildSchtasksXml(makeTask("30 9 * * *"), ["C:/akm.exe"], "C:/log");
+    expect(xml).toContain("<CalendarTrigger>");
+    expect(xml).toContain("<ScheduleByDay><DaysInterval>1</DaysInterval></ScheduleByDay>");
+    expect(xml).toContain("T09:30:00");
+  });
+
+  test("weekly on Wed -> CalendarTrigger Wednesday", () => {
+    const xml = buildSchtasksXml(makeTask("0 8 * * 3"), ["C:/akm.exe"], "C:/log");
+    expect(xml).toContain("<Wednesday />");
+    expect(xml).toContain("T08:00:00");
+  });
+
+  test("disabled task encodes Enabled=false", () => {
+    const t = makeTask("*/5 * * * *");
+    const xml = buildSchtasksXml({ ...t, enabled: false }, ["C:/akm.exe"], "C:/log");
+    expect(xml).toContain("<Enabled>false</Enabled>");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `akm tasks` for adding, removing, enabling, disabling, and running scheduled invocations of workflows or prompts — without an akm-owned daemon. Tasks are stored as markdown assets at `<stash>/tasks/<id>.md` and registered with the user's OS-native scheduler:

- **Linux** → crontab (per-user, with marker-bracketed blocks so user lines are never touched)
- **macOS** → launchd LaunchAgent (`~/Library/LaunchAgents/com.akm.task.<id>.plist`)
- **Windows** → schtasks.exe (under the `\akm\` folder)

A task targets exactly one of:

- a **workflow ref** → dispatched via the existing `startWorkflowRun()`
- a **prompt** → dispatched via the existing `runAgent()` against the configured agent harness (opencode, claude, codex, gemini, aider, or any user-defined profile). The prompt source can be the markdown body (`prompt: inline`), an asset ref like `agent:my-agent`, or a relative file path.

Run logs and JSONL history live under the XDG cache (`getCacheDir()/tasks/{logs,history}`). No DB changes — task files are the source of truth, the scheduler entries are derived deterministically from the task id.

Subcommands: `add`, `list`, `show`, `remove`, `enable`, `disable`, `run`, `history`, `sync`, `doctor`.

### Example

```bash
# Workflow target
akm tasks add daily-backup --schedule "0 9 * * *" --workflow workflow:backup

# Prompt target — inline body, default agent profile
akm tasks add daily-digest --schedule "@daily" \
  --prompt "Summarize today's commits in itlackey/akm." --profile opencode

# Prompt target — referencing a stash agent asset
akm tasks add standup --schedule "0 8 * * 1" \
  --prompt agent:standup-bot --profile claude
```

## Architecture

- **`src/tasks/schema.ts` / `parser.ts` / `validator.ts`** — task asset shape, frontmatter parser, and reachability checks (workflow ref, prompt asset/file, agent profile).
- **`src/tasks/schedule.ts`** — single cron-style frontend with three translators (cron line / launchd plist trigger / schtasks XML trigger). Supported subset: `*`, single integers, `*/N`, plus the `@hourly @daily @weekly @monthly` aliases. Patterns outside the subset are rejected with a `UsageError` so the user sees the limit at `tasks add` time, not at run time.
- **`src/tasks/backends/{cron,launchd,schtasks}.ts`** — each implements a small `TaskBackend` interface (`install`, `uninstall`, `setEnabled`, `list`). Exec + filesystem are dependency-injected so unit tests run on any platform.
- **`src/tasks/runner.ts`** — what `akm tasks run <id>` invokes; resolves the file, dispatches, captures stdout/stderr to `<cacheDir>/tasks/logs/<id>/<ts>.log`, appends a JSONL row to `<cacheDir>/tasks/history/<id>.jsonl`, and exits with a status code the OS scheduler can read.
- **`src/tasks/resolveAkmBin.ts`** — resolves an absolute argv prefix once at install time so the scheduler doesn't depend on PATH.
- **`src/commands/tasks.ts` + `src/cli.ts`** — handler functions and citty `defineCommand` wiring (mirrors the `workflow` subcommand pattern).

`task` is registered as a new asset type via `src/core/asset-spec.ts` (renderer + action builder, indexer matchers, asset registry).

## Test plan

- [x] `bun test ./tests/tasks-*` — 47 unit tests covering parser, schedule translators, crontab merge round-trip, plist + schtasks XML snapshots, and runner dispatch (workflow + prompt + disabled paths) with mocked `runAgent` and `startWorkflowRun`.
- [x] `bunx tsc --noEmit` — clean.
- [x] `bunx biome check src/tasks src/commands/tasks.ts ...` — clean.
- [x] Full suite `bun test ./tests` — 2465 pass, 21 skip, 10 fail (all 10 are pre-existing environment failures on this branch's baseline; my changes don't introduce new failures).
- [x] `akm tasks --help`, `akm tasks doctor`, `akm tasks list` smoke-tested locally.

Linux smoke flow (manual):
```
akm tasks add ping-wf --schedule "* * * * *" --workflow workflow:noop
crontab -l | grep akm:task
akm tasks history
akm tasks disable ping-wf
akm tasks remove ping-wf
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01HrJ4Ja9u6mWzJADgYx262M)_