### PR TITLE
feat(search): per-project utility scoring — scope usage signals by cwd anchor

### DIFF
--- a/src/commands/improve.ts
+++ b/src/commands/improve.ts
@@ -2810,7 +2810,7 @@ function buildUtilityMap(refs: ImproveEligibleRef[]): Map<string, number> {
     }
     const ids = [...idToRef.keys()];
     if (ids.length > 0) {
-      const scores = getUtilityScoresByIds(db, ids);
+      const { global: scores } = getUtilityScoresByIds(db, ids);
       for (const [id, score] of scores) {
         const ref = idToRef.get(id);
         if (ref) map.set(ref, score.utility);

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -12,10 +12,12 @@
 import { loadConfig } from "../core/config";
 import { rethrowIfTestIsolationError, UsageError } from "../core/errors";
 import { appendEvent } from "../core/events";
+import { isTransientStashPath } from "../core/paths";
 import { bumpUtilityScoresBatch, closeDatabase, openExistingDatabase } from "../indexer/db";
 import { searchLocal } from "../indexer/db-search";
 import type { StashEntryScope } from "../indexer/metadata";
 import { resolveSourceEntries } from "../indexer/search-source";
+import { getCurrentWorkflowScopeKey } from "../workflows/scope-key";
 // Eagerly import source providers to trigger self-registration before the
 // indexer or path-resolution code runs.
 import "../sources/providers/index";
@@ -303,7 +305,16 @@ function logSearchEvent(
       // The indexer overwrites these at next reindex; bumps are temporary hints.
       const resolvedIds = resolved.map((r) => r.entryId).filter((id): id is number => id !== undefined);
       if (resolvedIds.length > 0) {
-        bumpUtilityScoresBatch(db, resolvedIds, 1.0);
+        let scopeKey: string | undefined;
+        try {
+          const stashPath = response.stashDir;
+          const disabled =
+            process.env.AKM_DISABLE_SCOPED_UTILITY === "1" || (stashPath && isTransientStashPath(stashPath));
+          scopeKey = disabled ? undefined : getCurrentWorkflowScopeKey();
+        } catch {
+          // Non-fatal — fall back to global-only bumps on any error.
+        }
+        bumpUtilityScoresBatch(db, resolvedIds, 1.0, 0.1, scopeKey);
       }
       // Count registry hits separately so registry-only searches record a
       // non-zero resultCount. response.hits is always [] when source="registry".

--- a/src/indexer/db-search.ts
+++ b/src/indexer/db-search.ts
@@ -20,6 +20,7 @@ import type { AkmConfig, ImproveConfig } from "../core/config";
 import { getDbPath } from "../core/paths";
 import { warn } from "../core/warn";
 import type { AkmSearchType, BeliefFilterMode, SearchHitSize, SourceSearchHit } from "../sources/types";
+import { getCurrentWorkflowScopeKey } from "../workflows/scope-key";
 import {
   closeDatabase,
   getAllEntries,
@@ -354,6 +355,15 @@ async function searchDatabase(
       )
     : undefined;
 
+  // Resolve per-project scope key for scoped utility scoring.
+  // AKM_DISABLE_SCOPED_UTILITY=1 opts out (e.g. for registry searches or tests).
+  let scopeKey: string | undefined;
+  try {
+    scopeKey = process.env.AKM_DISABLE_SCOPED_UTILITY === "1" ? undefined : getCurrentWorkflowScopeKey();
+  } catch {
+    // Non-fatal — ranking proceeds without scoped utility on any error.
+  }
+
   applyRankingRules({
     db,
     query,
@@ -362,6 +372,7 @@ async function searchDatabase(
     projectContext,
     utilityDecayConfig,
     positiveFeedbackCounts,
+    scopeKey,
   });
 
   // ── minScore floor ──────────────────────────────────────────────────────

--- a/src/indexer/db.ts
+++ b/src/indexer/db.ts
@@ -330,6 +330,21 @@ function ensureSchema(db: Database, embeddingDim: number | undefined, options?: 
     );
   `);
 
+  // Per-project scoped utility scores — tracks usage per (entry, cwd-anchor)
+  // so assets useful in project A don't pollute rankings in project B.
+  // The global utility_scores table is preserved as a fallback / cold-start aid.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS utility_scores_scoped (
+      entry_id     INTEGER NOT NULL,
+      scope_key    TEXT NOT NULL,
+      utility      REAL NOT NULL DEFAULT 0,
+      last_used_at INTEGER NOT NULL,
+      PRIMARY KEY (entry_id, scope_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_utility_scores_scoped_entry_id
+      ON utility_scores_scoped(entry_id);
+  `);
+
   db.exec(`
     CREATE TABLE IF NOT EXISTS index_dir_state (
       dir_path          TEXT PRIMARY KEY,
@@ -558,6 +573,8 @@ function handleVersionUpgrade(db: Database): UsageEventRow[] {
   }
 
   db.exec("DROP TABLE IF EXISTS utility_scores");
+  db.exec("DROP TABLE IF EXISTS utility_scores_scoped");
+  db.exec("DROP INDEX IF EXISTS idx_utility_scores_scoped_entry_id");
   db.exec("DROP TABLE IF EXISTS usage_events");
   db.exec("DROP TABLE IF EXISTS embeddings");
   db.exec("DROP TABLE IF EXISTS entries_vec");
@@ -1024,6 +1041,11 @@ function deleteRelatedRows(db: Database, ids: Array<{ id: number }>): void {
     // Clean up utility scores before deleting entries
     try {
       db.prepare(`DELETE FROM utility_scores WHERE entry_id IN (${placeholders})`).run(...chunk);
+    } catch {
+      /* ignore */
+    }
+    try {
+      db.prepare(`DELETE FROM utility_scores_scoped WHERE entry_id IN (${placeholders})`).run(...chunk);
     } catch {
       /* ignore */
     }
@@ -1536,12 +1558,31 @@ export function getUtilityScore(db: Database, entryId: number): UtilityScoreRow 
 }
 
 /**
- * Batch-load utility scores for multiple entry IDs in a single query.
- * Returns a Map keyed by entry_id for O(1) lookup.
+ * A single row from `utility_scores_scoped`.
  */
-export function getUtilityScoresByIds(db: Database, ids: number[]): Map<number, UtilityScoreRow> {
-  if (ids.length === 0) return new Map();
-  const result = new Map<number, UtilityScoreRow>();
+export interface ScopedUtilityRow {
+  entryId: number;
+  scopeKey: string;
+  utility: number;
+  lastUsedAt: number;
+}
+
+/**
+ * Batch-load utility scores for multiple entry IDs in a single query.
+ * Returns a `{ global, scoped }` pair, both Maps keyed by entry_id.
+ *
+ * When `scopeKey` is provided a second query runs against
+ * `utility_scores_scoped` and the result is returned as `scoped`.
+ * Both maps are always present; `scoped` is empty when `scopeKey` is absent.
+ */
+export function getUtilityScoresByIds(
+  db: Database,
+  ids: number[],
+  scopeKey?: string,
+): { global: Map<number, UtilityScoreRow>; scoped: Map<number, ScopedUtilityRow> } {
+  const global = new Map<number, UtilityScoreRow>();
+  const scoped = new Map<number, ScopedUtilityRow>();
+  if (ids.length === 0) return { global, scoped };
   // Process in chunks to stay within SQLITE_MAX_VARIABLE_NUMBER
   for (let i = 0; i < ids.length; i += SQLITE_CHUNK_SIZE) {
     const chunk = ids.slice(i, i + SQLITE_CHUNK_SIZE);
@@ -1560,7 +1601,7 @@ export function getUtilityScoresByIds(db: Database, ids: number[]): Map<number, 
       updated_at: string;
     }>;
     for (const row of rows) {
-      result.set(row.entry_id, {
+      global.set(row.entry_id, {
         entryId: row.entry_id,
         utility: row.utility,
         showCount: row.show_count,
@@ -1570,8 +1611,28 @@ export function getUtilityScoresByIds(db: Database, ids: number[]): Map<number, 
         updatedAt: row.updated_at,
       });
     }
+    if (scopeKey) {
+      const scopedRows = db
+        .prepare(
+          `SELECT entry_id, scope_key, utility, last_used_at FROM utility_scores_scoped WHERE scope_key = ? AND entry_id IN (${placeholders})`,
+        )
+        .all(scopeKey, ...chunk) as Array<{
+        entry_id: number;
+        scope_key: string;
+        utility: number;
+        last_used_at: number;
+      }>;
+      for (const row of scopedRows) {
+        scoped.set(row.entry_id, {
+          entryId: row.entry_id,
+          scopeKey: row.scope_key,
+          utility: row.utility,
+          lastUsedAt: row.last_used_at,
+        });
+      }
+    }
   }
-  return result;
+  return { global, scoped };
 }
 
 /**
@@ -1767,12 +1828,23 @@ export function getRetrievalCounts(db: Database, refs: string[]): Map<string, nu
  * The indexer (`akm index`) will overwrite these values at next reindex run;
  * bumps are intentionally temporary hints between index runs, not permanent
  * overrides.
+ *
+ * When `scopeKey` is provided, also writes a scoped bump to
+ * `utility_scores_scoped` so per-project usage signals accumulate alongside
+ * the global ones. The global table is always updated regardless.
  */
-export function bumpUtilityScoresBatch(db: Database, entryIds: number[], reward: number, lr = 0.1): void {
+export function bumpUtilityScoresBatch(
+  db: Database,
+  entryIds: number[],
+  reward: number,
+  lr = 0.1,
+  scopeKey?: string,
+): void {
   if (entryIds.length === 0) return;
   db.transaction(() => {
-    const scoreMap = getUtilityScoresByIds(db, entryIds);
+    const { global: scoreMap } = getUtilityScoresByIds(db, entryIds);
     const now = new Date().toISOString();
+    const nowMs = Date.now();
     const stmt = db.prepare(
       `INSERT INTO utility_scores (entry_id, utility, show_count, search_count, select_rate, last_used_at, updated_at)
        VALUES (?, ?, 0, 0, 0, ?, ?)
@@ -1780,13 +1852,40 @@ export function bumpUtilityScoresBatch(db: Database, entryIds: number[], reward:
          utility = excluded.utility,
          updated_at = excluded.updated_at`,
     );
+    // Prepare scoped upsert once outside the loop when scopeKey is present.
+    const scopedStmt = scopeKey
+      ? db.prepare(
+          `INSERT INTO utility_scores_scoped (entry_id, scope_key, utility, last_used_at)
+           VALUES (?, ?, ?, ?)
+           ON CONFLICT(entry_id, scope_key) DO UPDATE SET
+             utility = excluded.utility,
+             last_used_at = excluded.last_used_at`,
+        )
+      : null;
     for (const entryId of entryIds) {
       const existing = scoreMap.get(entryId);
       const current = existing?.utility ?? 0;
       const next = Math.max(0, Math.min(1, current + lr * (reward - current)));
       stmt.run(entryId, next, now, now);
+      if (scopedStmt && scopeKey) {
+        // Retrieve the current scoped utility so we can apply the same EMA.
+        const scopedCurrent = getScopedUtility(db, entryId, scopeKey);
+        const scopedNext = Math.max(0, Math.min(1, scopedCurrent + lr * (reward - scopedCurrent)));
+        scopedStmt.run(entryId, scopeKey, scopedNext, nowMs);
+      }
     }
   })();
+}
+
+/**
+ * Return the current utility value for a single (entry_id, scope_key) pair.
+ * Returns 0 when no row exists yet.
+ */
+function getScopedUtility(db: Database, entryId: number, scopeKey: string): number {
+  const row = db
+    .prepare("SELECT utility FROM utility_scores_scoped WHERE entry_id = ? AND scope_key = ?")
+    .get(entryId, scopeKey) as { utility: number } | undefined;
+  return row?.utility ?? 0;
 }
 
 // ── Indexer-phase helpers (moved from indexer.ts) ────────────────────────────

--- a/src/indexer/ranking-contributors.ts
+++ b/src/indexer/ranking-contributors.ts
@@ -1,5 +1,5 @@
 import type { Database } from "bun:sqlite";
-import type { UtilityScoreRow } from "./db";
+import type { ScopedUtilityRow, UtilityScoreRow } from "./db";
 import { computeGraphBoost, type GraphBoostContext } from "./graph-boost";
 import type { ProjectContext } from "./project-context";
 import type { RankedEntryInput } from "./ranking";
@@ -50,6 +50,13 @@ export interface RankingContributor {
 
 export interface UtilityRankingContext extends RankingContext {
   utilityScores: Map<number, UtilityScoreRow>;
+  /**
+   * Per-project scoped utility scores loaded from `utility_scores_scoped`.
+   * Keyed by entry_id. When a scoped row exists for an entry the contributor
+   * blends: `finalUtility = scopedUtility * 0.7 + globalUtility * 0.3`.
+   * Absent or empty map falls back to global-only behaviour.
+   */
+  scopedUtilityScores?: Map<number, ScopedUtilityRow>;
   /**
    * Phase 2A / Rec 5: configurable forgetting curve parameters. When absent
    * the contributor falls back to {@link DEFAULT_RECENCY_HALF_LIFE_DAYS} and
@@ -257,18 +264,44 @@ const lessonStrengthContributor: RankingContributor = {
   },
 };
 
+/**
+ * Blend ratio for scoped vs. global utility signals.
+ *
+ * When a scoped row exists: `effectiveUtility = scoped * 0.7 + global * 0.3`
+ * This ensures the in-project signal strongly dominates while the global
+ * cold-start signal still helps when scoped history is sparse.
+ */
+const SCOPED_UTILITY_BLEND_SCOPED = 0.7;
+const SCOPED_UTILITY_BLEND_GLOBAL = 1 - SCOPED_UTILITY_BLEND_SCOPED;
+
 const utilityRankingContributor: UtilityRankingContributor = {
   name: "utility-ranking",
   appliesTo(item, ctx) {
     const utilScore = ctx.utilityScores.get(item.id);
-    return Boolean(utilScore && utilScore.utility > 0);
+    const scopedScore = ctx.scopedUtilityScores?.get(item.id);
+    return Boolean((utilScore && utilScore.utility > 0) || (scopedScore && scopedScore.utility > 0));
   },
   apply(item, ctx) {
     const utilScore = ctx.utilityScores.get(item.id);
-    if (!utilScore || utilScore.utility <= 0) return;
+    const scopedScore = ctx.scopedUtilityScores?.get(item.id);
+
+    // Determine effective utility: prefer scoped when present, blend with global.
+    const globalUtility = utilScore?.utility ?? 0;
+    const scopedUtility = scopedScore?.utility ?? 0;
+    const effectiveUtility =
+      scopedUtility > 0
+        ? scopedUtility * SCOPED_UTILITY_BLEND_SCOPED + globalUtility * SCOPED_UTILITY_BLEND_GLOBAL
+        : globalUtility;
+
+    if (effectiveUtility <= 0) return;
+
+    // Recency decay: use the global lastUsedAt for the decay factor (it's an
+    // ISO string with full resolution), falling back to scoped lastUsedAt (ms).
     let recencyFactor = 1;
-    if (utilScore.lastUsedAt) {
-      const lastUsedMs = new Date(utilScore.lastUsedAt).getTime();
+    const lastUsedRaw =
+      utilScore?.lastUsedAt ?? (scopedScore ? new Date(scopedScore.lastUsedAt).toISOString() : undefined);
+    if (lastUsedRaw) {
+      const lastUsedMs = new Date(lastUsedRaw).getTime();
       const daysSinceLastUse = Number.isNaN(lastUsedMs)
         ? Infinity
         : Math.max(0, (Date.now() - lastUsedMs) / (1000 * 60 * 60 * 24));
@@ -288,7 +321,7 @@ const utilityRankingContributor: UtilityRankingContributor = {
 
       recencyFactor = Math.exp(-daysSinceLastUse / safeHalfLife);
     }
-    const rawBoost = 1 + utilScore.utility * recencyFactor * UTILITY_WEIGHT;
+    const rawBoost = 1 + effectiveUtility * recencyFactor * UTILITY_WEIGHT;
     item.score *= Math.min(rawBoost, UTILITY_MAX_BOOST);
     item.utilityBoosted = true;
   },

--- a/src/indexer/ranking.ts
+++ b/src/indexer/ranking.ts
@@ -41,6 +41,13 @@ export interface RankEntriesOptions {
    * the contributor behaves exactly as it did pre-2A.
    */
   positiveFeedbackCounts?: Map<number, number>;
+  /**
+   * Scoped utility: SHA-256 project-anchor key from
+   * `getCurrentWorkflowScopeKey()`. When provided the ranking pipeline loads
+   * per-project utility scores in addition to the global ones and prefers the
+   * scoped signal when it exists (blend 0.7 scoped + 0.3 global).
+   */
+  scopeKey?: string;
 }
 
 export function normalizeFtsScores(results: DbSearchResult[]): Map<number, { score: number; result: DbSearchResult }> {
@@ -117,13 +124,15 @@ export function applyRankingRules(options: RankEntriesOptions): RankedEntryInput
     applyScoreContributors(item, rankingContext);
   }
 
-  const utilScoresMap = getUtilityScoresByIds(
+  const { global: utilScoresMap, scoped: scopedUtilScoresMap } = getUtilityScoresByIds(
     options.db,
     options.items.map((item) => item.id),
+    options.scopeKey,
   );
   const utilityContext = {
     ...rankingContext,
     utilityScores: utilScoresMap,
+    scopedUtilityScores: scopedUtilScoresMap,
     utilityDecayConfig: options.utilityDecayConfig,
     positiveFeedbackCounts: options.positiveFeedbackCounts,
   };

--- a/tests/scoped-utility.test.ts
+++ b/tests/scoped-utility.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Scoped utility scores — per-project usage signal isolation.
+ *
+ * Verifies:
+ *   1. Bumping entry X in scope A does not affect entry X in scope B.
+ *   2. `getUtilityScoresByIds` returns both global and scoped maps correctly.
+ *   3. The ranking contributor prefers scoped over global (blend 0.7/0.3).
+ *   4. Migration runs cleanly on a fresh DB and on a DB that already has
+ *      `utility_scores` rows (CREATE TABLE IF NOT EXISTS pattern).
+ */
+
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  bumpUtilityScoresBatch,
+  closeDatabase,
+  getUtilityScoresByIds,
+  openDatabase,
+  type ScopedUtilityRow,
+  type UtilityScoreRow,
+} from "../src/indexer/db";
+import type { StashEntry } from "../src/indexer/metadata";
+import type { RankedEntryInput } from "../src/indexer/ranking";
+import { applyUtilityContributors, type UtilityRankingContext } from "../src/indexer/ranking-contributors";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeTempDb(label: string): { db: Database; dbPath: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `akm-scoped-util-${label}-`));
+  const dbPath = path.join(dir, "index.db");
+  const db = openDatabase(dbPath);
+  return { db, dbPath };
+}
+
+function makeRankedItem(id: number, baseScore = 1): RankedEntryInput {
+  const entry: StashEntry = { name: `entry-${id}`, type: "skill" };
+  return { id, entry, filePath: `/stash/skills/entry-${id}.md`, score: baseScore, rankingMode: "fts" };
+}
+
+function makeCtx(
+  globalScores: Map<number, UtilityScoreRow>,
+  scopedScores?: Map<number, ScopedUtilityRow>,
+): UtilityRankingContext {
+  return {
+    db: null as unknown as Database,
+    query: "test",
+    queryLower: "test",
+    queryTokens: ["test"],
+    graphContext: null,
+    utilityScores: globalScores,
+    scopedUtilityScores: scopedScores,
+  };
+}
+
+function makeGlobalRow(id: number, utility: number): UtilityScoreRow {
+  return {
+    entryId: id,
+    utility,
+    showCount: 1,
+    searchCount: 1,
+    selectRate: 1,
+    lastUsedAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function makeScopedRow(id: number, scopeKey: string, utility: number): ScopedUtilityRow {
+  return {
+    entryId: id,
+    scopeKey,
+    utility,
+    lastUsedAt: Date.now(),
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("scoped utility scores — DB isolation", () => {
+  let db: Database;
+  let dbPath: string;
+
+  beforeEach(() => {
+    ({ db, dbPath } = makeTempDb("isolation"));
+    // Insert a minimal entry so foreign key constraints are satisfied
+    db.prepare(
+      "INSERT INTO entries (id, entry_key, dir_path, file_path, stash_dir, entry_json, search_text, entry_type) VALUES (1, 'skill:foo', '/s', '/s/foo.md', '/s', '{}', 'foo', 'skill')",
+    ).run();
+  });
+
+  afterEach(() => {
+    closeDatabase(db);
+    fs.rmSync(path.dirname(dbPath), { recursive: true, force: true });
+  });
+
+  test("bumping scope A does not affect scope B utility for the same entry", () => {
+    const scopeA = "dir:v1:aaaa";
+    const scopeB = "dir:v1:bbbb";
+
+    bumpUtilityScoresBatch(db, [1], 1.0, 0.1, scopeA);
+    bumpUtilityScoresBatch(db, [1], 1.0, 0.1, scopeA);
+
+    const { scoped: scopedA } = getUtilityScoresByIds(db, [1], scopeA);
+    const { scoped: scopedB } = getUtilityScoresByIds(db, [1], scopeB);
+
+    expect(scopedA.get(1)?.utility).toBeGreaterThan(0);
+    expect(scopedB.get(1)).toBeUndefined();
+  });
+
+  test("bumping scope B does not affect scope A", () => {
+    const scopeA = "dir:v1:aaaa";
+    const scopeB = "dir:v1:bbbb";
+
+    bumpUtilityScoresBatch(db, [1], 1.0, 0.1, scopeA);
+    bumpUtilityScoresBatch(db, [1], 1.0, 0.1, scopeB);
+    bumpUtilityScoresBatch(db, [1], 1.0, 0.1, scopeB);
+
+    const { scoped: scopedA } = getUtilityScoresByIds(db, [1], scopeA);
+    const { scoped: scopedB } = getUtilityScoresByIds(db, [1], scopeB);
+
+    // A was bumped once, B twice — they should differ
+    const utilA = scopedA.get(1)?.utility ?? 0;
+    const utilB = scopedB.get(1)?.utility ?? 0;
+    expect(utilA).toBeGreaterThan(0);
+    expect(utilB).toBeGreaterThan(utilA);
+  });
+});
+
+describe("getUtilityScoresByIds — dual maps", () => {
+  let db: Database;
+  let dbPath: string;
+
+  beforeEach(() => {
+    ({ db, dbPath } = makeTempDb("getutil"));
+    db.prepare(
+      "INSERT INTO entries (id, entry_key, dir_path, file_path, stash_dir, entry_json, search_text, entry_type) VALUES (1, 'skill:foo', '/s', '/s/foo.md', '/s', '{}', 'foo', 'skill')",
+    ).run();
+    db.prepare(
+      "INSERT INTO entries (id, entry_key, dir_path, file_path, stash_dir, entry_json, search_text, entry_type) VALUES (2, 'skill:bar', '/s', '/s/bar.md', '/s', '{}', 'bar', 'skill')",
+    ).run();
+  });
+
+  afterEach(() => {
+    closeDatabase(db);
+    fs.rmSync(path.dirname(dbPath), { recursive: true, force: true });
+  });
+
+  test("returns both global and scoped maps for the same ids", () => {
+    const scopeKey = "dir:v1:test";
+    bumpUtilityScoresBatch(db, [1, 2], 1.0, 0.1);
+    bumpUtilityScoresBatch(db, [1], 1.0, 0.1, scopeKey);
+
+    const { global, scoped } = getUtilityScoresByIds(db, [1, 2], scopeKey);
+
+    // Global: both entries should have a score
+    expect(global.get(1)?.utility).toBeGreaterThan(0);
+    expect(global.get(2)?.utility).toBeGreaterThan(0);
+
+    // Scoped: only entry 1 was bumped with scopeKey
+    expect(scoped.get(1)?.utility).toBeGreaterThan(0);
+    expect(scoped.get(2)).toBeUndefined();
+  });
+
+  test("scoped map is empty when no scopeKey is passed", () => {
+    bumpUtilityScoresBatch(db, [1], 1.0, 0.1, "dir:v1:test");
+    const { global, scoped } = getUtilityScoresByIds(db, [1]);
+    expect(global.get(1)?.utility).toBeGreaterThan(0);
+    expect(scoped.size).toBe(0);
+  });
+
+  test("returns empty maps for empty ids array", () => {
+    const { global, scoped } = getUtilityScoresByIds(db, []);
+    expect(global.size).toBe(0);
+    expect(scoped.size).toBe(0);
+  });
+});
+
+describe("ranking contributor — scoped preference", () => {
+  test("uses global utility when no scoped score exists", () => {
+    const item = makeRankedItem(1);
+    const globalScores = new Map([[1, makeGlobalRow(1, 0.5)]]);
+    const ctx = makeCtx(globalScores);
+    applyUtilityContributors(item, ctx);
+    expect(item.score).toBeGreaterThan(1);
+    expect(item.utilityBoosted).toBe(true);
+  });
+
+  test("prefers scoped over global — scoped=0.8 > global=0.2 yields higher boost", () => {
+    // With only global=0.2
+    const itemGlobalOnly = makeRankedItem(1);
+    const ctxGlobal = makeCtx(new Map([[1, makeGlobalRow(1, 0.2)]]));
+    applyUtilityContributors(itemGlobalOnly, ctxGlobal);
+
+    // With scoped=0.8 and global=0.2 → blend = 0.8*0.7 + 0.2*0.3 = 0.56 + 0.06 = 0.62
+    const itemScoped = makeRankedItem(1);
+    const ctxScoped = makeCtx(
+      new Map([[1, makeGlobalRow(1, 0.2)]]),
+      new Map([[1, makeScopedRow(1, "dir:v1:test", 0.8)]]),
+    );
+    applyUtilityContributors(itemScoped, ctxScoped);
+
+    expect(itemScoped.score).toBeGreaterThan(itemGlobalOnly.score);
+  });
+
+  test("blend ratio: effectiveUtility = scoped*0.7 + global*0.3 when scoped > 0", () => {
+    // Fixed values to verify the blend formula exactly
+    const scopedUtility = 0.6;
+    const globalUtility = 0.4;
+    // effective = 0.6 * 0.7 + 0.4 * 0.3 = 0.42 + 0.12 = 0.54
+    const expected = scopedUtility * 0.7 + globalUtility * 0.3;
+
+    // Use a fresh item and apply without recency decay (lastUsedAt = undefined)
+    const scopedRow: ScopedUtilityRow = {
+      entryId: 1,
+      scopeKey: "dir:v1:test",
+      utility: scopedUtility,
+      lastUsedAt: Date.now(),
+    };
+    const globalRow: UtilityScoreRow = {
+      entryId: 1,
+      utility: globalUtility,
+      showCount: 0,
+      searchCount: 0,
+      selectRate: 0,
+      lastUsedAt: undefined, // no recency factor (= 1)
+      updatedAt: new Date().toISOString(),
+    };
+
+    const item = makeRankedItem(1, 1.0);
+    const ctx = makeCtx(new Map([[1, globalRow]]), new Map([[1, scopedRow]]));
+    applyUtilityContributors(item, ctx);
+
+    // rawBoost = 1 + effective * 1 * 0.5 (UTILITY_WEIGHT=0.5)
+    const UTILITY_WEIGHT = 0.5;
+    const UTILITY_MAX_BOOST = 1.5;
+    const rawBoost = 1 + expected * UTILITY_WEIGHT;
+    const expectedScore = Math.min(rawBoost, UTILITY_MAX_BOOST);
+    expect(item.score).toBeCloseTo(expectedScore, 5);
+  });
+
+  test("falls back to global when scoped utility is 0", () => {
+    const globalUtility = 0.5;
+    // scopedScore.utility = 0 so the contributor should use globalUtility instead
+    const scopedRow: ScopedUtilityRow = {
+      entryId: 1,
+      scopeKey: "dir:v1:test",
+      utility: 0,
+      lastUsedAt: Date.now(), // recent, so recency factor = 1 (if it were used)
+    };
+    const globalRow: UtilityScoreRow = {
+      entryId: 1,
+      utility: globalUtility,
+      showCount: 0,
+      searchCount: 0,
+      selectRate: 0,
+      lastUsedAt: undefined, // no recency decay applied when undefined
+      updatedAt: new Date().toISOString(),
+    };
+
+    const item = makeRankedItem(1);
+    const ctx = makeCtx(new Map([[1, globalRow]]), new Map([[1, scopedRow]]));
+    applyUtilityContributors(item, ctx);
+
+    // scopedUtility=0 → effectiveUtility=globalUtility=0.5
+    // lastUsedRaw: globalRow.lastUsedAt=undefined, scopedRow.lastUsedAt=now → recent
+    // recencyFactor ≈ exp(0) = 1
+    // rawBoost = 1 + 0.5 * 1 * 0.5 = 1.25
+    const UTILITY_WEIGHT = 0.5;
+    const UTILITY_MAX_BOOST = 1.5;
+    const expectedScore = Math.min(1 + globalUtility * UTILITY_WEIGHT, UTILITY_MAX_BOOST);
+    expect(item.score).toBeCloseTo(expectedScore, 2); // tolerance 0.01 (recency ≈ 1 but may not be exact 1)
+  });
+});
+
+describe("schema migration safety", () => {
+  test("CREATE TABLE IF NOT EXISTS is idempotent on fresh DB", () => {
+    const { db: freshDb, dbPath: freshPath } = makeTempDb("fresh");
+    try {
+      const tables = freshDb
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='utility_scores_scoped'")
+        .all() as Array<{ name: string }>;
+      expect(tables.length).toBe(1);
+    } finally {
+      closeDatabase(freshDb);
+      fs.rmSync(path.dirname(freshPath), { recursive: true, force: true });
+    }
+  });
+
+  test("existing utility_scores rows survive openDatabase (no data loss)", () => {
+    const { db: existingDb, dbPath: existingPath } = makeTempDb("existing");
+    try {
+      // Add an entry and bump its global utility
+      existingDb
+        .prepare(
+          "INSERT INTO entries (id, entry_key, dir_path, file_path, stash_dir, entry_json, search_text, entry_type) VALUES (1, 'skill:foo', '/s', '/s/foo.md', '/s', '{}', 'foo', 'skill')",
+        )
+        .run();
+      bumpUtilityScoresBatch(existingDb, [1], 1.0, 0.1);
+      const { global: before } = getUtilityScoresByIds(existingDb, [1]);
+      expect(before.get(1)?.utility).toBeGreaterThan(0);
+
+      // Re-open the same DB (simulates a binary restart / second ensureSchema call)
+      closeDatabase(existingDb);
+      const reopenedDb = openDatabase(existingPath);
+      const { global: after } = getUtilityScoresByIds(reopenedDb, [1]);
+      expect(after.get(1)?.utility).toBeGreaterThan(0);
+      expect(after.get(1)?.utility).toBeCloseTo(before.get(1)?.utility, 5);
+      closeDatabase(reopenedDb);
+    } catch (err) {
+      try {
+        closeDatabase(existingDb);
+      } catch {
+        /* already closed */
+      }
+      throw err;
+    } finally {
+      fs.rmSync(path.dirname(existingPath), { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/scoped-utility.test.ts
+++ b/tests/scoped-utility.test.ts
@@ -299,14 +299,16 @@ describe("schema migration safety", () => {
         .run();
       bumpUtilityScoresBatch(existingDb, [1], 1.0, 0.1);
       const { global: before } = getUtilityScoresByIds(existingDb, [1]);
-      expect(before.get(1)?.utility).toBeGreaterThan(0);
+      const beforeUtility = before.get(1)?.utility;
+      expect(beforeUtility).toBeGreaterThan(0);
 
       // Re-open the same DB (simulates a binary restart / second ensureSchema call)
       closeDatabase(existingDb);
       const reopenedDb = openDatabase(existingPath);
       const { global: after } = getUtilityScoresByIds(reopenedDb, [1]);
-      expect(after.get(1)?.utility).toBeGreaterThan(0);
-      expect(after.get(1)?.utility).toBeCloseTo(before.get(1)?.utility, 5);
+      const afterUtility = after.get(1)?.utility;
+      expect(afterUtility).toBeGreaterThan(0);
+      expect(afterUtility).toBeCloseTo(beforeUtility as number, 5);
       closeDatabase(reopenedDb);
     } catch (err) {
       try {


### PR DESCRIPTION
## Summary

- Adds `utility_scores_scoped` table keyed by `(entry_id, scope_key)` where `scope_key` is a SHA-256 of the project-anchor directory (`getCurrentWorkflowScopeKey()`). Assets useful in project A no longer pollute rankings in project B.
- `bumpUtilityScoresBatch` gains an optional `scopeKey` parameter; `search.ts` passes the current scope on each user search (skipped for transient/test stash dirs and when `AKM_DISABLE_SCOPED_UTILITY=1`).
- `getUtilityScoresByIds` returns `{ global, scoped }` pair. The `utilityRankingContributor` blends them: `effectiveUtility = scoped * 0.7 + global * 0.3` when a scoped row exists, falling back to global-only for cold-start.
- Global `utility_scores` table is fully preserved — no schema or data migration risk.

## Schema change

```sql
CREATE TABLE IF NOT EXISTS utility_scores_scoped (
  entry_id     INTEGER NOT NULL,
  scope_key    TEXT NOT NULL,
  utility      REAL NOT NULL DEFAULT 0,
  last_used_at INTEGER NOT NULL,
  PRIMARY KEY (entry_id, scope_key)
);
CREATE INDEX IF NOT EXISTS idx_utility_scores_scoped_entry_id ON utility_scores_scoped(entry_id);
```

Safe on existing DBs (`CREATE TABLE IF NOT EXISTS`). Included in `handleVersionUpgrade` drop list for clean rebuilds.

## Blend ratio

`0.7 / 0.3` — strong in-project signal wins, but global cold-start signal still contributes when scoped history is sparse.

## Merge note

If `feat/search-project-context-ranking` is also open, that branch also touches `ranking-contributors.ts`. Merge that PR first to avoid a rebase conflict on `utilityRankingContributor`.

## Test plan

- [x] `bun test tests/scoped-utility.test.ts` — 11 new tests pass (scope isolation, dual-map returns, blend ratio exact verification, migration idempotency)
- [x] `bunx tsc --noEmit` — clean
- [x] `bun test` full suite — 3567 pass, 0 fail (pre-existing warnings in `consolidate.ts` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)