### PR TITLE
fix(sdk-runner): add SdkServer interface, proper _server typing, and closeServer() helper

### DIFF
--- a/src/integrations/agent/sdk-runner.ts
+++ b/src/integrations/agent/sdk-runner.ts
@@ -20,10 +20,29 @@ interface SdkClient {
   };
 }
 
-// Singleton server — started once per process, reused across calls
-let _server: { client: unknown; server: { close(): void } } | null = null;
+/** Typed server instance returned by `createOpencode`. */
+interface SdkServer {
+  client: SdkClient;
+  server: { close(): void };
+}
 
-async function getOrStartServer(profile: AgentProfile, llmConfig?: LlmConnectionConfig): Promise<{ client: unknown }> {
+// Singleton server — started once per process, reused across calls
+let _server: SdkServer | null = null;
+
+/**
+ * Close the singleton OpenCode SDK server and reset the handle.
+ * Primarily for use in tests to ensure clean teardown between test runs.
+ */
+export function closeServer(): void {
+  try {
+    _server?.server.close();
+  } catch {
+    /* ignore */
+  }
+  _server = null;
+}
+
+async function getOrStartServer(profile: AgentProfile, llmConfig?: LlmConnectionConfig): Promise<SdkServer> {
   if (_server) return _server;
 
   const { createOpencode } = await import("@opencode-ai/sdk").catch(() => {
@@ -54,15 +73,10 @@ async function getOrStartServer(profile: AgentProfile, llmConfig?: LlmConnection
     }
   }
 
-  _server = await createOpencode(Object.keys(sdkConfig).length > 0 ? { config: sdkConfig } : {});
+  _server = (await createOpencode(Object.keys(sdkConfig).length > 0 ? { config: sdkConfig } : {})) as SdkServer;
 
   process.once("exit", () => {
-    try {
-      _server?.server.close();
-    } catch {
-      /* ignore */
-    }
-    _server = null;
+    closeServer();
   });
 
   if (!_server) throw new Error("Failed to initialise OpenCode SDK server.");
@@ -79,7 +93,7 @@ export async function runAgentSdk(
 
   let client: SdkClient;
   try {
-    ({ client } = (await getOrStartServer(profile, llmConfig)) as { client: SdkClient });
+    ({ client } = await getOrStartServer(profile, llmConfig));
   } catch (e) {
     return {
       ok: false,


### PR DESCRIPTION
## Summary
- Introduces `SdkServer` interface to type the server returned by `createOpencode`
- `_server` is now typed as `SdkServer | null` instead of using `unknown`
- `getOrStartServer` return type is now `Promise<SdkServer>` — eliminates the `as { client: SdkClient }` cast at the call site
- Adds exported `closeServer()` helper for clean test teardown
- `process.once("exit", ...)` delegates to `closeServer()` to avoid duplicating cleanup logic

## Test plan
- [ ] `bunx tsc --noEmit` passes (only pre-existing `@opencode-ai/sdk` module error remains)
- [ ] `bunx biome check src/` passes
- [ ] `bun test` passes

Fixes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)