### PR TITLE
feat(improve): exploration-budget cap on fully-zero-feedback stash (O-4 / #377)

### DIFF
--- a/src/commands/improve.ts
+++ b/src/commands/improve.ts
@@ -114,6 +114,23 @@ export interface AkmImproveOptions {
    * reflect calls through a different profile.
    */
   agentProcess?: string;
+  /**
+   * Maximum number of refs to process in a cold-start exploration run (O-4 / #377).
+   *
+   * When the stash has fully-zero explicit feedback (no positive or negative
+   * feedback events), the improve loop falls back to all processable refs to
+   * avoid a no-op run. Without a cap, this causes cold-start oscillation:
+   *   - First run: all N assets processed → all enter 7-day reflect cooldown
+   *   - Next day: same N assets fire again → another big burst → silence
+   *
+   * Setting this cap to a small value (default: 10) spreads cold-start
+   * processing across multiple days, avoiding the burst-then-silence pattern.
+   * Set to 0 to disable the cap (allow all refs on cold-start, pre-O-4 behavior).
+   *
+   * Refs: Zoph & Le NAS controllers arXiv:1611.01578 — exploration budgets
+   * prevent oscillation. MemRL — utility-based sampling prevents pure coverage.
+   */
+  explorationBudget?: number;
 }
 
 export interface ImproveEligibleRef {
@@ -1242,21 +1259,51 @@ async function runImprovePreparationStage(args: {
     if (dbForRetrieval) closeDatabase(dbForRetrieval);
   }
 
+  // O-4 / #377: Detect a fully-zero-feedback stash (no positive or negative
+  // explicit feedback events across all candidates). This is the cold-start
+  // condition that causes oscillation: all N assets processed on day 1 → all
+  // enter reflect cooldown → burst on day 8 → silence again.
+  //
+  // On a fully-zero-feedback stash, cap the cold-start fallback to
+  // `explorationBudget` refs (default: 10). This spreads cold-start processing
+  // across multiple runs instead of flooding all N refs at once.
+  //
+  // The cap applies only when:
+  //   1. The stash has ZERO explicit feedback (no positive or negative events).
+  //   2. The fallback to all processableRefs would be triggered (no signals, no high-retrieval).
+  //   3. The scope is NOT "ref" (explicit ref scope always acts on the target).
+  //
+  // Once any explicit feedback exists, normal feedback-based eligibility takes over.
+  // Refs: Zoph & Le arXiv:1611.01578 — exploration budgets; MemRL — utility sampling.
+  const DEFAULT_EXPLORATION_BUDGET = 10;
+  const explorationBudget = options.explorationBudget ?? DEFAULT_EXPLORATION_BUDGET;
+  const isFullyZeroFeedback =
+    signalFiltered.length === 0 &&
+    processableRefs.every((r) => {
+      const s = feedbackSummary.get(r.ref);
+      return (s?.positive ?? 0) === 0 && (s?.negative ?? 0) === 0;
+    });
+
   // If the user explicitly scoped to a single ref, always act on it —
   // skip the signal/retrieval filter entirely. The filter exists to avoid
   // noisy "improve everything" runs; it should not gate an intentional
   // per-ref invocation where the user's explicit choice is the signal.
   //
   // For type/all scope with no signals yet (fresh environment), fall back
-  // to all processableRefs so that the first improve run is not a no-op.
+  // to all processableRefs (capped by explorationBudget on cold-start) so
+  // that the first improve run is not a no-op.
   const signalAndRetrievalRefs = [...signalFiltered, ...highRetrievalRefs];
+  const coldStartRefs: ImproveEligibleRef[] =
+    isFullyZeroFeedback && explorationBudget > 0 && scope.mode !== "ref"
+      ? processableRefs.slice(0, explorationBudget)
+      : processableRefs;
   const mergedRefs =
     scope.mode === "ref"
       ? processableRefs
       : options.requireFeedbackSignal
         ? signalFiltered
         : signalAndRetrievalRefs.length === 0
-          ? processableRefs
+          ? coldStartRefs
           : signalAndRetrievalRefs;
 
   const utilityMap = buildUtilityMap(mergedRefs);

--- a/tests/commands/improve-memory.test.ts
+++ b/tests/commands/improve-memory.test.ts
@@ -1884,7 +1884,7 @@ describe("O-3: reindex triggered after consolidation before graph extraction (#3
       distillFn: async ({ ref }) => ({
         schemaVersion: 1,
         ok: true,
-        outcome: "queued",
+        outcome: "queued" as const,
         inputRef: ref,
         lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson`,
       }),
@@ -1899,5 +1899,100 @@ describe("O-3: reindex triggered after consolidation before graph extraction (#3
     }
     // At minimum, either reindex was called or graph extraction ran
     expect(reindexCallOrder.length).toBeGreaterThan(0);
+  });
+});
+
+// ── O-4 / #377 — exploration-budget cap on fully-zero-feedback stash ──────────
+
+describe("O-4: explorationBudget caps cold-start refs on fully-zero-feedback stash (#377)", () => {
+  test("only explorationBudget refs are reflected when stash has zero feedback", async () => {
+    const stashDir = makeTempDir("akm-o4-budget-");
+    // Write 5 memories — all will be processable with no feedback
+    for (let i = 1; i <= 5; i++) {
+      writeMemory(stashDir, `mem-${i}`, { description: `Memory ${i}` }, `Memory ${i} content.`);
+    }
+    await buildIndex(stashDir);
+
+    const reflected: string[] = [];
+    await akmImprove({
+      scope: "memory",
+      stashDir,
+      explorationBudget: 2, // cap to 2 even though 5 are processable
+      config: {
+        semanticSearchMode: "off",
+        llm: {
+          endpoint: "http://localhost/chat/completions",
+          model: "test",
+          features: {},
+        },
+      },
+      ensureIndexFn: async () => false,
+      reflectFn: async ({ ref }) => {
+        reflected.push(ref ?? "");
+        return {
+          schemaVersion: 1,
+          ok: true,
+          proposal: makeProposal(ref ?? "memory:mem-1"),
+          ref: ref ?? "",
+          agentProfile: "test",
+          durationMs: 1,
+        };
+      },
+      distillFn: async ({ ref }) => ({
+        schemaVersion: 1,
+        ok: true,
+        outcome: "queued" as const,
+        inputRef: ref,
+        lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson`,
+      }),
+    });
+
+    // With explorationBudget=2 and 5 zero-feedback memories, at most 2 should be reflected
+    expect(reflected.length).toBeLessThanOrEqual(2);
+  });
+
+  test("explorationBudget=0 disables cap and allows all zero-feedback refs", async () => {
+    const stashDir = makeTempDir("akm-o4-no-budget-");
+    for (let i = 1; i <= 4; i++) {
+      writeMemory(stashDir, `item-${i}`, { description: `Item ${i}` }, `Item ${i} content.`);
+    }
+    await buildIndex(stashDir);
+
+    const reflected: string[] = [];
+    await akmImprove({
+      scope: "memory",
+      stashDir,
+      explorationBudget: 0, // disabled — all refs should pass
+      config: {
+        semanticSearchMode: "off",
+        llm: {
+          endpoint: "http://localhost/chat/completions",
+          model: "test",
+          features: {},
+        },
+      },
+      ensureIndexFn: async () => false,
+      reflectFn: async ({ ref }) => {
+        reflected.push(ref ?? "");
+        return {
+          schemaVersion: 1,
+          ok: true,
+          proposal: makeProposal(ref ?? "memory:item-1"),
+          ref: ref ?? "",
+          agentProfile: "test",
+          durationMs: 1,
+        };
+      },
+      distillFn: async ({ ref }) => ({
+        schemaVersion: 1,
+        ok: true,
+        outcome: "queued" as const,
+        inputRef: ref,
+        lessonRef: `lesson:${ref?.replace(/[:/]/g, "-") ?? "missing"}-lesson`,
+      }),
+    });
+
+    // explorationBudget=0 disables cap, so all 4 refs should be reflected
+    expect(reflected.length).toBeGreaterThanOrEqual(4);
   });
 });


### PR DESCRIPTION
## Summary
- Adds `explorationBudget` option (default: 10) to `AkmImproveOptions` that caps cold-start ref processing when the stash has zero explicit positive/negative feedback
- Prevents burst-then-silence oscillation: without the cap, all N assets fire on day 1, enter 7-day cooldown, then fire again as a burst on day 8
- Budget is bypassed when `explorationBudget=0` (pre-O-4 behavior) or when scope is `"ref"` (explicit targeting)
- Adds two regression tests: budget=2 caps 5-memory zero-feedback stash; budget=0 disables the cap

Refs: Zoph & Le arXiv:1611.01578 (exploration budgets prevent oscillation)

Closes #377

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bunx biome check src/ tests/` passes
- [x] `bun test tests/commands/improve-memory.test.ts` — 31 pass, 0 fail (includes O-3 and O-4 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)