### PR TITLE
refactor(core): delete dead exports with zero callers

### DIFF
--- a/src/core/asset-registry.ts
+++ b/src/core/asset-registry.ts
@@ -84,23 +84,3 @@ export const defaultRendererRegistry: RendererRegistry = {
     return ACTION_BUILDERS[type];
   },
 };
-
-/**
- * Build a registry from explicit maps. Useful for tests that need to assert
- * rendering behavior without touching the global singletons.
- */
-export function createRendererRegistry(maps: {
-  renderers?: Record<string, string>;
-  actionBuilders?: Record<string, (ref: string) => string>;
-}): RendererRegistry {
-  const renderers = maps.renderers ?? {};
-  const actionBuilders = maps.actionBuilders ?? {};
-  return {
-    rendererNameFor(type) {
-      return renderers[type];
-    },
-    actionBuilderFor(type) {
-      return actionBuilders[type];
-    },
-  };
-}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -803,15 +803,6 @@ function expandEnvVars<T>(value: T, fieldName?: string): T {
   return value;
 }
 
-function _readConfigObject(configPath: string): Record<string, unknown> | undefined {
-  try {
-    const text = fs.readFileSync(configPath, "utf8");
-    return parseConfigObjectFromText(text);
-  } catch {
-    return undefined;
-  }
-}
-
 function parseConfigObjectFromText(text: string): Record<string, unknown> | undefined {
   try {
     const raw = JSON.parse(stripJsonComments(text));

--- a/src/indexer/metadata.ts
+++ b/src/indexer/metadata.ts
@@ -1184,18 +1184,6 @@ export function extractDescriptionFromComments(filePath: string): string | null 
   return null;
 }
 
-export function extractFrontmatterDescription(filePath: string): string | null {
-  let content: string;
-  try {
-    content = fs.readFileSync(filePath, "utf8");
-  } catch {
-    return null;
-  }
-
-  const parsed = parseFrontmatter(content);
-  return toStringOrUndefined(parsed.data.description) ?? null;
-}
-
 export function extractPackageMetadata(
   dirPath: string,
 ): { name?: string; description?: string; keywords?: string[] } | null {


### PR DESCRIPTION
## Summary
- Deletes `extractFrontmatterDescription` from `src/indexer/metadata.ts` (zero callers)
- Deletes `createRendererRegistry` from `src/core/asset-registry.ts` (zero callers)
- Deletes `_readConfigObject` private function from `src/core/config.ts` (zero callers)
- Net: -41 lines

## Test plan
- [ ] `bunx tsc --noEmit` passes
- [ ] `bunx biome check src/` passes
- [ ] `bun test` passes
- [ ] No callers in `src/` (verified with `grep -r`)

Fixes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)