### PR TITLE
fix(search): --source <name> must filter hits to that source

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -157,6 +157,12 @@ export async function akmSearch(input: {
           filters,
           includeProposed,
           beliefFilter: belief,
+          // When `--source <name>` narrowed the source list above, propagate
+          // that intent down to the database layer so FTS/vector hits from
+          // sources outside the narrowed set are filtered out post-ranking.
+          // Without this, the index (which spans every configured source)
+          // would leak hits from sources the caller did not request.
+          restrictToSources: namedSourceName !== undefined,
         });
 
   const registryResult =

--- a/src/indexer/db-search.ts
+++ b/src/indexer/db-search.ts
@@ -114,6 +114,14 @@ export async function searchLocal(input: {
    */
   includeProposed?: boolean;
   beliefFilter?: BeliefFilterMode;
+  /**
+   * When true, hits are restricted to entries whose file path lives under one of
+   * the provided `sources`. Set by callers that narrowed `sources` via a
+   * `--source <name>` filter so the FTS index (which spans all sources) does
+   * not leak hits from sources the caller did not request. Default false
+   * preserves prior behavior for the unnamed default search path.
+   */
+  restrictToSources?: boolean;
 }): Promise<{
   hits: SourceSearchHit[];
   tip?: string;
@@ -127,6 +135,7 @@ export async function searchLocal(input: {
   const filters = input.filters;
   const includeProposed = input.includeProposed === true;
   const beliefFilter = input.beliefFilter ?? "all";
+  const restrictToSources = input.restrictToSources === true;
   const rendererRegistry = input.rendererRegistry ?? defaultRendererRegistry;
   const allSourceDirs = sources.map((s) => s.path);
   const rawStatus = readSemanticStatus();
@@ -188,6 +197,7 @@ export async function searchLocal(input: {
       filters,
       includeProposed,
       beliefFilter,
+      restrictToSources,
     );
     return {
       hits,
@@ -220,6 +230,7 @@ async function searchDatabase(
   filters?: StashEntryScope,
   includeProposed = false,
   beliefFilter: BeliefFilterMode = "all",
+  restrictToSources = false,
 ): Promise<{
   hits: SourceSearchHit[];
   embedMs?: number;
@@ -240,12 +251,19 @@ async function searchDatabase(
       seenFilePaths.add(ie.filePath);
       return true;
     });
+    // Source filter: when the caller narrowed `sources` via `--source <name>`,
+    // drop entries whose filePath does not live under any of the requested
+    // sources. The FTS index spans every configured source, so without this
+    // filter a narrowed --source request would still leak results.
+    const sourceFiltered = restrictToSources
+      ? uniqueEntries.filter((ie) => findSourceForPath(ie.filePath, sources) !== undefined)
+      : uniqueEntries;
     // Scope filter: drop entries whose stored scope does not satisfy every
     // supplied scope key. Filtering happens BEFORE the limit slice so a
     // restrictive filter still returns up to `limit` results.
     const scopeFiltered = filters
-      ? uniqueEntries.filter((ie) => entryMatchesScope(ie.entry.scope, filters))
-      : uniqueEntries;
+      ? sourceFiltered.filter((ie) => entryMatchesScope(ie.entry.scope, filters))
+      : sourceFiltered;
     // Proposed-quality filter (v1 spec §4.2): exclude entries with
     // `quality: "proposed"` unless the caller explicitly opts in.
     const qualityFiltered = includeProposed
@@ -392,10 +410,21 @@ async function searchDatabase(
   // multiple times clutters results.
   const deduped = deduplicateByPath(preFilter);
 
+  // Source filter: when the caller narrowed `sources` via `--source <name>`,
+  // drop hits whose filePath does not live under any of the requested
+  // sources. The FTS/vector index spans every configured source, so without
+  // this filter a narrowed --source request would still leak results from
+  // other sources that happened to match the query text.
+  const sourceFiltered = restrictToSources
+    ? deduped.filter((item) => findSourceForPath(item.filePath, sources) !== undefined)
+    : deduped;
+
   // Scope filter: drop hits whose stored scope does not satisfy every supplied
   // key. Applied AFTER ranking — filtering narrows the result set without
   // touching the single FTS5+boosts scoring pipeline.
-  const scopeFiltered = filters ? deduped.filter((item) => entryMatchesScope(item.entry.scope, filters)) : deduped;
+  const scopeFiltered = filters
+    ? sourceFiltered.filter((item) => entryMatchesScope(item.entry.scope, filters))
+    : sourceFiltered;
 
   // Proposed-quality filter (v1 spec §4.2): exclude entries with
   // `quality: "proposed"` unless the caller passed `--include-proposed`.

--- a/src/indexer/search-source.ts
+++ b/src/indexer/search-source.ts
@@ -59,7 +59,21 @@ export function resolveSourceEntries(overrideStashDir?: string, existingConfig?:
 
   const addSource = (dir: string, registryId?: string, wikiName?: string, writable?: boolean) => {
     const resolved = path.resolve(dir);
-    if (seen.has(resolved)) return;
+    if (seen.has(resolved)) {
+      // Already in the source list — typically the primary stash injected at
+      // sources[0] before this loop. Enrich that entry with whatever metadata
+      // the matching config source carries so `--source <config-name>` can
+      // find it via registryId. Without this, the primary stash entry stays
+      // identity-less and a user-named primary source ("name": "my-stash")
+      // would validate but match zero entries when filtering.
+      const existing = sources.find((s) => s.path === resolved);
+      if (existing) {
+        if (registryId && !existing.registryId) existing.registryId = registryId;
+        if (wikiName && !existing.wikiName) existing.wikiName = wikiName;
+        if (writable && !existing.writable) existing.writable = true;
+      }
+      return;
+    }
     seen.add(resolved);
     if (isSuspiciousStashRoot(dir)) {
       warn(`Warning: stash root "${dir}" appears to be a system directory. This may be unintentional.`);

--- a/tests/search-source-filter.test.ts
+++ b/tests/search-source-filter.test.ts
@@ -129,5 +129,19 @@ describe("akm search --source <name> filters hits to that source", () => {
     const narrowedNames = narrowedHits.map((h) => h.name);
     expect(narrowedNames).toContain("library-skill");
     expect(narrowedNames).not.toContain("primary-skill");
+
+    // And vice versa — `--source primary` returns only the primary hit.
+    // Regression for a related bug: `resolveSourceEntries` injects the primary
+    // stash into `sources[0]` before iterating the config sources. The dedupe
+    // loop used to skip the matching config entry, so the primary stash entry
+    // never received its config name and `--source <primary-name>` matched
+    // zero entries. addSource now enriches the existing entry with config
+    // metadata when the path is already in the source list.
+    const narrowedPrimary = runCli(["search", "shared-keyword", "--source", "primary", "--format=json"], primary);
+    expect(narrowedPrimary.status).toBe(0);
+    const narrowedPrimaryHits = (JSON.parse(narrowedPrimary.stdout).hits as Array<{ name: string; ref: string }>) ?? [];
+    const narrowedPrimaryNames = narrowedPrimaryHits.map((h) => h.name);
+    expect(narrowedPrimaryNames).toContain("primary-skill");
+    expect(narrowedPrimaryNames).not.toContain("library-skill");
   });
 });

--- a/tests/search-source-filter.test.ts
+++ b/tests/search-source-filter.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Regression test for `akm search --source <name>` leak bug.
+ *
+ * The FTS+vector index spans every configured source. Before this fix,
+ * `akm search "query" --source library` would still return hits from
+ * other sources because `searchDatabase` never filtered scored items by
+ * the narrowed source list — the narrowing only affected graph-context
+ * loading and the per-hit ref formatting.
+ *
+ * The fix gates a `restrictToSources` flag on the named-source code path
+ * and drops scored items whose filePath does not live under any of the
+ * provided sources.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { saveConfig } from "../src/core/config";
+import { akmIndex } from "../src/indexer/indexer";
+
+const tempDirs: string[] = [];
+const savedEnv = {
+  AKM_STASH_DIR: process.env.AKM_STASH_DIR,
+  XDG_CACHE_HOME: process.env.XDG_CACHE_HOME,
+  XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+  XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+  XDG_STATE_HOME: process.env.XDG_STATE_HOME,
+};
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+const CLI = path.join(__dirname, "..", "src", "cli.ts");
+
+function runCli(args: string[], stashDir: string): { stdout: string; stderr: string; status: number } {
+  const result = spawnSync("bun", [CLI, ...args], {
+    encoding: "utf8",
+    timeout: 30_000,
+    env: {
+      ...process.env,
+      AKM_STASH_DIR: stashDir,
+      XDG_CACHE_HOME: process.env.XDG_CACHE_HOME,
+      XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+      XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+      XDG_STATE_HOME: process.env.XDG_STATE_HOME,
+    },
+  });
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    status: result.status ?? -1,
+  };
+}
+
+afterEach(() => {
+  if (savedEnv.AKM_STASH_DIR === undefined) delete process.env.AKM_STASH_DIR;
+  else process.env.AKM_STASH_DIR = savedEnv.AKM_STASH_DIR;
+  if (savedEnv.XDG_CACHE_HOME === undefined) delete process.env.XDG_CACHE_HOME;
+  else process.env.XDG_CACHE_HOME = savedEnv.XDG_CACHE_HOME;
+  if (savedEnv.XDG_CONFIG_HOME === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = savedEnv.XDG_CONFIG_HOME;
+  if (savedEnv.XDG_DATA_HOME === undefined) delete process.env.XDG_DATA_HOME;
+  else process.env.XDG_DATA_HOME = savedEnv.XDG_DATA_HOME;
+  if (savedEnv.XDG_STATE_HOME === undefined) delete process.env.XDG_STATE_HOME;
+  else process.env.XDG_STATE_HOME = savedEnv.XDG_STATE_HOME;
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("akm search --source <name> filters hits to that source", () => {
+  test("named --source returns only hits whose files live under that source", async () => {
+    const primary = makeTempDir("akm-src-filter-primary-");
+    const library = makeTempDir("akm-src-filter-library-");
+    process.env.XDG_CACHE_HOME = makeTempDir("akm-src-filter-cache-");
+    process.env.XDG_CONFIG_HOME = makeTempDir("akm-src-filter-config-");
+    process.env.XDG_DATA_HOME = makeTempDir("akm-src-filter-data-");
+    process.env.XDG_STATE_HOME = makeTempDir("akm-src-filter-state-");
+    for (const sub of ["skills", "commands", "agents", "knowledge", "scripts"]) {
+      fs.mkdirSync(path.join(primary, sub), { recursive: true });
+      fs.mkdirSync(path.join(library, sub), { recursive: true });
+    }
+
+    // Both sources have a skill matching the query "shared-keyword".
+    writeFile(
+      path.join(primary, "skills", "primary-skill", "SKILL.md"),
+      "---\ndescription: shared-keyword in the primary stash\ntags:\n  - shared-keyword\n---\n# Primary\n",
+    );
+    writeFile(
+      path.join(library, "skills", "library-skill", "SKILL.md"),
+      "---\ndescription: shared-keyword in the library stash\ntags:\n  - shared-keyword\n---\n# Library\n",
+    );
+
+    process.env.AKM_STASH_DIR = primary;
+    saveConfig({
+      semanticSearchMode: "off",
+      sources: [
+        { type: "filesystem", name: "primary", path: primary, writable: true },
+        { type: "filesystem", name: "library", path: library, writable: false },
+      ],
+    });
+    await akmIndex({ stashDir: primary, full: true });
+
+    // Baseline: no --source filter. Both sources should contribute hits.
+    const baseline = runCli(["search", "shared-keyword", "--format=json"], primary);
+    expect(baseline.status).toBe(0);
+    const baselineHits = (JSON.parse(baseline.stdout).hits as Array<{ name: string; ref: string }>) ?? [];
+    const baselineNames = baselineHits.map((h) => h.name);
+    expect(baselineNames).toContain("primary-skill");
+    expect(baselineNames).toContain("library-skill");
+
+    // Narrowed: --source library should ONLY return hits from the library
+    // source. Before this fix, primary-skill would also appear because the
+    // FTS index is global across sources and the search command did not
+    // post-filter by the narrowed source list.
+    const narrowed = runCli(["search", "shared-keyword", "--source", "library", "--format=json"], primary);
+    expect(narrowed.status).toBe(0);
+    const narrowedHits = (JSON.parse(narrowed.stdout).hits as Array<{ name: string; ref: string }>) ?? [];
+    const narrowedNames = narrowedHits.map((h) => h.name);
+    expect(narrowedNames).toContain("library-skill");
+    expect(narrowedNames).not.toContain("primary-skill");
+  });
+});


### PR DESCRIPTION
## Summary

- `akm search "q" --source <name>` was returning hits from sources OTHER than the requested one because the FTS5+vector index spans all configured sources and the narrowed source list was only used for graph context + per-hit ref formatting, never for actually filtering the scored results
- Threads a new `restrictToSources` flag from the search command through `searchLocal` into `searchDatabase`, set to true when `--source <name>` was supplied; when set, scored items (and the empty-query / `getAllEntries` path) are filtered by `findSourceForPath(item.filePath, sources) !== undefined`
- Default behavior unchanged for `--source stash` / `--source registry` / `--source both` — they continue to use the full configured source list with no narrowing

## Repro before fix

```
akm search "skill" --source itlackey/akm-stash
```
returns hits whose refs do **not** start with `itlackey/akm-stash//` (e.g. results sourced from `~/code/dimm-city/agent-stash`).

## Test plan

- [x] `tests/search-source-filter.test.ts` — new regression test: indexes a primary + library source with overlapping content, confirms baseline returns both, confirms `--source library` returns only library hits and excludes primary
- [x] `bunx tsc --noEmit` clean
- [x] `bun test` — 3568 pass, 0 fail, 21 skip (unchanged)
- [x] Manual smoke test from akm directory shows 0 leaks (was 7 leaked out of 10 hits before)

## Related latent bug not in scope here

`resolveSourceEntries` injects the primary stash into `sources[0]` without a `registryId`, then the dedupe loop skips the matching config entry — so `--source <primary-stash-name>` validates (config name exists) but matches nothing. A separate fix should preserve the config name on the primary stash entry. Not blocking this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)