### PR TITLE
fix(health): per-run wallTimeMs from improve_runs row delta (#499)

### DIFF
--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -1191,12 +1191,20 @@ function buildPerRunSummaries(db: Database, since: string, until?: string): Impr
   for (const row of rows) {
     const startMs = new Date(row.started_at).getTime();
     const endMs = new Date(row.completed_at).getTime();
-    // Prefer the task_history interval (which has distinct start/end timestamps).
-    // Fall back to the improve_runs row's own delta (usually 0 because
-    // recordImproveRun writes started_at == completed_at == end-of-run timestamp).
-    const fallbackWallMs = Number.isFinite(startMs) && Number.isFinite(endMs) && endMs >= startMs ? endMs - startMs : 0;
-    const interval = Number.isFinite(startMs) ? findContainingTaskInterval(startMs, taskIntervals) : undefined;
-    const wallTimeMs = interval?.durationMs ?? fallbackWallMs;
+    // Prefer the improve_runs row's own (completed_at - started_at) delta:
+    // recordImproveRun now persists distinct start/end timestamps, so the
+    // row's own delta is the authoritative per-run wall time even for
+    // manually-invoked `akm improve` runs with no enclosing task_history.
+    // Only fall back to the task_history containing-interval join for legacy/
+    // backfill rows where started_at == completed_at (row delta is 0).
+    const hasRowDelta = Number.isFinite(startMs) && Number.isFinite(endMs) && endMs > startMs;
+    let wallTimeMs: number;
+    if (hasRowDelta) {
+      wallTimeMs = endMs - startMs;
+    } else {
+      const interval = Number.isFinite(startMs) ? findContainingTaskInterval(startMs, taskIntervals) : undefined;
+      wallTimeMs = interval?.durationMs ?? 0;
+    }
     summaries.push(projectImproveRunSummary(row, wallTimeMs));
   }
   return summaries;

--- a/tests/health-command.test.ts
+++ b/tests/health-command.test.ts
@@ -309,6 +309,97 @@ describe("akmHealth", () => {
     expect(result.schemaVersion).toBe(2);
   });
 
+  test("manual run row with distinct started_at<completed_at and no task_history yields wallTime from the row delta (#499)", () => {
+    const start = new Date(Date.now() - 60_000).toISOString();
+    const end = new Date(Date.now() - 45_000).toISOString(); // 15s row delta
+    const db = openStateDatabase();
+    try {
+      // No task_history interval — this is a manually-invoked `akm improve`.
+      recordImproveRun(db, {
+        id: "run-manual",
+        startedAt: start,
+        completedAt: end,
+        stashDir: "/tmp/stash",
+        dryRun: false,
+        profile: null,
+        scopeMode: "all",
+        scopeValue: null,
+        guidance: null,
+        ok: true,
+        result: fixtureResult({
+          schemaVersion: 1,
+          ok: true,
+          scope: { mode: "all" },
+          dryRun: false,
+          memorySummary: { eligible: 1, derived: 0 },
+          plannedRefs: [{ ref: "memory:m" }],
+          actions: [{ ref: "memory:m", mode: "distill", result: { outcome: "queued" } }],
+        }),
+      });
+    } finally {
+      db.close();
+    }
+
+    const result = akmHealth({ since: "7d" });
+
+    // wallTime comes from the row's own (completed_at - started_at) delta (15s),
+    // NOT from any task_history join (there is none).
+    expect(result.improve.wallTime.count).toBe(1);
+    expect(result.improve.wallTime.minMs).toBe(15_000);
+    expect(result.improve.wallTime.maxMs).toBe(15_000);
+  });
+
+  test("legacy row with started_at==completed_at falls back to containing task_history interval duration (#499)", () => {
+    const taskStart = new Date(Date.now() - 60_000).toISOString();
+    const taskEnd = new Date(Date.now() - 38_000).toISOString(); // 22s interval
+    // Legacy/backfill row: started_at == completed_at, falling inside the task interval.
+    const stamp = new Date(Date.now() - 50_000).toISOString();
+    const db = openStateDatabase();
+    try {
+      upsertTaskHistory(db, {
+        task_id: "akm-improve",
+        status: "completed",
+        started_at: taskStart,
+        completed_at: taskEnd,
+        failed_at: null,
+        log_path: null,
+        target_kind: "improve",
+        target_ref: null,
+        metadata_json: "{}",
+      });
+      recordImproveRun(db, {
+        id: "run-legacy",
+        startedAt: stamp,
+        completedAt: stamp,
+        stashDir: "/tmp/stash",
+        dryRun: false,
+        profile: null,
+        scopeMode: "all",
+        scopeValue: null,
+        guidance: null,
+        ok: true,
+        result: fixtureResult({
+          schemaVersion: 1,
+          ok: true,
+          scope: { mode: "all" },
+          dryRun: false,
+          memorySummary: { eligible: 1, derived: 0 },
+          plannedRefs: [{ ref: "memory:l" }],
+          actions: [{ ref: "memory:l", mode: "distill", result: { outcome: "queued" } }],
+        }),
+      });
+    } finally {
+      db.close();
+    }
+
+    const result = akmHealth({ since: "7d" });
+
+    // Row delta is 0, so wallTime is sourced from the containing task interval (22s).
+    expect(result.improve.wallTime.count).toBe(1);
+    expect(result.improve.wallTime.minMs).toBe(22_000);
+    expect(result.improve.wallTime.maxMs).toBe(22_000);
+  });
+
   test("reflect content-policy guard hits are counted separately from failed (Pattern A)", () => {
     const start = new Date(Date.now() - 60_000).toISOString();
     const end = new Date(Date.now() - 30_000).toISOString();


### PR DESCRIPTION
## Summary

Inverts the wall-time preference in `buildPerRunSummaries` (`src/commands/health.ts`) per issue #499.

Proposal steps 1-2 were already satisfied on `release/0.9.0` (improve-cli.ts captures a real start timestamp threaded into `writeImproveResultFile`/`recordTerminatedImproveRun`; `improve-result-file.ts` writes `started_at < completed_at`; `state-db.ts` persists distinct values). The one outstanding gap was proposal step 3.

### Change
- When the improve_runs row's own `started_at` and `completed_at` differ (`endMs > startMs`), use the row's own delta as `wallTimeMs` directly — no task_history consultation. This fixes manual `akm improve` runs with no enclosing `task_history` interval.
- When `started_at == completed_at` (legacy/backfill rows), fall back to the `task_history` containing-interval join (`findContainingTaskInterval`) — cron path preserved.
- Updated the stale code comment that previously described the row delta as the "usually 0" legacy fallback.
- No schema-version bump (columns already exist).

### Tests (`tests/health-command.test.ts`)
- Manual-style row with `started_at < completed_at` and NO matching task_history -> non-zero `wallTimeMs` equal to the row delta (15s).
- Legacy row with `started_at == completed_at` plus a containing `akm-improve` task_history interval -> `wallTimeMs` equal to the task interval duration (22s).

### Gates
- `bunx tsc --noEmit`: pass
- `bun run lint`: pass
- `bun test --timeout 30000 ./tests --path-ignore-patterns=tests/integration`: 3859 pass / 0 fail

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)