### PR TITLE
feat(setup): safe-by-default config management with deep-merge, --yes --file, and accurate backup paths

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -335,6 +335,8 @@ const setupCommand = defineCommand({
         // `~`, resolves relative paths against cwd, picks the YAML or JSON
         // parser based on the file extension, and surfaces any
         // read/parse/shape errors as ConfigError("INVALID_CONFIG_FILE").
+        // `runSetupFromConfig` is fully non-interactive; with `--yes` it also
+        // fills defaults for keys the file leaves missing.
         const { loadSetupConfigFromFile, runSetupFromConfig } = await import("./setup/setup");
         const loaded = await loadSetupConfigFromFile(args.from);
         const result = await runSetupFromConfig({
@@ -342,17 +344,20 @@ const setupCommand = defineCommand({
           dir: args.dir,
           noInit,
           probe: args.probe,
+          applyDefaults: args.yes,
         });
         output("setup", result);
         printSetupTtyHint(result);
       } else if (args.config) {
-        // Non-interactive config mode
+        // Non-interactive config mode. With `--yes`, defaults fill any keys
+        // the JSON blob leaves missing after the deep merge.
         const { runSetupFromConfig } = await import("./setup/setup");
         const result = await runSetupFromConfig({
           configJson: args.config,
           dir: args.dir,
           noInit,
           probe: args.probe,
+          applyDefaults: args.yes,
         });
         output("setup", result);
         printSetupTtyHint(result);

--- a/src/core/config-io.ts
+++ b/src/core/config-io.ts
@@ -94,18 +94,34 @@ const MAX_CONFIG_BACKUPS = 5;
  * timestamped set to {@link MAX_CONFIG_BACKUPS} most-recent entries.
  *
  * No-op when the source file does not exist (cold-start safe).
+ *
+ * Returns the written backup paths (the timestamped copy plus the
+ * `config.latest.json` pointer), or `undefined` when there was nothing to
+ * back up. Callers use the timestamped path to print the real backup
+ * location instead of a generic display string.
  */
-export function backupExistingConfig(configPath: string): void {
-  if (!fs.existsSync(configPath)) return;
+export interface ConfigBackupResult {
+  /** Absolute path to the timestamped `config-<timestamp>.json` snapshot. */
+  timestamped: string;
+  /** Absolute path to the rolling `config.latest.json` pointer. */
+  latest: string;
+}
+
+export function backupExistingConfig(configPath: string): ConfigBackupResult | undefined {
+  if (!fs.existsSync(configPath)) return undefined;
 
   const backupDir = path.join(getCacheDir(), "config-backups");
   fs.mkdirSync(backupDir, { recursive: true });
 
   const timestamp = new Date().toISOString().replace(/[.:]/g, "-");
-  fs.copyFileSync(configPath, path.join(backupDir, `config-${timestamp}.json`));
-  fs.copyFileSync(configPath, path.join(backupDir, "config.latest.json"));
+  const timestamped = path.join(backupDir, `config-${timestamp}.json`);
+  const latest = path.join(backupDir, "config.latest.json");
+  fs.copyFileSync(configPath, timestamped);
+  fs.copyFileSync(configPath, latest);
 
   pruneOldBackups(backupDir);
+
+  return { timestamped, latest };
 }
 
 function pruneOldBackups(backupDir: string): void {

--- a/src/setup/setup.ts
+++ b/src/setup/setup.ts
@@ -2075,10 +2075,7 @@ export async function runSetupWizard(opts?: { dir?: string; noInit?: boolean }):
 
   // Save config
   const cfgPath1 = getConfigPath();
-  if (fs.existsSync(cfgPath1)) {
-    backupExistingConfig(cfgPath1);
-    p.log.info(`Config backed up to ~/.cache/akm/config-backups/`);
-  }
+  backupAndAnnounce(cfgPath1);
   saveConfig(newConfig);
 
   if (semanticSearchMode.mode === "off") {
@@ -2170,6 +2167,20 @@ export async function runSetupWizard(opts?: { dir?: string; noInit?: boolean }):
 // ── Non-interactive / scripting entry points ─────────────────────────────────
 
 /**
+ * Back up an existing config file and print the real, timestamped backup
+ * location (not a generic display string). On a fresh install where there is
+ * nothing to back up, print a "nothing to back up" notice instead.
+ */
+function backupAndAnnounce(configPath: string): void {
+  const result = backupExistingConfig(configPath);
+  if (result) {
+    p.log.info(`Config backed up to ${result.timestamped}`);
+  } else {
+    p.log.info("No existing config to back up.");
+  }
+}
+
+/**
  * Run setup in non-interactive mode, applying all defaults.
  * Safe to call from CI or scripts. Idempotent — re-running produces the same result.
  */
@@ -2212,10 +2223,7 @@ export async function runSetupWithDefaults(opts: {
   }
 
   const cfgPath2 = getConfigPath();
-  if (fs.existsSync(cfgPath2)) {
-    backupExistingConfig(cfgPath2);
-    p.log.info(`Config backed up to ~/.cache/akm/config-backups/`);
-  }
+  backupAndAnnounce(cfgPath2);
   saveConfig(ctx.config);
 
   return {
@@ -2229,6 +2237,34 @@ export async function runSetupWithDefaults(opts: {
 }
 
 /**
+ * Recursively merge `incoming` into `base`: plain objects merge key-by-key,
+ * while arrays and scalars replace wholesale. A partial input therefore only
+ * updates the keys it carries and never drops sibling subkeys (e.g. a file
+ * containing `{ output: { format: "text" } }` leaves `output.detail` intact).
+ *
+ * `base` is treated as immutable — a fresh object graph is returned.
+ */
+function deepMergeConfig<T>(base: T, incoming: unknown): T {
+  if (!isPlainObject(incoming)) return incoming as T;
+  const baseObj = isPlainObject(base) ? (base as Record<string, unknown>) : {};
+  const out: Record<string, unknown> = { ...baseObj };
+  for (const [key, value] of Object.entries(incoming)) {
+    if (value === undefined) continue;
+    if (isPlainObject(value) && isPlainObject(baseObj[key])) {
+      out[key] = deepMergeConfig(baseObj[key], value);
+    } else {
+      out[key] = value;
+    }
+  }
+  return out as T;
+}
+
+/** True for non-null, non-array plain objects. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
  * Apply a JSON config blob non-interactively, merging it with the current config.
  * Validates required sub-fields and strips unknown/restricted keys.
  */
@@ -2237,6 +2273,12 @@ export async function runSetupFromConfig(opts: {
   dir?: string;
   noInit?: boolean;
   probe?: boolean;
+  /**
+   * When true (`--yes --file`), fill any keys still missing after the deep
+   * merge with non-interactive defaults — without overwriting values the file
+   * or existing config already supplied.
+   */
+  applyDefaults?: boolean;
 }): Promise<SetupSummary> {
   // Phase 1: Parse JSON
   type IncomingShape = Partial<AkmConfig> & {
@@ -2292,11 +2334,15 @@ export async function runSetupFromConfig(opts: {
   applyStashIsolationToEnv(stashDir, stashDirExplicit);
 
   let merged: AkmConfig = { ...current, stashDir };
-  // Apply non-llm/agent keys directly.
-  const mergedRec = merged as unknown as Record<string, unknown>;
+  // Deep-merge non-llm/agent keys: nested objects merge key-by-key so a
+  // partial `--file` only updates the keys it carries and never drops sibling
+  // subkeys (e.g. output.detail survives an output.format-only file). Arrays
+  // and scalars replace wholesale.
   for (const key of Object.keys(incoming)) {
     if (key === "llm" || key === "agent") continue;
-    mergedRec[key] = (incoming as Record<string, unknown>)[key];
+    const incomingVal = (incoming as Record<string, unknown>)[key];
+    const mergedRec = merged as unknown as Record<string, unknown>;
+    mergedRec[key] = deepMergeConfig(mergedRec[key], incomingVal);
   }
   // Translate legacy llm/agent inputs into the new shape.
   if (incoming.llm) {
@@ -2304,6 +2350,29 @@ export async function runSetupFromConfig(opts: {
   }
   if (incoming.agent) {
     merged = { ...merged, ...applyLegacyAgent(merged, incoming.agent) };
+  }
+
+  // With `--yes`, fill keys still missing after the merge with non-interactive
+  // defaults. Steps start from `merged` and their nonInteractive path only
+  // populates absent values, so nothing the file or existing config supplied
+  // is overwritten.
+  if (opts.applyDefaults) {
+    const ctx = createSetupContext(merged, { nonInteractive: true });
+    const { steps } = buildSetupSteps({
+      online: false,
+      semanticSearchOutcome: { mode: merged.semanticSearchMode, prepareAssets: false },
+      preferredStashDir: stashDir,
+    });
+    await runSetupSteps(steps, ctx);
+    if (!ctx.config.stashDir) ctx.apply({ stashDir });
+    if (!ctx.config.defaults?.agent) {
+      const detected = detectAgentCliProfiles(undefined);
+      const defaultProfile = pickDefaultAgentProfile(detected, undefined);
+      if (defaultProfile) {
+        ctx.apply(applyLegacyAgent(ctx.config, { default: defaultProfile }));
+      }
+    }
+    merged = ctx.config;
   }
 
   // Bootstrap directory structure
@@ -2332,10 +2401,7 @@ export async function runSetupFromConfig(opts: {
   }
 
   const cfgPath3 = getConfigPath();
-  if (fs.existsSync(cfgPath3)) {
-    backupExistingConfig(cfgPath3);
-    p.log.info(`Config backed up to ~/.cache/akm/config-backups/`);
-  }
+  backupAndAnnounce(cfgPath3);
   saveConfig(merged);
 
   return {

--- a/tests/setup/setup-safe-config.test.ts
+++ b/tests/setup/setup-safe-config.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for issue #511: safe-by-default `akm setup` config management.
+ *
+ * Covers the three non-interactive write paths (`runSetupFromConfig` and
+ * `runSetupWithDefaults`) and their merge / backup guarantees:
+ *   - `--file` / `--config` deep-merge: a partial input only updates the keys
+ *     it carries and never drops sibling subkeys.
+ *   - `--yes` idempotency: running N times == running once (fill-missing-only,
+ *     never overwrite an existing value).
+ *   - `--yes --file`: deep-merge plus defaults-fill, no prompts.
+ *   - no pre-existing key is silently dropped in any mode.
+ *   - a real (timestamped) backup is taken when a config already exists.
+ *
+ * Each test drives the setup functions directly inside an isolated XDG sandbox
+ * so config reads/writes/backups land in temp dirs, never the host config.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+import { resetConfigCache } from "../../src/core/config";
+import { getConfigPath } from "../../src/core/paths";
+import { runSetupFromConfig, runSetupWithDefaults } from "../../src/setup/setup";
+import {
+  type Cleanup,
+  sandboxXdgCacheHome,
+  sandboxXdgConfigHome,
+  sandboxXdgDataHome,
+  sandboxXdgStateHome,
+  writeSandboxConfig,
+} from "../_helpers/sandbox";
+
+let cleanup: Cleanup | undefined;
+
+beforeEach(() => {
+  // Chain isolated XDG dirs so config (write), cache (backups), data & state
+  // all resolve into temp dirs for the duration of the test.
+  const cfg = sandboxXdgConfigHome();
+  const cache = sandboxXdgCacheHome(cfg.cleanup);
+  const data = sandboxXdgDataHome(cache.cleanup);
+  const state = sandboxXdgStateHome(data.cleanup);
+  cleanup = state.cleanup;
+  resetConfigCache();
+});
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+});
+
+function readWrittenConfig(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(getConfigPath(), "utf8")) as Record<string, unknown>;
+}
+
+function backupDir(): string {
+  return path.join(process.env.XDG_CACHE_HOME as string, "akm", "config-backups");
+}
+
+/** A fully-populated, persistent (non-transient) starting config. */
+function seedFullConfig(): void {
+  writeSandboxConfig({
+    stashDir: "/home/tester/akm",
+    semanticSearchMode: "off",
+    output: { format: "json", detail: "full" },
+    profiles: { agent: { claude: { platform: "claude", bin: "claude" } } },
+    defaults: { agent: "claude" },
+    sources: [{ path: "/home/tester/akm/skills", type: "filesystem" }],
+    registries: [{ name: "default", url: "https://example.com/registry" }],
+  });
+  // writeSandboxConfig writes straight to disk, bypassing saveConfig's cache
+  // invalidation — drop the cache so loadUserConfig re-reads the seed.
+  resetConfigCache();
+}
+
+describe("runSetupFromConfig — deep merge", () => {
+  test("partial --file updates a nested key but preserves sibling subkeys", async () => {
+    seedFullConfig();
+
+    await runSetupFromConfig({
+      configJson: JSON.stringify({ output: { format: "text" } }),
+      noInit: true,
+    });
+
+    const written = readWrittenConfig();
+    const output = written.output as Record<string, unknown>;
+    // The updated subkey changed...
+    expect(output.format).toBe("text");
+    // ...but its sibling survived (the bug this fixes: shallow replace dropped it).
+    expect(output.detail).toBe("full");
+    // And unrelated top-level keys are untouched.
+    expect(written.profiles).toEqual({ agent: { claude: { platform: "claude", bin: "claude" } } });
+    expect(written.defaults).toEqual({ agent: "claude" });
+    expect(written.sources).toEqual([{ path: "/home/tester/akm/skills", type: "filesystem" }]);
+    expect(written.registries).toEqual([{ name: "default", url: "https://example.com/registry" }]);
+  });
+
+  test("--config follows the identical deep-merge semantics as --file", async () => {
+    seedFullConfig();
+
+    // --config and --file share runSetupFromConfig; this asserts the JSON-blob
+    // path deep-merges too (sibling subkey survives).
+    await runSetupFromConfig({
+      configJson: JSON.stringify({ output: { detail: "brief" } }),
+      noInit: true,
+    });
+
+    const output = readWrittenConfig().output as Record<string, unknown>;
+    expect(output.detail).toBe("brief");
+    expect(output.format).toBe("json");
+  });
+
+  test("nested profiles merge key-by-key (sibling agent profile survives)", async () => {
+    seedFullConfig();
+
+    // Adding a second agent profile must not drop the seeded `claude` profile.
+    await runSetupFromConfig({
+      configJson: JSON.stringify({
+        profiles: { agent: { opencode: { platform: "opencode", bin: "opencode" } } },
+      }),
+      noInit: true,
+    });
+
+    const profiles = readWrittenConfig().profiles as { agent: Record<string, unknown> };
+    expect(profiles.agent.claude).toEqual({ platform: "claude", bin: "claude" });
+    expect(profiles.agent.opencode).toEqual({ platform: "opencode", bin: "opencode" });
+  });
+
+  test("an empty --config drops no pre-existing key", async () => {
+    seedFullConfig();
+    const before = readWrittenConfig();
+
+    await runSetupFromConfig({ configJson: "{}", noInit: true });
+
+    const after = readWrittenConfig();
+    for (const key of Object.keys(before)) {
+      expect(after[key]).toEqual(before[key]);
+    }
+  });
+});
+
+describe("runSetupFromConfig — backup guarantees", () => {
+  test("creates a real timestamped backup when a config already exists", async () => {
+    seedFullConfig();
+
+    const result = await runSetupFromConfig({
+      configJson: JSON.stringify({ output: { format: "text" } }),
+      noInit: true,
+    });
+    expect(result.written).toBe(true);
+
+    const entries = fs.readdirSync(backupDir());
+    expect(entries.some((n) => /^config-.*\.json$/.test(n) && n !== "config.latest.json")).toBe(true);
+    expect(entries).toContain("config.latest.json");
+  });
+});
+
+describe("runSetupFromConfig — --yes (applyDefaults) deep-merge + fill", () => {
+  test("deep-merges the file and leaves non-file keys untouched", async () => {
+    seedFullConfig();
+
+    await runSetupFromConfig({
+      configJson: JSON.stringify({ output: { format: "text" } }),
+      noInit: true,
+      applyDefaults: true,
+    });
+
+    const written = readWrittenConfig();
+    const output = written.output as Record<string, unknown>;
+    expect(output.format).toBe("text");
+    expect(output.detail).toBe("full");
+    // Existing values preserved; defaults only fill what was missing.
+    expect(written.stashDir).toBe("/home/tester/akm");
+    expect(written.defaults).toEqual({ agent: "claude" });
+  });
+});
+
+describe("runSetupWithDefaults — idempotency", () => {
+  test("preserves every existing value and is byte-identical across runs", async () => {
+    seedFullConfig();
+
+    await runSetupWithDefaults({ noInit: true });
+    const first = fs.readFileSync(getConfigPath(), "utf8");
+
+    await runSetupWithDefaults({ noInit: true });
+    const second = fs.readFileSync(getConfigPath(), "utf8");
+
+    expect(second).toBe(first);
+
+    // No pre-existing value was overwritten by a default.
+    const written = JSON.parse(first) as Record<string, unknown>;
+    expect(written.stashDir).toBe("/home/tester/akm");
+    expect(written.output).toEqual({ format: "json", detail: "full" });
+    expect(written.sources).toEqual([{ path: "/home/tester/akm/skills", type: "filesystem" }]);
+    expect(written.registries).toEqual([{ name: "default", url: "https://example.com/registry" }]);
+    expect(written.defaults).toEqual({ agent: "claude" });
+  });
+
+  test("on a fresh install writes config and takes no backup", async () => {
+    // No seed: no config on disk yet.
+    expect(fs.existsSync(getConfigPath())).toBe(false);
+
+    const result = await runSetupWithDefaults({ noInit: true });
+    expect(result.written).toBe(true);
+    expect(fs.existsSync(getConfigPath())).toBe(true);
+
+    // Nothing to back up on a fresh install → no backup files written.
+    expect(fs.existsSync(backupDir())).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #511

## Summary
Hardens `akm setup`'s three non-interactive write paths against config clobbering.

### 1. Deep-merge for `--file` / `--config`
`runSetupFromConfig` previously shallow-replaced non-llm/agent top-level keys (`mergedRec[key] = incoming[key]`), wholesale-overwriting nested objects like `output`, `profiles`, `defaults`. It now recursively deep-merges via a new `deepMergeConfig` helper: plain objects merge key-by-key; arrays and scalars replace. A partial `--file` containing only `{"output":{"format":"text"}}` updates `output.format` and leaves `output.detail` (and every other top-level/nested key) intact.

### 2. `--yes --file` / `--yes --config`
Routing in `cli.ts` now sends file/config inputs to `runSetupFromConfig` (already fully non-interactive) and passes `--yes` through as `applyDefaults`, which fills defaults only for keys still missing after the deep-merge — without overwriting supplied values. The `--from`/`--config` mutual-exclusion guard is preserved.

### 3. `--yes` idempotency
Verified `runSetupWithDefaults` preserves every existing value and only fills missing keys (running N times == running once). Only the `stash-dir` step is `nonInteractive`, and its non-interactive path returns the existing `stashDir`, so no set value is overwritten by a default.

### 4. Accurate backup-path printing
`backupExistingConfig` now returns the written backup paths (`ConfigBackupResult`). All three non-interactive paths print the real timestamped backup location, or a "No existing config to back up." notice on fresh install — replacing the hardcoded generic display string.

## Tests
`tests/setup/setup-safe-config.test.ts` covers: partial deep-merge sibling survival, `--config` parity, nested `profiles` merge, empty-input no-key-dropped, real timestamped backup, `--yes --file` merge + fill, `runSetupWithDefaults` byte-identical idempotency, and fresh-install no-backup.

## Gates
- `bunx tsc --noEmit`: pass
- `bun run lint`: pass
- `bun test --timeout 30000 ./tests --path-ignore-patterns=tests/integration`: 3865 pass / 0 fail

Scope: `src/setup/setup.ts`, `src/cli.ts`, `src/core/config-io.ts`, and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)