### PR TITLE
refactor(tasks): flatten SelectBackendOptions discriminated union to flat interface

### DIFF
--- a/src/tasks/backends/index.ts
+++ b/src/tasks/backends/index.ts
@@ -29,20 +29,22 @@ export interface TaskBackend {
   list(): Promise<InstalledTaskRef[]> | InstalledTaskRef[];
 }
 
-export type SelectBackendOptions =
-  | { platform?: NodeJS.Platform; cron?: CronBackendOptions }
-  | { platform?: NodeJS.Platform; launchd?: LaunchdBackendOptions }
-  | { platform?: NodeJS.Platform; schtasks?: SchtasksBackendOptions };
+export interface SelectBackendOptions {
+  platform?: NodeJS.Platform;
+  cron?: CronBackendOptions;
+  launchd?: LaunchdBackendOptions;
+  schtasks?: SchtasksBackendOptions;
+}
 
 export function selectBackend(options: SelectBackendOptions = {}): TaskBackend {
-  const platform = (options as { platform?: NodeJS.Platform }).platform ?? process.platform;
+  const platform = options.platform ?? process.platform;
   switch (platform) {
     case "win32":
-      return SCHTASKS_BACKEND((options as { schtasks?: SchtasksBackendOptions }).schtasks);
+      return SCHTASKS_BACKEND(options.schtasks);
     case "darwin":
-      return LAUNCHD_BACKEND((options as { launchd?: LaunchdBackendOptions }).launchd);
+      return LAUNCHD_BACKEND(options.launchd);
     default:
-      return CRON_BACKEND((options as { cron?: CronBackendOptions }).cron);
+      return CRON_BACKEND(options.cron);
   }
 }
 


### PR DESCRIPTION
## Summary
- Replaces the 3-member discriminated union `SelectBackendOptions` with a single flat `interface` with all three backend option fields optional
- Eliminates all three `as { ... }` type casts inside `selectBackend`
- `options.platform`, `options.cron`, `options.launchd`, `options.schtasks` are now directly accessible

## Test plan
- [ ] `bunx tsc --noEmit` passes (no new errors)
- [ ] `bunx biome check src/` passes
- [ ] `bun test` passes

Fixes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)