### PR TITLE
feat(consolidate): consolidation.skipReasons per-ref multi-reason array

### DIFF
--- a/src/commands/consolidate.ts
+++ b/src/commands/consolidate.ts
@@ -142,7 +142,10 @@ export interface ConsolidateResult {
    * histogram input. Codes intentionally use snake_case; see
    * `ConsolidateSkipReason` in health.ts for the vocabulary.
    */
-  skipReasons?: Array<{ op: ConsolidateOpKind | "unknown"; ref: string; reason: string }>;
+  skipReasons?: Array<{
+    ref: string;
+    skips: Array<{ op: ConsolidateOpKind | "unknown"; reason: string }>;
+  }>;
   /**
    * Secondary memories absorbed into successful merge operations. 2026-05-26
    * accounting-leak fix: `merged` is an OP-LEVEL counter (1 per merge op), but
@@ -1178,12 +1181,19 @@ export async function akmConsolidate(opts: AkmConsolidateOptions = {}): Promise<
   // post-LLM op rejection site below also calls `pushSkipReason` so the
   // health rollup can aggregate without regex-parsing English warning
   // strings. See `/tmp/akm-health-investigations/tuning-reasons-investigation.md` §Q2.
-  const skipReasons: Array<{ op: ConsolidateOpKind | "unknown"; ref: string; reason: string }> = [];
-  // Tracks refs already emitted to skipReasons. A ref can only occupy one
-  // accounting bucket; subsequent skip ops for the same ref are recorded as
-  // warnings but must not push a second skipReasons entry (that would inflate
+  const skipReasons: Array<{
+    ref: string;
+    skips: Array<{ op: ConsolidateOpKind | "unknown"; reason: string }>;
+  }> = [];
+  // Per-ref grouping of skipReasons entries. A ref occupies exactly one
+  // accounting bucket and therefore exactly one skipReasons array entry;
+  // subsequent skip ops for the same ref append to that entry's `skips[]`
+  // rather than pushing a second array entry (that would inflate
   // Σ(skipReasons) and break the invariant by +1 per duplicate).
-  const skipReasonEmittedRefs = new Set<string>();
+  const skipReasonByRef = new Map<
+    string,
+    { ref: string; skips: Array<{ op: ConsolidateOpKind | "unknown"; reason: string }> }
+  >();
   const pushSkipReason = (op: ConsolidateOpKind | "unknown", ref: string, reason: string): void => {
     // 2026-05-27 cross-chunk double-count fix: if `ref` already contributed
     // to judgedNoAction in its own chunk (a different chunk proposed an op
@@ -1192,14 +1202,17 @@ export async function akmConsolidate(opts: AkmConsolidateOptions = {}): Promise<
     // Preserves the invariant: processed == actioned + judgedNoAction +
     // Σ(skipReasons) + failedChunkMemories.
     if (judgedNoActionRefs.delete(ref)) judgedNoAction--;
-    if (skipReasonEmittedRefs.has(ref)) {
-      // Already counted once. Record the extra skip for observability but
-      // don't push to skipReasons — that would break the accounting invariant.
-      warnings.push(`Skip: ${ref} already in skipReasons (${reason} via ${op}); not re-counted.`);
+    const existing = skipReasonByRef.get(ref);
+    if (existing) {
+      // Already counted once for accounting. Append the extra skip to the
+      // ref's grouped entry for observability without adding a new array
+      // entry (which would break the accounting invariant).
+      existing.skips.push({ op, reason });
       return;
     }
-    skipReasonEmittedRefs.add(ref);
-    skipReasons.push({ op, ref, reason });
+    const entry = { ref, skips: [{ op, reason }] };
+    skipReasonByRef.set(ref, entry);
+    skipReasons.push(entry);
   };
   // judgedNoAction tracks memories the LLM saw inside a chunk but proposed
   // no op for. Computed per chunk as `chunk.length − unique(targetRefs in ops)`.

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -774,16 +774,22 @@ function projectRunMetrics(result: Record<string, unknown>): ImproveHealthMetric
     metrics.consolidation.mergedSecondaries += toFiniteNumber(consolidation.mergedSecondaries);
     metrics.consolidation.failedChunkMemories += toFiniteNumber(consolidation.failedChunkMemories);
     // Structured emitter (new on this branch): consolidate.ts now pushes
-    // `{op, ref, reason}` entries to `skipReasons` for every deterministic
-    // post-LLM rejection. Pre-fix envelopes have neither field, so be
-    // defensive.
+    // per-ref grouped `{ref, skips: [{op, reason}]}` entries to `skipReasons`
+    // for every deterministic post-LLM rejection. Each ref appears once but
+    // may carry multiple skips; aggregate every reason. Pre-fix envelopes have
+    // neither field, so be defensive.
     const skipReasons = consolidation.skipReasons;
     if (Array.isArray(skipReasons)) {
       for (const entry of skipReasons) {
         if (!entry || typeof entry !== "object") continue;
-        const reason = (entry as Record<string, unknown>).reason;
-        if (typeof reason !== "string" || !reason.trim()) continue;
-        metrics.consolidation.skipReasons[reason] = (metrics.consolidation.skipReasons[reason] ?? 0) + 1;
+        const skips = (entry as Record<string, unknown>).skips;
+        if (!Array.isArray(skips)) continue;
+        for (const skip of skips) {
+          if (!skip || typeof skip !== "object") continue;
+          const reason = (skip as Record<string, unknown>).reason;
+          if (typeof reason !== "string" || !reason.trim()) continue;
+          metrics.consolidation.skipReasons[reason] = (metrics.consolidation.skipReasons[reason] ?? 0) + 1;
+        }
       }
     }
   }

--- a/tests/commands/consolidate/consolidate-pipeline-fixes.test.ts
+++ b/tests/commands/consolidate/consolidate-pipeline-fixes.test.ts
@@ -540,38 +540,76 @@ describe("ConsolidateResult.skipReasons / judgedNoAction — emitter contract", 
   it("envelope carries judgedNoAction and structured skipReasons", () => {
     type ConsolidateResultShape = {
       judgedNoAction?: number;
-      skipReasons?: Array<{ op: string; ref: string; reason: string }>;
+      skipReasons?: Array<{ ref: string; skips: Array<{ op: string; reason: string }> }>;
       merged: number;
     };
     const sample: ConsolidateResultShape = {
       merged: 0,
       judgedNoAction: 78,
       skipReasons: [
-        { op: "merge", ref: "memory:a", reason: "merge_missing_description" },
-        { op: "merge", ref: "memory:b", reason: "merge_missing_description" },
-        { op: "merge", ref: "memory:c", reason: "merge_sanitization_failed" },
-        { op: "delete", ref: "memory:d", reason: "captureMode_hot_refused" },
-        { op: "promote", ref: "memory:e", reason: "dedup_pending_proposal" },
+        { ref: "memory:a", skips: [{ op: "merge", reason: "merge_missing_description" }] },
+        { ref: "memory:b", skips: [{ op: "merge", reason: "merge_missing_description" }] },
+        { ref: "memory:c", skips: [{ op: "merge", reason: "merge_sanitization_failed" }] },
+        { ref: "memory:d", skips: [{ op: "delete", reason: "captureMode_hot_refused" }] },
+        { ref: "memory:e", skips: [{ op: "promote", reason: "dedup_pending_proposal" }] },
       ],
     };
 
     // merged == 0 is consistent with three Merge-op attempts that ALL hit a
     // skip reason. The invariant the investigation report was probing: if
     // every merge op recorded a skipReason, `merged` MUST be (mergeOpsAttempted - mergeSkips).
-    const mergeSkips = (sample.skipReasons ?? []).filter((s) => s.op === "merge").length;
+    const mergeSkips = (sample.skipReasons ?? []).flatMap((e) => e.skips).filter((s) => s.op === "merge").length;
     const mergeOpsAttempted = 3; // all three got a skip reason
     expect(sample.merged).toBe(mergeOpsAttempted - mergeSkips);
 
-    // Per-reason histogram is reconstructable client-side.
+    // Per-reason histogram is reconstructable client-side by aggregating every
+    // skip across all grouped ref entries.
     const histogram: Record<string, number> = {};
     for (const entry of sample.skipReasons ?? []) {
-      histogram[entry.reason] = (histogram[entry.reason] ?? 0) + 1;
+      for (const skip of entry.skips) {
+        histogram[skip.reason] = (histogram[skip.reason] ?? 0) + 1;
+      }
     }
     expect(histogram).toEqual({
       merge_missing_description: 2,
       merge_sanitization_failed: 1,
       captureMode_hot_refused: 1,
       dedup_pending_proposal: 1,
+    });
+  });
+
+  it("groups multiple skip ops for the same ref into one entry with skips.length === 2", () => {
+    // A ref hit by two distinct deterministic rejections (e.g.
+    // merge_participant_blocked then dedup_pending_proposal) must appear
+    // exactly once in skipReasons so skipReasons.length stays the unique-ref
+    // count (accounting invariant), while both reasons are retained in skips[].
+    type Grouped = Array<{ ref: string; skips: Array<{ op: string; reason: string }> }>;
+    const skipReasons: Grouped = [
+      {
+        ref: "memory:dup",
+        skips: [
+          { op: "merge", reason: "merge_participant_blocked" },
+          { op: "promote", reason: "dedup_pending_proposal" },
+        ],
+      },
+      { ref: "memory:other", skips: [{ op: "delete", reason: "captureMode_hot_refused" }] },
+    ];
+
+    // Each ref occupies exactly one array entry.
+    expect(skipReasons.length).toBe(2);
+    const dup = skipReasons.find((e) => e.ref === "memory:dup");
+    expect(dup?.skips.length).toBe(2);
+    // Health-style aggregation counts every skip across all refs.
+    const histogram: Record<string, number> = {};
+    for (const entry of skipReasons) {
+      for (const skip of entry.skips) {
+        histogram[skip.reason] = (histogram[skip.reason] ?? 0) + 1;
+      }
+    }
+    expect(histogram).toEqual({
+      merge_participant_blocked: 1,
+      dedup_pending_proposal: 1,
+      captureMode_hot_refused: 1,
     });
   });
 });
@@ -612,7 +650,7 @@ describe("ConsolidateResult accounting invariant — 2026-05-26 leak fix", () =>
   // shapes: an all-loaded-memory case (strict equality with skipReasons.length)
   // and a phantom-mixed case (equality after partitioning).
 
-  type SkipEntry = { op: string; ref: string; reason: string };
+  type SkipEntry = { ref: string; skips: Array<{ op: string; reason: string }> };
   type Envelope = {
     processed: number;
     promoted: { length: number };
@@ -668,26 +706,25 @@ describe("ConsolidateResult accounting invariant — 2026-05-26 leak fix", () =>
     const skipReasons: SkipEntry[] = [
       // Original 32 from the run (pre-fix, but post-fix they remain):
       ...Array.from({ length: 32 }, (_, i) => ({
-        op: "promote" as const,
         ref: `memory:s${i}`,
-        reason: "dedup_pending_proposal",
+        skips: [{ op: "promote" as const, reason: "dedup_pending_proposal" }],
       })),
       // Post-fix: 2 failed merges each emit primary + 2 secondaries.
       // Replace the 2 single-primary entries with 6 total (3 each).
       // NB: in real code the primary skipReason was already emitted by the
       // sanitization/missing-description guard pre-fix; the fix adds the
-      // 4 secondaries. For invariant arithmetic only the total count matters.
-      { op: "merge", ref: "memory:merge-fail-a", reason: "merge_sanitization_failed" },
-      { op: "merge", ref: "memory:sec-a1", reason: "merge_sanitization_failed" },
-      { op: "merge", ref: "memory:sec-a2", reason: "merge_sanitization_failed" },
-      { op: "merge", ref: "memory:sec-b1", reason: "merge_missing_description" },
-      { op: "merge", ref: "memory:sec-b2", reason: "merge_missing_description" },
+      // 4 secondaries. For invariant arithmetic only the unique-ref count
+      // matters, and each of these refs is distinct → one group entry each.
+      { ref: "memory:merge-fail-a", skips: [{ op: "merge", reason: "merge_sanitization_failed" }] },
+      { ref: "memory:sec-a1", skips: [{ op: "merge", reason: "merge_sanitization_failed" }] },
+      { ref: "memory:sec-a2", skips: [{ op: "merge", reason: "merge_sanitization_failed" }] },
+      { ref: "memory:sec-b1", skips: [{ op: "merge", reason: "merge_missing_description" }] },
+      { ref: "memory:sec-b2", skips: [{ op: "merge", reason: "merge_missing_description" }] },
       // 7 "not found" / failure sites that are in-chunk (post-fix all
       // emit a skipReason; pre-fix only a freeform warning):
       ...Array.from({ length: 7 }, (_, i) => ({
-        op: "promote" as const,
         ref: `memory:in-chunk-not-found-${i}`,
-        reason: "promote_ref_missing",
+        skips: [{ op: "promote" as const, reason: "promote_ref_missing" }],
       })),
     ];
     const envelope: Envelope = {
@@ -798,14 +835,12 @@ describe("ConsolidateResult accounting invariant — 2026-05-26 leak fix", () =>
       judgedNoAction: 76, // 77 pre-promote, -1 after B is moved to skipReasons
       skipReasons: [
         ...Array.from({ length: 35 }, (_, i) => ({
-          op: "promote" as const,
           ref: `memory:s${i}`,
-          reason: "dedup_pending_proposal",
+          skips: [{ op: "promote" as const, reason: "dedup_pending_proposal" }],
         })),
         {
-          op: "merge" as const,
           ref: "memory:cross-chunk-secondary",
-          reason: "merge_missing_description",
+          skips: [{ op: "merge" as const, reason: "merge_missing_description" }],
         },
       ],
       failedChunkMemories: 0,

--- a/tests/health-command.test.ts
+++ b/tests/health-command.test.ts
@@ -579,12 +579,19 @@ describe("akmHealth", () => {
             totalChunks: 3,
             judgedNoAction: 78,
             skipReasons: [
-              { op: "promote", ref: "memory:a", reason: "dedup_pending_proposal" },
-              { op: "promote", ref: "memory:b", reason: "dedup_pending_proposal" },
-              { op: "delete", ref: "memory:c", reason: "captureMode_hot_refused" },
-              { op: "delete", ref: "memory:d", reason: "captureMode_hot_refused" },
-              { op: "merge", ref: "memory:e", reason: "merge_missing_description" },
-              { op: "merge", ref: "memory:f", reason: "merge_sanitization_failed" },
+              { ref: "memory:a", skips: [{ op: "promote", reason: "dedup_pending_proposal" }] },
+              { ref: "memory:b", skips: [{ op: "promote", reason: "dedup_pending_proposal" }] },
+              { ref: "memory:c", skips: [{ op: "delete", reason: "captureMode_hot_refused" }] },
+              { ref: "memory:d", skips: [{ op: "delete", reason: "captureMode_hot_refused" }] },
+              // Multi-reason ref: one entry whose skips[] carries two ops.
+              // Health must aggregate BOTH reasons (today it counted one/ref).
+              {
+                ref: "memory:e",
+                skips: [
+                  { op: "merge", reason: "merge_missing_description" },
+                  { op: "merge", reason: "merge_sanitization_failed" },
+                ],
+              },
             ],
             warnings: [],
             durationMs: 37771,


### PR DESCRIPTION
## Summary
Reshapes `ConsolidateResult.skipReasons` from a flat `Array<{op, ref, reason}>` into a per-ref grouped `Array<{ref, skips: Array<{op, reason}>}>`, and updates its single internal builder and single downstream consumer.

- **`src/commands/consolidate.ts`**: type at the envelope + the local builder are now the grouped shape. The `skipReasonEmittedRefs` Set guard is replaced by a `Map<string, entry>` keyed by ref. First sighting of a ref creates the entry, pushes it to `skipReasons`, and registers it; subsequent sightings append `{op, reason}` to the existing entry's `skips[]`. `skipReasons.length` remains the unique-ref count, so the accounting invariant still holds.
- **`src/commands/health.ts`**: the rollup iterates `entry.skips` and aggregates every `skip.reason`, so multi-reason refs now contribute more than one count (previously one reason per ref). Defensive `Array.isArray`/non-object guards retained.
- **Tests**: fixtures in `consolidate-pipeline-fixes.test.ts` and `health-command.test.ts` updated to the grouped shape; added a grouping test (one ref hit by two ops -> `skips.length === 2`) and a multi-reason health-aggregation case.

Observability-only change. The invariant math, `judgedNoAction` promotion semantics, and `mergedSecondaries`/`failedChunkMemories` accounting are unchanged.

## Gates
- `bunx tsc --noEmit`: pass
- `bun run lint`: pass
- `bun test --timeout 30000 ./tests --path-ignore-patterns=tests/integration`: 3858 pass, 0 fail

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)