### PR TITLE
0.8.3 hotfix: release improve.lock on signal death + make 'quick' truly reflect-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.8.3] - 2026-06-08
+
+### Fixed
+
+- **`improve.lock` leaked on signal death (cron timeout).** The improve
+  SIGTERM/SIGINT/SIGHUP handler calls `process.exit()`, which skips `finally`
+  blocks — so the `finally` that releases `improve.lock` never ran, and every
+  timed-out cron run leaked the lock sentinel. (It wasn't a permanent deadlock
+  only because the next run reclaims a dead-PID lock, a path that PID reuse can
+  defeat.) The lock is now released from a `process.on("exit", …)` handler
+  registered at acquire time (exit handlers DO run on `process.exit()`), via a
+  new ownership-checked `releaseLockIfOwned(path, pid)` so a backstop release can
+  never delete a different run's lock. This generalizes to the budget watchdog
+  and any future exit path.
+- **`quick` profile was not quick.** It was documented "Reflect-only" but did
+  not disable the session-`extract` process (which is default-ON), so a `quick`
+  run processed the entire unindexed-session backlog (~40 min) — guaranteeing a
+  5-minute cron timeout → SIGTERM → the lock leak above, every run. `quick` now
+  explicitly sets `processes.extract.enabled: false`.
+
 ## [0.8.2] - 2026-06-05
 
 ### Added

--- a/src/assets/profiles/quick.json
+++ b/src/assets/profiles/quick.json
@@ -1,10 +1,11 @@
 {
-  "description": "Reflect-only pass — no distill, consolidate, memoryInference, or graphExtraction.",
+  "description": "Reflect-only pass — no extract, distill, consolidate, memoryInference, or graphExtraction.",
   "processes": {
     "reflect": {
       "enabled": true,
       "allowedTypes": ["agent", "command", "knowledge", "lesson", "memory", "skill", "wiki", "workflow"]
     },
+    "extract": { "enabled": false },
     "distill": { "enabled": false },
     "consolidate": { "enabled": false },
     "memoryInference": { "enabled": false },

--- a/src/commands/improve.ts
+++ b/src/commands/improve.ts
@@ -11,7 +11,7 @@ import type { AkmConfig } from "../core/config";
 import { getDefaultLlmConfig, loadConfig } from "../core/config";
 import { ConfigError, NotFoundError, rethrowIfTestIsolationError, UsageError } from "../core/errors";
 import { appendEvent, type EventEnvelope, type EventsContext, readEvents } from "../core/events";
-import { probeLock, releaseLock, tryAcquireLockSync } from "../core/file-lock";
+import { probeLock, releaseLock, releaseLockIfOwned, tryAcquireLockSync } from "../core/file-lock";
 import { parseFrontmatter } from "../core/frontmatter";
 import { detectAndWriteContradictions } from "../core/memory-contradiction-detect";
 import {
@@ -924,6 +924,18 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
     lockAcquired = false;
   };
 
+  // Signal-safe lock release (0.8.3 hotfix). The SIGTERM/SIGINT/SIGHUP handler
+  // in improve-cli.ts calls `process.exit()`, which does NOT run the `finally`
+  // below that owns lock release — so a cron-timeout SIGTERM leaked
+  // `improve.lock` every run. `process.exit()` DOES fire `'exit'` listeners,
+  // so we release the lock from one. `releaseLockIfOwned` only unlinks a lock
+  // still owned by this PID, so it is safe even if a later run re-acquired it.
+  // The listener is removed in the `finally` so the normal path stays single-release
+  // and repeated in-process `akmImprove` calls (tests) do not accumulate listeners.
+  const releaseLockOnExit = (): void => {
+    releaseLockIfOwned(resolvedLockPath, process.pid);
+  };
+
   const preEnsureCleanupWarnings: string[] = [];
   let plannedRefs: Awaited<ReturnType<typeof collectEligibleRefs>>["plannedRefs"];
   let memorySummary: Awaited<ReturnType<typeof collectEligibleRefs>>["memorySummary"];
@@ -938,6 +950,9 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
     if (!options.dryRun) {
       acquireLock();
       lockAcquired = true;
+      // Backstop release on process.exit() (signal handler / budget watchdog),
+      // which skips the finally below. Removed in that finally on the normal path.
+      process.on("exit", releaseLockOnExit);
 
       // Phase 4 triage pre-pass (§7, §13): drain the standing pending backlog
       // BEFORE ensureIndex so improve generates fresh proposals against a cleared
@@ -1398,6 +1413,9 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
     } catch {
       // ignore
     }
+    // The normal path released the lock above; drop the process.exit backstop so
+    // it does not fire later (or accumulate across repeated in-process calls).
+    process.removeListener("exit", releaseLockOnExit);
     // I1: close the long-lived state.db connection opened at the top of the run.
     try {
       eventsDb?.close();

--- a/src/core/file-lock.ts
+++ b/src/core/file-lock.ts
@@ -115,6 +115,28 @@ export function releaseLock(lockPath: string): void {
 }
 
 /**
+ * Release a lock ONLY if it is still owned by `ownerPid`. Safe to call from a
+ * `process.exit()` / `'exit'` handler as a backstop: `process.exit()` skips
+ * `finally` blocks — so the normal lock-release never runs on signal death
+ * (SIGTERM/SIGINT) — but it DOES fire `'exit'` listeners synchronously. Checking
+ * ownership first means that if the lock was already released and re-acquired by
+ * a different process, this leaves that process's lock intact (no cross-run
+ * deletion / PID-reuse footgun). Synchronous so it is valid inside an exit handler.
+ */
+export function releaseLockIfOwned(lockPath: string, ownerPid: number): void {
+  let rawContent: string;
+  try {
+    rawContent = fs.readFileSync(lockPath, "utf8");
+  } catch {
+    // Absent or unreadable — nothing of ours to release.
+    return;
+  }
+  if (extractHolderPid(rawContent) === ownerPid) {
+    releaseLock(lockPath);
+  }
+}
+
+/**
  * Extract a PID from a sentinel body. Accepts the two shapes used across
  * the codebase: a bare numeric string (config-io, vault, lockfile) and
  * a JSON object with a `pid` field (improve). Returns undefined when the

--- a/tests/commands/improve-profiles.test.ts
+++ b/tests/commands/improve-profiles.test.ts
@@ -47,6 +47,10 @@ describe("resolveImproveProfile", () => {
     const profile = resolveImproveProfile("quick", MINIMAL_CONFIG);
     expect(profile.description).toContain("Reflect-only");
     expect(profile.processes?.reflect?.enabled).toBe(true);
+    // 0.8.3: extract is default-ON, so "reflect-only" must disable it explicitly —
+    // otherwise `quick` runs the full session-extract backlog (~40 min) and cron
+    // timeouts SIGTERM it every run.
+    expect(profile.processes?.extract?.enabled).toBe(false);
     expect(profile.processes?.distill?.enabled).toBe(false);
     expect(profile.processes?.consolidate?.enabled).toBe(false);
     expect(profile.processes?.memoryInference?.enabled).toBe(false);

--- a/tests/file-lock.test.ts
+++ b/tests/file-lock.test.ts
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { releaseLock, releaseLockIfOwned, tryAcquireLockSync } from "../src/core/file-lock";
+import { type Cleanup, sandboxXdgDataHome } from "./_helpers/sandbox";
+
+const FILE_LOCK_MODULE = path.resolve(import.meta.dir, "../src/core/file-lock.ts");
+
+describe("releaseLockIfOwned", () => {
+  let dir: string;
+  let cleanup: Cleanup;
+  beforeEach(() => {
+    const r = sandboxXdgDataHome();
+    dir = r.dir;
+    cleanup = r.cleanup;
+  });
+  afterEach(() => cleanup());
+
+  test("releases a lock owned by this pid (JSON envelope)", () => {
+    const lock = path.join(dir, "improve.lock");
+    expect(tryAcquireLockSync(lock, JSON.stringify({ pid: process.pid, startedAt: "t" }))).toBe(true);
+    releaseLockIfOwned(lock, process.pid);
+    expect(fs.existsSync(lock)).toBe(false);
+  });
+
+  test("releases a lock owned by this pid (bare-pid sentinel)", () => {
+    const lock = path.join(dir, "bare.lock");
+    expect(tryAcquireLockSync(lock, String(process.pid))).toBe(true);
+    releaseLockIfOwned(lock, process.pid);
+    expect(fs.existsSync(lock)).toBe(false);
+  });
+
+  test("LEAVES a lock owned by a different pid (no cross-run deletion)", () => {
+    const lock = path.join(dir, "improve.lock");
+    // A different live-looking owner; releaseLockIfOwned must not touch it.
+    tryAcquireLockSync(lock, JSON.stringify({ pid: 2147480000, startedAt: "t" }));
+    releaseLockIfOwned(lock, process.pid);
+    expect(fs.existsSync(lock)).toBe(true);
+    releaseLock(lock);
+  });
+
+  test("is a no-op on an absent lock", () => {
+    expect(() => releaseLockIfOwned(path.join(dir, "missing.lock"), process.pid)).not.toThrow();
+  });
+});
+
+describe("lock release on process.exit (0.8.3 SIGTERM-leak regression, #improve.lock)", () => {
+  let dir: string;
+  let cleanup: Cleanup;
+  beforeEach(() => {
+    const r = sandboxXdgDataHome();
+    dir = r.dir;
+    cleanup = r.cleanup;
+  });
+  afterEach(() => cleanup());
+
+  // The improve signal handler (improve-cli.ts) calls process.exit() on
+  // SIGTERM/SIGINT/SIGHUP, which does NOT run `finally` blocks — so the lock's
+  // normal release never executes. It DOES fire 'exit' listeners, so improve.ts
+  // releases the lock from one. This subprocess proves that guarantee end-to-end.
+  test("process.exit() runs the 'exit' handler that releases the lock; finally is skipped", () => {
+    const lock = path.join(dir, "improve.lock");
+    const script = path.join(dir, "exit-release.ts");
+    fs.writeFileSync(
+      script,
+      [
+        `import { tryAcquireLockSync, releaseLockIfOwned } from ${JSON.stringify(FILE_LOCK_MODULE)};`,
+        `const lock = process.argv[2];`,
+        `tryAcquireLockSync(lock, JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }));`,
+        `process.on("exit", () => releaseLockIfOwned(lock, process.pid));`,
+        `try {`,
+        `  process.exit(143); // simulates the SIGTERM handler; the finally below is SKIPPED`,
+        `} finally {`,
+        `  // intentionally NOT reached — proves the lock release cannot rely on finally`,
+        `  process.stderr.write("FINALLY_RAN\\n");`,
+        `}`,
+      ].join("\n"),
+      "utf8",
+    );
+
+    const res = spawnSync("bun", [script, lock], { encoding: "utf8", timeout: 20_000 });
+    expect(res.status).toBe(143);
+    expect(res.stderr ?? "").not.toContain("FINALLY_RAN");
+    // The lock is gone even though process.exit() skipped the finally.
+    expect(fs.existsSync(lock)).toBe(false);
+  });
+});

--- a/tests/migration-help.test.ts
+++ b/tests/migration-help.test.ts
@@ -22,7 +22,14 @@ describe("migration help", () => {
 
   test("supports latest alias when changelog text is available", () => {
     const result = renderMigrationHelp("latest");
-    expect(result).toContain("## [0.8.2]");
+    // Derive the expected version from the changelog so this never re-breaks on a
+    // version bump: "latest" resolves to the newest RELEASED (non-Unreleased) section.
+    const changelog = fs.readFileSync(path.join(PROJECT_ROOT, "CHANGELOG.md"), "utf8");
+    const latest = [...changelog.matchAll(/^## \[([^\]]+)\]/gm)]
+      .map((m) => m[1])
+      .find((v) => v.toLowerCase() !== "unreleased");
+    expect(latest).toBeTruthy();
+    expect(result).toContain(`## [${latest}]`);
   });
 
   test("ensures published static files exist in the repo", () => {


### PR DESCRIPTION
## Bug
Cron-timeout SIGTERM leaked `improve.lock` every run: the improve signal handler calls `process.exit()`, which skips the `finally` that releases the lock. Compounded by the `quick` profile not disabling session-`extract` (default-on), so a `quick` run processed the full backlog (~40 min) and the 5-min cron timeout SIGTERM'd it every run.

## Fix (minimal, hotfix-scoped)
- Release the lock from a `process.on('exit', …)` handler registered at acquire time (exit handlers run on `process.exit()`, unlike `finally`), via a new ownership-checked `releaseLockIfOwned(path, pid)` (won't delete another run's lock).
- `quick` profile now sets `processes.extract.enabled: false` (truly reflect-only).
- Regression tests: `releaseLockIfOwned` unit + a subprocess test proving `process.exit()` releases the lock while `finally` is skipped; `quick` extract-disabled assertion. Robust migration-help latest-alias.

Deferred to 0.9.0 (out of hotfix scope): PID-reuse /proc hardening, lock heartbeat + lower age fallback, `--wait` lock-timeout flag, health leaked-lock advisory.

Gate green: unit 3862/0, integration 985/0, tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)