### PR TITLE
fix(distill): align timeout documentation with actual 600s default (D-6 / #397)

### DIFF
--- a/src/commands/distill.ts
+++ b/src/commands/distill.ts
@@ -12,7 +12,8 @@
  *
  *   - **Single bounded in-tree LLM call.** Wrapped in {@link tryLlmFeature}
  *     under the `feedback_distillation` gate (v1 spec §14). The wrapper
- *     enforces the 30 s hard timeout and converts disable / throw / timeout
+ *     enforces a hard timeout (default 600s / 10 min — overridable via
+ *     `opts.timeoutMs`) and converts disable / throw / timeout
  *     into a `null` return from `fn`, which we treat as a graceful
  *     "skipped" outcome (exit 0, no proposal, `distill_invoked` event with
  *     `outcome: "skipped"`).
@@ -875,8 +876,8 @@ export async function akmDistill(options: AkmDistillOptions): Promise<AkmDistill
     { role: "user", content: userPrompt },
   ];
 
-  // Single bounded LLM call. The wrapper handles the gate-check, 30 s
-  // timeout, and error fallback (returning `null`).
+  // Single bounded LLM call. The wrapper handles the gate-check, 600s
+  // (10 min) default timeout, and error fallback (returning `null`).
   const raw = await tryLlmFeature(
     "feedback_distillation",
     config,


### PR DESCRIPTION
## Summary
- Updates the module JSDoc comment on line 15 of distill.ts: "30 s hard timeout" → "600s / 10 min default timeout"
- Updates the inline comment before the `tryLlmFeature` call: "30 s timeout" → "600s (10 min) default timeout"
- The actual default in `feature-gate.ts` is `600_000` ms (10 minutes); the 30s claim was stale

Eliminates doc-drift that could cause operator confusion when tuning timeout values.

Closes #397

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bunx biome check src/ tests/` passes
- [x] `bun test ./tests/commands/` — 198 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)