### PR TITLE
fix(distill): restructure feedback as What-worked/What-failed verbal contrast (#371)

### DIFF
--- a/src/commands/distill.ts
+++ b/src/commands/distill.ts
@@ -273,7 +273,15 @@ interface BuildPromptInput {
   rejectedProposals?: Array<{ reason: string; contentPreview?: string }>;
 }
 
-/** Pure: build the user-prompt body. Exported for tests. */
+/**
+ * Pure: build the user-prompt body. Exported for tests.
+ *
+ * D-3 (#371): restructures the feedback section from raw JSON event lines into
+ * a Reflexion-style verbal contrast (`## What worked` / `## What failed`).
+ * The verbal format allows LLMs to use feedback as gradient signal rather than
+ * just metadata — capturing the +8% AlfWorld lift from arXiv:2303.11366 and
+ * the contrast-based rule-learning gain from ExpeL arXiv:2308.10144.
+ */
 export function buildDistillPrompt(input: BuildPromptInput): string {
   const lines: string[] = [];
   lines.push(`Asset ref: ${input.inputRef}`);
@@ -288,13 +296,55 @@ export function buildDistillPrompt(input: BuildPromptInput): string {
     lines.push("(asset is not currently indexed; distil from feedback signal alone)");
   }
   lines.push("");
-  lines.push("Recent feedback events (most recent last):");
+
   if (input.feedback.length === 0) {
-    lines.push("(no feedback events recorded — distil from the asset itself)");
+    lines.push("Recent feedback: (no feedback events recorded — distil from the asset itself)");
   } else {
+    // D-3 (#371): verbal contrast format for Reflexion verbal-gradient lift.
+    // Partition events into positive ("what worked") and negative ("what failed").
+    const positive: string[] = [];
+    const negative: string[] = [];
+    const neutral: string[] = [];
+
     for (const event of input.feedback) {
-      const meta = event.metadata ? ` ${JSON.stringify(event.metadata)}` : "";
-      lines.push(`- ${event.ts} ${event.eventType}${meta}`);
+      const meta = (event.metadata ?? {}) as Record<string, unknown>;
+      const signal = typeof meta.signal === "string" ? meta.signal : undefined;
+      const reason = typeof meta.reason === "string" ? meta.reason : "";
+      const note = typeof meta.note === "string" ? meta.note : "";
+      const detail = reason || note;
+      const line = detail ? `- ${event.ts}: ${detail}` : `- ${event.ts}: feedback received`;
+
+      if (signal === "positive") positive.push(line);
+      else if (signal === "negative") negative.push(line);
+      else
+        neutral.push(`- ${event.ts} ${event.eventType}${event.metadata ? ` ${JSON.stringify(event.metadata)}` : ""}`);
+    }
+
+    if (positive.length > 0 || negative.length > 0) {
+      if (positive.length > 0) {
+        lines.push("## What worked");
+        for (const l of positive) lines.push(l);
+        lines.push("");
+      }
+      if (negative.length > 0) {
+        lines.push("## What failed");
+        for (const l of negative) lines.push(l);
+        lines.push("");
+      }
+      if (neutral.length > 0) {
+        lines.push("## Other signals");
+        for (const l of neutral) lines.push(l);
+        lines.push("");
+      }
+    } else {
+      // No positive/negative signals — fall back to the pre-D3 flat format for
+      // non-feedback event types (e.g. reflect_invoked, distill_invoked).
+      lines.push("Recent feedback events (most recent last):");
+      for (const event of input.feedback) {
+        const meta = event.metadata ? ` ${JSON.stringify(event.metadata)}` : "";
+        lines.push(`- ${event.ts} ${event.eventType}${meta}`);
+      }
+      lines.push("");
     }
   }
   if (input.rejectedProposals && input.rejectedProposals.length > 0) {
@@ -311,7 +361,6 @@ export function buildDistillPrompt(input: BuildPromptInput): string {
       }
     }
   }
-  lines.push("");
   lines.push(`Produce the ${input.proposalKind === "knowledge" ? "knowledge" : "lesson"} markdown file now.`);
   return lines.join("\n");
 }

--- a/tests/distill.test.ts
+++ b/tests/distill.test.ts
@@ -175,13 +175,66 @@ describe("buildDistillPrompt", () => {
     expect(prompt).toContain("(asset is not currently indexed");
   });
 
-  test("formats feedback events compactly", () => {
+  test("D-3: negative signal feedback goes into '## What failed' section", () => {
     const prompt = buildDistillPrompt({
       inputRef: "skill:deploy",
       assetContent: null,
-      feedback: [{ ts: "2026-04-27T00:00:00Z", eventType: "feedback", metadata: { signal: "negative" } }],
+      feedback: [
+        {
+          ts: "2026-04-27T00:00:00Z",
+          eventType: "feedback",
+          metadata: { signal: "negative", reason: "Missed the rollback step" },
+        },
+      ],
     });
-    expect(prompt).toContain('2026-04-27T00:00:00Z feedback {"signal":"negative"}');
+    expect(prompt).toContain("## What failed");
+    expect(prompt).toContain("Missed the rollback step");
+    expect(prompt).not.toContain("## What worked");
+  });
+
+  test("D-3: positive signal feedback goes into '## What worked' section", () => {
+    const prompt = buildDistillPrompt({
+      inputRef: "skill:deploy",
+      assetContent: null,
+      feedback: [
+        {
+          ts: "2026-04-27T00:00:00Z",
+          eventType: "feedback",
+          metadata: { signal: "positive", note: "Deploy succeeded first try" },
+        },
+      ],
+    });
+    expect(prompt).toContain("## What worked");
+    expect(prompt).toContain("Deploy succeeded first try");
+    expect(prompt).not.toContain("## What failed");
+  });
+
+  test("D-3: mixed signals produce both What-worked and What-failed sections", () => {
+    const prompt = buildDistillPrompt({
+      inputRef: "skill:deploy",
+      assetContent: null,
+      feedback: [
+        { ts: "2026-04-26T00:00:00Z", eventType: "feedback", metadata: { signal: "positive", reason: "Quick" } },
+        { ts: "2026-04-27T00:00:00Z", eventType: "feedback", metadata: { signal: "negative", reason: "Broke prod" } },
+      ],
+    });
+    expect(prompt).toContain("## What worked");
+    expect(prompt).toContain("Quick");
+    expect(prompt).toContain("## What failed");
+    expect(prompt).toContain("Broke prod");
+  });
+
+  test("D-3: non-signal events fall back to flat format", () => {
+    // When no positive/negative signals are present, fall back to old format.
+    const prompt = buildDistillPrompt({
+      inputRef: "skill:deploy",
+      assetContent: null,
+      feedback: [{ ts: "2026-04-27T00:00:00Z", eventType: "reflect_invoked", metadata: { profile: "test" } }],
+    });
+    expect(prompt).toContain("Recent feedback events (most recent last):");
+    expect(prompt).toContain("reflect_invoked");
+    expect(prompt).not.toContain("## What failed");
+    expect(prompt).not.toContain("## What worked");
   });
 
   test("uses knowledge wording when targeting knowledge output", () => {
@@ -790,8 +843,9 @@ describe("akmDistill — excludeFeedbackFromRefs (#267)", () => {
     expect(result.outcome).toBe("queued");
     expect(result.filteredFeedbackCount).toBe(0);
     expect(result.feedbackFullyFiltered).toBe(false);
-    expect(receivedPrompt).toContain('"signal":"negative"');
-    expect(receivedPrompt).toContain('"signal":"positive"');
+    // D-3: negative/positive signals now appear in verbal contrast sections.
+    expect(receivedPrompt).toContain("## What failed");
+    expect(receivedPrompt).toContain("## What worked");
   });
 
   test("empty exclusion list is a no-op (no diagnostic fields stamped)", async () => {


### PR DESCRIPTION
## Summary

Fixes #371 — D-3: Restructure distill prompt as What-worked / What-failed contrast

Converts raw JSON event-line feedback in `buildDistillPrompt` into Reflexion-style verbal contrast sections, capturing the +8% AlfWorld lift from arXiv:2303.11366 and ExpeL contrast-based rule-learning from arXiv:2308.10144.

**Changes:** positive signals → `## What worked`, negative → `## What failed`, others → `## Other signals` (fallback to flat format when no signal type present)

## Test plan

- [x] `bun test tests/distill.test.ts` — 41 pass (4 new D-3 contrast tests)
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check src/ tests/` — clean

Part of Epic #399