### PR TITLE
feat(improve): emit improve_lock_recovered event on stale-lock recovery (O-7 / #394)

### DIFF
--- a/src/commands/improve.ts
+++ b/src/commands/improve.ts
@@ -563,6 +563,22 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
 
       if (!pidIsAlive || lockAgeMs > MAX_LOCK_AGE_MS) {
         // Stale lock — remove and retry once with O_EXCL
+        // O-7 / #394: Emit improve_lock_recovered event before recovery so the
+        // audit trail records the abnormal prior-run exit (Temporal/Airflow pattern).
+        try {
+          appendEvent({
+            eventType: "improve_lock_recovered",
+            metadata: {
+              stalePid: lock?.pid ?? null,
+              lockedAt: lock?.startedAt ?? null,
+              recoveredAt: new Date().toISOString(),
+              lockAgeMs,
+              reason: !pidIsAlive ? "pid_not_alive" : "lock_age_exceeded",
+            },
+          });
+        } catch {
+          /* event emission is best-effort; never block lock recovery */
+        }
         try {
           fs.unlinkSync(resolvedLockPath);
         } catch {


### PR DESCRIPTION
## Summary
- Emits `improve_lock_recovered` event before removing a stale lock, recording `stalePid`, `lockedAt`, `recoveredAt`, `lockAgeMs`, and `reason` (pid_not_alive or lock_age_exceeded)
- Event emission is wrapped in try/catch and is best-effort — never blocks the recovery path
- Uses the already-imported `appendEvent` from `core/events`

Stale lock recovery indicates a prior run crashed or was killed. Without an event, there is no way to detect abnormal run termination, investigate root causes, or alert on repeated occurrences. Temporal/Airflow pattern — all state transitions should be observable.

Closes #394

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bunx biome check src/ tests/` passes
- [x] `bun test ./tests/commands/` — 198 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)