### PR TITLE
feat(setup): Scheduled Tasks step with embedded core task templates (#512)

### DIFF
--- a/src/assets/tasks/core/backup.yml
+++ b/src/assets/tasks/core/backup.yml
@@ -1,0 +1,4 @@
+schedule: "0 3 * * 0"
+command: akm db backups
+enabled: true
+description: Weekly config/DB backup

--- a/src/assets/tasks/core/extract.yml
+++ b/src/assets/tasks/core/extract.yml
@@ -1,0 +1,4 @@
+schedule: "*/30 * * * *"
+command: akm extract
+enabled: true
+description: Extract insights from session files every 30 min

--- a/src/assets/tasks/core/improve.yml
+++ b/src/assets/tasks/core/improve.yml
@@ -1,0 +1,4 @@
+schedule: "0 2 * * *"
+command: akm improve --auto-accept safe
+enabled: true
+description: Run improve pipeline nightly

--- a/src/assets/tasks/core/index-refresh.yml
+++ b/src/assets/tasks/core/index-refresh.yml
@@ -1,0 +1,4 @@
+schedule: "0 4 * * *"
+command: akm index
+enabled: true
+description: Nightly incremental index refresh

--- a/src/assets/tasks/core/sync.yml
+++ b/src/assets/tasks/core/sync.yml
@@ -1,0 +1,4 @@
+schedule: "*/15 * * * *"
+command: akm sync
+enabled: true
+description: Sync stash changes to git remote every 15 min

--- a/src/assets/tasks/core/update-stashes.yml
+++ b/src/assets/tasks/core/update-stashes.yml
@@ -1,0 +1,4 @@
+schedule: "0 1 * * *"
+command: akm update
+enabled: true
+description: Pull latest changes for all managed stash sources

--- a/src/assets/tasks/core/version-check.yml
+++ b/src/assets/tasks/core/version-check.yml
@@ -1,0 +1,4 @@
+schedule: "0 9 * * 1"
+command: akm info --check-version
+enabled: true
+description: Weekly check for new akm releases

--- a/src/setup/setup.ts
+++ b/src/setup/setup.ts
@@ -16,6 +16,7 @@ import os from "node:os";
 import path from "node:path";
 import * as p from "@clack/prompts";
 import { akmInit, type InitResponse } from "../commands/init";
+import { akmTasksAdd, akmTasksList, akmTasksSetEnabled, akmTasksSync } from "../commands/tasks";
 import { isHttpUrl } from "../core/common";
 import type {
   AkmConfig,
@@ -46,6 +47,10 @@ import {
 import { type AgentDetectionResult, detectAgentCliProfiles, pickDefaultAgentProfile } from "../integrations/agent";
 import { probeLlmCapabilities } from "../llm/client";
 import { checkEmbeddingAvailability, DEFAULT_LOCAL_MODEL, isTransformersAvailable } from "../llm/embedder";
+import { saveGitStash } from "../sources/providers/git";
+import { backendNameForPlatform } from "../tasks/backends";
+import { type EmbeddedTask, listEmbeddedTasks } from "../tasks/embedded";
+import { parseSchedule } from "../tasks/schedule";
 import { detectAgentPlatforms, detectLMStudio, detectOllama, type LMStudioDetectionResult } from "./detect";
 import { detectHarnessConfigs, type HarnessLLMConfig } from "./harness-config-import";
 import { loadSetupStashes } from "./registry-stash-loader";
@@ -1843,6 +1848,153 @@ export function stepAgentCliDetection(
 // ── Main Wizard ─────────────────────────────────────────────────────────────
 
 /**
+ * Normalise a task id the same way `akm tasks` does (strip a trailing `.yml`
+ * / `.md` suffix, trim) so the wizard can match embedded template ids against
+ * the ids reported by `akmTasksList()`.
+ */
+function normaliseTaskIdForMatch(raw: string): string {
+  return raw.trim().replace(/\.(yml|md)$/, "");
+}
+
+/**
+ * Interactive-only setup step: enable/disable embedded core tasks.
+ *
+ * Presents a multi-select of the bundled core task templates pre-checked
+ * against the user's currently-enabled tasks. On confirm:
+ *   - newly-checked & absent  → copy template (with edited schedule) into the
+ *     primary stash via `akmTasksAdd`, then `akmTasksSync`, then `akm sync`
+ *     (a no-op for non-git stashes).
+ *   - newly-checked & present-but-disabled → `akmTasksSetEnabled(id, true)`.
+ *   - previously-enabled & now unchecked    → `akmTasksSetEnabled(id, false)`
+ *     (keeps the stash file, removes the scheduler entry).
+ *   - unchanged → no action.
+ *
+ * Exported for testing. Not registered as `nonInteractive`, so `akm init` /
+ * `--yes` never reach it.
+ *
+ * The task primitives + git-sync helper are injected via `deps` (defaulting
+ * to the real implementations) so tests can supply fakes without
+ * `mock.module`-ing the shared `commands/tasks` / `sources/providers/git`
+ * modules — which would leak into unrelated test files (Bun's `mock.module`
+ * is process-global and not reverted by `mock.restore()`).
+ */
+export interface ScheduledTasksDeps {
+  list: typeof akmTasksList;
+  add: typeof akmTasksAdd;
+  setEnabled: typeof akmTasksSetEnabled;
+  sync: typeof akmTasksSync;
+  gitSync: typeof saveGitStash;
+}
+
+const DEFAULT_SCHEDULED_TASKS_DEPS: ScheduledTasksDeps = {
+  list: akmTasksList,
+  add: akmTasksAdd,
+  setEnabled: akmTasksSetEnabled,
+  sync: akmTasksSync,
+  gitSync: saveGitStash,
+};
+
+export async function stepScheduledTasks(deps: ScheduledTasksDeps = DEFAULT_SCHEDULED_TASKS_DEPS): Promise<void> {
+  const embedded = listEmbeddedTasks();
+  if (embedded.length === 0) return;
+
+  // Snapshot current state so we can diff against the user's selection.
+  let installed: Awaited<ReturnType<typeof akmTasksList>>["tasks"] = [];
+  try {
+    installed = (await deps.list()).tasks;
+  } catch {
+    // A missing/empty tasks dir is fine — treat as nothing installed.
+    installed = [];
+  }
+  const byId = new Map<string, (typeof installed)[number]>();
+  for (const t of installed) byId.set(normaliseTaskIdForMatch(t.id), t);
+
+  // Pre-check tasks that are installed AND enabled.
+  const preChecked = embedded.filter((e) => byId.get(e.id)?.enabled === true).map((e) => e.id);
+
+  const stateLabel = (e: EmbeddedTask): string => {
+    const cur = byId.get(e.id);
+    if (!cur) return "not installed";
+    return cur.enabled ? "enabled" : "disabled";
+  };
+
+  const selected = await prompt(() =>
+    p.multiselect({
+      message: "Enable scheduled core tasks? (space to toggle, enter to confirm)",
+      required: false,
+      initialValues: preChecked,
+      options: embedded.map((e) => ({
+        value: e.id,
+        label: e.label,
+        hint: `${e.description} — ${e.schedule} [${stateLabel(e)}]`,
+      })),
+    }),
+  );
+
+  const selectedSet = new Set(selected as string[]);
+
+  // Resolve per-task schedule edits for newly-checked, not-yet-installed tasks.
+  const scheduleFor = new Map<string, string>();
+  for (const e of embedded) {
+    const cur = byId.get(e.id);
+    if (selectedSet.has(e.id) && !cur) {
+      const edited = await prompt(() =>
+        p.text({
+          message: `Schedule for ${e.label}?`,
+          initialValue: e.schedule,
+          validate(value) {
+            const candidate = (value ?? "").trim() || e.schedule;
+            try {
+              parseSchedule(candidate, backendNameForPlatform());
+            } catch (err) {
+              return err instanceof Error ? err.message : "Invalid schedule.";
+            }
+            return undefined;
+          },
+        }),
+      );
+      const sched = ((edited as string) ?? "").trim() || e.schedule;
+      scheduleFor.set(e.id, sched);
+    }
+  }
+
+  let syncNeeded = false;
+  for (const e of embedded) {
+    const cur = byId.get(e.id);
+    const checked = selectedSet.has(e.id);
+    if (checked && !cur) {
+      // New task: copy template into the primary stash + install scheduler entry.
+      const schedule = scheduleFor.get(e.id) ?? e.schedule;
+      await deps.add({
+        id: e.id,
+        schedule,
+        command: e.command,
+        description: e.description,
+      });
+      syncNeeded = true;
+    } else if (checked && cur && !cur.enabled) {
+      // Present but disabled → re-enable.
+      await deps.setEnabled(e.id, true);
+    } else if (!checked && cur?.enabled) {
+      // Previously enabled, now unchecked → disable (keep the stash file).
+      await deps.setEnabled(e.id, false);
+    }
+    // No state change → no action.
+  }
+
+  if (syncNeeded) {
+    // Reconcile scheduler entries with on-disk YAML, then commit the new file
+    // to git (a no-op for non-git stashes).
+    await deps.sync();
+    try {
+      deps.gitSync(undefined, "akm setup: enable scheduled tasks");
+    } catch {
+      // Non-fatal — the task is installed regardless of git sync outcome.
+    }
+  }
+}
+
+/**
  * Build the canonical list of `SetupStep`s for the interactive wizard.
  * Exposed (and exported) so tests and `akm init` can compose subsets.
  *
@@ -1967,6 +2119,15 @@ export function buildSetupSteps(options: {
       async run(ctx) {
         const output = await stepOutputConfig(ctx.config);
         ctx.apply({ output });
+      },
+    },
+    {
+      id: "scheduled-tasks",
+      label: "Scheduled Tasks",
+      // Interactive-only: `akm init` / `--yes` skip this step so headless
+      // runs never enable a scheduled task (see issue #512).
+      async run() {
+        await stepScheduledTasks();
       },
     },
   ];

--- a/src/tasks/embedded.ts
+++ b/src/tasks/embedded.ts
@@ -1,0 +1,90 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Embedded core task templates.
+ *
+ * A curated set of read-only YAML task templates ships inside the akm binary
+ * under `src/assets/tasks/core/`. They are resolved at runtime via
+ * `import.meta.dir` (mirroring `SKELETON_DIR` in
+ * src/commands/stash-skeleton.ts) and are NOT written to any stash at
+ * install/init time — the `akm setup` wizard copies a template into the
+ * primary stash only when the user opts in (copy-on-enable).
+ *
+ * Each entry exposes the parsed `command`, `schedule`, and `description`
+ * alongside the raw `yaml`, so the wizard can both render a choice and write
+ * the file verbatim (with an optional schedule edit applied).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { parse as yamlParse } from "yaml";
+
+/** Directory holding the bundled core task templates. */
+const CORE_TASKS_DIR = path.join(import.meta.dir, "../assets/tasks/core");
+
+export interface EmbeddedTask {
+  /**
+   * Task id as written to disk and registered with the scheduler — the
+   * template filename without its `.yml` suffix (e.g. `improve`). This is the
+   * id matched against `akm tasks list` output.
+   */
+  id: string;
+  /** Conceptual namespaced label shown in the wizard (e.g. `core/improve`). */
+  label: string;
+  /** Shell command the task runs on its schedule. */
+  command: string;
+  /** Default cron-style schedule shipped with the template. */
+  schedule: string;
+  /** Human-readable description shown in the wizard. */
+  description: string;
+  /** Raw template YAML, written verbatim (with schedule edits) on enable. */
+  yaml: string;
+}
+
+/**
+ * Enumerate the embedded core task templates from the bundled assets
+ * directory. Sorted by id for deterministic ordering. Returns an empty array
+ * if the directory is missing (defensive — a build without assets should not
+ * crash the wizard).
+ */
+export function listEmbeddedTasks(): EmbeddedTask[] {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(CORE_TASKS_DIR);
+  } catch {
+    return [];
+  }
+
+  const tasks: EmbeddedTask[] = [];
+  for (const entry of entries.sort()) {
+    if (!entry.endsWith(".yml")) continue;
+    const id = entry.slice(0, -4);
+    const filePath = path.join(CORE_TASKS_DIR, entry);
+    let yaml: string;
+    try {
+      yaml = fs.readFileSync(filePath, "utf8");
+    } catch {
+      continue;
+    }
+    let doc: { command?: unknown; schedule?: unknown; description?: unknown };
+    try {
+      doc = yamlParse(yaml) ?? {};
+    } catch {
+      continue;
+    }
+    const command = typeof doc.command === "string" ? doc.command : "";
+    const schedule = typeof doc.schedule === "string" ? doc.schedule : "";
+    const description = typeof doc.description === "string" ? doc.description : "";
+    tasks.push({
+      id,
+      label: `core/${id}`,
+      command,
+      schedule,
+      description,
+      yaml,
+    });
+  }
+  return tasks;
+}

--- a/tests/setup-scheduled-tasks.test.ts
+++ b/tests/setup-scheduled-tasks.test.ts
@@ -1,0 +1,184 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `stepScheduledTasks` — the `akm setup` Scheduled Tasks step (issue #512).
+ *
+ * Drives the step through a stubbed clack multiselect/text prompt and injected
+ * fake task primitives so the diff logic (add / enable / disable / no-op) and
+ * the copy-on-enable + sync behaviour are verified without touching the OS
+ * scheduler or git.
+ *
+ * Only `@clack/prompts` is `mock.module`-ed (the same module the existing
+ * setup-wizard test mocks); the task primitives and git-sync helper are passed
+ * in via `stepScheduledTasks(deps)` to avoid leaking module overrides into
+ * other test files.
+ */
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const CANCEL = Symbol("clack:cancel");
+
+const state = {
+  multiselectReturn: [] as string[],
+  textReturns: [] as string[],
+  multiselectConfig: undefined as
+    | { initialValues?: string[]; options: Array<{ value: string; label: string; hint?: string }> }
+    | undefined,
+};
+
+function resetClack() {
+  state.multiselectReturn = [];
+  state.textReturns = [];
+  state.multiselectConfig = undefined;
+}
+
+mock.module("@clack/prompts", () => ({
+  isCancel: (v: unknown) => v === CANCEL,
+  cancel: () => {},
+  multiselect: async (config: {
+    initialValues?: string[];
+    options: Array<{ value: string; label: string; hint?: string }>;
+  }) => {
+    state.multiselectConfig = { initialValues: config.initialValues, options: config.options };
+    return state.multiselectReturn;
+  },
+  text: async () => state.textReturns.shift() ?? "",
+  select: async () => "",
+  confirm: async () => false,
+  spinner: () => ({ start: () => {}, stop: () => {} }),
+  log: { info: () => {}, success: () => {}, warn: () => {}, step: () => {} },
+  intro: () => {},
+  outro: () => {},
+  note: () => {},
+}));
+
+// Restore the genuine `@clack/prompts` after this file so other suites that
+// rely on the real prompts (or their own clack mock) are unaffected.
+const REAL_CLACK = await import("@clack/prompts");
+afterAll(() => {
+  mock.module("@clack/prompts", () => REAL_CLACK);
+  mock.restore();
+});
+
+const setupModule = await import("../src/setup/setup");
+
+// ── Fake task primitives injected into the step ──────────────────────────────
+function makeDeps(installed: Array<{ id: string; enabled: boolean }>) {
+  const calls = {
+    added: [] as Array<{ id: string; schedule: string; command?: string | string[] }>,
+    enabled: [] as Array<{ id: string; enabled: boolean }>,
+    syncCalls: 0,
+    gitSyncCalls: 0,
+  };
+  const deps = {
+    list: async () =>
+      ({ tasks: installed }) as Awaited<ReturnType<typeof import("../src/commands/tasks").akmTasksList>>,
+    add: async (input: { id: string; schedule: string; command?: string | string[] }) => {
+      calls.added.push({ id: input.id, schedule: input.schedule, command: input.command });
+      return { id: input.id } as Awaited<ReturnType<typeof import("../src/commands/tasks").akmTasksAdd>>;
+    },
+    setEnabled: async (id: string, enabled: boolean) => {
+      calls.enabled.push({ id, enabled });
+      return { id, enabled, backend: "cron" };
+    },
+    sync: async () => {
+      calls.syncCalls += 1;
+      return { installed: [], removed: [], unchanged: [], skipped: [], backend: "cron" as const };
+    },
+    gitSync: (() => {
+      calls.gitSyncCalls += 1;
+      return { committed: true, pushed: false, skipped: false, output: "" };
+    }) as unknown as typeof import("../src/sources/providers/git").saveGitStash,
+  };
+  return { deps, calls };
+}
+
+describe("stepScheduledTasks", () => {
+  beforeEach(resetClack);
+
+  test("lists all 7 embedded tasks with id, description, and schedule in the multiselect", async () => {
+    const { deps } = makeDeps([]);
+    await setupModule.stepScheduledTasks(deps);
+    const opts = state.multiselectConfig?.options ?? [];
+    expect(opts.length).toBe(7);
+    const improve = opts.find((o) => o.value === "improve");
+    expect(improve?.label).toBe("core/improve");
+    expect(improve?.hint).toContain("Run improve pipeline nightly");
+    expect(improve?.hint).toContain("0 2 * * *");
+    expect(improve?.hint).toContain("not installed");
+  });
+
+  test("pre-checks already-installed enabled tasks; disabled/absent are not pre-checked", async () => {
+    const { deps } = makeDeps([
+      { id: "improve", enabled: true },
+      { id: "backup", enabled: false },
+    ]);
+    state.multiselectReturn = ["improve"]; // leave selection unchanged
+    await setupModule.stepScheduledTasks(deps);
+    expect(state.multiselectConfig?.initialValues).toEqual(["improve"]);
+    const opts = state.multiselectConfig?.options ?? [];
+    expect(opts.find((o) => o.value === "backup")?.hint).toContain("disabled");
+    expect(opts.find((o) => o.value === "improve")?.hint).toContain("enabled");
+  });
+
+  test("checking a previously-absent task copies template, installs, and syncs", async () => {
+    const { deps, calls } = makeDeps([]);
+    state.multiselectReturn = ["sync"];
+    state.textReturns = ["*/15 * * * *"]; // accept default schedule
+    await setupModule.stepScheduledTasks(deps);
+    expect(calls.added).toEqual([{ id: "sync", schedule: "*/15 * * * *", command: "akm sync" }]);
+    expect(calls.syncCalls).toBe(1);
+    expect(calls.gitSyncCalls).toBe(1);
+    expect(calls.enabled).toEqual([]);
+  });
+
+  test("edited schedule is validated and persisted into the add call", async () => {
+    const { deps, calls } = makeDeps([]);
+    state.multiselectReturn = ["extract"];
+    state.textReturns = ["0 5 * * *"]; // user edits the schedule
+    await setupModule.stepScheduledTasks(deps);
+    expect(calls.added).toEqual([{ id: "extract", schedule: "0 5 * * *", command: "akm extract" }]);
+  });
+
+  test("unchecking a previously-enabled task disables it (no add, keeps file)", async () => {
+    const { deps, calls } = makeDeps([{ id: "improve", enabled: true }]);
+    state.multiselectReturn = []; // uncheck improve
+    await setupModule.stepScheduledTasks(deps);
+    expect(calls.enabled).toEqual([{ id: "improve", enabled: false }]);
+    expect(calls.added).toEqual([]);
+    expect(calls.syncCalls).toBe(0);
+  });
+
+  test("re-checking a present-but-disabled task re-enables it", async () => {
+    const { deps, calls } = makeDeps([{ id: "backup", enabled: false }]);
+    state.multiselectReturn = ["backup"];
+    await setupModule.stepScheduledTasks(deps);
+    expect(calls.enabled).toEqual([{ id: "backup", enabled: true }]);
+    expect(calls.added).toEqual([]);
+  });
+
+  test("no state change produces no add/enable/disable/sync calls", async () => {
+    const { deps, calls } = makeDeps([{ id: "improve", enabled: true }]);
+    state.multiselectReturn = ["improve"]; // unchanged
+    await setupModule.stepScheduledTasks(deps);
+    expect(calls.added).toEqual([]);
+    expect(calls.enabled).toEqual([]);
+    expect(calls.syncCalls).toBe(0);
+    expect(calls.gitSyncCalls).toBe(0);
+  });
+});
+
+describe("scheduled-tasks step registration", () => {
+  test("is interactive-only (not nonInteractive) so --yes / init skip it", () => {
+    const { steps } = setupModule.buildSetupSteps({
+      online: false,
+      semanticSearchOutcome: { mode: "off", prepareAssets: false },
+    });
+    const step = steps.find((s) => s.id === "scheduled-tasks");
+    expect(step).toBeDefined();
+    expect(step?.label).toBe("Scheduled Tasks");
+    expect(step?.nonInteractive).toBeFalsy();
+    expect(steps[steps.length - 1]?.id).toBe("scheduled-tasks");
+  });
+});

--- a/tests/tasks-embedded.test.ts
+++ b/tests/tasks-embedded.test.ts
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Embedded core task registry — asserts the 7 bundled templates are present
+ * with the exact ids, commands, and default schedules from issue #512, and
+ * that they are read from the bundled assets dir (not any user stash).
+ */
+import { describe, expect, test } from "bun:test";
+import { listEmbeddedTasks } from "../src/tasks/embedded";
+
+const EXPECTED = [
+  { id: "improve", command: "akm improve --auto-accept safe", schedule: "0 2 * * *" },
+  { id: "update-stashes", command: "akm update", schedule: "0 1 * * *" },
+  { id: "backup", command: "akm db backups", schedule: "0 3 * * 0" },
+  { id: "version-check", command: "akm info --check-version", schedule: "0 9 * * 1" },
+  { id: "index-refresh", command: "akm index", schedule: "0 4 * * *" },
+  { id: "extract", command: "akm extract", schedule: "*/30 * * * *" },
+  { id: "sync", command: "akm sync", schedule: "*/15 * * * *" },
+] as const;
+
+describe("embedded core task registry", () => {
+  test("enumerates all 7 templates", () => {
+    const tasks = listEmbeddedTasks();
+    expect(tasks.length).toBe(7);
+  });
+
+  test("each template has the exact id, command, and default schedule", () => {
+    const tasks = listEmbeddedTasks();
+    const byId = new Map(tasks.map((t) => [t.id, t]));
+    for (const exp of EXPECTED) {
+      const got = byId.get(exp.id);
+      expect(got, `missing embedded task ${exp.id}`).toBeDefined();
+      expect(got?.command).toBe(exp.command);
+      expect(got?.schedule).toBe(exp.schedule);
+      expect(got?.description.length).toBeGreaterThan(0);
+      expect(got?.label).toBe(`core/${exp.id}`);
+      expect(got?.yaml).toContain(exp.command);
+    }
+  });
+});


### PR DESCRIPTION
Closes #512

## Summary
Adds a **Scheduled Tasks** step to the `akm setup` interactive wizard that lets users enable/disable a curated set of embedded core task templates, with copy-on-enable to the primary stash.

## Changes
- **Embedded templates** — 7 read-only YAML task templates under `src/assets/tasks/core/` (`improve`, `update-stashes`, `backup`, `version-check`, `index-refresh`, `extract`, `sync`) with the exact ids/commands/schedules/descriptions from the issue table. Bundled in the binary and resolved via `import.meta.dir` (mirroring `SKELETON_DIR`); never written to a stash at install/init time.
- **Registry** — `src/tasks/embedded.ts` enumerates the templates from the bundled assets dir, exposing `{ id, label, command, schedule, description, yaml }`.
- **Setup step** — `stepScheduledTasks` in `src/setup/setup.ts`, registered as the interactive-only `scheduled-tasks` step **after** existing steps (NOT `nonInteractive`), so `akm init` / `--yes` skip it. Uses clack `p.multiselect` + a per-task `p.text` schedule edit validated through `parseSchedule`. Already-installed tasks are pre-checked based on their current enabled state from `akmTasksList()`.
- **Apply on confirm** — newly-checked & absent → `akmTasksAdd` (command target, with edited schedule) + `akmTasksSync` + `akm sync` (`saveGitStash`, a no-op for non-git stashes); newly-checked & disabled → `akmTasksSetEnabled(id, true)`; previously-enabled & unchecked → `akmTasksSetEnabled(id, false)` (stash file retained); no change → no action. Task primitives + git-sync are injected via a `deps` parameter for leak-free testing.

## Tests
- `tests/tasks-embedded.test.ts` — asserts all 7 ids/commands/schedules.
- `tests/setup-scheduled-tasks.test.ts` — pre-check state, copy-on-enable + sync, disable-on-uncheck, no-op, schedule-edit persistence, and interactive-only registration.

## Gates
- `bunx tsc --noEmit` — pass
- `bun run lint` — pass
- `bun test ./tests` (excl. integration) — 3867 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)