### PR TITLE
feat(commands): add schemaVersion: 1 to ConsolidateResult and AkmAgentDispatchResult

### DIFF
--- a/src/commands/agent-dispatch.ts
+++ b/src/commands/agent-dispatch.ts
@@ -33,6 +33,7 @@ export interface AkmAgentDispatchOptions {
 }
 
 export interface AkmAgentDispatchResult {
+  schemaVersion: 1;
   ok: boolean;
   shape: "agent-result";
   profileName: string;
@@ -136,6 +137,7 @@ export async function akmAgentDispatch(options: AkmAgentDispatchOptions): Promis
   }
 
   return {
+    schemaVersion: 1 as const,
     ok: result.ok,
     shape: "agent-result",
     profileName: profile.name,

--- a/src/commands/consolidate.ts
+++ b/src/commands/consolidate.ts
@@ -41,6 +41,7 @@ export interface ConsolidatePromoteOp {
 export type ConsolidateOperation = ConsolidateMergeOp | ConsolidateDeleteOp | ConsolidatePromoteOp;
 
 export interface ConsolidateResult {
+  schemaVersion: 1;
   ok: boolean;
   shape: "consolidate-result";
   dryRun: boolean;
@@ -373,6 +374,7 @@ export async function akmConsolidate(opts: AkmConsolidateOptions = {}): Promise<
 
   if (!isLlmFeatureEnabled(config, "memory_consolidation")) {
     return {
+      schemaVersion: 1 as const,
       ok: true,
       shape: "consolidate-result" as const,
       dryRun: opts.dryRun ?? false,
@@ -395,6 +397,7 @@ export async function akmConsolidate(opts: AkmConsolidateOptions = {}): Promise<
 
   if (memories.length === 0) {
     return {
+      schemaVersion: 1 as const,
       ok: true,
       shape: "consolidate-result",
       dryRun: opts.dryRun ?? false,
@@ -490,6 +493,7 @@ export async function akmConsolidate(opts: AkmConsolidateOptions = {}): Promise<
   // -- Dry-run: show AI plan without executing any writes --------------------
   if (opts.dryRun) {
     return {
+      schemaVersion: 1 as const,
       ok: true,
       shape: "consolidate-result",
       dryRun: true,
@@ -513,6 +517,7 @@ export async function akmConsolidate(opts: AkmConsolidateOptions = {}): Promise<
       const answer = await promptConfirm(`Apply ${n} operations? [y/N] `);
       if (!answer) {
         return {
+          schemaVersion: 1 as const,
           ok: true,
           shape: "consolidate-result",
           dryRun: false,
@@ -727,6 +732,7 @@ export async function akmConsolidate(opts: AkmConsolidateOptions = {}): Promise<
   }
 
   return {
+    schemaVersion: 1 as const,
     ok: true,
     shape: "consolidate-result",
     dryRun: false,

--- a/src/commands/improve.ts
+++ b/src/commands/improve.ts
@@ -736,6 +736,7 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
       Date.now() - new Date(lastConsolidation.ts).getTime() < CONSOLIDATE_COOLDOWN_MS;
 
     let consolidation: ConsolidateResult = {
+      schemaVersion: 1,
       ok: true,
       shape: "consolidate-result",
       dryRun: false,


### PR DESCRIPTION
## Summary
- Adds `schemaVersion: 1` discriminant field to `ConsolidateResult` interface in `src/commands/consolidate.ts`
- Adds `schemaVersion: 1` discriminant field to `AkmAgentDispatchResult` interface in `src/commands/agent-dispatch.ts`
- Updates all 5 `ConsolidateResult` construction sites (consolidate.ts ×4, improve.ts ×1) and 1 `AkmAgentDispatchResult` construction site to include `schemaVersion: 1`
- Aligns these two response types with the universal `schemaVersion` discriminant present on all other command responses

## Test plan
- [ ] `bunx tsc --noEmit` passes (no new type errors)
- [ ] `bunx biome check src/` passes
- [ ] `bun test` passes
- [ ] JSON consumers can now discriminate on `schemaVersion === 1`

Fixes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)