### PR TITLE
feat(submit): add submit command (feedback, registry, gated metrics) [#505]

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -107,6 +107,7 @@ import { akmLint } from "./commands/lint";
 import { renderMigrationHelp } from "./commands/migration-help";
 import { registryCommand } from "./commands/registry-cli";
 import { rememberCommand } from "./commands/remember-cli";
+import { submitCommand } from "./commands/submit-cli";
 
 /**
  * Resolve the event source from the environment. When `AKM_EVENT_SOURCE` is
@@ -4577,6 +4578,7 @@ export const main = defineCommand({
     enable: enableCommand,
     disable: disableCommand,
     feedback: feedbackCommand,
+    submit: submitCommand,
     history: historyCommand,
     events: eventsCommand,
     lessons: lessonsCommand,

--- a/src/commands/submit-cli.ts
+++ b/src/commands/submit-cli.ts
@@ -1,0 +1,256 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `akm submit` — push structured data to external destinations.
+ *
+ * Subcommands:
+ *   - `submit feedback`  open a GitHub issue tagged `feedback` (supports --dry-run).
+ *   - `submit registry`  append a structured entry to the local registry
+ *                        manual-entries file (consistent with `registry build-index`).
+ *   - `submit metrics`   feature-gated stub. No analytics backend contract exists
+ *                        yet (no endpoint/schema/auth/opt-in policy), so this
+ *                        subcommand never silently transmits data; it fails with
+ *                        a clear "not yet available" error unless an explicit
+ *                        endpoint is supplied AND opt-in is set.
+ *
+ * Note: this is distinct from the top-level `akm feedback` command, which
+ * records *local* asset-ranking feedback into the index. `submit feedback`
+ * sends *project* feedback to GitHub as an issue.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { defineCommand } from "citty";
+import { output, runWithJsonErrors } from "../cli/shared";
+import { UsageError } from "../core/errors";
+import { getCacheDir } from "../core/paths";
+import { createIssue } from "../integrations/github";
+import { getHyphenatedBoolean } from "../output/context";
+import { parseRegistryIndex, type RegistryStashEntry } from "../registry/providers/static-index";
+
+// ── Shared label / repo defaults ──────────────────────────────────────────────
+
+const FEEDBACK_LABEL = "feedback";
+const DEFAULT_REPO = "itlackey/akm";
+
+function resolveRepo(repoFlag: string | undefined): { owner: string; repo: string } {
+  const raw = (repoFlag ?? DEFAULT_REPO).trim();
+  const parts = raw.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new UsageError(`Invalid --repo "${raw}". Expected owner/name (e.g. itlackey/akm).`, "INVALID_FLAG_VALUE");
+  }
+  return { owner: parts[0], repo: parts[1] };
+}
+
+// ── submit feedback ───────────────────────────────────────────────────────────
+
+const feedbackSubCommand = defineCommand({
+  meta: {
+    name: "feedback",
+    description: "Open a GitHub issue tagged `feedback`. Use --dry-run to preview the payload without a network call.",
+  },
+  args: {
+    title: { type: "string", description: "Issue title", required: false },
+    body: { type: "string", description: "Issue body (markdown)", required: false },
+    repo: { type: "string", description: `Target repo as owner/name (default: ${DEFAULT_REPO})` },
+    "dry-run": {
+      type: "boolean",
+      description: "Print the issue payload (title, body, label, repo) without performing a network call",
+      default: false,
+    },
+  },
+  run({ args }) {
+    return runWithJsonErrors(async () => {
+      const title = (args.title as string | undefined)?.trim();
+      const body = (args.body as string | undefined)?.trim() ?? "";
+      if (!title) {
+        throw new UsageError(
+          "Issue title is required. Usage: akm submit feedback --title <title> [--body <body>]",
+          "MISSING_REQUIRED_ARGUMENT",
+          'Pass a title, e.g. --title "Docs typo in setup guide".',
+        );
+      }
+      const { owner, repo } = resolveRepo(args.repo as string | undefined);
+      const dryRun = getHyphenatedBoolean(args, "dry-run");
+      const labels = [FEEDBACK_LABEL];
+
+      if (dryRun) {
+        output("submit-feedback", {
+          ok: true,
+          dryRun: true,
+          title,
+          body,
+          labels,
+          repo: `${owner}/${repo}`,
+        });
+        return;
+      }
+
+      const issue = await createIssue({ owner, repo, title, body, labels });
+      output("submit-feedback", {
+        ok: true,
+        dryRun: false,
+        number: issue.number,
+        url: issue.url,
+        title: issue.title,
+        labels,
+        repo: `${owner}/${repo}`,
+      });
+    });
+  },
+});
+
+// ── submit registry ───────────────────────────────────────────────────────────
+
+const REGISTRY_SOURCES = new Set(["npm", "github", "git", "local"]);
+
+function manualEntriesPath(override: string | undefined): string {
+  if (override?.trim()) return path.resolve(override.trim());
+  return path.join(getCacheDir(), "registry-build", "manual-entries.json");
+}
+
+function loadExistingEntries(file: string): RegistryStashEntry[] {
+  if (!fs.existsSync(file)) return [];
+  try {
+    const raw = JSON.parse(fs.readFileSync(file, "utf8"));
+    const candidate = Array.isArray(raw) ? raw : (raw as { stashes?: unknown }).stashes;
+    const parsed = parseRegistryIndex({ version: 3, updatedAt: new Date().toISOString(), stashes: candidate });
+    return parsed?.stashes ?? [];
+  } catch {
+    return [];
+  }
+}
+
+const registrySubCommand = defineCommand({
+  meta: {
+    name: "registry",
+    description:
+      "Append a structured entry to the local registry manual-entries file (consumed by `registry build-index`).",
+  },
+  args: {
+    ref: {
+      type: "positional",
+      description: "Install ref for the stash (e.g. npm:@scope/pkg, github:owner/repo)",
+      required: true,
+    },
+    id: { type: "string", description: "Stable entry id (defaults to the ref)" },
+    name: { type: "string", description: "Human-friendly stash name" },
+    description: { type: "string", description: "Short description" },
+    source: { type: "string", description: "Source kind: npm | github | git | local" },
+    homepage: { type: "string", description: "Homepage URL" },
+    out: { type: "string", description: "Override the manual-entries.json path" },
+  },
+  run({ args }) {
+    return runWithJsonErrors(() => {
+      const ref = (args.ref as string).trim();
+      if (!ref) {
+        throw new UsageError("A stash ref is required.", "MISSING_REQUIRED_ARGUMENT");
+      }
+      const name = (args.name as string | undefined)?.trim() || ref;
+      // Derive source from the ref prefix when not explicitly provided.
+      const derivedSource = ref.includes(":") ? ref.slice(0, ref.indexOf(":")) : undefined;
+      const source = ((args.source as string | undefined)?.trim() || derivedSource) ?? "";
+      if (!REGISTRY_SOURCES.has(source)) {
+        throw new UsageError(
+          `Missing or invalid --source. Provide one of: npm, github, git, local ` +
+            `(or use a ref prefixed with the source, e.g. "npm:pkg").`,
+          "INVALID_FLAG_VALUE",
+        );
+      }
+
+      const entry: RegistryStashEntry = {
+        id: (args.id as string | undefined)?.trim() || ref,
+        name,
+        ref,
+        source: source as RegistryStashEntry["source"],
+      };
+      const description = (args.description as string | undefined)?.trim();
+      if (description) entry.description = description;
+      const homepage = (args.homepage as string | undefined)?.trim();
+      if (homepage) entry.homepage = homepage;
+
+      const file = manualEntriesPath(args.out as string | undefined);
+      const existing = loadExistingEntries(file);
+      const replaced = existing.some((e) => e.id === entry.id);
+      const next = replaced ? existing.map((e) => (e.id === entry.id ? entry : e)) : [...existing, entry];
+
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, `${JSON.stringify({ stashes: next }, null, 2)}\n`, { mode: 0o600 });
+
+      output("submit-registry", {
+        ok: true,
+        path: file,
+        added: !replaced,
+        replaced,
+        entry,
+        total: next.length,
+      });
+    });
+  },
+});
+
+// ── submit metrics ────────────────────────────────────────────────────────────
+
+const metricsSubCommand = defineCommand({
+  meta: {
+    name: "metrics",
+    description:
+      "Submit process/tool-usage metrics to an analytics endpoint. " +
+      "Feature-gated: requires an explicit --endpoint AND --opt-in. No data is ever sent silently.",
+  },
+  args: {
+    endpoint: { type: "string", description: "Analytics API endpoint URL (no default — must be explicit)" },
+    "opt-in": {
+      type: "boolean",
+      description: "Explicit acknowledgement that metrics may be transmitted to --endpoint",
+      default: false,
+    },
+  },
+  run({ args }) {
+    return runWithJsonErrors(() => {
+      const endpoint = (args.endpoint as string | undefined)?.trim();
+      const optIn = getHyphenatedBoolean(args, "opt-in");
+      // No backend contract exists in-repo (endpoint/schema/auth/opt-in policy
+      // are unspecified — issue #505). Fail loudly rather than transmit data.
+      if (!endpoint || !optIn) {
+        throw new UsageError(
+          "`akm submit metrics` is not available yet: there is no defined analytics backend " +
+            "(endpoint, schema, auth, and opt-in policy are unspecified). " +
+            "To avoid silently transmitting data, this command is feature-gated and requires both " +
+            "--endpoint <url> and --opt-in once a contract is finalized.",
+          "INVALID_FLAG_VALUE",
+          "Track issue #505 for the metrics-to-API contract before enabling this path.",
+        );
+      }
+      // Even when both flags are set, the wire schema is not finalized; surface
+      // a clear non-zero error instead of POSTing an unversioned payload.
+      throw new UsageError(
+        "Metrics submission is feature-gated pending a finalized payload schema and auth model. " +
+          "Endpoint and opt-in were provided, but the analytics contract is not yet defined.",
+        "INVALID_FLAG_VALUE",
+      );
+    });
+  },
+});
+
+// ── Top-level command ─────────────────────────────────────────────────────────
+
+export const submitCommand = defineCommand({
+  meta: {
+    name: "submit",
+    description:
+      "Submit metrics, registry entries, or feedback to external destinations.\n\n" +
+      "Note: `submit feedback` opens a GitHub issue (project feedback); it is distinct from " +
+      "`akm feedback`, which records local asset-ranking feedback.",
+  },
+  subCommands: {
+    metrics: metricsSubCommand,
+    registry: registrySubCommand,
+    feedback: feedbackSubCommand,
+  },
+});
+
+// Internal exports for tests.
+export const __test = { resolveRepo, FEEDBACK_LABEL, DEFAULT_REPO };

--- a/src/integrations/github.ts
+++ b/src/integrations/github.ts
@@ -68,3 +68,81 @@ export function asRecord(value: unknown): Record<string, unknown> {
 export function asString(value: unknown): string | undefined {
   return typeof value === "string" && value ? value : undefined;
 }
+
+// ── Issue creation (write helper) ─────────────────────────────────────────────
+
+export interface CreateIssueOptions {
+  /** Repository owner (e.g. "itlackey"). */
+  owner: string;
+  /** Repository name (e.g. "akm"). */
+  repo: string;
+  /** Issue title. */
+  title: string;
+  /** Issue body (markdown). */
+  body: string;
+  /** Labels to attach to the issue. */
+  labels?: string[];
+  /** Override the GitHub API base (primarily for tests). Defaults to {@link GITHUB_API_BASE}. */
+  apiBase?: string;
+}
+
+export interface CreatedIssue {
+  /** Issue number assigned by GitHub. */
+  number: number;
+  /** Human-facing issue URL (html_url). */
+  url: string;
+  /** Issue title echoed back by the API. */
+  title: string;
+}
+
+/**
+ * Create a GitHub issue via the REST API. Requires an authenticated token
+ * (GITHUB_TOKEN / GH_TOKEN env, or `gh auth token`). Throws when no token is
+ * available or the API rejects the request.
+ *
+ * This is a thin write helper: it performs exactly one POST and surfaces the
+ * returned issue number/url. Callers are responsible for dry-run gating and
+ * user-facing output — this function always hits the network when invoked.
+ */
+export async function createIssue(options: CreateIssueOptions): Promise<CreatedIssue> {
+  const { owner, repo, title, body, labels } = options;
+  if (!owner.trim() || !repo.trim()) {
+    throw new Error("createIssue requires a non-empty owner and repo.");
+  }
+  if (!title.trim()) {
+    throw new Error("createIssue requires a non-empty title.");
+  }
+  if (resolveGithubToken() === undefined) {
+    throw new Error("No GitHub token available. Set GITHUB_TOKEN or GH_TOKEN, or run `gh auth login`, then retry.");
+  }
+
+  const base = (options.apiBase ?? GITHUB_API_BASE).replace(/\/+$/, "");
+  const url = `${base}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues`;
+  const payload: Record<string, unknown> = { title, body };
+  if (labels && labels.length > 0) payload.labels = labels;
+
+  const headers: Record<string, string> = {
+    ...(githubHeaders(url) as Record<string, string>),
+    "Content-Type": "application/json",
+  };
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`GitHub issue creation failed: HTTP ${response.status} from ${url}: ${text.slice(0, 200)}`);
+  }
+
+  const json = asRecord(await response.json());
+  const number = typeof json.number === "number" ? json.number : undefined;
+  const htmlUrl = asString(json.html_url);
+  if (number === undefined || htmlUrl === undefined) {
+    throw new Error("GitHub issue creation returned an unexpected response (missing number or html_url).");
+  }
+  return { number, url: htmlUrl, title: asString(json.title) ?? title };
+}

--- a/src/output/shapes/passthrough.ts
+++ b/src/output/shapes/passthrough.ts
@@ -66,6 +66,8 @@ const PASSTHROUGH_COMMANDS = [
   "secret-set",
   "secret-remove",
   "setup",
+  "submit-feedback",
+  "submit-registry",
   "tasks-add",
   "tasks-disable",
   "tasks-doctor",

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -1,14 +1,16 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import * as childProcess from "node:child_process";
-import { asRecord, asString, GITHUB_API_BASE, githubHeaders } from "../src/integrations/github";
+import { asRecord, asString, createIssue, GITHUB_API_BASE, githubHeaders } from "../src/integrations/github";
 
 // ── Environment helpers ─────────────────────────────────────────────────────
 
 const originalGithubToken = process.env.GITHUB_TOKEN;
 const originalGhToken = process.env.GH_TOKEN;
+const originalFetch = globalThis.fetch;
 
 afterEach(() => {
   mock.restore();
+  globalThis.fetch = originalFetch;
 
   if (originalGithubToken === undefined) {
     delete process.env.GITHUB_TOKEN;
@@ -192,5 +194,64 @@ describe("asString", () => {
 
   test("returns string with whitespace preserved", () => {
     expect(asString("  spaced  ")).toBe("  spaced  ");
+  });
+});
+
+// ── createIssue ───────────────────────────────────────────────────────────────
+
+describe("createIssue", () => {
+  test("POSTs to the repo issues endpoint with title, body and labels", async () => {
+    process.env.GITHUB_TOKEN = "ghp_test";
+    let captured: { url: string; method?: string; body: unknown } | undefined;
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      captured = { url, method: init?.method, body: JSON.parse(String(init?.body)) };
+      return new Response(JSON.stringify({ number: 7, html_url: "https://github.com/o/r/issues/7", title: "Hello" }), {
+        status: 201,
+      });
+    }) as unknown as typeof fetch;
+
+    const issue = await createIssue({ owner: "o", repo: "r", title: "Hello", body: "World", labels: ["feedback"] });
+
+    expect(captured?.method).toBe("POST");
+    expect(captured?.url).toBe("https://api.github.com/repos/o/r/issues");
+    expect(captured?.body).toEqual({ title: "Hello", body: "World", labels: ["feedback"] });
+    expect(issue).toEqual({ number: 7, url: "https://github.com/o/r/issues/7", title: "Hello" });
+  });
+
+  test("respects an apiBase override", async () => {
+    process.env.GITHUB_TOKEN = "ghp_test";
+    let capturedUrl = "";
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return new Response(JSON.stringify({ number: 1, html_url: "https://example.test/i/1" }), { status: 201 });
+    }) as unknown as typeof fetch;
+
+    await createIssue({ owner: "o", repo: "r", title: "t", body: "b", apiBase: "https://example.test/api/" });
+    expect(capturedUrl).toBe("https://example.test/api/repos/o/r/issues");
+  });
+
+  test("throws when no token is available", async () => {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    spyOn(childProcess, "spawnSync").mockReturnValue({ status: 1, stdout: "" } as never);
+    await expect(createIssue({ owner: "o", repo: "r", title: "t", body: "b" })).rejects.toThrow(/token/i);
+  });
+
+  test("throws on a non-OK response with the status in the message", async () => {
+    process.env.GITHUB_TOKEN = "ghp_test";
+    globalThis.fetch = (async () => new Response("Forbidden", { status: 403 })) as unknown as typeof fetch;
+    await expect(createIssue({ owner: "o", repo: "r", title: "t", body: "b" })).rejects.toThrow(/403/);
+  });
+
+  test("throws when the response is missing number or html_url", async () => {
+    process.env.GITHUB_TOKEN = "ghp_test";
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ title: "t" }), { status: 201 })) as unknown as typeof fetch;
+    await expect(createIssue({ owner: "o", repo: "r", title: "t", body: "b" })).rejects.toThrow(/unexpected response/);
+  });
+
+  test("requires a non-empty title", async () => {
+    process.env.GITHUB_TOKEN = "ghp_test";
+    await expect(createIssue({ owner: "o", repo: "r", title: "  ", body: "b" })).rejects.toThrow(/title/i);
   });
 });

--- a/tests/submit-cli.test.ts
+++ b/tests/submit-cli.test.ts
@@ -1,0 +1,200 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runCliCapture } from "./_helpers/cli";
+
+// ── Environment helpers ──────────────────────────────────────────────────────
+
+const originalGithubToken = process.env.GITHUB_TOKEN;
+const originalGhToken = process.env.GH_TOKEN;
+const originalFetch = globalThis.fetch;
+const createdTmpDirs: string[] = [];
+
+function createTmpDir(prefix = "akm-submit-cli-"): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  createdTmpDirs.push(dir);
+  return dir;
+}
+
+beforeEach(() => {
+  delete process.env.GITHUB_TOKEN;
+  delete process.env.GH_TOKEN;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalGithubToken === undefined) delete process.env.GITHUB_TOKEN;
+  else process.env.GITHUB_TOKEN = originalGithubToken;
+  if (originalGhToken === undefined) delete process.env.GH_TOKEN;
+  else process.env.GH_TOKEN = originalGhToken;
+  for (const dir of createdTmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── submit --help ─────────────────────────────────────────────────────────────
+
+describe("akm submit --help", () => {
+  test("lists metrics, registry, and feedback subcommands", async () => {
+    const result = await runCliCapture(["submit", "--help"]);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("metrics");
+    expect(result.stdout).toContain("registry");
+    expect(result.stdout).toContain("feedback");
+  });
+});
+
+// ── submit feedback ─────────────────────────────────────────────────────────
+
+describe("akm submit feedback", () => {
+  test("--dry-run prints payload with feedback label and target repo, no network call", async () => {
+    let fetchCalled = false;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("{}", { status: 201 });
+    }) as unknown as typeof fetch;
+
+    const result = await runCliCapture([
+      "submit",
+      "feedback",
+      "--dry-run",
+      "--title",
+      "Docs typo",
+      "--body",
+      "There is a typo in setup.",
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(fetchCalled).toBe(false);
+    const payload = JSON.parse(result.stdout);
+    expect(payload.dryRun).toBe(true);
+    expect(payload.title).toBe("Docs typo");
+    expect(payload.body).toBe("There is a typo in setup.");
+    expect(payload.labels).toEqual(["feedback"]);
+    expect(payload.repo).toBe("itlackey/akm");
+  });
+
+  test("creates an issue against a mocked GitHub API and surfaces the issue URL", async () => {
+    process.env.GITHUB_TOKEN = "ghp_test_token";
+    let captured: { url: string; body: unknown } | undefined;
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      captured = { url, body: JSON.parse(String(init?.body)) };
+      return new Response(
+        JSON.stringify({ number: 42, html_url: "https://github.com/itlackey/akm/issues/42", title: "Docs typo" }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await runCliCapture(["submit", "feedback", "--title", "Docs typo", "--body", "Body here"]);
+
+    expect(result.code).toBe(0);
+    expect(captured?.url).toContain("/repos/itlackey/akm/issues");
+    expect((captured?.body as { labels: string[] }).labels).toEqual(["feedback"]);
+    const payload = JSON.parse(result.stdout);
+    expect(payload.number).toBe(42);
+    expect(payload.url).toBe("https://github.com/itlackey/akm/issues/42");
+    expect(payload.labels).toEqual(["feedback"]);
+  });
+
+  test("fails with a clear error and non-zero exit when title is missing", async () => {
+    const result = await runCliCapture(["submit", "feedback", "--body", "no title"]);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain("title is required");
+  });
+
+  test("surfaces a clear non-zero error when the GitHub API rejects the request", async () => {
+    // Set a token so the request reaches the API; the API then rejects it.
+    // (The pure no-token path is covered deterministically in github.test.ts,
+    // where `gh auth token` is mocked; here a real `gh` may supply a token.)
+    process.env.GITHUB_TOKEN = "ghp_test_token";
+    globalThis.fetch = (async () => new Response("Bad credentials", { status: 401 })) as unknown as typeof fetch;
+    const result = await runCliCapture(["submit", "feedback", "--title", "X", "--body", "Y", "--repo", "o/r"]);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain("401");
+  });
+
+  test("rejects a malformed --repo", async () => {
+    const result = await runCliCapture(["submit", "feedback", "--title", "X", "--repo", "not-a-repo"]);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain("Invalid --repo");
+  });
+});
+
+// ── submit registry ─────────────────────────────────────────────────────────
+
+describe("akm submit registry", () => {
+  test("writes a structured entry with derived source to the manual-entries file", async () => {
+    const dir = createTmpDir();
+    const out = path.join(dir, "manual-entries.json");
+    const result = await runCliCapture([
+      "submit",
+      "registry",
+      "npm:@scope/my-stash",
+      "--name",
+      "My Stash",
+      "--description",
+      "A stash",
+      "--out",
+      out,
+    ]);
+
+    expect(result.code).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload.added).toBe(true);
+    expect(payload.entry.source).toBe("npm");
+    expect(payload.entry.ref).toBe("npm:@scope/my-stash");
+
+    const onDisk = JSON.parse(fs.readFileSync(out, "utf8"));
+    expect(onDisk.stashes).toHaveLength(1);
+    expect(onDisk.stashes[0].name).toBe("My Stash");
+    expect(onDisk.stashes[0].id).toBe("npm:@scope/my-stash");
+  });
+
+  test("replaces an existing entry with the same id (idempotent upsert)", async () => {
+    const dir = createTmpDir();
+    const out = path.join(dir, "manual-entries.json");
+    await runCliCapture(["submit", "registry", "npm:pkg", "--name", "First", "--out", out]);
+    const result = await runCliCapture(["submit", "registry", "npm:pkg", "--name", "Second", "--out", out]);
+
+    expect(result.code).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload.replaced).toBe(true);
+    const onDisk = JSON.parse(fs.readFileSync(out, "utf8"));
+    expect(onDisk.stashes).toHaveLength(1);
+    expect(onDisk.stashes[0].name).toBe("Second");
+  });
+
+  test("fails with a clear error when the source cannot be determined", async () => {
+    const dir = createTmpDir();
+    const out = path.join(dir, "manual-entries.json");
+    const result = await runCliCapture(["submit", "registry", "no-prefix-ref", "--out", out]);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain("--source");
+  });
+});
+
+// ── submit metrics (feature-gated stub) ──────────────────────────────────────
+
+describe("akm submit metrics", () => {
+  test("fails with a clear not-available error when flags are missing", async () => {
+    const result = await runCliCapture(["submit", "metrics"]);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain("not available");
+  });
+
+  test("still fails (no silent send) even when endpoint and opt-in are provided", async () => {
+    let fetchCalled = false;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    const result = await runCliCapture(["submit", "metrics", "--endpoint", "https://example.com/ingest", "--opt-in"]);
+    expect(result.code).toBe(2);
+    expect(fetchCalled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a net-new top-level `akm submit` command (citty `defineCommand` with `subCommands`, mirroring `registry-cli.ts`), wired into `src/cli.ts` and imported alongside `feedbackCommand`. Three subcommands:

- **`submit feedback`** — opens a GitHub issue tagged `feedback`. Supports `--dry-run` (prints the payload: title, body, label, target repo, no network call) and `--repo owner/name` (default `itlackey/akm`). Built on a new `createIssue()` write helper.
- **`submit registry`** — upserts a structured `RegistryStashEntry` into the local `manual-entries.json` consumed by `registry build-index`. Source is derived from the ref prefix (e.g. `npm:`) or `--source`.
- **`submit metrics`** — **feature-gated stub**. No analytics backend contract exists in this repo (endpoint, schema, auth, opt-in policy are unspecified). It never silently transmits data; it fails with a clear, non-zero error.

New `createIssue()` write helper in `src/integrations/github.ts`: token resolution (env / `gh auth token`), single POST, status/error surfacing, `apiBase` test seam, returns `{ number, url, title }`.

Registers `submit-feedback` / `submit-registry` output shapes (passthrough). New `.ts` files carry the MPL-2.0 header.

## Why draft / partial

Issue #505 is **not tractable** as a single fully-verified pass (per the brief): the metrics subcommand depends on a backend analytics API that does not exist or is specified anywhere in-repo. This PR lands the coherent, verified slice (github write helper + tests, `submit feedback` with dry-run + mocked-API creation, `submit registry`) and explicitly feature-gates `submit metrics` rather than silently sending data. The metrics-to-API path should be split into its own issue once a backend contract (endpoint/schema/auth/opt-in) is finalized.

## Tests

- `tests/github.test.ts`: 6 new `createIssue` cases (POST shape + labels, apiBase override, no-token, non-OK status, malformed response, empty title).
- `tests/submit-cli.test.ts`: `--help` lists all three subcommands; feedback dry-run (no fetch); mocked-API issue creation surfaces URL + `feedback` label; missing title / bad repo / API-reject errors; registry upsert + missing-source error; metrics gating (no silent send).

## Gates (local)

- `bunx tsc --noEmit` — pass
- `bun run lint` (biome + isolation + license-header) — pass
- `bun test ./tests --path-ignore-patterns=tests/integration` — 3876 pass, 0 fail

Closes #505
