### PR TITLE
fix(memory): name-based guard in isPendingMemory prevents .derived re-walk (#368)

### DIFF
--- a/src/indexer/memory-inference.ts
+++ b/src/indexer/memory-inference.ts
@@ -245,7 +245,7 @@ export function collectPendingMemories(stashRoot: string): MemoryRecord[] {
       continue;
     }
     const parsed = parseFrontmatter(raw);
-    if (!isPendingMemory(parsed.data)) continue;
+    if (!isPendingMemory(parsed.data, filePath)) continue;
 
     const relName = toMemoryName(memoriesDir, filePath);
     if (!relName) continue;
@@ -266,10 +266,26 @@ export function collectPendingMemories(stashRoot: string): MemoryRecord[] {
  * Predicate: true when the parsed frontmatter indicates the memory has not
  * yet been split AND is not itself an inferred child.
  *
+ * Also guards against `.derived` files whose `inferred:` frontmatter key has
+ * been dropped by a manual edit or schema-repair rewrite. The file name suffix
+ * is structural and immutable; frontmatter flags are mutable. A file whose
+ * path contains `.derived` is always treated as a derived child regardless of
+ * its frontmatter state — this prevents `<name>.derived.derived.md` chains.
+ *
+ * @param frontmatter - Parsed YAML frontmatter from the memory file.
+ * @param filePath    - Optional absolute path to the memory file. When
+ *                      supplied, the name-based guard is applied.
+ *
  * Exported for direct unit testing — keeping the predicate in one place
  * avoids drift between the walker, tests, and any future consumers.
  */
-export function isPendingMemory(frontmatter: Record<string, unknown>): boolean {
+export function isPendingMemory(frontmatter: Record<string, unknown>, filePath?: string): boolean {
+  // Name-based guard: a `.derived` suffix in the path means this file is a
+  // derived child regardless of what its frontmatter currently says.
+  if (filePath !== undefined) {
+    const base = path.basename(filePath, ".md");
+    if (base.endsWith(".derived")) return false;
+  }
   if (frontmatter[FM_INFERRED] === true) return false;
   if (frontmatter[FM_INFERENCE_PROCESSED] === true) return false;
   return true;

--- a/tests/memory-inference.test.ts
+++ b/tests/memory-inference.test.ts
@@ -130,6 +130,22 @@ describe("isPendingMemory", () => {
     expect(isPendingMemory({ inferred: "yes" })).toBe(true);
     expect(isPendingMemory({ inferenceProcessed: 1 })).toBe(true);
   });
+
+  test("name-based guard: .derived suffix blocks re-walk regardless of frontmatter", () => {
+    expect(isPendingMemory({}, "/stash/memories/auth-tips.derived.md")).toBe(false);
+    expect(isPendingMemory({ description: "anything" }, "/stash/memories/auth-tips.derived.md")).toBe(false);
+    expect(isPendingMemory({ inferred: false }, "/stash/memories/auth-tips.derived.md")).toBe(false);
+  });
+
+  test("name-based guard: non-.derived path is not affected", () => {
+    expect(isPendingMemory({ description: "anything" }, "/stash/memories/auth-tips.md")).toBe(true);
+    expect(isPendingMemory({}, "/stash/memories/nested/note.md")).toBe(true);
+  });
+
+  test("name-based guard: absent filePath falls back to frontmatter-only check", () => {
+    expect(isPendingMemory({})).toBe(true);
+    expect(isPendingMemory({ inferred: true })).toBe(false);
+  });
 });
 
 // ── collectPendingMemories ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #368 — M-2: isPendingMemory name-based guard against .derived re-walk

- Add optional `filePath` parameter to `isPendingMemory` that checks the `.derived` suffix in the file name in addition to frontmatter flags
- A file whose base name ends in `.derived` is now treated as a derived child regardless of its current frontmatter state — preventing `<name>.derived.derived.md` chains when schema-repair or manual edits drop the `inferred: true` key
- Updated call site in `collectPendingMemories` to pass the loop's `filePath`
- Backward compatible: callers without `filePath` retain the old frontmatter-only check

## Test plan

- [x] `bun test tests/memory-inference.test.ts` — all 22 tests pass (3 new name-guard tests added)
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check src/ tests/` — clean

Part of Epic #399