### PR TITLE
fix(core): remove IS_WINDOWS duplicate from paths.ts

### DIFF
--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -7,9 +7,8 @@
  */
 
 import path from "node:path";
+import { IS_WINDOWS } from "./common";
 import { ConfigError } from "./errors";
-
-const IS_WINDOWS = process.platform === "win32";
 
 // ── Config directory ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Removes the private `IS_WINDOWS` constant from `src/core/paths.ts` (line 12) since it duplicates the exported `IS_WINDOWS` in `src/core/common.ts`
- Adds `import { IS_WINDOWS } from "./common"` to `paths.ts`
- No behavior change

## Test plan
- [ ] `bunx tsc --noEmit` passes
- [ ] `bunx biome check src/` passes
- [ ] `bun test` passes

Fixes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)