### PR TITLE
refactor(core): centralize normalizeSince as parseSinceToIso in src/core/time.ts

### DIFF
--- a/src/commands/events.ts
+++ b/src/commands/events.ts
@@ -11,6 +11,7 @@
 import { parseAssetRef } from "../core/asset-ref";
 import { UsageError } from "../core/errors";
 import { type EventEnvelope, type EventsContext, readEvents, type TailOptions, tailEvents } from "../core/events";
+import { parseSinceToIso } from "../core/time";
 
 export interface EventsListOptions {
   since?: string;
@@ -47,7 +48,7 @@ function parseSinceFlag(since: string | undefined): {
     }
     return { sinceOffset: value };
   }
-  return { since: normalizeSince(trimmed) };
+  return { since: parseSinceToIso(trimmed) };
 }
 
 export interface EventsListResult {
@@ -70,31 +71,6 @@ function validateRef(ref: string | undefined): string | undefined {
   }
   parseAssetRef(trimmed);
   return trimmed;
-}
-
-function normalizeSince(since: string | undefined): string | undefined {
-  if (since === undefined) return undefined;
-  const trimmed = since.trim();
-  if (!trimmed) {
-    throw new UsageError("--since cannot be empty.", "INVALID_FLAG_VALUE");
-  }
-  // Accept ISO timestamp (preferred), epoch ms, or plain date.
-  if (/^\d+$/.test(trimmed)) {
-    const ms = Number.parseInt(trimmed, 10);
-    const d = new Date(ms);
-    if (Number.isNaN(d.getTime())) {
-      throw new UsageError(`Invalid --since value: ${since}`, "INVALID_FLAG_VALUE");
-    }
-    return d.toISOString();
-  }
-  const parsed = new Date(trimmed);
-  if (Number.isNaN(parsed.getTime())) {
-    throw new UsageError(
-      `Invalid --since value: ${since}. Expected ISO timestamp (e.g. 2026-04-01T00:00:00Z) or epoch ms.`,
-      "INVALID_FLAG_VALUE",
-    );
-  }
-  return parsed.toISOString();
 }
 
 export function akmEventsList(options: EventsListOptions = {}): EventsListResult {

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -18,6 +18,7 @@ import type { Database } from "bun:sqlite";
 import { parseAssetRef } from "../core/asset-ref";
 import { UsageError } from "../core/errors";
 import { type EventsContext, readEvents } from "../core/events";
+import { isoToSqlite, parseSinceToIso } from "../core/time";
 import { closeDatabase, openExistingDatabase } from "../indexer/db";
 import type { UsageEventRow } from "../indexer/usage-events";
 
@@ -70,38 +71,6 @@ export interface HistoryOptions {
 const PROPOSAL_EVENT_TYPES = new Set(["promoted", "rejected"]);
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
-function normalizeSince(since: string): string {
-  // Accept "YYYY-MM-DD", "YYYY-MM-DDTHH:MM:SSZ", epoch ms, or anything Date can parse.
-  const trimmed = since.trim();
-  if (!trimmed) {
-    throw new UsageError("--since cannot be empty.", "INVALID_FLAG_VALUE");
-  }
-  // Pure-digit input → epoch milliseconds
-  if (/^\d+$/.test(trimmed)) {
-    const ms = Number.parseInt(trimmed, 10);
-    const d = new Date(ms);
-    if (Number.isNaN(d.getTime())) {
-      throw new UsageError(`Invalid --since value: ${since}`, "INVALID_FLAG_VALUE");
-    }
-    return d
-      .toISOString()
-      .replace("T", " ")
-      .replace(/\.\d+Z$/, "");
-  }
-  const parsed = new Date(trimmed);
-  if (Number.isNaN(parsed.getTime())) {
-    throw new UsageError(
-      `Invalid --since value: ${since}. Expected ISO timestamp (e.g. 2026-04-01T00:00:00Z) or epoch ms.`,
-      "INVALID_FLAG_VALUE",
-    );
-  }
-  // Match the "YYYY-MM-DD HH:MM:SS" format SQLite's datetime('now') stores.
-  return parsed
-    .toISOString()
-    .replace("T", " ")
-    .replace(/\.\d+Z$/, "");
-}
 
 function parseMetadata(raw: string | null): unknown {
   if (!raw) return null;
@@ -162,7 +131,7 @@ export async function akmHistory(options: HistoryOptions = {}): Promise<HistoryR
     normalizedRef = trimmed;
   }
 
-  const sinceNormalized = options.since !== undefined ? normalizeSince(options.since) : undefined;
+  const sinceNormalized = options.since !== undefined ? isoToSqlite(parseSinceToIso(options.since)) : undefined;
 
   const db = options.db ?? openExistingDatabase();
   const ownsDb = options.db === undefined;

--- a/src/core/time.ts
+++ b/src/core/time.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared time and date utilities.
+ *
+ * Centralises parsing of user-facing `--since` values so that all consumers
+ * interpret the same set of formats (ISO-8601, epoch ms, plain date strings)
+ * consistently without private re-implementations drifting apart.
+ */
+
+import { UsageError } from "./errors";
+
+// ── Since-flag parsing ───────────────────────────────────────────────────────
+
+/**
+ * Parse a user-supplied `--since` value and return an ISO-8601 timestamp
+ * string (e.g. `"2026-01-15T10:30:00.000Z"`).
+ *
+ * Accepted input formats:
+ *   - ISO-8601 timestamp (preferred): `"2026-04-01T00:00:00Z"`
+ *   - Plain date: `"2026-04-01"` (interpreted as start-of-day UTC)
+ *   - Epoch milliseconds (pure digit string): `"1744329600000"`
+ *   - Any other value parseable by `new Date()`
+ *
+ * Callers that need a different wire format (e.g. SQLite `"YYYY-MM-DD HH:MM:SS"`)
+ * should convert the returned ISO string themselves.
+ *
+ * @throws {UsageError} when `since` is empty or cannot be parsed as a date.
+ */
+export function parseSinceToIso(since: string): string {
+  const trimmed = since.trim();
+  if (!trimmed) {
+    throw new UsageError("--since cannot be empty.", "INVALID_FLAG_VALUE");
+  }
+  // Pure-digit input → epoch milliseconds
+  if (/^\d+$/.test(trimmed)) {
+    const ms = Number.parseInt(trimmed, 10);
+    const d = new Date(ms);
+    if (Number.isNaN(d.getTime())) {
+      throw new UsageError(`Invalid --since value: ${since}`, "INVALID_FLAG_VALUE");
+    }
+    return d.toISOString();
+  }
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new UsageError(
+      `Invalid --since value: ${since}. Expected ISO timestamp (e.g. 2026-04-01T00:00:00Z) or epoch ms.`,
+      "INVALID_FLAG_VALUE",
+    );
+  }
+  return parsed.toISOString();
+}
+
+/**
+ * Convert an ISO-8601 timestamp string to the SQLite datetime format
+ * `"YYYY-MM-DD HH:MM:SS"` used by `datetime('now')`.
+ */
+export function isoToSqlite(iso: string): string {
+  return iso.replace("T", " ").replace(/\.\d+Z$/, "");
+}


### PR DESCRIPTION
## Summary
- Creates `src/core/time.ts` with two exports: `parseSinceToIso(since: string): string` and `isoToSqlite(iso: string): string`
- Removes the private `normalizeSince` from `events.ts` (which returned ISO-8601) and from `history.ts` (which returned SQLite format)
- `events.ts` calls `parseSinceToIso` directly; `history.ts` composes `isoToSqlite(parseSinceToIso(since))` to get SQLite format
- The two implementations no longer have any possibility of semantic drift

## Test plan
- [ ] `bunx tsc --noEmit` passes
- [ ] `bunx biome check src/` passes
- [ ] `bun test` passes

Fixes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)