### PR TITLE
port: 0.8.6 — consolidate.incrementalSince profile config field

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,10 @@ jobs:
             echo "Dispatched from default branch ($BRANCH)."
           elif [[ "$BRANCH" == release/* ]] && echo "$VERSION" | grep -qE '-'; then
             echo "Dispatched from release branch ($BRANCH) with prerelease version ($VERSION)."
+          elif [[ "$BRANCH" == hotfix/* ]] && ! echo "$VERSION" | grep -qE '-'; then
+            echo "Dispatched from hotfix branch ($BRANCH) with stable version ($VERSION)."
           else
-            echo "Releases must be dispatched from $DEFAULT, or from a release/* branch with a prerelease version (e.g. 0.6.0-rc1)."
+            echo "Releases must be dispatched from $DEFAULT, from a release/* branch with a prerelease version, or from a hotfix/* branch with a stable version."
             echo "Got branch=$BRANCH version=$VERSION"
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.8.6] - 2026-06-09
+
+### Added
+
+- **`consolidate.incrementalSince` profile config field.** Setting
+  `incrementalSince: "7d"` (or any duration string) in the `consolidate` block
+  of an improve profile narrows the candidate pool to memories modified within
+  that window plus their top-5 graph neighbours, keeping each pass focused on
+  recent changes. This makes it practical to run consolidation more often than
+  once per day (e.g. via `akm-improve-consolidate` every 4 h) without
+  re-scanning the full pool every time. The nightly default profile leaves this
+  unset (full-pool sweep, same as before). The `incrementalSince` option already
+  existed in `akmConsolidate()` but was hardcoded off at the call site; the
+  field is now surfaced in the config schema and read from the profile.
+
 ## [0.8.5] - 2026-06-09
 
 ### Fixed

--- a/schemas/akm-config.json
+++ b/schemas/akm-config.json
@@ -203,6 +203,10 @@
                         "minimum": 1,
                         "maximum": 50
                       },
+                      "incrementalSince": {
+                        "type": "string",
+                        "minLength": 1
+                      },
                       "applyMode": {
                         "type": "string",
                         "enum": [
@@ -323,6 +327,10 @@
                         "type": "integer",
                         "minimum": 1,
                         "maximum": 50
+                      },
+                      "incrementalSince": {
+                        "type": "string",
+                        "minLength": 1
                       },
                       "applyMode": {
                         "type": "string",
@@ -445,6 +453,10 @@
                         "minimum": 1,
                         "maximum": 50
                       },
+                      "incrementalSince": {
+                        "type": "string",
+                        "minLength": 1
+                      },
                       "applyMode": {
                         "type": "string",
                         "enum": [
@@ -565,6 +577,10 @@
                         "type": "integer",
                         "minimum": 1,
                         "maximum": 50
+                      },
+                      "incrementalSince": {
+                        "type": "string",
+                        "minLength": 1
                       },
                       "applyMode": {
                         "type": "string",
@@ -687,6 +703,10 @@
                         "minimum": 1,
                         "maximum": 50
                       },
+                      "incrementalSince": {
+                        "type": "string",
+                        "minLength": 1
+                      },
                       "applyMode": {
                         "type": "string",
                         "enum": [
@@ -808,6 +828,10 @@
                         "minimum": 1,
                         "maximum": 50
                       },
+                      "incrementalSince": {
+                        "type": "string",
+                        "minLength": 1
+                      },
                       "applyMode": {
                         "type": "string",
                         "enum": [
@@ -928,6 +952,10 @@
                         "type": "integer",
                         "minimum": 1,
                         "maximum": 50
+                      },
+                      "incrementalSince": {
+                        "type": "string",
+                        "minLength": 1
                       },
                       "applyMode": {
                         "type": "string",
@@ -1647,6 +1675,10 @@
                             "minimum": 1,
                             "maximum": 50
                           },
+                          "incrementalSince": {
+                            "type": "string",
+                            "minLength": 1
+                          },
                           "applyMode": {
                             "type": "string",
                             "enum": [
@@ -1767,6 +1799,10 @@
                             "type": "integer",
                             "minimum": 1,
                             "maximum": 50
+                          },
+                          "incrementalSince": {
+                            "type": "string",
+                            "minLength": 1
                           },
                           "applyMode": {
                             "type": "string",
@@ -1889,6 +1925,10 @@
                             "minimum": 1,
                             "maximum": 50
                           },
+                          "incrementalSince": {
+                            "type": "string",
+                            "minLength": 1
+                          },
                           "applyMode": {
                             "type": "string",
                             "enum": [
@@ -2009,6 +2049,10 @@
                             "type": "integer",
                             "minimum": 1,
                             "maximum": 50
+                          },
+                          "incrementalSince": {
+                            "type": "string",
+                            "minLength": 1
                           },
                           "applyMode": {
                             "type": "string",
@@ -2131,6 +2175,10 @@
                             "minimum": 1,
                             "maximum": 50
                           },
+                          "incrementalSince": {
+                            "type": "string",
+                            "minLength": 1
+                          },
                           "applyMode": {
                             "type": "string",
                             "enum": [
@@ -2252,6 +2300,10 @@
                             "minimum": 1,
                             "maximum": 50
                           },
+                          "incrementalSince": {
+                            "type": "string",
+                            "minLength": 1
+                          },
                           "applyMode": {
                             "type": "string",
                             "enum": [
@@ -2372,6 +2424,10 @@
                             "type": "integer",
                             "minimum": 1,
                             "maximum": 50
+                          },
+                          "incrementalSince": {
+                            "type": "string",
+                            "minLength": 1
                           },
                           "applyMode": {
                             "type": "string",
@@ -3073,6 +3129,10 @@
           "minimum": 1,
           "maximum": 50
         },
+        "incrementalSince": {
+          "type": "string",
+          "minLength": 1
+        },
         "applyMode": {
           "type": "string",
           "enum": [
@@ -3204,6 +3264,10 @@
                   "minimum": 1,
                   "maximum": 50
                 },
+                "incrementalSince": {
+                  "type": "string",
+                  "minLength": 1
+                },
                 "applyMode": {
                   "type": "string",
                   "enum": [
@@ -3324,6 +3388,10 @@
                   "type": "integer",
                   "minimum": 1,
                   "maximum": 50
+                },
+                "incrementalSince": {
+                  "type": "string",
+                  "minLength": 1
                 },
                 "applyMode": {
                   "type": "string",
@@ -3446,6 +3514,10 @@
                   "minimum": 1,
                   "maximum": 50
                 },
+                "incrementalSince": {
+                  "type": "string",
+                  "minLength": 1
+                },
                 "applyMode": {
                   "type": "string",
                   "enum": [
@@ -3566,6 +3638,10 @@
                   "type": "integer",
                   "minimum": 1,
                   "maximum": 50
+                },
+                "incrementalSince": {
+                  "type": "string",
+                  "minLength": 1
                 },
                 "applyMode": {
                   "type": "string",
@@ -3688,6 +3764,10 @@
                   "minimum": 1,
                   "maximum": 50
                 },
+                "incrementalSince": {
+                  "type": "string",
+                  "minLength": 1
+                },
                 "applyMode": {
                   "type": "string",
                   "enum": [
@@ -3809,6 +3889,10 @@
                   "minimum": 1,
                   "maximum": 50
                 },
+                "incrementalSince": {
+                  "type": "string",
+                  "minLength": 1
+                },
                 "applyMode": {
                   "type": "string",
                   "enum": [
@@ -3929,6 +4013,10 @@
                   "type": "integer",
                   "minimum": 1,
                   "maximum": 50
+                },
+                "incrementalSince": {
+                  "type": "string",
+                  "minLength": 1
                 },
                 "applyMode": {
                   "type": "string",

--- a/src/commands/consolidate.ts
+++ b/src/commands/consolidate.ts
@@ -2392,14 +2392,27 @@ async function checkPreEmitDedup(opts: {
  * everything changed or the index can't answer (fail-open to preserve merge
  * correctness). `since` is an ISO timestamp.
  */
+/**
+ * Parse a human-readable duration string (e.g. "30m", "24h", "7d") to an ISO
+ * timestamp representing `now - duration`. Returns the input unchanged when it
+ * doesn't match the pattern (assumed to already be an ISO timestamp).
+ */
+function parseSinceToIso(since: string): string {
+  const m = since.match(/^(\d+)(m|h|d)$/);
+  if (!m) return since;
+  const multiplier = { m: 60_000, h: 3_600_000, d: 86_400_000 }[m[2] as "m" | "h" | "d"];
+  return new Date(Date.now() - parseInt(m[1], 10) * multiplier).toISOString();
+}
+
 export function narrowToIncrementalCandidates(
   memories: MemoryEntry[],
   since: string,
   warnings: string[],
 ): MemoryEntry[] {
+  const sinceIso = parseSinceToIso(since);
   const isChanged = (m: MemoryEntry): boolean => {
     try {
-      return fs.statSync(m.filePath).mtime.toISOString() > since;
+      return fs.statSync(m.filePath).mtime.toISOString() > sinceIso;
     } catch {
       return true; // never silently drop a memory we cannot stat
     }
@@ -2434,7 +2447,7 @@ export function narrowToIncrementalCandidates(
 
   const candidates = memories.filter((m) => keep.has(m.name));
   warnings.push(
-    `Incremental consolidation: ${changed.length} changed + neighbours → ${candidates.length}/${memories.length} memories considered (since ${since}).`,
+    `Incremental consolidation: ${changed.length} changed + neighbours → ${candidates.length}/${memories.length} memories considered (since ${since}${sinceIso !== since ? ` = ${sinceIso}` : ""}).`,
   );
   return candidates;
 }

--- a/src/commands/improve.ts
+++ b/src/commands/improve.ts
@@ -2875,13 +2875,11 @@ async function runImprovePostLoopStage(args: {
       // Tie consolidate proposals back to this improve invocation so
       // accept-rate-per-run aggregation works. Mirrors reflect/propose/extract.
       sourceRun: `consolidate-${Date.now()}`,
-      // Full-pool sweep: consolidation only runs on the nightly default-profile
-      // pass (quick/frequent disable it), so a complete re-cluster is correct and
-      // affordable here. Do NOT pass incrementalSince — the time-window narrowing
-      // it triggers permanently excludes stale-but-unmerged duplicate clusters,
-      // starving merge recall and letting the pool grow unbounded. (The narrowing
-      // was a band-aid for an every-30-min consolidation cadence that the profile
-      // split has since eliminated.) lastConsolidateTs still gates whether we run.
+      // incrementalSince: when set in the profile config, narrows the candidate
+      // pool to memories modified within that window + their graph neighbours,
+      // keeping each pass focused on recent changes. Omit for a full-pool sweep
+      // (default for nightly passes). See config-schema.ts for guidance.
+      incrementalSince: improveProfile?.processes?.consolidate?.incrementalSince,
       maxChunkSize: improveProfile?.processes?.consolidate?.maxChunkSize,
       // Honor profile.autoAccept (already merged into options.autoAccept at the
       // top of akmImprove). The CLI parser always supplies 90 when --auto-accept

--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -151,6 +151,12 @@ export const ImproveProcessConfigSchema = z
     defaultSince: z.string().min(1).optional(),
     maxTotalChars: positiveInt.optional(),
     maxChunkSize: z.number().int().min(1).max(50).optional(),
+    // Consolidate process: when set, narrows the candidate pool to memories
+    // modified within this window (e.g. "7d", "48h") plus their graph
+    // neighbours. Useful when consolidation runs more than once per day —
+    // keeps each pass focused on recent changes without re-scanning the full
+    // pool. Leave unset (full-pool sweep) for the nightly default pass.
+    incrementalSince: z.string().min(1).optional(),
     // Triage process config (only meaningful for the `triage` process)
     applyMode: z.enum(["queue", "promote"]).optional(),
     policy: z.string().min(1).optional(),

--- a/src/core/config-types.ts
+++ b/src/core/config-types.ts
@@ -154,6 +154,15 @@ export interface ImproveProcessConfig {
    */
   maxChunkSize?: number;
   /**
+   * When set, narrows the consolidation candidate pool to memories modified
+   * within this window (e.g. `"7d"`, `"48h"`) plus their top-5 graph
+   * neighbours. Useful when consolidation runs more than once per day —
+   * keeps each pass focused on recent changes. Leave absent for a full-pool
+   * sweep (correct and affordable for nightly runs).
+   * Only meaningful on the `consolidate` process.
+   */
+  incrementalSince?: string;
+  /**
    * Full-corpus scan for the `graphExtraction` process.
    * When `true`, graph extraction runs on ALL stash files instead of only
    * the files touched by actionable refs in the current run.


### PR DESCRIPTION
Forward-port of the 0.8.6 hotfix to main (0.9.0).

Cherry-pick of `da949c03` from `hotfix/0.8.6`.

## What

Surfaces `incrementalSince` as a configurable field in the `consolidate` block of an improve profile. Setting it (e.g. `"7d"`) narrows the candidate pool to memories modified within that window plus their top-5 graph neighbours — making it practical to run consolidation more than once per day without re-scanning the full pool each time.

The `incrementalSince` option already existed in `akmConsolidate()` but was hardcoded off at the call site after the 0.8.5 full-pool sweep fix. This change makes it opt-in via config rather than hardcoded.

## Files changed

- `src/core/config/config-schema.ts` — add `incrementalSince: z.string().min(1).optional()` to `ImproveProcessConfigSchema`
- `src/commands/improve/improve.ts` — read `improveProfile?.processes?.consolidate?.incrementalSince` and pass to `akmConsolidate()`
- `schemas/akm-config.json` — regenerated
- `CHANGELOG.md` — 0.8.6 entry (note: version number stays at 0.9.0 on main)
- `.github/workflows/release.yml` — allow `hotfix/*` branches to dispatch stable releases

## Testing

`bun test` — 4172 pass, 0 fail