### PR TITLE
fix(indexer): semantic verification counts vault entries skipped for embeddings (#502)

### DIFF
--- a/src/indexer/db.ts
+++ b/src/indexer/db.ts
@@ -1501,6 +1501,13 @@ export function getEntryCount(db: Database): number {
   return row.cnt;
 }
 
+export function getEmbeddableEntryCount(db: Database): number {
+  const row = db.prepare("SELECT COUNT(*) AS cnt FROM entries WHERE entry_type != 'vault'").get() as {
+    cnt: number;
+  };
+  return row.cnt;
+}
+
 export function getEmbeddingCount(db: Database): number {
   const row = db.prepare("SELECT COUNT(*) AS cnt FROM embeddings").get() as { cnt: number };
   return row.cnt;

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -51,6 +51,7 @@ import {
   deleteEntriesByStashDir,
   deleteIndexDirStatesByStashDir,
   getAllEntriesForEmbedding,
+  getEmbeddableEntryCount,
   getEmbeddingCount,
   getEntriesByDir,
   getEntryCount,
@@ -367,7 +368,8 @@ async function runFinalizePhase(ctx: IndexRunContext): Promise<void> {
   warnIfVecMissing(db);
 
   const totalEntries = getEntryCount(db);
-  const verification = verifyIndexState(db, config, totalEntries, embeddingResult);
+  const semanticEntryCount = getEmbeddableEntryCount(db);
+  const verification = verifyIndexState(db, config, semanticEntryCount, embeddingResult);
 
   if (config.semanticSearchMode === "off") {
     clearSemanticStatus();
@@ -1437,14 +1439,14 @@ function getSemanticSearchLabel(
 function verifyIndexState(
   db: Database,
   config: AkmConfig,
-  totalEntries: number,
+  embeddableEntries: number,
   embeddingResult: EmbeddingGenerationResult,
 ): IndexVerification {
   const embeddingCount = getEmbeddingCount(db);
   const vecAvailable = isVecAvailable(db);
   const embeddingProvider = getEmbeddingProvider(config.embedding);
 
-  if (totalEntries === 0) {
+  if (embeddableEntries === 0) {
     return {
       ok: true,
       message: "Index ready. No assets were found yet.",
@@ -1452,7 +1454,7 @@ function verifyIndexState(
       semanticSearchMode: config.semanticSearchMode,
       semanticStatus: config.semanticSearchMode === "off" ? "disabled" : "pending",
       embeddingProvider,
-      entryCount: totalEntries,
+      entryCount: embeddableEntries,
       embeddingCount,
       vecAvailable,
     };
@@ -1466,21 +1468,21 @@ function verifyIndexState(
       semanticSearchMode: config.semanticSearchMode,
       semanticStatus: "disabled",
       embeddingProvider,
-      entryCount: totalEntries,
+      entryCount: embeddableEntries,
       embeddingCount,
       vecAvailable,
     };
   }
 
-  if (embeddingCount >= totalEntries) {
+  if (embeddingCount >= embeddableEntries) {
     return {
       ok: true,
-      message: `Semantic search ready (${embeddingCount}/${totalEntries} embeddings, ${vecAvailable ? "sqlite-vec active" : "JS fallback active"}).`,
+      message: `Semantic search ready (${embeddingCount}/${embeddableEntries} embeddings, ${vecAvailable ? "sqlite-vec active" : "JS fallback active"}).`,
       semanticSearchEnabled: true,
       semanticSearchMode: config.semanticSearchMode,
       semanticStatus: vecAvailable ? "ready-vec" : "ready-js",
       embeddingProvider,
-      entryCount: totalEntries,
+      entryCount: embeddableEntries,
       embeddingCount,
       vecAvailable,
     };
@@ -1490,7 +1492,7 @@ function verifyIndexState(
     ok: false,
     message:
       embeddingResult.message ??
-      `Semantic search verification failed (${embeddingCount}/${totalEntries} embeddings available).`,
+      `Semantic search verification failed (${embeddingCount}/${embeddableEntries} embeddings available).`,
     guidance:
       embeddingProvider === "remote"
         ? "Check your embedding endpoint and credentials, then retry `akm index --full --verbose`."
@@ -1499,7 +1501,7 @@ function verifyIndexState(
     semanticSearchMode: config.semanticSearchMode,
     semanticStatus: "blocked",
     embeddingProvider,
-    entryCount: totalEntries,
+    entryCount: embeddableEntries,
     embeddingCount,
     vecAvailable,
   };

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -8,6 +8,7 @@ import {
   DB_VERSION,
   deleteEntriesByDir,
   getAllEntries,
+  getEmbeddableEntryCount,
   getEntriesByDir,
   getEntryById,
   getEntryCount,
@@ -296,6 +297,41 @@ describe("Entry CRUD", () => {
 
       const remaining = getAllEntries(db);
       expect(remaining[0].entryKey).toBe("keep-1");
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  // Regression for #502: the embedding phase intentionally excludes vault
+  // entries (getAllEntriesForEmbedding filters entry_type != 'vault'). Semantic
+  // verification must track the embeddable count, not the full entry count, or a
+  // healthy index with vault entries is permanently reported as blocked.
+  test("getEmbeddableEntryCount excludes vault entries", () => {
+    const db = openDatabase(tmpDbPath());
+    try {
+      insertTestEntry(db, "asset-1", { type: "skill" });
+      insertTestEntry(db, "asset-2", { type: "command" });
+      insertTestEntry(db, "asset-3", { type: "script" });
+      insertTestEntry(db, "secret-1", { type: "vault" });
+      insertTestEntry(db, "secret-2", { type: "vault" });
+
+      // Full count includes vault rows; embeddable count excludes them.
+      expect(getEntryCount(db)).toBe(5);
+      expect(getEmbeddableEntryCount(db)).toBe(3);
+      expect(getEmbeddableEntryCount(db)).toBeLessThan(getEntryCount(db));
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("getEmbeddableEntryCount equals total when no vault entries exist", () => {
+    const db = openDatabase(tmpDbPath());
+    try {
+      insertTestEntry(db, "asset-1", { type: "skill" });
+      insertTestEntry(db, "asset-2", { type: "script" });
+
+      expect(getEmbeddableEntryCount(db)).toBe(getEntryCount(db));
+      expect(getEmbeddableEntryCount(db)).toBe(2);
     } finally {
       closeDatabase(db);
     }

--- a/tests/semantic-search-e2e.test.ts
+++ b/tests/semantic-search-e2e.test.ts
@@ -18,6 +18,7 @@ import { getDbPath } from "../src/core/paths";
 import {
   closeDatabase,
   EMBEDDING_DIM,
+  getEmbeddableEntryCount,
   getEmbeddingCount,
   getEntryCount,
   getMeta,
@@ -253,6 +254,13 @@ echo "Database migration finished successfully."
     }),
   );
 
+  // 6. Vault entry (#502) — vault rows are indexed for keyword search but are
+  //    intentionally excluded from embeddings (getAllEntriesForEmbedding filters
+  //    entry_type != 'vault'). Semantic verification must not count these.
+  const vaultsDir = path.join(stashDir, "vaults");
+  fs.mkdirSync(vaultsDir, { recursive: true });
+  fs.writeFileSync(path.join(vaultsDir, "prod.env"), "API_TOKEN=placeholder-not-a-real-secret\nDB_PASSWORD=example\n");
+
   return stashDir;
 }
 
@@ -307,6 +315,16 @@ describe.skipIf(!SEMANTIC_TESTS)("Semantic search end-to-end (real embeddings)",
     const result = await akmIndex({ stashDir, full: true });
     expect(result.totalEntries).toBeGreaterThan(0);
     expect(result.verification.semanticSearchEnabled).toBeTruthy();
+
+    // #502: a healthy index containing vault entries (which are excluded from
+    // embeddings) must still verify ok and land in a ready status — not blocked
+    // / verification-failed — because verification now tracks the embeddable
+    // entry count rather than the full entry count.
+    expect(result.verification.ok).toBe(true);
+    expect(["ready-js", "ready-vec"]).toContain(result.verification.semanticStatus);
+    // The user-facing entryCount reflects embeddable entries, so it equals the
+    // embedding count even though vault entries inflate the total entry count.
+    expect(result.verification.entryCount).toBe(result.verification.embeddingCount);
   }, 120_000); // 2 minute timeout for model download on first run
 
   // Restore env vars before each test in case the degradation describe
@@ -332,15 +350,19 @@ describe.skipIf(!SEMANTIC_TESTS)("Semantic search end-to-end (real embeddings)",
       // Verify hasEmbeddings flag is set
       expect(getMeta(db, "hasEmbeddings")).toBe("1");
 
-      // Verify embedding count matches entry count
+      // Verify embedding count matches the embeddable entry count. Vault rows
+      // (#502) are indexed for keyword search but excluded from embeddings, so
+      // the full entry count is strictly greater than the embeddable count.
       const entryCount = getEntryCount(db);
+      const embeddableCount = getEmbeddableEntryCount(db);
       const embeddingCount = getEmbeddingCount(db);
-      expect(entryCount).toBeGreaterThanOrEqual(5);
-      expect(embeddingCount).toBe(entryCount);
+      expect(entryCount).toBeGreaterThanOrEqual(6); // 5 assets + >=1 vault entry
+      expect(embeddableCount).toBeLessThan(entryCount); // vault entry is excluded
+      expect(embeddingCount).toBe(embeddableCount); // every embeddable entry embedded
 
       // Verify each embedding has the correct dimension (384 for bge-small-en-v1.5)
       const rows = db.prepare("SELECT id, embedding FROM embeddings").all() as Array<{ id: number; embedding: Buffer }>;
-      expect(rows.length).toBe(entryCount);
+      expect(rows.length).toBe(embeddableCount);
 
       for (const row of rows) {
         const f32 = new Float32Array(row.embedding.buffer, row.embedding.byteOffset, row.embedding.byteLength / 4);


### PR DESCRIPTION
## Summary

Semantic index verification falsely reported `blocked` whenever a stash contained vault entries. The embedding phase intentionally excludes vault rows (`getAllEntriesForEmbedding()` filters `AND e.entry_type != 'vault'`), but verification compared the stored `embeddingCount` against the FULL entry count, so a healthy index with N vault entries permanently showed `embeddingCount < totalEntries` and stuck in semantic `blocked` / verification-failed state.

## Changes

- `src/indexer/db.ts`: add exported `getEmbeddableEntryCount(db)` returning `COUNT(*) FROM entries WHERE entry_type != 'vault'`, mirroring `getEntryCount`.
- `src/indexer/indexer.ts`: finalize path computes `semanticEntryCount = getEmbeddableEntryCount(db)` and passes it to `verifyIndexState`. Inside `verifyIndexState`, the zero-entry short-circuit, the `embeddingCount >= ...` readiness gate, the `Semantic search ready (X/Y ...)` message, and the reported/persisted `entryCount` (writeSemanticStatus) now all use the embeddable count. Overall stats still use `getEntryCount`. The genuine-failure case (a real missing embedding on an embeddable entry) still reports `ok:false` / `blocked`.

## Tests

- `tests/db.test.ts`: `getEmbeddableEntryCount` excludes vault entries; equals total when no vault entries exist.
- `tests/semantic-search-e2e.test.ts`: adds a `vaults/prod.env` vault fixture; asserts total entry count > embeddable count, `embeddingCount == embeddable count`, and that verification stays `ok:true` with a ready status (not blocked).

## Gates

- `bunx tsc --noEmit`: pass
- `bun run lint`: pass
- `bun test --timeout 30000 ./tests --path-ignore-patterns=tests/integration`: pass (3859 pass / 0 fail)
- gated `AKM_SEMANTIC_TESTS=1` e2e: pass (9/9)

Closes #502