### PR TITLE
refactor(core): promote groupBy, firstString, stringArray from memory-improve.ts to common.ts

### DIFF
--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -369,3 +369,41 @@ function parseRetryAfter(response: Response): number | undefined {
 export function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
+
+// ── Generic data utilities ───────────────────────────────────────────────────
+
+/**
+ * Return the trimmed string if non-empty, otherwise `undefined`.
+ * Equivalent to `firstString` previously defined in `memory-improve.ts`.
+ */
+export function firstString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+/**
+ * Coerce an unknown value to a filtered, trimmed string array.
+ * Non-strings and empty/whitespace-only entries are dropped.
+ */
+export function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const out: string[] = [];
+  for (const item of value) {
+    if (typeof item === "string" && item.trim().length > 0) out.push(item.trim());
+  }
+  return out;
+}
+
+/**
+ * Group an array of values by a string key derived from each element.
+ * Returns a `Map` so insertion order within each group is preserved.
+ */
+export function groupBy<T>(values: T[], keyFn: (value: T) => string): Map<string, T[]> {
+  const groups = new Map<string, T[]>();
+  for (const value of values) {
+    const key = keyFn(value);
+    const existing = groups.get(key);
+    if (existing) existing.push(value);
+    else groups.set(key, [value]);
+  }
+  return groups;
+}

--- a/src/core/memory-improve.ts
+++ b/src/core/memory-improve.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { stringify as yamlStringify } from "yaml";
 import { makeAssetRef, parseAssetRef } from "./asset-ref";
+import { firstString, groupBy, stringArray } from "./common";
 import { parseFrontmatter } from "./frontmatter";
 
 export type MemoryPruneReason = "duplicate-derived" | "superseded-derived" | "obsolete-derived";
@@ -807,19 +808,6 @@ function sameStringArray(a: string[], b: string[]): boolean {
   return true;
 }
 
-function firstString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
-}
-
-function stringArray(value: unknown): string[] {
-  if (!Array.isArray(value)) return [];
-  const out: string[] = [];
-  for (const item of value) {
-    if (typeof item === "string" && item.trim().length > 0) out.push(item.trim());
-  }
-  return out;
-}
-
 function extractHeading(content: string): string | undefined {
   for (const line of content.split(/\r?\n/)) {
     const match = line.match(/^#\s+(.+)$/);
@@ -833,17 +821,6 @@ function firstNonEmpty(values: Array<string | undefined>): string | undefined {
     if (value && value.trim().length > 0) return value;
   }
   return undefined;
-}
-
-function groupBy<T>(values: T[], keyFn: (value: T) => string): Map<string, T[]> {
-  const groups = new Map<string, T[]>();
-  for (const value of values) {
-    const key = keyFn(value);
-    const existing = groups.get(key);
-    if (existing) existing.push(value);
-    else groups.set(key, [value]);
-  }
-  return groups;
 }
 
 function* walkMarkdownFiles(root: string): Generator<string> {


### PR DESCRIPTION
## Summary
- Adds `groupBy<T>`, `firstString`, and `stringArray` exports to `src/core/common.ts`
- Removes the private copies from `src/core/memory-improve.ts`
- `memory-improve.ts` now imports these utilities from `./common`
- `groupBy` in particular will be reinvented by future callers without this promotion

## Test plan
- [ ] `bunx tsc --noEmit` passes
- [ ] `bunx biome check src/` passes
- [ ] `bun test` passes

Fixes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)