### PR TITLE
feat(move): add `akm move` command to organize stash assets into subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `akm move <ref> <dest>` (alias `akm mv`) relocates an existing stash asset
+  into a subdirectory under the same type root and reindexes, so assets can be
+  organized into logical subdirectories (e.g.
+  `akm move knowledge:guide.md knowledge:personal/guide.md`). The destination
+  may be a full ref or a bare subpath that inherits the source type.
+  Directory-style assets (skill `SKILL.md`) are moved as a unit. The command
+  refuses when the source is missing, the destination already exists, the move
+  would change the asset type, the source lives in a read-only/registry source,
+  or the destination would escape the type root (path-traversal / absolute /
+  drive-letter destinations are rejected via the asset-ref name guards). (#504)
 - **Workflow runs record agent harness + session identity** — `akm workflow start`
   now persists the agent harness (e.g. `claude-code`, `opencode`) and the
   platform-native session id that owns each run. Identity is resolved best-effort

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -105,6 +105,7 @@ import { akmListSources, akmRemove, akmUpdate } from "./commands/installed-stash
 import { readKnowledgeInput, writeMarkdownAsset } from "./commands/knowledge";
 import { akmLint } from "./commands/lint";
 import { renderMigrationHelp } from "./commands/migration-help";
+import { akmMove } from "./commands/move";
 import { registryCommand } from "./commands/registry-cli";
 import { rememberCommand } from "./commands/remember-cli";
 
@@ -1087,6 +1088,33 @@ const showCommand = defineCommand({
         eventSource: resolveEventSource(),
       });
       output("show", result);
+    });
+  },
+});
+
+const moveCommand = defineCommand({
+  meta: {
+    name: "move",
+    description:
+      "Relocate an existing stash asset into a subdirectory under the same type root (e.g. akm move knowledge:guide.md knowledge:personal/guide.md)",
+  },
+  args: {
+    ref: {
+      type: "positional",
+      description: "Source asset ref ([origin//]type:name), e.g. knowledge:guide.md",
+      required: true,
+    },
+    dest: {
+      type: "positional",
+      description:
+        "Destination ref or subpath under the same type, e.g. knowledge:personal/guide.md or personal/guide.md",
+      required: true,
+    },
+  },
+  async run({ args }) {
+    await runWithJsonErrors(async () => {
+      const result = await akmMove({ ref: args.ref, dest: args.dest });
+      output("move", result);
     });
   },
 });
@@ -4600,6 +4628,9 @@ export const main = defineCommand({
     search: searchCommand,
     curate: curateCommand,
     show: showCommand,
+    move: moveCommand,
+    // Alias: `akm mv <ref> <dest>` behaves identically to `akm move`.
+    mv: moveCommand,
     workflow: workflowCommand,
     remember: rememberCommand,
     import: importKnowledgeCommand,

--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -1,0 +1,219 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `akm move <ref> <dest>` (alias `mv`) — relocate an existing stash asset into
+ * a subdirectory under the same type root, then reindex.
+ *
+ * Issue #504: organize existing stash assets into logical subdirectories. The
+ * path layer already accepts slash-bearing asset names (parseAssetRef /
+ * validateName permit subpaths with traversal guards; the indexer walks
+ * recursively). The missing piece was a user-facing relocation mechanism — not
+ * new path plumbing. This command provides exactly that and nothing more (no
+ * auto-categorization / LLM bucketing — see #503 for creation-time support).
+ *
+ * Flow:
+ *   1. Parse source ref + destination ref/subpath.
+ *   2. Resolve the source on disk, restricted to writable sources only
+ *      (registry-cached / read-only sources are refused).
+ *   3. Compute the destination path via the same type root + asset-spec, and
+ *      verify it stays within the source stash (isWithin) and keeps the same
+ *      type root.
+ *   4. Refuse if the destination already exists.
+ *   5. Move the whole asset unit (directory for skill assets, single file
+ *      otherwise) with mkdir -p on the destination parent.
+ *   6. Reindex the affected source so `show` / `search` find the new subpath.
+ *   7. Fire the single batch-at-boundary commit (#507) when the owning stash is
+ *      git-backed, so the rename + reindexed `.akm/` state land as one complete
+ *      commit (via `saveGitStash` → `git add -A`) instead of leaving dirty
+ *      working-tree residue. No-op for non-git / clean stashes.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { type AssetRef, parseAssetRef } from "../core/asset-ref";
+import { resolveAssetPathFromName, TYPE_DIRS } from "../core/asset-spec";
+import { isWithin } from "../core/common";
+import { NotFoundError, UsageError } from "../core/errors";
+import { appendEvent } from "../core/events";
+import { akmIndex } from "../indexer/indexer";
+import { resolveAssetPath } from "../indexer/path-resolver";
+import { findSourceForPath, getWritableStashDirs, resolveSourceEntries } from "../indexer/search-source";
+import { isGitBackedStash, saveGitStash } from "../sources/providers/git";
+
+export interface MoveResult {
+  ok: true;
+  type: string;
+  from: string;
+  to: string;
+  fromPath: string;
+  toPath: string;
+  stashDir: string;
+}
+
+/**
+ * Parse a destination argument. It may be a full ref (`knowledge:personal/guide.md`)
+ * or a bare subpath/name (`personal/guide.md`) that inherits the source type.
+ */
+function resolveDestRef(dest: string, sourceRef: AssetRef): AssetRef {
+  const trimmed = dest.trim();
+  if (!trimmed) {
+    throw new UsageError("Empty destination.", "MISSING_REQUIRED_ARGUMENT");
+  }
+  // A leading `type:` (before any `/`) marks a full ref. We look for a colon
+  // that occurs before the first slash so subpaths like `team:a/b` are still
+  // treated as refs while `a/b/c.md` is treated as a bare name.
+  const colon = trimmed.indexOf(":");
+  const slash = trimmed.indexOf("/");
+  const looksLikeRef = colon > 0 && (slash === -1 || colon < slash);
+  if (looksLikeRef) {
+    return parseAssetRef(trimmed);
+  }
+  // Bare subpath — reuse the source type and parse through the same validator
+  // so traversal / absolute / drive-letter guards apply uniformly.
+  return parseAssetRef(`${sourceRef.type}:${trimmed}`);
+}
+
+/**
+ * Move the on-disk unit for an asset. For directory-style assets (skill
+ * `SKILL.md`) the unit is the directory that contains the resolved file; for
+ * single-file assets it is the file itself. Returns the source/destination
+ * paths actually moved.
+ */
+function moveAssetUnit(args: { type: string; resolvedSourceFile: string; typeRoot: string; destFilePath: string }): {
+  fromUnit: string;
+  toUnit: string;
+} {
+  const { type, resolvedSourceFile, typeRoot, destFilePath } = args;
+
+  // Determine whether the asset is stored as a directory unit. The skill spec
+  // resolves to `<typeRoot>/<name>/SKILL.md`; the unit to move is the parent
+  // directory. All other built-in types are single files at the resolved path.
+  const isDirectoryUnit = type === "skill";
+
+  const fromUnit = isDirectoryUnit ? path.dirname(resolvedSourceFile) : resolvedSourceFile;
+  const toUnit = isDirectoryUnit ? path.dirname(destFilePath) : destFilePath;
+
+  // Guard against a no-op / overlapping move that would clobber the source.
+  if (path.resolve(fromUnit) === path.resolve(toUnit)) {
+    throw new UsageError("Destination is the same as the source; nothing to move.", "INVALID_FLAG_VALUE");
+  }
+
+  if (fs.existsSync(toUnit)) {
+    throw new UsageError(`Destination already exists: ${toUnit}. Refusing to overwrite.`, "RESOURCE_ALREADY_EXISTS");
+  }
+
+  // Keep the moved unit inside the type root so a destination directory can
+  // never escape via the directory-unit dirname computation.
+  if (!isWithin(toUnit, typeRoot) && path.resolve(toUnit) !== path.resolve(typeRoot)) {
+    throw new UsageError("Destination escapes the asset type root.", "PATH_ESCAPE_VIOLATION");
+  }
+
+  fs.mkdirSync(path.dirname(toUnit), { recursive: true });
+  fs.renameSync(fromUnit, toUnit);
+  return { fromUnit, toUnit };
+}
+
+/**
+ * Relocate an existing asset to a new name/subpath under the same type root.
+ */
+export async function akmMove(input: { ref: string; dest: string }): Promise<MoveResult> {
+  const sourceRef = parseAssetRef(input.ref);
+  const destRef = resolveDestRef(input.dest, sourceRef);
+
+  // (1) Destination must keep the same type root — a move never changes type.
+  if (destRef.type !== sourceRef.type) {
+    throw new UsageError(
+      `Move cannot change asset type (${sourceRef.type} -> ${destRef.type}). ` +
+        "The destination must stay under the same type root.",
+      "INVALID_FLAG_VALUE",
+    );
+  }
+
+  // (2) Resolve the source on disk, restricted to writable sources. This both
+  //     refuses moves out of read-only / registry-cached sources and ensures
+  //     we operate on the actual file rather than an index row.
+  const writableDirSet = new Set(getWritableStashDirs().map((d) => path.resolve(d)));
+  const resolvedSourceFile = await resolveAssetPath(sourceRef, {
+    mode: "disk-only",
+    writableDirSet,
+  });
+  if (!resolvedSourceFile) {
+    // Distinguish "exists but read-only" from "absent" for a clearer message.
+    const anywhere = await resolveAssetPath(sourceRef, { mode: "disk-only" });
+    if (anywhere) {
+      throw new UsageError(
+        `Asset "${sourceRef.type}:${sourceRef.name}" lives in a read-only source and cannot be moved. ` +
+          "Only assets in a writable stash can be relocated.",
+        "INVALID_FLAG_VALUE",
+      );
+    }
+    throw new NotFoundError(
+      `Asset not found for ref: ${sourceRef.type}:${sourceRef.name}. ` +
+        "Check the name with `akm search` or verify the asset exists in a writable stash.",
+    );
+  }
+
+  // (3) Determine the owning source root and recompute both type roots there.
+  const allSources = resolveSourceEntries();
+  const source = findSourceForPath(resolvedSourceFile, allSources);
+  if (!source || source.writable !== true) {
+    throw new UsageError(
+      `Asset "${sourceRef.type}:${sourceRef.name}" is not in a writable stash and cannot be moved.`,
+      "INVALID_FLAG_VALUE",
+    );
+  }
+  const stashDir = source.path;
+  const typeRoot = path.join(stashDir, TYPE_DIRS[sourceRef.type] ?? `${sourceRef.type}s`);
+
+  const destFilePath = resolveAssetPathFromName(destRef.type, typeRoot, destRef.name);
+  if (!isWithin(destFilePath, typeRoot)) {
+    throw new UsageError(
+      `Resolved destination path escapes its type root: "${destRef.name}".`,
+      "PATH_ESCAPE_VIOLATION",
+    );
+  }
+
+  const { fromUnit, toUnit } = moveAssetUnit({
+    type: sourceRef.type,
+    resolvedSourceFile,
+    typeRoot,
+    destFilePath,
+  });
+
+  // (4) Reindex the affected source so show/search resolve the new subpath and
+  //     drop the old one. A full reindex is the simplest correct option: the
+  //     move both adds a new path and removes the old one, and staleness
+  //     detection alone only notices newer files.
+  await akmIndex({ stashDir });
+
+  // (5) Single batch-at-boundary commit (#507). When the owning stash is a git
+  //     repo, stage the rename + reindexed `.akm/` state together as one commit
+  //     via the same `saveGitStash` path `akm sync` / improve auto-sync use —
+  //     NOT the retired per-asset commit. `saveGitStash` is a no-op for non-git
+  //     stashes and for a clean tree, and gates any push on writable + remote.
+  if (isGitBackedStash(stashDir)) {
+    saveGitStash(undefined, `Move ${sourceRef.type}:${sourceRef.name} -> ${destRef.type}:${destRef.name}`, true, {
+      repoDir: stashDir,
+    });
+  }
+
+  const result: MoveResult = {
+    ok: true,
+    type: sourceRef.type,
+    from: `${sourceRef.type}:${sourceRef.name}`,
+    to: `${destRef.type}:${destRef.name}`,
+    fromPath: fromUnit,
+    toPath: toUnit,
+    stashDir,
+  };
+
+  appendEvent({
+    eventType: "move",
+    ref: result.to,
+    metadata: { from: result.from, to: result.to, type: result.type },
+  });
+
+  return result;
+}

--- a/src/output/shapes/passthrough.ts
+++ b/src/output/shapes/passthrough.ts
@@ -52,6 +52,7 @@ const PASSTHROUGH_COMMANDS = [
   "init",
   "lint",
   "list",
+  "move",
   "proposal-accept-batch",
   "proposal-drain",
   "proposal-reject-batch",

--- a/src/output/text.ts
+++ b/src/output/text.ts
@@ -99,6 +99,7 @@ import "./text/info";
 import "./text/config";
 import "./text/feedback";
 import "./text/remember";
+import "./text/move";
 import "./text/import";
 import "./text/save";
 import "./text/enable-disable";

--- a/src/output/text/move.ts
+++ b/src/output/text/move.ts
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { registerTextFormatter } from "./registry";
+
+registerTextFormatter("move", (r) => {
+  const obj = (r ?? {}) as { from?: unknown; to?: unknown; toPath?: unknown };
+  const from = typeof obj.from === "string" ? obj.from : "?";
+  const to = typeof obj.to === "string" ? obj.to : "?";
+  const toPath = typeof obj.toPath === "string" ? ` (${obj.toPath})` : "";
+  return `Moved ${from} -> ${to}${toPath}`;
+});

--- a/tests/move-command.test.ts
+++ b/tests/move-command.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resetConfigCache } from "../src/core/config";
+import { runCliCapture } from "./_helpers/cli";
+import { type Cleanup, sandboxStashDir, sandboxXdgCacheHome, sandboxXdgConfigHome, withEnv } from "./_helpers/sandbox";
+
+// In-process harness (tests/_helpers/cli.ts): each runCli pins a fresh isolated
+// set of XDG dirs plus AKM_STASH_DIR and resets the config cache before driving
+// the CLI. `akm move` relocates an existing asset and reindexes (index.db, not
+// state.db), so the in-process write does not contend with the suite's open
+// state DB.
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+async function runCli(stashDir: string, args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  const xdgCache = makeTempDir("akm-move-cache-");
+  const xdgConfig = makeTempDir("akm-move-config-");
+  const xdgData = makeTempDir("akm-move-data-");
+  return withEnv(
+    {
+      AKM_STASH_DIR: stashDir,
+      XDG_CACHE_HOME: xdgCache,
+      XDG_CONFIG_HOME: xdgConfig,
+      XDG_DATA_HOME: xdgData,
+    },
+    async () => {
+      resetConfigCache();
+      const res = await runCliCapture(args);
+      return { code: res.code, stdout: res.stdout.trim(), stderr: res.stderr.trim() };
+    },
+  );
+}
+
+let envCleanup: Cleanup = () => {};
+
+beforeEach(() => {
+  const cacheResult = sandboxXdgCacheHome();
+  const cfgResult = sandboxXdgConfigHome(cacheResult.cleanup);
+  const stashResult = sandboxStashDir(cfgResult.cleanup);
+  envCleanup = stashResult.cleanup;
+});
+
+afterEach(() => {
+  envCleanup();
+  envCleanup = () => {};
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("move command", () => {
+  function makeStash(): string {
+    const stashDir = makeTempDir("akm-move-stash-");
+    writeFile(path.join(stashDir, "knowledge", "guide.md"), "# Guide\n\nHow to do the thing.\n");
+    writeFile(path.join(stashDir, "knowledge", "other.md"), "# Other\n\nAnother doc.\n");
+    writeFile(
+      path.join(stashDir, "skills", "release-review", "SKILL.md"),
+      "---\ndescription: Review a release plan\n---\n# Release Review\nCheck rollout.\n",
+    );
+    return stashDir;
+  }
+
+  test("relocates a knowledge asset into a subdirectory and reindexes", async () => {
+    const stashDir = makeStash();
+    const oldPath = path.join(stashDir, "knowledge", "guide.md");
+    const newPath = path.join(stashDir, "knowledge", "personal", "guide.md");
+
+    const res = await runCli(stashDir, ["move", "knowledge:guide.md", "knowledge:personal/guide.md", "--format=json"]);
+    expect(res.code).toBe(0);
+    const json = JSON.parse(res.stdout) as { ok: boolean; from: string; to: string; toPath: string };
+    expect(json.ok).toBe(true);
+    expect(json.from).toBe("knowledge:guide.md");
+    expect(json.to).toBe("knowledge:personal/guide.md");
+
+    // File physically moved; old path gone, new path present.
+    expect(fs.existsSync(oldPath)).toBe(false);
+    expect(fs.existsSync(newPath)).toBe(true);
+    expect(fs.readFileSync(newPath, "utf8")).toContain("How to do the thing.");
+
+    // show resolves the new subpath (reindex occurred).
+    const shown = await runCli(stashDir, ["show", "knowledge:personal/guide.md", "--format=json"]);
+    expect(shown.code).toBe(0);
+    const shownJson = JSON.parse(shown.stdout) as { content?: string };
+    expect(shownJson.content ?? "").toContain("How to do the thing.");
+  });
+
+  test("accepts a bare subpath destination (inherits source type)", async () => {
+    const stashDir = makeStash();
+    const res = await runCli(stashDir, ["move", "knowledge:guide.md", "team/guide.md", "--format=json"]);
+    expect(res.code).toBe(0);
+    expect(fs.existsSync(path.join(stashDir, "knowledge", "team", "guide.md"))).toBe(true);
+  });
+
+  test("moves a directory-style skill asset as a unit", async () => {
+    const stashDir = makeStash();
+    const res = await runCli(stashDir, ["move", "skill:release-review", "skill:ops/release-review", "--format=json"]);
+    expect(res.code).toBe(0);
+    expect(fs.existsSync(path.join(stashDir, "skills", "release-review"))).toBe(false);
+    expect(fs.existsSync(path.join(stashDir, "skills", "ops", "release-review", "SKILL.md"))).toBe(true);
+  });
+
+  test("refuses when the source asset does not exist", async () => {
+    const stashDir = makeStash();
+    const res = await runCli(stashDir, ["move", "knowledge:nope.md", "knowledge:sub/nope.md", "--format=json"]);
+    expect(res.code).not.toBe(0);
+    expect(`${res.stdout}${res.stderr}`).toMatch(/not found/i);
+  });
+
+  test("refuses when the destination already exists", async () => {
+    const stashDir = makeStash();
+    const res = await runCli(stashDir, ["move", "knowledge:guide.md", "knowledge:other.md", "--format=json"]);
+    expect(res.code).not.toBe(0);
+    expect(`${res.stdout}${res.stderr}`).toMatch(/already exists/i);
+    // Source untouched after a refused move.
+    expect(fs.existsSync(path.join(stashDir, "knowledge", "guide.md"))).toBe(true);
+  });
+
+  test("refuses a destination that would change the asset type", async () => {
+    const stashDir = makeStash();
+    const res = await runCli(stashDir, ["move", "knowledge:guide.md", "command:guide.md", "--format=json"]);
+    expect(res.code).not.toBe(0);
+    expect(`${res.stdout}${res.stderr}`).toMatch(/type/i);
+  });
+
+  test("rejects a path-traversal destination", async () => {
+    const stashDir = makeStash();
+    const res = await runCli(stashDir, ["move", "knowledge:guide.md", "knowledge:../escape.md", "--format=json"]);
+    expect(res.code).not.toBe(0);
+    expect(fs.existsSync(path.join(stashDir, "knowledge", "guide.md"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements issue #504 — organize existing stash assets into logical subdirectories.

Adds `akm move <ref> <dest>` (alias `akm mv`) that relocates an existing asset's file(s) into a subpath under the **same type root** and reindexes the affected source. The destination may be a full ref (`knowledge:guide.md -> knowledge:personal/guide.md`) or a bare subpath that inherits the source type (`personal/guide.md`).

This is the user-facing relocation mechanism that was missing — the path layer already accepts slash-bearing asset names and the indexer walks recursively, so no new path semantics or asset-ref format changes were needed. No auto-categorization / LLM bucketing (the broader interpretation tracked separately as #503).

## Behavior

- Resolves the source on disk restricted to **writable** stashes (`getWritableStashDirs` + `disk-only` resolution); read-only / registry-cached sources are refused.
- Computes the destination via `resolveAssetPathFromName` against the same type root and enforces `isWithin` containment.
- Refuses with a clear `UsageError` when: source missing, destination exists, destination changes the asset type, source is non-writable, or destination escapes the type root (path-traversal / absolute / drive-letter rejected via the asset-ref `validateName` guards).
- Moves the whole asset unit: the parent directory for directory-style skill assets (`SKILL.md`), the single file otherwise.
- Triggers a full reindex (`akmIndex`) so `show` / `search` find the new subpath and drop the old one.
- Emits a `move` event and a structured passthrough output shape + text formatter.

## Tests

New `tests/move-command.test.ts` (in-process CLI harness): happy-path relocate + `show` resolves the new subpath, bare-subpath destination, directory-style skill move, plus refusals (missing source, existing destination, type change, path traversal). 7/7 pass.

## Gates

- `bunx tsc --noEmit` — pass
- `bun run lint` (biome + isolation + license headers) — pass
- `bun test --timeout 30000 ./tests --path-ignore-patterns=tests/integration` — 3865 pass, 0 fail

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)