### PR TITLE
feat(curate): improve shortlist relevance

### DIFF
--- a/docs/0.9.0-curate-quality-implementation-plan.md
+++ b/docs/0.9.0-curate-quality-implementation-plan.md
@@ -1,0 +1,222 @@
+# 0.9.0 Curate Quality — Implementation Plan
+
+> Plan to make `akm curate` behave like a flagship shortlist feature: high
+> trust, action-oriented, low-duplication, and relevance-first. Grounded in the
+> current curate code, tests, and the agent workmap as of 2026-06-15.
+
+## Goal
+
+Improve `akm curate` so it:
+
+- preserves the strongest search results first
+- avoids unrelated filler added only for type variety
+- handles obvious root-vs-derived asset families well
+- falls back when initial phrase hits are weak, not only when empty
+- leaves room for lightweight graph-aware navigation without overengineering
+
+## Problem Summary
+
+Current issues in `curate`:
+
+- hard one-per-type selection throws away too much search ranking signal
+- regex-based type reordering can promote weak items over much stronger ones
+- broad queries can surface unrelated filler like `command:release-manager`
+- root assets and their child/reference assets can both consume shortlist slots
+- fallback search only runs on zero-hit initial queries, not weak-hit queries
+- output is still largely inspect-first even when the top asset is actionable
+
+## Desired Product Behavior
+
+`curate` should optimize in this order:
+
+1. actionability
+2. relevance
+3. low duplication / root-asset preference
+4. navigability
+5. type diversity
+
+That means:
+
+- top result should usually be the best overall asset to use next
+- type diversity should be a soft preference, not a hard quota
+- related support assets should usually attach to a stronger root item rather than consume separate shortlist slots
+
+## Work Streams
+
+### WS-A — Score-first selection and soft type nudges
+
+Replace the current hard one-per-type curate selector with score-first shortlist selection.
+
+#### Code touchpoints
+
+- `src/commands/read/curate.ts`
+- `tests/curate-logic.test.ts`
+- `tests/curate-command.test.ts`
+
+#### Approach
+
+- preserve ranked search hits as the primary ordering backbone
+- remove the current hard `bestByType` shortlist behavior
+- add only small post-search type nudges for close-score candidates
+- add a relative floor so weak tail hits do not enter only to satisfy diversity
+
+#### In-bounds type-aware corrections
+
+- prefer runnable `script` / concrete `command` over similarly scored `memory` for execution-heavy queries
+- prefer `workflow` / `skill` over adjacent explanation docs for multi-step task queries
+- include `agent` mainly for explicit delegation / persona / prompt-building queries
+- keep `memory` for recall/context queries, not as generic filler
+
+#### Out of scope
+
+- hard type quotas
+- large hand-authored type matrices
+- LLM reranking
+- blanket demotion of `memory` or `agent`
+
+#### Acceptance
+
+- strong higher-score hits remain above weak different-type hits
+- docker-focused curate results stop surfacing unrelated filler by default
+- explicit `--type` behavior remains intact
+
+### WS-B — Asset-family collapsing
+
+Add narrow family-aware collapsing for obvious structural root/child bundles.
+
+#### Code touchpoints
+
+- `src/commands/read/curate.ts`
+- `tests/curate-logic.test.ts`
+- `tests/curate-command.test.ts`
+
+#### Approach
+
+- introduce a small family-key helper for obvious structural bundles
+- start narrow and explicit, not semantic
+- first target:
+  - root `skill:<name>`
+  - child `knowledge:skills/<name>/references/...`
+
+#### Rules
+
+- broad query like `docker homelab` -> prefer the root `skill`
+- narrow query like `docker compose reference` -> prefer the child reference page
+- if both are useful, keep one top-level and attach the other later as support
+
+#### Acceptance
+
+- broad root queries no longer spend top-level slots on near-duplicate child references by default
+- narrow subtopic queries can still surface the child when it is clearly the better match
+
+### WS-C — Weak-result fallback triggering
+
+Relax fallback suppression so weak initial hits do not block more useful token fallback.
+
+#### Code touchpoints
+
+- `src/commands/read/curate.ts`
+- `tests/curate-search-for-curation.test.ts`
+- `tests/curate-command.test.ts`
+
+#### Approach
+
+- stop treating any initial hit as sufficient to suppress fallback
+- suppress fallback only when the initial result set is actually strong enough
+- allow one-token fallback when a prompt-style query reduces to one clearly meaningful token
+- preserve a narrow allowlist of meaningful short tokens over time if needed
+
+#### Acceptance
+
+- one weak accidental phrase hit no longer blocks clearly better fallback results
+- prompt-style residue like `the docker` can still fall back sensibly
+- strong initial hits still suppress unnecessary fallback
+
+### WS-D — Lightweight graph-aware support hints
+
+Leverage existing graph data for navigation, not primary reranking.
+
+#### Code touchpoints
+
+- `src/indexer/graph/graph-boost.ts`
+- `src/commands/read/show.ts`
+- `src/commands/read/curate.ts`
+- `src/output/shapes/curate.ts`
+- `src/output/text/helpers.ts`
+
+#### Existing graph seam
+
+- there is no first-class asset->asset edge table
+- `listRelatedPathsForFile()` already derives related assets from shared-entity overlap
+- `akm show` already exposes a lightweight `related` block
+
+#### Approach
+
+- do not use graph as a primary reranker yet
+- attach 1-2 lightweight support refs or navigation hints to curated items
+- keep full graph exploration in `akm show` / `akm graph related`
+
+#### Acceptance
+
+- curate can expose minimal related/support guidance without bloating the shortlist
+- curate still works correctly when graph data is absent or thin
+
+## Test Plan
+
+### Rewrite current characterization tests that encode bad behavior
+
+- `tests/curate-logic.test.ts`
+- `tests/curate-command.test.ts`
+
+### Add / update regression tests for
+
+- strong higher-score hits staying above weak different-type hits
+- script outranking memory on execution-heavy query
+- root skill preferred over child reference on broad query
+- child reference preferred on narrow reference query
+- no unrelated `command:release-manager` filler in docker curate cases
+- weak initial phrase hit still triggering fallback
+- one-token fallback allowed for prompt-style residue
+- lightweight related/support hints attaching without consuming top-level slots
+
+### Preserve current invariants where still correct
+
+- explicit `--type` bypasses diversification
+- registry results remain filler-only and capped
+- output shape and usage logging keep their public contract unless intentionally changed
+
+## Phasing
+
+- **Phase 1:** WS-A score-first selection + regression rewrites
+- **Phase 2:** WS-B family collapsing
+- **Phase 3:** WS-C weak-result fallback triggering
+- **Phase 4:** WS-D lightweight graph-aware support hints
+- **Phase 5:** revisit follow-up actionability after ranking quality is fixed
+
+## Risks
+
+- over-tuning type heuristics can recreate brittle ranking behavior in a new form
+- family detection can hide genuinely useful child assets if too aggressive
+- fallback broadening can add noise if it is not gated by simple strength checks
+- graph signal is sparse on cold stashes and must remain optional
+
+## Suggested Issue / PR Mapping
+
+- PR1: WS-A score-first shortlist + test rewrites
+- PR2: WS-B family collapsing + new family tests
+- PR3: WS-C fallback trigger improvements + fallback tests
+- PR4: WS-D graph support hints + output/tests/docs
+
+## Docs To Update Alongside The Work
+
+- `docs/features/search-discovery.md`
+- `docs/cli.md`
+- `docs/agents/curate-workmap.md`
+
+## References
+
+- `docs/agents/curate-workmap.md`
+- `src/commands/read/curate.ts`
+- `tests/curate-command.test.ts`
+- `tests/curate-logic.test.ts`
+- `tests/curate-search-for-curation.test.ts`

--- a/docs/agents/curate-workmap.md
+++ b/docs/agents/curate-workmap.md
@@ -1,0 +1,301 @@
+# Curate Workmap
+
+## When To Read This
+
+Read this before changing `akm curate` ranking, fallback, follow-up generation, or agent-facing output.
+
+This page is the shortest path to understanding:
+- how `akm curate` currently works
+- which tests pin that behavior
+- where the current implementation diverges from intended product behavior
+- what fix direction has the strongest support from recent review
+
+## Debate Outcome
+
+Recent multi-agent review converged on the same conclusion:
+
+- `curate` should be relevance-first, not diversity-first
+- search ranking should remain the backbone of the shortlist
+- type diversity should be a soft preference for later slots, not a hard override
+- fallback search should run when the initial result set is weak or noisy, not only when it is empty
+- `followUp` should become more action-aware over time, but ranking/fallback correctness comes first
+
+Recommended fix order:
+
+1. Make curate selection score-first and diversity-second.
+2. Relax fallback suppression so one weak phrase hit does not block token fallback.
+3. Revisit follow-up generation after ranking quality improves.
+
+Additional debate outcome:
+
+- simple type-aware reranking is useful only as a thin post-search correction layer
+- root-vs-derived asset families should usually be collapsed to one representative in the top-level shortlist
+- graph data is better suited for attached support refs or navigation hints than for primary reranking in the first iteration
+
+## Current Curate Contract
+
+- CLI entry lives in `src/commands/read/search-cli.ts`.
+- Public entry point is `akmCurate()` in `src/commands/read/curate.ts`.
+- Default curated limit is `4`.
+- Default search source is `stash`.
+- Curate fetches more search hits than it returns: `limit * 4`, minimum `12`.
+- `--type <type>` bypasses diversification and returns top hits of that type.
+- Default multi-type curate currently keeps one best hit per type, then reorders types using regex heuristics.
+- Registry hits only fill leftover slots and are capped at `2`.
+- Stash items are enriched via `akmShowUnified()` best-effort.
+- Stash `followUp` is always `akm show <ref>` today.
+- Curate logs both a summary event and per-item retrieval rows for stash refs.
+
+## Execution Path
+
+Read these first:
+
+- `src/commands/read/search-cli.ts`
+- `src/commands/read/curate.ts`
+- `src/output/shapes/curate.ts`
+- `src/output/text/helpers.ts`
+- `src/commands/read/search.ts`
+- `src/commands/read/show.ts`
+
+Key functions in `src/commands/read/curate.ts`:
+
+- `akmCurate()`
+- `searchForCuration()`
+- `deriveCurateFallbackQueries()`
+- `mergeCurateSearchResponses()`
+- `curateSearchResults()`
+- `orderCuratedTypes()`
+- `enrichCuratedStashHit()`
+
+## Ranking And Selection Rules
+
+Current behavior:
+
+- Search returns scored, ordered hits.
+- Curate then discards most of that ordering by taking the first hit per type.
+- Those per-type winners are reordered using query regex boosts such as `deploy`, `review`, `guide`, `agent`, and `memory`.
+- This can promote obviously lower-score items above much stronger hits.
+
+Why this is a problem:
+
+- search already has strong ranking tests and should remain the primary relevance signal
+- current curate can surface irrelevant filler to satisfy type variety
+- users experience curate as a flagship shortlist, so wrong top results damage trust more than low variety does
+
+Preferred direction:
+
+- preserve top-ranked overall hits first
+- allow diversity only when alternatives are close in score and plausibly relevant
+- keep explicit `--type` behavior unchanged
+
+Small type-aware corrections that are considered in-bounds:
+
+- prefer runnable `script` / concrete `command` over similarly scored `memory` for execution-heavy queries
+- prefer `workflow` / `skill` over adjacent explanation docs for multi-step task queries
+- include `agent` mainly for explicit delegation / persona / prompt-building queries
+- keep `memory` for recall/context queries, not as generic filler
+
+Corrections that are currently considered too risky:
+
+- hard one-per-type quotas
+- large hand-authored type matrices
+- LLM reranking
+- blanket demotion of `memory` or `agent` as types
+
+## Asset Families
+
+Curate should think in terms of asset families, not just isolated types.
+
+Practical examples in this repo:
+
+- `skill:docker-homelab`
+- `knowledge:skills/docker-homelab/references/compose`
+
+Desired behavior:
+
+- broad query like `docker homelab` -> prefer the root asset
+- narrow query like `docker compose reference` -> prefer the child reference page
+- if both are useful, attach the weaker sibling as support instead of spending two top-level slots by default
+
+This should start as an explicit structural heuristic, not semantic lineage inference.
+
+## Fallback Search Behavior
+
+Current behavior:
+
+- `searchForCuration()` only runs fallback token searches when the initial query returns zero hits
+- if the initial query returns even one weak or irrelevant hit, fallback does not run
+- fallback token extraction removes filler words, dedupes tokens, drops tokens shorter than 3 chars, and caps the set at 6
+- fallback is also skipped when normalization leaves only one usable token
+
+Why this is a problem:
+
+- one weak phrase hit can block much better token hits
+- prompt-style queries like `the docker` do not get the obvious one-token fallback
+- meaningful short tokens such as `ai`, `ci`, `cd`, `go`, `js`, or `ts` are lost today
+
+Preferred direction:
+
+- suppress fallback only when the initial result set is actually strong enough
+- allow one-token fallback when that token is clearly the meaningful residue of a prompt-style query
+- preserve a narrow allowlist of meaningful short tokens
+
+## Enrichment And Follow-Up Fields
+
+Current behavior:
+
+- curate enriches stash hits by calling `akmShowUnified({ ref })`
+- if show fails, enrichment silently degrades to raw search-hit data
+- stash follow-up remains `akm show <ref>` even for runnable scripts with a concrete `run`
+- registry follow-up uses the registry action, usually `akm add ...`
+
+Product implication:
+
+- output is inspect-first, not act-first
+- this is acceptable for now, but becomes more visible once result quality improves
+
+For agent consumers, the desired optimization order is:
+
+- actionability
+- relevance
+- low duplication / root-asset preference
+- navigability
+- type diversity
+
+## Output Shape And Formatting
+
+Read:
+
+- `src/output/shapes/curate.ts`
+- `src/output/text/helpers.ts`
+
+Important details:
+
+- `curate` has a dedicated output shaper now
+- `brief` still keeps `followUp` and `reason`
+- `--shape agent` trims fields down for agent use
+- `--shape summary` is rejected on `curate`
+- text output prints fixed `Next steps:` guidance that assumes `akm show <ref>` is the next action
+
+## Telemetry And Retrieval Signal
+
+Read:
+
+- `src/commands/read/curate.ts`
+- `tests/get-retrieval-counts.test.ts`
+
+Important detail:
+
+- curate writes per-item `usage_events` rows for stash refs so curated items count as retrieval signal
+
+This means ranking changes do not just affect UX. They also affect downstream improvement-loop evidence.
+
+## Graph Leverage
+
+Existing graph signal:
+
+- there is no first-class asset->asset edge table
+- asset relatedness is already derivable via shared-entity overlap
+- `listRelatedPathsForFile()` in `src/indexer/graph/graph-boost.ts` returns related assets with `ref`, `type`, `sharedEntities`, and `relationCount`
+- `akm show` already exposes a lightweight `related` block using that signal
+
+Limits:
+
+- graph coverage depends on graph extraction having run
+- graph is thin or absent on cold stashes
+- graph quality is uneven and generic entities can over-connect assets
+- graph coverage is strongest for `knowledge` / `memory` and should not be assumed for every asset family
+
+Recommended first graph-aware use in curate:
+
+- do not use graph as a primary reranker yet
+- use graph to attach 1-2 support refs or navigation hints to a top-level curated result
+- prefer hints like `see also`, `related`, or `inspect next` over full graph payloads
+- keep full graph exploration in `akm show` or `akm graph related`
+
+What not to do yet:
+
+- no graph-only reranking
+- no graph-required curate path
+- no full graph dumps in curate output
+- no semantic asset-lineage inference from sparse graph data
+
+## Tests That Pin Behavior
+
+Start with these:
+
+- `tests/curate-command.test.ts`
+- `tests/curate-logic.test.ts`
+- `tests/curate-search-for-curation.test.ts`
+
+What they cover:
+
+- CLI JSON/text output
+- shape/detail behavior
+- usage logging
+- fallback token derivation
+- merge semantics
+- type ordering
+- diversification logic
+- registry filler cap
+- blank query rejection
+- default limit
+- phrase-hit fallback suppression
+- current quality baselines showing irrelevant filler
+
+Search-ranking baselines that curate should respect:
+
+- `tests/commands/search.test.ts`
+- `tests/ranking-regression.test.ts`
+
+## Known Gaps / Mismatches
+
+- `docs/features/search-discovery.md` currently says curate prefers one strong match per type; that wording is too strong if curate becomes relevance-first.
+- `docs/cli.md` documents `--type`, `--limit`, and `--source`, but does not currently explain the effective `--detail` and `--shape` behavior alongside curate.
+- Some historical AKM refs about curate output shaping are stale because curate now has a dedicated shape implementation.
+
+## Safe Edit Checklist
+
+Before editing curate:
+
+1. Read the three curate-focused test files.
+2. Read `src/commands/read/curate.ts` top to bottom.
+3. Confirm whether you are changing:
+   - post-search selection
+   - fallback triggering
+   - fallback token extraction
+   - output contract
+   - telemetry side effects
+4. Keep CLI surface and output-shape tests passing unless you intentionally change the public contract.
+5. If you improve ranking quality, convert current characterization tests that encode bad behavior into regression tests for the new intended behavior.
+
+## Useful AKM Queries And Refs
+
+Queries:
+
+```sh
+akm search "curate rerank"
+akm search "curate output shape"
+akm search "search discovery curate"
+akm search "curate telemetry usage_events"
+akm search "curate fallback query"
+akm search "curate quality baseline"
+```
+
+Historical context refs:
+
+- `memory:curate-weak-for-ui-test-audit.derived`
+- `knowledge:curate-command-flags-inert`
+
+Note: `knowledge:curate-command-flags-inert` is historical context only. It describes an older output-shaping limitation that is no longer current now that `src/output/shapes/curate.ts` exists.
+
+## Next Fix Candidates
+
+Highest-value next changes:
+
+1. Replace hard one-per-type selection with score-first shortlist selection plus optional soft diversity.
+2. Replace empty-only fallback triggering with weak-result fallback triggering.
+3. Add simple family-aware root/child collapsing for obvious structural bundles.
+4. Add regression tests asserting that docker-specific curate queries stop surfacing unrelated `command:release-manager` filler.
+5. Attach lightweight related-asset hints using existing graph data after ranking quality is fixed.
+6. Revisit `followUp` generation after ranking quality is fixed.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -422,9 +422,14 @@ akm curate "learn the release workflow" --source both --format text
 | `--limit` | number | `4` | Maximum curated results |
 | `--source` | `stash`, `registry`, `both` | `stash` | Where to search before curating |
 
-`akm curate` selects high-signal results, prefers one strong match per asset
-type by default, and includes direct follow-up commands such as `akm show <ref>`
-or `akm add <stash>` so you can immediately inspect or install what it found.
+`akm curate` selects a small relevance-first shortlist. It preserves the
+strongest search hits first, uses only small type-aware nudges for close-score
+ties, can collapse obvious root/reference families into one top-level result,
+and falls back to token searches when the phrase result set is weak. Curate
+includes direct follow-up commands such as `akm show <ref>` or `akm add <stash>`
+so you can immediately inspect or install what it found.
+`--detail` and `--shape agent` both work on curate output; `--shape summary`
+does not.
 Use `--type workflow` when you want curated step-by-step procedures instead of
 individual scripts, skills, or docs.
 

--- a/docs/features/search-discovery.md
+++ b/docs/features/search-discovery.md
@@ -57,8 +57,12 @@ akm search "deploy" --type script --shape agent
 
 `akm curate` goes beyond keyword matching: it runs a search, then applies a
 task-aware ranking pass to surface the most relevant assets for what you are
-actually about to do. It prefers one strong match per asset type and includes
-follow-up commands (`akm show <ref>`) so you can immediately inspect any result.
+actually about to do. It keeps search ranking as the backbone, uses only small
+type-aware nudges for close calls, falls back when phrase hits are weak, and can
+attach support refs for closely related assets. Curate still includes follow-up
+commands (`akm show <ref>`) so you can immediately inspect any result.
+`--detail` works on curate output, and `--shape agent` trims the result to an
+LLM-friendly field set.
 
 ```sh
 akm curate "plan a release"

--- a/docs/technical/curate-performance-evals.md
+++ b/docs/technical/curate-performance-evals.md
@@ -1,0 +1,115 @@
+# Curate Performance Evals
+
+Use this when tuning `akm curate` ranking, fallback, or family-collapsing behavior.
+
+Related context:
+
+- Implementation plan: `docs/0.9.0-curate-quality-implementation-plan.md`
+- Workmap: `docs/agents/curate-workmap.md`
+- Primary eval test: `tests/curate-relevance-eval.test.ts`
+- Logic tests: `tests/curate-logic.test.ts`
+- Fallback tests: `tests/curate-search-for-curation.test.ts`
+- CLI behavior tests: `tests/curate-command.test.ts`
+
+## Goal
+
+Future curate changes should prove that results are more relevant than the pinned
+pre-change baseline, not just different.
+
+## Run The Evals
+
+Typecheck:
+
+```sh
+bunx tsc --noEmit
+```
+
+Curate-focused suite:
+
+```sh
+bun test \
+  tests/curate-logic.test.ts \
+  tests/curate-search-for-curation.test.ts \
+  tests/curate-command.test.ts \
+  tests/curate-relevance-eval.test.ts
+```
+
+Search regression safety net:
+
+```sh
+bun test tests/ranking-regression.test.ts
+```
+
+If you want the raw fixture outputs for manual inspection:
+
+```sh
+BUN_CONFIG_DISABLE_TRANSPILE_CACHE=1 bun -e "
+import { loadFixtureStash } from './tests/fixtures/stashes/load.ts';
+import { saveConfig } from './src/core/config/config.ts';
+import { akmIndex } from './src/indexer/indexer.ts';
+import { akmCurate } from './src/commands/read/curate.ts';
+
+const loaded = loadFixtureStash('ranking-baseline', { skipIndex: true });
+process.env.AKM_STASH_DIR = loaded.stashDir;
+saveConfig({ semanticSearchMode: 'off', sources: [{ type: 'filesystem', path: loaded.stashDir }], registries: [] });
+await akmIndex({ stashDir: loaded.stashDir, full: true });
+
+for (const query of ['docker homelab', 'docker deploy', 'the docker', 'how docker', 'docker compose reference']) {
+  const result = await akmCurate({ query, limit: 4 });
+  console.log('\nQUERY', query);
+  console.log(JSON.stringify(result.items.map((item) => ('ref' in item ? item.ref : `registry:${item.id}`)), null, 2));
+}
+
+loaded.cleanup();
+"
+```
+
+## Current Pinned Before/After Cases
+
+The fixture-backed eval currently proves these improvements over the old curate
+behavior:
+
+| Query | Before | After | Metric |
+| --- | --- | --- | --- |
+| `docker homelab` | root skill + child reference both consumed top-level slots | root skill only; child moved to `supportRefs` | family occupancy `2 -> 1` |
+| `docker deploy` | included unrelated `command:release-manager` filler | no `release-manager` filler | banned filler count `1 -> 0` |
+| `the docker` | no results | relevant docker results returned | result count `0 -> 2` |
+| `how docker` | no results | relevant docker results returned | result count `0 -> 2` |
+
+These are minimum guards, not the full product-quality bar.
+
+## What To Preserve
+
+- Broad family query: `docker homelab` -> `skill:docker-homelab`
+- Narrow family query: `docker compose reference` -> `knowledge:skills/docker-homelab/references/compose`
+- Prompt residue fallback: `the docker` should not return an empty list
+- Weak-hit fallback: one weak phrase hit must not suppress stronger token results
+- Explicit type filter: `--type` must still bypass diversification
+- Registry results remain filler-only and capped
+
+## Known Gotcha
+
+Reference-query detection must use word boundaries.
+
+Bad pattern:
+
+```ts
+/docs?/
+```
+
+That matches the `doc` substring inside `docker`, which incorrectly turns broad
+docker queries into reference/doc queries.
+
+Use the bounded pattern in `src/commands/read/curate.ts` instead:
+
+```ts
+const CURATE_REFERENCE_QUERY_RE = /\b(?:reference|docs?|guide|how|explain|learn|readme|why)\b/;
+```
+
+## When Adding New Eval Cases
+
+- Prefer fixture-backed queries in `ranking-baseline` when possible
+- Add synthetic tests only when the fixture does not isolate the behavior cleanly
+- Assert concrete refs or concrete metric deltas, not vague relevance claims
+- Keep the eval deterministic; do not depend on semantic-search model downloads
+- If you replace a pinned baseline, record the reason in the test file and in the PR

--- a/src/commands/read/curate.ts
+++ b/src/commands/read/curate.ts
@@ -133,6 +133,8 @@ type CollapsedCurateHit = {
   originalIndex: number;
 };
 
+const CURATE_REFERENCE_QUERY_RE = /\b(?:reference|docs?|guide|how|explain|learn|readme|why)\b/;
+
 /**
  * Fire-and-forget: log a curate event to the usage_events table and events.jsonl.
  * Never blocks the caller; errors are silently ignored.
@@ -212,8 +214,9 @@ export async function curateSearchResults(
     selectedStashHits = stashHits.slice(0, limit);
   } else {
     const selected = selectCuratedStashHits(query, stashHits, limit);
-    selectedStashHits = selected.selected;
-    supportRefsByRef = selected.supportRefsByRef;
+    const preferred = preferBroadRootRepresentative(query, selected.selected, stashHits, selected.supportRefsByRef);
+    selectedStashHits = preferred.selected;
+    supportRefsByRef = preferred.supportRefsByRef;
   }
 
   const selectedRegistryHits =
@@ -228,39 +231,6 @@ export async function curateSearchResults(
     )),
     ...selectedRegistryHits.map((hit) => buildCuratedRegistryItem(query, hit)),
   ].slice(0, limit);
-  if (!selectedType || selectedType === "any") {
-    const first = items[0];
-    if (first && "ref" in first && typeof first.ref === "string") {
-      const match = /^knowledge:skills\/([^/]+)\/references\/([^/]+(?:\/[^/]+)*)$/.exec(first.ref);
-      if (match) {
-        const lower = query.toLowerCase();
-        const topicTokens = match[2].split(/[^a-z0-9]+/i).filter(Boolean);
-        const wantsReference =
-          /(reference|docs?|guide|how|explain|learn|readme)/.test(lower) ||
-          topicTokens.some((token) => token.length >= 3 && lower.includes(token.toLowerCase()));
-        if (!wantsReference) {
-          const rootRef = `skill:${match[1]}`;
-          const rootHit = stashHits.find((hit) => hit.ref === rootRef);
-          if (rootHit) {
-            const supportRefs: CurateSupportRef[] = [];
-            if (Array.isArray((first as CuratedStashItem).supportRefs)) {
-              supportRefs.push(...((first as CuratedStashItem).supportRefs ?? []));
-            }
-            supportRefs.push({ ref: first.ref, type: first.type, reason: "Related family asset to inspect next." });
-
-            const promotedSelectedRefs = new Set(
-              items.filter((item): item is CuratedStashItem => "ref" in item).map((item) => item.ref),
-            );
-            promotedSelectedRefs.delete(first.ref);
-            promotedSelectedRefs.add(rootHit.ref);
-
-            items[0] = await enrichCuratedStashHit(query, rootHit, supportRefs, promotedSelectedRefs);
-          }
-        }
-      }
-    }
-  }
-
   return {
     query,
     summary: buildCurateSummary(query, items),
@@ -454,7 +424,7 @@ function parseCurateIntent(query: string): CurateIntent {
     multiStep: /(plan|workflow|steps?|procedure|rollout|review|migration|release|checklist)/.test(lower),
     delegation: /(agent|assistant|planner|reviewer|architect|prompt)/.test(lower),
     recall: /(memory|context|recall|remember)/.test(lower),
-    reference: /(guide|docs?|readme|reference|how|explain|learn|why)/.test(lower),
+    reference: CURATE_REFERENCE_QUERY_RE.test(lower),
   };
 }
 
@@ -534,7 +504,7 @@ function passesCurateScoreFloor(hit: AnnotatedCurateHit, leaderScore: number | u
 function isNarrowReferenceFamilyQuery(query: string, family: CurateFamily | undefined): boolean {
   if (!family || family.role !== "reference") return false;
   const lower = query.toLowerCase();
-  if (/(reference|docs?|guide|how|explain|learn|readme)/.test(lower)) return true;
+  if (CURATE_REFERENCE_QUERY_RE.test(lower)) return true;
   return family.topicTokens.some((token) => token.length >= 3 && lower.includes(token));
 }
 
@@ -628,6 +598,42 @@ function collapseCurateFamilies(
     hits: [...passthrough, ...collapsedFamilies].sort((a, b) => a.originalIndex - b.originalIndex),
     supportRefsByRef,
   };
+}
+
+function preferBroadRootRepresentative(
+  query: string,
+  selected: SourceSearchHit[],
+  allHits: SourceSearchHit[],
+  supportRefsByRef: Map<string, CurateSupportRef[]>,
+): { selected: SourceSearchHit[]; supportRefsByRef: Map<string, CurateSupportRef[]> } {
+  const first = selected[0];
+  if (!first) return { selected, supportRefsByRef };
+
+  const match = /^knowledge:skills\/([^/]+)\/references\/([^/]+(?:\/[^/]+)*)$/.exec(first.ref);
+  if (!match) return { selected, supportRefsByRef };
+
+  const lower = query.toLowerCase();
+  const topicTokens = match[2].split(/[^a-z0-9]+/i).filter(Boolean);
+  const wantsReference = CURATE_REFERENCE_QUERY_RE.test(lower) ||
+    topicTokens.some((token) => token.length >= 3 && lower.includes(token.toLowerCase()));
+  if (wantsReference) return { selected, supportRefsByRef };
+
+  const rootRef = `skill:${match[1]}`;
+  const rootHit = allHits.find((hit) => hit.ref === rootRef);
+  if (!rootHit) return { selected, supportRefsByRef };
+
+  const next = [rootHit, ...selected.filter((hit) => hit.ref !== first.ref && hit.ref !== rootRef)];
+  const merged = new Map(supportRefsByRef);
+  const priorSupport = merged.get(first.ref) ?? [];
+  for (const entry of priorSupport) appendCurateSupportRef(merged, rootRef, entry);
+  appendCurateSupportRef(merged, rootRef, {
+    ref: first.ref,
+    type: first.type,
+    reason: "Related family asset to inspect next.",
+  });
+  merged.delete(first.ref);
+
+  return { selected: next, supportRefsByRef: merged };
 }
 
 function mergeCurateSupportRefs(

--- a/src/commands/read/curate.ts
+++ b/src/commands/read/curate.ts
@@ -9,12 +9,13 @@
  * high-signal set of stash + registry hits and enrich each with the data
  * needed to act (ref, run, parameters, follow-up command).
  *
- * The exported `akmCurate()` API is the single entry point. Internal
- * helpers stay private. Tests can drive the public API or call the smaller
- * pure helpers (`curateSearchResults`, `orderCuratedTypes`,
- * `deriveCurateFallbackQueries`) by importing them directly.
+ * The exported `akmCurate()` API is the single entry point. Internal helpers
+ * stay private. Tests can drive the public API or call the smaller pure
+ * helpers (`curateSearchResults`, `deriveCurateFallbackQueries`,
+ * `mergeCurateSearchResponses`) by importing them directly.
  */
 
+import { parseAssetRef } from "../../core/asset/asset-ref";
 import { rethrowIfTestIsolationError, UsageError } from "../../core/errors";
 import { appendEvent } from "../../core/events";
 import { closeDatabase, openExistingDatabase } from "../../indexer/db/db";
@@ -23,6 +24,12 @@ import { truncateDescription } from "../../output/shapes";
 import type { RegistrySearchResultHit, SearchResponse, ShowResponse, SourceSearchHit } from "../../sources/types";
 import { akmSearch, parseSearchSource } from "./search";
 import { akmShowUnified } from "./show";
+
+export type CurateSupportRef = {
+  ref: string;
+  type?: string;
+  reason: string;
+};
 
 export type CuratedStashItem = {
   source: "stash";
@@ -34,6 +41,7 @@ export type CuratedStashItem = {
   keys?: string[];
   parameters?: string[];
   run?: string;
+  supportRefs?: CurateSupportRef[];
   followUp: string;
   reason: string;
   score?: number;
@@ -86,13 +94,44 @@ const CURATE_FALLBACK_FILTER_WORDS = new Set([
   "to",
   "with",
 ]);
-const CURATED_TYPE_FALLBACK_ORDER = ["skill", "command", "script", "knowledge", "agent", "memory"];
-const CURATED_TYPE_FALLBACK_INDEX = new Map(CURATED_TYPE_FALLBACK_ORDER.map((type, index) => [type, index]));
+const CURATE_SHORT_FALLBACK_TOKENS = new Set(["ai", "ci", "cd", "go", "js", "ts"]);
 const MIN_CURATE_FALLBACK_TOKEN_LENGTH = 3;
 const MAX_CURATE_FALLBACK_KEYWORDS = 6;
 export const CURATE_SEARCH_LIMIT_MULTIPLIER = 4;
 export const MIN_CURATE_SEARCH_LIMIT = 12;
 const DEFAULT_CURATE_LIMIT = 4;
+const CURATE_CLOSE_SCORE_BAND = 0.12;
+const CURATE_TAIL_SCORE_FLOOR = 0.35;
+const CURATE_RELATIVE_SCORE_FLOOR = 0.7;
+const CURATE_FALLBACK_TOP_SCORE_THRESHOLD = 0.8;
+const CURATE_FALLBACK_STRONG_SCORE_FLOOR = 0.35;
+const CURATE_FAMILY_SCORE_BAND = 0.15;
+const MAX_CURATE_SUPPORT_REFS = 2;
+
+type CurateIntent = {
+  executionHeavy: boolean;
+  multiStep: boolean;
+  delegation: boolean;
+  recall: boolean;
+  reference: boolean;
+};
+
+type CurateFamily =
+  | { key: string; role: "root" }
+  | { key: string; role: "reference"; topicTokens: string[] };
+
+type AnnotatedCurateHit = {
+  hit: SourceSearchHit;
+  rawScore: number;
+  adjustedScore: number;
+  originalIndex: number;
+  family?: CurateFamily;
+};
+
+type CollapsedCurateHit = {
+  hit: SourceSearchHit;
+  originalIndex: number;
+};
 
 /**
  * Fire-and-forget: log a curate event to the usage_events table and events.jsonl.
@@ -108,9 +147,6 @@ function logCurateEvent(query: string, result: CurateResponse): void {
   try {
     const db = openExistingDatabase();
     try {
-      // Summary row (entry_ref = NULL): preserves the query → itemRefs audit
-      // trail. Retrieval counting ignores NULL-ref rows, so this row is purely
-      // informational.
       insertUsageEvent(db, {
         event_type: "curate",
         query,
@@ -120,10 +156,6 @@ function logCurateEvent(query: string, result: CurateResponse): void {
         }),
         source: "user",
       });
-      // Per-item rows with entry_ref populated so curation registers as a real
-      // retrieval signal in getRetrievalCounts (which counts 'curate' events).
-      // Only stash items expose a canonical asset ref; registry hits
-      // (`registry:<id>`) have no asset ref and are skipped here.
       for (const item of result.items) {
         if (!("ref" in item) || typeof item.ref !== "string") continue;
         insertUsageEvent(db, {
@@ -138,14 +170,9 @@ function logCurateEvent(query: string, result: CurateResponse): void {
     }
   } catch (err) {
     rethrowIfTestIsolationError(err);
-    /* ignore logging failures */
   }
 }
 
-/**
- * Public curate entry point. Performs the search itself when
- * `options.searchResponse` is not supplied.
- */
 export async function akmCurate(options: CurateOptions): Promise<CurateResponse> {
   const trimmedQuery = options.query.trim();
   if (!trimmedQuery) {
@@ -154,6 +181,7 @@ export async function akmCurate(options: CurateOptions): Promise<CurateResponse>
       "MISSING_REQUIRED_ARGUMENT",
     );
   }
+
   const limit = options.limit && options.limit > 0 ? options.limit : DEFAULT_CURATE_LIMIT;
   const source = options.source ?? parseSearchSource("stash");
   const searchResponse =
@@ -161,8 +189,6 @@ export async function akmCurate(options: CurateOptions): Promise<CurateResponse>
     (await searchForCuration({
       query: options.query,
       type: options.type,
-      // Search deeper than the final curated count so we can pick one strong
-      // match per type and still have room for fallback retries.
       limit: Math.max(limit * CURATE_SEARCH_LIMIT_MULTIPLIER, MIN_CURATE_SEARCH_LIMIT),
       source,
     }));
@@ -181,26 +207,59 @@ export async function curateSearchResults(
   const registryHits = result.registryHits ?? [];
 
   let selectedStashHits: SourceSearchHit[];
+  let supportRefsByRef = new Map<string, CurateSupportRef[]>();
   if (selectedType && selectedType !== "any") {
     selectedStashHits = stashHits.slice(0, limit);
   } else {
-    const bestByType = new Map<string, SourceSearchHit>();
-    for (const hit of stashHits) {
-      if (!bestByType.has(hit.type)) bestByType.set(hit.type, hit);
-    }
-    const orderedTypes = orderCuratedTypes(query, Array.from(bestByType.keys()));
-    selectedStashHits = orderedTypes
-      .map((type) => bestByType.get(type))
-      .filter((hit): hit is SourceSearchHit => Boolean(hit));
+    const selected = selectCuratedStashHits(query, stashHits, limit);
+    selectedStashHits = selected.selected;
+    supportRefsByRef = selected.supportRefsByRef;
   }
 
   const selectedRegistryHits =
     selectedStashHits.length >= limit ? [] : registryHits.slice(0, Math.min(2, limit - selectedStashHits.length));
+  const selectedRefs = new Set(selectedStashHits.map((hit) => hit.ref));
 
   const items = [
-    ...(await Promise.all(selectedStashHits.slice(0, limit).map((hit) => enrichCuratedStashHit(query, hit)))),
+    ...(await Promise.all(
+      selectedStashHits
+        .slice(0, limit)
+        .map((hit) => enrichCuratedStashHit(query, hit, supportRefsByRef.get(hit.ref) ?? [], selectedRefs)),
+    )),
     ...selectedRegistryHits.map((hit) => buildCuratedRegistryItem(query, hit)),
   ].slice(0, limit);
+  if (!selectedType || selectedType === "any") {
+    const first = items[0];
+    if (first && "ref" in first && typeof first.ref === "string") {
+      const match = /^knowledge:skills\/([^/]+)\/references\/([^/]+(?:\/[^/]+)*)$/.exec(first.ref);
+      if (match) {
+        const lower = query.toLowerCase();
+        const topicTokens = match[2].split(/[^a-z0-9]+/i).filter(Boolean);
+        const wantsReference =
+          /(reference|docs?|guide|how|explain|learn|readme)/.test(lower) ||
+          topicTokens.some((token) => token.length >= 3 && lower.includes(token.toLowerCase()));
+        if (!wantsReference) {
+          const rootRef = `skill:${match[1]}`;
+          const rootHit = stashHits.find((hit) => hit.ref === rootRef);
+          if (rootHit) {
+            const supportRefs: CurateSupportRef[] = [];
+            if (Array.isArray((first as CuratedStashItem).supportRefs)) {
+              supportRefs.push(...((first as CuratedStashItem).supportRefs ?? []));
+            }
+            supportRefs.push({ ref: first.ref, type: first.type, reason: "Related family asset to inspect next." });
+
+            const promotedSelectedRefs = new Set(
+              items.filter((item): item is CuratedStashItem => "ref" in item).map((item) => item.ref),
+            );
+            promotedSelectedRefs.delete(first.ref);
+            promotedSelectedRefs.add(rootHit.ref);
+
+            items[0] = await enrichCuratedStashHit(query, rootHit, supportRefs, promotedSelectedRefs);
+          }
+        }
+      }
+    }
+  }
 
   return {
     query,
@@ -211,41 +270,12 @@ export async function curateSearchResults(
   };
 }
 
-export function orderCuratedTypes(query: string, types: string[]): string[] {
-  const lower = query.toLowerCase();
-  const boosts = new Map<string, number>();
-  const addBoost = (type: string, amount: number) => boosts.set(type, (boosts.get(type) ?? 0) + amount);
-
-  if (/(run|script|bash|shell|cli|execute|automation|deploy|build|test|lint)/.test(lower)) {
-    addBoost("script", 6);
-    addBoost("command", 4);
-  }
-  if (/(guide|docs?|readme|reference|how|explain|learn|why)/.test(lower)) {
-    addBoost("knowledge", 6);
-    addBoost("skill", 4);
-  }
-  if (/(agent|assistant|planner|review|analy[sz]e|architect|prompt)/.test(lower)) {
-    addBoost("agent", 6);
-    addBoost("skill", 3);
-  }
-  if (/(config|template|release|generate|command)/.test(lower)) {
-    addBoost("command", 5);
-  }
-  if (/(memory|context|recall|remember)/.test(lower)) {
-    addBoost("memory", 6);
-  }
-
-  return [...types].sort((a, b) => {
-    const boostDiff = (boosts.get(b) ?? 0) - (boosts.get(a) ?? 0);
-    if (boostDiff !== 0) return boostDiff;
-    return (
-      (CURATED_TYPE_FALLBACK_INDEX.get(a) ?? Number.MAX_SAFE_INTEGER) -
-      (CURATED_TYPE_FALLBACK_INDEX.get(b) ?? Number.MAX_SAFE_INTEGER)
-    );
-  });
-}
-
-async function enrichCuratedStashHit(query: string, hit: SourceSearchHit): Promise<CuratedStashItem> {
+async function enrichCuratedStashHit(
+  query: string,
+  hit: SourceSearchHit,
+  supportRefs: CurateSupportRef[],
+  selectedRefs: Set<string>,
+): Promise<CuratedStashItem> {
   let shown: ShowResponse | undefined;
   try {
     shown = await akmShowUnified({ ref: hit.ref });
@@ -255,6 +285,8 @@ async function enrichCuratedStashHit(query: string, hit: SourceSearchHit): Promi
 
   const description = shown?.description ?? hit.description;
   const preview = buildCuratedPreview(shown, hit);
+  const mergedSupportRefs = mergeCurateSupportRefs(supportRefs, shown?.related?.hits, selectedRefs, hit.ref);
+
   return {
     source: "stash",
     type: shown?.type ?? hit.type,
@@ -265,6 +297,7 @@ async function enrichCuratedStashHit(query: string, hit: SourceSearchHit): Promi
     ...(shown?.keys?.length ? { keys: shown.keys } : {}),
     ...(shown?.parameters?.length ? { parameters: shown.parameters } : {}),
     ...(shown?.run ? { run: shown.run } : {}),
+    ...(mergedSupportRefs.length > 0 ? { supportRefs: mergedSupportRefs } : {}),
     followUp: `akm show ${hit.ref}`,
     reason: buildCuratedReason(query, shown?.type ?? hit.type),
     ...(hit.score !== undefined ? { score: hit.score } : {}),
@@ -299,19 +332,19 @@ function buildCuratedPreview(shown: ShowResponse | undefined, hit: SourceSearchH
 function buildCuratedReason(query: string, type: string): string {
   switch (type) {
     case "script":
-      return `Best runnable script match for "${query}".`;
+      return `Strong runnable script match for "${query}".`;
     case "command":
-      return `Best reusable command/template match for "${query}".`;
+      return `Strong reusable command/template match for "${query}".`;
     case "knowledge":
-      return `Best reference document match for "${query}".`;
+      return `Strong reference document match for "${query}".`;
     case "skill":
-      return `Best instructions/workflow match for "${query}".`;
+      return `Strong instructions/workflow match for "${query}".`;
     case "agent":
-      return `Best specialized agent prompt match for "${query}".`;
+      return `Strong specialized agent prompt match for "${query}".`;
     case "memory":
-      return `Best saved context match for "${query}".`;
+      return `Strong saved context match for "${query}".`;
     default:
-      return `Best ${type} match for "${query}".`;
+      return `Strong ${type} match for "${query}".`;
   }
 }
 
@@ -320,35 +353,30 @@ function buildCurateSummary(query: string, items: CuratedItem[]): string {
     return `No curated assets were selected for "${query}".`;
   }
   const labels = items.map((item) => `${item.type}:${item.name}`);
-  return `Selected ${items.length} high-signal result${items.length === 1 ? "" : "s"}: ${labels.join(", ")}.`;
+  return `Selected ${items.length} curated result${items.length === 1 ? "" : "s"}: ${labels.join(", ")}.`;
 }
 
-function hasSearchResults(result: SearchResponse): boolean {
-  return result.hits.length > 0 || (result.registryHits?.length ?? 0) > 0;
-}
-
-/**
- * Extract a small set of fallback keywords when a prompt-style curate query
- * returns no hits as a whole phrase.
- *
- * We keep up to MAX_CURATE_FALLBACK_KEYWORDS distinct keywords and drop short
- * or common filler words so follow-up searches stay inexpensive while focusing
- * on higher-signal terms.
- */
 export function deriveCurateFallbackQueries(query: string): string[] {
-  return Array.from(
+  const normalizedWhole = query
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+  const tokens = Array.from(
     new Set(
       query
         .toLowerCase()
         .split(/[^a-z0-9]+/)
         .map((token) => token.trim())
-        // Keep longer tokens so fallback stays focused on higher-signal terms
-        // and avoids broad one- and two-letter matches that overwhelm curation.
         .filter(
-          (token) => token.length >= MIN_CURATE_FALLBACK_TOKEN_LENGTH && !CURATE_FALLBACK_FILTER_WORDS.has(token),
+          (token) =>
+            token.length > 0 &&
+            !CURATE_FALLBACK_FILTER_WORDS.has(token) &&
+            (token.length >= MIN_CURATE_FALLBACK_TOKEN_LENGTH || CURATE_SHORT_FALLBACK_TOKENS.has(token)),
         ),
     ),
   ).slice(0, MAX_CURATE_FALLBACK_KEYWORDS);
+  if (tokens.length === 1 && tokens[0] === normalizedWhole) return [];
+  return tokens;
 }
 
 export function mergeCurateSearchResponses(base: SearchResponse, extras: SearchResponse[]): SearchResponse {
@@ -400,10 +428,10 @@ export async function searchForCuration(input: {
   source: ReturnType<typeof parseSearchSource>;
 }): Promise<SearchResponse> {
   const initial = await akmSearch({ ...input, skipLogging: true });
-  if (hasSearchResults(initial)) return initial;
+  if (!shouldRunCurateFallback(initial, input.limit)) return initial;
 
   const fallbackQueries = deriveCurateFallbackQueries(input.query);
-  if (fallbackQueries.length <= 1) return initial;
+  if (fallbackQueries.length === 0) return initial;
 
   const fallbackResults = await Promise.all(
     fallbackQueries.map((token) =>
@@ -417,4 +445,223 @@ export async function searchForCuration(input: {
     ),
   );
   return mergeCurateSearchResponses(initial, fallbackResults);
+}
+
+function parseCurateIntent(query: string): CurateIntent {
+  const lower = query.toLowerCase();
+  return {
+    executionHeavy: /(run|script|bash|shell|cli|execute|automation|deploy|build|test|lint)/.test(lower),
+    multiStep: /(plan|workflow|steps?|procedure|rollout|review|migration|release|checklist)/.test(lower),
+    delegation: /(agent|assistant|planner|reviewer|architect|prompt)/.test(lower),
+    recall: /(memory|context|recall|remember)/.test(lower),
+    reference: /(guide|docs?|readme|reference|how|explain|learn|why)/.test(lower),
+  };
+}
+
+function computeCurateTypeNudge(type: string, intent: CurateIntent): number {
+  let nudge = 0;
+  if (intent.executionHeavy) {
+    if (type === "script") nudge += 0.06;
+    else if (type === "command") nudge += 0.04;
+    else if (type === "memory") nudge -= 0.04;
+  }
+  if (intent.multiStep) {
+    if (type === "workflow") nudge += 0.06;
+    else if (type === "skill") nudge += 0.04;
+    else if (type === "knowledge") nudge -= 0.02;
+  }
+  if (intent.delegation && type === "agent") nudge += 0.06;
+  if (intent.recall && type === "memory") nudge += 0.08;
+  if (intent.reference) {
+    if (type === "knowledge") nudge += 0.05;
+    else if (type === "skill") nudge += 0.02;
+  }
+  return nudge;
+}
+
+function getCurateFamily(ref: string): CurateFamily | undefined {
+  try {
+    const parsed = parseAssetRef(ref);
+    if (parsed.type === "skill") {
+      return { key: parsed.name, role: "root" };
+    }
+    if (parsed.type !== "knowledge") return undefined;
+    const match = /^skills\/([^/]+)\/references\/(.+)$/.exec(parsed.name);
+    if (!match) return undefined;
+    return {
+      key: match[1],
+      role: "reference",
+      topicTokens: match[2]
+        .split(/[^a-z0-9]+/i)
+        .map((token) => token.trim().toLowerCase())
+        .filter(Boolean),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function annotateCurateHit(query: string, hit: SourceSearchHit, index: number, intent: CurateIntent): AnnotatedCurateHit {
+  const rawScore = hit.score ?? 0;
+  const family = getCurateFamily(hit.ref);
+  let adjustedScore = rawScore + computeCurateTypeNudge(hit.type, intent);
+  if (family?.role === "root" && !isNarrowReferenceFamilyQuery(query, family)) adjustedScore += 0.07;
+  if (family?.role === "reference" && isNarrowReferenceFamilyQuery(query, family)) adjustedScore += 0.07;
+  return {
+    hit,
+    rawScore,
+    adjustedScore,
+    originalIndex: index,
+    family,
+  };
+}
+
+function compareCurateHits(a: AnnotatedCurateHit, b: AnnotatedCurateHit): number {
+  const rawDiff = b.rawScore - a.rawScore;
+  if (Math.abs(rawDiff) > CURATE_CLOSE_SCORE_BAND) return rawDiff;
+
+  const adjustedDiff = b.adjustedScore - a.adjustedScore;
+  if (adjustedDiff !== 0) return adjustedDiff;
+  if (rawDiff !== 0) return rawDiff;
+  return a.originalIndex - b.originalIndex;
+}
+
+function passesCurateScoreFloor(hit: AnnotatedCurateHit, leaderScore: number | undefined): boolean {
+  if (leaderScore === undefined) return true;
+  return hit.rawScore >= Math.max(CURATE_TAIL_SCORE_FLOOR, leaderScore * CURATE_RELATIVE_SCORE_FLOOR);
+}
+
+function isNarrowReferenceFamilyQuery(query: string, family: CurateFamily | undefined): boolean {
+  if (!family || family.role !== "reference") return false;
+  const lower = query.toLowerCase();
+  if (/(reference|docs?|guide|how|explain|learn|readme)/.test(lower)) return true;
+  return family.topicTokens.some((token) => token.length >= 3 && lower.includes(token));
+}
+
+function appendCurateSupportRef(
+  supportRefsByRef: Map<string, CurateSupportRef[]>,
+  ownerRef: string,
+  supportRef: CurateSupportRef,
+): void {
+  const existing = supportRefsByRef.get(ownerRef) ?? [];
+  if (existing.some((entry) => entry.ref === supportRef.ref)) return;
+  supportRefsByRef.set(ownerRef, [...existing, supportRef]);
+}
+
+function selectCuratedStashHits(
+  query: string,
+  hits: SourceSearchHit[],
+  limit: number,
+): { selected: SourceSearchHit[]; supportRefsByRef: Map<string, CurateSupportRef[]> } {
+  const intent = parseCurateIntent(query);
+  const collapsed = collapseCurateFamilies(query, hits);
+  const ranked = collapsed.hits
+    .map(({ hit, originalIndex }) => annotateCurateHit(query, hit, originalIndex, intent))
+    .sort(compareCurateHits);
+  const selected: AnnotatedCurateHit[] = [];
+  const supportRefsByRef = collapsed.supportRefsByRef;
+  let leaderScore: number | undefined;
+
+  for (const candidate of ranked) {
+    if (!passesCurateScoreFloor(candidate, leaderScore)) continue;
+
+    selected.push(candidate);
+    if (leaderScore === undefined) leaderScore = candidate.rawScore;
+    if (selected.length >= limit) break;
+  }
+
+  return { selected: selected.map((entry) => entry.hit), supportRefsByRef };
+}
+
+function collapseCurateFamilies(
+  query: string,
+  hits: SourceSearchHit[],
+): { hits: CollapsedCurateHit[]; supportRefsByRef: Map<string, CurateSupportRef[]> } {
+  const passthrough: CollapsedCurateHit[] = [];
+  const supportRefsByRef = new Map<string, CurateSupportRef[]>();
+  const groups = new Map<
+    string,
+    {
+      root?: CollapsedCurateHit;
+      references: CollapsedCurateHit[];
+    }
+  >();
+
+  for (const [index, hit] of hits.entries()) {
+    const family = getCurateFamily(hit.ref);
+    if (!family) {
+      passthrough.push({ hit, originalIndex: index });
+      continue;
+    }
+    const group = groups.get(family.key) ?? { references: [] };
+    if (family.role === "root") {
+      if (!group.root) group.root = { hit, originalIndex: index };
+    } else {
+      group.references.push({ hit, originalIndex: index });
+    }
+    groups.set(family.key, group);
+  }
+
+  const collapsedFamilies: CollapsedCurateHit[] = [];
+  for (const group of groups.values()) {
+    const bestReference = group.references[0];
+    const representative =
+      group.root && !isNarrowReferenceFamilyQuery(query, getCurateFamily(bestReference?.hit.ref ?? group.root.hit.ref))
+        ? group.root
+        : bestReference ?? group.root;
+    if (!representative) continue;
+
+    collapsedFamilies.push(representative);
+    const supportCandidates = [group.root, ...group.references].filter((entry): entry is CollapsedCurateHit => {
+      return entry !== undefined && entry.hit.ref !== representative.hit.ref;
+    });
+    for (const support of supportCandidates) {
+      appendCurateSupportRef(supportRefsByRef, representative.hit.ref, {
+        ref: support.hit.ref,
+        type: support.hit.type,
+        reason: "Related family asset to inspect next.",
+      });
+    }
+  }
+
+  return {
+    hits: [...passthrough, ...collapsedFamilies].sort((a, b) => a.originalIndex - b.originalIndex),
+    supportRefsByRef,
+  };
+}
+
+function mergeCurateSupportRefs(
+  seeded: CurateSupportRef[],
+  relatedHits:
+    | Array<{ ref?: string; path: string; type: string; sharedEntities: string[]; relationCount: number }>
+    | undefined,
+  selectedRefs: Set<string>,
+  ownerRef: string,
+): CurateSupportRef[] {
+  const merged: CurateSupportRef[] = [];
+  for (const entry of seeded) {
+    if (entry.ref === ownerRef || selectedRefs.has(entry.ref)) continue;
+    if (merged.some((existing) => existing.ref === entry.ref)) continue;
+    merged.push(entry);
+    if (merged.length >= MAX_CURATE_SUPPORT_REFS) return merged;
+  }
+
+  if (!Array.isArray(relatedHits)) return merged;
+  for (const hit of relatedHits) {
+    if (!hit.ref || hit.ref === ownerRef || selectedRefs.has(hit.ref)) continue;
+    if (merged.some((existing) => existing.ref === hit.ref)) continue;
+    merged.push({ ref: hit.ref, type: hit.type, reason: "Related asset via shared entities." });
+    if (merged.length >= MAX_CURATE_SUPPORT_REFS) break;
+  }
+  return merged;
+}
+
+function shouldRunCurateFallback(initial: SearchResponse, desiredCount: number): boolean {
+  const stashHits = initial.hits.filter((hit): hit is SourceSearchHit => hit.type !== "registry");
+  if (stashHits.length === 0) return true;
+
+  const topScore = stashHits[0]?.score ?? 0;
+  const strongFloor = Math.max(CURATE_FALLBACK_STRONG_SCORE_FLOOR, topScore * CURATE_RELATIVE_SCORE_FLOOR);
+  const strongCount = stashHits.filter((hit) => (hit.score ?? 0) >= strongFloor).length;
+  return !(topScore >= CURATE_FALLBACK_TOP_SCORE_THRESHOLD && strongCount >= Math.min(2, desiredCount));
 }

--- a/src/commands/read/curate.ts
+++ b/src/commands/read/curate.ts
@@ -105,7 +105,6 @@ const CURATE_TAIL_SCORE_FLOOR = 0.35;
 const CURATE_RELATIVE_SCORE_FLOOR = 0.7;
 const CURATE_FALLBACK_TOP_SCORE_THRESHOLD = 0.8;
 const CURATE_FALLBACK_STRONG_SCORE_FLOOR = 0.35;
-const CURATE_FAMILY_SCORE_BAND = 0.15;
 const MAX_CURATE_SUPPORT_REFS = 2;
 
 type CurateIntent = {
@@ -116,9 +115,7 @@ type CurateIntent = {
   reference: boolean;
 };
 
-type CurateFamily =
-  | { key: string; role: "root" }
-  | { key: string; role: "reference"; topicTokens: string[] };
+type CurateFamily = { key: string; role: "root" } | { key: string; role: "reference"; topicTokens: string[] };
 
 type AnnotatedCurateHit = {
   hit: SourceSearchHit;
@@ -471,7 +468,12 @@ function getCurateFamily(ref: string): CurateFamily | undefined {
   }
 }
 
-function annotateCurateHit(query: string, hit: SourceSearchHit, index: number, intent: CurateIntent): AnnotatedCurateHit {
+function annotateCurateHit(
+  query: string,
+  hit: SourceSearchHit,
+  index: number,
+  intent: CurateIntent,
+): AnnotatedCurateHit {
   const rawScore = hit.score ?? 0;
   const family = getCurateFamily(hit.ref);
   let adjustedScore = rawScore + computeCurateTypeNudge(hit.type, intent);
@@ -578,7 +580,7 @@ function collapseCurateFamilies(
     const representative =
       group.root && !isNarrowReferenceFamilyQuery(query, getCurateFamily(bestReference?.hit.ref ?? group.root.hit.ref))
         ? group.root
-        : bestReference ?? group.root;
+        : (bestReference ?? group.root);
     if (!representative) continue;
 
     collapsedFamilies.push(representative);
@@ -614,7 +616,8 @@ function preferBroadRootRepresentative(
 
   const lower = query.toLowerCase();
   const topicTokens = match[2].split(/[^a-z0-9]+/i).filter(Boolean);
-  const wantsReference = CURATE_REFERENCE_QUERY_RE.test(lower) ||
+  const wantsReference =
+    CURATE_REFERENCE_QUERY_RE.test(lower) ||
     topicTokens.some((token) => token.length >= 3 && lower.includes(token.toLowerCase()));
   if (wantsReference) return { selected, supportRefsByRef };
 

--- a/src/output/shapes/curate.ts
+++ b/src/output/shapes/curate.ts
@@ -31,12 +31,24 @@ const NORMAL_FIELDS = [
   "keys",
   "parameters",
   "run",
+  "supportRefs",
   "followUp",
   "reason",
   "score",
 ];
 // Agent shape: the minimal field set an LLM needs to decide and act.
-const AGENT_FIELDS = ["source", "type", "name", "ref", "id", "description", "followUp", "reason", "score"];
+const AGENT_FIELDS = [
+  "source",
+  "type",
+  "name",
+  "ref",
+  "id",
+  "description",
+  "supportRefs",
+  "followUp",
+  "reason",
+  "score",
+];
 
 function shapeCurateItem(
   item: Record<string, unknown>,

--- a/src/output/text/helpers.ts
+++ b/src/output/text/helpers.ts
@@ -1023,6 +1023,14 @@ export function formatCuratePlain(r: Record<string, unknown>, detail: DetailLeve
     }
     if (item.run) lines.push(`  run: ${String(item.run)}`);
     if (item.followUp) lines.push(`  show: ${String(item.followUp)}`);
+    if (Array.isArray(item.supportRefs) && item.supportRefs.length > 0) {
+      for (const support of item.supportRefs as Array<Record<string, unknown>>) {
+        if (!support.ref) continue;
+        const label = typeof support.type === "string" ? `[${support.type}] ` : "";
+        const why = typeof support.reason === "string" ? ` — ${support.reason}` : "";
+        lines.push(`  support: ${label}${String(support.ref)}${why}`);
+      }
+    }
     if (detail !== "brief" && item.reason) lines.push(`  why: ${String(item.reason)}`);
   }
 

--- a/tests/curate-command.test.ts
+++ b/tests/curate-command.test.ts
@@ -75,7 +75,13 @@ afterEach(() => {
 });
 
 describe("curate command", () => {
-  const rankingBaselineStash = path.join(__dirname, "fixtures", "stashes", "ranking-baseline");
+  const rankingBaselineFixture = path.join(__dirname, "fixtures", "stashes", "ranking-baseline");
+
+  function makeRankingBaselineStash(): string {
+    const stashDir = makeTempDir("akm-curate-ranking-baseline-");
+    fs.cpSync(rankingBaselineFixture, stashDir, { recursive: true });
+    return stashDir;
+  }
 
   function makeStash(): string {
     const stashDir = makeTempDir("akm-curate-stash-");
@@ -221,11 +227,17 @@ describe("curate command", () => {
   });
 
   test("docker homelab collapses family duplicates into one top-level result", async () => {
-    const output = await runCli(rankingBaselineStash, ["curate", "docker homelab", "--format=json", "--detail=full"]);
+    const stashDir = makeRankingBaselineStash();
+    const output = await runCli(stashDir, ["curate", "docker homelab", "--format=json", "--detail=full"]);
     const json = JSON.parse(output) as { items: Array<Record<string, unknown>> };
 
-    expect(json.items).toHaveLength(1);
     expect(json.items[0]?.ref).toBe("skill:docker-homelab");
+    const familyItems = json.items.filter(
+      (item) =>
+        item.ref === "skill:docker-homelab" ||
+        String(item.ref).startsWith("knowledge:skills/docker-homelab/references/"),
+    );
+    expect(familyItems).toHaveLength(1);
     expect(json.items[0]?.supportRefs).toEqual([
       {
         ref: "knowledge:skills/docker-homelab/references/compose",
@@ -241,7 +253,8 @@ describe("curate command", () => {
   });
 
   test("weak prompt residue now falls back to docker results", async () => {
-    const output = await runCli(rankingBaselineStash, ["curate", "the docker", "--format=json", "--detail=full"]);
+    const stashDir = makeRankingBaselineStash();
+    const output = await runCli(stashDir, ["curate", "the docker", "--format=json", "--detail=full"]);
     const json = JSON.parse(output) as { items: Array<Record<string, unknown>> };
 
     expect(json.items.length).toBeGreaterThan(0);
@@ -249,7 +262,8 @@ describe("curate command", () => {
   });
 
   test("docker deploy no longer surfaces release-manager filler", async () => {
-    const output = await runCli(rankingBaselineStash, ["curate", "docker deploy", "--format=json", "--detail=full"]);
+    const stashDir = makeRankingBaselineStash();
+    const output = await runCli(stashDir, ["curate", "docker deploy", "--format=json", "--detail=full"]);
     const json = JSON.parse(output) as { items: Array<Record<string, unknown>> };
 
     expect(json.items.some((item) => item.ref === "command:release-manager")).toBe(false);

--- a/tests/curate-command.test.ts
+++ b/tests/curate-command.test.ts
@@ -75,6 +75,8 @@ afterEach(() => {
 });
 
 describe("curate command", () => {
+  const rankingBaselineStash = path.join(__dirname, "fixtures", "stashes", "ranking-baseline");
+
   function makeStash(): string {
     const stashDir = makeTempDir("akm-curate-stash-");
     writeFile(path.join(stashDir, "scripts", "deploy.sh"), "#!/usr/bin/env bash\necho deploy\n");
@@ -112,18 +114,17 @@ describe("curate command", () => {
     }
   });
 
-  test("prefers one strong match per asset type by default", async () => {
+  test("explicit --type keeps the top hits of the requested type", async () => {
     const stashDir = makeStash();
     writeFile(
       path.join(stashDir, "commands", "release-notes.md"),
       "---\ndescription: Draft release notes\n---\nWrite release notes for {{version}}\n",
     );
 
-    const output = await runCli(stashDir, ["curate", "release", "--format=json"]);
+    const output = await runCli(stashDir, ["curate", "release", "--type", "command", "--format=json"]);
     const json = JSON.parse(output) as { items: Array<Record<string, unknown>> };
-    const commandItems = json.items.filter((item) => item.type === "command");
 
-    expect(commandItems.length).toBe(1);
+    expect(json.items.map((item) => item.ref)).toEqual(["command:release", "command:release-notes"]);
   });
 
   test("text output includes direct refs and follow-up commands", async () => {
@@ -217,5 +218,36 @@ describe("curate command", () => {
     // The error envelope is pretty-printed JSON on stderr.
     const parsed = JSON.parse(res.stderr.trim());
     expect(parsed.code).toBe("INVALID_SHAPE_VALUE");
+  });
+
+  test("docker homelab collapses family duplicates into one top-level result", async () => {
+    const output = await runCli(rankingBaselineStash, ["curate", "docker homelab", "--format=json", "--detail=full"]);
+    const json = JSON.parse(output) as { items: Array<Record<string, unknown>> };
+
+    expect(json.items).toHaveLength(1);
+    expect(json.items[0]?.ref).toBe("knowledge:skills/docker-homelab/references/compose");
+    expect(json.items[0]?.supportRefs).toEqual([
+      { ref: "skill:docker-homelab", type: "skill", reason: "Related family asset to inspect next." },
+      {
+        ref: "knowledge:skills/docker-homelab/references/containers",
+        type: "knowledge",
+        reason: "Related family asset to inspect next.",
+      },
+    ]);
+  });
+
+  test("weak prompt residue now falls back to docker results", async () => {
+    const output = await runCli(rankingBaselineStash, ["curate", "the docker", "--format=json", "--detail=full"]);
+    const json = JSON.parse(output) as { items: Array<Record<string, unknown>> };
+
+    expect(json.items.length).toBeGreaterThan(0);
+    expect(String(json.items[0]?.ref)).toContain("docker-homelab");
+  });
+
+  test("docker deploy no longer surfaces release-manager filler", async () => {
+    const output = await runCli(rankingBaselineStash, ["curate", "docker deploy", "--format=json", "--detail=full"]);
+    const json = JSON.parse(output) as { items: Array<Record<string, unknown>> };
+
+    expect(json.items.some((item) => item.ref === "command:release-manager")).toBe(false);
   });
 });

--- a/tests/curate-command.test.ts
+++ b/tests/curate-command.test.ts
@@ -225,9 +225,13 @@ describe("curate command", () => {
     const json = JSON.parse(output) as { items: Array<Record<string, unknown>> };
 
     expect(json.items).toHaveLength(1);
-    expect(json.items[0]?.ref).toBe("knowledge:skills/docker-homelab/references/compose");
+    expect(json.items[0]?.ref).toBe("skill:docker-homelab");
     expect(json.items[0]?.supportRefs).toEqual([
-      { ref: "skill:docker-homelab", type: "skill", reason: "Related family asset to inspect next." },
+      {
+        ref: "knowledge:skills/docker-homelab/references/compose",
+        type: "knowledge",
+        reason: "Related family asset to inspect next.",
+      },
       {
         ref: "knowledge:skills/docker-homelab/references/containers",
         type: "knowledge",
@@ -241,7 +245,7 @@ describe("curate command", () => {
     const json = JSON.parse(output) as { items: Array<Record<string, unknown>> };
 
     expect(json.items.length).toBeGreaterThan(0);
-    expect(String(json.items[0]?.ref)).toContain("docker-homelab");
+    expect(json.items[0]?.ref).toBe("skill:docker-homelab");
   });
 
   test("docker deploy no longer surfaces release-manager filler", async () => {

--- a/tests/curate-logic.test.ts
+++ b/tests/curate-logic.test.ts
@@ -153,9 +153,13 @@ describe("curateSearchResults", () => {
 
     expect(result.items).toHaveLength(1);
     const first = result.items[0] as Record<string, unknown>;
-    expect(first.ref).toBe("knowledge:skills/docker-homelab/references/compose");
+    expect(first.ref).toBe("skill:docker-homelab");
     expect(first.supportRefs).toEqual([
-      { ref: "skill:docker-homelab", type: "skill", reason: "Related family asset to inspect next." },
+      {
+        ref: "knowledge:skills/docker-homelab/references/compose",
+        type: "knowledge",
+        reason: "Related family asset to inspect next.",
+      },
       {
         ref: "knowledge:skills/docker-homelab/references/networking",
         type: "knowledge",

--- a/tests/curate-logic.test.ts
+++ b/tests/curate-logic.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "bun:test";
+import { akmCurate, curateSearchResults, deriveCurateFallbackQueries, mergeCurateSearchResponses } from "../src/commands/read/curate";
+import { UsageError } from "../src/core/errors";
+import type { RegistrySearchResultHit, SearchResponse, SourceSearchHit } from "../src/sources/types";
+
+function stashHit(
+  overrides: Partial<SourceSearchHit> & Pick<SourceSearchHit, "type" | "name" | "ref" | "path">,
+): SourceSearchHit {
+  return {
+    origin: null,
+    ...overrides,
+  };
+}
+
+function registryHit(
+  overrides: Partial<RegistrySearchResultHit> & Pick<RegistrySearchResultHit, "name" | "id">,
+): RegistrySearchResultHit {
+  return {
+    type: "registry",
+    ...overrides,
+  };
+}
+
+function searchResponse(overrides: Partial<SearchResponse> = {}): SearchResponse {
+  return {
+    schemaVersion: 1,
+    stashDir: "/tmp/stash",
+    source: "stash",
+    hits: [],
+    ...overrides,
+  };
+}
+
+describe("deriveCurateFallbackQueries", () => {
+  test("drops filler words, dedupes tokens, preserves meaningful short tokens, and caps fallback keywords", () => {
+    expect(
+      deriveCurateFallbackQueries("How do I deploy to CI/CD with Docker docker release rollback staging prod now"),
+    ).toEqual(["deploy", "ci", "cd", "docker", "release", "rollback"]);
+  });
+
+  test("allows one-token prompt residue fallback", () => {
+    expect(deriveCurateFallbackQueries("the docker")).toEqual(["docker"]);
+  });
+
+  test("returns an empty list when the normalized query is already a single usable token", () => {
+    expect(deriveCurateFallbackQueries("docker")).toEqual([]);
+  });
+});
+
+describe("mergeCurateSearchResponses", () => {
+  test("keeps the highest-scoring duplicate stash and registry hits and merges warnings", () => {
+    const base = searchResponse({
+      hits: [stashHit({ type: "skill", name: "docker-homelab", ref: "skill:docker-homelab", path: "/tmp/a", score: 0.3 })],
+      registryHits: [registryHit({ name: "docker-kit", id: "reg-1", score: 0.2 })],
+      tip: "No phrase results.",
+      warnings: ["base warning"],
+    });
+    const merged = mergeCurateSearchResponses(base, [
+      searchResponse({
+        hits: [
+          stashHit({ type: "skill", name: "docker-homelab", ref: "skill:docker-homelab", path: "/tmp/a", score: 0.9 }),
+          stashHit({ type: "script", name: "docker-clean", ref: "script:docker-clean", path: "/tmp/b", score: 0.5 }),
+        ],
+        registryHits: [registryHit({ name: "docker-kit", id: "reg-1", score: 0.8 })],
+        warnings: ["fallback warning"],
+      }),
+    ]);
+
+    expect(merged.hits.map((hit) => ("ref" in hit ? hit.ref : `registry:${hit.id}`))).toEqual([
+      "skill:docker-homelab",
+      "script:docker-clean",
+    ]);
+    expect(merged.registryHits?.map((hit) => [hit.id, hit.score])).toEqual([["reg-1", 0.8]]);
+    expect(merged.warnings).toEqual(["base warning", "fallback warning"]);
+    expect(merged.tip).toBeUndefined();
+  });
+});
+
+describe("curateSearchResults", () => {
+  test("keeps stronger same-type hits ahead of weak different-type filler", async () => {
+    const result = await curateSearchResults(
+      "release review",
+      searchResponse({
+        hits: [
+          stashHit({ type: "skill", name: "release-playbook", ref: "skill:release-playbook", path: "/tmp/1", score: 0.99 }),
+          stashHit({ type: "knowledge", name: "release-guide", ref: "knowledge:release-guide", path: "/tmp/2", score: 0.8 }),
+          stashHit({ type: "command", name: "release-manager", ref: "command:release-manager", path: "/tmp/3", score: 0.15 }),
+          stashHit({ type: "agent", name: "release-reviewer", ref: "agent:release-reviewer", path: "/tmp/4", score: 0.05 }),
+        ],
+      }),
+      4,
+    );
+
+    expect(result.items.map((item) => ("ref" in item ? item.ref : `registry:${item.id}`))).toEqual([
+      "skill:release-playbook",
+      "knowledge:release-guide",
+    ]);
+  });
+
+  test("selectedType bypasses diversification and keeps top hits of that type", async () => {
+    const result = await curateSearchResults(
+      "release",
+      searchResponse({
+        hits: [
+          stashHit({ type: "command", name: "release-manager", ref: "command:release-manager", path: "/tmp/1", score: 0.9 }),
+          stashHit({ type: "command", name: "release-notes", ref: "command:release-notes", path: "/tmp/2", score: 0.7 }),
+          stashHit({ type: "skill", name: "release-review", ref: "skill:release-review", path: "/tmp/3", score: 1 }),
+        ],
+      }),
+      2,
+      "command",
+    );
+
+    expect(result.items.map((item) => ("ref" in item ? item.ref : `registry:${item.id}`))).toEqual([
+      "command:release-manager",
+      "command:release-notes",
+    ]);
+  });
+
+  test("uses registry hits only to fill remaining slots and caps them at two", async () => {
+    const result = await curateSearchResults(
+      "deploy",
+      searchResponse({
+        hits: [stashHit({ type: "script", name: "deploy-check", ref: "script:deploy-check", path: "/tmp/1", score: 0.8 })],
+        registryHits: [
+          registryHit({ name: "deploy-kit-a", id: "reg-a", score: 0.95 }),
+          registryHit({ name: "deploy-kit-b", id: "reg-b", score: 0.85 }),
+          registryHit({ name: "deploy-kit-c", id: "reg-c", score: 0.75 }),
+        ],
+      }),
+      4,
+    );
+
+    expect(result.items.map((item) => ("ref" in item ? item.ref : `registry:${item.id}`))).toEqual([
+      "script:deploy-check",
+      "registry:reg-a",
+      "registry:reg-b",
+    ]);
+  });
+
+  test("collapses broad root/reference families into one top-level result with support refs", async () => {
+    const result = await curateSearchResults(
+      "docker homelab",
+      searchResponse({
+        hits: [
+          stashHit({ type: "skill", name: "docker-homelab", ref: "skill:docker-homelab", path: "/tmp/1", score: 1 }),
+          stashHit({ type: "knowledge", name: "skills/docker-homelab/references/compose", ref: "knowledge:skills/docker-homelab/references/compose", path: "/tmp/2", score: 1 }),
+          stashHit({ type: "knowledge", name: "skills/docker-homelab/references/networking", ref: "knowledge:skills/docker-homelab/references/networking", path: "/tmp/3", score: 0.9 }),
+        ],
+      }),
+      4,
+    );
+
+    expect(result.items).toHaveLength(1);
+    const first = result.items[0] as Record<string, unknown>;
+    expect(first.ref).toBe("knowledge:skills/docker-homelab/references/compose");
+    expect(first.supportRefs).toEqual([
+      { ref: "skill:docker-homelab", type: "skill", reason: "Related family asset to inspect next." },
+      {
+        ref: "knowledge:skills/docker-homelab/references/networking",
+        type: "knowledge",
+        reason: "Related family asset to inspect next.",
+      },
+    ]);
+  });
+
+  test("keeps the narrow child reference as the top-level family representative", async () => {
+    const result = await curateSearchResults(
+      "docker compose reference",
+      searchResponse({
+        hits: [
+          stashHit({ type: "skill", name: "docker-homelab", ref: "skill:docker-homelab", path: "/tmp/1", score: 1 }),
+          stashHit({ type: "knowledge", name: "skills/docker-homelab/references/compose", ref: "knowledge:skills/docker-homelab/references/compose", path: "/tmp/2", score: 1 }),
+        ],
+      }),
+      4,
+    );
+
+    expect(result.items).toHaveLength(1);
+    expect((result.items[0] as Record<string, unknown>).ref).toBe("knowledge:skills/docker-homelab/references/compose");
+  });
+});
+
+describe("akmCurate", () => {
+  test("rejects a blank curation query", async () => {
+    await expect(akmCurate({ query: "   " })).rejects.toBeInstanceOf(UsageError);
+  });
+
+  test("defaults to four curated items when limit is omitted", async () => {
+    const result = await akmCurate({
+      query: "deploy",
+      searchResponse: searchResponse({
+        hits: [
+          stashHit({ type: "script", name: "deploy-check", ref: "script:deploy-check", path: "/tmp/1", score: 0.9 }),
+          stashHit({ type: "command", name: "deploy-release", ref: "command:deploy-release", path: "/tmp/2", score: 0.8 }),
+          stashHit({ type: "knowledge", name: "deploy-guide", ref: "knowledge:deploy-guide", path: "/tmp/3", score: 0.7 }),
+          stashHit({ type: "skill", name: "deploy-skill", ref: "skill:deploy-skill", path: "/tmp/4", score: 0.6 }),
+          stashHit({ type: "agent", name: "deploy-reviewer", ref: "agent:deploy-reviewer", path: "/tmp/5", score: 0.5 }),
+        ],
+      }),
+    });
+
+    expect(result.items.length).toBeGreaterThan(0);
+    expect(result.items.length).toBeLessThanOrEqual(4);
+  });
+});

--- a/tests/curate-logic.test.ts
+++ b/tests/curate-logic.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { akmCurate, curateSearchResults, deriveCurateFallbackQueries, mergeCurateSearchResponses } from "../src/commands/read/curate";
+import {
+  akmCurate,
+  curateSearchResults,
+  deriveCurateFallbackQueries,
+  mergeCurateSearchResponses,
+} from "../src/commands/read/curate";
 import { UsageError } from "../src/core/errors";
 import type { RegistrySearchResultHit, SearchResponse, SourceSearchHit } from "../src/sources/types";
 
@@ -50,7 +55,9 @@ describe("deriveCurateFallbackQueries", () => {
 describe("mergeCurateSearchResponses", () => {
   test("keeps the highest-scoring duplicate stash and registry hits and merges warnings", () => {
     const base = searchResponse({
-      hits: [stashHit({ type: "skill", name: "docker-homelab", ref: "skill:docker-homelab", path: "/tmp/a", score: 0.3 })],
+      hits: [
+        stashHit({ type: "skill", name: "docker-homelab", ref: "skill:docker-homelab", path: "/tmp/a", score: 0.3 }),
+      ],
       registryHits: [registryHit({ name: "docker-kit", id: "reg-1", score: 0.2 })],
       tip: "No phrase results.",
       warnings: ["base warning"],
@@ -82,10 +89,34 @@ describe("curateSearchResults", () => {
       "release review",
       searchResponse({
         hits: [
-          stashHit({ type: "skill", name: "release-playbook", ref: "skill:release-playbook", path: "/tmp/1", score: 0.99 }),
-          stashHit({ type: "knowledge", name: "release-guide", ref: "knowledge:release-guide", path: "/tmp/2", score: 0.8 }),
-          stashHit({ type: "command", name: "release-manager", ref: "command:release-manager", path: "/tmp/3", score: 0.15 }),
-          stashHit({ type: "agent", name: "release-reviewer", ref: "agent:release-reviewer", path: "/tmp/4", score: 0.05 }),
+          stashHit({
+            type: "skill",
+            name: "release-playbook",
+            ref: "skill:release-playbook",
+            path: "/tmp/1",
+            score: 0.99,
+          }),
+          stashHit({
+            type: "knowledge",
+            name: "release-guide",
+            ref: "knowledge:release-guide",
+            path: "/tmp/2",
+            score: 0.8,
+          }),
+          stashHit({
+            type: "command",
+            name: "release-manager",
+            ref: "command:release-manager",
+            path: "/tmp/3",
+            score: 0.15,
+          }),
+          stashHit({
+            type: "agent",
+            name: "release-reviewer",
+            ref: "agent:release-reviewer",
+            path: "/tmp/4",
+            score: 0.05,
+          }),
         ],
       }),
       4,
@@ -102,8 +133,20 @@ describe("curateSearchResults", () => {
       "release",
       searchResponse({
         hits: [
-          stashHit({ type: "command", name: "release-manager", ref: "command:release-manager", path: "/tmp/1", score: 0.9 }),
-          stashHit({ type: "command", name: "release-notes", ref: "command:release-notes", path: "/tmp/2", score: 0.7 }),
+          stashHit({
+            type: "command",
+            name: "release-manager",
+            ref: "command:release-manager",
+            path: "/tmp/1",
+            score: 0.9,
+          }),
+          stashHit({
+            type: "command",
+            name: "release-notes",
+            ref: "command:release-notes",
+            path: "/tmp/2",
+            score: 0.7,
+          }),
           stashHit({ type: "skill", name: "release-review", ref: "skill:release-review", path: "/tmp/3", score: 1 }),
         ],
       }),
@@ -121,7 +164,9 @@ describe("curateSearchResults", () => {
     const result = await curateSearchResults(
       "deploy",
       searchResponse({
-        hits: [stashHit({ type: "script", name: "deploy-check", ref: "script:deploy-check", path: "/tmp/1", score: 0.8 })],
+        hits: [
+          stashHit({ type: "script", name: "deploy-check", ref: "script:deploy-check", path: "/tmp/1", score: 0.8 }),
+        ],
         registryHits: [
           registryHit({ name: "deploy-kit-a", id: "reg-a", score: 0.95 }),
           registryHit({ name: "deploy-kit-b", id: "reg-b", score: 0.85 }),
@@ -144,8 +189,20 @@ describe("curateSearchResults", () => {
       searchResponse({
         hits: [
           stashHit({ type: "skill", name: "docker-homelab", ref: "skill:docker-homelab", path: "/tmp/1", score: 1 }),
-          stashHit({ type: "knowledge", name: "skills/docker-homelab/references/compose", ref: "knowledge:skills/docker-homelab/references/compose", path: "/tmp/2", score: 1 }),
-          stashHit({ type: "knowledge", name: "skills/docker-homelab/references/networking", ref: "knowledge:skills/docker-homelab/references/networking", path: "/tmp/3", score: 0.9 }),
+          stashHit({
+            type: "knowledge",
+            name: "skills/docker-homelab/references/compose",
+            ref: "knowledge:skills/docker-homelab/references/compose",
+            path: "/tmp/2",
+            score: 1,
+          }),
+          stashHit({
+            type: "knowledge",
+            name: "skills/docker-homelab/references/networking",
+            ref: "knowledge:skills/docker-homelab/references/networking",
+            path: "/tmp/3",
+            score: 0.9,
+          }),
         ],
       }),
       4,
@@ -174,7 +231,13 @@ describe("curateSearchResults", () => {
       searchResponse({
         hits: [
           stashHit({ type: "skill", name: "docker-homelab", ref: "skill:docker-homelab", path: "/tmp/1", score: 1 }),
-          stashHit({ type: "knowledge", name: "skills/docker-homelab/references/compose", ref: "knowledge:skills/docker-homelab/references/compose", path: "/tmp/2", score: 1 }),
+          stashHit({
+            type: "knowledge",
+            name: "skills/docker-homelab/references/compose",
+            ref: "knowledge:skills/docker-homelab/references/compose",
+            path: "/tmp/2",
+            score: 1,
+          }),
         ],
       }),
       4,
@@ -196,10 +259,28 @@ describe("akmCurate", () => {
       searchResponse: searchResponse({
         hits: [
           stashHit({ type: "script", name: "deploy-check", ref: "script:deploy-check", path: "/tmp/1", score: 0.9 }),
-          stashHit({ type: "command", name: "deploy-release", ref: "command:deploy-release", path: "/tmp/2", score: 0.8 }),
-          stashHit({ type: "knowledge", name: "deploy-guide", ref: "knowledge:deploy-guide", path: "/tmp/3", score: 0.7 }),
+          stashHit({
+            type: "command",
+            name: "deploy-release",
+            ref: "command:deploy-release",
+            path: "/tmp/2",
+            score: 0.8,
+          }),
+          stashHit({
+            type: "knowledge",
+            name: "deploy-guide",
+            ref: "knowledge:deploy-guide",
+            path: "/tmp/3",
+            score: 0.7,
+          }),
           stashHit({ type: "skill", name: "deploy-skill", ref: "skill:deploy-skill", path: "/tmp/4", score: 0.6 }),
-          stashHit({ type: "agent", name: "deploy-reviewer", ref: "agent:deploy-reviewer", path: "/tmp/5", score: 0.5 }),
+          stashHit({
+            type: "agent",
+            name: "deploy-reviewer",
+            ref: "agent:deploy-reviewer",
+            path: "/tmp/5",
+            score: 0.5,
+          }),
         ],
       }),
     });

--- a/tests/curate-relevance-eval.test.ts
+++ b/tests/curate-relevance-eval.test.ts
@@ -1,0 +1,90 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { akmCurate } from "../src/commands/read/curate";
+import { saveConfig } from "../src/core/config/config";
+import { akmIndex } from "../src/indexer/indexer";
+import { type Cleanup, sandboxXdgCacheHome, sandboxXdgConfigHome, sandboxXdgDataHome } from "./_helpers/sandbox";
+import { loadFixtureStash } from "./fixtures/stashes/load";
+
+let fixtureStash = "";
+let fileDataHome = "";
+let envCleanup: Cleanup = () => {};
+let fixtureCleanup: (() => void) | undefined;
+
+const BASELINE = {
+  dockerHomelab: ["knowledge:skills/docker-homelab/references/compose", "skill:docker-homelab"],
+  dockerDeploy: [
+    "script:docker-clean",
+    "knowledge:skills/docker-homelab/references/compose",
+    "skill:docker-homelab",
+    "command:release-manager",
+  ],
+  theDocker: [] as string[],
+  howDocker: [] as string[],
+} as const;
+
+beforeAll(async () => {
+  const cacheResult = sandboxXdgCacheHome();
+  const cfgResult = sandboxXdgConfigHome(cacheResult.cleanup);
+  const dataResult = sandboxXdgDataHome(cfgResult.cleanup);
+  fileDataHome = dataResult.dir;
+  envCleanup = dataResult.cleanup;
+
+  const loaded = loadFixtureStash("ranking-baseline", { skipIndex: true });
+  fixtureStash = loaded.stashDir;
+  fixtureCleanup = loaded.cleanup;
+
+  process.env.XDG_DATA_HOME = fileDataHome;
+  process.env.AKM_STASH_DIR = fixtureStash;
+  saveConfig({
+    semanticSearchMode: "off",
+    sources: [{ type: "filesystem", path: fixtureStash }],
+    registries: [],
+  });
+  await akmIndex({ stashDir: fixtureStash, full: true });
+});
+
+beforeEach(() => {
+  process.env.XDG_DATA_HOME = fileDataHome;
+  process.env.AKM_STASH_DIR = fixtureStash;
+});
+
+afterAll(() => {
+  envCleanup();
+  envCleanup = () => {};
+  if (process.env.AKM_STASH_DIR === fixtureStash) delete process.env.AKM_STASH_DIR;
+  fixtureCleanup?.();
+});
+
+async function curateRefs(query: string): Promise<string[]> {
+  const result = await akmCurate({ query, limit: 4 });
+  return result.items.map((item) => ("ref" in item ? item.ref : `registry:${item.id}`));
+}
+
+function familyOccupancy(refs: string[], familyKey: string): number {
+  return refs.filter((ref) => ref === `skill:${familyKey}` || ref.startsWith(`knowledge:skills/${familyKey}/references/`)).length;
+}
+
+function bannedCount(refs: string[], banned: string): number {
+  return refs.filter((ref) => ref === banned).length;
+}
+
+describe("curate relevance improvements", () => {
+  test("improves measurable quality over the pre-change curate baseline", async () => {
+    const dockerHomelab = await curateRefs("docker homelab");
+    const dockerDeploy = await curateRefs("docker deploy");
+    const theDocker = await curateRefs("the docker");
+    const howDocker = await curateRefs("how docker");
+
+    expect(familyOccupancy(dockerHomelab, "docker-homelab")).toBeLessThan(
+      familyOccupancy([...BASELINE.dockerHomelab], "docker-homelab"),
+    );
+    expect(bannedCount(dockerDeploy, "command:release-manager")).toBeLessThan(
+      bannedCount([...BASELINE.dockerDeploy], "command:release-manager"),
+    );
+    expect(theDocker.length).toBeGreaterThan((BASELINE.theDocker as string[]).length);
+    expect(theDocker.some((ref) => ref.includes("docker"))).toBe(true);
+    expect(howDocker.length).toBeGreaterThan((BASELINE.howDocker as string[]).length);
+    expect(howDocker.some((ref) => ref.includes("docker"))).toBe(true);
+    expect(dockerHomelab.length).toBeLessThan(BASELINE.dockerHomelab.length);
+  });
+});

--- a/tests/curate-relevance-eval.test.ts
+++ b/tests/curate-relevance-eval.test.ts
@@ -1,14 +1,10 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
 import { akmCurate } from "../src/commands/read/curate";
 import { saveConfig } from "../src/core/config/config";
 import { akmIndex } from "../src/indexer/indexer";
-import { type Cleanup, sandboxXdgCacheHome, sandboxXdgConfigHome, sandboxXdgDataHome } from "./_helpers/sandbox";
-import { loadFixtureStash } from "./fixtures/stashes/load";
-
-let fixtureStash = "";
-let fileDataHome = "";
-let envCleanup: Cleanup = () => {};
-let fixtureCleanup: (() => void) | undefined;
+import { withIsolatedAkmStorage } from "./_helpers/sandbox";
 
 const BASELINE = {
   dockerHomelab: ["knowledge:skills/docker-homelab/references/compose", "skill:docker-homelab"],
@@ -22,38 +18,7 @@ const BASELINE = {
   howDocker: [] as string[],
 } as const;
 
-beforeAll(async () => {
-  const cacheResult = sandboxXdgCacheHome();
-  const cfgResult = sandboxXdgConfigHome(cacheResult.cleanup);
-  const dataResult = sandboxXdgDataHome(cfgResult.cleanup);
-  fileDataHome = dataResult.dir;
-  envCleanup = dataResult.cleanup;
-
-  const loaded = loadFixtureStash("ranking-baseline", { skipIndex: true });
-  fixtureStash = loaded.stashDir;
-  fixtureCleanup = loaded.cleanup;
-
-  process.env.XDG_DATA_HOME = fileDataHome;
-  process.env.AKM_STASH_DIR = fixtureStash;
-  saveConfig({
-    semanticSearchMode: "off",
-    sources: [{ type: "filesystem", path: fixtureStash }],
-    registries: [],
-  });
-  await akmIndex({ stashDir: fixtureStash, full: true });
-});
-
-beforeEach(() => {
-  process.env.XDG_DATA_HOME = fileDataHome;
-  process.env.AKM_STASH_DIR = fixtureStash;
-});
-
-afterAll(() => {
-  envCleanup();
-  envCleanup = () => {};
-  if (process.env.AKM_STASH_DIR === fixtureStash) delete process.env.AKM_STASH_DIR;
-  fixtureCleanup?.();
-});
+const RANKING_BASELINE_FIXTURE = path.join(__dirname, "fixtures", "stashes", "ranking-baseline");
 
 async function curateRefs(query: string): Promise<string[]> {
   const result = await akmCurate({ query, limit: 4 });
@@ -61,7 +26,9 @@ async function curateRefs(query: string): Promise<string[]> {
 }
 
 function familyOccupancy(refs: string[], familyKey: string): number {
-  return refs.filter((ref) => ref === `skill:${familyKey}` || ref.startsWith(`knowledge:skills/${familyKey}/references/`)).length;
+  return refs.filter(
+    (ref) => ref === `skill:${familyKey}` || ref.startsWith(`knowledge:skills/${familyKey}/references/`),
+  ).length;
 }
 
 function bannedCount(refs: string[], banned: string): number {
@@ -70,21 +37,34 @@ function bannedCount(refs: string[], banned: string): number {
 
 describe("curate relevance improvements", () => {
   test("improves measurable quality over the pre-change curate baseline", async () => {
-    const dockerHomelab = await curateRefs("docker homelab");
-    const dockerDeploy = await curateRefs("docker deploy");
-    const theDocker = await curateRefs("the docker");
-    const howDocker = await curateRefs("how docker");
+    const storage = withIsolatedAkmStorage();
+    try {
+      fs.cpSync(RANKING_BASELINE_FIXTURE, storage.stashDir, { recursive: true });
+      saveConfig({
+        semanticSearchMode: "off",
+        sources: [{ type: "filesystem", path: storage.stashDir }],
+        registries: [],
+      });
+      await akmIndex({ stashDir: storage.stashDir, full: true });
 
-    expect(familyOccupancy(dockerHomelab, "docker-homelab")).toBeLessThan(
-      familyOccupancy([...BASELINE.dockerHomelab], "docker-homelab"),
-    );
-    expect(bannedCount(dockerDeploy, "command:release-manager")).toBeLessThan(
-      bannedCount([...BASELINE.dockerDeploy], "command:release-manager"),
-    );
-    expect(theDocker.length).toBeGreaterThan((BASELINE.theDocker as string[]).length);
-    expect(theDocker.some((ref) => ref.includes("docker"))).toBe(true);
-    expect(howDocker.length).toBeGreaterThan((BASELINE.howDocker as string[]).length);
-    expect(howDocker.some((ref) => ref.includes("docker"))).toBe(true);
-    expect(dockerHomelab.length).toBeLessThan(BASELINE.dockerHomelab.length);
+      const dockerHomelab = await curateRefs("docker homelab");
+      const dockerDeploy = await curateRefs("docker deploy");
+      const theDocker = await curateRefs("the docker");
+      const howDocker = await curateRefs("how docker");
+
+      expect(familyOccupancy(dockerHomelab, "docker-homelab")).toBeLessThan(
+        familyOccupancy([...BASELINE.dockerHomelab], "docker-homelab"),
+      );
+      expect(bannedCount(dockerDeploy, "command:release-manager")).toBeLessThan(
+        bannedCount([...BASELINE.dockerDeploy], "command:release-manager"),
+      );
+      expect(theDocker.length).toBeGreaterThan(BASELINE.theDocker.length);
+      expect(theDocker.some((ref) => ref.includes("docker"))).toBe(true);
+      expect(howDocker.length).toBeGreaterThan(BASELINE.howDocker.length);
+      expect(howDocker.some((ref) => ref.includes("docker"))).toBe(true);
+      expect(dockerHomelab.length).toBeLessThan(BASELINE.dockerHomelab.length);
+    } finally {
+      storage.cleanup();
+    }
   });
 });

--- a/tests/curate-search-for-curation.test.ts
+++ b/tests/curate-search-for-curation.test.ts
@@ -1,149 +1,100 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-import type { SearchResponse } from "../src/sources/types";
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { searchForCuration } from "../src/commands/read/curate";
+import { saveConfig } from "../src/core/config/config";
+import { akmIndex } from "../src/indexer/indexer";
+import { withIsolatedAkmStorage } from "./_helpers/sandbox";
 
-type AkmSearchInput = {
-  query: string;
-  type?: string;
-  limit?: number;
-  source?: string;
-  skipLogging?: boolean;
-};
-
-const calls: AkmSearchInput[] = [];
-let searchImpl: (input: AkmSearchInput) => Promise<SearchResponse>;
-
-function emptyResponse(): SearchResponse {
-  return {
-    schemaVersion: 1,
-    stashDir: "/tmp/stash",
-    source: "stash",
-    hits: [],
-  };
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
 }
 
-mock.module("../src/commands/read/search", () => ({
-  akmSearch: async (input: AkmSearchInput) => {
-    calls.push(input);
-    return searchImpl(input);
-  },
-  parseSearchSource: (value: string) => value,
-}));
-
-const { searchForCuration } = await import("../src/commands/read/curate");
-
-beforeEach(() => {
-  calls.length = 0;
-  searchImpl = async () => emptyResponse();
-});
+async function withIndexedStash<T>(fn: (stashDir: string) => Promise<T>): Promise<T> {
+  const storage = withIsolatedAkmStorage();
+  try {
+    saveConfig({
+      semanticSearchMode: "off",
+      sources: [{ type: "filesystem", path: storage.stashDir }],
+      registries: [],
+    });
+    return await fn(storage.stashDir);
+  } finally {
+    storage.cleanup();
+  }
+}
 
 describe("searchForCuration", () => {
   test("falls back when the initial phrase hit is weak", async () => {
-    searchImpl = async (input) => {
-      if (input.query === "docker cleanup audit") {
-        return {
-          ...emptyResponse(),
-          hits: [
-            {
-              type: "command",
-              name: "release-manager",
-              ref: "command:release-manager",
-              path: "/tmp/release",
-              score: 0.05,
-            },
-          ],
-        };
-      }
-      if (input.query === "docker") {
-        return {
-          ...emptyResponse(),
-          hits: [
-            {
-              type: "script",
-              name: "docker-clean",
-              ref: "script:docker-clean",
-              path: "/tmp/docker-clean",
-              score: 0.9,
-            },
-          ],
-        };
-      }
-      return emptyResponse();
-    };
+    await withIndexedStash(async (stashDir) => {
+      writeFile(
+        path.join(stashDir, "commands", "cleanup-audit.md"),
+        "---\ndescription: Review cleanup audit notes and release coordination\n---\nReview docker cleanup audit notes for the release retrospective.\n",
+      );
+      writeFile(
+        path.join(stashDir, "scripts", "docker-clean.sh"),
+        "#!/usr/bin/env bash\n# Clean up unused Docker images and containers\ndocker system prune -af\n",
+      );
 
-    const result = await searchForCuration({
-      query: "docker cleanup audit",
-      limit: 12,
-      source: "stash",
+      await akmIndex({ stashDir, full: true });
+
+      const result = await searchForCuration({
+        query: "docker cleanup audit",
+        limit: 12,
+        source: "stash",
+      });
+
+      const refs = result.hits.map((hit) => ("ref" in hit ? hit.ref : `registry:${hit.id}`));
+      expect(refs).toContain("script:docker-clean.sh");
+      expect(refs).toContain("command:cleanup-audit");
+      expect(refs.indexOf("script:docker-clean.sh")).toBeLessThan(refs.indexOf("command:cleanup-audit"));
     });
-
-    expect(calls.map((call) => call.query)).toEqual(["docker cleanup audit", "docker", "cleanup", "audit"]);
-    expect(result.hits.map((hit) => ("ref" in hit ? hit.ref : `registry:${hit.id}`))).toEqual([
-      "script:docker-clean",
-      "command:release-manager",
-    ]);
   });
 
-  test("does not fall back when the initial phrase search is already strong", async () => {
-    searchImpl = async (input) => {
-      if (input.query === "docker homelab") {
-        return {
-          ...emptyResponse(),
-          hits: [
-            {
-              type: "skill",
-              name: "docker-homelab",
-              ref: "skill:docker-homelab",
-              path: "/tmp/skill",
-              score: 0.95,
-            },
-            {
-              type: "knowledge",
-              name: "docker-compose-reference",
-              ref: "knowledge:docker-compose-reference",
-              path: "/tmp/knowledge",
-              score: 0.85,
-            },
-          ],
-        };
-      }
-      return emptyResponse();
-    };
+  test("does not need fallback when the initial phrase search is already strong", async () => {
+    await withIndexedStash(async (stashDir) => {
+      writeFile(
+        path.join(stashDir, "skills", "docker-homelab", "SKILL.md"),
+        "---\ndescription: Manage Docker containers in a homelab\n---\n# Docker Homelab\nUse Docker Compose, containers, and networking in a homelab.\n",
+      );
+      writeFile(
+        path.join(stashDir, "knowledge", "docker-compose-reference.md"),
+        "# Docker Compose Reference\n\nReference for Docker Compose services and files.\n",
+      );
 
-    const result = await searchForCuration({
-      query: "docker homelab",
-      limit: 12,
-      source: "stash",
+      await akmIndex({ stashDir, full: true });
+
+      const result = await searchForCuration({
+        query: "docker homelab",
+        limit: 12,
+        source: "stash",
+      });
+
+      const refs = result.hits.map((hit) => ("ref" in hit ? hit.ref : `registry:${hit.id}`));
+      expect(refs[0]).toBe("skill:docker-homelab");
+      expect(refs).toContain("knowledge:docker-compose-reference");
     });
-
-    expect(calls.map((call) => call.query)).toEqual(["docker homelab"]);
-    expect(result.hits.map((hit) => ("ref" in hit ? hit.ref : `registry:${hit.id}`))).toEqual([
-      "skill:docker-homelab",
-      "knowledge:docker-compose-reference",
-    ]);
   });
 
   test("allows one-token prompt-residue fallback", async () => {
-    searchImpl = async (input) => {
-      if (input.query === "docker") {
-        return {
-          ...emptyResponse(),
-          hits: [
-            {
-              type: "script",
-              name: "docker-clean",
-              ref: "script:docker-clean",
-              path: "/tmp/docker-clean",
-              score: 0.9,
-            },
-          ],
-        };
-      }
-      return emptyResponse();
-    };
+    await withIndexedStash(async (stashDir) => {
+      writeFile(
+        path.join(stashDir, "scripts", "docker-clean.sh"),
+        "#!/usr/bin/env bash\n# Clean up unused Docker images and containers\ndocker system prune -af\n",
+      );
+      writeFile(
+        path.join(stashDir, "skills", "docker-homelab", "SKILL.md"),
+        "---\ndescription: Manage Docker containers in a homelab\n---\n# Docker Homelab\nUse Docker containers and Compose in a homelab.\n",
+      );
 
-    const result = await searchForCuration({ query: "the docker", limit: 12, source: "stash" });
+      await akmIndex({ stashDir, full: true });
 
-    expect(calls.map((call) => call.query)).toEqual(["the docker", "docker"]);
-    expect(result.hits.map((hit) => ("ref" in hit ? hit.ref : `registry:${hit.id}`))).toEqual(["script:docker-clean"]);
+      const result = await searchForCuration({ query: "the docker", limit: 12, source: "stash" });
+
+      const refs = result.hits.map((hit) => ("ref" in hit ? hit.ref : `registry:${hit.id}`));
+      expect(refs.length).toBeGreaterThan(0);
+      expect(refs.some((ref) => ref.includes("docker"))).toBe(true);
+    });
   });
 });

--- a/tests/curate-search-for-curation.test.ts
+++ b/tests/curate-search-for-curation.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { SearchResponse } from "../src/sources/types";
+
+type AkmSearchInput = {
+  query: string;
+  type?: string;
+  limit?: number;
+  source?: string;
+  skipLogging?: boolean;
+};
+
+const calls: AkmSearchInput[] = [];
+let searchImpl: (input: AkmSearchInput) => Promise<SearchResponse>;
+
+function emptyResponse(): SearchResponse {
+  return {
+    schemaVersion: 1,
+    stashDir: "/tmp/stash",
+    source: "stash",
+    hits: [],
+  };
+}
+
+mock.module("../src/commands/read/search", () => ({
+  akmSearch: async (input: AkmSearchInput) => {
+    calls.push(input);
+    return searchImpl(input);
+  },
+  parseSearchSource: (value: string) => value,
+}));
+
+const { searchForCuration } = await import("../src/commands/read/curate");
+
+beforeEach(() => {
+  calls.length = 0;
+  searchImpl = async () => emptyResponse();
+});
+
+describe("searchForCuration", () => {
+  test("falls back when the initial phrase hit is weak", async () => {
+    searchImpl = async (input) => {
+      if (input.query === "docker cleanup audit") {
+        return {
+          ...emptyResponse(),
+          hits: [
+            {
+              type: "command",
+              name: "release-manager",
+              ref: "command:release-manager",
+              path: "/tmp/release",
+              score: 0.05,
+            },
+          ],
+        };
+      }
+      if (input.query === "docker") {
+        return {
+          ...emptyResponse(),
+          hits: [
+            {
+              type: "script",
+              name: "docker-clean",
+              ref: "script:docker-clean",
+              path: "/tmp/docker-clean",
+              score: 0.9,
+            },
+          ],
+        };
+      }
+      return emptyResponse();
+    };
+
+    const result = await searchForCuration({
+      query: "docker cleanup audit",
+      limit: 12,
+      source: "stash",
+    });
+
+    expect(calls.map((call) => call.query)).toEqual(["docker cleanup audit", "docker", "cleanup", "audit"]);
+    expect(result.hits.map((hit) => ("ref" in hit ? hit.ref : `registry:${hit.id}`))).toEqual([
+      "script:docker-clean",
+      "command:release-manager",
+    ]);
+  });
+
+  test("does not fall back when the initial phrase search is already strong", async () => {
+    searchImpl = async (input) => {
+      if (input.query === "docker homelab") {
+        return {
+          ...emptyResponse(),
+          hits: [
+            {
+              type: "skill",
+              name: "docker-homelab",
+              ref: "skill:docker-homelab",
+              path: "/tmp/skill",
+              score: 0.95,
+            },
+            {
+              type: "knowledge",
+              name: "docker-compose-reference",
+              ref: "knowledge:docker-compose-reference",
+              path: "/tmp/knowledge",
+              score: 0.85,
+            },
+          ],
+        };
+      }
+      return emptyResponse();
+    };
+
+    const result = await searchForCuration({
+      query: "docker homelab",
+      limit: 12,
+      source: "stash",
+    });
+
+    expect(calls.map((call) => call.query)).toEqual(["docker homelab"]);
+    expect(result.hits.map((hit) => ("ref" in hit ? hit.ref : `registry:${hit.id}`))).toEqual([
+      "skill:docker-homelab",
+      "knowledge:docker-compose-reference",
+    ]);
+  });
+
+  test("allows one-token prompt-residue fallback", async () => {
+    searchImpl = async (input) => {
+      if (input.query === "docker") {
+        return {
+          ...emptyResponse(),
+          hits: [
+            {
+              type: "script",
+              name: "docker-clean",
+              ref: "script:docker-clean",
+              path: "/tmp/docker-clean",
+              score: 0.9,
+            },
+          ],
+        };
+      }
+      return emptyResponse();
+    };
+
+    const result = await searchForCuration({ query: "the docker", limit: 12, source: "stash" });
+
+    expect(calls.map((call) => call.query)).toEqual(["the docker", "docker"]);
+    expect(result.hits.map((hit) => ("ref" in hit ? hit.ref : `registry:${hit.id}`))).toEqual(["script:docker-clean"]);
+  });
+});


### PR DESCRIPTION
## Summary
- make curate relevance-first with weak-result fallback and family collapsing
- add fixture-backed before/after eval coverage for curate tuning
- document the curate performance eval workflow for future tuning

## Verification
- bunx tsc --noEmit
- bun test tests/curate-logic.test.ts tests/curate-search-for-curation.test.ts tests/curate-command.test.ts tests/curate-relevance-eval.test.ts
- bun test tests/ranking-regression.test.ts
