### PR TITLE
fix(improve): skip reflect for unsupported asset types before dispatch

### DIFF
--- a/src/commands/improve.ts
+++ b/src/commands/improve.ts
@@ -59,7 +59,7 @@ import { type AkmDistillResult, akmDistill, deriveLessonRef, isDistillRefusedInp
 import { deriveKnowledgeRef } from "./distill-promotion-policy";
 import { countEvalCases, writeEvalCase } from "./eval-cases";
 import { akmLint } from "./lint/index";
-import { type AkmReflectResult, akmReflect } from "./reflect";
+import { type AkmReflectResult, akmReflect, REFLECT_ALLOWED_TYPES } from "./reflect";
 import { runSchemaRepairPass } from "./schema-repair";
 import { checkDeadUrls, type DeadUrl } from "./url-checker";
 
@@ -172,6 +172,7 @@ export interface ImproveActionResult {
     | "reflect"
     | "reflect-failed"
     | "reflect-cooldown"
+    | "reflect-skipped"
     | "distill"
     | "distill-skipped"
     | "memory-prune"
@@ -247,6 +248,8 @@ export interface AkmImproveResult {
   proposalsExpired?: number;
   /** Number of reflect actions that were skipped due to cooldown/dedup signals. */
   reflectCooldownActions?: number;
+  /** Number of reflect actions skipped because the asset type is not supported by reflect. */
+  reflectSkippedActions?: number;
 }
 
 type ImproveScope = ReturnType<typeof resolveImproveScope>;
@@ -904,6 +907,7 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
       ...(orphansPurged !== undefined ? { orphansPurged } : {}),
       ...(proposalsExpired !== undefined && proposalsExpired > 0 ? { proposalsExpired } : {}),
       reflectCooldownActions: finalActions.filter((a) => a.mode === "reflect-cooldown").length,
+      reflectSkippedActions: finalActions.filter((a) => a.mode === "reflect-skipped").length,
     };
     if (!result.dryRun)
       emitImproveCompletedEvent(
@@ -965,6 +969,7 @@ function emitImproveCompletedEvent(
     reflect: 0,
     reflectFailed: 0,
     reflectCooldown: 0,
+    reflectSkipped: 0,
     distill: 0,
     distillSkipped: 0,
     memoryPrune: 0,
@@ -982,6 +987,9 @@ function emitImproveCompletedEvent(
         break;
       case "reflect-cooldown":
         actionCounts.reflectCooldown += 1;
+        break;
+      case "reflect-skipped":
+        actionCounts.reflectSkipped += 1;
         break;
       case "distill":
         actionCounts.distill += 1;
@@ -1022,6 +1030,7 @@ function emitImproveCompletedEvent(
         errorActions: actionCounts.error,
         reflectFailedActions: actionCounts.reflectFailed,
         reflectCooldownActions: actionCounts.reflectCooldown,
+        reflectSkippedActions: actionCounts.reflectSkipped,
         reflectsWithErrorContext: result.reflectsWithErrorContext ?? 0,
         coverageGapCount: result.coverageGaps?.length ?? 0,
         executionLogCandidateCount: result.executionLogCandidates?.length ?? 0,
@@ -1864,145 +1873,159 @@ async function runImproveLoopStage(args: {
       // path is also a no-op for them — we just avoid unnecessary agent spawns.
       // D2: distillOnlyRefs also skip the reflect call (reflect-cooled, distill path only).
       if (!isDistillOnly && !planned.ref.endsWith(".derived")) {
-        // O-5 / #378: only inject reflect-originator errors into the reflect call.
-        // Cross-task errors (e.g. schema-repair) must NOT contaminate reflect prompts.
-        const reflectErrors = recentErrors.reflect ?? [];
-        if (reflectErrors.length > 0) reflectsWithErrorContext++;
-        // O-1 (#364): pass remaining budget as timeoutMs so the agent spawn is
-        // bounded by the wall-clock deadline rather than the default per-profile timeout.
-        const reflectBudgetMs = remainingBudgetMs();
-        const reflectCallArgs = {
-          ref: planned.ref,
-          task: options.task,
-          ...(options.stashDir ? { stashDir: options.stashDir } : {}),
-          ...(reflectErrors.length > 0 ? { avoidPatterns: [...reflectErrors] } : {}),
-          agentProcess: options.agentProcess ?? "reflect",
-          eventSource: "improve" as const,
-          ...(reflectBudgetMs > 0 ? { timeoutMs: reflectBudgetMs } : {}),
-        };
-        // R-2 / #389: Self-consistency multi-sample voting for high-utility refs.
-        // Self-Consistency arXiv:2203.11171 — N=3 samples beat single-shot quality.
-        const refUtility = utilityMap.get(planned.ref) ?? 0;
-        const useConsistency = refUtility >= SC_THRESHOLD && SC_N >= 2;
-        let reflectResult: AkmReflectResult;
-        if (useConsistency) {
-          const samples: AkmReflectResult[] = [];
-          for (let s = 0; s < SC_N; s++) {
-            if (remainingBudgetMs() <= 0) break;
-            // draftMode: skip DB write so each sample doesn't create a proposal.
-            samples.push(await reflectFn({ ...reflectCallArgs, draftMode: true }));
-          }
-          const winner = pickMajorityVote(
-            samples.length > 0 ? samples : [await reflectFn({ ...reflectCallArgs, draftMode: true })],
-          );
-          // Persist only the majority-vote winner as a single real proposal.
-          if (winner.ok && primaryStashDir) {
-            const persistResult = createProposal(primaryStashDir, {
-              ref: winner.proposal.ref,
-              source: "reflect",
-              sourceRun: `reflect-sc-${Date.now()}`,
-              payload: winner.proposal.payload,
-            });
-            reflectResult = isProposalSkipped(persistResult)
-              ? {
-                  schemaVersion: 1,
-                  ok: false,
-                  reason: "cooldown" as const,
-                  error: `SC proposal skipped: ${persistResult.message}`,
-                  ref: winner.ref,
-                  exitCode: null,
-                }
-              : { ...winner, proposal: persistResult };
-          } else {
-            reflectResult = winner;
-          }
-        } else {
-          reflectResult = await reflectFn(reflectCallArgs);
-        }
-        const isCooldown = !reflectResult.ok && reflectResult.reason === "cooldown";
-        actions.push({
-          ref: planned.ref,
-          mode: reflectResult.ok ? "reflect" : isCooldown ? "reflect-cooldown" : "reflect-failed",
-          result: reflectResult,
-        });
-        // Cooldown skips are not failures — do not pollute recentErrors with them
-        // (those get injected as `avoidPatterns` into the next reflect prompt).
-        if (!reflectResult.ok && !isCooldown) {
-          const errMsg = reflectResult.error ?? reflectResult.reason ?? "unknown reflect error";
-          pushRecentError("reflect", errMsg);
-        }
-        // improve_reflect_outcome — per-asset metric for tuning the reflect path.
-        appendEvent(
-          {
-            eventType: "improve_reflect_outcome",
+        // Type guard: skip reflect for unsupported types (script, vault, task, etc.).
+        // These types are rejected by akmReflect with a parse_error — filter them
+        // here to avoid wasting a reflect slot. Mirror of REFLECT_ALLOWED_TYPES in
+        // reflect.ts (the authoritative source of truth, exported for this check).
+        if (!REFLECT_ALLOWED_TYPES.has(parsedPlannedRef.type)) {
+          actions.push({
             ref: planned.ref,
-            metadata: {
-              ok: reflectResult.ok,
-              durationMs: reflectResult.ok ? reflectResult.durationMs : undefined,
-              agentProfile: reflectResult.ok ? reflectResult.agentProfile : undefined,
-              reason: reflectResult.ok ? undefined : reflectResult.reason,
+            mode: "reflect-skipped",
+            result: { ok: true, reason: "unsupported-type" },
+          });
+        } else {
+          // O-5 / #378: only inject reflect-originator errors into the reflect call.
+          // Cross-task errors (e.g. schema-repair) must NOT contaminate reflect prompts.
+          const reflectErrors = recentErrors.reflect ?? [];
+          if (reflectErrors.length > 0) reflectsWithErrorContext++;
+          // O-1 (#364): pass remaining budget as timeoutMs so the agent spawn is
+          // bounded by the wall-clock deadline rather than the default per-profile timeout.
+          const reflectBudgetMs = remainingBudgetMs();
+          const reflectCallArgs = {
+            ref: planned.ref,
+            task: options.task,
+            ...(options.stashDir ? { stashDir: options.stashDir } : {}),
+            ...(reflectErrors.length > 0 ? { avoidPatterns: [...reflectErrors] } : {}),
+            agentProcess: options.agentProcess ?? "reflect",
+            eventSource: "improve" as const,
+            ...(reflectBudgetMs > 0 ? { timeoutMs: reflectBudgetMs } : {}),
+          };
+          // R-2 / #389: Self-consistency multi-sample voting for high-utility refs.
+          // Self-Consistency arXiv:2203.11171 — N=3 samples beat single-shot quality.
+          const refUtility = utilityMap.get(planned.ref) ?? 0;
+          const useConsistency = refUtility >= SC_THRESHOLD && SC_N >= 2;
+          let reflectResult: AkmReflectResult;
+          if (useConsistency) {
+            const samples: AkmReflectResult[] = [];
+            for (let s = 0; s < SC_N; s++) {
+              if (remainingBudgetMs() <= 0) break;
+              // draftMode: skip DB write so each sample doesn't create a proposal.
+              samples.push(await reflectFn({ ...reflectCallArgs, draftMode: true }));
+            }
+            const winner = pickMajorityVote(
+              samples.length > 0 ? samples : [await reflectFn({ ...reflectCallArgs, draftMode: true })],
+            );
+            // Persist only the majority-vote winner as a single real proposal.
+            if (winner.ok && primaryStashDir) {
+              const persistResult = createProposal(primaryStashDir, {
+                ref: winner.proposal.ref,
+                source: "reflect",
+                sourceRun: `reflect-sc-${Date.now()}`,
+                payload: winner.proposal.payload,
+              });
+              reflectResult = isProposalSkipped(persistResult)
+                ? {
+                    schemaVersion: 1,
+                    ok: false,
+                    reason: "cooldown" as const,
+                    error: `SC proposal skipped: ${persistResult.message}`,
+                    ref: winner.ref,
+                    exitCode: null,
+                  }
+                : { ...winner, proposal: persistResult };
+            } else {
+              reflectResult = winner;
+            }
+          } else {
+            reflectResult = await reflectFn(reflectCallArgs);
+          }
+          const isCooldown = !reflectResult.ok && reflectResult.reason === "cooldown";
+          actions.push({
+            ref: planned.ref,
+            mode: reflectResult.ok ? "reflect" : isCooldown ? "reflect-cooldown" : "reflect-failed",
+            result: reflectResult,
+          });
+          // Cooldown skips are not failures — do not pollute recentErrors with them
+          // (those get injected as `avoidPatterns` into the next reflect prompt).
+          if (!reflectResult.ok && !isCooldown) {
+            const errMsg = reflectResult.error ?? reflectResult.reason ?? "unknown reflect error";
+            pushRecentError("reflect", errMsg);
+          }
+          // improve_reflect_outcome — per-asset metric for tuning the reflect path.
+          appendEvent(
+            {
+              eventType: "improve_reflect_outcome",
+              ref: planned.ref,
+              metadata: {
+                ok: reflectResult.ok,
+                durationMs: reflectResult.ok ? reflectResult.durationMs : undefined,
+                agentProfile: reflectResult.ok ? reflectResult.agentProfile : undefined,
+                reason: reflectResult.ok ? undefined : reflectResult.reason,
+              },
             },
-          },
-          eventsCtx,
-        );
+            eventsCtx,
+          );
 
-        // Phase 6A (Advantage D6a): Confidence-driven auto-accept.
-        //
-        // The existing `--auto-accept` flag (commit 0c5eaa1) is a 0-100 integer
-        // threshold; `undefined` means auto-accept is disabled. Until this
-        // wave, the consolidate path treated any non-undefined value as a
-        // whole-batch "safe" accept (see TODO in consolidate.ts). Now that
-        // reflect proposals carry a self-reported `confidence` score in
-        // [0, 1], we can compare per-proposal: confidence >= threshold/100
-        // auto-accepts via the standard `promoteProposal` path; otherwise the
-        // proposal waits in the pending queue for human review.
-        //
-        // Plan default is 0.8 (per `self-improvement-enhancements-plan.md`
-        // line 184). We honour the existing CLI default (90 → 0.9) because
-        // that is what users have been seeing since 0c5eaa1; the plan and the
-        // existing default agree directionally that high-confidence-only is
-        // the right policy. The CLI flag is the single knob.
-        if (
-          reflectResult.ok &&
-          options.autoAccept !== undefined &&
-          typeof reflectResult.proposal.confidence === "number" &&
-          primaryStashDir
-        ) {
-          const threshold = options.autoAccept / 100;
-          const confidence = reflectResult.proposal.confidence;
-          if (confidence >= threshold) {
-            try {
-              const cfg = options.config ?? loadConfig();
-              const promotion = await promoteProposal(primaryStashDir, cfg, reflectResult.proposal.id, {}, undefined);
-              appendEvent(
-                {
-                  eventType: "promoted",
-                  ref: promotion.ref,
-                  metadata: {
-                    proposalId: promotion.proposal.id,
-                    source: promotion.proposal.source,
-                    ...(promotion.proposal.sourceRun !== undefined ? { sourceRun: promotion.proposal.sourceRun } : {}),
-                    assetPath: promotion.assetPath,
-                    autoAccept: true,
-                    confidence,
-                    threshold,
+          // Phase 6A (Advantage D6a): Confidence-driven auto-accept.
+          //
+          // The existing `--auto-accept` flag (commit 0c5eaa1) is a 0-100 integer
+          // threshold; `undefined` means auto-accept is disabled. Until this
+          // wave, the consolidate path treated any non-undefined value as a
+          // whole-batch "safe" accept (see TODO in consolidate.ts). Now that
+          // reflect proposals carry a self-reported `confidence` score in
+          // [0, 1], we can compare per-proposal: confidence >= threshold/100
+          // auto-accepts via the standard `promoteProposal` path; otherwise the
+          // proposal waits in the pending queue for human review.
+          //
+          // Plan default is 0.8 (per `self-improvement-enhancements-plan.md`
+          // line 184). We honour the existing CLI default (90 → 0.9) because
+          // that is what users have been seeing since 0c5eaa1; the plan and the
+          // existing default agree directionally that high-confidence-only is
+          // the right policy. The CLI flag is the single knob.
+          if (
+            reflectResult.ok &&
+            options.autoAccept !== undefined &&
+            typeof reflectResult.proposal.confidence === "number" &&
+            primaryStashDir
+          ) {
+            const threshold = options.autoAccept / 100;
+            const confidence = reflectResult.proposal.confidence;
+            if (confidence >= threshold) {
+              try {
+                const cfg = options.config ?? loadConfig();
+                const promotion = await promoteProposal(primaryStashDir, cfg, reflectResult.proposal.id, {}, undefined);
+                appendEvent(
+                  {
+                    eventType: "promoted",
+                    ref: promotion.ref,
+                    metadata: {
+                      proposalId: promotion.proposal.id,
+                      source: promotion.proposal.source,
+                      ...(promotion.proposal.sourceRun !== undefined
+                        ? { sourceRun: promotion.proposal.sourceRun }
+                        : {}),
+                      assetPath: promotion.assetPath,
+                      autoAccept: true,
+                      confidence,
+                      threshold,
+                    },
                   },
-                },
-                eventsCtx,
-              );
-              info(
-                `[improve] auto-accepted ${promotion.ref} (confidence=${confidence.toFixed(2)} >= threshold=${threshold.toFixed(2)})`,
-              );
-            } catch (err) {
-              // Auto-accept failures (validation, write error, etc.) must not
-              // poison the loop — surface a warning and leave the proposal
-              // pending so the reviewer can deal with it manually.
-              warn(
-                `[improve] auto-accept failed for ${reflectResult.proposal.ref}: ${err instanceof Error ? err.message : String(err)}`,
-              );
+                  eventsCtx,
+                );
+                info(
+                  `[improve] auto-accepted ${promotion.ref} (confidence=${confidence.toFixed(2)} >= threshold=${threshold.toFixed(2)})`,
+                );
+              } catch (err) {
+                // Auto-accept failures (validation, write error, etc.) must not
+                // poison the loop — surface a warning and leave the proposal
+                // pending so the reviewer can deal with it manually.
+                warn(
+                  `[improve] auto-accept failed for ${reflectResult.proposal.ref}: ${err instanceof Error ? err.message : String(err)}`,
+                );
+              }
             }
           }
-        }
+        } // end else (REFLECT_ALLOWED_TYPES check)
       } else if (!isDistillOnly && planned.ref.endsWith(".derived")) {
         // B6: .derived refs skip reflect; record synthetic skip action.
         actions.push({

--- a/src/commands/reflect.ts
+++ b/src/commands/reflect.ts
@@ -220,7 +220,7 @@ const MAX_REJECTED_PROPOSALS = 3;
  * Observed regression: proposal `8737ab63` (May 2026) prepended frontmatter to
  * a `.ts` script file via reflect. This whitelist prevents that.
  */
-const REFLECT_ALLOWED_TYPES: ReadonlySet<string> = new Set([
+export const REFLECT_ALLOWED_TYPES: ReadonlySet<string> = new Set([
   "knowledge",
   "memory",
   "lesson",

--- a/tests/commands/improve-reflect-unsupported-type-skip.test.ts
+++ b/tests/commands/improve-reflect-unsupported-type-skip.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Regression test: improve must not dispatch unsupported asset types (script,
+ * vault, task, …) to the reflect path.
+ *
+ * Before this fix, `src/commands/reflect.ts` contained an internal guard
+ * (REFLECT_ALLOWED_TYPES) that rejected non-markdown-canonical types with a
+ * `parse_error`, but the improve loop dispatched those refs unconditionally —
+ * they burned a reflect slot and recorded `reflect-failed` actions. In the
+ * 2026-05-22T05:10 run, 2 of 4 reflect-failed actions were script-type rejections.
+ *
+ * The fix exports REFLECT_ALLOWED_TYPES from reflect.ts and adds a pre-check
+ * in the improve loop at the reflect dispatch site: refs whose type is NOT in
+ * the set are short-circuited with mode `reflect-skipped` and reason
+ * `"unsupported-type"` instead of calling akmReflect.
+ *
+ * This test pins the planner-side contract:
+ *
+ *   1. A stash containing a `script:*` ref that would otherwise be a reflect
+ *      candidate never causes akmReflect to be called.
+ *   2. The action for that ref is recorded as `reflect-skipped` (not
+ *      `reflect-failed`) so the run summary is not polluted with bogus failures.
+ *   3. A co-located `skill:*` ref (an allowed type) IS reflected normally —
+ *      the guard does not accidentally block allowed types.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { AkmDistillResult } from "../../src/commands/distill";
+import { akmImprove } from "../../src/commands/improve";
+import type { AkmReflectOptions, AkmReflectResult } from "../../src/commands/reflect";
+import { REFLECT_ALLOWED_TYPES } from "../../src/commands/reflect";
+import { saveConfig } from "../../src/core/config";
+import { appendEvent } from "../../src/core/events";
+import { akmIndex } from "../../src/indexer/indexer";
+
+const tempDirs: string[] = [];
+const savedEnv = {
+  AKM_STASH_DIR: process.env.AKM_STASH_DIR,
+  AKM_DATA_DIR: process.env.AKM_DATA_DIR,
+  AKM_STATE_DIR: process.env.AKM_STATE_DIR,
+  XDG_CACHE_HOME: process.env.XDG_CACHE_HOME,
+  XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+  XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+  XDG_STATE_HOME: process.env.XDG_STATE_HOME,
+};
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function indexStash(stashDir: string): Promise<void> {
+  process.env.AKM_STASH_DIR = stashDir;
+  saveConfig({ semanticSearchMode: "off" });
+  await akmIndex({ stashDir, full: true });
+}
+
+function makeStubReflectResult(ref: string): AkmReflectResult {
+  return {
+    schemaVersion: 1,
+    ok: true,
+    ref,
+    agentProfile: "test-agent",
+    durationMs: 1,
+    proposal: {
+      id: `reflect-${ref.replace(/[^a-z0-9]/gi, "-")}`,
+      ref,
+      status: "pending",
+      source: "reflect",
+      createdAt: "2026-05-22T00:00:00.000Z",
+      updatedAt: "2026-05-22T00:00:00.000Z",
+      payload: { content: "# stub reflect" },
+    },
+  };
+}
+
+function makeStubDistillResult(ref: string): AkmDistillResult {
+  return {
+    schemaVersion: 1,
+    ok: true,
+    outcome: "queued",
+    inputRef: ref,
+    lessonRef: `lesson:${ref.replace(/[:/]/g, "-")}-lesson`,
+  };
+}
+
+beforeEach(() => {
+  process.env.AKM_DATA_DIR = makeTempDir("akm-improve-reflect-unsupported-type-data-");
+  process.env.AKM_STATE_DIR = makeTempDir("akm-improve-reflect-unsupported-type-state-");
+  process.env.XDG_CACHE_HOME = makeTempDir("akm-improve-reflect-unsupported-type-cache-");
+  process.env.XDG_CONFIG_HOME = makeTempDir("akm-improve-reflect-unsupported-type-config-");
+});
+
+afterEach(() => {
+  if (savedEnv.AKM_STASH_DIR === undefined) delete process.env.AKM_STASH_DIR;
+  else process.env.AKM_STASH_DIR = savedEnv.AKM_STASH_DIR;
+  if (savedEnv.AKM_DATA_DIR === undefined) delete process.env.AKM_DATA_DIR;
+  else process.env.AKM_DATA_DIR = savedEnv.AKM_DATA_DIR;
+  if (savedEnv.AKM_STATE_DIR === undefined) delete process.env.AKM_STATE_DIR;
+  else process.env.AKM_STATE_DIR = savedEnv.AKM_STATE_DIR;
+  if (savedEnv.XDG_CACHE_HOME === undefined) delete process.env.XDG_CACHE_HOME;
+  else process.env.XDG_CACHE_HOME = savedEnv.XDG_CACHE_HOME;
+  if (savedEnv.XDG_CONFIG_HOME === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = savedEnv.XDG_CONFIG_HOME;
+  if (savedEnv.XDG_DATA_HOME === undefined) delete process.env.XDG_DATA_HOME;
+  else process.env.XDG_DATA_HOME = savedEnv.XDG_DATA_HOME;
+  if (savedEnv.XDG_STATE_HOME === undefined) delete process.env.XDG_STATE_HOME;
+  else process.env.XDG_STATE_HOME = savedEnv.XDG_STATE_HOME;
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("REFLECT_ALLOWED_TYPES export", () => {
+  test("does not include 'script'", () => {
+    expect(REFLECT_ALLOWED_TYPES.has("script")).toBe(false);
+  });
+
+  test("does not include 'vault'", () => {
+    expect(REFLECT_ALLOWED_TYPES.has("vault")).toBe(false);
+  });
+
+  test("does not include 'task'", () => {
+    expect(REFLECT_ALLOWED_TYPES.has("task")).toBe(false);
+  });
+
+  test("includes all markdown-canonical types", () => {
+    for (const t of ["knowledge", "memory", "lesson", "wiki", "skill", "agent", "command", "workflow"]) {
+      expect(REFLECT_ALLOWED_TYPES.has(t)).toBe(true);
+    }
+  });
+});
+
+describe("improve loop: unsupported-type reflect pre-check", () => {
+  test("script:* ref is recorded as reflect-skipped, not reflect-failed, and akmReflect is NOT called", async () => {
+    const stash = makeTempDir("akm-improve-reflect-unsupported-stash-");
+
+    // Create a script asset — stored under scripts/ with a .sh extension.
+    fs.mkdirSync(path.join(stash, "scripts"), { recursive: true });
+    fs.writeFileSync(path.join(stash, "scripts", "deploy.sh"), "#!/usr/bin/env bash\necho 'deploy'\n", "utf8");
+
+    // Also create a skill so we can assert that allowed types still flow through.
+    fs.mkdirSync(path.join(stash, "skills", "deploy-guide"), { recursive: true });
+    fs.writeFileSync(
+      path.join(stash, "skills", "deploy-guide", "SKILL.md"),
+      "---\ndescription: Deploy guide\nwhen_to_use: When deploying\n---\n\nDeploy carefully.\n",
+      "utf8",
+    );
+
+    await indexStash(stash);
+
+    // Inject positive feedback so both refs pass the signal filter inside improve.
+    appendEvent({ eventType: "feedback", ref: "script:deploy.sh", metadata: { signal: "positive", note: "fixture" } });
+    appendEvent({
+      eventType: "feedback",
+      ref: "skill:deploy-guide",
+      metadata: { signal: "positive", note: "fixture" },
+    });
+
+    const reflectCalls: AkmReflectOptions[] = [];
+
+    const result = await akmImprove({
+      stashDir: stash,
+      ensureIndexFn: async () => undefined,
+      reindexFn: async () => ({
+        schemaVersion: 1,
+        ok: true,
+        indexed: 0,
+        warnings: [],
+        errors: [],
+        durationMs: 0,
+      }),
+      reflectFn: async (options): Promise<AkmReflectResult> => {
+        reflectCalls.push(options);
+        return makeStubReflectResult(options.ref ?? "unknown");
+      },
+      distillFn: async (options): Promise<AkmDistillResult> => makeStubDistillResult(options.ref),
+    });
+
+    // Core assertion 1: akmReflect was never called for the script ref.
+    const reflectedRefs = reflectCalls.map((c) => c.ref ?? "");
+    expect(reflectedRefs.filter((r) => r.startsWith("script:"))).toEqual([]);
+
+    // Core assertion 2: the script ref action is recorded as reflect-skipped.
+    const scriptActions = (result.actions ?? []).filter((a) => a.ref === "script:deploy.sh");
+    expect(scriptActions.length).toBeGreaterThan(0);
+    const reflectFailedActions = scriptActions.filter((a) => a.mode === "reflect-failed");
+    expect(reflectFailedActions).toEqual([]);
+    const reflectSkippedActions = scriptActions.filter((a) => a.mode === "reflect-skipped");
+    expect(reflectSkippedActions.length).toBeGreaterThan(0);
+    // Reason must be "unsupported-type" — not a generic failure.
+    for (const action of reflectSkippedActions) {
+      expect((action.result as { reason?: string }).reason).toBe("unsupported-type");
+    }
+
+    // Core assertion 3: the allowed-type skill ref IS reflected normally (type
+    // guard must not block allowed types).
+    const skillActions = (result.actions ?? []).filter((a) => a.ref === "skill:deploy-guide");
+    const skillReflectActions = skillActions.filter((a) => a.mode === "reflect");
+    expect(skillReflectActions.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- `script`, `vault`, and `task` refs were being dispatched to `akmReflect` even though reflect hard-rejects them via `REFLECT_ALLOWED_TYPES`. Each wasted a reflect slot and surfaced as `reflect-failed` in the improve result (2 of 4 failures in the 2026-05-22T05:10 run were this)
- Exports `REFLECT_ALLOWED_TYPES` from `reflect.ts` (was unexported)
- Adds a pre-check in the improve loop at the reflect dispatch site — refs whose type is not in the allowed set are recorded as `reflect-skipped` (reason: `"unsupported-type"`) instead of calling `akmReflect`
- Adds `reflect-skipped` to `ImproveActionResult` mode union, action counter, result envelope, and `improve_completed` event metadata

## Test plan
- [ ] `tests/commands/improve-reflect-unsupported-type-skip.test.ts`: `script:*` ref → `reflect-skipped` (akmReflect not called); co-located `skill:*` ref → `reflect` (unaffected)
- [ ] Full suite: 3480 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)