### PR TITLE
feat(memory): LLM contradiction-detection pass writing contradictedBy edges (#367)

### DIFF
--- a/src/commands/improve.ts
+++ b/src/commands/improve.ts
@@ -8,6 +8,7 @@ import { loadConfig } from "../core/config";
 import { ConfigError, NotFoundError, UsageError } from "../core/errors";
 import { appendEvent, type EventEnvelope, type EventsContext, readEvents } from "../core/events";
 import { parseFrontmatter } from "../core/frontmatter";
+import { detectAndWriteContradictions } from "../core/memory-contradiction-detect";
 import {
   type ArchivedMemoryCleanupRecord,
   analyzeMemoryCleanup,
@@ -440,6 +441,20 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
     primaryStashDir = undefined;
   }
   const cleanupParentRef = memoryCleanupParentRef(scope, options.stashDir);
+
+  // M-1 (#367): Run contradiction-detection BEFORE analyzeMemoryCleanup so
+  // the SCC resolver in resolveFamilyContradictions has edges to work on.
+  // Best-effort: failures are warnings, never fatal.
+  if (primaryStashDir && shouldAnalyzeMemoryCleanup(scope, memorySummary.eligible, primaryStashDir)) {
+    try {
+      const config = options.config ?? loadConfig();
+      await detectAndWriteContradictions(primaryStashDir, config);
+    } catch (err) {
+      // Non-fatal: contradiction detection is a best-effort pass.
+      warn(`[improve] contradiction detection failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
   const memoryCleanupPlan = shouldAnalyzeMemoryCleanup(scope, memorySummary.eligible, primaryStashDir)
     ? analyzeMemoryCleanup(primaryStashDir as string, cleanupParentRef ? { parentRef: cleanupParentRef } : undefined)
     : undefined;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -147,6 +147,14 @@ export interface LlmFeatureFlags {
    * returning an empty enrichment object (no description/searchHints/tags update).
    */
   metadata_enhance?: boolean;
+  /**
+   * Gates the M-1 contradiction-detection pass in `akm improve` (#367).
+   * Default: false. When enabled, derived memories within the same parent family
+   * are checked pairwise for contradictions using an LLM judge, and
+   * `contradictedBy` edges are written to their frontmatter so the SCC resolver
+   * in `resolveFamilyContradictions` has edges to work on.
+   */
+  memory_contradiction_detection?: boolean;
 }
 
 export interface RegistryConfigEntry {

--- a/src/core/memory-contradiction-detect.ts
+++ b/src/core/memory-contradiction-detect.ts
@@ -1,0 +1,316 @@
+/**
+ * LLM-based contradiction-detection pass for derived memories (M-1 / #367).
+ *
+ * Runs BEFORE `analyzeMemoryCleanup` to populate `contradictedBy` frontmatter
+ * edges so the existing `resolveFamilyContradictions` SCC resolver has real
+ * input to work on. Without this pass the SCC resolver operates on a nearly
+ * empty edge graph because no automated subsystem was previously generating
+ * contradiction edges — the elegant Tarjan implementation in memory-improve.ts
+ * had no input.
+ *
+ * # Algorithm
+ *
+ *   1. Collect all derived memories grouped by `parentRef` family.
+ *   2. For each family, enumerate candidate pairs (limited to MAX_FAMILY_SIZE).
+ *   3. For each pair, call the LLM to judge whether the two memories are in
+ *      direct factual conflict.
+ *   4. For confirmed contradictions, write `contradictedBy` edges directly to
+ *      the losing memory's frontmatter (same mechanism as `persistBeliefStateTransition`).
+ *
+ * # LLM Feature Gate
+ *
+ * The pass is gated behind `memory_contradiction_detection` in
+ * `config.llm.features`. When the gate is disabled or no LLM is configured,
+ * the pass is a no-op and `analyzeMemoryCleanup` proceeds with only manually
+ * annotated edges.
+ *
+ * # References
+ *
+ * - Zep / Graphiti (arXiv:2501.13956): writes contradiction edges at detection time.
+ * - ATMS (de Kleer 1986): assumption-based truth maintenance via edge propagation.
+ * - mem0 contradiction probe (arXiv:2504.19413): pairwise LLM-judge pattern.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { stringify as yamlStringify } from "yaml";
+import { type ChatMessage, chatCompletion, parseEmbeddedJsonResponse } from "../llm/client";
+import { tryLlmFeature } from "../llm/feature-gate";
+import type { AkmConfig, LlmConnectionConfig } from "./config";
+import { parseFrontmatter } from "./frontmatter";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * Maximum family size for pairwise contradiction checking. Families larger
+ * than this are skipped to bound the LLM call count (O(n²) pairs).
+ */
+const MAX_FAMILY_SIZE = 8;
+
+/**
+ * Maximum number of contradiction pairs to check per improve run, across all
+ * families. Prevents runaway LLM usage on stashes with many memories.
+ */
+const MAX_PAIRS_PER_RUN = 20;
+
+/**
+ * Truncation limit for memory body content sent to the LLM judge.
+ * Keeps prompts compact while preserving the key factual claims.
+ */
+const BODY_TRUNCATION = 800;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface ContradictionDetectionResult {
+  /** Number of derived memory families examined. */
+  familiesExamined: number;
+  /** Number of pairwise LLM contradiction checks performed. */
+  pairsChecked: number;
+  /** Number of contradiction edges written to frontmatter. */
+  edgesWritten: number;
+  /** Warnings generated during detection (e.g. LLM failures, parse errors). */
+  warnings: string[];
+}
+
+interface DerivedMemoryEntry {
+  filePath: string;
+  ref: string;
+  parentRef: string;
+  body: string;
+  description: string;
+}
+
+// ── Prompt builder ────────────────────────────────────────────────────────────
+
+function buildContradictionJudgePrompt(a: DerivedMemoryEntry, b: DerivedMemoryEntry): string {
+  return [
+    "You are evaluating two derived memory entries to determine if they contain",
+    "directly contradictory factual claims about the same subject.",
+    "",
+    "Memory A:",
+    `Ref: ${a.ref}`,
+    `Description: ${a.description || "(none)"}`,
+    "Content:",
+    "```",
+    a.body.slice(0, BODY_TRUNCATION),
+    "```",
+    "",
+    "Memory B:",
+    `Ref: ${b.ref}`,
+    `Description: ${b.description || "(none)"}`,
+    "Content:",
+    "```",
+    b.body.slice(0, BODY_TRUNCATION),
+    "```",
+    "",
+    "Answer ONLY with valid JSON — no prose, no code fences:",
+    '{"contradicts": true|false, "reason": "<one sentence explaining why or why not>"}',
+    "",
+    "A contradiction means the memories make mutually exclusive factual claims about the",
+    "same topic (e.g. Memory A says 'always use VPN' while Memory B says 'VPN is optional').",
+    "If the memories are complementary, about different topics, or one supersedes the other",
+    "without direct conflict, return false.",
+  ].join("\n");
+}
+
+// ── Filesystem helpers ────────────────────────────────────────────────────────
+
+function* walkMarkdownFilesLocal(root: string): Generator<string> {
+  if (!fs.existsSync(root)) return;
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) yield* walkMarkdownFilesLocal(full);
+    else if (entry.isFile() && entry.name.endsWith(".md")) yield full;
+  }
+}
+
+function toMemoryRef(memoriesDir: string, filePath: string): string | undefined {
+  const rel = path.relative(memoriesDir, filePath);
+  if (!rel || rel.startsWith("..")) return undefined;
+  const name = rel.replace(/\\/g, "/").replace(/\.md$/i, "");
+  return `memory:${name}`;
+}
+
+function isDerivedMemory(filePath: string, frontmatter: Record<string, unknown>): boolean {
+  // Name-based guard (M-2): the .derived suffix is structural and immutable.
+  const base = path.basename(filePath, ".md");
+  if (base.endsWith(".derived")) return true;
+  // Frontmatter-based guard: inferred: true marks explicit child memories.
+  return frontmatter.inferred === true;
+}
+
+function resolveParentRef(filePath: string, frontmatter: Record<string, unknown>): string | undefined {
+  // Prefer the explicit source: frontmatter.
+  const source = frontmatter.source;
+  if (typeof source === "string" && source.startsWith("memory:")) return source;
+  // Fall back to deriving parent from the file name (strip .derived suffix).
+  const base = path.basename(filePath, ".md");
+  if (base.endsWith(".derived")) {
+    const parentName = base.slice(0, -".derived".length);
+    const dir = path.dirname(filePath);
+    const memoriesDir = path.dirname(dir) === dir ? dir : path.dirname(filePath);
+    const rel = path.relative(memoriesDir, path.join(path.dirname(filePath), parentName));
+    return `memory:${rel.replace(/\\/g, "/")}`;
+  }
+  return undefined;
+}
+
+// ── Edge writing ─────────────────────────────────────────────────────────────
+
+/**
+ * Write a `contradictedBy` edge to the losing memory's frontmatter file.
+ * Preserves all existing frontmatter keys; only adds/updates `contradictedBy`
+ * and `beliefState: contradicted`.
+ */
+function writeContradictedByEdge(filePath: string, contradictedByRef: string): void {
+  const raw = fs.readFileSync(filePath, "utf8");
+  const parsed = parseFrontmatter(raw);
+
+  const existing: string[] = Array.isArray(parsed.data.contradictedBy) ? (parsed.data.contradictedBy as string[]) : [];
+  if (existing.includes(contradictedByRef)) return; // Edge already written.
+
+  const updatedContradictedBy = [...new Set([...existing, contradictedByRef])].sort();
+  const nextFrontmatter: Record<string, unknown> = {
+    ...parsed.data,
+    contradictedBy: updatedContradictedBy,
+    beliefState: "contradicted",
+  };
+
+  const fmStr = yamlStringify(nextFrontmatter).trimEnd();
+  const body = parsed.content;
+  const next = `---\n${fmStr}\n---\n${body}`;
+  fs.writeFileSync(filePath, next, "utf8");
+}
+
+// ── Main entry point ──────────────────────────────────────────────────────────
+
+/**
+ * Run the LLM-based contradiction-detection pass on derived memories in
+ * `<stashDir>/memories/`. Writes `contradictedBy` frontmatter edges for
+ * confirmed contradiction pairs so the subsequent `resolveFamilyContradictions`
+ * SCC pass has edges to work on.
+ *
+ * @param stashDir - Root stash directory.
+ * @param config   - Loaded AKM config (used to access LLM settings).
+ * @param chat     - Optional chat seam for testing (defaults to chatCompletion).
+ */
+export async function detectAndWriteContradictions(
+  stashDir: string,
+  config: AkmConfig,
+  chat: (llmConfig: LlmConnectionConfig, messages: ChatMessage[]) => Promise<string> = chatCompletion,
+): Promise<ContradictionDetectionResult> {
+  const result: ContradictionDetectionResult = {
+    familiesExamined: 0,
+    pairsChecked: 0,
+    edgesWritten: 0,
+    warnings: [],
+  };
+
+  if (!config.llm) return result;
+
+  // Collect derived memories grouped by parent.
+  const memoriesDir = path.join(stashDir, "memories");
+  const byParent = new Map<string, DerivedMemoryEntry[]>();
+
+  for (const filePath of walkMarkdownFilesLocal(memoriesDir)) {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(filePath, "utf8");
+    } catch {
+      continue;
+    }
+    const parsed = parseFrontmatter(raw);
+    if (!isDerivedMemory(filePath, parsed.data)) continue;
+    const parentRef = resolveParentRef(filePath, parsed.data);
+    if (!parentRef) continue;
+    const ref = toMemoryRef(memoriesDir, filePath);
+    if (!ref) continue;
+
+    const entry: DerivedMemoryEntry = {
+      filePath,
+      ref,
+      parentRef,
+      body: parsed.content.trim(),
+      description: typeof parsed.data.description === "string" ? parsed.data.description : "",
+    };
+    const family = byParent.get(parentRef) ?? [];
+    family.push(entry);
+    byParent.set(parentRef, family);
+  }
+
+  let totalPairsChecked = 0;
+
+  for (const [, family] of byParent) {
+    if (family.length < 2) continue;
+    if (family.length > MAX_FAMILY_SIZE) {
+      result.warnings.push(
+        `Skipping contradiction check for family of ${family.length} members (exceeds MAX_FAMILY_SIZE=${MAX_FAMILY_SIZE})`,
+      );
+      continue;
+    }
+
+    result.familiesExamined++;
+
+    for (let i = 0; i < family.length - 1; i++) {
+      for (let j = i + 1; j < family.length; j++) {
+        if (totalPairsChecked >= MAX_PAIRS_PER_RUN) break;
+
+        const a = family[i];
+        const b = family[j];
+        if (!a || !b) continue;
+
+        // Skip pairs where an edge already exists.
+        const aRaw = fs.readFileSync(a.filePath, "utf8");
+        const aParsed = parseFrontmatter(aRaw);
+        const aCB: string[] = Array.isArray(aParsed.data.contradictedBy)
+          ? (aParsed.data.contradictedBy as string[])
+          : [];
+        if (aCB.includes(b.ref)) continue;
+
+        const prompt = buildContradictionJudgePrompt(a, b);
+        const judgeResult = await tryLlmFeature(
+          "memory_contradiction_detection",
+          config,
+          async () => {
+            if (!config.llm) return null;
+            return chat(config.llm, [
+              { role: "system", content: "Return only valid JSON. No prose." },
+              { role: "user", content: prompt },
+            ]);
+          },
+          null, // Fallback: null means "skip" — gate disabled or LLM call failed.
+        );
+
+        totalPairsChecked++;
+        result.pairsChecked++;
+
+        if (!judgeResult) continue; // Feature gate disabled or LLM call failed.
+
+        let parsed: { contradicts: boolean; reason?: string } | null | undefined = null;
+        try {
+          parsed = parseEmbeddedJsonResponse<{ contradicts: boolean; reason?: string }>(judgeResult);
+        } catch {
+          result.warnings.push(`Could not parse contradiction judge response for pair ${a.ref} / ${b.ref}`);
+          continue;
+        }
+
+        if (!parsed?.contradicts) continue;
+
+        // Write contradiction edges: both members get contradictedBy pointing to each other.
+        try {
+          writeContradictedByEdge(a.filePath, b.ref);
+          writeContradictedByEdge(b.filePath, a.ref);
+          result.edgesWritten += 2;
+        } catch (err) {
+          result.warnings.push(
+            `Failed to write contradiction edge ${a.ref} <-> ${b.ref}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+
+      if (totalPairsChecked >= MAX_PAIRS_PER_RUN) break;
+    }
+  }
+
+  return result;
+}

--- a/tests/commands/improve-memory.test.ts
+++ b/tests/commands/improve-memory.test.ts
@@ -1594,3 +1594,96 @@ describe("D-2: reject-aware cooldown for distill (#370)", () => {
     expect(distilledRefs).toContain("memory:auth-tips");
   });
 });
+
+// ── M-1 / #367 — contradiction-detection unit tests ──────────────────────────
+
+describe("M-1: contradiction-detection pass writes contradictedBy edges (#367)", () => {
+  test("detectAndWriteContradictions is a no-op when no LLM is configured", async () => {
+    const { detectAndWriteContradictions } = await import("../../src/core/memory-contradiction-detect");
+    const stashDir = makeTempDir("akm-m1-no-llm-");
+    writeMemory(stashDir, "auth-tips.derived", { inferred: true, source: "memory:auth-tips" }, "Always use VPN.");
+    writeMemory(stashDir, "auth-tips.derived2", { inferred: true, source: "memory:auth-tips" }, "VPN is optional.");
+
+    const result = await detectAndWriteContradictions(stashDir, {
+      stashDir,
+      sources: [{ type: "filesystem", name: "stash", path: stashDir, writable: true }],
+      defaultWriteTarget: "stash",
+      // No llm config — should be a no-op.
+    } as Parameters<typeof detectAndWriteContradictions>[1]);
+
+    // No LLM → no pairs checked → no edges written.
+    expect(result.pairsChecked).toBe(0);
+    expect(result.edgesWritten).toBe(0);
+  });
+
+  test("detectAndWriteContradictions writes contradictedBy edges when LLM judges true", async () => {
+    const { detectAndWriteContradictions } = await import("../../src/core/memory-contradiction-detect");
+    const stashDir = makeTempDir("akm-m1-detect-");
+    writeMemory(stashDir, "auth-tips.derived", { inferred: true, source: "memory:auth-tips" }, "Always use VPN.");
+    writeMemory(
+      stashDir,
+      "auth-tips.derived2",
+      { inferred: true, source: "memory:auth-tips" },
+      "VPN is never required.",
+    );
+
+    const result = await detectAndWriteContradictions(
+      stashDir,
+      {
+        stashDir,
+        sources: [{ type: "filesystem", name: "stash", path: stashDir, writable: true }],
+        defaultWriteTarget: "stash",
+        llm: {
+          endpoint: "http://localhost/v1/chat",
+          model: "test",
+          features: { memory_contradiction_detection: true },
+        },
+      } as Parameters<typeof detectAndWriteContradictions>[1],
+      // Inject a fake chat that always returns "contradicts: true".
+      async () => JSON.stringify({ contradicts: true, reason: "Direct factual conflict about VPN requirement." }),
+    );
+
+    expect(result.pairsChecked).toBe(1);
+    expect(result.edgesWritten).toBe(2); // Both sides get a contradictedBy edge.
+
+    // Verify frontmatter was updated.
+    const file1 = path.join(stashDir, "memories", "auth-tips.derived.md");
+    const file2 = path.join(stashDir, "memories", "auth-tips.derived2.md");
+    const raw1 = fs.readFileSync(file1, "utf8");
+    const raw2 = fs.readFileSync(file2, "utf8");
+    expect(raw1).toContain("contradictedBy");
+    expect(raw2).toContain("contradictedBy");
+    expect(raw1).toContain("auth-tips.derived2");
+    expect(raw2).toContain("auth-tips.derived");
+  });
+
+  test("detectAndWriteContradictions skips pair when LLM judges no contradiction", async () => {
+    const { detectAndWriteContradictions } = await import("../../src/core/memory-contradiction-detect");
+    const stashDir = makeTempDir("akm-m1-no-contradiction-");
+    writeMemory(stashDir, "auth-tips.derived", { inferred: true, source: "memory:auth-tips" }, "Use VPN for prod.");
+    writeMemory(
+      stashDir,
+      "auth-tips.derived2",
+      { inferred: true, source: "memory:auth-tips" },
+      "Enable 2FA before deploys.",
+    );
+
+    const result = await detectAndWriteContradictions(
+      stashDir,
+      {
+        stashDir,
+        sources: [{ type: "filesystem", name: "stash", path: stashDir, writable: true }],
+        defaultWriteTarget: "stash",
+        llm: {
+          endpoint: "http://localhost/v1/chat",
+          model: "test",
+          features: { memory_contradiction_detection: true },
+        },
+      } as Parameters<typeof detectAndWriteContradictions>[1],
+      async () => JSON.stringify({ contradicts: false, reason: "These are complementary security measures." }),
+    );
+
+    expect(result.pairsChecked).toBe(1);
+    expect(result.edgesWritten).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #367 — M-1: Add contradiction-detection pass writing contradictedBy edges

Creates `src/core/memory-contradiction-detect.ts` with `detectAndWriteContradictions` — an LLM-based pairwise contradiction check that populates `contradictedBy` frontmatter edges, activating the existing `resolveFamilyContradictions` SCC resolver that previously had no input.

Feature gate: `memory_contradiction_detection` in `config.llm.features` (default: false). Called in `akmImprove` before `analyzeMemoryCleanup` (best-effort; failures are warnings).

References: Zep/Graphiti arXiv:2501.13956, ATMS de Kleer 1986, mem0 arXiv:2504.19413

## Test plan

- [x] `bun test tests/commands/improve-memory.test.ts` — 20 pass (3 new M-1 unit tests)
- [x] Tests cover: no-LLM no-op, contradiction detected + edges written, no-contradiction skips
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check src/ tests/` — clean

Part of Epic #399