### PR TITLE
fix(improve): bypass reflect/distill cooldowns on explicit --scope <ref> (#365)

### DIFF
--- a/src/commands/improve.ts
+++ b/src/commands/improve.ts
@@ -1085,8 +1085,20 @@ async function runImprovePreparationStage(args: {
   let fullySkippedCount = 0;
   const preCooldownCount = postCleanupRefs.length;
 
+  // O-2 (#365): When the user explicitly targets a single ref via `--scope`,
+  // their intent is unambiguous — they want a fresh evaluation now. Cooldown
+  // policies are designed for unattended nightly runs; silently blocking an
+  // explicit retry violates the principle of least surprise (Sagas, 1987).
+  const scopeRefBypass = scope.mode === "ref";
+
   for (const r of postCleanupRefs) {
     if (validationFailureRefs.has(r.ref)) continue;
+
+    // When --scope <ref> is active, bypass all cooldown checks for this ref.
+    if (scopeRefBypass) {
+      eligibleRefs.push(r);
+      continue;
+    }
 
     const onReflectCooldown = reflectCooledRefs.has(r.ref);
     const onDistillCooldown = DISTILL_COOLDOWN_DAYS_PREFILT > 0 && distillCooledRefs.has(r.ref);
@@ -1464,7 +1476,13 @@ async function runImproveLoopStage(args: {
 
       // distillCooledRefs guard: pre-filter emitted synthetic actions for distill-candidate
       // refs; non-candidate refs in the set are blocked here.
-      if (shouldAttemptDistill && !skipMemoryDistillForWeakSignal && !distillCooledRefs.has(planned.ref)) {
+      // O-2 (#365): bypass the distill cooldown when the user explicitly targeted
+      // this ref via --scope — their intent overrides unattended-run policies.
+      if (
+        shouldAttemptDistill &&
+        !skipMemoryDistillForWeakSignal &&
+        (!distillCooledRefs.has(planned.ref) || explicitRefScope)
+      ) {
         // TODO(refactor): single call site needs both lesson+knowledge refs for proposal dedup. If a third target ref type is added, extract deriveAllTargetRefs(inputRef): string[].
         const lessonRef = deriveLessonRef(planned.ref);
         const knowledgeRef = deriveKnowledgeRef(planned.ref);

--- a/tests/commands/improve-memory.test.ts
+++ b/tests/commands/improve-memory.test.ts
@@ -1413,3 +1413,105 @@ describe("akm improve memory cleanup", () => {
     expect(fs.existsSync(path.join(stashDir, ".akm", "consolidate-backup", staleBackupTs))).toBe(false);
   });
 });
+
+// ── O-2 / #365 — scope-ref cooldown bypass ──────────────────────────────────
+
+describe("O-2: --scope <ref> bypasses reflect/distill cooldowns (#365)", () => {
+  test("explicit --scope <ref> reflects even when ref is on reflect cooldown", async () => {
+    const stashDir = makeTempDir("akm-o2-reflect-bypass-");
+    writeMemory(stashDir, "auth-tips", { description: "auth memory" }, "Auth tips content.");
+    await buildIndex(stashDir);
+
+    const reflectedRefs: string[] = [];
+    const now = Date.now();
+    // Simulate recent reflect_invoked that would normally trigger the cooldown.
+    appendEvent({ eventType: "reflect_invoked", ref: "memory:auth-tips" }, { now: () => now - 60 * 1000 });
+
+    await akmImprove({
+      // scope "ref" targeting the cooled ref — should bypass cooldown.
+      scope: "memory:auth-tips",
+      stashDir,
+      reflectCooldownDays: 7,
+      ensureIndexFn: async () => false,
+      reindexFn: async () => ({
+        schemaVersion: 1,
+        ok: true,
+        indexed: 0,
+        warnings: [],
+        errors: [],
+        durationMs: 0,
+      }),
+      reflectFn: async ({ ref }) => {
+        if (ref) reflectedRefs.push(ref);
+        return {
+          schemaVersion: 1,
+          ok: true,
+          proposal: makeProposal(ref ?? "memory:missing"),
+          ref: ref ?? "",
+          agentProfile: "test",
+          durationMs: 1,
+        } satisfies AkmReflectResult;
+      },
+      distillFn: async ({ ref }) =>
+        ({
+          schemaVersion: 1,
+          ok: true,
+          outcome: "queued",
+          inputRef: ref,
+          lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson`,
+        }) satisfies AkmDistillResult,
+    });
+
+    // With scope-ref bypass, the ref should have been reflected despite cooldown.
+    expect(reflectedRefs).toContain("memory:auth-tips");
+  });
+
+  test("non-ref scope (scope: 'memory') still respects reflect cooldown", async () => {
+    const stashDir = makeTempDir("akm-o2-no-bypass-");
+    writeMemory(stashDir, "auth-tips-2", { description: "auth memory 2" }, "Auth tips 2.");
+    await buildIndex(stashDir);
+
+    const reflectedRefs: string[] = [];
+    const now = Date.now();
+    // Simulate recent reflect_invoked for the ref.
+    appendEvent({ eventType: "reflect_invoked", ref: "memory:auth-tips-2" }, { now: () => now - 60 * 1000 });
+
+    await akmImprove({
+      // scope "type" (memory) — cooldown should still apply.
+      scope: "memory",
+      stashDir,
+      reflectCooldownDays: 7,
+      ensureIndexFn: async () => false,
+      reindexFn: async () => ({
+        schemaVersion: 1,
+        ok: true,
+        indexed: 0,
+        warnings: [],
+        errors: [],
+        durationMs: 0,
+      }),
+      reflectFn: async ({ ref }) => {
+        if (ref) reflectedRefs.push(ref);
+        return {
+          schemaVersion: 1,
+          ok: true,
+          proposal: makeProposal(ref ?? "memory:missing"),
+          ref: ref ?? "",
+          agentProfile: "test",
+          durationMs: 1,
+        } satisfies AkmReflectResult;
+      },
+      distillFn: async ({ ref }) =>
+        ({
+          schemaVersion: 1,
+          ok: true,
+          outcome: "queued",
+          inputRef: ref,
+          lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson`,
+        }) satisfies AkmDistillResult,
+    });
+
+    // Without scope-ref bypass, the cooled ref should NOT be reflected.
+    expect(reflectedRefs).not.toContain("memory:auth-tips-2");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #365 — O-2: Bypass cooldowns on explicit --scope <ref>

When a user runs `akm improve --scope skill:deploy`, they are explicitly requesting a fresh evaluation. Previously, this was silently blocked by the same cooldown that protects unattended nightly runs.

**Changes:**
- Phase 3 cooldown partitioning: when `scope.mode === "ref"`, push all refs directly to `eligibleRefs` bypassing both `reflectCooledRefs` and `distillCooledRefs` checks
- Inner loop distill guard: also bypass `distillCooledRefs.has()` when `explicitRefScope` is active

## Test plan

- [x] `bun test tests/commands/improve-memory.test.ts` — 19 pass
- [x] 2 new tests: scope-ref bypass reflects cooled ref; type-scope still respects cooldown
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check src/ tests/` — clean

Part of Epic #399