### PR TITLE
fix(setup,paths): stop silently clobbering host config under transient AKM_STASH_DIR

### DIFF
--- a/docs/technical/incidents/2026-05-23-setup-clobbers-user-config.md
+++ b/docs/technical/incidents/2026-05-23-setup-clobbers-user-config.md
@@ -1,0 +1,112 @@
+# Bug: `akm setup --yes --dir .` writes to user's global config even with `AKM_STASH_DIR` set
+
+**Discovered:** 2026-05-23
+**AKM version:** 0.8.0-rc.4 (`release/0.8.0` @ 0e1d339)
+**Severity:** High — silent corruption of user's global config; only detectable by explicit `akm config get stashDir` check.
+
+## Summary
+
+`akm setup --yes --dir .` writes its resulting config to the user's **global** `~/.config/akm/config.json` even when `AKM_STASH_DIR` and `AKM_DATA_DIR` env vars are exported to point at a temp directory. The env isolation correctly redirects stash and data file paths but does **not** redirect config persistence. When a test harness or smoke-test script then removes the temp stash, the user's global config is left with `stashDir` pointing at a deleted path. AKM silently falls back to `~/akm` for stash operations so the breakage is invisible to the user until they explicitly inspect the config.
+
+## Reproduction
+
+```bash
+# Confirm starting state
+akm config get stashDir
+# → "/home/founder3/akm"
+
+# Run a setup smoke test in an isolated temp stash
+cd /tmp && rm -rf repro-stash && mkdir -p repro-stash && cd repro-stash && \
+  AKM_DATA_DIR=$(pwd)/data AKM_STASH_DIR=$(pwd) \
+  bun /path/to/akm/dist/cli.js setup --yes --dir .
+
+# Re-check the global config from the user's shell
+akm config get stashDir
+# → "/tmp/repro-stash"   ← BUG: env-isolated setup leaked into global config
+
+# Worse, after cleanup:
+cd / && rm -rf /tmp/repro-stash
+akm config get stashDir
+# → "/tmp/repro-stash"   ← still pointing at a deleted dir
+akm improve  # silently falls back to ~/akm; user has no idea config is broken
+```
+
+## Real-world impact (incident on this machine)
+
+A parallel Claude Code session (sessionId `e702fb7d-1095-42a7-98eb-e71974457c77`, working in `~/code/github/itlackey/akm/` on the 0.8.0 release-readiness audit) ran:
+
+```bash
+# 06:28:35Z
+cd /tmp && rm -rf tw-stash && mkdir -p tw-stash && cd tw-stash && \
+  AKM_DATA_DIR=$(pwd)/data AKM_STASH_DIR=$(pwd) \
+  /home/founder3/code/github/itlackey/akm/dist/cli.js setup --yes --dir .
+
+# 06:28:48Z
+cd /tmp/tw-stash && rm -rf data .akm; \
+  AKM_DATA_DIR=$(pwd)/data AKM_STASH_DIR=$(pwd) \
+  bun /home/founder3/code/github/itlackey/akm/dist/cli.js setup --yes --dir .
+
+# 06:34:29Z
+rm -rf /tmp/tw-stash && echo "cleaned"
+```
+
+Result: the user's `~/.config/akm/config.json` was rewritten with `stashDir: "/tmp/tw-stash"`, the entire `llm` block was dropped, all 4 `profiles.llm.*` entries (qwen-9b/ministral-3b/gemma-e4b/default) were lost, `profiles.improve.default.processes` lost `consolidate` and `feedbackDistillation`, the `defaults` block was lost, and `configVersion` was dropped. Setup *also* added `index.stalenessDetection` defaults and `profiles.agent.opencode` (= `github-copilot/gpt-5-mini`).
+
+The breakage was silent for ~5.5 hours until a memory write returned `"stashRoot": "/home/founder3/akm"` despite the configured `stashDir` being `/tmp/tw-stash`, prompting investigation.
+
+## Forensic trail
+
+Two consecutive `saveConfig()` backups exist 6ms apart, confirming a single-process write:
+
+```text
+~/.cache/akm/config-backups/config-2026-05-23T06-28-48-123Z.json  ← 12,279 bytes, stashDir: /home/founder3/akm  (healthy)
+~/.cache/akm/config-backups/config-2026-05-23T06-28-48-129Z.json  ← 12,274 bytes, stashDir: /tmp/tw-stash         (broken)
+```
+
+The canonical attribution log for cross-session investigation is `~/.local/state/akm-claude/events.jsonl` — it captures one `tool_observation` event per Bash call, per session, including sessionId, timestamp, and full command. Grep for any suspect literal (e.g. `tw-stash`) to find the originating session and command.
+
+## Root cause
+
+`src/setup/setup.ts` calls `saveConfig(...)` at lines 1842, 1971, and 2082. `saveConfig` (in `src/core/config.ts:956+`) writes to the path returned by the config-path resolver, which honors `XDG_CONFIG_HOME` but **not** `AKM_STASH_DIR`. So when the user sets `AKM_STASH_DIR=/tmp/X` and `AKM_DATA_DIR=/tmp/X/data` (which is the documented isolation pattern, e.g. in `scripts/akm-eval/src/sources/sandbox.ts`), config writes still target the host's `~/.config/akm/config.json`.
+
+There is a guard in `src/commands/init.ts:41-46` that *refuses* `/tmp/*`, `/var/tmp/*`, `/private/tmp/*` as a stashDir — but that guard applies to `akm init`, not to `akm setup`.
+
+The companion bug: `~/.cache/akm/config-backups/` is also not isolated. The 32-byte backups created at minute-marks throughout the day (e.g. `config-2026-05-23T05-15-30-150Z.json` = `{"agent":{"default":"opencode"}}`) prove that any subprocess `saveConfig({minimal})` writes to the user's cache regardless of env isolation. This pollutes the backup directory and makes legitimate backups hard to find.
+
+## Proposed fixes
+
+1. **Honor `AKM_STASH_DIR` in `saveConfig`.** When `AKM_STASH_DIR` is set and points at a directory the process can write to, write config to `$AKM_STASH_DIR/config.json` (or under `$AKM_STASH_DIR/.akm/config.json`) instead of the host's global config. This is the same pattern the data dir already uses for `state.db` etc.
+2. **Apply the `init.ts` tmp-guard to `setup`.** `src/commands/init.ts:41-46` refuses `stashDir.startsWith("/tmp/")`. The same refusal should apply in `setup` unless `--force` is passed. This prevents *any* setup invocation from persisting a `/tmp/...` stashDir to the user's global config.
+3. **Add `--config-out <path>` to `akm setup`.** Explicit redirection for test harnesses that intentionally want their own config file.
+4. **Add `akm doctor` health check.** A new subcommand (or extension of `akm health`) that verifies: `stashDir` is readable; `stashDir` parent exists; `stashDir` matches what `akm info` reports as `stashRoot`. Suggests `mv -fv ~/.cache/akm/config-backups/config-<largest-pre-incident>.json ~/.config/akm/config.json` when corruption is detected.
+5. **Isolate `~/.cache/akm/config-backups/`.** The backup write path must honor `XDG_CACHE_HOME` and/or `AKM_CACHE_DIR`. Currently any subprocess `saveConfig()` pollutes the host's backup dir.
+6. **Print a stark warning when `AKM_STASH_DIR` is set but config persistence is not redirected.** Until fix #1 lands, at minimum `setup` should warn: `"WARNING: AKM_STASH_DIR=$X is set, but config will be written to $HOST_CONFIG. Pass --config-out to redirect, or fix #N."`
+
+## Recovery procedure for users hit by this bug
+
+```bash
+# 1. Diagnose
+akm config get stashDir
+grep STASH_DIR_UNREADABLE ~/.cache/akm/tasks/logs/akm-improve.log | head -3
+
+# 2. Find the largest pre-incident backup
+ls -lat ~/.cache/akm/config-backups/config-*.json | awk '$5 > 5000 {print}' | head -5
+
+# 3. Restore (use mv, not rm, so the broken config is preserved)
+mv -v ~/.config/akm/config.json ~/.config/akm/config.broken-$(date +%Y%m%d-%H%M).json
+mv -v ~/.cache/akm/config-backups/config-<largest>.json ~/.config/akm/config.json
+
+# 4. Verify
+akm config get stashDir
+akm config list | jq '{stashDir, llm, defaults, profiles: .profiles | keys}'
+```
+
+AKM auto-migrates older schemas on first read after restore.
+
+## Related
+
+- `src/setup/setup.ts:1842,1971,2082` — `saveConfig` call sites in setup
+- `src/core/config.ts:956+` — `saveConfig` implementation (config-path resolver)
+- `src/commands/init.ts:41-46` — existing `/tmp/*` guard (not applied to setup)
+- `scripts/akm-eval/src/sources/sandbox.ts` — correct env-isolation pattern for stash + data; sets `HOME=root` precisely to dodge this category of leakage
+- `~/.local/state/akm-claude/events.jsonl` — multi-session Bash command log used for attribution

--- a/scripts/akm-eval/src/sources/sandbox.ts
+++ b/scripts/akm-eval/src/sources/sandbox.ts
@@ -8,10 +8,14 @@
  *   - the memory-safety runner (mandatory isolation; mutates the stash),
  *   - Phase 5's graph A/B harness (will reuse this verbatim).
  *
- * Mirrors the test-isolation contract from release/0.8.0
- * (`7d8b28a`, `23373b5`, `cc95085`, `35ec047`): AKM_STASH_DIR + AKM_DATA_DIR
- * + HOME all point inside the sandbox, so no akm code path can escape into
- * the real user directories.
+ * Isolation contract (updated for PR #449 / 2026-05-23 incident):
+ *   - AKM_STASH_DIR   → $root/stash  (transient path, triggers paths.ts
+ *                        transient-isolation rule → config writes go to
+ *                        $STASH/.akm instead of $HOME/.config/akm)
+ *   - AKM_DATA_DIR    → $root/data   (index.db, workflow.db, akm.lock)
+ *   - HOME            → $root        (state dir falls to $HOME/.local/state/akm;
+ *                        cache dir falls to $HOME/.cache/akm — both isolated)
+ * No akm code path can escape into the real user directories.
  */
 
 import fs from "node:fs";

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -75,7 +75,7 @@ const CONFIG_HINTS: Partial<Record<ConfigErrorCode, string>> = {
   TEST_ISOLATION_MISSING:
     "Under bun test, when AKM_STASH_DIR is set you MUST also set XDG_DATA_HOME (or AKM_DATA_DIR) and XDG_STATE_HOME (or AKM_STATE_DIR) to temp directories so the test does not touch the developer's real ~/.local/share/akm or ~/.local/state/akm.",
   SETUP_TMP_STASH_REFUSED:
-    "Use a persistent directory, or set AKM_FORCE_SETUP_TMP_STASH=1 to opt in to a sandboxed setup (config is then routed to $stashDir/.akm/ automatically).",
+    "Use a persistent directory, or set AKM_FORCE_SETUP_TMP_STASH=1 to opt in to a sandboxed setup (setup also pre-sets AKM_STASH_DIR so config and cache writes auto-isolate into $stashDir/.akm/ — host config is preserved).",
 };
 
 /** Default hint for each UsageError code. */

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -29,6 +29,7 @@ export type ConfigErrorCode =
   // refuse persisting a temp-dir stashDir to the user's real config.
   // See src/commands/init.ts.
   | "INIT_TMP_STASH_REFUSED"
+  | "SETUP_TMP_STASH_REFUSED"
   // Defense-in-depth sentinel raised under `bun test` / NODE_ENV=test
   // when a test sets AKM_STASH_DIR but forgets to also point
   // XDG_DATA_HOME / AKM_DATA_DIR (and XDG_STATE_HOME / AKM_STATE_DIR)
@@ -73,6 +74,8 @@ const CONFIG_HINTS: Partial<Record<ConfigErrorCode, string>> = {
     'Run `akm setup` or `akm config set profiles.llm.default \'{"endpoint":"...","model":"..."}\' to configure an LLM profile.',
   TEST_ISOLATION_MISSING:
     "Under bun test, when AKM_STASH_DIR is set you MUST also set XDG_DATA_HOME (or AKM_DATA_DIR) and XDG_STATE_HOME (or AKM_STATE_DIR) to temp directories so the test does not touch the developer's real ~/.local/share/akm or ~/.local/state/akm.",
+  SETUP_TMP_STASH_REFUSED:
+    "Use a persistent directory, or set AKM_FORCE_SETUP_TMP_STASH=1 to opt in to a sandboxed setup (config is then routed to $stashDir/.akm/ automatically).",
 };
 
 /** Default hint for each UsageError code. */

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -27,6 +27,26 @@ function isUnderBunTest(env: NodeJS.ProcessEnv): boolean {
 }
 
 /**
+ * Returns true when the given path is in a directory family the OS may
+ * reap (or that the user has clearly designated as a sandbox by virtue
+ * of placing it under `/tmp` or `/private/var/folders`). Used to decide
+ * whether `AKM_STASH_DIR=$tmpdir` should also isolate config + cache
+ * writes (so a test harness's `akm setup --yes --dir .` cannot silently
+ * clobber the user's `~/.config/akm/config.json`). See
+ * BUG-setup-clobbers-user-config.md for the incident that motivated this.
+ */
+export function isTransientStashPath(p: string): boolean {
+  return (
+    p.startsWith("/tmp/") ||
+    p === "/tmp" ||
+    p.startsWith("/var/tmp/") ||
+    p === "/var/tmp" ||
+    p.startsWith("/private/tmp/") ||
+    p.startsWith("/private/var/folders/")
+  );
+}
+
+/**
  * Build a TEST_ISOLATION_MISSING ConfigError describing which env var(s)
  * must be set so the data/state path resolves into a temp dir instead of
  * the user's real XDG home.
@@ -47,6 +67,32 @@ function testIsolationError(directoryKind: "data" | "state"): ConfigError {
 export function getConfigDir(env: NodeJS.ProcessEnv = process.env, platform = process.platform): string {
   const override = env.AKM_CONFIG_DIR?.trim();
   if (override) return override;
+
+  // Explicit XDG override wins next — tests and operators that pre-arrange
+  // an isolated config dir via XDG_CONFIG_HOME (or %APPDATA% on Windows)
+  // must be honored as set, so the AKM_STASH_DIR transient-isolation rule
+  // below does not silently move config away from where they pointed it.
+  if (platform === "win32") {
+    const appData = env.APPDATA?.trim();
+    if (appData) return path.join(appData, "akm");
+  } else {
+    const xdgConfigHome = env.XDG_CONFIG_HOME?.trim();
+    if (xdgConfigHome) return path.join(xdgConfigHome, "akm");
+  }
+
+  // Isolation safety: when AKM_STASH_DIR points at a transient/sandbox path
+  // (/tmp, /var/tmp, /private/var/folders) AND no explicit config dir
+  // override is set, route config writes into `${AKM_STASH_DIR}/.akm`
+  // instead of the user's host ~/.config/akm. This prevents the documented
+  // isolation pattern
+  //   AKM_DATA_DIR=/tmp/x AKM_STASH_DIR=/tmp/x akm setup --yes --dir .
+  // from silently clobbering the host config. See
+  // BUG-setup-clobbers-user-config.md for the incident.
+  // Daily users with a persistent AKM_STASH_DIR=~/my-stash are unaffected.
+  const stashOverride = env.AKM_STASH_DIR?.trim();
+  if (stashOverride && isTransientStashPath(stashOverride)) {
+    return path.join(stashOverride, ".akm");
+  }
 
   if (platform === "win32") {
     const appData = env.APPDATA?.trim();
@@ -84,6 +130,24 @@ export function getConfigPath(): string {
 export function getCacheDir(): string {
   const override = process.env.AKM_CACHE_DIR?.trim();
   if (override) return override;
+
+  // Explicit XDG/platform overrides win before the transient-stash isolation
+  // rule below — tests that pre-arrange XDG_CACHE_HOME (or %LOCALAPPDATA%)
+  // must be honored without being silently moved into the stash dir.
+  if (!IS_WINDOWS) {
+    const xdgCacheHome = process.env.XDG_CACHE_HOME?.trim();
+    if (xdgCacheHome) return path.join(xdgCacheHome, "akm");
+  }
+
+  // Isolation safety (mirrors getConfigDir): when AKM_STASH_DIR points at a
+  // transient path AND no explicit cache override is set, route cache writes
+  // into `${AKM_STASH_DIR}/.akm/cache` so that config backups, registry-index
+  // cache, and other regenerable artifacts do not pollute the user's host
+  // ~/.cache/akm directory.
+  const stashOverride = process.env.AKM_STASH_DIR?.trim();
+  if (stashOverride && isTransientStashPath(stashOverride)) {
+    return path.join(stashOverride, ".akm", "cache");
+  }
 
   if (IS_WINDOWS) {
     const localAppData = process.env.LOCALAPPDATA?.trim();

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -29,11 +29,17 @@ function isUnderBunTest(env: NodeJS.ProcessEnv): boolean {
 /**
  * Returns true when the given path is in a directory family the OS may
  * reap (or that the user has clearly designated as a sandbox by virtue
- * of placing it under `/tmp` or `/private/var/folders`). Used to decide
- * whether `AKM_STASH_DIR=$tmpdir` should also isolate config + cache
- * writes (so a test harness's `akm setup --yes --dir .` cannot silently
- * clobber the user's `~/.config/akm/config.json`). See
- * BUG-setup-clobbers-user-config.md for the incident that motivated this.
+ * of placing it under `/tmp` or a macOS per-user temp dir). Used to
+ * decide whether `AKM_STASH_DIR=$tmpdir` should also isolate config +
+ * cache writes (so a test harness's `akm setup --yes --dir .` cannot
+ * silently clobber the user's `~/.config/akm/config.json`). See
+ * `docs/technical/incidents/2026-05-23-setup-clobbers-user-config.md`
+ * for the incident that motivated this.
+ *
+ * Both `/var/folders/*` and `/private/var/folders/*` are matched because
+ * `os.tmpdir()` on macOS may return either form depending on whether the
+ * caller has canonicalised the path (the realpath of `/var/folders` is
+ * `/private/var/folders`, but `path.resolve()` does not follow symlinks).
  */
 export function isTransientStashPath(p: string): boolean {
   return (
@@ -42,7 +48,8 @@ export function isTransientStashPath(p: string): boolean {
     p.startsWith("/var/tmp/") ||
     p === "/var/tmp" ||
     p.startsWith("/private/tmp/") ||
-    p.startsWith("/private/var/folders/")
+    p.startsWith("/private/var/folders/") ||
+    p.startsWith("/var/folders/")
   );
 }
 
@@ -87,7 +94,7 @@ export function getConfigDir(env: NodeJS.ProcessEnv = process.env, platform = pr
   // isolation pattern
   //   AKM_DATA_DIR=/tmp/x AKM_STASH_DIR=/tmp/x akm setup --yes --dir .
   // from silently clobbering the host config. See
-  // BUG-setup-clobbers-user-config.md for the incident.
+  // docs/technical/incidents/2026-05-23-setup-clobbers-user-config.md for the incident.
   // Daily users with a persistent AKM_STASH_DIR=~/my-stash are unaffected.
   const stashOverride = env.AKM_STASH_DIR?.trim();
   if (stashOverride && isTransientStashPath(stashOverride)) {
@@ -132,9 +139,26 @@ export function getCacheDir(): string {
   if (override) return override;
 
   // Explicit XDG/platform overrides win before the transient-stash isolation
-  // rule below — tests that pre-arrange XDG_CACHE_HOME (or %LOCALAPPDATA%)
-  // must be honored without being silently moved into the stash dir.
-  if (!IS_WINDOWS) {
+  // rule below — tests and operators that pre-arrange XDG_CACHE_HOME (or
+  // %LOCALAPPDATA% / %USERPROFILE% / %APPDATA% on Windows) must be honored
+  // as set, so the AKM_STASH_DIR transient rule does not silently move cache
+  // writes away from where they pointed them.
+  if (IS_WINDOWS) {
+    const localAppData = process.env.LOCALAPPDATA?.trim();
+    if (localAppData) return path.join(localAppData, "akm");
+
+    const userProfile = process.env.USERPROFILE?.trim();
+    if (userProfile) return path.join(userProfile, "AppData", "Local", "akm");
+
+    const appData = process.env.APPDATA?.trim();
+    if (appData) {
+      // Heuristic fallback: APPDATA points to %APPDATA% (Roaming), so
+      // navigate to the sibling "Local" directory. This is typically
+      // C:\Users\<name>\AppData\Roaming → C:\Users\<name>\AppData\Local\akm.
+      // Preferred: set LOCALAPPDATA to avoid this navigation.
+      return path.join(appData, "..", "Local", "akm");
+    }
+  } else {
     const xdgCacheHome = process.env.XDG_CACHE_HOME?.trim();
     if (xdgCacheHome) return path.join(xdgCacheHome, "akm");
   }
@@ -150,28 +174,12 @@ export function getCacheDir(): string {
   }
 
   if (IS_WINDOWS) {
-    const localAppData = process.env.LOCALAPPDATA?.trim();
-    if (localAppData) return path.join(localAppData, "akm");
-
-    const userProfile = process.env.USERPROFILE?.trim();
-    if (userProfile) return path.join(userProfile, "AppData", "Local", "akm");
-
-    const appData = process.env.APPDATA?.trim();
-    if (!appData) {
-      throw new ConfigError(
-        "Unable to determine cache directory. Set LOCALAPPDATA, USERPROFILE, or APPDATA.",
-        "CONFIG_DIR_UNRESOLVABLE",
-      );
-    }
-    // Heuristic fallback: APPDATA points to %APPDATA% (Roaming), so navigate
-    // to the sibling "Local" directory. This is typically
-    // C:\Users\<name>\AppData\Roaming → C:\Users\<name>\AppData\Local\akm.
-    // Preferred: set LOCALAPPDATA to avoid this navigation.
-    return path.join(appData, "..", "Local", "akm");
+    // None of LOCALAPPDATA / USERPROFILE / APPDATA were set above.
+    throw new ConfigError(
+      "Unable to determine cache directory. Set LOCALAPPDATA, USERPROFILE, or APPDATA.",
+      "CONFIG_DIR_UNRESOLVABLE",
+    );
   }
-
-  const xdgCacheHome = process.env.XDG_CACHE_HOME?.trim();
-  if (xdgCacheHome) return path.join(xdgCacheHome, "akm");
 
   const home = process.env.HOME?.trim();
   if (!home) return path.join("/tmp", "akm-cache");

--- a/src/setup/setup.ts
+++ b/src/setup/setup.ts
@@ -21,7 +21,8 @@ import type {
   SourceConfigEntry,
 } from "../core/config";
 import { DEFAULT_CONFIG, getDefaultLlmConfig, loadUserConfig, saveConfig } from "../core/config";
-import { getConfigPath, getDefaultStashDir } from "../core/paths";
+import { ConfigError } from "../core/errors";
+import { getConfigPath, getDefaultStashDir, isTransientStashPath } from "../core/paths";
 import { warn } from "../core/warn";
 import { closeDatabase, isVecAvailable, openDatabase } from "../indexer/db";
 import { akmIndex } from "../indexer/indexer";
@@ -35,6 +36,36 @@ import { probeLlmCapabilities } from "../llm/client";
 import { checkEmbeddingAvailability, DEFAULT_LOCAL_MODEL, isTransformersAvailable } from "../llm/embedder";
 import { detectAgentPlatforms, detectOllama } from "./detect";
 import { createSetupContext, runSetupSteps, type SetupStep } from "./steps";
+
+// ── Setup sandbox guard ─────────────────────────────────────────────────────
+
+/**
+ * Refuse to persist an explicit `--dir /tmp/...` stashDir to the user's
+ * config. The OS may reap the directory at any time, and the next run will
+ * see a `stashDir` that points at a deleted path (falling back to ~/akm
+ * silently). Mirrors the `assertInitSandbox` check in commands/init.ts, but
+ * fires under all runtimes (not just `bun test`) because `akm setup --dir
+ * /tmp/X` is a documented isolation pattern that has been observed to
+ * silently clobber the host config — see BUG-setup-clobbers-user-config.md.
+ *
+ * Escape hatch: set `AKM_FORCE_SETUP_TMP_STASH=1` to override (combine with
+ * `AKM_CONFIG_DIR` if you also want to redirect the resulting config write).
+ * Together with the `isTransientStashPath` rule in `getConfigDir`, this
+ * means: even when the user opts out of the guard, config writes still
+ * isolate into the stash rather than clobbering the host.
+ */
+function assertSetupSandbox(stashDir: string, dirExplicitlyProvided: boolean): void {
+  if (!dirExplicitlyProvided) return;
+  if (process.env.AKM_FORCE_SETUP_TMP_STASH === "1") return;
+  if (!isTransientStashPath(stashDir)) return;
+  throw new ConfigError(
+    `refusing to run \`akm setup --dir ${stashDir}\`: the path is in a transient/sandbox directory family the OS may reap. ` +
+      "Persisting it as the user's stashDir would leave the next run pointing at a deleted path (silently falling back to ~/akm). " +
+      "Use a persistent directory, OR set AKM_FORCE_SETUP_TMP_STASH=1 if you intentionally want a sandbox setup " +
+      "(in which case config is routed to $stashDir/.akm/config.json automatically — host config is preserved).",
+    "SETUP_TMP_STASH_REFUSED",
+  );
+}
 
 // ── Interfaces ──────────────────────────────────────────────────────────────
 
@@ -1753,6 +1784,10 @@ export async function runSetupWizard(opts?: { dir?: string; noInit?: boolean }):
   // Resolve stash directory early so akmInit can run before any prompts
   const resolvedStashDir = opts?.dir ? path.resolve(opts.dir) : (current.stashDir ?? getDefaultStashDir());
 
+  // Refuse explicit --dir /tmp/... before doing any work — protects the host
+  // config from being clobbered with a stashDir that the OS may reap.
+  assertSetupSandbox(resolvedStashDir, opts?.dir != null);
+
   // Bootstrap directory structure before any prompts so the stash exists
   // even if the wizard is interrupted after this point.
   if (!opts?.noInit) {
@@ -1941,6 +1976,8 @@ export async function runSetupWithDefaults(opts: {
   const current = loadUserConfig();
   const stashDir = opts.dir ? path.resolve(opts.dir) : (current.stashDir ?? getDefaultStashDir());
 
+  assertSetupSandbox(stashDir, opts.dir != null);
+
   // Bootstrap directory structure first
   let initResult: InitResponse | undefined;
   if (!opts.noInit) {
@@ -2038,6 +2075,8 @@ export async function runSetupFromConfig(opts: {
     : incoming.stashDir
       ? path.resolve(incoming.stashDir)
       : (current.stashDir ?? getDefaultStashDir());
+
+  assertSetupSandbox(stashDir, opts.dir != null || incoming.stashDir != null);
 
   let merged: AkmConfig = { ...current, stashDir };
   // Apply non-llm/agent keys directly.

--- a/src/setup/setup.ts
+++ b/src/setup/setup.ts
@@ -46,13 +46,14 @@ import { createSetupContext, runSetupSteps, type SetupStep } from "./steps";
  * silently). Mirrors the `assertInitSandbox` check in commands/init.ts, but
  * fires under all runtimes (not just `bun test`) because `akm setup --dir
  * /tmp/X` is a documented isolation pattern that has been observed to
- * silently clobber the host config — see BUG-setup-clobbers-user-config.md.
+ * silently clobber the host config — see
+ * `docs/technical/incidents/2026-05-23-setup-clobbers-user-config.md`.
  *
- * Escape hatch: set `AKM_FORCE_SETUP_TMP_STASH=1` to override (combine with
- * `AKM_CONFIG_DIR` if you also want to redirect the resulting config write).
- * Together with the `isTransientStashPath` rule in `getConfigDir`, this
- * means: even when the user opts out of the guard, config writes still
- * isolate into the stash rather than clobbering the host.
+ * Escape hatch: set `AKM_FORCE_SETUP_TMP_STASH=1` to override. When the
+ * escape hatch is on, `applyStashIsolationToEnv` below also pre-sets
+ * `AKM_STASH_DIR` so that the `getConfigDir` / `getCacheDir` isolation
+ * rules fire and config + cache writes route into `$stashDir/.akm/`
+ * instead of the user's host `~/.config/akm`.
  */
 function assertSetupSandbox(stashDir: string, dirExplicitlyProvided: boolean): void {
   if (!dirExplicitlyProvided) return;
@@ -62,9 +63,28 @@ function assertSetupSandbox(stashDir: string, dirExplicitlyProvided: boolean): v
     `refusing to run \`akm setup --dir ${stashDir}\`: the path is in a transient/sandbox directory family the OS may reap. ` +
       "Persisting it as the user's stashDir would leave the next run pointing at a deleted path (silently falling back to ~/akm). " +
       "Use a persistent directory, OR set AKM_FORCE_SETUP_TMP_STASH=1 if you intentionally want a sandbox setup " +
-      "(in which case config is routed to $stashDir/.akm/config.json automatically — host config is preserved).",
+      "(setup will also auto-isolate config + cache writes into $stashDir/.akm/ so the host config is preserved).",
     "SETUP_TMP_STASH_REFUSED",
   );
+}
+
+/**
+ * Propagate the explicit `--dir <stashDir>` choice to the env so that the
+ * `getConfigDir` / `getCacheDir` isolation rules in `src/core/paths.ts`
+ * actually fire for the duration of this setup run. Without this, a CLI
+ * caller who passes `--dir /tmp/X` but doesn't pre-export `AKM_STASH_DIR`
+ * would still write config to the host `~/.config/akm/config.json`. We
+ * only set the env var when:
+ *   - `--dir` was explicitly provided (we have an operator-stated stash), AND
+ *   - `AKM_STASH_DIR` is not already set (caller's explicit env wins).
+ * The set is process-wide; for the CLI that's the right scope (the process
+ * is about to do all its work against this stash). For tests, each test
+ * already isolates env via beforeEach/afterEach so there is no leak.
+ */
+function applyStashIsolationToEnv(stashDir: string, dirExplicitlyProvided: boolean): void {
+  if (!dirExplicitlyProvided) return;
+  if (process.env.AKM_STASH_DIR?.trim()) return;
+  process.env.AKM_STASH_DIR = stashDir;
 }
 
 // ── Interfaces ──────────────────────────────────────────────────────────────
@@ -1787,6 +1807,7 @@ export async function runSetupWizard(opts?: { dir?: string; noInit?: boolean }):
   // Refuse explicit --dir /tmp/... before doing any work — protects the host
   // config from being clobbered with a stashDir that the OS may reap.
   assertSetupSandbox(resolvedStashDir, opts?.dir != null);
+  applyStashIsolationToEnv(resolvedStashDir, opts?.dir != null);
 
   // Bootstrap directory structure before any prompts so the stash exists
   // even if the wizard is interrupted after this point.
@@ -1977,6 +1998,7 @@ export async function runSetupWithDefaults(opts: {
   const stashDir = opts.dir ? path.resolve(opts.dir) : (current.stashDir ?? getDefaultStashDir());
 
   assertSetupSandbox(stashDir, opts.dir != null);
+  applyStashIsolationToEnv(stashDir, opts.dir != null);
 
   // Bootstrap directory structure first
   let initResult: InitResponse | undefined;
@@ -2076,7 +2098,9 @@ export async function runSetupFromConfig(opts: {
       ? path.resolve(incoming.stashDir)
       : (current.stashDir ?? getDefaultStashDir());
 
-  assertSetupSandbox(stashDir, opts.dir != null || incoming.stashDir != null);
+  const stashDirExplicit = opts.dir != null || incoming.stashDir != null;
+  assertSetupSandbox(stashDir, stashDirExplicit);
+  applyStashIsolationToEnv(stashDir, stashDirExplicit);
 
   let merged: AkmConfig = { ...current, stashDir };
   // Apply non-llm/agent keys directly.

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -123,6 +123,12 @@ describe("getConfigPath", () => {
   test("defaults to ~/.config/akm when XDG_CONFIG_HOME is unset", () => {
     const home = makeTmpDir();
     delete process.env.XDG_CONFIG_HOME;
+    // Defense against CI environments where AKM_STASH_DIR is inherited
+    // from outer test isolation: if it points at a transient path,
+    // getConfigDir's isolation rule fires and overrides the HOME-based
+    // fallback this test is verifying. See
+    // docs/technical/incidents/2026-05-23-setup-clobbers-user-config.md.
+    delete process.env.AKM_STASH_DIR;
     process.env.HOME = home;
 
     expect(getConfigPath()).toBe(path.join(home, ".config", "akm", "config.json"));

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -129,6 +129,54 @@ describe("getConfigDir", () => {
     const result = getConfigDir({ AKM_CONFIG_DIR: "/override/config", HOME: "/home/user" }, "linux");
     expect(result).toBe("/override/config");
   });
+
+  // Regression: BUG-setup-clobbers-user-config.md. When the user (or a
+  // test harness) sets AKM_STASH_DIR to a transient path, config writes
+  // must NOT target the user's host ~/.config/akm — they must route into
+  // the stash so saveConfig() can never silently clobber the host.
+  test("AKM_STASH_DIR=/tmp/X routes config to /tmp/X/.akm (isolation safety)", () => {
+    const result = getConfigDir({ AKM_STASH_DIR: "/tmp/test-stash", HOME: "/home/user" }, "linux");
+    expect(result).toBe(path.join("/tmp/test-stash", ".akm"));
+  });
+
+  test("AKM_STASH_DIR=/var/tmp/X also triggers isolation", () => {
+    const result = getConfigDir({ AKM_STASH_DIR: "/var/tmp/build-1234", HOME: "/home/user" }, "linux");
+    expect(result).toBe(path.join("/var/tmp/build-1234", ".akm"));
+  });
+
+  test("AKM_STASH_DIR=/private/var/folders/... (macOS mktemp) also triggers isolation", () => {
+    const result = getConfigDir(
+      { AKM_STASH_DIR: "/private/var/folders/zz/abc/T/akm-test", HOME: "/Users/user" },
+      "darwin",
+    );
+    expect(result).toBe(path.join("/private/var/folders/zz/abc/T/akm-test", ".akm"));
+  });
+
+  test("AKM_STASH_DIR=~/my-stash (persistent path) does NOT redirect — daily users unaffected", () => {
+    const result = getConfigDir({ AKM_STASH_DIR: "/home/user/my-stash", HOME: "/home/user" }, "linux");
+    expect(result).toBe(path.join("/home/user", ".config", "akm"));
+  });
+
+  test("AKM_CONFIG_DIR override beats AKM_STASH_DIR isolation rule (explicit wins)", () => {
+    const result = getConfigDir(
+      { AKM_CONFIG_DIR: "/keep/host/config", AKM_STASH_DIR: "/tmp/transient", HOME: "/home/user" },
+      "linux",
+    );
+    expect(result).toBe("/keep/host/config");
+  });
+
+  test("XDG_CONFIG_HOME also beats AKM_STASH_DIR isolation rule (existing tests rely on this)", () => {
+    const result = getConfigDir(
+      { XDG_CONFIG_HOME: "/iso/cfg", AKM_STASH_DIR: "/tmp/transient", HOME: "/home/user" },
+      "linux",
+    );
+    expect(result).toBe(path.join("/iso/cfg", "akm"));
+  });
+
+  test("APPDATA on Windows also beats AKM_STASH_DIR isolation rule", () => {
+    const result = getConfigDir({ APPDATA: String.raw`C:\iso\cfg`, AKM_STASH_DIR: "/tmp/transient" }, "win32");
+    expect(result).toBe(path.join(String.raw`C:\iso\cfg`, "akm"));
+  });
 });
 
 // ── getConfigPath ───────────────────────────────────────────────────────────
@@ -170,6 +218,43 @@ describe("getCacheDir", () => {
     process.env.AKM_CACHE_DIR = "/override/cache";
     const result = getCacheDir();
     expect(result).toBe("/override/cache");
+  });
+
+  // Regression: BUG-setup-clobbers-user-config.md companion fix. When
+  // AKM_STASH_DIR is transient, cache (which holds config-backups/) must
+  // also isolate into the stash so saveConfig backup writes do not
+  // pollute the user's host ~/.cache/akm/config-backups/.
+  test("AKM_STASH_DIR=/tmp/X routes cache to /tmp/X/.akm/cache (isolation safety)", () => {
+    delete process.env.AKM_CACHE_DIR;
+    delete process.env.XDG_CACHE_HOME;
+    process.env.HOME = "/home/user";
+    process.env.AKM_STASH_DIR = "/tmp/test-cache-stash";
+    const result = getCacheDir();
+    expect(result).toBe(path.join("/tmp/test-cache-stash", ".akm", "cache"));
+  });
+
+  test("AKM_STASH_DIR=~/persistent does NOT redirect cache (daily users unaffected)", () => {
+    delete process.env.AKM_CACHE_DIR;
+    delete process.env.XDG_CACHE_HOME;
+    process.env.HOME = "/home/user";
+    process.env.AKM_STASH_DIR = "/home/user/my-stash";
+    const result = getCacheDir();
+    expect(result).toBe(path.join("/home/user", ".cache", "akm"));
+  });
+
+  test("AKM_CACHE_DIR beats AKM_STASH_DIR isolation rule", () => {
+    process.env.AKM_CACHE_DIR = "/override/cache";
+    process.env.AKM_STASH_DIR = "/tmp/transient";
+    const result = getCacheDir();
+    expect(result).toBe("/override/cache");
+  });
+
+  test("XDG_CACHE_HOME also beats AKM_STASH_DIR isolation rule (existing tests rely on this)", () => {
+    delete process.env.AKM_CACHE_DIR;
+    process.env.XDG_CACHE_HOME = "/iso/cache";
+    process.env.AKM_STASH_DIR = "/tmp/transient";
+    const result = getCacheDir();
+    expect(result).toBe(path.join("/iso/cache", "akm"));
   });
 });
 

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -130,7 +130,7 @@ describe("getConfigDir", () => {
     expect(result).toBe("/override/config");
   });
 
-  // Regression: BUG-setup-clobbers-user-config.md. When the user (or a
+  // Regression: docs/technical/incidents/2026-05-23-setup-clobbers-user-config.md. When the user (or a
   // test harness) sets AKM_STASH_DIR to a transient path, config writes
   // must NOT target the user's host ~/.config/akm — they must route into
   // the stash so saveConfig() can never silently clobber the host.
@@ -201,6 +201,10 @@ describe("getCacheDir", () => {
   test("falls back to HOME/.cache on Unix when XDG_CACHE_HOME is unset", () => {
     delete process.env.AKM_CACHE_DIR;
     delete process.env.XDG_CACHE_HOME;
+    // Clear AKM_STASH_DIR too — under CI, it can be inherited from outer
+    // test isolation pointing at a transient dir, which would trigger the
+    // new isolation rule and override this test's HOME-based expectation.
+    delete process.env.AKM_STASH_DIR;
     process.env.HOME = "/home/user";
     const result = getCacheDir();
     expect(result).toBe(path.join("/home/user", ".cache", "akm"));
@@ -209,6 +213,7 @@ describe("getCacheDir", () => {
   test("falls back to /tmp/akm-cache when HOME is also unset", () => {
     delete process.env.AKM_CACHE_DIR;
     delete process.env.XDG_CACHE_HOME;
+    delete process.env.AKM_STASH_DIR;
     delete process.env.HOME;
     const result = getCacheDir();
     expect(result).toBe(path.join("/tmp", "akm-cache"));
@@ -220,7 +225,7 @@ describe("getCacheDir", () => {
     expect(result).toBe("/override/cache");
   });
 
-  // Regression: BUG-setup-clobbers-user-config.md companion fix. When
+  // Regression: docs/technical/incidents/2026-05-23-setup-clobbers-user-config.md companion fix. When
   // AKM_STASH_DIR is transient, cache (which holds config-backups/) must
   // also isolate into the stash so saveConfig backup writes do not
   // pollute the user's host ~/.cache/akm/config-backups/.

--- a/tests/setup-tmp-stash-guard.test.ts
+++ b/tests/setup-tmp-stash-guard.test.ts
@@ -1,0 +1,186 @@
+// Regression tests for BUG-setup-clobbers-user-config.md.
+//
+// Two layers of defense, both tested here:
+//   1. assertSetupSandbox (in src/setup/setup.ts): refuses `akm setup --dir
+//      /tmp/X` unless AKM_FORCE_SETUP_TMP_STASH=1. Tested indirectly by
+//      invoking runSetupWithDefaults / runSetupFromConfig with /tmp paths.
+//   2. getConfigDir (in src/core/paths.ts): when AKM_STASH_DIR points at a
+//      transient path, isolates config writes into $STASH/.akm/. Tested
+//      end-to-end by running setup with the escape hatch and asserting the
+//      host config file is untouched.
+//
+// Both layers are intentionally redundant: layer 1 fails fast for the
+// common case; layer 2 ensures that even when the user opts in to the
+// escape hatch, the host config is still preserved.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runSetupFromConfig, runSetupWithDefaults } from "../src/setup/setup";
+
+const SAVED_ENV: Record<string, string | undefined> = {};
+const TRACKED_ENV = [
+  "AKM_STASH_DIR",
+  "AKM_DATA_DIR",
+  "AKM_STATE_DIR",
+  "AKM_CACHE_DIR",
+  "AKM_CONFIG_DIR",
+  "AKM_FORCE_SETUP_TMP_STASH",
+  "XDG_DATA_HOME",
+  "XDG_STATE_HOME",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
+  "HOME",
+];
+
+beforeEach(() => {
+  for (const key of TRACKED_ENV) SAVED_ENV[key] = process.env[key];
+});
+
+afterEach(() => {
+  for (const key of TRACKED_ENV) {
+    if (SAVED_ENV[key] === undefined) delete process.env[key];
+    else process.env[key] = SAVED_ENV[key];
+  }
+});
+
+// ── Layer 1: assertSetupSandbox refuses /tmp/* explicit --dir ───────────────
+
+describe("setup tmp-stash guard (layer 1: assertSetupSandbox)", () => {
+  test("runSetupWithDefaults refuses --dir /tmp/X by default", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-setup-guard-"));
+    try {
+      // Set up the transient stash env so getConfigDir would isolate (layer
+      // 2). Layer 1 should still throw before we reach saveConfig.
+      process.env.AKM_STASH_DIR = tmpDir;
+      process.env.AKM_DATA_DIR = path.join(tmpDir, "data");
+      process.env.AKM_STATE_DIR = path.join(tmpDir, "state");
+      process.env.XDG_DATA_HOME = path.join(tmpDir, "data");
+      process.env.XDG_STATE_HOME = path.join(tmpDir, "state");
+      // Make sure the escape hatch is NOT set.
+      delete process.env.AKM_FORCE_SETUP_TMP_STASH;
+
+      await expect(runSetupWithDefaults({ dir: tmpDir, noInit: true })).rejects.toThrow(
+        /SETUP_TMP_STASH_REFUSED|transient\/sandbox/,
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("runSetupFromConfig refuses --dir /tmp/X by default", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-setup-guard-"));
+    try {
+      process.env.AKM_STASH_DIR = tmpDir;
+      process.env.AKM_DATA_DIR = path.join(tmpDir, "data");
+      process.env.AKM_STATE_DIR = path.join(tmpDir, "state");
+      process.env.XDG_DATA_HOME = path.join(tmpDir, "data");
+      process.env.XDG_STATE_HOME = path.join(tmpDir, "state");
+      delete process.env.AKM_FORCE_SETUP_TMP_STASH;
+
+      await expect(runSetupFromConfig({ configJson: "{}", dir: tmpDir, noInit: true })).rejects.toThrow(
+        /SETUP_TMP_STASH_REFUSED|transient\/sandbox/,
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("AKM_FORCE_SETUP_TMP_STASH=1 opts out of the refusal", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-setup-guard-"));
+    try {
+      process.env.AKM_STASH_DIR = tmpDir;
+      process.env.AKM_DATA_DIR = path.join(tmpDir, "data");
+      process.env.AKM_STATE_DIR = path.join(tmpDir, "state");
+      process.env.XDG_DATA_HOME = path.join(tmpDir, "data");
+      process.env.XDG_STATE_HOME = path.join(tmpDir, "state");
+      process.env.AKM_FORCE_SETUP_TMP_STASH = "1";
+
+      // Should NOT throw the SETUP_TMP_STASH_REFUSED error. We do not assert
+      // the call fully succeeds (it depends on a lot of subsystems being
+      // available); we just assert the guard doesn't fire.
+      await expect(runSetupWithDefaults({ dir: tmpDir, noInit: true })).resolves.toMatchObject({ stashDir: tmpDir });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("a persistent --dir (e.g. ~/test-stash) is NOT refused", async () => {
+    const persistentDir = fs.mkdtempSync(path.join(os.homedir(), ".akm-setup-guard-test-"));
+    try {
+      process.env.AKM_STASH_DIR = persistentDir;
+      process.env.AKM_DATA_DIR = path.join(persistentDir, "data");
+      process.env.AKM_STATE_DIR = path.join(persistentDir, "state");
+      process.env.XDG_DATA_HOME = path.join(persistentDir, "data");
+      process.env.XDG_STATE_HOME = path.join(persistentDir, "state");
+      // Critically: persistentDir is under HOME (not /tmp), so guard does
+      // not fire. Need a config-dir override since persistent stash does
+      // not trigger the isolation rule.
+      process.env.AKM_CONFIG_DIR = path.join(persistentDir, "config");
+      delete process.env.AKM_FORCE_SETUP_TMP_STASH;
+
+      await expect(runSetupWithDefaults({ dir: persistentDir, noInit: true })).resolves.toMatchObject({
+        stashDir: persistentDir,
+      });
+    } finally {
+      fs.rmSync(persistentDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── Layer 2: getConfigDir isolation under transient AKM_STASH_DIR ──────────
+
+describe("setup config isolation (layer 2: getConfigDir under transient stash)", () => {
+  test("even with escape hatch, config writes do NOT touch host ~/.config/akm/config.json", async () => {
+    // Verify the second layer: when AKM_FORCE_SETUP_TMP_STASH is set
+    // (operator override), the assertSetupSandbox guard yields — but the
+    // getConfigDir isolation rule still routes config writes into the
+    // stash. The host config file at ~/.config/akm/config.json must not
+    // be modified.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-setup-isolation-"));
+    const hostConfigContent = '{"hostConfigCanary":true,"stashDir":"/home/test/host-akm"}\n';
+
+    // Synthesize a host config in a sandboxed HOME so we can assert it
+    // really stays untouched. (Pointing HOME at the temp dir effectively
+    // moves the host's ~/.config/akm into our sandbox; if isolation
+    // works, the file at HOME/.config/akm/config.json remains as
+    // hostConfigContent. If isolation fails, setup overwrites it.)
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "akm-setup-fakehome-"));
+    const hostConfigDir = path.join(fakeHome, ".config", "akm");
+    fs.mkdirSync(hostConfigDir, { recursive: true });
+    const hostConfigPath = path.join(hostConfigDir, "config.json");
+    fs.writeFileSync(hostConfigPath, hostConfigContent);
+    const hostMtimeBefore = fs.statSync(hostConfigPath).mtimeMs;
+
+    try {
+      process.env.HOME = fakeHome;
+      process.env.AKM_STASH_DIR = tmpDir;
+      process.env.AKM_DATA_DIR = path.join(tmpDir, "data");
+      process.env.AKM_STATE_DIR = path.join(tmpDir, "state");
+      process.env.XDG_DATA_HOME = path.join(tmpDir, "data");
+      process.env.XDG_STATE_HOME = path.join(tmpDir, "state");
+      // Important: do NOT set AKM_CONFIG_DIR — we want to verify the
+      // isolation rule fires (which it does only when AKM_CONFIG_DIR is
+      // unset and AKM_STASH_DIR is transient).
+      delete process.env.AKM_CONFIG_DIR;
+      delete process.env.XDG_CONFIG_HOME;
+      process.env.AKM_FORCE_SETUP_TMP_STASH = "1";
+
+      await runSetupWithDefaults({ dir: tmpDir, noInit: true });
+
+      // The host config must be byte-identical to what we wrote before.
+      const hostConfigAfter = fs.readFileSync(hostConfigPath, "utf8");
+      expect(hostConfigAfter).toBe(hostConfigContent);
+      const hostMtimeAfter = fs.statSync(hostConfigPath).mtimeMs;
+      expect(hostMtimeAfter).toBe(hostMtimeBefore);
+
+      // The isolated config must have been written into the stash.
+      const isolatedConfigPath = path.join(tmpDir, ".akm", "config.json");
+      expect(fs.existsSync(isolatedConfigPath)).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/setup-tmp-stash-guard.test.ts
+++ b/tests/setup-tmp-stash-guard.test.ts
@@ -1,4 +1,4 @@
-// Regression tests for BUG-setup-clobbers-user-config.md.
+// Regression tests for docs/technical/incidents/2026-05-23-setup-clobbers-user-config.md.
 //
 // Two layers of defense, both tested here:
 //   1. assertSetupSandbox (in src/setup/setup.ts): refuses `akm setup --dir
@@ -125,6 +125,84 @@ describe("setup tmp-stash guard (layer 1: assertSetupSandbox)", () => {
       });
     } finally {
       fs.rmSync(persistentDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── Layer 1.5: --dir alone (no AKM_STASH_DIR pre-set) still isolates ───────
+
+describe("setup pre-sets AKM_STASH_DIR when --dir is given (so layer 2 fires)", () => {
+  test("--dir /tmp/X without pre-set AKM_STASH_DIR routes config into the stash too", async () => {
+    // Reproduces the exact bug Copilot flagged: a CLI caller who passes
+    // --dir /tmp/X but does NOT pre-export AKM_STASH_DIR would, without
+    // applyStashIsolationToEnv, still see getConfigDir() fall through to
+    // the host ~/.config/akm and clobber it. Setup must propagate the
+    // operator's --dir choice to AKM_STASH_DIR so the isolation rule fires.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-setup-isolation-cli-"));
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "akm-setup-fakehome-cli-"));
+    const hostConfigDir = path.join(fakeHome, ".config", "akm");
+    fs.mkdirSync(hostConfigDir, { recursive: true });
+    const hostConfigPath = path.join(hostConfigDir, "config.json");
+    const hostConfigContent = '{"cliCanary":true}\n';
+    fs.writeFileSync(hostConfigPath, hostConfigContent);
+    const hostMtimeBefore = fs.statSync(hostConfigPath).mtimeMs;
+
+    try {
+      process.env.HOME = fakeHome;
+      // CRITICALLY: do NOT set AKM_STASH_DIR before the call. We want the
+      // setup code to set it for us. This mirrors the CLI invocation
+      // `akm setup --dir /tmp/X` with no env pre-arrangement.
+      delete process.env.AKM_STASH_DIR;
+      process.env.AKM_DATA_DIR = path.join(tmpDir, "data");
+      process.env.AKM_STATE_DIR = path.join(tmpDir, "state");
+      process.env.XDG_DATA_HOME = path.join(tmpDir, "data");
+      process.env.XDG_STATE_HOME = path.join(tmpDir, "state");
+      delete process.env.AKM_CONFIG_DIR;
+      delete process.env.XDG_CONFIG_HOME;
+      process.env.AKM_FORCE_SETUP_TMP_STASH = "1"; // opt past layer 1
+
+      await runSetupWithDefaults({ dir: tmpDir, noInit: true });
+
+      // The host config must be byte-identical, even though we did not
+      // pre-set AKM_STASH_DIR ourselves.
+      const hostConfigAfter = fs.readFileSync(hostConfigPath, "utf8");
+      expect(hostConfigAfter).toBe(hostConfigContent);
+      expect(fs.statSync(hostConfigPath).mtimeMs).toBe(hostMtimeBefore);
+
+      // And the isolated config must have landed in the stash.
+      expect(fs.existsSync(path.join(tmpDir, ".akm", "config.json"))).toBe(true);
+
+      // Setup is expected to have pre-set AKM_STASH_DIR for the duration
+      // of the call (we don't reset it; the afterEach hook does).
+      expect(process.env.AKM_STASH_DIR ?? "").toBe(tmpDir);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  test("operator-set AKM_STASH_DIR wins over the auto-set (existing env preserved)", async () => {
+    // If the operator already exported AKM_STASH_DIR=somewhere-else, do not
+    // overwrite it. (Defense against a setup call that uses --dir for stash
+    // bootstrap but expects config to follow a different env-anchored path.)
+    const stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-setup-prefer-env-stash-"));
+    const envStashDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-setup-prefer-env-other-"));
+
+    try {
+      process.env.AKM_STASH_DIR = envStashDir;
+      process.env.AKM_DATA_DIR = path.join(stashDir, "data");
+      process.env.AKM_STATE_DIR = path.join(stashDir, "state");
+      process.env.XDG_DATA_HOME = path.join(stashDir, "data");
+      process.env.XDG_STATE_HOME = path.join(stashDir, "state");
+      process.env.AKM_FORCE_SETUP_TMP_STASH = "1";
+
+      await runSetupWithDefaults({ dir: stashDir, noInit: true });
+
+      // The pre-existing AKM_STASH_DIR was NOT overwritten by the --dir value.
+      expect(process.env.AKM_STASH_DIR ?? "").toBe(envStashDir);
+    } finally {
+      fs.rmSync(stashDir, { recursive: true, force: true });
+      fs.rmSync(envStashDir, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary

`akm setup --yes --dir .` was silently rewriting the user's host `~/.config/akm/config.json` even when `AKM_STASH_DIR` and `AKM_DATA_DIR` were set to point at a temp directory. The env isolation correctly redirected stash and data file paths but did NOT redirect config persistence. When the temp stash was later cleaned up, the user's global config was left pointing at a deleted path; akm silently fell back to `~/akm` for stash operations so the breakage was invisible until they explicitly inspected the config.

The bug is documented in [`docs/technical/incidents/2026-05-23-setup-clobbers-user-config.md`](./docs/technical/incidents/2026-05-23-setup-clobbers-user-config.md) (now committed) — including reproduction, forensic trail, root cause, and recovery procedure for anyone hit by it before this lands.

This is the same incident that motivated the release-readiness audit's verification tripwire, which itself silently corrupted my own host config for ~5.5 hours.

## Fix design — two layers of defense

### Layer 1: `assertSetupSandbox` (in `src/setup/setup.ts`)

Refuses
```
akm setup --dir <transient/path>
```
under all runtimes — not just `bun test` — unless `AKM_FORCE_SETUP_TMP_STASH=1` is set. Wired into all three entry points: `runSetupWizard`, `runSetupWithDefaults`, `runSetupFromConfig`. Mirrors the existing `assertInitSandbox` in `src/commands/init.ts` but fires outside the test runner too. New `SETUP_TMP_STASH_REFUSED` `ConfigError` code with a canned hint pointing at the escape hatch.

### Layer 2: `getConfigDir` / `getCacheDir` isolation rule (in `src/core/paths.ts`)

When `AKM_STASH_DIR` points at a transient path family (`/tmp/`, `/var/tmp/`, `/private/var/folders/`) AND no explicit config/cache override is set (`AKM_CONFIG_DIR`, `XDG_CONFIG_HOME`, `AKM_CACHE_DIR`, `XDG_CACHE_HOME`), config and cache writes route into `${AKM_STASH_DIR}/.akm/` and `${AKM_STASH_DIR}/.akm/cache/` respectively.

Even when the operator opts in to `AKM_FORCE_SETUP_TMP_STASH=1`, the host config remains untouched — config writes follow the stash.

**Crucially:** daily users with a persistent `AKM_STASH_DIR=~/my-stash` see no change. The new rule only fires for transient path families. The precedence ordering means existing tests that pre-arrange `XDG_CONFIG_HOME` for isolation continue to work as before.

### Helper

`isTransientStashPath()` exported from `src/core/paths.ts` and reused by both the path resolvers and the setup guard, so the definition of "transient" stays single-sourced.

## Why both layers?

- Layer 1 fails fast and gives operators a clear error.
- Layer 2 is the structural backstop: if anything else in akm grows a `saveConfig()` call site that gets invoked under an isolated stash, the host config is still protected — no second round of incidents.

## Test plan

- [x] `tests/paths.test.ts` — extends `getConfigDir`/`getCacheDir` coverage for transient `AKM_STASH_DIR`:
  - `AKM_STASH_DIR=/tmp/X` redirects config to `/tmp/X/.akm` and cache to `/tmp/X/.akm/cache`
  - `AKM_STASH_DIR=/var/tmp/X` and `/private/var/folders/...` (macOS mktemp) also redirect
  - `AKM_STASH_DIR=~/persistent` does NOT redirect (daily users unaffected)
  - `AKM_CONFIG_DIR`, `XDG_CONFIG_HOME`, `AKM_CACHE_DIR`, `XDG_CACHE_HOME` all win over the new rule
  - Windows: `APPDATA` also wins
- [x] `tests/setup-tmp-stash-guard.test.ts` — end-to-end coverage:
  - `runSetupWithDefaults({ dir: /tmp/X })` rejects with `SETUP_TMP_STASH_REFUSED` by default
  - `runSetupFromConfig({ dir: /tmp/X })` rejects the same way
  - `AKM_FORCE_SETUP_TMP_STASH=1` lets the call succeed (returns `{ stashDir: /tmp/X }`)
  - Persistent `--dir` (under `~/`) is NOT refused
  - With the escape hatch enabled, a synthesized host `config.json` in a fake HOME is byte-identical (mtime unchanged) after setup runs — and the isolated config landed at `$STASH/.akm/config.json`
- [x] Full suite: **3531 pass / 0 fail / 21 skip** (was 3515 → +16 new tests, zero regressions)
- [x] `bunx tsc --noEmit` → 0 errors
- [x] `bun run lint` → 0 errors (2 pre-existing warnings unchanged)
- [ ] Manual smoke after merge: confirm `akm setup --dir /tmp/x` exits 2 with the migration hint
- [ ] Manual smoke: confirm `AKM_FORCE_SETUP_TMP_STASH=1 akm setup --dir /tmp/x` succeeds and writes to `/tmp/x/.akm/config.json` (host config untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)