### PR TITLE
Add `fact` asset type for durable stash-level knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ See [docs/getting-started.md](docs/getting-started.md) for a full walkthrough.
 | **wiki** | A page inside a multi-wiki knowledge base | `wiki:ops/runbook` |
 | **lesson** | Distilled feedback insight | `lesson:prefer-dry-run` |
 | **memory** | Recalled context from a previous session | `memory:vpn-note` |
+| **fact** | Durable stash-level fact (identity, conventions, stash-meta) | `fact:team/tool-stack` |
 
 See [docs/concepts.md](docs/concepts.md) for classification rules and the ref format.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -101,6 +101,7 @@ There are eleven asset types:
 | **wiki** | A page inside a multi-wiki knowledge base | Markdown page with TOC / section / lines views (see [wikis.md](wikis.md)) |
 | **lesson** | A distilled feedback lesson | `when_to_use` guidance plus the lesson body (see [`akm improve`](cli.md#improve)) |
 | **memory** | Context from external systems | Background information the agent should consider |
+| **fact** | A durable stash-level fact | Mostly-static semantic knowledge — personal/team/project details, coding conventions / "constitution", and stash-meta (naming conventions, active projects). `category` scopes it; `pinned: true` marks always-injected core context (see [design note](design/fact-asset-type.md)) |
 
 ### Classification Taxonomy
 

--- a/docs/design/fact-asset-type.md
+++ b/docs/design/fact-asset-type.md
@@ -1,0 +1,137 @@
+# Design: the `fact` asset type — durable stash-level knowledge
+
+Status: accepted (phase 1 implemented)
+Author: akm
+Date: 2026-06-20
+
+## Problem
+
+akm has no home for **durable, mostly-static facts about a user, team, or
+project**. Concretely, users want a stash to carry things like:
+
+- **Personal** — name, email, address, timezone, favorite blogs, writing/working style.
+- **Team** — tool stacks, primary languages, CI/CD platform, deployment targets, web addresses.
+- **Conventions / constitution** — coding conventions, architecture principles, lint rules.
+- **Stash meta** — folder organization, naming conventions, expected frontmatter, the active-projects list.
+
+Today these have nowhere first-class to live:
+
+- `memory` is **episodic** — recency-decayed, belief-state ranked, captured ad-hoc via `akm remember`. It models "what I observed in a session," not "what is durably true about this stash."
+- `knowledge` is curated **reference material** — documents an agent reads on demand, not stash-level identity/conventions injected as context.
+- `lesson` is a **`when_to_use` trigger** distilled from feedback.
+- The `.meta/` convention (`src/core/asset/stash-meta.ts`, `docs/concepts.md` "Stash orientation") is **documentary only**: not indexed, not searchable, not ranked, and not surfaced to agents automatically.
+
+## Conceptual grounding
+
+The agent-memory literature splits long-term memory three ways (CoALA,
+*Cognitive Architectures for Language Agents*, arXiv:2309.02427; echoed by
+LangMem and Letta/MemGPT). akm already covers two of the three:
+
+| Memory class | "answers" | akm |
+| --- | --- | --- |
+| **Episodic** — timestamped events | "what happened" | `session` (#561) |
+| **Procedural** — executable how-to | "how to do X" | `skill`, `command`, `workflow` |
+| **Semantic** — durable facts/identity | "what is true" | **`fact` (this doc)** |
+
+Karpathy's operating-system analogy frames the design: model weights are the
+CPU/ROM (can't retrain), the context window is scarce RAM, and everything else
+is disk that must be *paged in*. A fact is **disk-resident knowledge selectively
+loaded into RAM** — neither baked into weights nor permanently pinned in the
+system prompt. Anthropic's *Effective context engineering for AI agents*
+reinforces this: curate aggressively, prefer just-in-time retrieval, and pin
+only a small high-signal core (cf. CLAUDE.md, kept short).
+
+## Design
+
+### Type: `fact`
+
+A first-class, indexed, searchable markdown asset type. Stored under
+`facts/` in a stash; ref form `fact:<name>` (nesting allowed, e.g.
+`fact:team/tool-stack`). Singular name matches akm convention
+(`skill`, `memory`, `lesson`, `task`, `session`).
+
+```
+<stash>/facts/
+  personal/identity.md         # fact:personal/identity
+  personal/writing-style.md
+  team/tool-stack.md
+  conventions/coding.md         # the "constitution"
+  meta/naming-conventions.md
+  meta/active-projects.md
+```
+
+### One type, categorized — not a type explosion
+
+Rather than separate `fact` / `constitution` / `profile` types, a single
+`fact` type carries a `category` frontmatter dimension. This keeps akm's
+minimalist type set and matches the LangMem "namespace/scope" approach.
+Recommended values: `personal`, `team`, `project`, `convention`, `meta`.
+Normative facts (the "constitution") are stored as facts and phrased as
+guidance at injection time.
+
+### Frontmatter
+
+```yaml
+---
+description: <one-line, indexed for search>   # like other markdown types
+category: personal|team|project|convention|meta
+pinned: false        # true → part of the always-injected core (keep this set small)
+updated: 2026-06-20
+---
+```
+
+`description` and `category` are the curation surface; `pinned` selects the
+small always-on core. Additional keys (`source`, `status`, …) are accepted
+but not required in phase 1.
+
+### Retrieval & injection model: pinned core + JIT retrieval
+
+Two tiers, matching the context-engineering guidance:
+
+1. **`pinned: true` facts** form the small always-injected core (CLAUDE.md
+   style — keep it short). Phase 1 makes `pinned` a real, captured, query-
+   surfaceable property (tag + search hint + ranking boost); **phase 2** wires
+   the assembled pinned-core into harness system prompts.
+2. **Everything else** stays on "disk" and is surfaced through normal
+   `akm search` / `akm curate` / `akm show` (JIT retrieval). This works the
+   day the type ships — no new retrieval path required.
+
+### Ranking
+
+`fact` gets a high `TYPE_BOOST` (authoritative, like `knowledge`), plus a
+modest additional boost for `pinned` facts so the core outranks ordinary
+facts on otherwise-equal queries.
+
+## Implementation (phase 1)
+
+Following the `session`/`task` template, metadata is encoded as tags +
+search hints (no new DB columns or `StashEntry` fields):
+
+| Concern | File |
+| --- | --- |
+| Type spec | `src/core/asset/asset-spec.ts` — `fact` in `ASSET_SPECS_INTERNAL` |
+| Renderer + action | `src/core/asset/asset-registry.ts` — `TYPE_TO_RENDERER`, `ACTION_BUILDERS` |
+| Renderer + metadata | `src/output/renderers.ts` — `factMdRenderer`, `applyFactMetadata` |
+| File classification | `src/indexer/walk/matchers.ts` — `DIR_TYPE_MAP` `facts/` |
+| Ranking | `src/indexer/search/ranking-contributors.ts` — `TYPE_BOOST` + pinned contributor |
+| Lint | `src/commands/lint/fact-linter.ts` + `registry.ts` (warns on missing `category`) |
+| Authoring hint | `src/integrations/agent/prompts.ts` — `TYPE_HINTS.fact` |
+| Graph extraction (opt-in) | `src/core/config/config-schema.ts` — allow `fact` |
+| Type union | derived automatically from the registry (`src/core/common.ts`) |
+
+`fact:` refs resolve automatically — the ref resolver derives its type set
+from the registry (`src/commands/lint/base-linter.ts` contract note).
+
+## Phase 2 (follow-up, not in this change)
+
+- Assemble the pinned-fact core and inject it into harness system prompts
+  (`src/integrations/agent/**`, per-harness builders).
+- Optional `akm fact` CLI surface and a hot-capture path (à la `akm remember`).
+- Staleness/conflict handling (`status: active|stale|superseded`), since the
+  documented failure mode of fact stores is update, not storage.
+
+## Relationship to `.meta/`
+
+`.meta/` stays the human-oriented, non-indexed orientation convention.
+`fact` is its machine-facing sibling: indexed, searchable, rankable, and
+(phase 2) agent-injected.

--- a/docs/technical/v1-architecture-spec.md
+++ b/docs/technical/v1-architecture-spec.md
@@ -339,7 +339,7 @@ union. The v1 contract is:
 - **Well-known types**, each with a renderer, a directory under the working
   stash, and frontmatter expectations:
   `skill`, `command`, `agent`, `knowledge`, `script`, `memory`, `workflow`,
-  `env`, `vault`, `secret`, `wiki`, `task`, `session`, and (Planned for v1)
+  `env`, `vault`, `secret`, `wiki`, `task`, `session`, `fact`, and (Planned for v1)
   `lesson`. See
   §13. The `task` type stores cron-style scheduled invocations of workflows or
   prompts; `akm tasks` registers them with the OS-native scheduler (cron /
@@ -354,7 +354,12 @@ union. The v1 contract is:
   generated, searchable record of a prior agent session, written by the
   `extract` pass to `sessions/<harness>/<id>.md`; it carries `log_path` +
   `access` frontmatter so an agent can navigate into the raw session log, and an
-  LLM `## Summary` / `## Key topics` body that is the searchable surface.
+  LLM `## Summary` / `## Key topics` body that is the searchable surface. The
+  `fact` type stores durable stash-level semantic knowledge (personal/team/project
+  details, coding conventions / "constitution", and stash-meta such as naming
+  conventions or the active-projects list); `category` scopes the fact and
+  `pinned: true` marks the small always-injected core (see
+  `docs/design/fact-asset-type.md`).
 - **Plugin-registered types** are allowed via `registerAssetType()` (see
   `src/core/asset-spec.ts`) and behave like well-known types as long as they
   register a renderer. Unknown types parse, index, and search; they render as

--- a/schemas/akm-config.json
+++ b/schemas/akm-config.json
@@ -3554,7 +3554,8 @@
                 "workflow",
                 "lesson",
                 "task",
-                "wiki"
+                "wiki",
+                "fact"
               ]
             },
             "minItems": 1
@@ -7495,7 +7496,8 @@
                     "workflow",
                     "lesson",
                     "task",
-                    "wiki"
+                    "wiki",
+                    "fact"
                   ]
                 },
                 "minItems": 1

--- a/src/commands/lint/fact-linter.ts
+++ b/src/commands/lint/fact-linter.ts
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { BaseLinter } from "./base-linter";
+import type { LintContext, LintIssue } from "./types";
+
+/** Recommended `category` values for facts (see docs/design/fact-asset-type.md). */
+const KNOWN_CATEGORIES = new Set(["personal", "team", "project", "convention", "meta"]);
+
+/**
+ * Linter for `facts/` assets.
+ *
+ * Extra check beyond base:
+ *   - `missing-category`: a fact without a non-empty `category` frontmatter
+ *     key. Category scopes the fact (personal/team/project/convention/meta)
+ *     and drives how it is surfaced/injected, so it is expected. Reported as a
+ *     non-fixable warning — we cannot infer the right scope automatically.
+ */
+export class FactLinter extends BaseLinter {
+  readonly types = ["facts"] as const;
+
+  lint(ctx: LintContext): LintIssue[] {
+    const issues = this.runBaseChecks(ctx);
+
+    const category = typeof ctx.data.category === "string" ? ctx.data.category.trim() : "";
+    if (!category) {
+      issues.push({
+        file: ctx.relPath,
+        issue: "missing-category",
+        detail: "fact is missing a `category` (personal|team|project|convention|meta)",
+        fixed: false,
+      });
+    } else if (!KNOWN_CATEGORIES.has(category)) {
+      issues.push({
+        file: ctx.relPath,
+        issue: "missing-category",
+        detail: `unrecognized category "${category}" (expected one of: ${[...KNOWN_CATEGORIES].join(", ")})`,
+        fixed: false,
+      });
+    }
+
+    return issues;
+  }
+}

--- a/src/commands/lint/index.ts
+++ b/src/commands/lint/index.ts
@@ -43,6 +43,7 @@ const STASH_SUBDIRS = [
   "lessons",
   "tasks",
   "knowledge",
+  "facts",
 ] as const;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/src/commands/lint/registry.ts
+++ b/src/commands/lint/registry.ts
@@ -5,6 +5,7 @@
 import { AgentLinter } from "./agent-linter";
 import { CommandLinter } from "./command-linter";
 import { DefaultLinter } from "./default-linter";
+import { FactLinter } from "./fact-linter";
 import { KnowledgeLinter } from "./knowledge-linter";
 import { MemoryLinter } from "./memory-linter";
 import { SkillLinter } from "./skill-linter";
@@ -21,6 +22,7 @@ const LINTERS: AssetLinter[] = [
   new KnowledgeLinter(),
   new SkillLinter(),
   new TaskLinter(),
+  new FactLinter(),
 ];
 
 // Single shared DefaultLinter instance — used both as the explicit "lessons"

--- a/src/commands/lint/types.ts
+++ b/src/commands/lint/types.ts
@@ -13,7 +13,8 @@ export type LintIssueType =
   | "invalid-task-yaml"
   | "missing-ref"
   | "dangerous-vault-key"
-  | "invalid-workflow-structure";
+  | "invalid-workflow-structure"
+  | "missing-category";
 
 export interface LintIssue {
   file: string;

--- a/src/core/asset/asset-registry.ts
+++ b/src/core/asset/asset-registry.ts
@@ -32,6 +32,7 @@ export const TYPE_TO_RENDERER: Record<string, string> = {
   wiki: "wiki-md",
   task: "task-yaml",
   session: "session-md",
+  fact: "fact-md",
 };
 
 /** Map asset types to action builder functions for search results. */
@@ -53,6 +54,7 @@ export const ACTION_BUILDERS: Record<string, (ref: string) => string> = {
     `akm tasks show ${ref.replace(/^task:/, "")} -> inspect; akm tasks run <id> -> run now; akm tasks remove <id> -> unschedule`,
   session: (ref) =>
     `akm show ${ref} -> read the session summary; follow the \`access\` frontmatter to open the raw log at \`log_path\``,
+  fact: (ref) => `akm show ${ref} -> read the stash fact and apply it as durable context`,
 };
 
 /**

--- a/src/core/asset/asset-spec.ts
+++ b/src/core/asset/asset-spec.ts
@@ -181,6 +181,20 @@ const ASSET_SPECS_INTERNAL: Record<string, AssetSpec> = {
     actionBuilder: (ref) =>
       `akm show ${ref} -> read the session summary; follow the \`access\` frontmatter to open the raw log at \`log_path\``,
   },
+  // Durable stash-level semantic knowledge — facts about the user, team, or
+  // project (personal details, team tool stacks, coding conventions /
+  // "constitution", and stash-meta like naming conventions or the active
+  // projects list). Unlike `memory` (episodic, recency-decayed) these are
+  // mostly-static declarations meant to be reliably surfaced as context. A
+  // plain markdown spec; `category` frontmatter scopes the fact and
+  // `pinned: true` marks the small always-injected core. See
+  // docs/design/fact-asset-type.md.
+  fact: {
+    stashDir: "facts",
+    ...markdownSpec,
+    rendererName: "fact-md",
+    actionBuilder: (ref) => `akm show ${ref} -> read the stash fact and apply it as durable context`,
+  },
 };
 
 export const ASSET_SPECS: Record<string, AssetSpec> = ASSET_SPECS_INTERNAL;

--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -40,6 +40,7 @@ export const ASSET_TYPES = Object.freeze([...getAssetTypes()] as [
   "lesson",
   "task",
   "session",
+  "fact",
 ]);
 export type AkmAssetType = (typeof ASSET_TYPES)[number];
 export const ASSET_TYPE_SET: ReadonlySet<AkmAssetType> = new Set(ASSET_TYPES);

--- a/src/core/config/config-schema.ts
+++ b/src/core/config/config-schema.ts
@@ -655,6 +655,7 @@ const GRAPH_EXTRACTION_INCLUDE_TYPES_ALLOWED = [
   "lesson",
   "task",
   "wiki",
+  "fact",
 ] as const;
 
 const INDEX_PASS_PROVIDER_KEYS = new Set([

--- a/src/indexer/search/ranking-contributors.ts
+++ b/src/indexer/search/ranking-contributors.ts
@@ -15,6 +15,9 @@ const TYPE_BOOST: Record<string, number> = {
   agent: 0.3,
   script: 0.2,
   knowledge: 0.22,
+  // Facts are authoritative, durable declarations about the stash — rank them
+  // alongside knowledge so they surface reliably when relevant.
+  fact: 0.22,
   memory: -0.02,
 };
 
@@ -269,6 +272,25 @@ const lessonStrengthContributor: RankingContributor = {
 };
 
 /**
+ * Pinned-fact boost.
+ *
+ * Facts marked `pinned: true` form the small always-injected "core context"
+ * (see docs/design/fact-asset-type.md). The fact metadata contributor records
+ * a `pinned` search hint; here we give those facts a modest additive boost so
+ * the core outranks ordinary facts on otherwise-equal queries. Capped small so
+ * it cannot overpower an exact-name match.
+ */
+const pinnedFactRankingContributor: RankingContributor = {
+  name: "pinned-fact-ranking",
+  appliesTo(item) {
+    return item.entry.type === "fact" && (item.entry.searchHints?.includes("pinned") ?? false);
+  },
+  adjust() {
+    return 0.15;
+  },
+};
+
+/**
  * Blend ratio for scoped vs. global utility signals.
  *
  * When a scoped row exists: `effectiveUtility = scoped * 0.7 + global * 0.3`
@@ -379,6 +401,7 @@ export const defaultRankingContributors: RankingContributor[] = [
   graphRankingContributor,
   captureModeRankingContributor,
   lessonStrengthContributor,
+  pinnedFactRankingContributor,
   projectContextRankingContributor,
 ];
 

--- a/src/indexer/walk/matchers.ts
+++ b/src/indexer/walk/matchers.ts
@@ -99,6 +99,15 @@ const DIR_TYPE_MAP: DirTypeRule[] = [
     type: "session",
     test: (ext) => ext === ".md",
   },
+  {
+    // Durable stash-level facts live under `facts/<category>/<name>.md`.
+    // classifyByDirectory walks every ancestor dir, so nested category
+    // subdirs still match. Without this entry a fact file would fall through
+    // to classifyBySmartMd and be mistyped as `knowledge`.
+    dir: "facts",
+    type: "fact",
+    test: (ext) => ext === ".md",
+  },
 ];
 
 const COMMAND_PLACEHOLDER_RE = /\$ARGUMENTS|\$[123]\b/;

--- a/src/integrations/agent/prompts.ts
+++ b/src/integrations/agent/prompts.ts
@@ -67,6 +67,7 @@ const TYPE_HINTS: Record<string, string> = {
   script: "script assets are executable text files. Include a shebang and minimal usage comment.",
   env: "env assets are `.env` files holding a group of related CONFIGURATION for an app/service (KEY=VALUE pairs, `#` comments) — URLs, flags, and any credentials it needs. Values may or may not be sensitive; all are protected (key names discoverable, values stay on disk). Inject with `akm env run env:<name> -- <cmd>` (the safe path — values never reach stdout/your context); do NOT run `akm env export` and read its output, as that prints values. For a single sensitive value used on its own for authentication (token, key, cert) use a `secret` instead. Never echo values back to the user.",
   wiki: "wiki assets are markdown reference pages with `# Title` and structured headings.",
+  fact: "fact assets are durable stash-level facts (personal/team/project details, coding conventions, stash-meta). Frontmatter SHOULD include `description` and a `category` (personal|team|project|convention|meta); set `pinned: true` only for the small always-injected core. Keep each fact short, high-signal, and self-contained — it is durable context, not an episodic note.",
 };
 
 function hintForType(type: string): string {

--- a/src/output/renderers.ts
+++ b/src/output/renderers.ts
@@ -560,6 +560,48 @@ const sessionMdRenderer: AssetRenderer = {
   },
 };
 
+// ── 9. fact-md ───────────────────────────────────────────────────────────────
+
+/**
+ * Renderer for the `fact` asset type. A fact is durable stash-level semantic
+ * knowledge (personal/team/project details, coding conventions, stash-meta).
+ * It carries `category` (personal|team|project|convention|meta) and an
+ * optional `pinned` flag marking it as part of the always-injected core. The
+ * renderer surfaces a one-liner (category + pinned marker) so an agent can tell
+ * at a glance what kind of fact it is and whether it is core context.
+ */
+const factMdRenderer: AssetRenderer = {
+  name: "fact-md",
+
+  buildShowResponse(ctx: RenderContext): ShowResponse {
+    const name = deriveName(ctx);
+    const parsed = parseFrontmatter(ctx.content());
+    const fm = parsed.data;
+    const category = asNonEmptyString(fm.category);
+    const description = asNonEmptyString(fm.description);
+    const pinned = fm.pinned === true;
+    const headerParts = [
+      category ? `category: ${category}` : undefined,
+      pinned ? "pinned (core context)" : undefined,
+    ].filter((p): p is string => !!p);
+    const action = [
+      "Durable stash fact — apply it as background context.",
+      headerParts.length > 0 ? headerParts.join("  ") : undefined,
+    ]
+      .filter((p): p is string => !!p)
+      .join("\n");
+
+    return {
+      type: "fact",
+      name,
+      path: ctx.absPath,
+      action,
+      description,
+      content: parsed.content,
+    };
+  },
+};
+
 function applySessionMetadata(entry: StashEntry, ctx: RenderContext): void {
   try {
     const fm = applyFrontmatterDescriptionAndTags(entry, ctx);
@@ -585,6 +627,33 @@ function applyTocMetadata(entry: StashEntry, ctx: RenderContext): void {
     if (toc.headings.length > 0) entry.toc = toc.headings;
   } catch {
     // Non-fatal: skip TOC if file can't be read
+  }
+}
+
+/**
+ * Fact metadata: surface `category` and the `pinned` core marker as tags +
+ * search hints (no dedicated DB columns — same encoding pattern as session /
+ * task). `pinned` is mirrored to both a `pinned` tag and a `pinned` search
+ * hint so the ranking contributor can detect it and queries can target it.
+ */
+function applyFactMetadata(entry: StashEntry, ctx: RenderContext): void {
+  try {
+    const fm = applyFrontmatterDescriptionAndTags(entry, ctx);
+    const tags = new Set<string>([...(entry.tags ?? []), "fact"]);
+    const hints = new Set<string>(entry.searchHints ?? []);
+    const category = asNonEmptyString(fm.category);
+    if (category) {
+      tags.add(category);
+      hints.add(`category:${category}`);
+    }
+    if (fm.pinned === true) {
+      tags.add("pinned");
+      hints.add("pinned");
+    }
+    entry.tags = Array.from(tags).filter(Boolean);
+    if (hints.size > 0) entry.searchHints = Array.from(hints).filter(Boolean);
+  } catch {
+    // Non-fatal: skip metadata extraction on parse error
   }
 }
 
@@ -745,6 +814,12 @@ registerMetadataContributor({
   contribute: (entry, ctx) => applySessionMetadata(entry, ctx.renderContext),
 });
 
+registerMetadataContributor({
+  name: "fact-md-metadata",
+  appliesTo: ({ rendererName }) => rendererName === "fact-md",
+  contribute: (entry, ctx) => applyFactMetadata(entry, ctx.renderContext),
+});
+
 // ── Registration ─────────────────────────────────────────────────────────────
 
 /** All built-in renderers. */
@@ -762,6 +837,7 @@ const builtinRenderers: AssetRenderer[] = [
   secretFileRenderer,
   taskMdRenderer,
   sessionMdRenderer,
+  factMdRenderer,
 ];
 
 /**
@@ -780,6 +856,7 @@ export {
   agentMdRenderer,
   commandMdRenderer,
   envFileRenderer,
+  factMdRenderer,
   INTERPRETER_MAP,
   knowledgeMdRenderer,
   lessonMdRenderer,

--- a/tests/asset-spec.test.ts
+++ b/tests/asset-spec.test.ts
@@ -45,8 +45,9 @@ describe("getAssetTypes", () => {
     expect(types).toContain("lesson");
     expect(types).toContain("task");
     expect(types).toContain("session"); // #561
+    expect(types).toContain("fact");
     expect(types).not.toContain("vault");
-    expect(types).toHaveLength(13);
+    expect(types).toHaveLength(14);
   });
 });
 

--- a/tests/asset-type-union-source.test.ts
+++ b/tests/asset-type-union-source.test.ts
@@ -38,9 +38,11 @@ const PRE_WS7_UNION = [
  * Intentional additions to the union since the pre-WS7 baseline:
  *   - `task`  — WS7 registry/union drift fix (#490).
  *   - `session` — #561 indexes agent sessions as a first-class asset type.
- * Both are deliberate, separately-reviewed registry additions.
+ *   - `fact` — durable stash-level semantic knowledge (see
+ *     docs/design/fact-asset-type.md).
+ * All are deliberate, separately-reviewed registry additions.
  */
-const INTENTIONAL_ADDITIONS = ["session", "task"] as const;
+const INTENTIONAL_ADDITIONS = ["fact", "session", "task"] as const;
 
 describe("ASSET_TYPES is the single source of truth (derived from ASSET_SPECS)", () => {
   test("ASSET_TYPES equals the registry key set (no drift)", () => {

--- a/tests/completions.test.ts
+++ b/tests/completions.test.ts
@@ -128,7 +128,7 @@ describe("completions command", () => {
   test("contains flag value completions for --type", () => {
     expect(script).toContain("--type)");
     expect(script).toContain(
-      "skill command agent knowledge workflow script memory env secret wiki lesson task session any",
+      "skill command agent knowledge workflow script memory env secret wiki lesson task session fact any",
     );
   });
 

--- a/tests/fact-asset.test.ts
+++ b/tests/fact-asset.test.ts
@@ -1,0 +1,130 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Unit + integration tests for the `fact` asset type — durable stash-level
+ * semantic knowledge (see docs/design/fact-asset-type.md):
+ *   - registered through the single-source-of-truth registry, so it appears in
+ *     the asset-type union and the renderer/action maps;
+ *   - files under facts/ classify + resolve as `fact` (incl. nested category dirs);
+ *   - `pinned: true` facts get an additive ranking boost over ordinary facts;
+ *   - the fact linter flags a missing/unknown `category`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { akmLint } from "../src/commands/lint";
+import { ACTION_BUILDERS, TYPE_TO_RENDERER } from "../src/core/asset/asset-registry";
+import {
+  deriveCanonicalAssetNameFromStashRoot,
+  getAssetTypes,
+  isRelevantAssetFile,
+  resolveAssetPathFromName,
+  TYPE_DIRS,
+} from "../src/core/asset/asset-spec";
+import { ASSET_TYPE_SET, ASSET_TYPES, isAssetType } from "../src/core/common";
+import type { StashEntry } from "../src/indexer/passes/metadata";
+import type { RankedEntryInput } from "../src/indexer/search/ranking";
+import { applyScoreContributors, type RankingContext } from "../src/indexer/search/ranking-contributors";
+
+const tempDirs: string[] = [];
+function makeTempStash(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-fact-"));
+  tempDirs.push(dir);
+  return dir;
+}
+function cleanup() {
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe("fact asset type is registered via the single source of truth", () => {
+  test("fact appears in the registry key set and the derived union", () => {
+    expect(getAssetTypes()).toContain("fact");
+    expect(ASSET_TYPES).toContain("fact");
+    expect(ASSET_TYPE_SET.has("fact" as (typeof ASSET_TYPES)[number])).toBe(true);
+    expect(isAssetType("fact")).toBe(true);
+  });
+
+  test("fact has a stash dir, renderer, and action builder", () => {
+    expect(TYPE_DIRS.fact).toBe("facts");
+    expect(TYPE_TO_RENDERER.fact).toBe("fact-md");
+    expect(typeof ACTION_BUILDERS.fact).toBe("function");
+    expect(ACTION_BUILDERS.fact?.("fact:team/tool-stack")).toMatch(/akm show fact:team\/tool-stack/);
+  });
+});
+
+describe("fact file layout", () => {
+  test("markdown files under facts/ are relevant; nested category dirs resolve", () => {
+    expect(isRelevantAssetFile("fact", "tool-stack.md")).toBe(true);
+    expect(isRelevantAssetFile("fact", "notes.txt")).toBe(false);
+
+    const stashRoot = "/stash";
+    const filePath = path.join(stashRoot, "facts", "team", "tool-stack.md");
+    const name = deriveCanonicalAssetNameFromStashRoot("fact", stashRoot, filePath);
+    expect(name).toBe("team/tool-stack");
+  });
+
+  test("resolveAssetPathFromName maps a name back under facts/", () => {
+    const p = resolveAssetPathFromName("fact", "/stash/facts", "team/tool-stack");
+    expect(p.replace(/\\/g, "/")).toBe("/stash/facts/team/tool-stack.md");
+  });
+});
+
+describe("pinned facts rank above ordinary facts", () => {
+  function factEntry(name: string, pinned: boolean): RankedEntryInput {
+    const entry: StashEntry = {
+      name,
+      type: "fact",
+      searchHints: pinned ? ["pinned", "category:team"] : ["category:team"],
+    };
+    return { id: 1, entry, filePath: `/s/facts/${name}.md`, score: 1, rankingMode: "fts" };
+  }
+  // A query that matches neither fact name, so only type + pinned boosts differ.
+  const ctx = {
+    query: "deployment targets",
+    queryLower: "deployment targets",
+    queryTokens: ["deployment", "targets"],
+    graphContext: null,
+  } as unknown as RankingContext;
+
+  test("pinned fact ends with a strictly higher score", () => {
+    const pinned = factEntry("alpha", true);
+    const plain = factEntry("beta", false);
+    applyScoreContributors(pinned, ctx);
+    applyScoreContributors(plain, ctx);
+    expect(pinned.score).toBeGreaterThan(plain.score);
+  });
+});
+
+describe("fact linter flags category problems", () => {
+  function writeFact(stashRoot: string, rel: string, body: string): void {
+    const full = path.join(stashRoot, "facts", rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, body, "utf8");
+  }
+
+  test("missing category is flagged; valid category is clean", () => {
+    const stashRoot = makeTempStash();
+    writeFact(stashRoot, "team/no-category.md", "---\ndescription: team stack\n---\n\nWe use Bun.\n");
+    writeFact(stashRoot, "team/tool-stack.md", "---\ndescription: team stack\ncategory: team\n---\n\nWe use Bun.\n");
+
+    const result = akmLint({ dir: stashRoot });
+    const missing = result.flagged.filter((i) => i.issue === "missing-category");
+    expect(missing).toHaveLength(1);
+    expect(missing[0].file).toContain("no-category.md");
+    cleanup();
+  });
+
+  test("unrecognized category is flagged", () => {
+    const stashRoot = makeTempStash();
+    writeFact(stashRoot, "weird.md", "---\ndescription: x\ncategory: banana\n---\n\nbody\n");
+    const result = akmLint({ dir: stashRoot });
+    const missing = result.flagged.filter((i) => i.issue === "missing-category");
+    expect(missing).toHaveLength(1);
+    expect(missing[0].detail).toContain("banana");
+    cleanup();
+  });
+});

--- a/tests/file-context.test.ts
+++ b/tests/file-context.test.ts
@@ -558,15 +558,16 @@ describe("Renderer", () => {
     expect(response.content).not.toContain("Setup");
   });
 
-  test("getAllRenderers() returns all 13 built-in renderers", async () => {
+  test("getAllRenderers() returns all 14 built-in renderers", async () => {
     const all = await getAllRenderers();
-    expect(all).toHaveLength(13);
+    expect(all).toHaveLength(14);
 
     const names = all.map((r) => r.name).sort();
     expect(names).toEqual([
       "agent-md",
       "command-md",
       "env-file",
+      "fact-md",
       "knowledge-md",
       "lesson-md",
       "memory-md",


### PR DESCRIPTION
## Summary

Introduces **`fact`** — a first-class, searchable asset type for durable, mostly-static **semantic knowledge** about a user, team, or project:

- **Personal** — name, email, writing/working style, favorite blogs
- **Team** — tool stacks, web addresses, primary languages
- **Conventions / "constitution"** — coding conventions, architecture principles
- **Stash-meta** — naming conventions, folder organization, expected frontmatter, active-projects list

This fills the **semantic-memory** gap in akm's type system, alongside the existing **episodic** (`session`, #561) and **procedural** (`skill`/`command`/`workflow`) types. The taxonomy follows the agent-memory literature (CoALA, LangMem, Letta/MemGPT); the retrieval model follows Karpathy's RAM/disk framing and Anthropic's context-engineering guidance. Full rationale and citations: [`docs/design/fact-asset-type.md`](docs/design/fact-asset-type.md).

## Design

- **One categorized type, not a type explosion.** Facts live at `facts/<category>/<name>.md` (ref `fact:...`). A `category` frontmatter field scopes each fact (`personal|team|project|convention|meta`); the "constitution" is stored as facts and phrased as guidance at injection time.
- **Pinned core + just-in-time retrieval.** `pinned: true` marks the small always-injected core; everything else surfaces through normal `akm search`/`curate`/`show`. JIT retrieval works the day this lands.

## What's in this PR (phase 1 — fully wired & tested)

- Type spec, `fact-md` renderer + action builder, `facts/` classification, and metadata (`category`/`pinned` → tags + search hints, mirroring the `session`/`task` pattern — **no new DB columns**).
- Ranking: high type boost (0.22, like `knowledge`) plus an additional boost for `pinned` facts.
- `FactLinter` warning on missing/unknown `category`; authoring hint for `akm propose`/`reflect`; opt-in graph-extraction.
- Docs: design note, README / `concepts.md` / v1-spec type tables. New `tests/fact-asset.test.ts` plus updated enumeration tests.

`fact:` refs resolve automatically — the ref grammar derives from the asset registry.

## Phase 2 (documented, not in this PR)

- Assemble the pinned core and inject it into harness system prompts.
- Optional `akm fact` CLI / hot-capture path (à la `akm remember`).
- Staleness/conflict handling (`status: active|stale|superseded`).

## Testing

- `tsc` clean; biome clean; license / test-isolation / runtime-boundary lints pass.
- Unit suite: **4986 pass / 4 fail**. The 4 failures (auto-migration write-failure ×2, curate `--shape`, migrate-storage differential) **fail identically on a clean `main` checkout** in this environment — pre-existing/environmental, **0 regressions** from this change (verified via `git stash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lw6MiHeCJkwWpBwtas992w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lw6MiHeCJkwWpBwtas992w)_