### PR TITLE
fix(commands): promote stripMarkdownFences to core/markdown.ts with <think> block support

### DIFF
--- a/src/commands/distill.ts
+++ b/src/commands/distill.ts
@@ -56,6 +56,7 @@ import { ConfigError, UsageError } from "../core/errors";
 import { appendEvent, readEvents } from "../core/events";
 import { parseFrontmatter } from "../core/frontmatter";
 import { lintLessonContent } from "../core/lesson-lint";
+import { stripMarkdownFences } from "../core/markdown";
 import { createProposal, type Proposal, type ProposalsContext } from "../core/proposals";
 import { lookup as indexerLookup } from "../indexer/indexer";
 import { type ChatMessage, chatCompletion, parseEmbeddedJsonResponse } from "../llm/client";
@@ -676,18 +677,4 @@ async function defaultLookup(ref: string): Promise<string | null> {
   } catch {
     return null;
   }
-}
-
-/** Best-effort fence stripping. Keeps the body intact when no fence is present. */
-function stripMarkdownFences(raw: string): string {
-  // Strip <think>…</think> reasoning blocks first — local LLMs (e.g. Qwen3)
-  // emit these before the content, which breaks YAML frontmatter detection.
-  const stripped = raw
-    .trim()
-    .replace(/<think>[\s\S]*?<\/think>/gi, "")
-    .trim();
-  // Only strip outer triple-fence pairs — leave inner code blocks alone.
-  const fence = stripped.match(/^```(?:markdown|md)?\s*\n([\s\S]*?)\n```\s*$/i);
-  if (fence) return fence[1].trim();
-  return stripped;
 }

--- a/src/commands/reflect.ts
+++ b/src/commands/reflect.ts
@@ -26,6 +26,7 @@ import { loadConfig } from "../core/config";
 import { ConfigError, UsageError } from "../core/errors";
 import { appendEvent, readEvents } from "../core/events";
 import { lintLessonContent } from "../core/lesson-lint";
+import { stripMarkdownFences } from "../core/markdown";
 import { type CreateProposalInput, createProposal, type Proposal, type ProposalsContext } from "../core/proposals";
 import { lookup } from "../indexer/indexer";
 import {
@@ -125,16 +126,10 @@ function buildSchemaHints(type: string, content: string | undefined): string[] {
 
 function fallbackPayloadFromRawContent(stdout: string, ref: string | undefined) {
   if (!ref) return undefined;
-  const trimmed = stripMarkdownFence(stdout).trim();
+  const trimmed = stripMarkdownFences(stdout).trim();
   if (!trimmed) return undefined;
   if (!looksLikeAssetContent(trimmed)) return undefined;
   return { ref, content: trimmed };
-}
-
-function stripMarkdownFence(stdout: string): string {
-  const trimmed = stdout.trim();
-  const match = trimmed.match(/^```(?:markdown|md)?\s*\n([\s\S]*?)\n```$/i);
-  return match?.[1] ?? trimmed;
 }
 
 function looksLikeAssetContent(value: string): boolean {

--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -104,3 +104,21 @@ export function formatToc(toc: KnowledgeToc): string {
   parts.push(`\n${toc.totalLines} lines total`);
   return parts.join("\n");
 }
+
+// ── Fence stripping ──────────────────────────────────────────────────────────
+
+/**
+ * Best-effort fence stripping. Strips `<think>` reasoning blocks emitted by
+ * local LLMs (e.g. Qwen3) before the content, which otherwise breaks YAML
+ * frontmatter detection. Only strips outer triple-fence pairs — leaves inner
+ * code blocks intact.
+ */
+export function stripMarkdownFences(raw: string): string {
+  const stripped = raw
+    .trim()
+    .replace(/<think>[\s\S]*?<\/think>/gi, "")
+    .trim();
+  const fence = stripped.match(/^```(?:markdown|md)?\s*\n([\s\S]*?)\n```\s*$/i);
+  if (fence) return fence[1].trim();
+  return stripped;
+}


### PR DESCRIPTION
## Summary
- Promotes `stripMarkdownFences` from `distill.ts` to `src/core/markdown.ts` as an exported utility
- The promoted version correctly strips `<think>...</think>` reasoning blocks emitted by local LLMs (e.g. Qwen3) before fence-stripping — the old `reflect.ts:stripMarkdownFence` lacked this, causing silent failures
- `reflect.ts` now imports `stripMarkdownFences` from `core/markdown` and removes its private `stripMarkdownFence` function
- `distill.ts` removes its local copy and imports from `core/markdown`

## Test plan
- [ ] `bunx tsc --noEmit` passes
- [ ] `bunx biome check src/` passes
- [ ] `bun test` passes
- [ ] Verify `stripMarkdownFences` exported from `src/core/markdown.ts`

Fixes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)