### PR TITLE
feat(env): substitute ${secret:NAME} tokens in env values at run time

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2379,6 +2379,34 @@ async function runEnvInjected(
     const excluded = new Set(opts.except);
     envValues = Object.fromEntries(Object.entries(allValues).filter(([k]) => !excluded.has(k)));
   }
+  // Substitute `${secret:NAME}` tokens in values with the value of the sibling
+  // secret asset in the SAME stash. The lookup is injected so commands/env.ts
+  // keeps its narrow dependency surface; we resolve each name against this env's
+  // own `source`. A missing secret is a hard error — inject NOTHING (no partial
+  // injection). Resolved values are never logged or printed.
+  const { resolveSecretTokens } = await import("./commands/env.js");
+  const { readValue } = await import("./commands/secret.js");
+  const secretsRoot = path.join(source.path, "secrets");
+  const resolveSecret = (secretName: string): string | undefined => {
+    const secretPath = resolveAssetPathFromName("secret", secretsRoot, secretName);
+    // Defense-in-depth: ensure the resolved path stays inside the secrets dir.
+    if (!isWithin(secretPath, secretsRoot)) {
+      throw new UsageError(`Secret name "${secretName}" escapes the secrets directory.`);
+    }
+    if (!fs.existsSync(secretPath)) return undefined;
+    // Match `secret run`: read utf8, do not trim (stay consistent with that path).
+    return readValue(secretPath).toString("utf8");
+  };
+  const { values: substituted, missing } = resolveSecretTokens(envValues, resolveSecret);
+  if (missing.length > 0) {
+    const envRef = makeEnvRef(name, source);
+    throw new NotFoundError(
+      `Env "${envRef}" references secret(s) not found in its stash: ${missing.map((n) => `secret:${n}`).join(", ")}. Nothing was injected.`,
+      "FILE_NOT_FOUND",
+      `Create the missing secret, e.g. \`akm secret set secret:${missing[0]}\`.`,
+    );
+  }
+  envValues = substituted;
   const keys = Object.keys(envValues);
 
   // Scan injected keys for known process-hijacking variables (LD_PRELOAD,
@@ -2454,7 +2482,7 @@ const envRunCommand = defineCommand({
   meta: {
     name: "run",
     description:
-      "Run a command with the env file injected into its environment: `akm env run <ref> -- <command>`. Use `-- $SHELL` for an interactive session. Restrict which variables are injected with --only / --except.",
+      "Run a command with the env file injected into its environment: `akm env run <ref> -- <command>`. Use `-- $SHELL` for an interactive session. Restrict which variables are injected with --only / --except. Values may embed `${secret:NAME}` tokens, replaced at run time with the sibling `secret:NAME` value from the same stash.",
   },
   args: {
     target: { type: "positional", description: "Env ref", required: true },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2482,6 +2482,7 @@ const envRunCommand = defineCommand({
   meta: {
     name: "run",
     description:
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: literal `${secret:NAME}` token syntax documented for users, not interpolation
       "Run a command with the env file injected into its environment: `akm env run <ref> -- <command>`. Use `-- $SHELL` for an interactive session. Restrict which variables are injected with --only / --except. Values may embed `${secret:NAME}` tokens, replaced at run time with the sibling `secret:NAME` value from the same stash.",
   },
   args: {

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -34,6 +34,14 @@
  *
  * Value parsing is delegated to the `dotenv` package — we deliberately do not
  * implement our own quoting/escaping rules for security-sensitive content.
+ *
+ * Secret-token substitution: env VALUES may embed `${secret:NAME}` tokens, which
+ * are replaced at `env run` time with the value of the sibling `secret:NAME`
+ * asset in the SAME stash (see `resolveSecretTokens`). Substitution applies to
+ * values only, never keys; only the `${secret:...}` form is recognised —
+ * shell-style `${VAR}` / `$VAR` are left untouched. The secret lookup is
+ * injected so this module keeps its narrow dependency surface (dotenv +
+ * core/common) and never reaches into the secret resolver/source machinery.
  */
 
 import fs from "node:fs";
@@ -173,6 +181,12 @@ export function injectIntoEnv(
  * `X=$(rm -rf ~)`, which would execute if `source`d directly, but dotenv parses
  * it to the literal string `$(rm -rf ~)` and we re-emit it single-quoted. This
  * backs `akm env export <ref> --out <file>` (file-only; never printed to stdout).
+ *
+ * NOTE: `${secret:NAME}` token substitution is intentionally NOT applied here.
+ * The export path emits values single-quoted as literals, so an unsubstituted
+ * `${secret:NAME}` is written verbatim (it would expand to nothing under POSIX
+ * shells, never to the secret). Secret-token resolution is scoped to the
+ * `env run` value-injection path only; see `resolveSecretTokens`.
  */
 export function buildShellExportScript(envPath: string): string {
   const env = loadEnv(envPath);
@@ -185,6 +199,59 @@ export function buildShellExportScript(envPath: string): string {
     lines.push(`export ${key}='${escaped}'`);
   }
   return lines.length > 0 ? `${lines.join("\n")}\n` : "";
+}
+
+/**
+ * Matches a `${secret:NAME}` substitution token in an env value. The captured
+ * NAME accepts the same character set as a secret asset name (letters, digits,
+ * `_`, `.`, `/`, `-`). Only this exact form is recognised — shell-style
+ * `${VAR}` and `$VAR` deliberately do not match and are left untouched.
+ */
+const SECRET_TOKEN_RE = /\$\{secret:([A-Za-z0-9_./-]+)\}/g;
+
+/**
+ * Replace every `${secret:NAME}` token in each value with the corresponding
+ * secret value, looked up via the injected `resolveSecret`. Keys are never
+ * touched. Multiple tokens per value and tokens embedded in larger strings
+ * (e.g. `Bearer ${secret:a}:${secret:b}`) are all substituted.
+ *
+ * `resolveSecret` returns `undefined` for an unknown secret name; such names are
+ * collected into `missing` (de-duplicated, in first-seen order) and their tokens
+ * are left unsubstituted in the returned values. Callers MUST treat a non-empty
+ * `missing` as a hard error and inject NOTHING — never partially inject.
+ *
+ * The lookup is injected so this module does not import the secret
+ * resolver/source machinery directly, preserving its narrow dependency surface.
+ * Resolved secret values must never be logged or printed by callers.
+ */
+export function resolveSecretTokens(
+  values: Record<string, string>,
+  resolveSecret: (name: string) => string | undefined,
+): { values: Record<string, string>; missing: string[] } {
+  const missing: string[] = [];
+  const missingSeen = new Set<string>();
+  const out: Record<string, string> = {};
+  const cache = new Map<string, string | undefined>();
+
+  for (const [key, value] of Object.entries(values)) {
+    out[key] = value.replace(SECRET_TOKEN_RE, (match, name: string) => {
+      let resolved = cache.get(name);
+      if (!cache.has(name)) {
+        resolved = resolveSecret(name);
+        cache.set(name, resolved);
+      }
+      if (resolved === undefined) {
+        if (!missingSeen.has(name)) {
+          missingSeen.add(name);
+          missing.push(name);
+        }
+        return match;
+      }
+      return resolved;
+    });
+  }
+
+  return { values: out, missing };
 }
 
 /** Create an empty env file (does nothing if it already exists). */

--- a/tests/env-path-run.test.ts
+++ b/tests/env-path-run.test.ts
@@ -150,6 +150,57 @@ describe("env run", () => {
     expect(stderr.trim()).toBe("");
   });
 
+  test("substitutes ${secret:NAME} tokens with the sibling secret value", () => {
+    const stashDir = makeStash();
+    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
+    fs.mkdirSync(path.join(stashDir, "secrets"), { recursive: true });
+    fs.writeFileSync(path.join(stashDir, "secrets", "my_api_token"), "s3cr3t", "utf8");
+    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "API_KEY=Bearer ${secret:my_api_token}\n", "utf8");
+
+    const { stdout, status } = spawnCli(["env", "run", "env:prod", "--", "bash", "-lc", "printf '%s' \"$API_KEY\""], {
+      AKM_STASH_DIR: stashDir,
+    });
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe("Bearer s3cr3t");
+  });
+
+  test("substitutes multiple tokens embedded in a value and leaves ${HOME} untouched", () => {
+    const stashDir = makeStash();
+    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
+    fs.mkdirSync(path.join(stashDir, "secrets"), { recursive: true });
+    fs.writeFileSync(path.join(stashDir, "secrets", "a"), "AAA", "utf8");
+    fs.writeFileSync(path.join(stashDir, "secrets", "b"), "BBB", "utf8");
+    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "PAIR=${secret:a}:${secret:b}\nKEEP=${HOME}\n", "utf8");
+
+    const { stdout, status } = spawnCli(
+      ["env", "run", "env:prod", "--", "bash", "-lc", 'printf \'%s|%s\' "$PAIR" "$KEEP"'],
+      { AKM_STASH_DIR: stashDir },
+    );
+
+    expect(status).toBe(0);
+    // PAIR fully substituted; KEEP left as the literal token (no secret named HOME).
+    expect(stdout.trim()).toBe("AAA:BBB|${HOME}");
+  });
+
+  test("exits non-zero and injects nothing when a referenced secret is missing", async () => {
+    const stashDir = makeStash();
+    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
+    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "API_KEY=${secret:absent}\n", "utf8");
+
+    const { stdout, stderr, status } = await runCli(["env", "run", "env:prod", "--", "true"], {
+      AKM_STASH_DIR: stashDir,
+    });
+
+    expect(status).not.toBe(0);
+    const parsed = JSON.parse(stderr.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("secret:absent");
+    expect(parsed.error).toContain("env:prod");
+    // No value content leaked to stdout.
+    expect(stdout.trim()).toBe("");
+  });
+
   test("rejects the removed single-key `<ref>/KEY` form with a signpost to secrets", async () => {
     const stashDir = makeStash();
     fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });

--- a/tests/env-secret-tokens.test.ts
+++ b/tests/env-secret-tokens.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { resolveSecretTokens } from "../src/commands/env";
+
+// ── resolveSecretTokens: env value `${secret:NAME}` substitution ─────────────
+//
+// The helper substitutes inside VALUES only, recognises only the
+// `${secret:...}` form, supports multiple/embedded tokens, and reports missing
+// secrets without partially mutating (callers must reject on `missing`).
+
+describe("resolveSecretTokens", () => {
+  test("substitutes a single token", () => {
+    const { values, missing } = resolveSecretTokens({ API_KEY: "${secret:my_api_token}" }, (name) =>
+      name === "my_api_token" ? "s3cr3t" : undefined,
+    );
+    expect(values.API_KEY).toBe("s3cr3t");
+    expect(missing).toEqual([]);
+  });
+
+  test("substitutes multiple tokens embedded in a larger string", () => {
+    const { values, missing } = resolveSecretTokens(
+      { AUTH: "Bearer ${secret:a}:${secret:b}" },
+      (name) => ({ a: "AAA", b: "BBB" })[name],
+    );
+    expect(values.AUTH).toBe("Bearer AAA:BBB");
+    expect(missing).toEqual([]);
+  });
+
+  test("substitutes the same token appearing multiple times", () => {
+    const { values } = resolveSecretTokens({ PAIR: "${secret:x}-${secret:x}" }, () => "1");
+    expect(values.PAIR).toBe("1-1");
+  });
+
+  test("leaves shell-style ${VAR} and literal $VAR untouched", () => {
+    const { values, missing } = resolveSecretTokens(
+      { HOME_REF: "${HOME}", PLAIN: "$VAR", LITERAL: "no tokens here" },
+      () => {
+        throw new Error("resolver must not be called for non-secret tokens");
+      },
+    );
+    expect(values.HOME_REF).toBe("${HOME}");
+    expect(values.PLAIN).toBe("$VAR");
+    expect(values.LITERAL).toBe("no tokens here");
+    expect(missing).toEqual([]);
+  });
+
+  test("never substitutes keys, only values", () => {
+    const { values } = resolveSecretTokens({ "${secret:k}": "v" }, () => "RESOLVED");
+    expect(Object.keys(values)).toEqual(["${secret:k}"]);
+    expect(values["${secret:k}"]).toBe("v");
+  });
+
+  test("reports missing secrets (de-duplicated, first-seen order) and leaves their tokens", () => {
+    const { values, missing } = resolveSecretTokens(
+      { A: "${secret:gone}", B: "${secret:gone} ${secret:also}" },
+      () => undefined,
+    );
+    expect(missing).toEqual(["gone", "also"]);
+    // Tokens for missing secrets are left intact (caller must reject, not inject).
+    expect(values.A).toBe("${secret:gone}");
+    expect(values.B).toBe("${secret:gone} ${secret:also}");
+  });
+
+  test("supports the full secret-name character set (letters, digits, _ . / -)", () => {
+    const { values, missing } = resolveSecretTokens({ V: "${secret:ns/sub.key-name_1}" }, (name) =>
+      name === "ns/sub.key-name_1" ? "ok" : undefined,
+    );
+    expect(values.V).toBe("ok");
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Adds runtime substitution of `${secret:NAME}` tokens in env-asset values during `akm env run`. Each token is replaced with the value of the sibling `secret:NAME` asset in the **same stash** before injection into the child process environment.

Closes #509

## What changed
- **`src/commands/env.ts`** — new `resolveSecretTokens(values, resolveSecret)` helper. Scans each VALUE for `\$\{secret:([A-Za-z0-9_./-]+)\}`, substitutes every match (multiple/embedded tokens supported), and returns `{ values, missing }`. The secret lookup is injected, so env.ts keeps its narrow dependency surface (dotenv + core/common) and never imports the secret resolver/source machinery.
- **`src/cli.ts` `runEnvInjected`** — wires substitution in after `--only`/`--except` filtering and before building `mergedEnv`. Secrets resolve within the env's own `source` via `resolveAssetPathFromName` + `readValue` (utf8, untrimmed, matching `secret run`). A missing secret throws `NotFoundError` naming the missing secret(s) and the env ref, with a `akm secret set` hint — and **nothing is injected** (no partial injection).
- Scope: VALUES only, never keys; only the `${secret:...}` form — shell-style `${VAR}`/`$VAR` left untouched.
- `env_access` audit event stays values-free (key names only).
- Export path (`buildShellExportScript` / `akm env export`) intentionally does **not** substitute; documented in its header note.
- `env run` command description updated to document the syntax.

## Tests
- `tests/env-secret-tokens.test.ts` — unit coverage for the helper: single token, multiple/embedded tokens, repeated token, key-not-substituted, shell-`${VAR}`/`$VAR` untouched, missing-secret reporting (de-dup, first-seen order), full name charset.
- `tests/env-path-run.test.ts` — e2e `env run`: substitution into child process, multi-token + `${HOME}` untouched, and missing-secret exits non-zero with no stdout leak.

## Gates
- `bunx tsc --noEmit` — pass
- `bun run lint` — pass (exit 0; remaining `noTemplateCurlyInString` are warnings on intentional literal token strings in tests)
- `bun test ./tests --path-ignore-patterns=tests/integration` (env/secret area) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)