### PR TITLE
feat(search): auto-boost project-relevant assets via cwd project-context ranking

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -674,6 +674,12 @@ const searchCommand = defineCommand({
     },
     format: { type: "string", description: "Output format (json|jsonl|text|yaml)" },
     detail: { type: "string", description: "Detail level (brief|normal|full|summary|agent)" },
+    "no-project-context": {
+      type: "boolean",
+      description:
+        "Disable the automatic project-context ranking boost (also disabled by AKM_DISABLE_PROJECT_CONTEXT=1).",
+      default: false,
+    },
   },
   async run({ args }) {
     await runWithJsonErrors(async () => {
@@ -694,6 +700,10 @@ const searchCommand = defineCommand({
       const filters = parseScopeFilterFlags(filterTokens, "--filter");
       const includeProposed = (args as Record<string, unknown>)["include-proposed"] === true;
       const belief = parseBeliefFilterMode(typeof args.belief === "string" ? args.belief : undefined);
+      const noProjectContext = getHyphenatedBoolean(args, "no-project-context");
+      // --no-project-context sets env so searchDatabase picks it up without
+      // threading the flag through the entire call stack.
+      if (noProjectContext) process.env.AKM_DISABLE_PROJECT_CONTEXT = "1";
       const result = await akmSearch({
         query,
         type,

--- a/src/indexer/db-search.ts
+++ b/src/indexer/db-search.ts
@@ -40,6 +40,7 @@ import {
   loadGraphBoostContext,
 } from "./graph-boost";
 import { isProposedQuality, type StashEntry, type StashEntryScope } from "./metadata";
+import { resolveProjectContext } from "./project-context";
 import { applyRankingRules, combineSearchScores, normalizeFtsScores } from "./ranking";
 import { enrichSearchHit } from "./search-hit-enrichers";
 import { buildEditHint, findSourceForPath, isEditable, type SearchSource } from "./search-source";
@@ -329,6 +330,11 @@ async function searchDatabase(
     return loadGraphBoostContext(allSourceDirs, query, config, db);
   })();
 
+  // Resolve project-context tokens from the current working directory once
+  // per search invocation. Returns null when running from home dir / /tmp,
+  // or when the caller has set AKM_DISABLE_PROJECT_CONTEXT=1.
+  const projectContext = process.env.AKM_DISABLE_PROJECT_CONTEXT === "1" ? null : resolveProjectContext(process.cwd());
+
   // Phase 2A / Rec 5: resolve forgetting-curve config and skip the feedback
   // count query when the boost cannot make a difference (default ≤ 1.0 means
   // boost^count == 1 — zero overhead for the common case).
@@ -353,6 +359,7 @@ async function searchDatabase(
     query,
     items: scored,
     graphContext,
+    projectContext,
     utilityDecayConfig,
     positiveFeedbackCounts,
   });

--- a/src/indexer/project-context.ts
+++ b/src/indexer/project-context.ts
@@ -1,0 +1,217 @@
+/**
+ * Project-context resolution for search ranking.
+ *
+ * Extracts meaningful identifier tokens from the current working directory
+ * so the ranking pipeline can boost assets that are relevant to the active
+ * project. Token extraction tries, in order:
+ *
+ *   1. `.git/config` remote-origin URL basename (strips `.git` extension)
+ *   2. `package.json` `name` field (last `/`-separated segment, minus common
+ *      framework suffixes)
+ *   3. Basename of the directory returned by `resolveWorkflowScopeAnchor`
+ *   4. `null` — no meaningful project context (home dir, /tmp, etc.)
+ *
+ * Tokens are lowercased, split on `[-_/]`, then filtered through a noise-word
+ * blocklist. A maximum of 5 tokens is kept.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveWorkflowScopeAnchor } from "../workflows/scope-key.js";
+
+// Words that appear in almost every project name and carry no discriminating
+// signal for ranking. Filtered out after token splitting.
+const TOKEN_BLOCKLIST = new Set([
+  "my",
+  "the",
+  "app",
+  "lib",
+  "sdk",
+  "api",
+  "cli",
+  "tool",
+  "kit",
+  "core",
+  "main",
+  "index",
+  "src",
+  "test",
+]);
+
+// Common suffixes stripped from package.json `name` before tokenisation so
+// that e.g. `akm-cli` contributes `akm` rather than `akm` + `cli` (which is
+// in the blocklist anyway, but explicit stripping keeps the raw name shorter).
+const STRIP_SUFFIXES = ["-cli", "-app", "-lib", "-sdk", "-plugin"];
+
+const MAX_TOKENS = 5;
+
+// Paths that are definitely NOT a meaningful project root (home dir, tmp).
+// When `resolveWorkflowScopeAnchor` returns one of these we return `null`.
+function isNoiseRoot(dir: string): boolean {
+  const homedir = os.homedir();
+  const normalized = dir.replace(/\/+$/, "");
+  if (normalized === homedir || normalized === homedir.replace(/\/+$/, "")) return true;
+  // /tmp or /tmp/… (any depth)
+  if (normalized === "/tmp" || normalized.startsWith("/tmp/")) return true;
+  // Windows-style temp
+  const tmpdir = os.tmpdir();
+  if (normalized === tmpdir || normalized.startsWith(tmpdir + path.sep)) return true;
+  return false;
+}
+
+export interface ProjectContext {
+  /** Lowercase project identifier tokens, e.g. `Set { "akm" }` for the akm repo. */
+  tokens: Set<string>;
+}
+
+/**
+ * Filesystem abstraction injected during tests so callers can supply fixture
+ * files without touching the real FS.
+ */
+export interface FsOverride {
+  readFileSync(filePath: string, encoding: BufferEncoding): string;
+}
+
+/**
+ * Resolve the project context for the given working directory.
+ *
+ * @param cwd       - Directory to inspect. Defaults to `process.cwd()`.
+ * @param fsOverride - Optional FS override for unit testing.
+ * @returns `ProjectContext` with a non-empty `tokens` set, or `null` when no
+ *          meaningful context can be derived (home dir, /tmp, extraction failed).
+ */
+export function resolveProjectContext(cwd?: string, fsOverride?: FsOverride): ProjectContext | null {
+  const effectiveCwd = cwd ?? process.cwd();
+  const readFile = fsOverride?.readFileSync ?? ((p: string, enc: BufferEncoding) => fs.readFileSync(p, enc));
+
+  // Attempt 1 — git remote-origin URL
+  const gitConfigPath = path.join(effectiveCwd, ".git", "config");
+  const gitTokens = tryExtractGitTokens(gitConfigPath, readFile);
+  if (gitTokens !== null && gitTokens.size > 0) {
+    return { tokens: gitTokens };
+  }
+
+  // Attempt 2 — package.json name
+  const pkgJsonPath = path.join(effectiveCwd, "package.json");
+  const pkgTokens = tryExtractPackageJsonTokens(pkgJsonPath, readFile);
+  if (pkgTokens !== null && pkgTokens.size > 0) {
+    return { tokens: pkgTokens };
+  }
+
+  // Attempt 3 — workflow scope anchor basename
+  try {
+    const anchor = resolveWorkflowScopeAnchor(effectiveCwd);
+    if (isNoiseRoot(anchor)) return null;
+    const baseName = path.basename(anchor);
+    const tokens = tokenize(baseName);
+    if (tokens.size > 0) {
+      return { tokens };
+    }
+  } catch {
+    // Ignore errors from scope anchor resolution (e.g. during testing).
+  }
+
+  return null;
+}
+
+// ── Private helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Parse `.git/config` for the `[remote "origin"]` section and extract the
+ * repo name from the `url =` line.
+ *
+ *   url = git@github.com:itlackey/akm.git   → "akm"
+ *   url = https://github.com/itlackey/akm   → "akm"
+ */
+function tryExtractGitTokens(
+  gitConfigPath: string,
+  readFile: (p: string, enc: BufferEncoding) => string,
+): Set<string> | null {
+  try {
+    const content = readFile(gitConfigPath, "utf-8");
+    const urlMatch = extractRemoteOriginUrl(content);
+    if (!urlMatch) return null;
+
+    // Strip .git extension, then take the last path segment.
+    const withoutGit = urlMatch.replace(/\.git$/, "");
+    const segments = withoutGit.replace(/\/$/, "").split(/[/:]/).filter(Boolean);
+    const repoName = segments[segments.length - 1] ?? "";
+    const tokens = tokenize(repoName);
+    return tokens.size > 0 ? tokens : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extracts the `url =` value from the `[remote "origin"]` section of a git
+ * config file. Returns `null` when the section or key is absent.
+ */
+function extractRemoteOriginUrl(content: string): string | null {
+  // Split into sections delimited by `[...]` headers.
+  const lines = content.split(/\r?\n/);
+  let inOrigin = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("[")) {
+      // New section header
+      inOrigin = /^\[remote\s+"origin"\]$/i.test(trimmed);
+      continue;
+    }
+    if (inOrigin) {
+      const m = trimmed.match(/^url\s*=\s*(.+)$/i);
+      if (m) return m[1].trim();
+    }
+  }
+  return null;
+}
+
+/**
+ * Read `package.json` and extract the `name` field as tokens.
+ */
+function tryExtractPackageJsonTokens(
+  pkgPath: string,
+  readFile: (p: string, enc: BufferEncoding) => string,
+): Set<string> | null {
+  try {
+    const content = readFile(pkgPath, "utf-8");
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    if (typeof parsed.name !== "string" || !parsed.name) return null;
+
+    // For scoped packages (@org/pkg-name) take the last `/`-separated segment.
+    const rawName = parsed.name.split("/").pop() ?? parsed.name;
+
+    // Strip common framework suffixes before tokenising.
+    let strippedName = rawName;
+    for (const suffix of STRIP_SUFFIXES) {
+      if (strippedName.endsWith(suffix)) {
+        strippedName = strippedName.slice(0, -suffix.length);
+        break; // only strip one suffix
+      }
+    }
+
+    const tokens = tokenize(strippedName);
+    return tokens.size > 0 ? tokens : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Split a raw name string into lowercase tokens, then filter through the
+ * blocklist and cap at `MAX_TOKENS`.
+ *
+ *   "akm-cli"   → Set { "akm" }
+ *   "my-app"    → Set {}  (all tokens blocked)
+ *   "openpalm"  → Set { "openpalm" }
+ */
+function tokenize(raw: string): Set<string> {
+  const parts = raw
+    .toLowerCase()
+    .split(/[-_/]+/)
+    .filter(Boolean)
+    .filter((t) => !TOKEN_BLOCKLIST.has(t))
+    .slice(0, MAX_TOKENS);
+  return new Set(parts);
+}

--- a/src/indexer/ranking-contributors.ts
+++ b/src/indexer/ranking-contributors.ts
@@ -1,6 +1,7 @@
 import type { Database } from "bun:sqlite";
 import type { UtilityScoreRow } from "./db";
 import { computeGraphBoost, type GraphBoostContext } from "./graph-boost";
+import type { ProjectContext } from "./project-context";
 import type { RankedEntryInput } from "./ranking";
 
 const TYPE_BOOST: Record<string, number> = {
@@ -37,6 +38,8 @@ export interface RankingContext {
   queryLower: string;
   queryTokens: string[];
   graphContext: GraphBoostContext | null;
+  /** Project-context tokens derived from the current working directory. */
+  projectContext?: ProjectContext | null;
 }
 
 export interface RankingContributor {
@@ -291,6 +294,42 @@ const utilityRankingContributor: UtilityRankingContributor = {
   },
 };
 
+/**
+ * Project-context boost.
+ *
+ * Auto-boosts assets whose name, tags, aliases, or search hints contain tokens
+ * derived from the current working directory's project name. For example, when
+ * running `akm search` from the `akm` git repo, assets tagged `akm` or named
+ * `akm-*` receive an additive boost.
+ *
+ * The boost is capped at 0.5 so it can never overpower an exact-name match
+ * (which contributes 2.0). Each matching token adds 0.2 up to the cap.
+ *
+ * Skipped entirely when `projectContext` is absent or has no tokens (e.g.
+ * when running from home dir, /tmp, or when disabled via
+ * `--no-project-context` / `AKM_DISABLE_PROJECT_CONTEXT=1`).
+ */
+const projectContextRankingContributor: RankingContributor = {
+  name: "project-context-ranking",
+  appliesTo(_item, ctx) {
+    return ctx.projectContext != null && ctx.projectContext.tokens.size > 0;
+  },
+  adjust(item, ctx) {
+    if (!ctx.projectContext) return 0;
+    const fields = [
+      item.entry.name ?? "",
+      ...(item.entry.tags ?? []),
+      ...(item.entry.aliases ?? []),
+      ...(item.entry.searchHints ?? []),
+    ].map((s) => s.toLowerCase());
+    let hits = 0;
+    for (const token of ctx.projectContext.tokens) {
+      if (fields.some((f) => f.includes(token))) hits++;
+    }
+    return Math.min(0.5, hits * 0.2);
+  },
+};
+
 export const defaultRankingContributors: RankingContributor[] = [
   exactNameRankingContributor,
   typeRankingContributor,
@@ -303,6 +342,7 @@ export const defaultRankingContributors: RankingContributor[] = [
   graphRankingContributor,
   captureModeRankingContributor,
   lessonStrengthContributor,
+  projectContextRankingContributor,
 ];
 
 export const defaultUtilityRankingContributors: UtilityRankingContributor[] = [utilityRankingContributor];

--- a/src/indexer/ranking.ts
+++ b/src/indexer/ranking.ts
@@ -2,6 +2,7 @@ import type { Database } from "bun:sqlite";
 import { type DbSearchResult, getUtilityScoresByIds } from "./db";
 import type { GraphBoostContext } from "./graph-boost";
 import type { StashEntry } from "./metadata";
+import type { ProjectContext } from "./project-context";
 import { applyScoreContributors, applyUtilityContributors } from "./ranking-contributors";
 
 export interface RankedEntryInput {
@@ -18,6 +19,12 @@ export interface RankEntriesOptions {
   query: string;
   items: RankedEntryInput[];
   graphContext: GraphBoostContext | null;
+  /**
+   * Project-context tokens derived from the current working directory.
+   * When supplied, assets that match these tokens receive an additive
+   * ranking boost. Pass `null` to explicitly disable (e.g. `--no-project-context`).
+   */
+  projectContext?: ProjectContext | null;
   /**
    * Phase 2A / Rec 5: optional configurable forgetting curve. When absent,
    * the utility recency decay falls back to its pre-2A default
@@ -103,6 +110,7 @@ export function applyRankingRules(options: RankEntriesOptions): RankedEntryInput
     queryLower,
     queryTokens,
     graphContext: options.graphContext,
+    projectContext: options.projectContext,
   };
 
   for (const item of options.items) {

--- a/tests/project-context.test.ts
+++ b/tests/project-context.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for resolveProjectContext.
+ *
+ * All tests use the `fsOverride` parameter to avoid touching the real
+ * filesystem. The `cwd` parameter is used to control which directory
+ * is being "tested" without actually changing the process working directory.
+ */
+
+import { describe, expect, test } from "bun:test";
+import os from "node:os";
+import path from "node:path";
+import { resolveProjectContext } from "../src/indexer/project-context";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal fsOverride that returns specific file contents for specific
+ * paths and throws ENOENT for everything else.
+ */
+function buildFs(files: Record<string, string>) {
+  return {
+    readFileSync(filePath: string, _enc: BufferEncoding): string {
+      if (filePath in files) return files[filePath];
+      const err = new Error(`ENOENT: no such file or directory, open '${filePath}'`) as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      throw err;
+    },
+  };
+}
+
+// A fake "project root" that is not the home dir or /tmp.
+const FAKE_PROJECT = "/projects/my-project";
+
+// ── git config extraction ────────────────────────────────────────────────────
+
+describe("resolveProjectContext — git config", () => {
+  test("SSH git URL extracts repo name correctly", () => {
+    const gitConfig = `
+[core]
+  repositoryformatversion = 0
+[remote "origin"]
+  url = git@github.com:itlackey/akm.git
+  fetch = +refs/heads/*:refs/remotes/origin/*
+`;
+    const fs = buildFs({ [`${FAKE_PROJECT}/.git/config`]: gitConfig });
+    const ctx = resolveProjectContext(FAKE_PROJECT, fs);
+    expect(ctx).not.toBeNull();
+    expect(ctx?.tokens).toEqual(new Set(["akm"]));
+  });
+
+  test("HTTPS git URL extracts repo name correctly", () => {
+    const gitConfig = `
+[remote "origin"]
+  url = https://github.com/itlackey/akm
+`;
+    const fs = buildFs({ [`${FAKE_PROJECT}/.git/config`]: gitConfig });
+    const ctx = resolveProjectContext(FAKE_PROJECT, fs);
+    expect(ctx).not.toBeNull();
+    expect(ctx?.tokens).toEqual(new Set(["akm"]));
+  });
+
+  test("multi-token repo name is split on hyphens", () => {
+    const gitConfig = `
+[remote "origin"]
+  url = git@github.com:acme/open-palm.git
+`;
+    const fs = buildFs({ [`${FAKE_PROJECT}/.git/config`]: gitConfig });
+    const ctx = resolveProjectContext(FAKE_PROJECT, fs);
+    expect(ctx).not.toBeNull();
+    // "open" is not in the blocklist; "palm" is not either
+    expect(ctx?.tokens).toEqual(new Set(["open", "palm"]));
+  });
+
+  test("git URL with .git extension stripped", () => {
+    const gitConfig = `
+[remote "origin"]
+  url = https://github.com/itlackey/my-tool-kit.git
+`;
+    const fs = buildFs({ [`${FAKE_PROJECT}/.git/config`]: gitConfig });
+    const ctx = resolveProjectContext(FAKE_PROJECT, fs);
+    // "my", "tool", "kit" are all in blocklist → no tokens survive
+    // falls through to package.json and then scope-anchor
+    // (no package.json in this FS fixture, so anchor is used)
+    // The anchor is FAKE_PROJECT → basename "my-project" → tokens: ["project"]
+    // (since "my" is blocked)
+    expect(ctx).not.toBeNull();
+  });
+
+  test("git config without remote origin falls through to package.json", () => {
+    const gitConfig = `
+[core]
+  repositoryformatversion = 0
+`;
+    const pkgJson = JSON.stringify({ name: "cool-project" });
+    const fs = buildFs({
+      [`${FAKE_PROJECT}/.git/config`]: gitConfig,
+      [`${FAKE_PROJECT}/package.json`]: pkgJson,
+    });
+    const ctx = resolveProjectContext(FAKE_PROJECT, fs);
+    expect(ctx).not.toBeNull();
+    expect(ctx?.tokens).toEqual(new Set(["cool", "project"]));
+  });
+});
+
+// ── package.json extraction ──────────────────────────────────────────────────
+
+describe("resolveProjectContext — package.json", () => {
+  test("simple package name extracts tokens", () => {
+    const pkgJson = JSON.stringify({ name: "cool-project" });
+    const fs = buildFs({ [`${FAKE_PROJECT}/package.json`]: pkgJson });
+    const ctx = resolveProjectContext(FAKE_PROJECT, fs);
+    expect(ctx).not.toBeNull();
+    expect(ctx?.tokens).toEqual(new Set(["cool", "project"]));
+  });
+
+  test("scoped package name uses last segment", () => {
+    const pkgJson = JSON.stringify({ name: "@acme/event-bus" });
+    const fs = buildFs({ [`${FAKE_PROJECT}/package.json`]: pkgJson });
+    const ctx = resolveProjectContext(FAKE_PROJECT, fs);
+    expect(ctx).not.toBeNull();
+    expect(ctx?.tokens).toEqual(new Set(["event", "bus"]));
+  });
+
+  test("common suffixes are stripped before tokenising", () => {
+    const pkgJson = JSON.stringify({ name: "my-service-cli" });
+    const fs = buildFs({ [`${FAKE_PROJECT}/package.json`]: pkgJson });
+    const ctx = resolveProjectContext(FAKE_PROJECT, fs);
+    expect(ctx).not.toBeNull();
+    // "my" blocked, "service" survives, "-cli" stripped before split
+    expect(ctx?.tokens.has("service")).toBe(true);
+    expect(ctx?.tokens.has("cli")).toBe(false);
+  });
+
+  test("package name 'akm' returns token Set { 'akm' }", () => {
+    const pkgJson = JSON.stringify({ name: "akm" });
+    const fs = buildFs({ [`${FAKE_PROJECT}/package.json`]: pkgJson });
+    const ctx = resolveProjectContext(FAKE_PROJECT, fs);
+    expect(ctx).not.toBeNull();
+    expect(ctx?.tokens).toEqual(new Set(["akm"]));
+  });
+});
+
+// ── Noise root guard ─────────────────────────────────────────────────────────
+
+describe("resolveProjectContext — noise roots", () => {
+  test("returns null when cwd is the home directory", () => {
+    // Home dir has neither .git/config nor package.json in our fake FS,
+    // so it falls through to the scope-anchor path which returns homedir —
+    // the noise-root guard then returns null.
+    const homedir = os.homedir();
+    const ctx = resolveProjectContext(homedir, buildFs({}));
+    expect(ctx).toBeNull();
+  });
+
+  test("returns null when cwd is /tmp", () => {
+    const ctx = resolveProjectContext("/tmp", buildFs({}));
+    expect(ctx).toBeNull();
+  });
+
+  test("returns null when cwd is a sub-path of /tmp", () => {
+    const ctx = resolveProjectContext("/tmp/some-runner-dir", buildFs({}));
+    expect(ctx).toBeNull();
+  });
+});
+
+// ── Token blocklist ──────────────────────────────────────────────────────────
+
+describe("resolveProjectContext — token blocklist", () => {
+  test("all-blocked tokens from package.json fall through to scope-anchor basename", () => {
+    // "my-app" → tokens ["my", "app"] → both blocked → falls through
+    const pkgJson = JSON.stringify({ name: "my-app" });
+    const fs = buildFs({ [`${FAKE_PROJECT}/package.json`]: pkgJson });
+    const ctx = resolveProjectContext(FAKE_PROJECT, fs);
+    // FAKE_PROJECT basename is "my-project" → "project" survives
+    expect(ctx).not.toBeNull();
+    expect(ctx?.tokens.has("my")).toBe(false);
+    expect(ctx?.tokens.has("app")).toBe(false);
+  });
+
+  test("blocklist words are filtered individually", () => {
+    const gitConfig = `
+[remote "origin"]
+  url = git@github.com:acme/sdk-core-lib.git
+`;
+    const fs = buildFs({ [`${FAKE_PROJECT}/.git/config`]: gitConfig });
+    const ctx = resolveProjectContext(FAKE_PROJECT, fs);
+    // "sdk", "core", "lib" are all blocked — falls through to scope anchor
+    // FAKE_PROJECT → "my-project" → "project"
+    if (ctx) {
+      expect(ctx.tokens.has("sdk")).toBe(false);
+      expect(ctx.tokens.has("core")).toBe(false);
+      expect(ctx.tokens.has("lib")).toBe(false);
+    }
+  });
+});
+
+// ── Token cap ────────────────────────────────────────────────────────────────
+
+describe("resolveProjectContext — token cap", () => {
+  test("returns at most 5 tokens", () => {
+    // Construct a name with many non-blocked segments
+    const pkgJson = JSON.stringify({ name: "alpha-beta-gamma-delta-epsilon-zeta-eta" });
+    const fs = buildFs({ [`${FAKE_PROJECT}/package.json`]: pkgJson });
+    const ctx = resolveProjectContext(FAKE_PROJECT, fs);
+    expect(ctx).not.toBeNull();
+    expect(ctx?.tokens.size ?? 0).toBeLessThanOrEqual(5);
+  });
+});
+
+// ── fsOverride contract ──────────────────────────────────────────────────────
+
+describe("resolveProjectContext — fsOverride injection", () => {
+  test("fsOverride is used instead of real FS", () => {
+    // This directory does NOT exist on disk — the test only works if the
+    // override is actually used.
+    const fakeDir = path.join(os.tmpdir(), `akm-test-nonexistent-${Date.now()}`);
+    const gitConfig = `
+[remote "origin"]
+  url = git@github.com:test/fixture-project.git
+`;
+    const fs = buildFs({ [`${fakeDir}/.git/config`]: gitConfig });
+    const ctx = resolveProjectContext(fakeDir, fs);
+    // fixture-project → ["fixture", "project"]
+    expect(ctx).not.toBeNull();
+    expect(ctx?.tokens.has("fixture")).toBe(true);
+    expect(ctx?.tokens.has("project")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/indexer/project-context.ts` with `resolveProjectContext(cwd?, fsOverride?)` that extracts project identifier tokens from `.git/config` remote-origin URL, `package.json` name, or workflow-scope-anchor basename
- Adds `project-context-ranking` RankingContributor in `ranking-contributors.ts` that gives a +0.2/token (capped at +0.5) boost to assets whose name/tags/aliases/searchHints match project tokens
- Threads `projectContext` through `RankEntriesOptions` → `RankingContext` → `applyRankingRules` in `ranking.ts`
- Wires `resolveProjectContext(process.cwd())` into `db-search.ts` `searchDatabase()`
- Adds `--no-project-context` CLI flag and `AKM_DISABLE_PROJECT_CONTEXT=1` env opt-out in `cli.ts`
- 16 new unit tests in `tests/project-context.test.ts` covering git config, package.json, noise roots, blocklist, token cap, and fsOverride injection

## Motivation

`akm search "improve performance"` run from the akm project directory was surfacing equities research and print/design assets because the ranker had no awareness of the current project. Assets tagged `akm` or named `akm-*` now rank higher when searching from the akm repo (or any other project directory).

## Test plan

- [ ] `bunx tsc --noEmit` — zero errors
- [ ] `bun test tests/project-context.test.ts` — 16 pass, 0 fail
- [ ] `bun test` — full suite passes (3556 pass, 0 fail)
- [ ] From akm dir: `akm search "improve performance"` — `akm-*` assets rank higher than unrelated assets
- [ ] From any non-project dir or with `--no-project-context` — behavior is identical to pre-change

🤖 Generated with [Claude Code](https://claude.com/claude-code)