### PR TITLE
fix(consolidate): failure-rate-based abort replacing consecutive-count (C-6 / #392)

### DIFF
--- a/src/commands/consolidate.ts
+++ b/src/commands/consolidate.ts
@@ -648,17 +648,27 @@ export async function akmConsolidate(opts: AkmConsolidateOptions = {}): Promise<
   warn(`[consolidate] ${memories.length} memories / ${chunks.length} chunk(s) / chunk_size=${chunkSize}`);
 
   const chunkOpsArrays: ConsolidateOperation[][] = [];
-  let consecutiveFailures = 0;
+  // C-6 / #392: Replace two-consecutive-failures abort with failure-rate threshold.
+  // Consecutive-count policies are brittle against transient LM Studio reloads:
+  // two transient failures abort the run even though the next chunk would succeed.
+  // Rate-based abort (≥50% failure over ≥4 chunks) is more robust.
+  // Tanenbaum, Distributed Systems §8 — rate-based policies with minimum sample sizes.
+  let totalChunksProcessed = 0;
+  let totalChunksFailed = 0;
+  const ABORT_MIN_CHUNKS = 4;
+  const ABORT_FAILURE_RATE = 0.5;
 
   for (let chunkIdx = 0; chunkIdx < chunks.length; chunkIdx++) {
-    // Abort early if the first chunk failed — the LLM/agent is likely unavailable
-    // and continuing would waste minutes processing chunks that will all fail the same way.
-    if (chunkIdx > 0 && consecutiveFailures >= 2) {
-      const skipped = chunks.length - chunkIdx;
-      warnings.push(
-        `Consolidation aborted after ${consecutiveFailures} consecutive chunk failures — LLM may be unavailable. ${skipped} chunk(s) skipped.`,
-      );
-      break;
+    // Abort if failure rate >= 50% over at least 4 processed chunks.
+    if (totalChunksProcessed >= ABORT_MIN_CHUNKS) {
+      const failureRate = totalChunksFailed / totalChunksProcessed;
+      if (failureRate >= ABORT_FAILURE_RATE) {
+        const skipped = chunks.length - chunkIdx;
+        warnings.push(
+          `Consolidation aborted — failure rate ${(failureRate * 100).toFixed(0)}% over ${totalChunksProcessed} chunks (>= ${ABORT_FAILURE_RATE * 100}% threshold). LLM may be unavailable. ${skipped} chunk(s) skipped.`,
+        );
+        break;
+      }
     }
 
     const chunk = chunks[chunkIdx];
@@ -685,7 +695,8 @@ export async function akmConsolidate(opts: AkmConsolidateOptions = {}): Promise<
 
     if (!raw.ok) {
       warnings.push(raw.error ?? `chunk ${chunkIdx + 1} failed`);
-      consecutiveFailures++;
+      totalChunksProcessed++;
+      totalChunksFailed++;
       continue;
     }
 
@@ -701,11 +712,12 @@ export async function akmConsolidate(opts: AkmConsolidateOptions = {}): Promise<
           ? " (empty response — if using a thinking model, disable thinking mode)"
           : "";
       warnings.push(`Chunk ${chunkIdx + 1}: invalid plan from AI — skipping.${hint}`);
-      consecutiveFailures++;
+      totalChunksProcessed++;
+      totalChunksFailed++;
       continue;
     }
 
-    consecutiveFailures = 0; // reset on success
+    totalChunksProcessed++; // success
 
     const ops: ConsolidateOperation[] = [];
     for (const op of parsed.operations) {


### PR DESCRIPTION
## Summary
- Replaces the two-consecutive-failures abort with a rate-based threshold: abort if >= 50% of chunks failed over at least 4 processed chunks
- Adds `totalChunksProcessed` and `totalChunksFailed` counters; removes `consecutiveFailures`
- Constants: `ABORT_MIN_CHUNKS=4`, `ABORT_FAILURE_RATE=0.5`
- Failure rate check runs at the start of each chunk iteration after the minimum sample size is reached

Two consecutive transient LM Studio reloads no longer abort consolidation. The rate-based policy rides through isolated transient failures. Tanenbaum, Distributed Systems §8.

Closes #392

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bunx biome check src/ tests/` passes
- [x] `bun test ./tests/commands/` — 198 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)