### PR TITLE
fix(improve): reject-aware distill cooldown after proposal_rejected event (#370)

### DIFF
--- a/src/commands/improve.ts
+++ b/src/commands/improve.ts
@@ -1531,6 +1531,42 @@ async function runImproveLoopStage(args: {
             info(`[improve] ${completedCount}/${loopRefs.length} ${planned.ref}`);
             continue;
           }
+
+          // D-2 (#370): reject-aware cooldown for distill. When the reviewer
+          // recently rejected a distilled lesson or knowledge proposal for this
+          // asset, skip re-distillation for DISTILL_REJECT_COOLDOWN_DAYS.
+          // Prevents the same rejected proposal from returning the next day.
+          // References: ExpeL arXiv:2308.10144, STaR arXiv:2203.14465.
+          const DISTILL_REJECT_COOLDOWN_MS = daysToMs(options.distillCooldownDays ?? 30);
+          const recentlyRejectedLesson =
+            DISTILL_REJECT_COOLDOWN_MS > 0 &&
+            !explicitRefScope && // O-2: bypass when --scope <ref> is explicit
+            (rejectedProposalsByRef.has(lessonRef) || rejectedProposalsByRef.has(knowledgeRef));
+          if (recentlyRejectedLesson) {
+            const rejectedEntry = rejectedProposalsByRef.get(lessonRef) ?? rejectedProposalsByRef.get(knowledgeRef);
+            const rejectedAgeMs = rejectedEntry ? Date.now() - new Date(rejectedEntry.ts).getTime() : 0;
+            if (rejectedAgeMs < DISTILL_REJECT_COOLDOWN_MS) {
+              actions.push({
+                ref: planned.ref,
+                mode: "distill-skipped",
+                result: { ok: true, reason: "distill reject cooldown" },
+              });
+              appendEvent(
+                {
+                  eventType: "improve_skipped",
+                  ref: planned.ref,
+                  metadata: {
+                    reason: "distill_reject_cooldown",
+                    cooldownDays: options.distillCooldownDays ?? 30,
+                  },
+                },
+                eventsCtx,
+              );
+              completedCount++;
+              info(`[improve] ${completedCount}/${loopRefs.length} ${planned.ref}`);
+              continue;
+            }
+          }
         }
 
         const distillResult = await distillFn({

--- a/tests/commands/improve-memory.test.ts
+++ b/tests/commands/improve-memory.test.ts
@@ -1424,45 +1424,21 @@ describe("O-2: --scope <ref> bypasses reflect/distill cooldowns (#365)", () => {
 
     const reflectedRefs: string[] = [];
     const now = Date.now();
-    // Simulate recent reflect_invoked that would normally trigger the cooldown.
     appendEvent({ eventType: "reflect_invoked", ref: "memory:auth-tips" }, { now: () => now - 60 * 1000 });
 
     await akmImprove({
-      // scope "ref" targeting the cooled ref — should bypass cooldown.
       scope: "memory:auth-tips",
       stashDir,
       reflectCooldownDays: 7,
       ensureIndexFn: async () => false,
-      reindexFn: async () => ({
-        schemaVersion: 1,
-        ok: true,
-        indexed: 0,
-        warnings: [],
-        errors: [],
-        durationMs: 0,
-      }),
+      reindexFn: async () => ({ schemaVersion: 1, ok: true, indexed: 0, warnings: [], errors: [], durationMs: 0 }),
       reflectFn: async ({ ref }) => {
         if (ref) reflectedRefs.push(ref);
-        return {
-          schemaVersion: 1,
-          ok: true,
-          proposal: makeProposal(ref ?? "memory:missing"),
-          ref: ref ?? "",
-          agentProfile: "test",
-          durationMs: 1,
-        } satisfies AkmReflectResult;
+        return { schemaVersion: 1, ok: true, proposal: makeProposal(ref ?? "memory:missing"), ref: ref ?? "", agentProfile: "test", durationMs: 1 } satisfies AkmReflectResult;
       },
-      distillFn: async ({ ref }) =>
-        ({
-          schemaVersion: 1,
-          ok: true,
-          outcome: "queued",
-          inputRef: ref,
-          lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson`,
-        }) satisfies AkmDistillResult,
+      distillFn: async ({ ref }) => ({ schemaVersion: 1, ok: true, outcome: "queued", inputRef: ref, lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson` }) satisfies AkmDistillResult,
     });
 
-    // With scope-ref bypass, the ref should have been reflected despite cooldown.
     expect(reflectedRefs).toContain("memory:auth-tips");
   });
 
@@ -1473,45 +1449,21 @@ describe("O-2: --scope <ref> bypasses reflect/distill cooldowns (#365)", () => {
 
     const reflectedRefs: string[] = [];
     const now = Date.now();
-    // Simulate recent reflect_invoked for the ref.
     appendEvent({ eventType: "reflect_invoked", ref: "memory:auth-tips-2" }, { now: () => now - 60 * 1000 });
 
     await akmImprove({
-      // scope "type" (memory) — cooldown should still apply.
       scope: "memory",
       stashDir,
       reflectCooldownDays: 7,
       ensureIndexFn: async () => false,
-      reindexFn: async () => ({
-        schemaVersion: 1,
-        ok: true,
-        indexed: 0,
-        warnings: [],
-        errors: [],
-        durationMs: 0,
-      }),
+      reindexFn: async () => ({ schemaVersion: 1, ok: true, indexed: 0, warnings: [], errors: [], durationMs: 0 }),
       reflectFn: async ({ ref }) => {
         if (ref) reflectedRefs.push(ref);
-        return {
-          schemaVersion: 1,
-          ok: true,
-          proposal: makeProposal(ref ?? "memory:missing"),
-          ref: ref ?? "",
-          agentProfile: "test",
-          durationMs: 1,
-        } satisfies AkmReflectResult;
+        return { schemaVersion: 1, ok: true, proposal: makeProposal(ref ?? "memory:missing"), ref: ref ?? "", agentProfile: "test", durationMs: 1 } satisfies AkmReflectResult;
       },
-      distillFn: async ({ ref }) =>
-        ({
-          schemaVersion: 1,
-          ok: true,
-          outcome: "queued",
-          inputRef: ref,
-          lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson`,
-        }) satisfies AkmDistillResult,
+      distillFn: async ({ ref }) => ({ schemaVersion: 1, ok: true, outcome: "queued", inputRef: ref, lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson` }) satisfies AkmDistillResult,
     });
 
-    // Without scope-ref bypass, the cooled ref should NOT be reflected.
     expect(reflectedRefs).not.toContain("memory:auth-tips-2");
   });
 });
@@ -1531,36 +1483,14 @@ describe("O-1: wall-clock budget AbortSignal propagated to sub-calls (#364)", ()
       stashDir,
       timeoutMs: 60_000,
       ensureIndexFn: async () => false,
-      reindexFn: async () => ({
-        schemaVersion: 1,
-        ok: true,
-        indexed: 0,
-        warnings: [],
-        errors: [],
-        durationMs: 0,
-      }),
+      reindexFn: async () => ({ schemaVersion: 1, ok: true, indexed: 0, warnings: [], errors: [], durationMs: 0 }),
       reflectFn: async (opts) => {
         capturedTimeouts.push(opts.timeoutMs);
-        return {
-          schemaVersion: 1,
-          ok: true,
-          proposal: makeProposal(opts.ref ?? "memory:budget-test"),
-          ref: opts.ref ?? "",
-          agentProfile: "test",
-          durationMs: 1,
-        } satisfies AkmReflectResult;
+        return { schemaVersion: 1, ok: true, proposal: makeProposal(opts.ref ?? "memory:budget-test"), ref: opts.ref ?? "", agentProfile: "test", durationMs: 1 } satisfies AkmReflectResult;
       },
-      distillFn: async ({ ref }) =>
-        ({
-          schemaVersion: 1,
-          ok: true,
-          outcome: "queued",
-          inputRef: ref,
-          lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson`,
-        }) satisfies AkmDistillResult,
+      distillFn: async ({ ref }) => ({ schemaVersion: 1, ok: true, outcome: "queued", inputRef: ref, lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson` }) satisfies AkmDistillResult,
     });
 
-    // reflectFn should have been called with a positive timeoutMs bounded by the budget.
     expect(capturedTimeouts.length).toBeGreaterThan(0);
     const firstTimeout = capturedTimeouts[0];
     expect(firstTimeout).toBeDefined();
@@ -1578,31 +1508,89 @@ describe("O-1: wall-clock budget AbortSignal propagated to sub-calls (#364)", ()
       stashDir,
       timeoutMs: 5_000,
       ensureIndexFn: async () => false,
-      reindexFn: async () => ({
-        schemaVersion: 1,
-        ok: true,
-        indexed: 0,
-        warnings: [],
-        errors: [],
-        durationMs: 0,
-      }),
+      reindexFn: async () => ({ schemaVersion: 1, ok: true, indexed: 0, warnings: [], errors: [], durationMs: 0 }),
       reflectFn: async (opts) => ({
-        schemaVersion: 1,
-        ok: true,
+        schemaVersion: 1, ok: true,
         proposal: makeProposal(opts.ref ?? "memory:timer-test"),
-        ref: opts.ref ?? "",
-        agentProfile: "test",
-        durationMs: 1,
+        ref: opts.ref ?? "", agentProfile: "test", durationMs: 1,
       }),
       distillFn: async ({ ref }) => ({
-        schemaVersion: 1,
-        ok: true,
-        outcome: "queued",
-        inputRef: ref,
+        schemaVersion: 1, ok: true, outcome: "queued", inputRef: ref,
         lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson`,
       }),
     });
 
     expect(result.ok).toBe(true);
+  });
+});
+
+// ── D-2 / #370 — reject-aware distill cooldown ───────────────────────────────
+
+describe("D-2: reject-aware cooldown for distill (#370)", () => {
+  test("distill is skipped when the lesson for an asset was recently rejected", async () => {
+    const stashDir = makeTempDir("akm-d2-reject-cooldown-");
+    writeMemory(stashDir, "auth-tips", { description: "auth memory" }, "Auth tips content.");
+    await buildIndex(stashDir);
+
+    const distilledRefs: string[] = [];
+    const now = Date.now();
+    appendEvent(
+      { eventType: "proposal_rejected", ref: "lesson:memory-auth-tips-lesson", metadata: { reason: "Too generic" } },
+      { now: () => now - 60 * 1000 },
+    );
+
+    const result = await akmImprove({
+      scope: "memory",
+      stashDir,
+      distillCooldownDays: 30,
+      ensureIndexFn: async () => false,
+      reindexFn: async () => ({ schemaVersion: 1, ok: true, indexed: 0, warnings: [], errors: [], durationMs: 0 }),
+      reflectFn: async ({ ref }) => ({
+        schemaVersion: 1, ok: true,
+        proposal: makeProposal(ref ?? "memory:auth-tips"),
+        ref: ref ?? "", agentProfile: "test", durationMs: 1,
+      }),
+      distillFn: async ({ ref }) => {
+        if (ref) distilledRefs.push(ref);
+        return { schemaVersion: 1, ok: true, outcome: "queued", inputRef: ref, lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson` } satisfies AkmDistillResult;
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(distilledRefs).not.toContain("memory:auth-tips");
+    const distillSkipped = result.actions?.find((a) => a.ref === "memory:auth-tips" && a.mode === "distill-skipped");
+    expect(distillSkipped).toBeDefined();
+  });
+
+  test("D-2: --scope <ref> bypasses distill reject cooldown (O-2 interaction)", async () => {
+    const stashDir = makeTempDir("akm-d2-scope-bypass-");
+    writeMemory(stashDir, "auth-tips", { description: "auth memory" }, "Auth tips content.");
+    await buildIndex(stashDir);
+
+    const distilledRefs: string[] = [];
+    const now = Date.now();
+    appendEvent(
+      { eventType: "proposal_rejected", ref: "lesson:memory-auth-tips-lesson", metadata: { reason: "Too generic" } },
+      { now: () => now - 60 * 1000 },
+    );
+
+    await akmImprove({
+      scope: "memory:auth-tips",
+      stashDir,
+      distillCooldownDays: 30,
+      ensureIndexFn: async () => false,
+      reindexFn: async () => ({ schemaVersion: 1, ok: true, indexed: 0, warnings: [], errors: [], durationMs: 0 }),
+      reflectFn: async ({ ref }) => ({
+        schemaVersion: 1, ok: true,
+        proposal: makeProposal(ref ?? "memory:auth-tips"),
+        ref: ref ?? "", agentProfile: "test", durationMs: 1,
+      }),
+      distillFn: async ({ ref }) => {
+        if (ref) distilledRefs.push(ref);
+        return { schemaVersion: 1, ok: true, outcome: "queued", inputRef: ref, lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson` } satisfies AkmDistillResult;
+      },
+    });
+
+    expect(distilledRefs).toContain("memory:auth-tips");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #370 — D-2: Reject-aware cooldown for distill (proposal_rejected event)

Extends the distill dedup gate to check `rejectedProposalsByRef` for the derived lesson/knowledge ref. A reviewer rejection now triggers a cooldown (defaults to `distillCooldownDays ?? 30`) preventing the same proposal from re-appearing the next day. Bypassed when `scope.mode === "ref"` (O-2 interaction).

## Test plan

- [x] `bun test tests/commands/improve-memory.test.ts` — 19 pass (2 new D-2 tests)
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check src/ tests/` — clean

Part of Epic #399