### PR TITLE
hotfix/0.8.4: tasks sync schedule drift + improve --skip-if-locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.8.4] - 2026-06-08
+
+### Fixed
+
+- **`akm tasks sync` ignored schedule changes.** Sync classified any task already
+  present in the OS scheduler as "unchanged" without comparing its installed
+  entry, so editing a task's `schedule:` in the `.yml` never reached the crontab —
+  the only way to apply a new schedule was to `remove` and re-`add` the task. The
+  same gap affected `tasks enable`/`disable`, which merely toggled the existing
+  cron line's comment and so re-enabled a stale schedule. Sync now compares the
+  backend's installed signature against the signature the current definition would
+  produce and reinstalls on drift (reported in a new `updated[]` field);
+  `enable`/`disable` reinstall from the current `.yml` instead of toggling in
+  place. Backends that can't cheaply read their installed form fall back to an
+  idempotent reinstall, so the fix is correct on launchd/schtasks too. The cron
+  backend gains `expectedSignature()` and a signature on each `list()` entry.
+
+### Added
+
+- **`akm improve --skip-if-locked`.** When another improve run already holds the
+  lock, the run logs and exits 0 with a no-op result (`skipped.reason:
+  "lock-held"`) instead of failing with the "already running" config error
+  (exit 78). Intended for high-frequency scheduled runs (e.g. an every-30-min
+  `quick` pass) that would otherwise pile up exit-78 failures whenever a longer
+  run overlaps them. Default off — the hard error is preserved for interactive
+  use. The result is still recorded so the skip is auditable.
+
 ## [0.8.3] - 2026-06-08
 
 ### Fixed

--- a/src/commands/improve-cli.ts
+++ b/src/commands/improve-cli.ts
@@ -67,6 +67,12 @@ export const improveCommand = defineCommand({
         "Emit the full JSON result on stdout (legacy behaviour). (0.8.0+: full result is recorded in the improve_runs table of state.db and stdout is empty; use this flag for the prior behaviour, e.g. `akm improve --json-to-stdout | jq`.)",
       default: false,
     },
+    "skip-if-locked": {
+      type: "boolean",
+      description:
+        "If another improve run already holds the lock, skip gracefully (exit 0) instead of failing with 'already running' (exit 78). Use for high-frequency scheduled runs so they don't pile up failures while a longer run is in progress.",
+      default: false,
+    },
     profile: {
       type: "string",
       description:
@@ -115,6 +121,7 @@ export const improveCommand = defineCommand({
       const minRetrievalCountRaw = getHyphenatedArg<string>(args, "min-retrieval-count");
       const minRetrievalCount = parseNonNegativeIntFlag(minRetrievalCountRaw, "--min-retrieval-count");
       const requireFeedbackSignal = getHyphenatedBoolean(args, "require-feedback-signal");
+      const skipIfLocked = getHyphenatedBoolean(args, "skip-if-locked");
       const profileArg = getStringArg(args, "profile");
       // Only set the keys the user actually passed (citty leaves the flag
       // undefined unless `--sync`/`--no-sync` / `--push`/`--no-push` appears),
@@ -197,6 +204,7 @@ export const improveCommand = defineCommand({
           ...(timeoutMs !== undefined ? { timeoutMs } : {}),
           ...(minRetrievalCount !== undefined ? { minRetrievalCount } : {}),
           ...(requireFeedbackSignal ? { requireFeedbackSignal } : {}),
+          ...(skipIfLocked ? { skipIfLocked } : {}),
           ...(profileArg !== undefined ? { profile: profileArg } : {}),
           ...(Object.keys(syncOverride).length > 0 ? { sync: syncOverride } : {}),
           consolidateOptions: {

--- a/src/commands/improve.ts
+++ b/src/commands/improve.ts
@@ -99,6 +99,14 @@ export interface AkmImproveOptions {
   /** Wall-clock budget for the entire improve run in milliseconds. Defaults to 2 hours. */
   timeoutMs?: number;
   limit?: number;
+  /**
+   * When another improve run already holds the lock, skip gracefully (return a
+   * no-op result, exit 0) instead of failing with a "already running" config
+   * error (exit 78). Intended for high-frequency scheduled runs (e.g. the
+   * every-30-min `quick` pass) that would otherwise pile up exit-78 failures
+   * whenever a longer run is in progress. Default: false (preserve hard error).
+   */
+  skipIfLocked?: boolean;
   /** Named improve profile from profiles.improve or built-in profile names (default, quick, thorough, memory-focus). */
   profile?: string;
   consolidateOptions?: Omit<AkmConsolidateOptions, "config" | "stashDir">;
@@ -240,6 +248,12 @@ export interface AkmImproveResult {
     value?: string;
   };
   dryRun: boolean;
+  /**
+   * Present when the run did no work because another improve held the lock and
+   * `skipIfLocked` was set. The run still exits 0 and records a (non-productive)
+   * row so the skip is auditable; `reason` is `"lock-held"`.
+   */
+  skipped?: { reason: string };
   guidance?: string;
   memorySummary: {
     eligible: number;
@@ -853,10 +867,10 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
     : path.join(options.stashDir ?? ".", ".akm", "improve.lock");
   const MAX_LOCK_AGE_MS = 4 * 60 * 60 * 1000; // 4 hours
 
-  const acquireLock = (): void => {
+  const acquireLock = (): "acquired" | "skipped" => {
     fs.mkdirSync(path.dirname(resolvedLockPath), { recursive: true });
     const lockPayload = () => JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() });
-    if (tryAcquireLockSync(resolvedLockPath, lockPayload())) return;
+    if (tryAcquireLockSync(resolvedLockPath, lockPayload())) return "acquired";
 
     // Lock file already exists — probe to determine whether it's still held
     // or whether the prior run died without cleaning up.
@@ -890,11 +904,24 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
         /* event emission is best-effort; never block lock recovery */
       }
       releaseLock(resolvedLockPath);
-      if (tryAcquireLockSync(resolvedLockPath, lockPayload())) return;
+      if (tryAcquireLockSync(resolvedLockPath, lockPayload())) return "acquired";
+      // Lost the race to another run that grabbed the freed stale lock.
+      if (options.skipIfLocked) {
+        warn("[improve] another run acquired the lock during stale recovery; skipping (--skip-if-locked)");
+        return "skipped";
+      }
       throw new ConfigError(
         `akm improve is already running. Delete ${resolvedLockPath} to force.`,
         "INVALID_CONFIG_FILE",
       );
+    }
+
+    // Lock is held by a live run within the staleness window.
+    if (options.skipIfLocked) {
+      warn(
+        `[improve] another improve run holds the lock (PID ${lock?.pid}, started ${lock?.startedAt}); skipping (--skip-if-locked)`,
+      );
+      return "skipped";
     }
 
     throw new ConfigError(
@@ -948,7 +975,21 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
     // The dry-run branch below produces plannedRefs/memorySummary WITHOUT the lock
     // or triage (decision: dry-run never mutates the queue).
     if (!options.dryRun) {
-      acquireLock();
+      if (acquireLock() === "skipped") {
+        // Another improve holds the lock and the caller asked to skip rather
+        // than fail. Return a clean no-op result (exit 0) before any index/DB
+        // work — never registered the exit listener, never set lockAcquired,
+        // so we release nothing belonging to the run that owns the lock.
+        return {
+          schemaVersion: 1,
+          ok: true,
+          scope,
+          dryRun: false,
+          skipped: { reason: "lock-held" },
+          memorySummary: { eligible: 0, derived: 0 },
+          plannedRefs: [],
+        };
+      }
       lockAcquired = true;
       // Backstop release on process.exit() (signal handler / budget watchdog),
       // which skips the finally below. Removed in that finally on the normal path.

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -20,7 +20,7 @@ import { ConfigError, NotFoundError, UsageError } from "../core/errors";
 import { getTaskHistoryDir, getTaskLogDir } from "../core/paths";
 import { listAgentProfileNames } from "../integrations/agent";
 import { resolveAssetPath } from "../sources/resolve";
-import { backendNameForPlatform, selectBackend } from "../tasks/backends";
+import { backendNameForPlatform, selectBackend, type TaskBackend } from "../tasks/backends";
 import { parseTaskDocument } from "../tasks/parser";
 import { resolveAkmInvocation } from "../tasks/resolveAkmBin";
 import { exitCodeForStatus, readTaskHistory, runTask, type TaskRunResult } from "../tasks/runner";
@@ -297,7 +297,13 @@ export async function akmTasksSetEnabled(
   fs.writeFileSync(filePath, updated, "utf8");
   const sched = selectBackend();
   try {
-    await sched.setEnabled(normalised, enabled);
+    // Reinstall from the (just-updated) definition rather than only toggling
+    // the comment. A plain toggle leaves a stale schedule in place if the
+    // .yml's `schedule:` changed while the task was disabled — re-enabling
+    // would silently keep the old cron line. install() renders the block with
+    // both the current schedule and the new enabled state, and is idempotent.
+    const task = parseTaskDocument({ yaml: updated, filePath, id: normalised });
+    await sched.install(task);
   } catch (err) {
     // Roll the file back so the YAML source-of-truth and the OS
     // scheduler don't diverge silently when the backend call fails.
@@ -341,6 +347,8 @@ export async function akmTasksHistory(input: { id?: string; limit?: number }): P
 
 export interface TasksSyncResult {
   installed: string[];
+  /** Tasks whose installed schedule/enabled state drifted from the .yml and were reinstalled. */
+  updated: string[];
   removed: string[];
   unchanged: string[];
   skipped: { id: string; reason: string }[];
@@ -351,9 +359,12 @@ export interface TasksSyncResult {
  * Reconcile the on-disk task files with the OS scheduler.
  *   • install missing tasks (after validating them — invalid files are
  *     skipped with a per-task reason rather than aborting the whole sync)
+ *   • reinstall tasks whose schedule or enabled state changed in the .yml
+ *     (drift detected by comparing the backend's installed signature against
+ *     the signature the current definition would produce)
  *   • remove orphan scheduler entries that no longer have a backing file
  */
-export async function akmTasksSync(): Promise<TasksSyncResult> {
+export async function akmTasksSync(deps: { backend?: TaskBackend } = {}): Promise<TasksSyncResult> {
   const stashDir = resolveStashDir();
   const typeRoot = path.join(stashDir, "tasks");
   if (fs.existsSync(typeRoot)) warnLegacyMdTaskFiles(typeRoot);
@@ -363,10 +374,13 @@ export async function akmTasksSync(): Promise<TasksSyncResult> {
         .filter((f) => f.endsWith(".yml"))
         .map((f) => f.slice(0, -4))
     : [];
-  const sched = selectBackend();
+  const sched = deps.backend ?? selectBackend();
   const backend = backendNameForPlatform();
-  const present = new Set((await sched.list()).map((t) => t.id));
+  // Map id → installed signature so sync can detect schedule/enabled drift on
+  // tasks that already exist in the scheduler, not just presence/absence.
+  const present = new Map((await sched.list()).map((t) => [t.id, t.signature] as const));
   const installed: string[] = [];
+  const updated: string[] = [];
   const unchanged: string[] = [];
   const skipped: { id: string; reason: string }[] = [];
 
@@ -385,22 +399,34 @@ export async function akmTasksSync(): Promise<TasksSyncResult> {
       skipped.push({ id, reason: err instanceof Error ? err.message : String(err) });
       continue;
     }
-    if (present.has(id)) {
+    if (!present.has(id)) {
+      await sched.install(task);
+      installed.push(id);
+      continue;
+    }
+    // Already installed — reconcile against the current definition. Compare the
+    // installed signature to what this task would render to; reinstall on drift.
+    // When the backend can't produce a signature (no expectedSignature, or it
+    // didn't record one), reinstall unconditionally — install() is idempotent,
+    // so the cost is one crontab write and correctness is guaranteed.
+    const installedSig = present.get(id);
+    const expectedSig = sched.expectedSignature?.(task);
+    if (installedSig !== undefined && expectedSig !== undefined && installedSig === expectedSig) {
       unchanged.push(id);
     } else {
       await sched.install(task);
-      installed.push(id);
+      updated.push(id);
     }
   }
 
   const removed: string[] = [];
-  for (const installedId of present) {
+  for (const installedId of present.keys()) {
     if (!fileIds.includes(installedId)) {
       await sched.uninstall(installedId);
       removed.push(installedId);
     }
   }
-  return { installed, removed, unchanged, skipped, backend: sched.name };
+  return { installed, updated, removed, unchanged, skipped, backend: sched.name };
 }
 
 export interface TasksDoctorResult {

--- a/src/tasks/backends/cron.ts
+++ b/src/tasks/backends/cron.ts
@@ -88,12 +88,11 @@ export function CRON_BACKEND(options: CronBackendOptions = {}): TaskBackend {
     },
     list(): InstalledTaskRef[] {
       const existing = readCrontab(exec);
-      const ids: string[] = [];
-      for (const line of existing.split(/\r?\n/)) {
-        const m = line.match(BLOCK_RE);
-        if (m) ids.push(m[1]);
-      }
-      return ids.map((id) => ({ id }));
+      return listBlocks(existing).map(({ id, body }) => ({ id, signature: normalizeSignature(body) }));
+    },
+    expectedSignature(task: TaskDocument): string {
+      const cronLine = buildCronLine(task, akmArgv, logDir);
+      return normalizeSignature(cronBlockBody(cronLine, task.enabled));
     },
   };
 }
@@ -108,9 +107,50 @@ export function buildCronLine(task: TaskDocument, akmArgv: string[], logDir: str
   return `${cronExpr} ${cmd} >> ${quoteForCron(logPath)} 2>&1`;
 }
 
+/** The crontab line as it appears inside a block — commented when disabled. */
+export function cronBlockBody(cronLine: string, enabled: boolean): string {
+  return enabled ? cronLine : `${DISABLED_PREFIX}${cronLine}`;
+}
+
 export function renderBlock(id: string, cronLine: string, enabled: boolean): string {
-  const body = enabled ? cronLine : `${DISABLED_PREFIX}${cronLine}`;
-  return [BEGIN(id), body, END(id)].join("\n");
+  return [BEGIN(id), cronBlockBody(cronLine, enabled), END(id)].join("\n");
+}
+
+/**
+ * Parse the akm-owned blocks out of a crontab, returning each task id with the
+ * raw body line(s) between its BEGIN/END markers. Used by `list()` to build a
+ * drift signature, and exported for tests.
+ */
+export function listBlocks(existing: string): Array<{ id: string; body: string }> {
+  const out: Array<{ id: string; body: string }> = [];
+  const lines = existing.split(/\r?\n/);
+  let currentId: string | null = null;
+  let body: string[] = [];
+  for (const line of lines) {
+    const begin = line.match(BLOCK_RE);
+    if (begin) {
+      currentId = begin[1];
+      body = [];
+      continue;
+    }
+    if (currentId !== null && line === END(currentId)) {
+      out.push({ id: currentId, body: body.join("\n") });
+      currentId = null;
+      body = [];
+      continue;
+    }
+    if (currentId !== null) body.push(line);
+  }
+  return out;
+}
+
+/** Collapse incidental whitespace so signature comparison ignores it. */
+function normalizeSignature(body: string): string {
+  return body
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+    .join("\n");
 }
 
 export function upsertBlock(existing: string, id: string, block: string): string {

--- a/src/tasks/backends/index.ts
+++ b/src/tasks/backends/index.ts
@@ -22,6 +22,14 @@ import { SCHTASKS_BACKEND, type SchtasksBackendOptions } from "./schtasks";
 
 export interface InstalledTaskRef {
   id: string;
+  /**
+   * Opaque, backend-specific fingerprint of the *currently installed* entry
+   * (e.g. the cron line incl. enabled/disabled state). `tasks sync` compares
+   * it against {@link TaskBackend.expectedSignature} to detect schedule drift
+   * on tasks that already exist in the scheduler. Undefined when the backend
+   * cannot cheaply read its installed form — sync then reinstalls to be safe.
+   */
+  signature?: string;
 }
 
 export interface TaskBackend {
@@ -31,6 +39,14 @@ export interface TaskBackend {
   uninstall(id: string): Promise<void> | void;
   setEnabled(id: string, enabled: boolean): Promise<void> | void;
   list(): Promise<InstalledTaskRef[]> | InstalledTaskRef[];
+  /**
+   * The signature the task *should* have once installed, derived from its
+   * current on-disk definition. Compared against {@link InstalledTaskRef.signature}
+   * during `tasks sync` so a changed schedule (or enabled state) is reinstalled
+   * instead of being silently reported "unchanged". Optional — backends that
+   * omit it fall back to always-reinstall during sync.
+   */
+  expectedSignature?(task: TaskDocument): string;
 }
 
 export interface SelectBackendOptions {

--- a/tests/commands/improve/improve-skip-if-locked.test.ts
+++ b/tests/commands/improve/improve-skip-if-locked.test.ts
@@ -1,0 +1,117 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `--skip-if-locked` (0.8.4 hotfix). When another improve run already holds the
+ * lock, a run started with `skipIfLocked: true` returns a clean no-op result
+ * (ok:true, `skipped.reason === "lock-held"`) and exits 0 instead of throwing
+ * the "already running" ConfigError (exit 78). Without the flag the hard error
+ * is preserved.
+ *
+ * The lock is pre-created owned by THIS process's pid so `probeLock` classifies
+ * it as held (live pid, within the staleness window) rather than stale.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { akmImprove } from "../../../src/commands/improve";
+import type { AkmConfig } from "../../../src/core/config";
+import { saveConfig } from "../../../src/core/config";
+import type { Cleanup } from "../../_helpers/sandbox";
+import {
+  sandboxStashDir,
+  sandboxXdgCacheHome,
+  sandboxXdgConfigHome,
+  sandboxXdgDataHome,
+  sandboxXdgStateHome,
+} from "../../_helpers/sandbox";
+
+const TIMEOUT_MS = 20_000;
+
+let cleanup: Cleanup = () => {};
+let stashDir = "";
+
+/** Cheap config — every heavy improve sub-process disabled. */
+function quietConfig(): AkmConfig {
+  return {
+    semanticSearchMode: "off",
+    defaults: { improve: "quiet-test" },
+    profiles: {
+      improve: {
+        "quiet-test": {
+          processes: {
+            reflect: { enabled: false },
+            distill: { enabled: false },
+            consolidate: { enabled: false },
+            memoryInference: { enabled: false },
+            graphExtraction: { enabled: false },
+            extract: { enabled: false },
+            triage: { enabled: false },
+          },
+        },
+      },
+    },
+  } as unknown as AkmConfig;
+}
+
+/** Plant a live (held) lock owned by this process. */
+function plantHeldLock(): string {
+  const lockPath = path.join(stashDir, ".akm", "improve.lock");
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }), "utf8");
+  return lockPath;
+}
+
+beforeEach(() => {
+  let chain: Cleanup = () => {};
+  chain = sandboxXdgCacheHome(chain).cleanup;
+  chain = sandboxXdgConfigHome(chain).cleanup;
+  chain = sandboxXdgDataHome(chain).cleanup;
+  chain = sandboxXdgStateHome(chain).cleanup;
+  const stash = sandboxStashDir(chain);
+  stashDir = stash.dir;
+  cleanup = stash.cleanup;
+  saveConfig({ semanticSearchMode: "off" });
+});
+
+afterEach(() => {
+  cleanup();
+  cleanup = () => {};
+  stashDir = "";
+});
+
+describe("akm improve — skip-if-locked", () => {
+  test(
+    "returns a skipped no-op result when the lock is held and skipIfLocked is set",
+    async () => {
+      const lockPath = plantHeldLock();
+
+      const result = await akmImprove({
+        scope: "memory",
+        stashDir,
+        config: quietConfig(),
+        skipIfLocked: true,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.skipped?.reason).toBe("lock-held");
+      // The other run's lock is left exactly as we planted it — never released.
+      expect(fs.existsSync(lockPath)).toBe(true);
+      expect(JSON.parse(fs.readFileSync(lockPath, "utf8")).pid).toBe(process.pid);
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "throws 'already running' when the lock is held and skipIfLocked is NOT set",
+    async () => {
+      plantHeldLock();
+      await expect(akmImprove({ scope: "memory", stashDir, config: quietConfig() })).rejects.toThrow(
+        /already running/i,
+      );
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/tests/tasks-cron-backend.test.ts
+++ b/tests/tasks-cron-backend.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, test } from "bun:test";
-import { buildCronLine, removeBlock, renderBlock, toggleBlock, upsertBlock } from "../src/tasks/backends/cron";
+import {
+  buildCronLine,
+  CRON_BACKEND,
+  type CronExec,
+  type CronExecResult,
+  cronBlockBody,
+  listBlocks,
+  removeBlock,
+  renderBlock,
+  toggleBlock,
+  upsertBlock,
+} from "../src/tasks/backends/cron";
 import type { TaskDocument } from "../src/tasks/schema";
 
 const TASK: TaskDocument = {
@@ -95,5 +106,92 @@ describe("cron backend helpers", () => {
     const reenabled = toggleBlock(disabled, "ping", true);
     expect(reenabled).toContain("* * * * * X");
     expect(reenabled).not.toContain("akm:disabled");
+  });
+
+  test("cronBlockBody comments only when disabled", () => {
+    expect(cronBlockBody("* * * * * X", true)).toBe("* * * * * X");
+    expect(cronBlockBody("* * * * * X", false)).toBe("# akm:disabled * * * * * X");
+  });
+
+  test("listBlocks parses id and body between markers", () => {
+    const crontab = [
+      "# user line",
+      "# akm:task ping BEGIN",
+      "*/15 * * * * /bin/akm tasks run ping",
+      "# akm:task ping END",
+      "# akm:task other BEGIN",
+      "# akm:disabled 0 2 * * * /bin/akm tasks run other",
+      "# akm:task other END",
+    ].join("\n");
+    expect(listBlocks(crontab)).toEqual([
+      { id: "ping", body: "*/15 * * * * /bin/akm tasks run ping" },
+      { id: "other", body: "# akm:disabled 0 2 * * * /bin/akm tasks run other" },
+    ]);
+  });
+});
+
+// ── drift detection (the `tasks sync` schedule-change fix) ───────────────────
+
+/** In-memory crontab so the backend never touches the real one. */
+function memoryExec(initial = ""): CronExec & { current: () => string } {
+  let store = initial;
+  return {
+    read(): CronExecResult {
+      return { status: 0, stdout: store, stderr: "" };
+    },
+    write(content: string): CronExecResult {
+      store = content;
+      return { status: 0, stdout: "", stderr: "" };
+    },
+    current: () => store,
+  };
+}
+
+const SYNC_TASK: TaskDocument = {
+  schemaVersion: 1,
+  id: "ping",
+  schedule: "*/15 * * * *",
+  enabled: true,
+  target: { kind: "workflow", ref: "workflow:noop", params: {} },
+  source: { path: "/stash/tasks/ping.yml" },
+};
+
+describe("cron backend drift detection", () => {
+  const opts = (exec: CronExec) => ({ exec, logDir: "/var/log/akm", akmArgv: ["/usr/local/bin/akm"] });
+
+  test("list() returns a signature equal to expectedSignature for an installed task", () => {
+    const exec = memoryExec();
+    const backend = CRON_BACKEND(opts(exec));
+    backend.install(SYNC_TASK);
+    const listed = backend.list();
+    expect(listed).toHaveLength(1);
+    expect(listed[0].id).toBe("ping");
+    expect(listed[0].signature).toBe(backend.expectedSignature?.(SYNC_TASK));
+  });
+
+  test("expectedSignature changes when the schedule changes (drift is detectable)", () => {
+    const exec = memoryExec();
+    const backend = CRON_BACKEND(opts(exec));
+    backend.install(SYNC_TASK);
+    const installedSig = backend.list()[0].signature;
+    const rescheduled: TaskDocument = { ...SYNC_TASK, schedule: "45 */6 * * *" };
+    expect(backend.expectedSignature?.(rescheduled)).not.toBe(installedSig);
+  });
+
+  test("expectedSignature changes when enabled flips", () => {
+    const backend = CRON_BACKEND(opts(memoryExec()));
+    const enabledSig = backend.expectedSignature?.({ ...SYNC_TASK, enabled: true });
+    const disabledSig = backend.expectedSignature?.({ ...SYNC_TASK, enabled: false });
+    expect(enabledSig).not.toBe(disabledSig);
+  });
+
+  test("signature is stable across reinstall when nothing changed", () => {
+    const backend = CRON_BACKEND(opts(memoryExec()));
+    backend.install(SYNC_TASK);
+    const sig1 = backend.list()[0].signature;
+    backend.install(SYNC_TASK);
+    const sig2 = backend.list()[0].signature;
+    expect(sig1).toBe(sig2);
+    expect(sig1).toBe(backend.expectedSignature?.(SYNC_TASK));
   });
 });

--- a/tests/tasks-sync.test.ts
+++ b/tests/tasks-sync.test.ts
@@ -1,0 +1,130 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `akm tasks sync` schedule-drift detection (0.8.4 hotfix).
+ *
+ * Before the fix, sync classified any task already present in the scheduler as
+ * "unchanged" without comparing its cron line, so a changed `schedule:` in the
+ * .yml never reached the crontab. These tests drive the real `akmTasksSync`
+ * with an injected cron backend (in-memory crontab) and assert that a changed
+ * schedule is detected and reinstalled.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { akmTasksSync } from "../src/commands/tasks";
+import { CRON_BACKEND, type CronExec, type CronExecResult } from "../src/tasks/backends/cron";
+import type { Cleanup } from "./_helpers/sandbox";
+import { sandboxStashDir, sandboxXdgConfigHome, sandboxXdgStateHome } from "./_helpers/sandbox";
+
+let cleanup: Cleanup = () => {};
+let stashDir = "";
+let tasksDir = "";
+
+function memoryExec(initial = ""): CronExec & { current: () => string } {
+  let store = initial;
+  return {
+    read: (): CronExecResult => ({ status: 0, stdout: store, stderr: "" }),
+    write: (content: string): CronExecResult => {
+      store = content;
+      return { status: 0, stdout: "", stderr: "" };
+    },
+    current: () => store,
+  };
+}
+
+function writeTask(id: string, schedule: string, enabled = true): void {
+  fs.writeFileSync(
+    path.join(tasksDir, `${id}.yml`),
+    `schedule: "${schedule}"\ncommand: echo ${id}\nenabled: ${enabled}\nname: ${id}\n`,
+    "utf8",
+  );
+}
+
+beforeEach(() => {
+  let chain: Cleanup = () => {};
+  chain = sandboxXdgConfigHome(chain).cleanup;
+  chain = sandboxXdgStateHome(chain).cleanup;
+  const stash = sandboxStashDir(chain);
+  stashDir = stash.dir;
+  cleanup = stash.cleanup;
+  tasksDir = path.join(stashDir, "tasks");
+  fs.mkdirSync(tasksDir, { recursive: true });
+});
+
+afterEach(() => {
+  cleanup();
+  cleanup = () => {};
+  stashDir = "";
+  tasksDir = "";
+});
+
+describe("akmTasksSync — schedule drift", () => {
+  const backendFor = (exec: CronExec) =>
+    CRON_BACKEND({ exec, logDir: "/var/log/akm", akmArgv: ["/usr/local/bin/akm"] });
+
+  test("installs missing, then reports unchanged on a no-op re-sync", async () => {
+    const exec = memoryExec();
+    const backend = backendFor(exec);
+    writeTask("alpha", "*/15 * * * *");
+    writeTask("beta", "0 2 * * *");
+
+    const first = await akmTasksSync({ backend });
+    expect(first.installed.sort()).toEqual(["alpha", "beta"]);
+    expect(first.updated).toEqual([]);
+
+    const second = await akmTasksSync({ backend });
+    expect(second.installed).toEqual([]);
+    expect(second.updated).toEqual([]);
+    expect(second.unchanged.sort()).toEqual(["alpha", "beta"]);
+  });
+
+  test("detects a changed schedule and reinstalls it (the bug fix)", async () => {
+    const exec = memoryExec();
+    const backend = backendFor(exec);
+    writeTask("alpha", "*/15 * * * *");
+    writeTask("beta", "0 2 * * *");
+    await akmTasksSync({ backend });
+
+    // Edit beta's schedule on disk, as `akm tasks` never rewrites it.
+    writeTask("beta", "45 */6 * * *");
+
+    const result = await akmTasksSync({ backend });
+    expect(result.updated).toEqual(["beta"]);
+    expect(result.unchanged).toEqual(["alpha"]);
+    expect(result.installed).toEqual([]);
+    // The crontab now carries the new schedule, not the stale one.
+    expect(exec.current()).toContain("45 */6 * * * /usr/local/bin/akm tasks run beta");
+    expect(exec.current()).not.toContain("0 2 * * * /usr/local/bin/akm tasks run beta");
+  });
+
+  test("detects an enabled→disabled flip and reinstalls commented", async () => {
+    const exec = memoryExec();
+    const backend = backendFor(exec);
+    writeTask("alpha", "*/15 * * * *", true);
+    await akmTasksSync({ backend });
+    expect(exec.current()).not.toContain("# akm:disabled");
+
+    writeTask("alpha", "*/15 * * * *", false);
+    const result = await akmTasksSync({ backend });
+    expect(result.updated).toEqual(["alpha"]);
+    expect(exec.current()).toContain("# akm:disabled */15 * * * * /usr/local/bin/akm tasks run alpha");
+  });
+
+  test("removes orphaned scheduler entries with no backing file", async () => {
+    const exec = memoryExec();
+    const backend = backendFor(exec);
+    writeTask("alpha", "*/15 * * * *");
+    writeTask("gamma", "0 5 * * *");
+    await akmTasksSync({ backend });
+
+    fs.rmSync(path.join(tasksDir, "gamma.yml"));
+    const result = await akmTasksSync({ backend });
+    expect(result.removed).toEqual(["gamma"]);
+    expect(exec.current()).not.toContain("tasks run gamma");
+    expect(exec.current()).toContain("tasks run alpha");
+  });
+});


### PR DESCRIPTION
## 0.8.4 hotfix — two fixes

### 1. \`akm tasks sync\` ignored schedule changes
Sync marked any already-installed task **unchanged** without comparing its cron line, so an edited \`schedule:\` never reached the crontab — only \`remove\`+\`add\` applied a new schedule. \`enable\`/\`disable\` had the same gap (toggled the comment, kept the stale schedule).

**Fix:** sync compares the backend's installed signature against the signature the current \`.yml\` renders to and reinstalls on drift (new \`updated[]\` field). \`enable\`/\`disable\` now reinstall from the current \`.yml\`. Cron backend gains \`expectedSignature()\` + a per-entry \`signature\` on \`list()\`; backends without it fall back to an idempotent reinstall (correct on launchd/schtasks).

### 2. \`akm improve --skip-if-locked\`
When another improve holds the lock, the run logs and **exits 0** with a no-op result (\`skipped.reason: "lock-held"\`) instead of failing with "already running" (**exit 78**). For high-frequency scheduled runs (e.g. an every-30-min \`quick\` pass) that overlap a longer run. Default off.

## Tests
- Cron drift unit tests (signature / expectedSignature / listBlocks)
- \`akmTasksSync\` integration via injected backend: install → unchanged → updated-on-drift → removed
- \`--skip-if-locked\` integration: skip vs preserved hard-error
- Full \`lint\` + \`tsc\` + unit + integration green (0 fail at CI parallelism)
- Manual CLI: skip → exit 0 + lock intact; no flag → exit 78

🤖 Generated with [Claude Code](https://claude.com/claude-code)