### PR TITLE
feat(distill): force LLM merge when knowledge destination exists (D-1 / #369)

### DIFF
--- a/src/commands/distill.ts
+++ b/src/commands/distill.ts
@@ -545,21 +545,113 @@ export async function akmDistill(options: AkmDistillOptions): Promise<AkmDistill
         });
 
   if (promotion?.promote && promotion.content && (targetKind === "knowledge" || targetKind === "auto")) {
+    // D-1 / #369: When the destination knowledge file already exists, route
+    // through the LLM for contradiction resolution instead of silently
+    // overwriting. Follows mem0 ADD/UPDATE/DELETE/NOOP pattern (arXiv:2504.19413 §3.2)
+    // and A-MEM dynamic linking (arXiv:2502.12110).
+    let resolvedPromotionContent = promotion.content;
+    const existingKnowledgePath = await lookup(promotion.knowledgeRef);
+    const existingKnowledgeContent =
+      existingKnowledgePath && fs.existsSync(existingKnowledgePath)
+        ? (() => {
+            try {
+              return fs.readFileSync(existingKnowledgePath, "utf8");
+            } catch {
+              return null;
+            }
+          })()
+        : null;
+
+    if (existingKnowledgeContent && config?.llm) {
+      // Existing content found: call LLM for contradiction-resolution merge.
+      const mergePrompt = [
+        "You are merging two versions of a knowledge document.",
+        "Existing content is already committed; new content comes from a memory distillation run.",
+        "Choose one of: ADD (combine both), UPDATE (replace existing with new), NOOP (keep existing unchanged).",
+        'Return ONLY valid JSON: {"action": "ADD"|"UPDATE"|"NOOP", "content": "<merged markdown if ADD/UPDATE, empty string if NOOP>"}',
+        "",
+        "## Existing knowledge content",
+        "```",
+        existingKnowledgeContent.slice(0, 3000),
+        "```",
+        "",
+        "## New content from distillation",
+        "```",
+        promotion.content.slice(0, 3000),
+        "```",
+      ].join("\n");
+
+      try {
+        const mergeResponse = await chat(config.llm, [
+          { role: "system", content: "Return only valid JSON. No prose." },
+          { role: "user", content: mergePrompt },
+        ]);
+        const mergeResult = parseEmbeddedJsonResponse<{
+          action: "ADD" | "UPDATE" | "NOOP";
+          content?: string;
+        }>(mergeResponse);
+
+        if (mergeResult?.action === "NOOP") {
+          // Existing content is authoritative — no update needed.
+          appendEvent({
+            eventType: "distill_invoked",
+            ref: inputRef,
+            metadata: {
+              outcome: "skipped" as const,
+              lessonRef: promotion.knowledgeRef,
+              message: "D-1: LLM resolved destination conflict as NOOP — existing content kept",
+            },
+          });
+          return {
+            schemaVersion: 1,
+            ok: true,
+            outcome: "skipped",
+            inputRef,
+            lessonRef: promotion.knowledgeRef,
+            message: "Existing knowledge content unchanged (contradiction resolution: NOOP)",
+          };
+        }
+
+        if (mergeResult?.action && (mergeResult.action === "ADD" || mergeResult.action === "UPDATE")) {
+          if (mergeResult.content?.trim()) {
+            resolvedPromotionContent = mergeResult.content;
+          }
+        }
+      } catch {
+        // LLM merge failed — fall through with the original promotion content.
+        // The reviewer will see both versions in the proposal diff.
+      }
+    } else if (existingKnowledgeContent && !config?.llm) {
+      // No LLM configured: include existing content as context in the proposal
+      // so the reviewer can do the contradiction resolution manually.
+      resolvedPromotionContent = [
+        promotion.content,
+        "",
+        "---",
+        "<!-- D-1 / #369: Existing knowledge content is shown below for reviewer reference. -->",
+        "<!-- Review: decide whether to ADD (merge), UPDATE (replace), or NOOP (keep existing). -->",
+        "",
+        "## Existing content (for reviewer reference)",
+        "",
+        existingKnowledgeContent,
+      ].join("\n");
+    }
+
     // Apply quality gate to fast-path knowledge promotion (Risk 4 fix).
     if (isLlmFeatureEnabled(config, "lesson_quality_gate")) {
-      const judgeResult = await runLessonQualityJudge(config, promotion.content, assetContent ?? "", chat);
+      const judgeResult = await runLessonQualityJudge(config, resolvedPromotionContent, assetContent ?? "", chat);
       if (!judgeResult.pass) {
         return writeQualityRejection(
           stash,
           inputRef,
           promotion.knowledgeRef,
-          promotion.content,
+          resolvedPromotionContent,
           judgeResult.score,
           judgeResult.reason,
         );
       }
     }
-    const knowledgeParsed = parseFrontmatter(promotion.content);
+    const knowledgeParsed = parseFrontmatter(resolvedPromotionContent);
     const proposalResult = createProposal(
       stash,
       {
@@ -567,7 +659,7 @@ export async function akmDistill(options: AkmDistillOptions): Promise<AkmDistill
         source: "distill",
         ...(options.sourceRun !== undefined ? { sourceRun: options.sourceRun } : {}),
         payload: {
-          content: promotion.content,
+          content: resolvedPromotionContent,
           ...(Object.keys(knowledgeParsed.data).length > 0 ? { frontmatter: knowledgeParsed.data } : {}),
         },
       },

--- a/tests/distill.test.ts
+++ b/tests/distill.test.ts
@@ -973,3 +973,116 @@ describe("akmDistill — success envelope shape contract (#284)", () => {
     expect((result as unknown as { schemaVersion: number }).schemaVersion).toBe(1);
   });
 });
+
+// ── D-1 / #369 — fast path forces LLM when destination knowledge exists ───────
+
+describe("D-1: fast path calls LLM merge when destination knowledge exists (#369)", () => {
+  test("NOOP: LLM says no update needed — proposal is skipped", async () => {
+    const stash = makeStashDir();
+    // Create an existing knowledge file at the destination
+    const existingKnowledgePath = path.join(stash, "knowledge", "auth-guide.md");
+    fs.mkdirSync(path.dirname(existingKnowledgePath), { recursive: true });
+    fs.writeFileSync(existingKnowledgePath, "---\ndescription: Auth guide\n---\nExisting auth content.\n", "utf8");
+
+    const memPath1 = path.join(stash, "memories", "auth-guide.md");
+    fs.mkdirSync(path.dirname(memPath1), { recursive: true });
+    fs.writeFileSync(
+      memPath1,
+      [
+        "---",
+        "description: VPN required",
+        "source: skill:deploy",
+        "observed_at: 2026-04-20",
+        "confidence: 0.95",
+        "---",
+        "",
+        "Always connect the VPN.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    // LLM returns NOOP — keep existing content
+    const chatCalls: string[] = [];
+    const result = await akmDistill({
+      ref: "memory:auth-guide",
+      proposalKind: "auto",
+      stashDir: stash,
+      config: {
+        stashDir: stash,
+        sources: [{ type: "filesystem", name: "stash", path: stash, writable: true }],
+        defaultWriteTarget: "stash",
+        llm: { endpoint: "http://localhost/v1/chat", model: "test" },
+      } as import("../src/core/config").AkmConfig,
+      lookupFn: async (ref: string) => {
+        if (ref === "memory:auth-guide") return memPath1;
+        if (ref.includes("auth-guide")) return existingKnowledgePath;
+        return null;
+      },
+      readEventsFn: eventsFor("memory:auth-guide", ["positive", "positive"]),
+      chat: async (_cfg, msgs) => {
+        chatCalls.push(msgs[1]?.content ?? "");
+        return JSON.stringify({ action: "NOOP", content: "" });
+      },
+    });
+
+    // D-1: NOOP → proposal not created, outcome skipped
+    expect(result.ok).toBe(true);
+    expect(result.outcome).toBe("skipped");
+    expect(chatCalls.length).toBeGreaterThan(0); // LLM was called for merge resolution
+  });
+
+  test("UPDATE: LLM produces merged content — proposal queued with merged content", async () => {
+    const stash = makeStashDir();
+    const existingKnowledgePath = path.join(stash, "knowledge", "auth-guide2.md");
+    fs.mkdirSync(path.dirname(existingKnowledgePath), { recursive: true });
+    fs.writeFileSync(existingKnowledgePath, "---\ndescription: Auth guide v1\n---\nOld auth content.\n", "utf8");
+
+    const memPath2 = path.join(stash, "memories", "auth-guide2.md");
+    fs.mkdirSync(path.dirname(memPath2), { recursive: true });
+    fs.writeFileSync(
+      memPath2,
+      [
+        "---",
+        "description: VPN required v2",
+        "source: skill:deploy",
+        "observed_at: 2026-04-21",
+        "confidence: 0.95",
+        "---",
+        "",
+        "Updated auth tips.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const mergedContent = "---\ndescription: Auth guide v2 (merged)\n---\nMerged auth content.\n";
+    const result = await akmDistill({
+      ref: "memory:auth-guide2",
+      proposalKind: "auto",
+      stashDir: stash,
+      config: {
+        stashDir: stash,
+        sources: [{ type: "filesystem", name: "stash", path: stash, writable: true }],
+        defaultWriteTarget: "stash",
+        llm: { endpoint: "http://localhost/v1/chat", model: "test" },
+      } as import("../src/core/config").AkmConfig,
+      lookupFn: async (ref: string) => {
+        if (ref === "memory:auth-guide2") return memPath2;
+        if (ref.includes("auth-guide2")) return existingKnowledgePath;
+        return null;
+      },
+      readEventsFn: eventsFor("memory:auth-guide2", ["positive", "positive"]),
+      chat: async () => JSON.stringify({ action: "UPDATE", content: mergedContent }),
+    });
+
+    // D-1: UPDATE → proposal queued with merged content
+    expect(result.ok).toBe(true);
+    expect(result.outcome).toBe("queued");
+    const { listProposals } = await import("../src/core/proposals");
+    const proposals = listProposals(stash, { ref: result.lessonRef });
+    expect(proposals.length).toBeGreaterThan(0);
+    const proposal = proposals[0];
+    expect(proposal?.payload.content).toContain("Merged auth content");
+  });
+});


### PR DESCRIPTION
## Summary

- Before creating a knowledge proposal for `promotion.knowledgeRef`, check if an existing knowledge file is present via `lookup()`
- If it exists and an LLM is configured: call LLM for ADD/UPDATE/NOOP contradiction resolution
- NOOP returns a skipped outcome (existing content kept); UPDATE/ADD uses the LLM-merged content in the proposal
- If no LLM is configured: embed existing content as reviewer context in the proposal with inline instruction
- Gate on LLM availability; falls back gracefully

## Motivation

The fast path silently overwrote existing knowledge content without contradiction resolution, risking accumulated knowledge loss. mem0 ADD/UPDATE/DELETE/NOOP pattern (arXiv:2504.19413 §3.2), A-MEM dynamic linking (arXiv:2502.12110).

## Test plan

- [x] 2 new D-1 tests in `tests/distill.test.ts`: NOOP skips proposal, UPDATE queues merged content
- [x] All 45 distill tests pass

Closes #369
Part of Epic #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)