### PR TITLE
docs: align install URL with release artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Everything else supports one of those steps.
 
 ```sh
 # Standalone binary (no runtime dependencies)
-curl -fsSL https://raw.githubusercontent.com/itlackey/akm/main/install.sh | bash
+curl -fsSL https://github.com/itlackey/akm/releases/latest/download/install.sh | bash
 
 # Or via Bun
 bun install -g akm-cli


### PR DESCRIPTION
## Summary
- switch the README standalone installer command to the release artifact URL
- keep the install instructions aligned with the tagged-release path described in #479

## Validation
- verified `README.md` now uses `releases/latest/download/install.sh`
- verified `docs/getting-started.md` and `.github/README.npm.md` do not still reference the raw `main` installer URL
- `bun` is not installed in this runner, so no project checks were available for this docs-only change

Closes #479
