### PR TITLE
fix(tests): isolate improve argv-coercion tests from real stash

### DIFF
--- a/tests/commands/reflect-propose-cli.test.ts
+++ b/tests/commands/reflect-propose-cli.test.ts
@@ -84,6 +84,15 @@ const VALID_SKILL_PAYLOAD = JSON.stringify({
 });
 
 beforeEach(() => {
+  // Isolate from the user's real stash. The two trivial argv-coercion tests
+  // (`empty scope becomes all-mode`, `type scope is preserved`) call
+  // `akmImprove({ dryRun: true })` without passing `stashDir`, which makes
+  // `resolveSourceEntries(undefined)` fall back to `resolveStashDir()` →
+  // `~/akm`. ensureIndex then walks the real 163 MB stash and the tests
+  // time out at the default 5 s. Setting AKM_STASH_DIR to an empty temp
+  // dir keeps the argv-coercion assertions intact (scope is parsed before
+  // any stash IO) and runs the whole file in ~4 s instead of ~53 s.
+  process.env.AKM_STASH_DIR = makeTempDir("akm-improve-cli-stash-root-");
   process.env.AKM_DATA_DIR = makeTempDir("akm-improve-cli-data-");
   process.env.AKM_STATE_DIR = makeTempDir("akm-improve-cli-state-");
   process.env.XDG_CACHE_HOME = makeTempDir("akm-improve-cli-cache-");


### PR DESCRIPTION
## Summary
- Fixes 2 pre-existing timeouts: \`improve argv coercion > empty scope becomes all-mode\` and \`type scope is preserved\` (both in \`tests/commands/reflect-propose-cli.test.ts\`).
- Root cause: \`beforeEach\` set \`AKM_STATE_DIR\`/\`XDG_DATA_HOME\`/\`XDG_STATE_HOME\` (from the May 20 isolation patch \`599ae1a\`) but never set \`AKM_STASH_DIR\`. Tests that didn't pass \`stashDir\` explicitly walked the real 163MB user stash through \`ensureIndex\`, taking ~25s per test (5s timeout → fail).
- One-line fix: set \`process.env.AKM_STASH_DIR\` to a temp dir in \`beforeEach\`.
- File completes in 3.7s now (was 53.7s); test suite green at default 5s timeout.

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun run lint\` clean
- [x] \`bun test tests/commands/reflect-propose-cli.test.ts\` — 6/6 pass at default 5s timeout
- [x] \`bun test ./tests --timeout 60000\` — 3422 pass / 21 skip / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)