### PR TITLE
feat(llm): detect HTML/non-JSON provider responses as a distinct outcome (#497)

### DIFF
--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -279,6 +279,13 @@ export interface ImproveHealthMetrics {
      */
     unaccounted: number;
     /**
+     * Parents whose LLM call returned an HTML body (e.g. LM Studio serving its
+     * web UI) instead of JSON. Surfaced distinctly from `skippedNoFacts` so a
+     * provider-load failure is observable rather than masked as an empty-result
+     * skip. Sourced from the `memoryInference` envelope's `htmlErrorCount`.
+     */
+    htmlErrorCount: number;
+    /**
      * Count of envelopes that contributed to the yield denominator. A run
      * is yield-eligible iff its `memoryInference` envelope has a
      * `cacheHits` field (i.e. it post-dates the cache-hits metric). Older
@@ -323,6 +330,14 @@ export interface ImproveHealthMetrics {
     cacheHitRate: number;
     truncations: number;
     failures: number;
+    /**
+     * Asset extractions where the provider returned an HTML body (e.g. LM
+     * Studio serving its web UI) instead of JSON. Tracked distinctly from
+     * `failures` so a provider-load failure is observable rather than folded
+     * into the generic failure count. Sourced from the graph-extraction
+     * telemetry's `htmlErrorCount`.
+     */
+    htmlErrors: number;
     durationMs: number;
   };
   /**
@@ -551,6 +566,7 @@ function createUnknownImproveMetrics(): ImproveHealthMetrics {
       skippedChildExists: 0,
       skippedAborted: 0,
       unaccounted: 0,
+      htmlErrorCount: 0,
       yieldEligibleRuns: 0,
       yieldEligibleConsidered: 0,
       yieldEligibleWritten: 0,
@@ -568,6 +584,7 @@ function createUnknownImproveMetrics(): ImproveHealthMetrics {
       cacheHitRate: 0,
       truncations: 0,
       failures: 0,
+      htmlErrors: 0,
       durationMs: 0,
     },
     sessionExtraction: {
@@ -800,6 +817,7 @@ function projectRunMetrics(result: Record<string, unknown>): ImproveHealthMetric
     metrics.memoryInference.skippedChildExists += toFiniteNumber(memoryInference.skippedChildExists);
     metrics.memoryInference.skippedAborted += toFiniteNumber(memoryInference.skippedAborted);
     metrics.memoryInference.unaccounted += toFiniteNumber(memoryInference.unaccounted);
+    metrics.memoryInference.htmlErrorCount += toFiniteNumber(memoryInference.htmlErrorCount);
     // Yield-rate gating: pre-cache-feature envelopes lack the `cacheHits`
     // field entirely. Treating their `considered` as freshAttempts (since
     // cacheHits=0) is mathematically tempting but operationally wrong —
@@ -827,6 +845,7 @@ function projectRunMetrics(result: Record<string, unknown>): ImproveHealthMetric
       metrics.graphExtraction.cacheMisses += toFiniteNumber(telemetry.cacheMisses);
       metrics.graphExtraction.truncations += toFiniteNumber(telemetry.truncationCount);
       metrics.graphExtraction.failures += toFiniteNumber(telemetry.failureCount);
+      metrics.graphExtraction.htmlErrors += toFiniteNumber(telemetry.htmlErrorCount);
     }
   }
   metrics.graphExtraction.durationMs += toFiniteNumber(result.graphExtractionDurationMs);
@@ -965,6 +984,7 @@ function mergeImproveMetrics(dst: ImproveHealthMetrics, src: ImproveHealthMetric
   dst.memoryInference.skippedChildExists += src.memoryInference.skippedChildExists;
   dst.memoryInference.skippedAborted += src.memoryInference.skippedAborted;
   dst.memoryInference.unaccounted += src.memoryInference.unaccounted;
+  dst.memoryInference.htmlErrorCount += src.memoryInference.htmlErrorCount;
   dst.memoryInference.yieldEligibleRuns += src.memoryInference.yieldEligibleRuns;
   dst.memoryInference.yieldEligibleConsidered += src.memoryInference.yieldEligibleConsidered;
   dst.memoryInference.yieldEligibleWritten += src.memoryInference.yieldEligibleWritten;
@@ -976,6 +996,7 @@ function mergeImproveMetrics(dst: ImproveHealthMetrics, src: ImproveHealthMetric
   dst.graphExtraction.cacheMisses += src.graphExtraction.cacheMisses;
   dst.graphExtraction.truncations += src.graphExtraction.truncations;
   dst.graphExtraction.failures += src.graphExtraction.failures;
+  dst.graphExtraction.htmlErrors += src.graphExtraction.htmlErrors;
   dst.graphExtraction.durationMs += src.graphExtraction.durationMs;
   dst.sessionExtraction.sessionsScanned += src.sessionExtraction.sessionsScanned;
   dst.sessionExtraction.sessionsExtracted += src.sessionExtraction.sessionsExtracted;
@@ -1434,8 +1455,10 @@ const INTERESTING_DELTA_PATHS = [
   "improve.memoryInference.written",
   "improve.memoryInference.yieldRate",
   "improve.memoryInference.skippedNoFacts",
+  "improve.memoryInference.htmlErrorCount",
   "improve.graphExtraction.cacheHitRate",
   "improve.graphExtraction.failures",
+  "improve.graphExtraction.htmlErrors",
   "improve.sessionExtraction.sessionsScanned",
   "improve.sessionExtraction.proposalsCreated",
   "improve.autoAccept.promoted",

--- a/src/indexer/graph-extraction.ts
+++ b/src/indexer/graph-extraction.ts
@@ -97,6 +97,13 @@ export interface GraphExtractionTelemetry {
   cacheMisses: number;
   truncationCount: number;
   failureCount: number;
+  /**
+   * Asset extractions where the provider returned an HTML body (e.g. LM Studio
+   * serving its web UI) instead of JSON. Tracked distinctly from
+   * `failureCount` so a provider-load failure is observable in health output
+   * rather than folded into the generic failure count (#497).
+   */
+  htmlErrorCount?: number;
 }
 
 /** Persisted graph shape loaded from SQLite. */
@@ -516,11 +523,13 @@ export async function runGraphExtractionPass(
     cacheMisses: 0,
     truncationCount: 0,
     failureCount: 0,
+    htmlErrorCount: 0,
   };
   const canReusePreviousGraph = previousGraph.telemetry?.extractorId === extractorId;
   const runtimeTelemetry: graphExtract.GraphRuntimeTelemetry = {
     truncationCount: 0,
     failureCount: 0,
+    htmlErrorCount: 0,
     filteredGenericEntities: 0,
     filteredInvalidRelations: 0,
     filteredLowConfidenceRelations: 0,
@@ -807,6 +816,7 @@ export async function runGraphExtractionPass(
   );
   telemetry.truncationCount = runtimeTelemetry.truncationCount ?? 0;
   telemetry.failureCount = runtimeTelemetry.failureCount ?? 0;
+  telemetry.htmlErrorCount = runtimeTelemetry.htmlErrorCount ?? 0;
 
   const qualityConsidered = mergedNodes.length;
   const qualityExtracted = mergedNodes.filter((node) => node.status === "extracted" && node.entities.length > 0).length;

--- a/src/indexer/memory-inference.ts
+++ b/src/indexer/memory-inference.ts
@@ -48,7 +48,7 @@ import { warn } from "../core/warn";
 import { type WriteTargetSource, writeAssetToSource } from "../core/write-source";
 import { isProcessEnabled } from "../llm/feature-gate";
 import { resolveIndexPassLLM } from "../llm/index-passes";
-import type { DerivedMemoryDraft } from "../llm/memory-infer";
+import type { DerivedMemoryDraft, MemoryInferTelemetry } from "../llm/memory-infer";
 import * as memoryInfer from "../llm/memory-infer";
 import { withLlmCache } from "./llm-cache";
 import type { SearchSource } from "./search-source";
@@ -101,6 +101,13 @@ export interface MemoryInferenceResult {
    * Exposed (not asserted) so health can surface drift loudly.
    */
   unaccounted: number;
+  /**
+   * Parents whose LLM call returned an HTML body (e.g. LM Studio serving its
+   * web UI) instead of JSON. Tracked distinctly from `skippedNoFacts` so a
+   * provider-load failure is observable in health output rather than masked as
+   * a generic empty-result skip.
+   */
+  htmlErrorCount: number;
 }
 
 export interface MemoryInferencePassOptions {
@@ -160,7 +167,13 @@ export async function runMemoryInferencePass(
     skippedChildExists: 0,
     skippedAborted: 0,
     unaccounted: 0,
+    htmlErrorCount: 0,
   };
+
+  // Mutable sink threaded into compressMemoryToDerivedMemory so the per-call
+  // HTML-error categorization (which is otherwise swallowed inside the feature
+  // gate) bubbles up into the pass result.
+  const inferTelemetry: MemoryInferTelemetry = {};
 
   // Gate 1 — feature gate via isProcessEnabled, which reads the 0.8.0 path
   // (profiles.improve.default.processes.memoryInference.enabled). Defaults to
@@ -229,9 +242,16 @@ export async function runMemoryInferencePass(
             record.body,
             reEnrich ?? false,
             () =>
-              memoryInfer.compressMemoryToDerivedMemory(llmConfig, record.body, signal, config, (evt) => {
-                warn(`[akm] LLM fallback for ${evt.feature}: ${evt.reason}`);
-              }),
+              memoryInfer.compressMemoryToDerivedMemory(
+                llmConfig,
+                record.body,
+                signal,
+                config,
+                (evt) => {
+                  warn(`[akm] LLM fallback for ${evt.feature}: ${evt.reason}`);
+                },
+                inferTelemetry,
+              ),
             validate,
             undefined,
             "",
@@ -241,9 +261,16 @@ export async function runMemoryInferencePass(
               },
             },
           )
-        : await memoryInfer.compressMemoryToDerivedMemory(llmConfig, record.body, signal, config, (evt) => {
-            warn(`[akm] LLM fallback for ${evt.feature}: ${evt.reason}`);
-          });
+        : await memoryInfer.compressMemoryToDerivedMemory(
+            llmConfig,
+            record.body,
+            signal,
+            config,
+            (evt) => {
+              warn(`[akm] LLM fallback for ${evt.feature}: ${evt.reason}`);
+            },
+            inferTelemetry,
+          );
 
       if (!derived) {
         return { skipped: true, fromCache } as const;
@@ -314,6 +341,8 @@ export async function runMemoryInferencePass(
       currentRef: pending[i]?.ref,
     });
   }
+
+  result.htmlErrorCount = inferTelemetry.htmlErrorCount ?? 0;
 
   return result;
 }

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -62,9 +62,33 @@ export function redactErrorBody(input: string): string {
 export type LlmCallErrorCode =
   | "rate_limited" // HTTP 429
   | "provider_error" // HTTP 5xx
+  | "provider_html_error" // body is HTML (e.g. LM Studio web UI) instead of JSON
   | "network_error" // fetch failed / timeout
   | "parse_error" // response received but JSON parse failed
   | "timeout"; // request exceeded timeoutMs
+
+/**
+ * Detect a response body that is an HTML document rather than the expected
+ * JSON. LM Studio (and similar local providers) can serve their web UI on
+ * partial-load / startup failures, producing an HTML page where the OpenAI
+ * API contract promises JSON.
+ */
+function isHtmlResponse(body: string): boolean {
+  const lower = body.trimStart().toLowerCase();
+  return lower.startsWith("<!doctype html") || lower.startsWith("<html");
+}
+
+/**
+ * Produce a short plain-text excerpt of an HTML body for inclusion in error
+ * messages: strip tags, collapse whitespace, and truncate.
+ */
+function htmlExcerpt(body: string): string {
+  const text = body
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text.length > ERROR_BODY_MAX_LEN ? `${text.slice(0, ERROR_BODY_MAX_LEN)}…` : text;
+}
 
 export class LlmCallError extends Error {
   constructor(
@@ -184,6 +208,13 @@ export async function chatCompletion(
     if (status === 429) {
       throw new LlmCallError(`LLM request rate limited (429) ${config.endpoint}: ${safeBody}`, "rate_limited", status);
     }
+    if (status >= 500 && isHtmlResponse(rawBody)) {
+      throw new LlmCallError(
+        `LLM provider returned HTML instead of JSON (${status}) ${config.endpoint}: ${htmlExcerpt(rawBody)}`,
+        "provider_html_error",
+        status,
+      );
+    }
     if (status >= 500) {
       throw new LlmCallError(
         `LLM provider error (${status}) ${config.endpoint}: ${safeBody}`,
@@ -194,7 +225,27 @@ export async function chatCompletion(
     throw new LlmCallError(`LLM request failed (${status}) ${config.endpoint}: ${safeBody}`, "provider_error", status);
   }
 
-  const json = (await response.json()) as ChatCompletionResponse;
+  // A 2xx response is still an error if the body is HTML where JSON was
+  // expected (e.g. a provider serving its web UI). Read the raw body first so
+  // we can categorize an HTML page distinctly from a malformed-JSON parse_error.
+  const rawOkBody = await response.text();
+  if (isHtmlResponse(rawOkBody)) {
+    throw new LlmCallError(
+      `LLM provider returned HTML instead of JSON (${response.status}) ${config.endpoint}: ${htmlExcerpt(rawOkBody)}`,
+      "provider_html_error",
+      response.status,
+    );
+  }
+  let json: ChatCompletionResponse;
+  try {
+    json = JSON.parse(rawOkBody) as ChatCompletionResponse;
+  } catch {
+    throw new LlmCallError(
+      `LLM response was not valid JSON ${config.endpoint}: ${redactErrorBody(rawOkBody)}`,
+      "parse_error",
+      response.status,
+    );
+  }
   const content = (json.choices?.[0]?.message?.content ?? "").trim();
   const reasoning = (json.choices?.[0]?.message?.reasoning_content ?? "").trim();
   return content || reasoning;

--- a/src/llm/graph-extract.ts
+++ b/src/llm/graph-extract.ts
@@ -26,7 +26,7 @@ import userPromptTemplate from "../assets/prompts/graph-extract-user-prompt.md" 
 import { toErrorMessage } from "../core/common";
 import type { AkmConfig, LlmConnectionConfig } from "../core/config";
 import { warn, warnVerbose } from "../core/warn";
-import { chatCompletion, parseEmbeddedJsonResponse } from "./client";
+import { chatCompletion, LlmCallError, parseEmbeddedJsonResponse } from "./client";
 import { type TryLlmFeatureFallbackEvent, tryLlmFeature } from "./feature-gate";
 
 /**
@@ -116,6 +116,7 @@ export interface GraphBatchState {
 export interface GraphRuntimeTelemetry {
   truncationCount?: number;
   failureCount?: number;
+  htmlErrorCount?: number;
   filteredGenericEntities?: number;
   filteredInvalidRelations?: number;
   filteredLowConfidenceRelations?: number;
@@ -866,6 +867,12 @@ export async function extractGraphFromBody(
               `Consider increasing llm.contextLength in config.json.`,
           );
           return empty("context_limit", "failed");
+        } else if (err instanceof LlmCallError && err.code === "provider_html_error") {
+          bumpTelemetry(options.telemetry, "htmlErrorCount");
+          warn(
+            `graph extraction: provider returned HTML instead of JSON for asset; promptChars=${userPrompt.length}${formatContextHint(llmConfig)}: ${errMsg}`,
+          );
+          return empty("llm_error", "failed");
         } else {
           bumpTelemetry(options.telemetry, "failureCount");
           warn(

--- a/src/llm/memory-infer.ts
+++ b/src/llm/memory-infer.ts
@@ -23,7 +23,7 @@
 import { toErrorMessage } from "../core/common";
 import type { AkmConfig, LlmConnectionConfig } from "../core/config";
 import { warn } from "../core/warn";
-import { chatCompletion, parseEmbeddedJsonResponse } from "./client";
+import { chatCompletion, LlmCallError, parseEmbeddedJsonResponse } from "./client";
 import { type TryLlmFeatureFallbackEvent, tryLlmFeature } from "./feature-gate";
 
 /** Hard cap on body chars sent to the model — pragmatic and matches `runLlmEnrich`. */
@@ -46,6 +46,17 @@ export interface DerivedMemoryDraft {
   tags: string[];
   searchHints: string[];
   content: string;
+}
+
+/**
+ * Mutable telemetry sink for the memory-inference pass. `compressMemoryToDerivedMemory`
+ * does not carry a telemetry struct of its own, so the caller passes a small
+ * sink that the helper bumps when it categorizes a distinct failure class
+ * (currently: a provider returning HTML where JSON was expected).
+ */
+export interface MemoryInferTelemetry {
+  /** Calls where the provider returned an HTML body instead of JSON. */
+  htmlErrorCount?: number;
 }
 
 /**
@@ -89,6 +100,7 @@ export async function compressMemoryToDerivedMemory(
   signal?: AbortSignal,
   akmConfig?: AkmConfig,
   onFallback?: (evt: TryLlmFeatureFallbackEvent) => void,
+  telemetry?: MemoryInferTelemetry,
 ): Promise<DerivedMemoryDraft | undefined> {
   const trimmedBody = body.trim();
   if (!trimmedBody) return undefined;
@@ -142,6 +154,11 @@ export async function compressMemoryToDerivedMemory(
         }
         return { title, description, tags, searchHints, content };
       } catch (err) {
+        if (err instanceof LlmCallError && err.code === "provider_html_error") {
+          if (telemetry) telemetry.htmlErrorCount = (telemetry.htmlErrorCount ?? 0) + 1;
+          warn(`memory inference: provider returned HTML instead of JSON; skipping memory: ${toErrorMessage(err)}`);
+          return undefined;
+        }
         warn(`memory inference failed: ${toErrorMessage(err)}`);
         return undefined;
       }

--- a/tests/commands/improve-memory.test.ts
+++ b/tests/commands/improve-memory.test.ts
@@ -1141,6 +1141,7 @@ describe("akm improve memory cleanup", () => {
           skippedChildExists: 0,
           skippedAborted: 0,
           unaccounted: 0,
+          htmlErrorCount: 0,
           cacheHits: 0,
         } satisfies MemoryInferenceResult;
       },
@@ -1178,6 +1179,7 @@ describe("akm improve memory cleanup", () => {
       skippedChildExists: 0,
       skippedAborted: 0,
       unaccounted: 0,
+      htmlErrorCount: 0,
       cacheHits: 0,
     });
     expect(result.graphExtraction?.written).toBe(true);
@@ -1227,6 +1229,7 @@ describe("akm improve memory cleanup", () => {
           skippedChildExists: 0,
           skippedAborted: 0,
           unaccounted: 0,
+          htmlErrorCount: 0,
           cacheHits: 0,
         } satisfies MemoryInferenceResult;
       },
@@ -1388,6 +1391,7 @@ describe("akm improve memory cleanup", () => {
         skippedChildExists: 0,
         skippedAborted: 0,
         unaccounted: 0,
+        htmlErrorCount: 0,
         cacheHits: 0,
       }),
       graphExtractionFn: async () => ({

--- a/tests/commands/improve-reflect-unsupported-type-skip.test.ts
+++ b/tests/commands/improve-reflect-unsupported-type-skip.test.ts
@@ -339,6 +339,7 @@ describe("improve envelope: per-phase wall-clock durations are emitted at the to
           skippedRateLimited: 0,
           skippedBudget: 0,
           unaccounted: 0,
+          htmlErrorCount: 0,
           cacheHits: 0,
           skippedChildExists: 0,
           skippedAborted: 0,

--- a/tests/integration/indexer.test.ts
+++ b/tests/integration/indexer.test.ts
@@ -815,6 +815,7 @@ test("akmIndex does not run slow passes", async () => {
     skippedChildExists: 0,
     skippedAborted: 0,
     unaccounted: 0,
+    htmlErrorCount: 0,
     cacheHits: 0,
   });
   const graphSpy = spyOn(graphExtract, "runGraphExtractionPass").mockResolvedValue({

--- a/tests/llm-client.test.ts
+++ b/tests/llm-client.test.ts
@@ -212,6 +212,99 @@ describe("chatCompletion error redaction", () => {
   });
 });
 
+// ── HTML / non-JSON response categorization (#497) ──────────────────────────
+
+function createResponseServer(
+  statusCode: number,
+  body: string,
+  contentType = "text/html",
+): { url: string; server: ReturnType<typeof Bun.serve> } {
+  const server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(body, { status: statusCode, headers: { "Content-Type": contentType } });
+    },
+  });
+  return { url: `http://localhost:${server.port}`, server };
+}
+
+const LM_STUDIO_HTML =
+  '<!DOCTYPE html>\n<html lang="en"><head><title>LM Studio</title></head>' +
+  '<body><div id="app">Loading…</div></body></html>';
+
+describe("chatCompletion HTML response categorization", () => {
+  async function callExpectingError(config: LlmConnectionConfig): Promise<LlmCallError> {
+    let caught: unknown;
+    try {
+      await chatCompletion(config, [{ role: "user", content: "hi" }]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(LlmCallError);
+    return caught as LlmCallError;
+  }
+
+  test("HTML 500 body produces provider_html_error (not provider_error)", async () => {
+    const { url, server } = createResponseServer(500, LM_STUDIO_HTML);
+    try {
+      const err = await callExpectingError({ endpoint: url, model: "test-model" });
+      expect(err.code).toBe("provider_html_error");
+      expect(err.statusCode).toBe(500);
+      expect(err.message).toContain("(500)");
+      expect(err.message).toContain(url);
+      // Excerpt should be plain text (tags stripped).
+      expect(err.message).not.toContain("<html");
+      expect(err.message).toContain("LM Studio");
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("HTML 502 body also produces provider_html_error", async () => {
+    const { url, server } = createResponseServer(502, LM_STUDIO_HTML);
+    try {
+      const err = await callExpectingError({ endpoint: url, model: "test-model" });
+      expect(err.code).toBe("provider_html_error");
+      expect(err.statusCode).toBe(502);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("JSON 500 body still produces the generic provider_error path", async () => {
+    const { url, server } = createResponseServer(500, '{"error":"upstream exploded"}', "application/json");
+    try {
+      const err = await callExpectingError({ endpoint: url, model: "test-model" });
+      expect(err.code).toBe("provider_error");
+      expect(err.statusCode).toBe(500);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("non-error HTML 200 (where JSON expected) surfaces provider_html_error, not a raw SyntaxError", async () => {
+    const { url, server } = createResponseServer(200, LM_STUDIO_HTML);
+    try {
+      const err = await callExpectingError({ endpoint: url, model: "test-model" });
+      expect(err.code).toBe("provider_html_error");
+      expect(err.statusCode).toBe(200);
+      expect(err.message).not.toContain("<html");
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("malformed (non-HTML) JSON 200 still maps to parse_error", async () => {
+    const { url, server } = createResponseServer(200, "this is not json {", "application/json");
+    try {
+      const err = await callExpectingError({ endpoint: url, model: "test-model" });
+      expect(err.code).toBe("parse_error");
+    } finally {
+      server.stop();
+    }
+  });
+});
+
 describe("parseEmbeddedJsonResponse", () => {
   test("parses direct JSON", () => {
     expect(parseEmbeddedJsonResponse<{ ok: boolean }>('{"ok":true}')).toEqual({ ok: true });

--- a/tests/memory-inference.test.ts
+++ b/tests/memory-inference.test.ts
@@ -192,6 +192,7 @@ describe("runMemoryInferencePass — disabled by default", () => {
       skippedChildExists: 0,
       skippedAborted: 0,
       unaccounted: 0,
+      htmlErrorCount: 0,
     });
   });
 
@@ -270,6 +271,7 @@ describe("runMemoryInferencePass — feature flag and per-pass key are orthogona
       skippedChildExists: 0,
       skippedAborted: 0,
       unaccounted: 0,
+      htmlErrorCount: 0,
     });
     expect(invocations).toBe(0);
     // Parent is not mutated when the feature gate blocks.
@@ -344,6 +346,7 @@ describe("runMemoryInferencePass — enabled", () => {
       skippedChildExists: 0,
       skippedAborted: 0,
       unaccounted: 0,
+      htmlErrorCount: 0,
     });
 
     const derived = parseFrontmatter(fs.readFileSync(path.join(tmpStash, "memories", "parent.derived.md"), "utf8"));


### PR DESCRIPTION
Closes #497

Adds a distinct error/outcome category for provider responses whose body is HTML (e.g. LM Studio serving its web UI on partial-load failures) instead of the expected JSON.

## Changes
- **src/llm/client.ts**: new `provider_html_error` code in `LlmCallErrorCode`; `isHtmlResponse()` + `htmlExcerpt()` helpers. A 5xx HTML body throws `provider_html_error` (before the generic 5xx branch). A 2xx body is read raw — an HTML page throws `provider_html_error`; a malformed non-HTML body still maps to `parse_error`. Existing redaction is retained for non-HTML bodies.
- **src/llm/graph-extract.ts**: `htmlErrorCount` added to `GraphRuntimeTelemetry`; the catch bumps `htmlErrorCount` (not `failureCount`) for the HTML class, after the context-size branch.
- **src/indexer/graph-extraction.ts**: `htmlErrorCount` threaded through `GraphExtractionTelemetry` so it reaches the `improve_runs` envelope.
- **src/llm/memory-infer.ts**: `MemoryInferTelemetry` sink; the catch categorizes the HTML class distinctly from the generic failure path.
- **src/indexer/memory-inference.ts**: threads the sink and surfaces `htmlErrorCount` on `MemoryInferenceResult`.
- **src/commands/health.ts**: `htmlErrorCount` (memoryInference) and `htmlErrors` (graphExtraction) added to `ImproveHealthMetrics`, aggregated/merged, and exposed in delta paths so `akm health` surfaces them.

Does NOT implement retry — that is #498.

## Acceptance / tests
New tests in `tests/llm-client.test.ts` cover HTML 500, HTML 502, JSON 500 (unchanged generic path), HTML 200, and malformed-JSON 200.

## Gates
- `bunx tsc --noEmit`: pass
- `bun run lint`: pass (biome + isolation + license-header)
- `bun test --timeout 30000 ./tests --path-ignore-patterns=tests/integration`: 3862 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)