### PR TITLE
fix(test): migration-help latest alias + CHANGELOG for 0.8.1

### DIFF
--- a/tests/migration-help.test.ts
+++ b/tests/migration-help.test.ts
@@ -22,7 +22,7 @@ describe("migration help", () => {
 
   test("supports latest alias when changelog text is available", () => {
     const result = renderMigrationHelp("latest");
-    expect(result).toContain("## [0.8.0]");
+    expect(result).toContain("## [0.8.1]");
   });
 
   test("ensures published static files exist in the repo", () => {


### PR DESCRIPTION
Fixes the test regression introduced by adding the 0.8.1 CHANGELOG entry.

The `migration help > supports latest alias` test hardcoded `## [0.8.0]` as the expected latest version. Adding `## [0.8.1]` to CHANGELOG.md caused `resolveLatestVersion()` to return `0.8.1` instead, breaking the assertion.

## Changes
- `CHANGELOG.md` — add `[0.8.1]` release notes
- `tests/migration-help.test.ts` — update latest alias assertion from `0.8.0` → `0.8.1`