### PR TITLE
refactor(write-source): unify per-asset git commit into batch-at-boundary (#507)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   monitor needs regardless of design. The session-monitoring/agent-steering loop is
   deferred to #506 and requires a separately approved design.
 
+### Changed
+
+- **Unified git commit model — single batch-at-boundary commit** (#507). Writing
+  or deleting an asset on a git-backed source no longer commits (and optionally
+  pushes) **per asset**. `writeAssetToSource` / `deleteAssetFromSource` now
+  perform a plain filesystem write/unlink for every kind, and git-backed targets
+  are committed **once** at the operation boundary (`akm remember --target`,
+  proposal accept/revert, consolidate) as a single complete commit — `git add -A`
+  stages `.akm/` state + sibling assets together — pushed under the same
+  `writable + remote` gate as `akm save`/`akm sync`. This removes the noisy,
+  incomplete per-asset commits (~25 per improve run) and leaves no dirty
+  working-tree residue.
+
+### Deprecated
+
+- **`options.pushOnCommit`** (#507). The per-asset push-on-commit knob is retired.
+  Existing configs still parse — its push intent is mapped onto the batch push
+  gate and a one-time deprecation warning is emitted when the option is
+  encountered. Remove it and rely on `writable: true` + a configured remote.
+
 ## [0.8.2] - 2026-06-05
 
 ### Added

--- a/docs/features/sources-registries.md
+++ b/docs/features/sources-registries.md
@@ -120,6 +120,13 @@ akm save my-skills -m "Update"   # Named writable git source
 Push behavior depends on configuration: if the stash is a git repo with a
 remote and `writable: true`, save also pushes. Otherwise it commits only.
 
+> **0.9.0:** writes that land on a writable git source via `--target` (e.g.
+> `akm remember --target my-skills`, proposal accept/revert, consolidate) are
+> committed automatically in a single batch at the end of the operation — one
+> complete commit (staging `.akm/` + assets together), pushed under the same
+> `writable + remote` gate as `akm save`. The legacy per-asset `options.pushOnCommit`
+> knob is deprecated; remove it and rely on `writable: true` + push instead.
+
 **Example: publish your own stash**
 
 ```sh

--- a/docs/migration/v0.8-to-v0.9.md
+++ b/docs/migration/v0.8-to-v0.9.md
@@ -89,6 +89,28 @@ triage. **0.9.0** removes the `manage-akm-proposals`-driven prompt-task guidance
 from setup/docs; the deterministic `akm proposal drain` verb plus the optional
 judgment tier (or the folded pre-pass) is the supported path.
 
+## Single batch-at-boundary git commit (`options.pushOnCommit` deprecated)
+
+0.9.0 unifies the two commit models for git-backed sources onto a single
+**batch-at-boundary** model (issue #507). Previously, writing an asset to a
+writable git `--target` committed (and optionally pushed) **per asset**, gated
+on `options.pushOnCommit`. That staged only the single asset file (leaving
+`.akm/` state dirty) and produced one noisy commit per asset.
+
+Now every write/delete to a source is a plain filesystem operation with **no**
+per-asset commit. Git-backed targets are committed **once** at the end of the
+operation (e.g. `akm remember --target <git-source>`, proposal accept/revert,
+consolidate) as a single complete commit (`git add -A` staging `.akm/` + assets
+together), pushed under the same `writable + remote` gate as `akm save`/`akm sync`.
+
+**Migration:** `options.pushOnCommit` is **deprecated**. Existing configs still
+parse — its push intent is honored via the batch push gate, and akm prints a
+one-time deprecation warning when it encounters the option. Remove
+`pushOnCommit` from your source config and rely on `writable: true` (plus a
+configured remote) to push. No behavior is lost: a writable git target with a
+remote is still pushed; a target without a remote (or with push disabled)
+commits only.
+
 ## `vault` → `env` / `secret`
 
 0.9.0 also removes the deprecated `vault` asset type. Its replacement, the `env`

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -163,9 +163,15 @@ deleteAssetFromSource(source, config, ref)
 The flow:
 
 1. Refuse if the source is not `writable`.
-2. Plain filesystem write to `path.join(source.path, …)`.
-3. For `kind === "git"`, run `git add` + `git commit` (and `git push` when
-   `options.pushOnCommit` is set).
+2. Plain filesystem write to `path.join(source.path, …)` — for **every** kind,
+   with no commit (0.9.0, issue #507).
+
+Git-backed targets are committed in a single batch at the operation boundary via
+`commitWriteTargetBoundary(target, message, { push })`, which delegates to
+`saveGitStash`: `git add -A` (staging `.akm/` + sibling assets as one complete
+commit), a guarded commit, and a push gated on `writable && hasRemote &&
+push !== false`. The old per-asset commit/push path (`options.pushOnCommit`) is
+deprecated and no longer commits per asset.
 
 `writable` is a config flag, not an interface concern. Defaults: `true` for
 `filesystem`, `false` for everything else. `writable: true` on `website` or

--- a/docs/technical/v1-architecture-spec.md
+++ b/docs/technical/v1-architecture-spec.md
@@ -171,19 +171,25 @@ export async function writeAssetToSource(
 
   const filePath = resolveAssetPath(source.path(), ref);
   await writeFile(filePath, content);
-
-  // git-specific convenience: commit and optionally push
-  if (source.kind === "git") {
-    await git("-C", source.path(), "add", filePath);
-    await git("-C", source.path(), "commit", "-m", `Update ${formatRef(ref)}`);
-    if (config.options.pushOnCommit) {
-      await git("-C", source.path(), "push");
-    }
-  }
+  // No commit here — for any kind. See the 0.9.0 amendment below.
 }
 ```
 
-This is the **only** place in the codebase that branches on `source.kind`, and it's intentional — "git has a commit step" is domain knowledge, not polymorphism. If a third kind ever needs special write handling, it gets added here. If it becomes more than two or three cases, revisit and introduce a hook. For v1 it's two cases.
+> **0.9.0 amendment (issue #507) — single batch-at-boundary commit.** The
+> original v1 design committed (and optionally pushed) per asset write for
+> `kind === "git"`, gated on `config.options.pushOnCommit`. That model staged
+> only the single asset file (leaving `.akm/` state dirty) and produced one
+> noisy commit per asset (~25 per improve run). It is **retired**. `writeAssetToSource`
+> / `deleteAssetFromSource` now perform a plain filesystem write/unlink for
+> **every** kind and never commit. Git-backed targets are committed **once** at
+> the operation boundary by `commitWriteTargetBoundary(target, message, { push })`,
+> which delegates to `saveGitStash` — `git add -A` (staging `.akm/` + sibling
+> assets as one complete commit), a guarded commit, and a push gated on
+> `writable && hasRemote && push !== false` (the same gate as `improve` sync
+> push). The deprecated `pushOnCommit` knob still parses but only maps its push
+> intent onto that gate and emits a one-time deprecation warning.
+
+With the commit removed, `writeAssetToSource` no longer branches on `source.kind` for commit behaviour — the only remaining `kind` check is the unsupported-kind guard (filesystem / git only).
 
 ### 2.7 Delete is symmetric
 
@@ -196,17 +202,12 @@ export async function deleteAssetFromSource(
   if (!config.writable) throw new UsageError(/* ... */);
   const filePath = resolveAssetPath(source.path(), ref);
   await unlink(filePath);
-  if (source.kind === "git") {
-    await git("-C", source.path(), "add", filePath);
-    await git("-C", source.path(), "commit", "-m", `Remove ${formatRef(ref)}`);
-    if (config.options.pushOnCommit) {
-      await git("-C", source.path(), "push");
-    }
-  }
+  // No commit here — for any kind (0.9.0 amendment, issue #507). The caller
+  // fires commitWriteTargetBoundary() once after a batch of mutations.
 }
 ```
 
-Same pattern.
+Same pattern — symmetric with the write path, and likewise committed once at the operation boundary rather than per asset.
 
 ---
 
@@ -408,8 +409,10 @@ introduces on the locked hit type. Both are optional. Renderers in
       "writable": true },
 
     { "name": "team", "kind": "git",
-      "options": { "url": "git+https://github.com/team/kit", "pushOnCommit": true },
+      "options": { "url": "git+https://github.com/team/kit" },
       "writable": true },
+    // 0.9.0: a writable git source with a remote is pushed by the single
+    // boundary commit; the old per-asset `pushOnCommit` knob is deprecated.
 
     { "name": "upstream", "kind": "git",
       "options": { "url": "git+https://github.com/someone/kit" },

--- a/src/commands/consolidate.ts
+++ b/src/commands/consolidate.ts
@@ -31,7 +31,12 @@ import { detectTruncatedDescription } from "../core/text-truncation";
 export { hasSupersededStatus, validateProposalFrontmatter };
 
 import { warn } from "../core/warn";
-import { deleteAssetFromSource, resolveWriteTarget, writeAssetToSource } from "../core/write-source";
+import {
+  commitWriteTargetBoundary,
+  deleteAssetFromSource,
+  resolveWriteTarget,
+  writeAssetToSource,
+} from "../core/write-source";
 import type { DbIndexedEntry } from "../indexer/db";
 import {
   closeDatabase,
@@ -2023,6 +2028,15 @@ export async function akmConsolidate(opts: AkmConsolidateOptions = {}): Promise<
         pushSkipReason("contradict", op.ref, "contradict_write_failed");
       }
     }
+  }
+
+  // 0.9.0 (issue #507): batch-at-boundary commit. The merge/delete loop above
+  // wrote one merged primary and deleted N secondaries to the resolved target
+  // with NO per-asset commit. If the target is a writable git source and any
+  // asset was mutated, commit the whole batch ONCE here (stages .akm/ +
+  // siblings together). No-op for filesystem/primary-stash targets.
+  if (merged > 0 || deleted > 0) {
+    commitWriteTargetBoundary(target, `Consolidate: ${merged} merged, ${deleted} removed`);
   }
 
   cleanupJournal(stashDir, timestamp);

--- a/src/commands/knowledge.ts
+++ b/src/commands/knowledge.ts
@@ -16,7 +16,12 @@ import { resolveAssetPathFromName } from "../core/asset-spec";
 import { isHttpUrl, isWithin, tryReadStdinText } from "../core/common";
 import { loadConfig } from "../core/config";
 import { UsageError } from "../core/errors";
-import { resolveWriteTarget, writeAssetToSource } from "../core/write-source";
+import {
+  commitWriteTargetBoundary,
+  formatRefForMessage,
+  resolveWriteTarget,
+  writeAssetToSource,
+} from "../core/write-source";
 import { fetchWebsiteMarkdownSnapshot } from "../sources/website-ingest";
 
 const MAX_CAPTURED_ASSET_SLUG_LENGTH = 64;
@@ -133,7 +138,8 @@ export async function writeMarkdownAsset(options: {
   target?: string;
 }): Promise<{ ref: string; path: string; stashDir: string }> {
   const cfg = loadConfig();
-  const { source, config } = resolveWriteTarget(cfg, options.target);
+  const target = resolveWriteTarget(cfg, options.target);
+  const { source, config } = target;
 
   const typeRoot = path.join(source.path, options.type === "knowledge" ? "knowledge" : "memories");
   const normalizedName = normalizeMarkdownAssetName(
@@ -154,12 +160,11 @@ export async function writeMarkdownAsset(options: {
     );
   }
 
-  const result = await writeAssetToSource(
-    source,
-    config,
-    { type: options.type, name: normalizedName },
-    options.content,
-  );
+  const ref = { type: options.type, name: normalizedName };
+  const result = await writeAssetToSource(source, config, ref, options.content);
+  // 0.9.0 (issue #507): single batch commit at the write boundary for git
+  // targets. No-op for filesystem/primary-stash targets.
+  commitWriteTargetBoundary(target, `Update ${formatRefForMessage(ref)}`);
   return {
     ref: result.ref,
     path: result.path,

--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -252,6 +252,11 @@ export const DefaultsSchema = z
 
 const SourceConfigEntryOptionsSchema = z
   .object({
+    /**
+     * @deprecated 0.9.0 (issue #507). Retired per-asset push-on-commit. Kept so
+     * old configs still parse; its intent maps onto the batch push gate and
+     * encountering it emits a one-time deprecation warning.
+     */
     pushOnCommit: z.boolean().optional(),
   })
   .passthrough();

--- a/src/core/config-types.ts
+++ b/src/core/config-types.ts
@@ -290,7 +290,14 @@ export interface ConfiguredSource {
 
 /** Provider-specific options for a configured source entry. */
 export interface SourceConfigEntryOptions {
-  /** When true and the source is a git repo, akm runs `git push` after every asset commit. */
+  /**
+   * @deprecated 0.9.0 (issue #507). The per-asset commit/push path is retired:
+   * akm now commits writes in a single batch at the operation boundary and
+   * pushes when the target is writable with a remote (same gate as `sync.push`).
+   * The field still parses so old configs load; its push intent is mapped onto
+   * the batch push gate, and an encountered value emits a one-time deprecation
+   * warning. Prefer `writable: true` + sync push instead.
+   */
   pushOnCommit?: boolean;
   /** Pass-through catch-all for provider-specific options. */
   [key: string]: unknown;

--- a/src/core/proposals.ts
+++ b/src/core/proposals.ts
@@ -49,7 +49,13 @@ import { NotFoundError, UsageError } from "./errors";
 import { appendEvent } from "./events";
 import { runProposalValidators } from "./proposal-validators";
 import { warn } from "./warn";
-import { resolveWriteTarget, type WriteTargetSource, writeAssetToSource } from "./write-source";
+import {
+  commitWriteTargetBoundary,
+  formatRefForMessage,
+  resolveWriteTarget,
+  type WriteTargetSource,
+  writeAssetToSource,
+} from "./write-source";
 
 // ── Source allow-list (F-4 / #385) ──────────────────────────────────────────
 
@@ -1021,6 +1027,9 @@ export async function promoteProposal(
   }
 
   const written = await writeAssetToSource(target.source, target.config, ref, proposal.payload.content);
+  // 0.9.0 (issue #507): single batch commit at the write boundary for git
+  // targets. No-op for filesystem/primary-stash targets.
+  commitWriteTargetBoundary(target, `Update ${formatRefForMessage(ref)}`);
 
   const archived = archiveProposal(stashDir, id, "accepted", undefined, ctx);
 
@@ -1110,6 +1119,9 @@ export async function revertProposal(
 
   const target = resolveWriteTarget(config, options.target);
   const written = await writeAssetToSource(target.source, target.config, ref, backupContent);
+  // 0.9.0 (issue #507): single batch commit at the write boundary for git
+  // targets. No-op for filesystem/primary-stash targets.
+  commitWriteTargetBoundary(target, `Revert ${formatRefForMessage(ref)}`);
 
   // Update the archived proposal record to status: "reverted" and bump
   // updatedAt + review so the audit trail reflects the second decision.

--- a/src/core/write-source.ts
+++ b/src/core/write-source.ts
@@ -3,27 +3,30 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 /**
- * write-source — the only place in the codebase that branches on `source.kind`.
+ * write-source — the command-layer helper that performs asset writes.
  *
- * v1 architecture spec §2.6 / §2.7 / §10 step 5: writing to a source is *not*
- * a SourceProvider interface concern. It's a small command-layer helper that
- * does a plain filesystem write, plus a git-specific commit (and optional
- * push) when the source is backed by a git working tree.
+ * v1 architecture spec §2.6 / §2.7 / §10 step 5 (amended for 0.9.0): writing to
+ * a source is *not* a SourceProvider interface concern. It's a small
+ * command-layer helper that does a plain filesystem write for **every** kind.
  *
- * If a third kind ever needs special write handling, it gets added here. For
- * v1 there are exactly two cases. Adding more parallel scoring systems for
- * different provider kinds is explicitly disallowed by CLAUDE.md.
+ * 0.9.0 amendment (issue #507): the per-asset git commit/push path is retired.
+ * `writeAssetToSource` / `deleteAssetFromSource` no longer branch on `kind` for
+ * commit behaviour — they only ever touch the filesystem. Git-backed targets
+ * are committed in a SINGLE batch at the operation boundary via
+ * {@link commitWriteTargetBoundary} (which delegates to `saveGitStash`). This
+ * stages `.akm/` + sibling assets together as one complete commit instead of
+ * one noisy, incomplete commit per asset.
  *
- * This module is the **single dispatch point** for `kind`-branching write
- * logic. Callers (remember, import, source-add, etc.) MUST go through
- * `writeAssetToSource` / `deleteAssetFromSource` rather than re-inlining the
- * filesystem-write + git-commit dance.
+ * This module is still the **single dispatch point** for write/delete: callers
+ * (remember, import, source-add, etc.) MUST go through `writeAssetToSource` /
+ * `deleteAssetFromSource` rather than re-inlining a filesystem write, and they
+ * fire {@link commitWriteTargetBoundary} once after a batch of mutations to a
+ * writable git target.
  */
 
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { getCachePaths, parseGitRepoUrl } from "../sources/providers/git";
+import { getCachePaths, parseGitRepoUrl, saveGitStash } from "../sources/providers/git";
 import type { AssetRef } from "./asset-ref";
 import { makeAssetRef } from "./asset-ref";
 import { resolveAssetPathFromName, TYPE_DIRS } from "./asset-spec";
@@ -146,16 +149,13 @@ export function assertWritableAllowedForKind(entry: Pick<SourceConfigEntry, "typ
  * `ref`. Always:
  *
  *   1. Refuses if `config.writable` is not truthy (per §5.4).
- *   2. Performs a plain filesystem write to `path.join(source.path, …)`.
+ *   2. Rejects unsupported kinds (anything but `filesystem` / `git`).
+ *   3. Performs a plain filesystem write to `path.join(source.path, …)`.
  *
- * For sources of `kind === "git"`, additionally:
- *
- *   3. `git -C <path> add <file>`
- *   4. `git -C <path> commit -m "Update <ref>"`
- *   5. `git -C <path> push` when `config.options.pushOnCommit` is truthy.
- *
- * Any other `kind` reaching this helper is a configuration bug — the loader
- * rejects unsupported writable kinds — so we throw {@link ConfigError}.
+ * No commit runs here — for **every** kind. Git-backed targets are committed in
+ * one batch at the operation boundary via {@link commitWriteTargetBoundary}
+ * (0.9.0 amendment, issue #507). The caller fires that boundary commit once
+ * after a batch of mutations to a writable git target.
  */
 export async function writeAssetToSource(
   source: WriteTargetSource,
@@ -164,21 +164,21 @@ export async function writeAssetToSource(
   content: string,
 ): Promise<{ path: string; ref: string }> {
   ensureWritable(source, config);
+  assertSupportedKind(source);
 
   const filePath = resolveAssetFilePath(source, ref);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   const normalized = content.endsWith("\n") ? content : `${content}\n`;
   fs.writeFileSync(filePath, normalized, "utf8");
 
-  await runKindSpecificCommit(source, config, filePath, `Update ${formatRefForMessage(ref)}`);
-
   return { path: filePath, ref: makeAssetRef(ref.type, ref.name, ref.origin) };
 }
 
 /**
  * Delete the asset at `ref` from `source`. Symmetric to
- * {@link writeAssetToSource}: same writable check, same git-commit-and-push
- * convenience for `kind === "git"`.
+ * {@link writeAssetToSource}: same writable check, same unsupported-kind guard,
+ * a plain `unlink` with no commit. Git-backed targets are committed once at the
+ * operation boundary via {@link commitWriteTargetBoundary}.
  */
 export async function deleteAssetFromSource(
   source: WriteTargetSource,
@@ -186,6 +186,7 @@ export async function deleteAssetFromSource(
   ref: AssetRef,
 ): Promise<{ path: string; ref: string }> {
   ensureWritable(source, config);
+  assertSupportedKind(source);
 
   const filePath = resolveAssetFilePath(source, ref);
   if (!fs.existsSync(filePath)) {
@@ -196,9 +197,67 @@ export async function deleteAssetFromSource(
   }
   fs.unlinkSync(filePath);
 
-  await runKindSpecificCommit(source, config, filePath, `Remove ${formatRefForMessage(ref)}`);
-
   return { path: filePath, ref: makeAssetRef(ref.type, ref.name, ref.origin) };
+}
+
+/**
+ * Fire the one-shot batch-at-boundary commit for a resolved write target.
+ *
+ * 0.9.0 (issue #507): replaces the retired per-asset git commit. Callers invoke
+ * this EXACTLY ONCE after a batch of writes/deletes to a resolved write target.
+ * It is a no-op for any non-git target (plain filesystem sources and the
+ * primary stash stay non-committing here — the primary stash is committed by
+ * the existing improve auto-sync boundary).
+ *
+ * For a git target it delegates to `saveGitStash(name, message, writable, …)`,
+ * which stages `.akm/` + sibling assets together (`git add -A`), commits once,
+ * and pushes when the target is writable, has a remote, and `push !== false`.
+ *
+ * The push intent honours a deprecated `options.pushOnCommit` on the source
+ * config (mapped onto the batch push gate) when `push` is not explicitly set.
+ */
+export function commitWriteTargetBoundary(
+  target: ResolvedWriteTarget,
+  message: string,
+  options?: { push?: boolean },
+): void {
+  if (target.source.kind !== "git") return;
+
+  warnIfPushOnCommit(target.config);
+
+  // Map the deprecated per-asset `pushOnCommit` intent onto the batch push gate
+  // when the caller did not pass an explicit push toggle. `saveGitStash` still
+  // gates the actual push on writable + remote, so this only ever opts *in*.
+  const push = options?.push ?? (target.config.options?.pushOnCommit === true ? true : undefined);
+
+  const writable = resolveWritable(target.config);
+  // Commit against the already-resolved repo directory (target.source.path)
+  // rather than re-resolving the stash by name through config. The write helper
+  // resolved this exact path; the boundary commit must operate on the SAME
+  // directory so the staged batch matches what was just written.
+  saveGitStash(undefined, message, writable, {
+    repoDir: target.source.path,
+    ...(push === undefined ? {} : { push }),
+  });
+}
+
+/**
+ * Emit a one-time deprecation warning the first time a source config carrying
+ * `options.pushOnCommit` is encountered. The field still parses (for old
+ * configs) but its per-asset push-on-commit behaviour is retired; its intent is
+ * now honoured via the batch push gate (writable + remote + push toggle).
+ */
+let pushOnCommitWarned = false;
+function warnIfPushOnCommit(config: SourceConfigEntry): void {
+  if (config.options?.pushOnCommit === undefined) return;
+  if (pushOnCommitWarned) return;
+  pushOnCommitWarned = true;
+  const label = config.name ? ` on source "${config.name}"` : "";
+  process.stderr.write(
+    `warning: \`options.pushOnCommit\`${label} is deprecated (0.9.0) and no longer commits per asset. ` +
+      "akm now commits writes in a single batch at the operation boundary and pushes when the target is " +
+      "writable with a remote. Remove the option or rely on sync push instead.\n",
+  );
 }
 
 // ── Write-target resolution (locked decision 3) ─────────────────────────────
@@ -283,12 +342,10 @@ export function resolveWriteTarget(akmConfig: AkmConfig, explicitTarget?: string
   //
   // The primary stash stays `kind: "filesystem"` on purpose, even when it is a
   // git repo on disk (recognized elsewhere via isGitBackedStash). Returning
-  // `kind: "git"` here would route every asset write through the per-asset
-  // runGitCommit, which is INCOMPLETE (stages only the single asset file,
-  // leaving .akm/proposals + other state dirty) and NOISY (one commit per
-  // asset, ~25 per improve run). Recognition is decoupled: per-write stays
-  // non-committing, and the primary stash is committed in a single batch at
-  // operation boundaries (e.g. the end-of-run improve auto-sync via saveGitStash).
+  // `kind: "git"` here would fire the boundary commit on every write through
+  // this resolver, double-committing the primary stash which is already
+  // committed in a single batch at operation boundaries (e.g. the end-of-run
+  // improve auto-sync via saveGitStash). Per-write stays non-committing.
   try {
     const stashDir = resolveStashDir({ readOnly: true });
     return {
@@ -337,25 +394,14 @@ function resolveAssetFilePath(source: WriteTargetSource, ref: AssetRef): string 
   return assetPath;
 }
 
-async function runKindSpecificCommit(
-  source: WriteTargetSource,
-  config: SourceConfigEntry,
-  filePath: string,
-  message: string,
-): Promise<void> {
-  if (source.kind === "filesystem") {
-    return; // No commit step.
-  }
-  if (source.kind === "git") {
-    runGitCommit(source.path, filePath, message);
-    if (config.options?.pushOnCommit) {
-      runGitPush(source.path);
-    }
-    return;
-  }
-  // Reject any other kind reaching the helper. The config loader is the
-  // first line of defence (assertWritableAllowedForKind), but we throw here
-  // so external callers that bypass the loader still get a clear error.
+/**
+ * Reject any kind reaching the write/delete helpers other than the two
+ * supported writable kinds. The config loader is the first line of defence
+ * (assertWritableAllowedForKind), but we throw here so external callers that
+ * bypass the loader still get a clear error.
+ */
+function assertSupportedKind(source: WriteTargetSource): void {
+  if (source.kind === "filesystem" || source.kind === "git") return;
   throw new ConfigError(
     `write-source: unsupported kind "${source.kind}" for source "${source.name}". ` +
       "Writes are only defined for `filesystem` and `git` sources.",
@@ -364,50 +410,7 @@ async function runKindSpecificCommit(
   );
 }
 
-function runGitCommit(repoDir: string, filePath: string, message: string): void {
-  // Stage the specific file rather than `add -A` so unrelated working-tree
-  // changes don't get folded into the asset commit.
-  const relPath = path.relative(repoDir, filePath) || filePath;
-  const addResult = spawnSync("git", ["-C", repoDir, "add", "--", relPath], { encoding: "utf8" });
-  if (addResult.status !== 0) {
-    throw new Error(`git add failed: ${addResult.stderr?.trim() || "unknown error"}`);
-  }
-
-  // Defense in depth: sanitize the commit subject one more time at the spawn
-  // boundary. Callers should already pass sanitized strings (via
-  // formatRefForMessage / saveGitStash), but this guards against future
-  // refactors that forget. Empty after sanitize falls back to a safe stub.
-  const safeMessage = sanitizeCommitMessage(message) || "akm update";
-
-  // Provide a fallback identity so fresh CI/test environments without
-  // user.name/user.email configured can always commit.
-  const commitResult = spawnSync(
-    "git",
-    ["-C", repoDir, "-c", "user.name=akm", "-c", "user.email=akm@local", "commit", "-m", safeMessage],
-    { encoding: "utf8" },
-  );
-  if (commitResult.status !== 0) {
-    // `nothing to commit` is a no-op success — the file may have matched the
-    // existing tree exactly. Surface other errors verbatim.
-    const stderr = commitResult.stderr ?? "";
-    if (
-      /nothing to commit|no changes added/i.test(stderr) ||
-      /nothing to commit|no changes added/i.test(commitResult.stdout ?? "")
-    ) {
-      return;
-    }
-    throw new Error(`git commit failed: ${stderr.trim() || "unknown error"}`);
-  }
-}
-
-function runGitPush(repoDir: string): void {
-  const pushResult = spawnSync("git", ["-C", repoDir, "push"], { encoding: "utf8", timeout: 120_000 });
-  if (pushResult.status !== 0) {
-    throw new Error(`git push failed: ${pushResult.stderr?.trim() || "unknown error"}`);
-  }
-}
-
-function formatRefForMessage(ref: AssetRef): string {
+export function formatRefForMessage(ref: AssetRef): string {
   // Sanitize each component independently. `ref.origin` originates from user
   // config and could contain CR/LF that would otherwise be smuggled into the
   // commit subject and forge trailers downstream. `ref.type` and `ref.name`

--- a/tests/core/write-source.test.ts
+++ b/tests/core/write-source.test.ts
@@ -5,12 +5,15 @@
  *
  *   - writable refusal (default-resolution + explicit `writable: false`)
  *   - plain filesystem write
- *   - git commit on success
- *   - git commit + push when `pushOnCommit` is set
- *   - git delete (commits the deletion)
+ *   - git write/delete leaves the file on disk with NO per-write commit (0.9.0)
+ *   - the single batch-at-boundary commit (issue #507) produces exactly one
+ *     complete commit + clean tree, pushes per the writable+remote+push gate,
+ *     and is a no-op for filesystem targets
+ *   - deprecated `pushOnCommit` maps onto the batch push gate
  *   - rejection of `writable: true` on website / npm at config load
  *   - rejection of unsupported `kind` reaching the helper
  *   - resolveWriteTarget precedence (explicit → defaultWriteTarget → stashDir)
+ *   - commit-message sanitization (issue #270) via the boundary commit
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -23,7 +26,10 @@ import type { SourceConfigEntry } from "../../src/core/config";
 import { ConfigError, UsageError } from "../../src/core/errors";
 import {
   assertWritableAllowedForKind,
+  commitWriteTargetBoundary,
   deleteAssetFromSource,
+  formatRefForMessage,
+  type ResolvedWriteTarget,
   resolveWritable,
   resolveWriteTarget,
   sanitizeCommitMessage,
@@ -200,72 +206,154 @@ describe("writeAssetToSource — filesystem", () => {
   });
 });
 
-// ── writeAssetToSource — git ────────────────────────────────────────────────
+// ── writeAssetToSource — git (0.9.0 batch-at-boundary, issue #507) ───────────
 
-describe("writeAssetToSource — git", () => {
-  test("performs a git commit after writing", async () => {
+function gitTarget(workDir: string, opts?: { writable?: boolean; pushOnCommit?: boolean }): ResolvedWriteTarget {
+  const config: SourceConfigEntry = {
+    type: "git",
+    name: "team",
+    writable: opts?.writable ?? true,
+    ...(opts?.pushOnCommit !== undefined ? { options: { pushOnCommit: opts.pushOnCommit } } : {}),
+  };
+  return { source: { kind: "git", name: "team", path: workDir }, config };
+}
+
+describe("writeAssetToSource — git (no per-write commit)", () => {
+  test("git write leaves the file on disk with NO per-write commit", async () => {
     const { workDir } = initBareGitRepo();
-    const source: WriteTargetSource = { kind: "git", name: "team", path: workDir };
-    const config: SourceConfigEntry = { type: "git", writable: true };
+    const target = gitTarget(workDir);
 
-    await writeAssetToSource(source, config, { type: "memory", name: "alpha" }, "body");
+    await writeAssetToSource(target.source, target.config, { type: "memory", name: "alpha" }, "body");
 
+    // The file is written...
+    expect(fs.existsSync(path.join(workDir, "memories", "alpha.md"))).toBe(true);
+    // ...but no commit ran: HEAD is still the seed, and the working tree is dirty.
+    const log = spawnSync("git", ["-C", workDir, "log", "--format=%s", "-1"], { encoding: "utf8" });
+    expect(log.stdout.trim()).toBe("seed");
+    const status = spawnSync("git", ["-C", workDir, "status", "--porcelain"], { encoding: "utf8" });
+    expect(status.stdout.trim()).not.toBe("");
+  });
+
+  test("the boundary commit produces exactly one complete commit and a clean tree", async () => {
+    const { workDir } = initBareGitRepo();
+    const target = gitTarget(workDir);
+
+    await writeAssetToSource(target.source, target.config, { type: "memory", name: "alpha" }, "body");
+    commitWriteTargetBoundary(target, "Update memory:alpha");
+
+    // Exactly one new commit on top of the seed.
+    const count = spawnSync("git", ["-C", workDir, "rev-list", "--count", "HEAD"], { encoding: "utf8" });
+    expect(count.stdout.trim()).toBe("2");
     const log = spawnSync("git", ["-C", workDir, "log", "--format=%s", "-1"], { encoding: "utf8" });
     expect(log.stdout.trim()).toBe("Update memory:alpha");
-    // Working tree should be clean post-commit.
+    // No dirty residue: the boundary commit staged the asset (add -A).
     const status = spawnSync("git", ["-C", workDir, "status", "--porcelain"], { encoding: "utf8" });
     expect(status.stdout.trim()).toBe("");
   });
 
-  test("pushes when pushOnCommit option is set", async () => {
+  test("multiple writes collapse into ONE boundary commit (batch-at-boundary)", async () => {
+    const { workDir } = initBareGitRepo();
+    const target = gitTarget(workDir);
+
+    await writeAssetToSource(target.source, target.config, { type: "memory", name: "one" }, "a");
+    await writeAssetToSource(target.source, target.config, { type: "memory", name: "two" }, "b");
+    await deleteAssetFromSource(target.source, target.config, { type: "memory", name: "one" });
+    commitWriteTargetBoundary(target, "Batch update");
+
+    // Only one commit was produced for the whole batch.
+    const count = spawnSync("git", ["-C", workDir, "rev-list", "--count", "HEAD"], { encoding: "utf8" });
+    expect(count.stdout.trim()).toBe("2");
+    // The surviving asset is tracked; the deleted one is gone; tree is clean.
+    expect(fs.existsSync(path.join(workDir, "memories", "two.md"))).toBe(true);
+    expect(fs.existsSync(path.join(workDir, "memories", "one.md"))).toBe(false);
+    const status = spawnSync("git", ["-C", workDir, "status", "--porcelain"], { encoding: "utf8" });
+    expect(status.stdout.trim()).toBe("");
+  });
+
+  test("boundary commit pushes when target is writable with a remote", async () => {
     const { remoteDir, workDir } = initBareGitRepo();
-    const source: WriteTargetSource = { kind: "git", name: "team", path: workDir };
-    const config: SourceConfigEntry = {
-      type: "git",
-      writable: true,
-      options: { pushOnCommit: true },
-    };
+    const target = gitTarget(workDir, { writable: true });
 
-    await writeAssetToSource(source, config, { type: "memory", name: "pushed" }, "body");
+    await writeAssetToSource(target.source, target.config, { type: "memory", name: "pushed" }, "body");
+    commitWriteTargetBoundary(target, "Update memory:pushed");
 
-    // Confirm the commit landed on the bare remote.
     const remoteLog = spawnSync("git", ["--git-dir", remoteDir, "log", "--format=%s", "-1", "main"], {
       encoding: "utf8",
     });
     expect(remoteLog.stdout.trim()).toBe("Update memory:pushed");
   });
 
-  test("does not push when pushOnCommit is absent", async () => {
+  test("boundary commit does not push when push is disabled", async () => {
     const { remoteDir, workDir } = initBareGitRepo();
-    const source: WriteTargetSource = { kind: "git", name: "team", path: workDir };
-    const config: SourceConfigEntry = { type: "git", writable: true };
+    const target = gitTarget(workDir, { writable: true });
 
-    await writeAssetToSource(source, config, { type: "memory", name: "local-only" }, "body");
+    await writeAssetToSource(target.source, target.config, { type: "memory", name: "local-only" }, "body");
+    commitWriteTargetBoundary(target, "Update memory:local-only", { push: false });
+
+    // Commit landed locally...
+    const localLog = spawnSync("git", ["-C", workDir, "log", "--format=%s", "-1"], { encoding: "utf8" });
+    expect(localLog.stdout.trim()).toBe("Update memory:local-only");
+    // ...but the remote still only has the seed commit.
+    const remoteLog = spawnSync("git", ["--git-dir", remoteDir, "log", "--format=%s", "-1", "main"], {
+      encoding: "utf8",
+    });
+    expect(remoteLog.stdout.trim()).toBe("seed");
+  });
+
+  test("deprecated pushOnCommit maps onto the batch push gate (still pushes)", async () => {
+    const { remoteDir, workDir } = initBareGitRepo();
+    const target = gitTarget(workDir, { writable: true, pushOnCommit: true });
+
+    await writeAssetToSource(target.source, target.config, { type: "memory", name: "legacy" }, "body");
+    commitWriteTargetBoundary(target, "Update memory:legacy");
 
     const remoteLog = spawnSync("git", ["--git-dir", remoteDir, "log", "--format=%s", "-1", "main"], {
       encoding: "utf8",
     });
-    // Remote still only has the seed commit.
-    expect(remoteLog.stdout.trim()).toBe("seed");
+    expect(remoteLog.stdout.trim()).toBe("Update memory:legacy");
+  });
+
+  test("commitWriteTargetBoundary is a no-op for filesystem targets", async () => {
+    const { workDir } = initBareGitRepo();
+    const fsTarget: ResolvedWriteTarget = {
+      source: { kind: "filesystem", name: "fs", path: workDir },
+      config: { type: "filesystem", name: "fs", writable: true },
+    };
+
+    await writeAssetToSource(fsTarget.source, fsTarget.config, { type: "memory", name: "x" }, "body");
+    commitWriteTargetBoundary(fsTarget, "should be ignored");
+
+    // No commit ran (HEAD still seed) even though workDir is a git repo —
+    // filesystem targets never commit at this boundary.
+    const log = spawnSync("git", ["-C", workDir, "log", "--format=%s", "-1"], { encoding: "utf8" });
+    expect(log.stdout.trim()).toBe("seed");
   });
 });
 
 // ── deleteAssetFromSource ───────────────────────────────────────────────────
 
 describe("deleteAssetFromSource", () => {
-  test("removes the asset and commits the removal on git sources", async () => {
+  test("git delete removes the file with no per-write commit; boundary commits the removal", async () => {
     const { workDir } = initBareGitRepo();
-    const source: WriteTargetSource = { kind: "git", name: "team", path: workDir };
-    const config: SourceConfigEntry = { type: "git", writable: true };
+    const target = gitTarget(workDir);
 
-    await writeAssetToSource(source, config, { type: "memory", name: "doomed" }, "body");
+    // Seed an asset and commit it as a boundary so we start from a clean tree.
+    await writeAssetToSource(target.source, target.config, { type: "memory", name: "doomed" }, "body");
+    commitWriteTargetBoundary(target, "Add memory:doomed");
     expect(fs.existsSync(path.join(workDir, "memories", "doomed.md"))).toBe(true);
 
-    await deleteAssetFromSource(source, config, { type: "memory", name: "doomed" });
+    // Delete leaves the file gone but does NOT commit on its own.
+    await deleteAssetFromSource(target.source, target.config, { type: "memory", name: "doomed" });
     expect(fs.existsSync(path.join(workDir, "memories", "doomed.md"))).toBe(false);
+    let log = spawnSync("git", ["-C", workDir, "log", "--format=%s", "-1"], { encoding: "utf8" });
+    expect(log.stdout.trim()).toBe("Add memory:doomed");
 
-    const log = spawnSync("git", ["-C", workDir, "log", "--format=%s", "-1"], { encoding: "utf8" });
+    // Boundary commits the removal as one commit; tree clean afterwards.
+    commitWriteTargetBoundary(target, "Remove memory:doomed");
+    log = spawnSync("git", ["-C", workDir, "log", "--format=%s", "-1"], { encoding: "utf8" });
     expect(log.stdout.trim()).toBe("Remove memory:doomed");
+    const status = spawnSync("git", ["-C", workDir, "status", "--porcelain"], { encoding: "utf8" });
+    expect(status.stdout.trim()).toBe("");
   });
 
   test("filesystem delete is a plain unlink (no commit)", async () => {
@@ -447,16 +535,17 @@ describe("sanitizeCommitMessage", () => {
 
 // ── git commit message sanitization end-to-end (issue #270) ─────────────────
 
-describe("writeAssetToSource — commit message sanitization (issue #270)", () => {
+describe("commit message sanitization (issue #270, via boundary commit)", () => {
   test("ref.origin with embedded newline does not produce multi-line commit", async () => {
     const { workDir } = initBareGitRepo();
-    const source: WriteTargetSource = { kind: "git", name: "team", path: workDir };
-    const config: SourceConfigEntry = { type: "git", writable: true };
+    const target = gitTarget(workDir);
 
     // Newline-laden origin: an attacker who controls a config entry could
     // otherwise smuggle trailers into the commit subject.
     const malignOrigin = "team\n\nCo-Authored-By: attacker <evil@example>";
-    await writeAssetToSource(source, config, { type: "memory", name: "alpha", origin: malignOrigin }, "body");
+    const ref = { type: "memory" as const, name: "alpha", origin: malignOrigin };
+    await writeAssetToSource(target.source, target.config, ref, "body");
+    commitWriteTargetBoundary(target, `Update ${formatRefForMessage(ref)}`);
 
     const fullLog = spawnSync("git", ["-C", workDir, "log", "--format=%B%x00", "-1"], { encoding: "utf8" });
     // Trim the NUL terminator we used as a record separator. The remaining
@@ -472,13 +561,14 @@ describe("writeAssetToSource — commit message sanitization (issue #270)", () =
 
   test("ref.origin with NUL byte is sanitized (commit succeeds)", async () => {
     const { workDir } = initBareGitRepo();
-    const source: WriteTargetSource = { kind: "git", name: "team", path: workDir };
-    const config: SourceConfigEntry = { type: "git", writable: true };
+    const target = gitTarget(workDir);
 
     // A NUL byte in argv would make git reject the commit outright. We strip
     // it so the commit succeeds with the rest of the origin intact.
     const malignOrigin = "team\x00hidden";
-    await writeAssetToSource(source, config, { type: "memory", name: "beta", origin: malignOrigin }, "body");
+    const ref = { type: "memory" as const, name: "beta", origin: malignOrigin };
+    await writeAssetToSource(target.source, target.config, ref, "body");
+    commitWriteTargetBoundary(target, `Update ${formatRefForMessage(ref)}`);
 
     const log = spawnSync("git", ["-C", workDir, "log", "--format=%s", "-1"], { encoding: "utf8" });
     expect(log.stdout.includes("\x00")).toBe(false);


### PR DESCRIPTION
Closes #507.

## Summary

Collapse the two commit models for git-backed sources onto a single **batch-at-boundary** model and retire the per-asset git commit path.

### Core
- `write-source.ts`: `writeAssetToSource` / `deleteAssetFromSource` now perform a plain filesystem write/unlink for **every** kind with **no** commit. Removed `runKindSpecificCommit`, `runGitCommit`, `runGitPush`. The only remaining `kind` branch is the unsupported-kind guard (`assertSupportedKind`).
- New `commitWriteTargetBoundary(target, message, { push })` fires the one-shot batch commit for **git targets only** (no-op for filesystem / primary stash). It delegates to `saveGitStash` against the already-resolved `target.source.path` (`git add -A` → staging `.akm/` + sibling assets as one complete commit → guarded commit → push gated on `writable && remote && push !== false`).
- Kept `sanitizeCommitMessage`; exported `formatRefForMessage` so callers build messages.

### Callers threaded with the boundary commit
- `knowledge.ts` (1 write)
- `proposals.ts` accept + revert
- `consolidate.ts` — **once** after the merge/delete loop (not per asset), only when assets were mutated
- `memory-inference.ts` writes hardcoded filesystem → unaffected.

### Deprecation
- `options.pushOnCommit` still parses (config-types + schema marked `@deprecated`); emits a one-time deprecation warning when encountered; its push intent is mapped onto the batch push gate.

### Tests
- Re-homed the git write/delete cases in `tests/core/write-source.test.ts` to assert (a) git writes leave the file on disk with **no** per-write commit and (b) the boundary commit produces exactly one complete commit + clean tree. Added batch-collapse, push-gate, `pushOnCommit`-maps-to-gate, and filesystem-no-op cases. Preserved the #270 sanitization coverage via the boundary path.

### Docs
- `v1-architecture-spec.md` (deliberate spec amendment), `architecture.md`, `features/sources-registries.md`, a 0.9.0 migration note, and a CHANGELOG entry.

## Gates
- `bunx tsc --noEmit`: pass
- `bun run lint`: pass
- `bun test --timeout 30000 ./tests --path-ignore-patterns=tests/integration`: **3861 pass / 0 fail / 9 skip**

🤖 Generated with [Claude Code](https://claude.com/claude-code)