### PR TITLE
feat(schema-repair): route LLM writes through proposal queue (M-3 / #387)

### DIFF
--- a/src/commands/improve.ts
+++ b/src/commands/improve.ts
@@ -175,7 +175,8 @@ export interface AkmImproveResult {
   schemaRepairs?: Array<{
     ref: string;
     reason: string;
-    outcome: "written" | "skipped" | "error";
+    outcome: "queued" | "written" | "skipped" | "error";
+    proposalId?: string;
     error?: string;
   }>;
   consolidation?: ConsolidateResult;
@@ -214,7 +215,8 @@ interface ImprovePreparationResult {
   schemaRepairs: Array<{
     ref: string;
     reason: string;
-    outcome: "written" | "skipped" | "error";
+    outcome: "queued" | "written" | "skipped" | "error";
+    proposalId?: string;
     error?: string;
   }>;
   lintSummary?: { fixed: number; flagged: number };

--- a/src/commands/schema-repair.ts
+++ b/src/commands/schema-repair.ts
@@ -17,7 +17,8 @@ import { parseAssetRef } from "../core/asset-ref";
 import type { LlmConnectionConfig } from "../core/config";
 import { appendEvent, readEvents } from "../core/events";
 import { parseFrontmatter } from "../core/frontmatter";
-import { info } from "../core/warn";
+import { createProposal, isProposalSkipped } from "../core/proposals";
+import { info, warn } from "../core/warn";
 import { resolveAssetPath } from "../indexer/path-resolver";
 import { chatCompletion, parseEmbeddedJsonResponse } from "../llm/client";
 
@@ -28,12 +29,25 @@ export interface SchemaRepairFailure {
   reason: string;
 }
 
-export type SchemaRepairOutcome = "written" | "skipped" | "error";
+/**
+ * Schema-repair outcome values (M-3 / #387).
+ *
+ *   - `queued`  — LLM generated fields were written to the proposal queue
+ *                 (replaces the previous `written` path which wrote directly
+ *                 to disk, bypassing the proposal queue safety invariant).
+ *   - `written` — Legacy / direct-write path (retained for backward compat;
+ *                 no longer emitted by the default implementation).
+ *   - `skipped` — Asset didn't need repair or was on cooldown.
+ *   - `error`   — LLM call failed or JSON could not be parsed.
+ */
+export type SchemaRepairOutcome = "queued" | "written" | "skipped" | "error";
 
 export interface SchemaRepairRecord {
   ref: string;
   reason: string;
   outcome: SchemaRepairOutcome;
+  /** Proposal id when outcome is "queued". */
+  proposalId?: string;
   error?: string;
 }
 
@@ -44,12 +58,14 @@ export interface SchemaRepairOptions {
   budgetMs: number;
   /** LLM config to use for repair calls. */
   llmConfig: LlmConnectionConfig;
-  /** Optional stash directory for asset resolution. */
+  /** Optional stash directory for proposal queue writes (M-3 / #387). When absent, falls back to direct write. */
   stashDir?: string;
   /** Override the asset file-path resolver (test seam). */
   findFilePath?: (ref: string, stashDir?: string) => Promise<string | null> | string | null;
   /** Whether a given ref is a lesson candidate (affects which fields to repair). */
   isLessonCandidateFn?: (ref: string) => boolean;
+  /** Override the LLM chat function (test seam). Defaults to {@link chatCompletion}. */
+  chatFn?: (llmConfig: LlmConnectionConfig, messages: Array<{ role: string; content: string }>) => Promise<string>;
 }
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -78,6 +94,7 @@ export async function runSchemaRepairPass(
     stashDir,
     findFilePath = defaultFindFilePath,
     isLessonCandidateFn = defaultIsLessonCandidate,
+    chatFn = chatCompletion,
   } = options;
 
   for (const failure of failures) {
@@ -121,7 +138,7 @@ export async function runSchemaRepairPass(
       info(`[improve] schema-repair ${failure.ref} (${fieldList})`);
 
       const bodyPreview = (fm.content ?? raw).slice(0, 2000);
-      const llmResponse = await chatCompletion(llmConfig, [
+      const llmResponse = await chatFn(llmConfig, [
         {
           role: "system",
           content: `You generate concise asset frontmatter fields. Respond with a JSON object containing only the missing fields. No prose, no markdown fences.`,
@@ -148,15 +165,59 @@ export async function runSchemaRepairPass(
       if (parsed.when_to_use) newFm.when_to_use = parsed.when_to_use;
       const fmStr = yamlStringify(newFm).trimEnd();
       const newContent = `---\n${fmStr}\n---\n${fm.content}`;
-      fs.writeFileSync(filePath, newContent, "utf8");
-      info(`[improve] schema-repair written: ${failure.ref}`);
-      appendEvent({
-        eventType: "schema_repair_invoked",
-        ref: failure.ref,
-        metadata: { outcome: "written", reason: failure.reason },
-      });
-      repairs.push({ ref: failure.ref, reason: failure.reason, outcome: "written" });
-      repairedRefs.add(failure.ref);
+
+      // M-3 / #387: Route through proposal queue instead of writing directly to
+      // disk. This restores akm's safety invariant — the proposal queue is the
+      // only path to a committed asset write. LLM-generated `description` /
+      // `when_to_use` fields can be incorrect; routing through the queue makes
+      // them human-reviewable before they affect search ranking and curate hints.
+      // mem0 open gaps (arXiv:2504.19413) — any LLM write to a memory field
+      // should be human-reviewable.
+      if (stashDir) {
+        const proposalResult = createProposal(stashDir, {
+          ref: failure.ref,
+          source: "schema-repair",
+          payload: {
+            content: newContent,
+            ...(Object.keys(newFm).length > 0 ? { frontmatter: newFm } : {}),
+          },
+        });
+
+        if (isProposalSkipped(proposalResult)) {
+          info(`[improve] schema-repair proposal skipped for ${failure.ref}: ${proposalResult.message}`);
+          repairs.push({ ref: failure.ref, reason: failure.reason, outcome: "skipped" });
+          continue;
+        }
+
+        info(`[improve] schema-repair queued: ${failure.ref} (proposal id: ${proposalResult.id})`);
+        appendEvent({
+          eventType: "schema_repair_invoked",
+          ref: failure.ref,
+          metadata: { outcome: "queued", reason: failure.reason, proposalId: proposalResult.id },
+        });
+        repairs.push({
+          ref: failure.ref,
+          reason: failure.reason,
+          outcome: "queued",
+          proposalId: proposalResult.id,
+        });
+        // Mark as repaired so the caller removes it from the validation-failure set.
+        repairedRefs.add(failure.ref);
+      } else {
+        // Fallback: no stash dir available — write directly (legacy path).
+        // This should not occur in production; stashDir is always provided by
+        // `runSchemaRepairPass` callers in improve.ts.
+        warn(`[improve] schema-repair: no stashDir available for ${failure.ref}, falling back to direct write`);
+        fs.writeFileSync(filePath, newContent, "utf8");
+        info(`[improve] schema-repair written: ${failure.ref}`);
+        appendEvent({
+          eventType: "schema_repair_invoked",
+          ref: failure.ref,
+          metadata: { outcome: "written", reason: failure.reason },
+        });
+        repairs.push({ ref: failure.ref, reason: failure.reason, outcome: "written" });
+        repairedRefs.add(failure.ref);
+      }
     } catch (e) {
       appendEvent({
         eventType: "schema_repair_invoked",

--- a/tests/commands/improve-memory.test.ts
+++ b/tests/commands/improve-memory.test.ts
@@ -1753,3 +1753,68 @@ describe("M-1: contradiction-detection pass writes contradictedBy edges (#367)",
     expect(result.edgesWritten).toBe(0);
   });
 });
+
+// ── M-3 / #387 — schema-repair routes through proposal queue ─────────────────
+
+describe("M-3: schema-repair routes through proposal queue (#387)", () => {
+  test("runSchemaRepairPass queues a proposal instead of writing directly to disk", async () => {
+    const { runSchemaRepairPass } = await import("../../src/commands/schema-repair");
+    const { listProposals } = await import("../../src/core/proposals");
+
+    const stashDir = makeTempDir("akm-m3-schema-repair-");
+    const memFile = path.join(stashDir, "memories", "auth-guide.md");
+    fs.mkdirSync(path.dirname(memFile), { recursive: true });
+    fs.writeFileSync(memFile, "---\n---\nAuth guide content.\n", "utf8");
+
+    const result = await runSchemaRepairPass([{ ref: "memory:auth-guide", reason: "missing description" }], {
+      startMs: Date.now(),
+      budgetMs: 30_000,
+      stashDir,
+      llmConfig: { endpoint: "http://localhost/v1/chat", model: "test" },
+      findFilePath: async () => memFile,
+      isLessonCandidateFn: () => false,
+      chatFn: async () => JSON.stringify({ description: "Authentication guide for the service." }),
+    });
+
+    // M-3: proposal queued (not written to disk directly)
+    expect(result.repairs.length).toBe(1);
+    const repair = result.repairs[0];
+    expect(repair?.outcome).toBe("queued");
+    expect(repair?.proposalId).toBeDefined();
+    expect(result.repairedRefs.has("memory:auth-guide")).toBe(true);
+
+    // File should NOT be modified (write went through proposal queue)
+    const fileContent = fs.readFileSync(memFile, "utf8");
+    expect(fileContent).not.toContain("Authentication guide");
+
+    // Proposal should exist in the queue
+    const proposals = listProposals(stashDir);
+    expect(proposals.length).toBe(1);
+    expect(proposals[0]?.ref).toBe("memory:auth-guide");
+    expect(proposals[0]?.payload.content).toContain("Authentication guide");
+  });
+
+  test("runSchemaRepairPass falls back to direct write when stashDir is absent", async () => {
+    const { runSchemaRepairPass } = await import("../../src/commands/schema-repair");
+
+    const stashDir = makeTempDir("akm-m3-fallback-");
+    const memFile = path.join(stashDir, "memories", "auth2.md");
+    fs.mkdirSync(path.dirname(memFile), { recursive: true });
+    fs.writeFileSync(memFile, "---\n---\nAuth content.\n", "utf8");
+
+    const result = await runSchemaRepairPass([{ ref: "memory:auth2", reason: "missing description" }], {
+      startMs: Date.now(),
+      budgetMs: 30_000,
+      // No stashDir: triggers legacy direct-write path
+      llmConfig: { endpoint: "http://localhost/v1/chat", model: "test" },
+      findFilePath: async () => memFile,
+      isLessonCandidateFn: () => false,
+      chatFn: async () => JSON.stringify({ description: "Auth content description." }),
+    });
+
+    // Fallback: direct write
+    expect(result.repairs[0]?.outcome).toBe("written");
+    const fileContent = fs.readFileSync(memFile, "utf8");
+    expect(fileContent).toContain("Auth content description.");
+  });
+});


### PR DESCRIPTION
## Summary

- Route `schema-repair.ts` LLM-generated `description`/`when_to_use` field writes through `createProposal` with `source: "schema-repair"` instead of writing directly to disk
- Add `chatFn` test seam to `SchemaRepairOptions` for deterministic testing
- Update `SchemaRepairOutcome` to include `"queued"` outcome; update `ImprovePreparationResult.schemaRepairs` type to match
- Fallback to direct write (with warning) only when `stashDir` is absent

## Motivation

Schema-repair was the only LLM-driven write path bypassing the proposal queue, violating akm's safety invariant. LLM-generated `description`/`when_to_use` fields affect search ranking and curate hints — incorrect values are invisible failures. mem0 arXiv:2504.19413.

## Test plan

- [x] 2 new M-3 tests in `tests/commands/improve-memory.test.ts`: proposal queued path, fallback direct-write path
- [x] All 28 improve-memory tests pass

Closes #387
Part of Epic #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)