### PR TITLE
feat(reflect): extend quality gate to reflect proposals (R-5 / #374)

### DIFF
--- a/src/commands/distill.ts
+++ b/src/commands/distill.ts
@@ -390,7 +390,16 @@ function buildJudgePrompt(lessonContent: string, sourceContent: string): string 
   ].join("\n");
 }
 
-async function runLessonQualityJudge(
+/**
+ * Run the LLM-as-judge quality gate on a proposal's content.
+ *
+ * Exported so reflect.ts can apply the same gate to reflect proposals (R-5 / #374).
+ * Gated behind `lesson_quality_gate` (or its alias `proposal_quality_gate`) at
+ * the call site via {@link isLlmFeatureEnabled}.
+ *
+ * Fail-open: returns `pass: true` on timeout, parse failure, or missing LLM.
+ */
+export async function runLessonQualityJudge(
   config: AkmConfig,
   lessonContent: string,
   sourceContent: string,

--- a/src/commands/reflect.ts
+++ b/src/commands/reflect.ts
@@ -23,6 +23,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { parseAssetRef } from "../core/asset-ref";
 import { resolveStashDir } from "../core/common";
+import { loadConfig } from "../core/config";
 import { ConfigError, UsageError } from "../core/errors";
 import { appendEvent, readEvents } from "../core/events";
 import { parseFrontmatter } from "../core/frontmatter";
@@ -52,6 +53,8 @@ import {
   type RejectedProposalContext,
 } from "../integrations/agent/prompts";
 import { runAgentSdk } from "../integrations/agent/sdk-runner";
+import { chatCompletion } from "../llm/client";
+import { isLlmFeatureEnabled } from "../llm/feature-gate";
 import {
   baseFailureFields,
   enoentHintMessage,
@@ -59,7 +62,7 @@ import {
   loadAgentConfigFromDisk,
   resolveAgentProfile,
 } from "./agent-support";
-import { deriveLessonRef } from "./distill";
+import { deriveLessonRef, runLessonQualityJudge } from "./distill";
 
 export interface AkmReflectOptions {
   /** Optional asset ref (`type:name`) to focus on. */
@@ -86,6 +89,20 @@ export interface AkmReflectOptions {
    * mistakes across assets.
    */
   avoidPatterns?: string[];
+  /**
+   * Optional chat seam for the proposal quality gate (R-5 / #374).
+   * Defaults to {@link chatCompletion}. Injected in tests to avoid real LLM calls.
+   */
+  chat?: (
+    config: import("../core/config").LlmConnectionConfig,
+    messages: import("../llm/client").ChatMessage[],
+  ) => Promise<string>;
+  /**
+   * Override the loaded AkmConfig (test seam + for the quality gate).
+   * Needed by R-5 to access llm.features.proposal_quality_gate without
+   * a real config file in tests.
+   */
+  config?: import("../core/config").AkmConfig;
   /**
    * Named process to use for per-process agent config lookup. Defaults to
    * `"reflect"`. When an explicit `--profile` flag is given, the process
@@ -481,7 +498,70 @@ export async function akmReflect(options: AkmReflectOptions = {}): Promise<AkmRe
     }
   }
 
-  // 7. Create the proposal. The proposal queue is the ONLY thing reflect
+  // 7. R-5 / #374: Apply the proposal quality gate when enabled.
+  // Mirrors the `lesson_quality_gate` on distill proposals. The gate uses
+  // `runLessonQualityJudge` from distill.ts and is gated behind either
+  // `llm.features.proposal_quality_gate` or `llm.features.lesson_quality_gate`
+  // (legacy alias). Fail-open: any judge error passes through.
+  // G-Eval (arXiv:2303.16634) — quality judgment before admission.
+  const runtimeConfig =
+    options.config ??
+    (() => {
+      try {
+        return loadConfig();
+      } catch {
+        return undefined;
+      }
+    })();
+  const chatFn = options.chat ?? chatCompletion;
+  const qualityGateEnabled =
+    isLlmFeatureEnabled(runtimeConfig, "proposal_quality_gate") ||
+    isLlmFeatureEnabled(runtimeConfig, "lesson_quality_gate");
+
+  if (qualityGateEnabled && runtimeConfig) {
+    const assetContent: string | null = (() => {
+      if (!options.ref) return null;
+      try {
+        const refParsed = parseAssetRef(options.ref);
+        const candidates = [
+          path.join(stash, `${refParsed.type}s`, `${refParsed.name}.md`),
+          path.join(stash, `${refParsed.type}s`, refParsed.name, "index.md"),
+        ];
+        for (const p of candidates) {
+          if (fs.existsSync(p)) return fs.readFileSync(p, "utf8");
+        }
+        return null;
+      } catch {
+        return null;
+      }
+    })();
+
+    const judgeResult = await runLessonQualityJudge(runtimeConfig, payload.content, assetContent ?? "", chatFn);
+    if (!judgeResult.pass) {
+      // Quality gate rejected the proposal — surface as parse_error so the
+      // improve orchestrator can log it and move on without crashing.
+      appendEvent({
+        eventType: "reflect_completed",
+        ref: payload.ref,
+        metadata: {
+          source: "reflect",
+          qualityRejected: true,
+          qualityScore: judgeResult.score,
+          qualityReason: judgeResult.reason,
+        },
+      });
+      return {
+        schemaVersion: 1,
+        ok: false,
+        reason: "parse_error" as const,
+        error: `Reflect proposal quality gate rejected: score=${judgeResult.score}, reason="${judgeResult.reason}"`,
+        ...(options.ref ? { ref: options.ref } : {}),
+        exitCode: result.exitCode,
+      };
+    }
+  }
+
+  // 8. Create the proposal. The proposal queue is the ONLY thing reflect
   // writes — promotion to a real asset is gated by `akm proposal accept`.
   //
   // R-4 / #373: Stamp `derived_from_reflect: true` in the frontmatter of any

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -165,6 +165,18 @@ export interface LlmFeatureFlags {
    */
   lesson_quality_gate?: boolean;
   /**
+   * Gates the LLM-as-judge quality gate on reflect proposals (R-5 / #374).
+   *
+   * When true, each proposal from `akm reflect` is scored by the judge before
+   * entering the proposal queue. Fail-open: judge failures always pass. Uses the
+   * same `runLessonQualityJudge` infrastructure as `lesson_quality_gate`.
+   *
+   * Also extends `lesson_quality_gate` semantics — both flags are checked by
+   * the reflect quality gate. Set either to enable it on reflect proposals.
+   * Default: false.
+   */
+  proposal_quality_gate?: boolean;
+  /**
    * Gates the `akm index` metadata-enhancement pass. Default: false.
    * When false (or absent), metadata enhancement is skipped and falls back to
    * returning an empty enrichment object (no description/searchHints/tags update).
@@ -1206,7 +1218,9 @@ const LOCKED_LLM_FEATURE_KEYS: ReadonlySet<string> = new Set([
   "graph_extraction",
   "memory_consolidation",
   "lesson_quality_gate",
+  "proposal_quality_gate",
   "metadata_enhance",
+  "memory_contradiction_detection",
 ]);
 
 function parseLlmFeatures(raw: Record<string, unknown>): LlmFeatureFlags {

--- a/tests/reflect-propose.test.ts
+++ b/tests/reflect-propose.test.ts
@@ -811,3 +811,70 @@ describe("R-4: reflect stamps derived_from_reflect on lesson proposals (#373)", 
     expect(proposal?.payload.frontmatter?.["derived_from_reflect"]).toBeUndefined();
   });
 });
+
+// ── R-5 / #374 — quality gate on reflect proposals ───────────────────────────
+
+describe("R-5: proposal quality gate applied to reflect proposals (#374)", () => {
+  test("quality gate blocks reflect proposal when judge score < 3", async () => {
+    const stash = makeStashDir();
+    const lessonFile = path.join(stash, "lessons", "rg-over-grep.md");
+    fs.mkdirSync(path.dirname(lessonFile), { recursive: true });
+    fs.writeFileSync(lessonFile, "---\ndescription: Use rg\n---\nUse rg.\n", "utf8");
+
+    const result = await akmReflect({
+      ref: "lesson:rg-over-grep",
+      stashDir: stash,
+      agentProfile: makeProfile(),
+      runAgentOptions: { spawn: fakeSpawn(VALID_LESSON_PAYLOAD, "", 0) },
+      config: {
+        stashDir: stash,
+        sources: [{ type: "filesystem", name: "stash", path: stash, writable: true }],
+        defaultWriteTarget: "stash",
+        llm: {
+          endpoint: "http://localhost/v1/chat",
+          model: "test",
+          features: { proposal_quality_gate: true },
+        },
+      } as import("../src/core/config").AkmConfig,
+      // Judge returns score=1 (below 3 threshold) — proposal should be rejected
+      chat: async () => JSON.stringify({ score: 1, reason: "Too generic, no actionable content." }),
+    });
+
+    // R-5: quality gate rejected the proposal
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.error).toContain("quality gate rejected");
+    // No proposal should be in the queue
+    expect(listProposals(stash).length).toBe(0);
+  });
+
+  test("quality gate passes reflect proposal when judge score >= 3", async () => {
+    const stash = makeStashDir();
+    const lessonFile = path.join(stash, "lessons", "rg-over-grep.md");
+    fs.mkdirSync(path.dirname(lessonFile), { recursive: true });
+    fs.writeFileSync(lessonFile, "---\ndescription: Use rg\n---\nUse rg.\n", "utf8");
+
+    const result = await akmReflect({
+      ref: "lesson:rg-over-grep",
+      stashDir: stash,
+      agentProfile: makeProfile(),
+      runAgentOptions: { spawn: fakeSpawn(VALID_LESSON_PAYLOAD, "", 0) },
+      config: {
+        stashDir: stash,
+        sources: [{ type: "filesystem", name: "stash", path: stash, writable: true }],
+        defaultWriteTarget: "stash",
+        llm: {
+          endpoint: "http://localhost/v1/chat",
+          model: "test",
+          features: { proposal_quality_gate: true },
+        },
+      } as import("../src/core/config").AkmConfig,
+      // Judge returns score=4 (above threshold) — proposal should pass
+      chat: async () => JSON.stringify({ score: 4, reason: "Clear and actionable." }),
+    });
+
+    // R-5: quality gate passed — proposal created
+    expect(result.ok).toBe(true);
+    expect(listProposals(stash).length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Export `runLessonQualityJudge` from `distill.ts` so reflect can use the same gate
- Apply quality judge in `akmReflect` when `llm.features.proposal_quality_gate` (or `lesson_quality_gate`) is enabled
- Proposals scoring below 3/5 are rejected with `parse_error` reason
- Add `proposal_quality_gate` to `LlmFeatureFlags` and `LOCKED_LLM_FEATURE_KEYS`
- Add `chat` and `config` test seams to `AkmReflectOptions`

## Motivation

Distill proposals were quality-gated; reflect proposals were not. G-Eval arXiv:2303.16634 — quality judgment before admission is standard in any HITL review queue; the cost of a bad proposal reaching the reviewer exceeds the cost of one extra LLM call.

## Test plan

- [x] 2 new R-5 tests in `tests/reflect-propose.test.ts`: gate blocks score<3, gate passes score≥3
- [x] All 31 reflect-propose tests pass

Closes #374
Part of Epic #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)