### PR TITLE
feat(improve): add {triage_promoted}/{triage_rejected}/{runId} sync commit tokens

### DIFF
--- a/docs/technical/improve-autosync-investigation.md
+++ b/docs/technical/improve-autosync-investigation.md
@@ -593,16 +593,21 @@ before the string is handed to `saveGitStash` (which still sanitizes it to a
 single line). Unknown tokens pass through verbatim, so templates are
 forward-compatible and a literal brace is harmless.
 
-Supported tokens (the "free" set — derived from data already on the run result):
+Supported tokens. The "free" set is derived from data already on the run
+result; the remaining tokens required extra plumbing (capturing the triage
+pre-pass `DrainResult` and threading the CLI-minted `runId` onto the result):
 
-| token | value |
-|-------|-------|
-| `{timestamp}` | `YYYY-MM-DD HH:MM:SS` (UTC) |
-| `{date}` | `YYYY-MM-DD` (UTC) |
-| `{time}` | `HH:MM:SS` (UTC) |
-| `{scope}` | scope value (a ref/type) or the scope mode (`all`) |
-| `{refs}` | number of planned refs processed this run |
-| `{accepted}` | proposals auto-accepted by the confidence gate |
+| token | value | source |
+|-------|-------|--------|
+| `{timestamp}` | `YYYY-MM-DD HH:MM:SS` (UTC) | free |
+| `{date}` | `YYYY-MM-DD` (UTC) | free |
+| `{time}` | `HH:MM:SS` (UTC) | free |
+| `{scope}` | scope value (a ref/type) or the scope mode (`all`) | free |
+| `{refs}` | number of planned refs processed this run | free |
+| `{accepted}` | proposals auto-accepted by the confidence gate | free |
+| `{triage_promoted}` | proposals promoted by the triage pre-pass (`0` if triage did not run) | extra plumbing (`result.triage`) |
+| `{triage_rejected}` | proposals rejected by the triage pre-pass (`0` if triage did not run) | extra plumbing (`result.triage`) |
+| `{runId}` | this run's id (empty string when absent) | extra plumbing (`result.runId`) |
 
 Example:
 

--- a/src/commands/improve-cli.ts
+++ b/src/commands/improve-cli.ts
@@ -193,6 +193,7 @@ export const improveCommand = defineCommand({
           dryRun,
           target: targetArg,
           autoAccept,
+          ...(runId !== undefined ? { runId } : {}),
           ...(limitRaw !== undefined ? { limit: limitRaw } : {}),
           ...(timeoutMs !== undefined ? { timeoutMs } : {}),
           ...(minRetrievalCount !== undefined ? { minRetrievalCount } : {}),

--- a/src/commands/improve.ts
+++ b/src/commands/improve.ts
@@ -75,7 +75,7 @@ import {
   shouldSkipRef,
 } from "./improve-profiles";
 import { akmLint } from "./lint/index";
-import { drainProposals } from "./proposal/drain";
+import { type DrainResult, drainProposals } from "./proposal/drain";
 import { resolveDrainPolicy } from "./proposal/drain-policies";
 import { type AkmReflectResult, akmReflect } from "./reflect";
 import { runSchemaRepairPass } from "./schema-repair";
@@ -96,6 +96,12 @@ export interface AkmImproveOptions {
   autoAccept?: number;
   stashDir?: string;
   config?: AkmConfig;
+  /**
+   * Run identifier minted by the CLI (`buildImproveRunId()`). Threaded onto the
+   * result so health/run records and sync-commit templates (`{runId}`) can read
+   * it. Undefined for programmatic callers that do not mint one.
+   */
+  runId?: string;
   /** Wall-clock budget for the entire improve run in milliseconds. Defaults to 2 hours. */
   timeoutMs?: number;
   limit?: number;
@@ -335,6 +341,20 @@ export interface AkmImproveResult {
    */
   gateAutoAcceptFailedCount?: number;
   /**
+   * Triage pre-pass outcome (array lengths from the pre-pass `DrainResult`
+   * mapped to counts). Present only when the triage pre-pass actually ran
+   * (non-dry-run, triage process enabled, whole-stash / type-scoped run);
+   * omitted entirely otherwise to keep the envelope tidy.
+   */
+  triage?: { promoted: number; rejected: number; deferred: number; skippedByCap: number };
+  /**
+   * Run identifier minted by the CLI (`buildImproveRunId()`) and threaded
+   * through `options.runId`. Surfaced on the result so health/run records and
+   * the `{runId}` sync-commit token can read it. Absent for programmatic
+   * callers that did not mint one.
+   */
+  runId?: string;
+  /**
    * End-of-run auto-sync outcome for a git-backed primary stash. Present only
    * when sync was attempted (non-dry-run, git-backed stash, sync not disabled).
    * `skipped: true` covers both a no-op `saveGitStash` and a caught failure
@@ -461,6 +481,9 @@ function resolveImproveScope(scope: string | undefined): { mode: "all" | "type" 
  *   {scope}      scope value (e.g. a ref/type) or the scope mode (`all`)
  *   {refs}       number of planned refs this run processed
  *   {accepted}   number of proposals auto-accepted by the confidence gate
+ *   {triage_promoted}  proposals promoted by the triage pre-pass (0 if triage did not run)
+ *   {triage_rejected}  proposals rejected by the triage pre-pass (0 if triage did not run)
+ *   {runId}      this run's id (empty string when absent)
  *
  * The result is still passed through `sanitizeCommitMessage` downstream in
  * `saveGitStash`, so token values never widen the commit-message attack surface
@@ -471,7 +494,13 @@ function resolveImproveScope(scope: string | undefined): { mode: "all" | "type" 
  */
 export function renderSyncCommitMessage(
   template: string,
-  result: { scope: { mode: string; value?: string }; plannedRefs: unknown[]; gateAutoAcceptedCount?: number },
+  result: {
+    scope: { mode: string; value?: string };
+    plannedRefs: unknown[];
+    gateAutoAcceptedCount?: number;
+    triage?: { promoted: number; rejected: number; deferred: number; skippedByCap: number };
+    runId?: string;
+  },
   nowMs: number,
 ): string {
   const iso = new Date(nowMs).toISOString();
@@ -482,6 +511,9 @@ export function renderSyncCommitMessage(
     scope: result.scope.value ?? result.scope.mode,
     refs: String(result.plannedRefs.length),
     accepted: String(result.gateAutoAcceptedCount ?? 0),
+    triage_promoted: String(result.triage?.promoted ?? 0),
+    triage_rejected: String(result.triage?.rejected ?? 0),
+    runId: result.runId ?? "",
   };
   return template.replace(/\{(\w+)\}/g, (match, key: string) => (Object.hasOwn(tokens, key) ? tokens[key] : match));
 }
@@ -930,6 +962,7 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
   let profileFilteredRefs: Awaited<ReturnType<typeof collectEligibleRefs>>["profileFilteredRefs"];
   let memoryCleanupPlan: ReturnType<typeof analyzeMemoryCleanup> | undefined;
   let guidance: string | undefined;
+  let triageDrain: DrainResult | undefined;
 
   try {
     // Acquire the lock and run the triage pre-pass for non-dry-run executions.
@@ -959,7 +992,7 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
             const judgment = triageConfig?.judgment
               ? resolveTriageJudgmentRunner(triageConfig.judgment, _earlyConfig)
               : null;
-            await drainProposalsFn({
+            triageDrain = await drainProposalsFn({
               stashDir: primaryStashDir,
               policy,
               applyMode,
@@ -1303,6 +1336,17 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
         const f = preparation.gateAutoAcceptFailedCount + loopGateFailedCount + postLoopGateFailedCount;
         return f > 0 ? { gateAutoAcceptFailedCount: f } : {};
       })(),
+      ...(triageDrain
+        ? {
+            triage: {
+              promoted: triageDrain.promoted.length,
+              rejected: triageDrain.rejected.length,
+              deferred: triageDrain.deferred.length,
+              skippedByCap: triageDrain.skippedByCap.length,
+            },
+          }
+        : {}),
+      ...(options.runId !== undefined ? { runId: options.runId } : {}),
     };
     if (!result.dryRun)
       emitImproveCompletedEvent(

--- a/tests/commands/improve/improve-sync-message.test.ts
+++ b/tests/commands/improve/improve-sync-message.test.ts
@@ -19,6 +19,8 @@ function fakeResult(
     scope: { mode: string; value?: string };
     plannedRefs: unknown[];
     gateAutoAcceptedCount?: number;
+    triage?: { promoted: number; rejected: number; deferred: number; skippedByCap: number };
+    runId?: string;
   }> = {},
 ) {
   return {
@@ -52,9 +54,32 @@ describe("renderSyncCommitMessage", () => {
   });
 
   test("unknown tokens pass through verbatim (forward-compatible)", () => {
-    expect(renderSyncCommitMessage("a {nope} b {triage_promoted} c", fakeResult(), NOW)).toBe(
-      "a {nope} b {triage_promoted} c",
+    expect(renderSyncCommitMessage("a {nope} b {alsoNope} c", fakeResult(), NOW)).toBe("a {nope} b {alsoNope} c");
+  });
+
+  test("triage + runId tokens render from the result when triage ran and a runId is present", () => {
+    const out = renderSyncCommitMessage(
+      "akm improve {runId}: +{triage_promoted} triaged, -{triage_rejected}, {accepted} accepted @ {timestamp}",
+      fakeResult({
+        gateAutoAcceptedCount: 4,
+        triage: { promoted: 5, rejected: 2, deferred: 1, skippedByCap: 0 },
+        runId: "run-abc123",
+      }),
+      NOW,
     );
+    expect(out).toBe("akm improve run-abc123: +5 triaged, -2, 4 accepted @ 2026-06-02 21:30:45");
+  });
+
+  test("triage tokens default to 0 when the result has no triage field (triage did not run)", () => {
+    expect(renderSyncCommitMessage("{triage_promoted}/{triage_rejected}", fakeResult(), NOW)).toBe("0/0");
+  });
+
+  test("runId renders the empty string when the result has no runId", () => {
+    expect(renderSyncCommitMessage("[{runId}]", fakeResult(), NOW)).toBe("[]");
+  });
+
+  test("runId renders the run's id when present", () => {
+    expect(renderSyncCommitMessage("{runId}", fakeResult({ runId: "run-xyz" }), NOW)).toBe("run-xyz");
   });
 
   test("a template with no tokens (the default) renders unchanged", () => {


### PR DESCRIPTION
Closes #508

Extends `renderSyncCommitMessage` (src/commands/improve.ts) with three new sync-commit-message tokens. All additive and backward-compatible — unknown tokens still pass through verbatim.

## Changes
- **Triage tokens** (`{triage_promoted}` / `{triage_rejected}`): the triage pre-pass `DrainResult` is now captured into `triageDrain` (previously discarded) and surfaced on `AkmImproveResult` as an optional `triage: { promoted, rejected, deferred, skippedByCap }` count object, populated only when triage ran (array lengths -> counts, tidy-envelope convention). Both tokens default to `0` when triage did not run.
- **`{runId}` token**: `AkmImproveOptions` gains `runId?: string`; improve-cli.ts threads `buildImproveRunId()` into it; the value is surfaced on `AkmImproveResult.runId` for symmetry (health/run records can read it). Token renders `""` when absent.
- Docs: supported-tokens table in docs/technical/improve-autosync-investigation.md lists the three new tokens and notes they require extra plumbing vs the "free" set.
- Tests: new coverage for all three tokens plus the no-triage / no-runId defaults. The unknown-token-passthrough test now uses a genuinely unknown token (it previously asserted on `{triage_promoted}`).

`renderSyncCommitMessage` stays pure (clock injected).

## Gates
- `bunx tsc --noEmit` — pass
- `bun run lint` — pass
- `bun test --timeout 30000 ./tests --path-ignore-patterns=tests/integration` — pass (3861 pass, 9 skip, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)