### PR TITLE
fix(graph-extract): tighten isContextSizeError to eliminate gemma false-positives

### DIFF
--- a/src/llm/graph-extract.ts
+++ b/src/llm/graph-extract.ts
@@ -62,16 +62,23 @@ const USER_PROMPT_PREFIX = userPromptTemplate
 /**
  * Detect whether an error message indicates a context size exceeded condition.
  * Covers common patterns from OpenAI-compatible APIs (LM Studio, Ollama, etc).
+ *
+ * Requires BOTH a context keyword AND token-count/overflow evidence so that
+ * model prose merely mentioning "context size" / "context length" (e.g. gemma
+ * narrating about a document) does not get misclassified as a provider
+ * context-limit error (#496).
  */
-function isContextSizeError(message: string): boolean {
+export function isContextSizeError(message: string): boolean {
   const lower = message.toLowerCase();
-  return (
-    lower.includes("context size") ||
-    lower.includes("context length") ||
-    lower.includes("context_window") ||
-    lower.includes("prompt too long") ||
-    (lower.includes("exceeds") && lower.includes("context"))
-  );
+  const contextKw = /context (size|length|window)|prompt too long|exceeds.*context/.test(lower);
+  if (!contextKw) {
+    return false;
+  }
+  const evidence =
+    /\b\d+\s*(token|tokens|tk)\b/.test(lower) ||
+    /max(imum)?\s+(context|token|input)/.test(lower) ||
+    /exceeded|over.*limit|too.*long/.test(lower);
+  return evidence;
 }
 
 /** Single edge. `type` is optional — callers tolerate undefined and use "" for grouping. */

--- a/tests/graph-extract-context-error.test.ts
+++ b/tests/graph-extract-context-error.test.ts
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Unit tests for {@link isContextSizeError} (#496).
+ *
+ * The predicate must distinguish genuine provider context-limit errors from
+ * model prose that merely mentions "context size" / "context length". Models
+ * like gemma-4-e4b emit narration containing those phrases, which previously
+ * produced false-positive `context_limit` reclassifications.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { isContextSizeError } from "../src/llm/graph-extract";
+
+describe("isContextSizeError", () => {
+  test("returns false for gemma-style prose without token/overflow evidence", () => {
+    expect(isContextSizeError("blame the context size of the document")).toBe(false);
+    expect(isContextSizeError("context length of the response was fine")).toBe(false);
+    expect(isContextSizeError("I considered the context window of the situation")).toBe(false);
+  });
+
+  test("returns true for genuine provider overflow phrasings", () => {
+    expect(
+      isContextSizeError("This model's maximum context length is 8192 tokens, however you requested 9000 tokens"),
+    ).toBe(true);
+    expect(isContextSizeError("prompt too long")).toBe(true);
+    expect(isContextSizeError("context size exceeded")).toBe(true);
+    expect(isContextSizeError("input exceeds context window of 4096 tokens")).toBe(true);
+  });
+
+  test("returns false when no context keyword is present", () => {
+    expect(isContextSizeError("some unrelated 4096 tokens message")).toBe(false);
+    expect(isContextSizeError("request failed with status 500")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Narrows the private `isContextSizeError(message)` predicate in `src/llm/graph-extract.ts` to a two-clause check: it now requires BOTH a context keyword AND token-count/overflow evidence. This eliminates false-positive `context_limit` reclassifications (and the bogus `failureCount` bumps) caused by models like gemma-4-e4b emitting prose that merely mentions "context size"/"context length".

- `contextKw`: `/context (size|length|window)|prompt too long|exceeds.*context/`
- `evidence`: `\b\d+\s*(token|tokens|tk)\b` OR `max(imum)?\s+(context|token|input)` OR `exceeded|over.*limit|too.*long`
- Returns `contextKw && evidence` (false if no `contextKw`).

The function is now `export`ed so it is unit-testable. Both call sites are unaffected.

## Tests

New `tests/graph-extract-context-error.test.ts`:
- gemma-style prose ("blame the context size of the document", "context length of the response") returns `false`
- genuine overflows (OpenAI "maximum context length is 8192 tokens", "prompt too long", "context size exceeded", "exceeds context window of 4096 tokens") return `true`

The existing adaptive-batching test (`tests/graph-extraction-batch.test.ts`, throws "context size exceeded") still classifies as a context error since "exceeded" satisfies the new evidence clause — no regression.

## Gates
- `bunx tsc --noEmit`: pass
- `bun run lint`: pass
- `bun test --timeout 30000 ./tests --path-ignore-patterns=tests/integration`: pass

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)