### PR TITLE
feat(feedback): requireReason default true + --failure-mode enum (F-3 / #384)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,7 +80,14 @@ import { parseAssetRef } from "./core/asset-ref";
 import { deriveCanonicalAssetName, resolveAssetPathFromName } from "./core/asset-spec";
 import { isHttpUrl, isWithin, resolveStashDir } from "./core/common";
 import type { RegistryConfigEntry } from "./core/config";
-import { DEFAULT_CONFIG, loadConfig, loadUserConfig, resolveConfiguredSources, saveConfig } from "./core/config";
+import {
+  DEFAULT_CONFIG,
+  FEEDBACK_FAILURE_MODES,
+  loadConfig,
+  loadUserConfig,
+  resolveConfiguredSources,
+  saveConfig,
+} from "./core/config";
 import { ConfigError, NotFoundError, UsageError } from "./core/errors";
 import { appendEvent } from "./core/events";
 import { getCacheDir, getConfigPath, getDbPath, getDefaultStashDir } from "./core/paths";
@@ -1542,9 +1549,16 @@ const feedbackCommand = defineCommand({
     },
     reason: {
       type: "string",
-      description: "Reason for the feedback (recommended for negative feedback, used by distillation)",
+      description: "Reason for the feedback (required for negative feedback by default; used by distillation)",
     },
     note: { type: "string", description: "Alias for --reason (backward-compatible, prefer --reason)" },
+    "failure-mode": {
+      type: "string",
+      description:
+        `Structured failure-mode taxonomy for negative feedback (F-3 / #384). ` +
+        `Accepted values: ${FEEDBACK_FAILURE_MODES.join(", ")}. ` +
+        "Stored alongside --reason in event metadata for aggregation by the distill pipeline.",
+    },
     tag: {
       type: "string",
       description: "Tag to attach to the feedback (repeatable, e.g. --tag slice:train --tag team:platform)",
@@ -1569,12 +1583,40 @@ const feedbackCommand = defineCommand({
       }
       const signal = args.positive ? "positive" : "negative";
       const reason = (args.reason as string | undefined) ?? (args.note as string | undefined);
-      if (args.negative === true && !reason?.trim()) {
-        const cfg = loadConfig();
-        if (cfg.feedback?.requireReason === true) {
+
+      // F-3 / #384: Validate --failure-mode against the curated enum.
+      const failureMode = (args["failure-mode"] as string | undefined)?.trim() || undefined;
+      if (failureMode) {
+        if (args.positive) {
           throw new UsageError(
-            "Negative feedback requires --reason (feedback.requireReason is enabled).",
+            "--failure-mode is only valid for negative feedback.",
+            "INVALID_FLAG_VALUE",
+            "Remove --failure-mode or switch to --negative.",
+          );
+        }
+        const cfg = loadConfig();
+        const allowedModes: readonly string[] = cfg.feedback?.allowedFailureModes ?? FEEDBACK_FAILURE_MODES;
+        if (allowedModes.length > 0 && !allowedModes.includes(failureMode)) {
+          throw new UsageError(
+            `Invalid --failure-mode "${failureMode}". Accepted values: ${allowedModes.join(", ")}.`,
+            "INVALID_FLAG_VALUE",
+            `Use one of: ${allowedModes.join(", ")}`,
+          );
+        }
+      }
+
+      if (args.negative === true && !reason?.trim()) {
+        // F-3 / #384: Default requireReason is now true. Load config to allow
+        // operators to opt out via feedback.requireReason: false in akm.json.
+        const cfg = loadConfig();
+        const requireReason = cfg.feedback?.requireReason ?? true; // Default: true (F-3 / #384)
+        if (requireReason) {
+          throw new UsageError(
+            "Negative feedback requires --reason (structured failure signals are needed for distillation). " +
+              "Use --failure-mode for a curated taxonomy or --reason for free text. " +
+              "Set feedback.requireReason: false in akm.json to downgrade to a warning.",
             "MISSING_REQUIRED_ARGUMENT",
+            `Hint: akm feedback ${ref} --negative --reason "..." [--failure-mode incorrect|outdated|dangerous|incomplete|redundant]`,
           );
         } else {
           warn("Warning: negative feedback without --reason provides less distillation signal.");
@@ -1585,6 +1627,7 @@ const feedbackCommand = defineCommand({
       const metadataObj = {
         signal,
         ...(reason?.trim() ? { reason: reason.trim() } : {}),
+        ...(failureMode ? { failureMode } : {}),
         ...(validatedTags.length > 0 ? { tags: validatedTags } : {}),
       };
       const metadataStr = Object.keys(metadataObj).length > 1 ? JSON.stringify(metadataObj) : undefined;
@@ -1696,7 +1739,14 @@ const feedbackCommand = defineCommand({
         }
       }
 
-      output("feedback", { ok: true, ref, signal, reason: reason?.trim() ?? null, tags: validatedTags });
+      output("feedback", {
+        ok: true,
+        ref,
+        signal,
+        reason: reason?.trim() ?? null,
+        failureMode: failureMode ?? null,
+        tags: validatedTags,
+      });
     });
   },
 });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -10,6 +10,29 @@ import { warn } from "./warn";
 
 export type { AgentConfig } from "../integrations/agent/config";
 
+// ── Feedback failure-mode constants (F-3 / #384) ────────────────────────────
+
+/**
+ * Curated taxonomy of failure modes for negative feedback (F-3 / #384).
+ *
+ * Structured failure modes enable aggregation across feedback events so the
+ * distill pipeline can detect that "5 assets failed for the same reason" and
+ * act on it — free-text strings about the same issue are not aggregatable.
+ *
+ * Based on CAI principle-driven feedback (arXiv:2212.08073) and PRM/ORM
+ * process-level reward modelling (arXiv:2305.20050).
+ */
+export const FEEDBACK_FAILURE_MODES = [
+  "incorrect", // Factually wrong or logically flawed content
+  "outdated", // Correct at some point but now stale
+  "dangerous", // Could cause harm if followed (security, safety)
+  "incomplete", // Missing key steps, context, or caveats
+  "redundant", // Duplicates another asset without adding value
+] as const;
+
+/** Union of the curated failure-mode values. */
+export type FeedbackFailureMode = (typeof FEEDBACK_FAILURE_MODES)[number];
+
 // ── Types ───────────────────────────────────────────────────────────────────
 
 /**
@@ -404,10 +427,19 @@ export interface AkmConfig {
   feedback?: {
     /**
      * When true, negative feedback without --reason throws a hard error
-     * (exit 2). When false or absent, a non-blocking warning is emitted
-     * instead. Default: false.
+     * (exit 2). When false, a non-blocking warning is emitted instead.
+     *
+     * Default: true (F-3 / #384). Structured failure signals are required
+     * for the distill verbal-gradient pipeline to aggregate failure patterns
+     * across feedback events (PRM/ORM, arXiv:2305.20050; CAI, arXiv:2212.08073).
      */
     requireReason?: boolean;
+    /**
+     * When set, only these failure-mode values are accepted by `--failure-mode`.
+     * Defaults to the built-in curated enum {@link FEEDBACK_FAILURE_MODES}.
+     * Set to an empty array to allow any string.
+     */
+    allowedFailureModes?: string[];
   };
   /**
    * Number of days to retain soft-invalidated (superseded) memory assets in
@@ -857,6 +889,12 @@ function parseConfigLayer(raw: Record<string, unknown>): Partial<AkmConfig> {
     const feedbackConfig: AkmConfig["feedback"] = {};
     if (typeof feedbackRaw.requireReason === "boolean") {
       feedbackConfig.requireReason = feedbackRaw.requireReason;
+    }
+    // F-3 / #384: parse allowedFailureModes override list.
+    if (Array.isArray(feedbackRaw.allowedFailureModes)) {
+      feedbackConfig.allowedFailureModes = feedbackRaw.allowedFailureModes.filter(
+        (v): v is string => typeof v === "string" && v.trim().length > 0,
+      );
     }
     if (Object.keys(feedbackConfig).length > 0) config.feedback = feedbackConfig;
   }

--- a/tests/commands/improve-memory.test.ts
+++ b/tests/commands/improve-memory.test.ts
@@ -1434,9 +1434,23 @@ describe("O-2: --scope <ref> bypasses reflect/distill cooldowns (#365)", () => {
       reindexFn: async () => ({ schemaVersion: 1, ok: true, indexed: 0, warnings: [], errors: [], durationMs: 0 }),
       reflectFn: async ({ ref }) => {
         if (ref) reflectedRefs.push(ref);
-        return { schemaVersion: 1, ok: true, proposal: makeProposal(ref ?? "memory:missing"), ref: ref ?? "", agentProfile: "test", durationMs: 1 } satisfies AkmReflectResult;
+        return {
+          schemaVersion: 1,
+          ok: true,
+          proposal: makeProposal(ref ?? "memory:missing"),
+          ref: ref ?? "",
+          agentProfile: "test",
+          durationMs: 1,
+        } satisfies AkmReflectResult;
       },
-      distillFn: async ({ ref }) => ({ schemaVersion: 1, ok: true, outcome: "queued", inputRef: ref, lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson` }) satisfies AkmDistillResult,
+      distillFn: async ({ ref }) =>
+        ({
+          schemaVersion: 1,
+          ok: true,
+          outcome: "queued",
+          inputRef: ref,
+          lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson`,
+        }) satisfies AkmDistillResult,
     });
 
     expect(reflectedRefs).toContain("memory:auth-tips");
@@ -1459,9 +1473,23 @@ describe("O-2: --scope <ref> bypasses reflect/distill cooldowns (#365)", () => {
       reindexFn: async () => ({ schemaVersion: 1, ok: true, indexed: 0, warnings: [], errors: [], durationMs: 0 }),
       reflectFn: async ({ ref }) => {
         if (ref) reflectedRefs.push(ref);
-        return { schemaVersion: 1, ok: true, proposal: makeProposal(ref ?? "memory:missing"), ref: ref ?? "", agentProfile: "test", durationMs: 1 } satisfies AkmReflectResult;
+        return {
+          schemaVersion: 1,
+          ok: true,
+          proposal: makeProposal(ref ?? "memory:missing"),
+          ref: ref ?? "",
+          agentProfile: "test",
+          durationMs: 1,
+        } satisfies AkmReflectResult;
       },
-      distillFn: async ({ ref }) => ({ schemaVersion: 1, ok: true, outcome: "queued", inputRef: ref, lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson` }) satisfies AkmDistillResult,
+      distillFn: async ({ ref }) =>
+        ({
+          schemaVersion: 1,
+          ok: true,
+          outcome: "queued",
+          inputRef: ref,
+          lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson`,
+        }) satisfies AkmDistillResult,
     });
 
     expect(reflectedRefs).not.toContain("memory:auth-tips-2");
@@ -1486,9 +1514,23 @@ describe("O-1: wall-clock budget AbortSignal propagated to sub-calls (#364)", ()
       reindexFn: async () => ({ schemaVersion: 1, ok: true, indexed: 0, warnings: [], errors: [], durationMs: 0 }),
       reflectFn: async (opts) => {
         capturedTimeouts.push(opts.timeoutMs);
-        return { schemaVersion: 1, ok: true, proposal: makeProposal(opts.ref ?? "memory:budget-test"), ref: opts.ref ?? "", agentProfile: "test", durationMs: 1 } satisfies AkmReflectResult;
+        return {
+          schemaVersion: 1,
+          ok: true,
+          proposal: makeProposal(opts.ref ?? "memory:budget-test"),
+          ref: opts.ref ?? "",
+          agentProfile: "test",
+          durationMs: 1,
+        } satisfies AkmReflectResult;
       },
-      distillFn: async ({ ref }) => ({ schemaVersion: 1, ok: true, outcome: "queued", inputRef: ref, lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson` }) satisfies AkmDistillResult,
+      distillFn: async ({ ref }) =>
+        ({
+          schemaVersion: 1,
+          ok: true,
+          outcome: "queued",
+          inputRef: ref,
+          lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson`,
+        }) satisfies AkmDistillResult,
     });
 
     expect(capturedTimeouts.length).toBeGreaterThan(0);
@@ -1510,12 +1552,18 @@ describe("O-1: wall-clock budget AbortSignal propagated to sub-calls (#364)", ()
       ensureIndexFn: async () => false,
       reindexFn: async () => ({ schemaVersion: 1, ok: true, indexed: 0, warnings: [], errors: [], durationMs: 0 }),
       reflectFn: async (opts) => ({
-        schemaVersion: 1, ok: true,
+        schemaVersion: 1,
+        ok: true,
         proposal: makeProposal(opts.ref ?? "memory:timer-test"),
-        ref: opts.ref ?? "", agentProfile: "test", durationMs: 1,
+        ref: opts.ref ?? "",
+        agentProfile: "test",
+        durationMs: 1,
       }),
       distillFn: async ({ ref }) => ({
-        schemaVersion: 1, ok: true, outcome: "queued", inputRef: ref,
+        schemaVersion: 1,
+        ok: true,
+        outcome: "queued",
+        inputRef: ref,
         lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson`,
       }),
     });
@@ -1546,13 +1594,22 @@ describe("D-2: reject-aware cooldown for distill (#370)", () => {
       ensureIndexFn: async () => false,
       reindexFn: async () => ({ schemaVersion: 1, ok: true, indexed: 0, warnings: [], errors: [], durationMs: 0 }),
       reflectFn: async ({ ref }) => ({
-        schemaVersion: 1, ok: true,
+        schemaVersion: 1,
+        ok: true,
         proposal: makeProposal(ref ?? "memory:auth-tips"),
-        ref: ref ?? "", agentProfile: "test", durationMs: 1,
+        ref: ref ?? "",
+        agentProfile: "test",
+        durationMs: 1,
       }),
       distillFn: async ({ ref }) => {
         if (ref) distilledRefs.push(ref);
-        return { schemaVersion: 1, ok: true, outcome: "queued", inputRef: ref, lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson` } satisfies AkmDistillResult;
+        return {
+          schemaVersion: 1,
+          ok: true,
+          outcome: "queued",
+          inputRef: ref,
+          lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson`,
+        } satisfies AkmDistillResult;
       },
     });
 
@@ -1581,13 +1638,22 @@ describe("D-2: reject-aware cooldown for distill (#370)", () => {
       ensureIndexFn: async () => false,
       reindexFn: async () => ({ schemaVersion: 1, ok: true, indexed: 0, warnings: [], errors: [], durationMs: 0 }),
       reflectFn: async ({ ref }) => ({
-        schemaVersion: 1, ok: true,
+        schemaVersion: 1,
+        ok: true,
         proposal: makeProposal(ref ?? "memory:auth-tips"),
-        ref: ref ?? "", agentProfile: "test", durationMs: 1,
+        ref: ref ?? "",
+        agentProfile: "test",
+        durationMs: 1,
       }),
       distillFn: async ({ ref }) => {
         if (ref) distilledRefs.push(ref);
-        return { schemaVersion: 1, ok: true, outcome: "queued", inputRef: ref, lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson` } satisfies AkmDistillResult;
+        return {
+          schemaVersion: 1,
+          ok: true,
+          outcome: "queued",
+          inputRef: ref,
+          lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson`,
+        } satisfies AkmDistillResult;
       },
     });
 

--- a/tests/feedback-command.test.ts
+++ b/tests/feedback-command.test.ts
@@ -245,3 +245,111 @@ describe("akm feedback", () => {
     expect(afterMemories[0]?.whyMatched).toContain("usage history boost");
   });
 });
+
+// ── F-3 / #384 — requireReason default true + --failure-mode enum ─────────────
+
+describe("F-3: requireReason default + --failure-mode enum (#384)", () => {
+  test("negative feedback without --reason fails by default (requireReason default: true)", async () => {
+    const stashDir = makeTempDir("akm-f3-require-reason-");
+    process.env.XDG_CACHE_HOME = makeTempDir("akm-f3-cache-");
+    process.env.XDG_CONFIG_HOME = makeTempDir("akm-f3-config-");
+    process.env.XDG_DATA_HOME = makeTempDir("akm-f3-data-");
+    process.env.XDG_STATE_HOME = makeTempDir("akm-f3-state-");
+
+    writeFile(path.join(stashDir, "memories", "auth.md"), "---\ndescription: auth\n---\nAuth tips.\n");
+    await buildIndex(stashDir);
+
+    // No --reason: should fail with exit code 2 by default (requireReason: true)
+    const result = runCli(["feedback", "memory:auth", "--negative", "--format=json"]);
+    expect(result.status).toBe(2);
+    const out = parseJsonOutput(result);
+    expect(out.ok).toBe(false);
+    expect(String(out.error)).toContain("requires --reason");
+  });
+
+  test("negative feedback with --reason succeeds", async () => {
+    const stashDir = makeTempDir("akm-f3-with-reason-");
+    process.env.XDG_CACHE_HOME = makeTempDir("akm-f3-cache2-");
+    process.env.XDG_CONFIG_HOME = makeTempDir("akm-f3-config2-");
+    process.env.XDG_DATA_HOME = makeTempDir("akm-f3-data2-");
+    process.env.XDG_STATE_HOME = makeTempDir("akm-f3-state2-");
+
+    writeFile(path.join(stashDir, "memories", "auth.md"), "---\ndescription: auth\n---\nAuth tips.\n");
+    await buildIndex(stashDir);
+
+    const result = runCli(["feedback", "memory:auth", "--negative", "--reason", "outdated content", "--format=json"]);
+    expect(result.status).toBe(0);
+    const out = parseJsonOutput(result);
+    expect(out.ok).toBe(true);
+    expect(out.signal).toBe("negative");
+  });
+
+  test("--failure-mode with valid enum value is accepted and appears in output", async () => {
+    const stashDir = makeTempDir("akm-f3-failure-mode-");
+    process.env.XDG_CACHE_HOME = makeTempDir("akm-f3-cache3-");
+    process.env.XDG_CONFIG_HOME = makeTempDir("akm-f3-config3-");
+    process.env.XDG_DATA_HOME = makeTempDir("akm-f3-data3-");
+    process.env.XDG_STATE_HOME = makeTempDir("akm-f3-state3-");
+
+    writeFile(path.join(stashDir, "memories", "auth.md"), "---\ndescription: auth\n---\nAuth tips.\n");
+    await buildIndex(stashDir);
+
+    const result = runCli([
+      "feedback",
+      "memory:auth",
+      "--negative",
+      "--reason",
+      "content is wrong",
+      "--failure-mode",
+      "incorrect",
+      "--format=json",
+    ]);
+    expect(result.status).toBe(0);
+    const out = parseJsonOutput(result);
+    expect(out.ok).toBe(true);
+    expect(out.failureMode).toBe("incorrect");
+  });
+
+  test("--failure-mode with invalid value is rejected (exit 2)", async () => {
+    const stashDir = makeTempDir("akm-f3-bad-mode-");
+    process.env.XDG_CACHE_HOME = makeTempDir("akm-f3-cache4-");
+    process.env.XDG_CONFIG_HOME = makeTempDir("akm-f3-config4-");
+    process.env.XDG_DATA_HOME = makeTempDir("akm-f3-data4-");
+    process.env.XDG_STATE_HOME = makeTempDir("akm-f3-state4-");
+
+    writeFile(path.join(stashDir, "memories", "auth.md"), "---\ndescription: auth\n---\nAuth tips.\n");
+    await buildIndex(stashDir);
+
+    const result = runCli([
+      "feedback",
+      "memory:auth",
+      "--negative",
+      "--reason",
+      "broken",
+      "--failure-mode",
+      "totally-invalid-mode",
+      "--format=json",
+    ]);
+    expect(result.status).toBe(2);
+    const out = parseJsonOutput(result);
+    expect(out.ok).toBe(false);
+    expect(String(out.error)).toContain("totally-invalid-mode");
+  });
+
+  test("--failure-mode on --positive is rejected (exit 2)", async () => {
+    const stashDir = makeTempDir("akm-f3-mode-on-pos-");
+    process.env.XDG_CACHE_HOME = makeTempDir("akm-f3-cache5-");
+    process.env.XDG_CONFIG_HOME = makeTempDir("akm-f3-config5-");
+    process.env.XDG_DATA_HOME = makeTempDir("akm-f3-data5-");
+    process.env.XDG_STATE_HOME = makeTempDir("akm-f3-state5-");
+
+    writeFile(path.join(stashDir, "memories", "auth.md"), "---\ndescription: auth\n---\nAuth tips.\n");
+    await buildIndex(stashDir);
+
+    const result = runCli(["feedback", "memory:auth", "--positive", "--failure-mode", "incorrect", "--format=json"]);
+    expect(result.status).toBe(2);
+    const out = parseJsonOutput(result);
+    expect(out.ok).toBe(false);
+    expect(String(out.error)).toContain("only valid for negative");
+  });
+});


### PR DESCRIPTION
## Summary

- Flip `feedback.requireReason` default to `true` so `akm feedback <ref> --negative` requires `--reason` by default (operators can opt out via `feedback.requireReason: false` in `akm.json`)
- Add `FEEDBACK_FAILURE_MODES` curated enum (`incorrect` / `outdated` / `dangerous` / `incomplete` / `redundant`) and `--failure-mode` flag to `akm feedback`
- Validate `--failure-mode` against the enum; reject invalid values (exit 2); reject `--failure-mode` on `--positive` signals
- Surface `failureMode` in feedback output JSON and `events.jsonl` metadata for aggregation by the distill pipeline

## Motivation

Structured failure modes enable aggregation across feedback events — detecting that 5 assets failed for `"incorrect"` is actionable; 5 free-text strings about the same issue are not. Refs: CAI (arXiv:2212.08073), PRM/ORM (arXiv:2305.20050).

## Test plan

- [x] `tests/feedback-command.test.ts` — 5 new F-3 tests covering: requireReason default enforcement, --reason allows negative, valid --failure-mode accepted in output, invalid mode rejected (exit 2), --failure-mode on --positive rejected (exit 2)
- [x] Full test suite passes (10 total in feedback-command.test.ts)

Closes #384
Part of Epic #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)