### PR TITLE
feat(standards): surface stash standards + wiki schema to authoring agents

### DIFF
--- a/docs/design/standards-wiki-schema-PLAN.md
+++ b/docs/design/standards-wiki-schema-PLAN.md
@@ -1,0 +1,115 @@
+# AKM Standards — Final Implementation Plan (two separate features)
+
+Status: build-ready. Supersedes the prior drafts and `docs/design/standards-wiki-schema-DRAFT-INPUT.md`.
+
+## The central correction: these are TWO features, not one
+
+Earlier drafts muddied **wiki schemas** and **stash standards** into a single "standards context" with a blended precedence stack. They are distinct features that fire on **mutually exclusive targets** and share almost nothing:
+
+| | **Feature A — Wiki schema** | **Feature B — Stash standards** |
+|---|---|---|
+| Governs | pages **inside one wiki** | authoring of **stash assets** (skill/command/agent/fact/…) |
+| Source of truth | `wikis/<name>/schema.md` (local to that wiki) | `fact` assets, scoped by `category` frontmatter |
+| Fires when | edit target is **under `wikis/<name>/`** | edit target is a **non-wiki asset** |
+| Content | pageKind, voice, citation/xref/contradiction policy | naming, tag vocabulary, frontmatter, per-type conventions |
+| Scope | one wiki | whole stash |
+
+A wiki-page edit and a stash-asset edit are **never the same target**. Global stash standards do **not** cascade into wikis (a wiki owns its schema; asset-naming/tag rules are irrelevant to a wiki page). There is therefore **no cross-feature precedence stack** — selection is by target type, full stop.
+
+**Neither fires (empty `standardsContext`):** a wiki `raw/` file, a wiki infra file (`schema.md`/`index.md`/`log.md`) edited as itself, or a non-wiki asset when no `convention`/`meta` facts exist. A and B do not partition all targets — there is a safe third "no injection" bucket, and readers degrade to empty without error.
+
+They share exactly one thing: a thin seam at the prompt boundary — one optional `standardsContext?: string` field. Each feature is independently shippable and independently valuable. **Recommended order: Feature A first** (smaller, self-contained, leans on existing wiki infra).
+
+The guiding thesis for both: *surface the relevant rulebook to the agent at write-time so it stops inventing conventions.* Neither feature parses rules in its MVP — the doc bodies travel to the agent as prose. (Rule *parsing* exists only to let a machine *enforce* rules — that is lint, deferred §4.)
+
+---
+
+## Shared seam (built once, by whichever feature ships first)
+
+- `prompts.ts` — add optional `standardsContext?: string` to `ReflectPromptInput` (`prompts.ts:153`) and `ProposePromptInput`; push it as a section **before** the "Current asset content" block (ahead of the guard at `prompts.ts:255`). NOTE: both dispatch routes (agent-file-write and direct-LLM-JSON) flow through the single `buildReflectPrompt` call (`reflect.ts:1052`; the branch is just the last `sections.push` at `prompts.ts:393`), so one `sections.push` reaches both — no separate wiring. Same single-builder shape for `buildProposePrompt`.
+
+That is the whole overlap: one optional string field. No cap, no helper, no shared resolver, no rule model. Each feature's resolver returns a plain `string` (empty = inject nothing).
+
+---
+
+## Feature A — Wiki schema delivery
+
+**Goal:** when an agent edits a file under `wikis/<name>/`, inject *that* wiki's `schema.md` **body** into the write-time prompt.
+
+**Why it's small:** wiki infra already exists — `SCHEMA_MD`/`WIKI_SPECIAL_FILES` constants (`wiki.ts:61-68`), `resolveWikiDir`, the disk-read pattern in `readSchemaDescription` (`wiki.ts:281-296`). The only gap is that `readSchemaDescription` reads the frontmatter `description` and **discards the body** — yet the body *is* the rulebook (in `schema-template.md` the description is one sentence, line 2; the page contract / operations / hard rules are all body, lines 14-61).
+
+**Build**
+- `src/wiki/wiki.ts` — `export function loadWikiSchema(stashRoot, name): { body: string; frontmatter: Record<string,unknown> }`, beside `readSchemaDescription`, reusing `SCHEMA_MD` and the swallow-and-degrade read. Missing/malformed → empty body, never throws. Leave `readSchemaDescription` untouched (it's correct for `listWikis` summaries).
+- Resolution: given an edit target, extract the wiki name from the path/ref (`extractWikiNameFromRef`, `wiki.ts:141`); if it's a wiki page (not `raw/`, not the special files themselves), `standardsContext = loadWikiSchema(name).body` (empty string otherwise). No cap, no wrapping — the body goes straight to the agent.
+- Wire the call at the reflect assembly seam (`reflect.ts:983-985`) and in `propose.ts`.
+
+**DoD**
+- Editing `wiki:research/foo` injects `wikis/research/schema.md` **body** (not just the description); editing `wiki:product/foo` injects product's schema, never research's.
+- Missing/malformed schema → no injection, no crash. No index rebuild needed.
+- Test asserts injected text contains body-derived rules (a hard-rule line / the pageKind list), not merely the description string.
+- `bun run check` green.
+
+---
+
+## Feature B — Stash authoring standards
+
+**Goal:** when an agent creates/edits a **non-wiki** asset, inject the relevant `category: convention`/`meta` `fact` bodies so naming/tag/frontmatter conventions are followed.
+
+**Why it builds cleanly on existing primitives:** `fact` already exists with `category` frontmatter (`personal|team|project|convention|meta`, `src/commands/lint/fact-linter.ts:9`) and nested refs are free (`facts/conventions/x.md` → `fact:conventions/x`, `asset-spec.ts:34-38`). Standards are just facts; this feature is **content + a small resolver + the shared prompt seam**.
+
+**Build**
+- `src/core/standards/resolve-stash-standards.ts` — `resolveStashStandards(stashRoot): string`: enumerate facts, select those with `category: convention`/`meta` by **frontmatter** (no path globbing, no index dependency), concatenate their **bodies** in stable enumeration order (each preceded by a one-line `# <ref>` header so the agent knows provenance). Returns `""` if none. No cap, no parsing, no rule objects, no warnings.
+- Skip entirely when the target is a wiki page (that's Feature A's domain) — the two never both fire.
+- Wire at the same reflect/propose seams.
+- Scaffold a starter `facts/conventions/` / `facts/meta/` set (plural spelling matches `fact-asset-type.md:58`) as templates, authored as ordinary facts.
+
+**DoD**
+- Editing `skill:x` injects convention/meta fact bodies; editing a wiki page injects **none** of them.
+- Facts selected by `category` frontmatter regardless of subdirectory; flat and nested layouts resolve identically.
+- `bun run check` green.
+
+---
+
+## Decisions (apply to both features)
+
+1. **Format** — rules are authored as fenced ` ```akm-standards ` (facts) / ` ```akm-wiki-schema ` (schema) blocks **in the markdown body**, co-located with their prose. Fully supported by akm's read paths (the prior "fenced = invisible" claim was false: `prompts.ts:376` preserves fenced content as "load-bearing"; `markdown.ts:128` "leaves inner code blocks intact"; the only fence-blanking is one broken-ref lint check, `src/commands/lint/base-linter.ts:253`). The MVP does **not parse** these blocks — they reach the agent as body text.
+2. **Deliver bodies, not descriptions** — Feature A injects the schema body; `readSchemaDescription` stays for summaries only.
+3. **No cap** — bodies are injected whole. Standards docs are small human-authored files; capping/truncation machinery is not worth its complexity. (If a stash ever grows standards large enough to crowd the prompt, per-type scoping — deferred §4 — is the fix, not a runtime cap.)
+4. **Precedence is prompt prose** — at most the relevant doc(s) per feature, in order. No `layer: number` engine, no cross-feature stack.
+5. **Direct edits allowed** — schema.md and standards facts are directly editable; not proposal-queue-locked.
+
+---
+
+## Deferred follow-ups (NOT built now)
+
+| Deferred item | Belongs to | Build it when |
+|---|---|---|
+| Fenced-block parser + structured rule model — *if built, A parses `akm-wiki-schema` and B parses `akm-standards` into **separate** rule models; never one unified parser/store* | both | you build deterministic lint |
+| pageKind lint (`WikiLintKind` + `severity` on findings, gate on `mode: closed`) | A | authors want CI to catch invalid pageKinds — the *first* lint to add (local, low-noise) |
+| Global standards lint (tag-vocabulary / naming across assets) | B | only after pageKind lint proves the model; expect tuning, false-positives |
+| TYPE_HINTS migration to `facts/conventions/assets/<type>.md` (+ FactLinter basename/category checks) | B | drift between built-in hints and authored conventions actually bites |
+| — cheap alternative: resolver *also* includes an authored `fact:conventions/assets/<type>` body when present, **without** removing built-in `TYPE_HINTS` | B | you want per-type conventions now, with ~no new machinery |
+| info-string-aware `stripFencedBlocks` (~10 lines, keeps refs inside `akm-*` blocks xref-validated) | both | a real standards doc references an asset inside a fenced block |
+| Automated standards maintenance (improve pass) | both | manual editing + lint warnings prove insufficient against real usage data |
+
+---
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Re-muddying the two features | Selection is by target type; the only shared code is the `standardsContext` prompt field. Each feature has its own resolver and DoD. |
+| Under-building (description-only) | Feature A DoD requires a test asserting body-derived rules reach the agent. |
+| Standards bodies bloat the prompt | Small in practice (human-authored schema/convention docs). No cap by choice; per-type scoping (deferred §4) is the trigger if they ever grow large. The existing stdin transport (`spawn.ts`) already handles oversized prompts. |
+| Malformed schema/fact body | Readers degrade to empty, never throw; a doc with no fenced block is valid prose. |
+| Scope creep back to the heavy plan | Deferred items stay out until a concrete trigger fires. |
+
+---
+
+## Owner decisions (resolved)
+
+1. Body cap → **removed**; bodies injected whole (standards docs are small; scoping is the deferred fix if ever needed).
+2. Direct edits → allowed.
+3. Automated maintenance → cut; future follow-up only.
+4. Complexity → MVP per feature is "load body → inject"; cap, parser, rule model, precedence engine, TYPE_HINTS migration, and all lint deferred.
+5. **Wiki schema and stash standards are separate features** — separate resolvers, separate triggers, no blended precedence. Ship **Feature A first**.

--- a/src/assets/prompts/extract-session.md
+++ b/src/assets/prompts/extract-session.md
@@ -28,7 +28,7 @@ Things NOT to extract:
 - Started: {{STARTED_AT}}
 - Ended: {{ENDED_AT}}
 - Project hint: {{PROJECT_HINT}}
-
+{{STANDARDS}}
 ## Filtered session transcript
 
 The transcript below has already had read-only `akm` meta-ops and platform boilerplate stripped. Only content that might carry signal remains.

--- a/src/commands/improve/consolidate.ts
+++ b/src/commands/improve/consolidate.ts
@@ -17,6 +17,7 @@ import { getDefaultLlmConfig, loadConfig } from "../../core/config/config";
 import { ConfigError } from "../../core/errors";
 // Note: appendEvent import removed (WS-3a: archive TTL machinery retired)
 import { parseEmbeddedJsonResponse } from "../../core/parse";
+import { resolveStashStandards } from "../../core/standards/resolve-stash-standards";
 import { detectTruncatedDescription } from "../../core/text-truncation";
 import {
   hasHotCaptureMode,
@@ -761,6 +762,7 @@ export function buildChunkPrompt(
   totalChunks: number,
   bodyTruncation: number,
   pendingProposalBodyHashes: Set<string> = new Set(),
+  standardsContext = "",
 ): string {
   const start = memories[0] ? `memory:${memories[0].name}` : "";
   const end = memories[memories.length - 1] ? `memory:${memories[memories.length - 1].name}` : "";
@@ -799,6 +801,12 @@ export function buildChunkPrompt(
     `Chunk ${chunkIndex + 1} of ${totalChunks}, memories ${start}–${end}:`,
     "",
   ];
+
+  if (standardsContext.trim()) {
+    lines.push("Standards to follow (the rulebook for this target):");
+    lines.push(standardsContext.trim());
+    lines.push("");
+  }
 
   // Top-of-prompt protection block for hot refs. Neutral phrasing — avoid
   // op-words like "promote", "merge", "contradict" so the model doesn't
@@ -1763,6 +1771,11 @@ async function akmConsolidateInner(
       ` / pending-proposal hashes: ${pendingProposalBodyHashes.size}`,
   );
 
+  // Consolidate output merges memories (non-wiki) → stash authoring standards.
+  // Resolved ONCE per run and passed to each chunk prompt (facts not re-read
+  // per chunk).
+  const standardsContext = resolveStashStandards(stashDir);
+
   const chunkOpsArrays: ConsolidateOperation[][] = [];
   // Structured skip-reason histogram (2026-05-26): every deterministic
   // post-LLM op rejection site below also calls `pushSkipReason` so the
@@ -1898,6 +1911,7 @@ async function akmConsolidateInner(
       chunks.length,
       bodyTruncation,
       pendingProposalBodyHashes,
+      standardsContext,
     );
 
     let raw = await tryLlmFeature(

--- a/src/commands/improve/distill.ts
+++ b/src/commands/improve/distill.ts
@@ -68,6 +68,7 @@ import { appendEvent, readEvents } from "../../core/events";
 import type { EligibilitySource } from "../../core/improve-types";
 import { lintLessonContent } from "../../core/lesson-lint";
 import { getDbPath } from "../../core/paths";
+import { resolveStashStandards } from "../../core/standards/resolve-stash-standards";
 import { openStateDatabase } from "../../core/state-db";
 import { warnVerbose } from "../../core/warn";
 import { closeDatabase, getAllEntries, openDatabase } from "../../indexer/db/db";
@@ -514,6 +515,11 @@ interface BuildPromptInput {
    * proposals that have already been reviewed and refused.
    */
   rejectedProposals?: Array<{ reason: string; contentPreview?: string }>;
+  /**
+   * Stash authoring standards (convention/meta fact bodies) for non-wiki
+   * output. Empty/omitted when none exist; gated on non-empty before injection.
+   */
+  standardsContext?: string;
 }
 
 /**
@@ -529,6 +535,11 @@ export function buildDistillPrompt(input: BuildPromptInput): string {
   const lines: string[] = [];
   lines.push(`Asset ref: ${input.inputRef}`);
   lines.push("");
+  if (input.standardsContext?.trim()) {
+    lines.push("Standards to follow (the rulebook for this target):");
+    lines.push(input.standardsContext.trim());
+    lines.push("");
+  }
   lines.push("Asset content:");
   if (input.assetContent) {
     const body = input.assetContent.trim().slice(0, 3000);
@@ -1250,12 +1261,16 @@ export async function akmDistill(options: AkmDistillOptions): Promise<AkmDistill
     }
   }
 
+  // Distill output is a lesson/knowledge (non-wiki) → stash authoring
+  // standards. Resolved once for this single call.
+  const standardsContext = resolveStashStandards(stash);
   const baseUserPrompt = buildDistillPrompt({
     inputRef,
     assetContent,
     feedback,
     proposalKind: effectiveProposalKind,
     ...(rejectedForRef.length > 0 ? { rejectedProposals: rejectedForRef } : {}),
+    ...(standardsContext.trim() ? { standardsContext } : {}),
   });
   const userPrompt = clsContext ? `${baseUserPrompt}${clsContext}` : baseUserPrompt;
   const messages: ChatMessage[] = [

--- a/src/commands/improve/extract-prompt.ts
+++ b/src/commands/improve/extract-prompt.ts
@@ -120,6 +120,12 @@ export interface ExtractPromptInput {
   events: SessionEvent[];
   /** Inline refs the agent already preserved during the session. */
   inlineRefs: InlineRefMention[];
+  /**
+   * Stash authoring standards (convention/meta fact bodies). Extract output is
+   * memories/lessons/knowledge (non-wiki). Empty/omitted when none exist;
+   * rendered to an empty string in the template when absent.
+   */
+  standardsContext?: string;
 }
 
 /**
@@ -166,6 +172,11 @@ export function buildExtractPrompt(input: ExtractPromptInput): string {
   const ref = input.data.ref;
   const startedAt = ref.startedAt ? new Date(ref.startedAt).toISOString() : "unknown";
   const endedAt = ref.endedAt ? new Date(ref.endedAt).toISOString() : "unknown";
+  // Optional standards block — rendered to the lead-in + body when present,
+  // or an empty string (no section) when absent. Gated on non-empty.
+  const standards = input.standardsContext?.trim()
+    ? `\n## Standards to follow (the rulebook for this target)\n\n${input.standardsContext.trim()}\n`
+    : "";
   return promptTemplate
     .replace("{{HARNESS}}", ref.harness)
     .replace("{{TITLE}}", ref.title ?? "(no title)")
@@ -173,6 +184,7 @@ export function buildExtractPrompt(input: ExtractPromptInput): string {
     .replace("{{ENDED_AT}}", endedAt)
     .replace("{{PROJECT_HINT}}", ref.projectHint ?? "(no project hint)")
     .replace("{{ALREADY_PRESERVED}}", formatAlreadyPreserved(input.inlineRefs))
+    .replace("{{STANDARDS}}", standards)
     .replace("{{TRANSCRIPT}}", formatTranscript(input.events));
 }
 

--- a/src/commands/improve/extract.ts
+++ b/src/commands/improve/extract.ts
@@ -34,6 +34,7 @@ import { getDefaultLlmConfig, loadConfig } from "../../core/config/config";
 import { ConfigError, UsageError } from "../../core/errors";
 import { appendEvent } from "../../core/events";
 import { probeLock, releaseLock, tryAcquireLockSync } from "../../core/file-lock";
+import { resolveStashStandards } from "../../core/standards/resolve-stash-standards";
 import {
   type ExtractedSessionRow,
   getExtractedSessionsMap,
@@ -473,6 +474,10 @@ async function processSession(
   // file read is incurred.
   prior: ExtractedSessionRow | undefined,
   force: boolean,
+  // Stash authoring standards (convention/meta fact bodies) for non-wiki
+  // output. Resolved ONCE per run by the caller and threaded in so facts are
+  // not re-read per session. Empty string when none exist.
+  standardsContext: string,
 ): Promise<ExtractedSessionResult> {
   const warnings: string[] = [];
   let data: ReturnType<SessionLogHarness["readSession"]>;
@@ -572,7 +577,12 @@ async function processSession(
     }
   }
 
-  const prompt = buildExtractPrompt({ data, events: filtered.events, inlineRefs: data.inlineRefs });
+  const prompt = buildExtractPrompt({
+    data,
+    events: filtered.events,
+    inlineRefs: data.inlineRefs,
+    ...(standardsContext.trim() ? { standardsContext } : {}),
+  });
 
   // #561 — ADDITIVE session indexing. Generate + write the session asset
   // (`sessions/<harness>/<id>.md`). FAIL-OPEN: any failure only records a
@@ -1046,6 +1056,11 @@ export async function akmExtract(options: AkmExtractOptions): Promise<AkmExtract
     };
   }
 
+  // Stash authoring standards (convention/meta fact bodies) for non-wiki
+  // extract output. Resolved ONCE per run and threaded into each session's
+  // prompt so facts are not re-read per session.
+  const extractStandardsContext = resolveStashStandards(stashDir);
+
   for (const summary of candidates) {
     // #602 — the already-extracted skip moved INTO processSession (the content
     // hash needs the session body, only available after readSession). The prior
@@ -1112,6 +1127,7 @@ export async function akmExtract(options: AkmExtractOptions): Promise<AkmExtract
         schemaSimilarityCtx,
         prior,
         options.force === true,
+        extractStandardsContext,
       );
       sessions.push(result);
       // #626 — triage aggregation. A session reached the triage gate only when it

--- a/src/commands/improve/procedural.ts
+++ b/src/commands/improve/procedural.ts
@@ -31,6 +31,7 @@ import { getDefaultLlmConfig, loadConfig } from "../../core/config/config";
 import { appendEvent, type EventsContext } from "../../core/events";
 import type { EligibilitySource, ProceduralCompilationResult } from "../../core/improve-types";
 import { parseEmbeddedJsonResponse } from "../../core/parse";
+import { resolveStashStandards } from "../../core/standards/resolve-stash-standards";
 import { warn } from "../../core/warn";
 import { closeDatabase, type DbIndexedEntry, getAllEntries, openExistingDatabase } from "../../indexer/db/db";
 import { resolveImproveProcessRunnerFromProfile, runnerIsLlm } from "../../integrations/agent/runner";
@@ -204,12 +205,17 @@ export function deriveProceduralWorkflowRef(cluster: SequenceCluster): string {
 // ── Prompt + parse ──────────────────────────────────────────────────────────────
 
 /** Assemble the per-sequence user prompt fed to the procedural LLM. */
-export function buildProceduralPrompt(cluster: SequenceCluster): string {
+export function buildProceduralPrompt(cluster: SequenceCluster, standardsContext = ""): string {
   const lines: string[] = [
     `A recurring successful action sequence observed across ${cluster.members.length} sessions.`,
     "",
-    "Ordered actions (turn EACH into exactly one step, in this order):",
   ];
+  if (standardsContext.trim()) {
+    lines.push("Standards to follow (the rulebook for this target):");
+    lines.push(standardsContext.trim());
+    lines.push("");
+  }
+  lines.push("Ordered actions (turn EACH into exactly one step, in this order):");
   cluster.normalized.forEach((step, i) => {
     lines.push(`${i + 1}. ${step}`);
   });
@@ -378,6 +384,10 @@ export async function akmProcedural(opts: AkmProceduralOptions): Promise<Procedu
     return finish({ sequencesScanned, clustersFormed: 0 });
   }
 
+  // Procedural output is a workflow (non-wiki) → stash authoring standards.
+  // Resolved ONCE per run and passed to each sequence prompt.
+  const standardsContext = resolveStashStandards(stashDir);
+
   for (const cluster of clusters) {
     if (opts.signal?.aborted) {
       warnings.push("aborted-mid-run");
@@ -386,7 +396,7 @@ export async function akmProcedural(opts: AkmProceduralOptions): Promise<Procedu
     clustersFormed += 1;
     const workflowRef = deriveProceduralWorkflowRef(cluster);
 
-    const prompt = buildProceduralPrompt(cluster);
+    const prompt = buildProceduralPrompt(cluster, standardsContext);
     const raw = await llmFn(prompt);
     const doc = parseProceduralWorkflow(raw, cluster.normalized.length);
 

--- a/src/commands/improve/recombine.ts
+++ b/src/commands/improve/recombine.ts
@@ -49,6 +49,7 @@ import { getDefaultLlmConfig, loadConfig } from "../../core/config/config";
 import { appendEvent, type EventsContext } from "../../core/events";
 import type { EligibilitySource, RecombineResult } from "../../core/improve-types";
 import { parseEmbeddedJsonResponse } from "../../core/parse";
+import { resolveStashStandards } from "../../core/standards/resolve-stash-standards";
 import {
   decayUnseenRecombineHypotheses,
   findMatchingRecombineHypothesis,
@@ -320,12 +321,17 @@ function readBody(entry: DbIndexedEntry): string {
 }
 
 /** Assemble the per-cluster user prompt fed to the recombine LLM. */
-export function buildClusterPrompt(cluster: MemoryCluster): string {
+export function buildClusterPrompt(cluster: MemoryCluster, standardsContext = ""): string {
   const lines: string[] = [
     `Shared signal: ${cluster.signature}`,
     `Cluster of ${cluster.members.length} related memories:`,
     "",
   ];
+  if (standardsContext.trim()) {
+    lines.push("Standards to follow (the rulebook for this target):");
+    lines.push(standardsContext.trim());
+    lines.push("");
+  }
   for (const m of cluster.members) {
     lines.push(`[memory:${m.entry.name}]`);
     if (m.entry.description) lines.push(`Description: ${m.entry.description}`);
@@ -497,6 +503,10 @@ export async function akmRecombine(opts: AkmRecombineOptions): Promise<Recombine
   // run — everything else is decayed after the loop.
   const seenThisRun = new Set<string>();
 
+  // Recombine output is knowledge/lesson (non-wiki) → stash authoring
+  // standards. Resolved ONCE per run and passed to each cluster prompt.
+  const standardsContext = resolveStashStandards(stashDir);
+
   try {
     for (const cluster of clusters) {
       if (opts.signal?.aborted) {
@@ -505,7 +515,7 @@ export async function akmRecombine(opts: AkmRecombineOptions): Promise<Recombine
       }
       clustersFormed += 1;
 
-      const prompt = buildClusterPrompt(cluster);
+      const prompt = buildClusterPrompt(cluster, standardsContext);
       const raw = await llmFn(prompt);
       const generalization = parseGeneralization(raw);
 

--- a/src/commands/improve/reflect.ts
+++ b/src/commands/improve/reflect.ts
@@ -38,6 +38,7 @@ import { ConfigError, UsageError } from "../../core/errors";
 import { appendEvent, readEvents } from "../../core/events";
 import type { EligibilitySource } from "../../core/improve-types";
 import { lintLessonContent } from "../../core/lesson-lint";
+import { resolveStandardsContext } from "../../core/standards/resolve-standards-context";
 import { lookup } from "../../indexer/indexer";
 import {
   type AgentConfig,
@@ -986,6 +987,9 @@ export async function akmReflect(options: AkmReflectOptions = {}): Promise<AkmRe
   // Reflexion-style verbal-RL: inject rejected proposals so the agent avoids
   // reproducing proposals that have already been reviewed and refused.
   const rejectedProposals = readRejectedProposals(stash, options.ref);
+  // Standards "rulebook" for this target — wiki schema (wiki page) or stash
+  // convention/meta facts (non-wiki asset); empty when neither fires.
+  const standardsContext = resolveStandardsContext(options.ref, stash);
 
   // 5. Spawn the agent — with optional Self-Refine loop (R-1 / #372).
   //
@@ -1058,6 +1062,7 @@ export async function akmReflect(options: AkmReflectOptions = {}): Promise<AkmRe
         ...(schemaHints.length > 0 ? { schemaHints } : {}),
         ...(relatedLessons.length > 0 ? { relatedLessons } : {}),
         ...(options.task ? { task: options.task } : {}),
+        ...(standardsContext.trim() ? { standardsContext } : {}),
         ...(options.avoidPatterns && options.avoidPatterns.length > 0 ? { avoidPatterns: options.avoidPatterns } : {}),
         ...(rejectedProposals.length > 0 ? { rejectedProposals } : {}),
         // R-1: inject prior draft as self-critique target on iterations > 0

--- a/src/commands/proposal/propose.ts
+++ b/src/commands/proposal/propose.ts
@@ -20,6 +20,7 @@ import { TYPE_DIRS } from "../../core/asset/asset-spec";
 import { resolveStashDir } from "../../core/common";
 import { ConfigError, UsageError } from "../../core/errors";
 import { appendEvent } from "../../core/events";
+import { resolveStandardsContext } from "../../core/standards/resolve-standards-context";
 import {
   type AgentConfig,
   type AgentFailureReason,
@@ -174,10 +175,15 @@ export async function akmPropose(options: AkmProposeOptions): Promise<AkmPropose
   );
   const resolvedDraftPath = await draftFilePath;
 
+  // Standards "rulebook" for this target — wiki schema (wiki page) or stash
+  // convention/meta facts (non-wiki asset); empty when neither fires.
+  const standardsContext = resolveStandardsContext(`${options.type}:${options.name}`, stash);
+
   const prompt = buildProposePrompt({
     type: options.type,
     name: options.name,
     task: options.task,
+    ...(standardsContext.trim() ? { standardsContext } : {}),
     draftFilePath: resolvedDraftPath,
   });
 

--- a/src/commands/sources/schema-repair.ts
+++ b/src/commands/sources/schema-repair.ts
@@ -21,6 +21,7 @@ import { assembleAsset } from "../../core/asset/asset-serialize";
 import { parseFrontmatter } from "../../core/asset/frontmatter";
 import type { LlmConnectionConfig } from "../../core/config/config";
 import { appendEvent, readEvents } from "../../core/events";
+import { resolveStandardsContext } from "../../core/standards/resolve-standards-context";
 import { info, warn } from "../../core/warn";
 import { resolveAssetPath } from "../../indexer/walk/path-resolver";
 import { chatCompletion, parseEmbeddedJsonResponse } from "../../llm/client";
@@ -169,6 +170,13 @@ export async function runSchemaRepairPass(
       info(`[improve] schema-repair ${failure.ref} (${fieldList})`);
 
       const bodyPreview = (fm.content ?? raw).slice(0, 2000);
+      // Standards "rulebook" for this target — wiki schema (wiki page) or stash
+      // convention/meta facts (non-wiki asset); empty when neither fires or no
+      // stash dir is available. `resolveStandardsContext` dispatches on the ref.
+      const standardsContext = stashDir ? resolveStandardsContext(failure.ref, stashDir) : "";
+      const standardsSection = standardsContext.trim()
+        ? `\n\nStandards to follow (the rulebook for this target):\n${standardsContext.trim()}`
+        : "";
       const llmResponse = await chatFn(llmConfig, [
         {
           role: "system",
@@ -176,7 +184,7 @@ export async function runSchemaRepairPass(
         },
         {
           role: "user",
-          content: `Generate the missing frontmatter fields (${fieldList}) for this ${parseAssetRef(failure.ref).type} asset. Return ONLY valid JSON like {"description": "...", "when_to_use": "..."}\n\n${bodyPreview}`,
+          content: `Generate the missing frontmatter fields (${fieldList}) for this ${parseAssetRef(failure.ref).type} asset. Return ONLY valid JSON like {"description": "...", "when_to_use": "..."}${standardsSection}\n\n${bodyPreview}`,
         },
       ]);
 

--- a/src/core/standards/resolve-standards-context.ts
+++ b/src/core/standards/resolve-standards-context.ts
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Dispatch resolver for the standards prompt seam — selects which of the two
+ * standards features fires for a given write target, mutually exclusively:
+ *
+ *   - **Feature A — wiki schema**: the target is a wiki page (a ref/path under
+ *     `wikis/<name>/`, NOT a `raw/` file and NOT a wiki infra file
+ *     `schema.md`/`index.md`/`log.md`). Returns that wiki's `schema.md` body.
+ *   - **Feature B — stash standards**: the target is any non-wiki asset.
+ *     Returns the concatenated `category: convention`/`meta` fact bodies.
+ *   - **Neither fires**: a wiki `raw/` file or a wiki infra file. Returns `""`.
+ *
+ * The two NEVER both fire. Both underlying readers degrade to `""` on
+ * missing/malformed input and never throw, so this resolver never throws.
+ */
+
+import { extractWikiNameFromRef, INDEX_MD, LOG_MD, loadWikiSchema, SCHEMA_MD } from "../../wiki/wiki";
+import { resolveStashStandards } from "./resolve-stash-standards";
+
+/** Wiki infra files that are not authored pages (relative to the wiki root). */
+const WIKI_INFRA_BASENAMES: ReadonlySet<string> = new Set([SCHEMA_MD, INDEX_MD, LOG_MD]);
+
+/**
+ * Resolve the standards context for a write target identified by its asset ref.
+ *
+ * @param ref       Canonical asset ref of the write target (e.g. `skill:foo`,
+ *                  `wiki:research/topics/x`). When undefined, the target is a
+ *                  non-wiki authoring flow → stash standards.
+ * @param stashRoot Stash root directory.
+ */
+export function resolveStandardsContext(ref: string | undefined, stashRoot: string): string {
+  const wikiName = ref ? extractWikiNameFromRef(ref) : undefined;
+  if (!wikiName) {
+    // Non-wiki asset target → Feature B (stash authoring standards).
+    return resolveStashStandards(stashRoot);
+  }
+
+  // Wiki target. Extract the page path after `wiki:<name>/`.
+  const prefix = `wiki:${wikiName}/`;
+  const pagePath = ref?.startsWith(prefix) ? ref.slice(prefix.length) : "";
+
+  // `wiki:<name>` with no page, a `raw/` file, or a wiki infra file → neither
+  // feature fires.
+  if (!pagePath) return "";
+  if (pagePath === "raw" || pagePath.startsWith("raw/")) return "";
+  // Infra files (`schema`/`index`/`log`) are only special at the WIKI ROOT.
+  // A nested page like `wiki:research/analysis/schema` is a genuine page and
+  // must NOT be suppressed, so only check when the page is at root depth.
+  if (!pagePath.includes("/")) {
+    // Refs drop the `.md` extension; compare against both forms defensively.
+    if (WIKI_INFRA_BASENAMES.has(pagePath) || WIKI_INFRA_BASENAMES.has(`${pagePath}.md`)) {
+      return "";
+    }
+  }
+
+  // A genuine wiki page → Feature A (that wiki's schema body).
+  return loadWikiSchema(stashRoot, wikiName).body;
+}

--- a/src/core/standards/resolve-stash-standards.ts
+++ b/src/core/standards/resolve-stash-standards.ts
@@ -1,0 +1,94 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Resolve the stash-authoring "standards" context (Feature B of the standards
+ * plan): gather the bodies of `fact` assets whose `category` frontmatter is
+ * `convention` or `meta` so naming / tag / frontmatter conventions are surfaced
+ * to the agent when it creates or edits a non-wiki asset.
+ *
+ * Selection is by **frontmatter `category`**, never by path — flat
+ * (`facts/x.md`) and nested (`facts/conventions/x.md`) layouts resolve
+ * identically. The MVP does no parsing of fenced blocks, no rule objects, and
+ * no warnings: it concatenates the selected facts' bodies in stable enumeration
+ * order, each preceded by a one-line `# <ref>` provenance header. Returns `""`
+ * when no matching facts exist.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { parseFrontmatter } from "../asset/frontmatter";
+
+/** `category` values that mark a fact as an authoring standard. */
+const STANDARD_CATEGORIES = new Set(["convention", "meta"]);
+
+/** Directory (under the stash root) where `fact` assets live. */
+const FACTS_SUBDIR = "facts";
+
+/**
+ * Recursively collect `.md` files under `dir` in stable (sorted) enumeration
+ * order. Returns absolute paths. Missing dir → `[]`.
+ */
+function collectMarkdownFiles(dir: string): string[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const results: string[] = [];
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectMarkdownFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/**
+ * Derive a fact ref (`fact:conventions/naming`) from an absolute markdown path
+ * relative to the facts root. Mirrors the canonical-name derivation in
+ * `asset-spec.ts` (POSIX separators, `.md` stripped).
+ */
+function toFactRef(factsRoot: string, absPath: string): string {
+  const rel = path.relative(factsRoot, absPath).split(path.sep).join("/");
+  const name = rel.endsWith(".md") ? rel.slice(0, -3) : rel;
+  return `fact:${name}`;
+}
+
+export function resolveStashStandards(stashRoot: string): string {
+  const factsRoot = path.join(stashRoot, FACTS_SUBDIR);
+  const sections: string[] = [];
+
+  for (const absPath of collectMarkdownFiles(factsRoot)) {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(absPath, "utf8");
+    } catch {
+      continue;
+    }
+
+    let category = "";
+    let body = "";
+    try {
+      const parsed = parseFrontmatter(raw);
+      category = typeof parsed.data.category === "string" ? parsed.data.category.trim() : "";
+      body = parsed.content;
+    } catch {
+      continue;
+    }
+
+    if (!STANDARD_CATEGORIES.has(category)) continue;
+
+    const trimmed = body.trim();
+    if (!trimmed) continue; // skip stub facts with frontmatter but no body
+
+    sections.push(`# ${toFactRef(factsRoot, absPath)}\n${trimmed}`);
+  }
+
+  return sections.join("\n\n");
+}

--- a/src/integrations/agent/prompts.ts
+++ b/src/integrations/agent/prompts.ts
@@ -165,6 +165,13 @@ export interface ReflectPromptInput {
   /** Optional operator task/focus hint. */
   task?: string;
   /**
+   * Standards "rulebook" for this write target — the wiki schema body (for a
+   * wiki-page target) or the concatenated convention/meta fact bodies (for a
+   * non-wiki asset target). Mutually exclusive by target; empty when neither
+   * fires. Injected verbatim as its own prompt section before the asset content.
+   */
+  standardsContext?: string;
+  /**
    * When provided, the agent is instructed to write the improved content
    * directly to this path using its file tools. No stdout JSON is expected.
    * When absent, the agent returns a JSON payload via stdout (legacy path).
@@ -250,6 +257,11 @@ export function buildReflectPrompt(input: ReflectPromptInput): ReflectPromptResu
     sections.push(
       "No usage feedback recorded. Limit your proposal to schema and structural improvements only: missing required frontmatter fields, unclear `when_to_use`, ambiguous description, or broken formatting. Do not speculate about runtime weaknesses you have not observed.",
     );
+  }
+
+  if (input.standardsContext?.trim()) {
+    sections.push("Standards to follow (the rulebook for this target):");
+    sections.push(input.standardsContext.trim());
   }
 
   if (input.assetContent?.trim()) {
@@ -401,6 +413,14 @@ export interface ProposePromptInput {
   /** Optional extra schema hints. */
   schemaHints?: string[];
   /**
+   * Standards "rulebook" for this write target — the wiki schema body (for a
+   * wiki-page target) or the concatenated convention/meta fact bodies (for a
+   * non-wiki asset target). Mutually exclusive by target; empty when neither
+   * fires. Injected verbatim as its own prompt section before the proposal
+   * contract.
+   */
+  standardsContext?: string;
+  /**
    * When provided, the agent is instructed to write the new asset content
    * directly to this path using its file tools. No stdout JSON is expected.
    * When absent, the agent returns a JSON payload via stdout (legacy path).
@@ -422,6 +442,10 @@ export function buildProposePrompt(input: ProposePromptInput): string {
     sections.push("Schema / lint hints:");
     for (const line of input.schemaHints) sections.push(`- ${line}`);
   }
+  if (input.standardsContext?.trim()) {
+    sections.push("Standards to follow (the rulebook for this target):");
+    sections.push(input.standardsContext.trim());
+  }
   sections.push("Produce a single proposal that, if accepted, would land as the asset described above.");
   sections.push(input.draftFilePath ? fileWriteContract(input.draftFilePath) : RESPONSE_CONTRACT_JSON);
   return sections.join("\n\n");
@@ -435,6 +459,12 @@ export interface SchemaRepairPromptInput {
   reason: string;
   /** Current verbatim file content of the failing asset. */
   assetContent: string;
+  /**
+   * Standards "rulebook" for this target — wiki schema (wiki page) or stash
+   * convention/meta facts (non-wiki asset). Empty/omitted when neither fires;
+   * gated on non-empty before injection.
+   */
+  standardsContext?: string;
   /**
    * When provided, the agent writes directly to this file path using its
    * file-editing tools. When absent, the agent returns a JSON payload via
@@ -457,6 +487,10 @@ export function buildSchemaRepairPrompt(input: SchemaRepairPromptInput): string 
   );
   sections.push(`Target ref: ${input.ref}`);
   sections.push(`Schema requirements for ${input.type} assets: ${hintForType(input.type)}`);
+  if (input.standardsContext?.trim()) {
+    sections.push("Standards to follow (the rulebook for this target):");
+    sections.push(input.standardsContext.trim());
+  }
   const CONTENT_CAP = 3000;
   const body = input.assetContent.trimEnd();
   const truncated = body.length > CONTENT_CAP;

--- a/src/wiki/wiki.ts
+++ b/src/wiki/wiki.ts
@@ -295,6 +295,44 @@ function readSchemaDescription(wikiDir: string): string | undefined {
   }
 }
 
+/**
+ * Load a wiki's `schema.md` body and frontmatter.
+ *
+ * Unlike {@link readSchemaDescription} (which returns only the frontmatter
+ * `description` for `listWikis` summaries), this returns the markdown **body**
+ * — everything after the closing `---` of the frontmatter — which is where the
+ * page contract, operations, and hard rules live. The body is the rulebook
+ * injected into the write-time prompt for wiki-page edits.
+ *
+ * Swallow-and-degrade like the existing reader: a missing file, an unresolvable
+ * wiki dir, or malformed content yields `{ body: "", frontmatter: {} }`. Never
+ * throws.
+ */
+export function loadWikiSchema(
+  stashRoot: string,
+  name: string,
+): { body: string; frontmatter: Record<string, unknown> } {
+  const empty = { body: "", frontmatter: {} as Record<string, unknown> };
+  let wikiDir: string;
+  try {
+    wikiDir = resolveWikiDir(stashRoot, name);
+  } catch {
+    return empty;
+  }
+  let raw: string;
+  try {
+    raw = fs.readFileSync(path.join(wikiDir, SCHEMA_MD), "utf8");
+  } catch {
+    return empty;
+  }
+  try {
+    const parsed = parseFrontmatter(raw);
+    return { body: parsed.content, frontmatter: parsed.data };
+  } catch {
+    return empty;
+  }
+}
+
 function toIsoDate(ms: number): string {
   return new Date(ms).toISOString();
 }

--- a/tests/standards-dispatch.test.ts
+++ b/tests/standards-dispatch.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for the standards dispatch resolver (Step 2 of the
+ * standards plan, docs/design/standards-wiki-schema-PLAN.md):
+ *
+ *   resolveStandardsContext(ref, stashRoot) — the single place that selects
+ *   which standards feature fires for a write target, mutually exclusively:
+ *     - wiki page  → Feature A (that wiki's schema.md body)
+ *     - non-wiki   → Feature B (convention/meta fact bodies)
+ *     - wiki raw/  → neither (empty)
+ *     - wiki infra → neither (empty)
+ *
+ * Pure disk reads through the same resolver the reflect/propose call sites use;
+ * no spawn/serve, fast.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { resolveStandardsContext } from "../src/core/standards/resolve-standards-context";
+import { makeStashDir, type SandboxedDir } from "./_helpers/sandbox";
+
+describe("resolveStandardsContext", () => {
+  let sb: SandboxedDir;
+  beforeEach(() => {
+    sb = makeStashDir();
+  });
+  afterEach(() => sb.cleanup());
+
+  function writeSchema(name: string, body: string): void {
+    const dir = path.join(sb.dir, "wikis", name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "schema.md"),
+      ["---", `description: ${name} wiki schema`, "pageKind: [note, source]", "---", "", body, ""].join("\n"),
+      "utf8",
+    );
+  }
+
+  function writeFact(relPath: string, category: string, body: string): void {
+    const abs = path.join(sb.dir, "facts", relPath);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, `---\ncategory: ${category}\n---\n\n${body}\n`, "utf8");
+  }
+
+  // ── Feature A — wiki page targets pull that wiki's schema body ────────────
+
+  test("a wiki-page target injects body-derived rules from that wiki's schema", () => {
+    writeSchema("research", "# Page contract\n\nHard rule: every page MUST cite a source.");
+
+    const out = resolveStandardsContext("wiki:research/topics/photosynthesis", sb.dir);
+    // Body-derived rule, NOT merely the frontmatter description.
+    expect(out).toContain("Hard rule: every page MUST cite a source.");
+    expect(out).toContain("# Page contract");
+    expect(out).not.toContain("description:");
+  });
+
+  test("editing one wiki's page pulls that wiki's schema, never the other's", () => {
+    writeSchema("research", "Research rule: cite a source.");
+    writeSchema("product", "Product rule: link the spec.");
+
+    const research = resolveStandardsContext("wiki:research/foo", sb.dir);
+    expect(research).toContain("Research rule: cite a source.");
+    expect(research).not.toContain("Product rule: link the spec.");
+
+    const product = resolveStandardsContext("wiki:product/foo", sb.dir);
+    expect(product).toContain("Product rule: link the spec.");
+    expect(product).not.toContain("Research rule: cite a source.");
+  });
+
+  // ── Feature B — non-wiki asset targets pull convention/meta facts ─────────
+
+  test("a non-wiki asset target injects the convention/meta fact bodies", () => {
+    writeFact("conventions/naming.md", "convention", "Use kebab-case for asset names.");
+    writeFact("meta/projects.md", "meta", "Active project: akm.");
+
+    const out = resolveStandardsContext("skill:deploy", sb.dir);
+    expect(out).toContain("# fact:conventions/naming");
+    expect(out).toContain("Use kebab-case for asset names.");
+    expect(out).toContain("# fact:meta/projects");
+    expect(out).toContain("Active project: akm.");
+  });
+
+  test("an undefined target (chooser flow) falls back to stash standards", () => {
+    writeFact("conventions/naming.md", "convention", "Use kebab-case for asset names.");
+    const out = resolveStandardsContext(undefined, sb.dir);
+    expect(out).toContain("Use kebab-case for asset names.");
+  });
+
+  // ── Mutual exclusion ──────────────────────────────────────────────────────
+
+  test("a wiki-page target gets NO stash-standards facts", () => {
+    writeSchema("research", "Research rule: cite a source.");
+    writeFact("conventions/naming.md", "convention", "Use kebab-case for asset names.");
+
+    const out = resolveStandardsContext("wiki:research/foo", sb.dir);
+    expect(out).toContain("Research rule: cite a source.");
+    expect(out).not.toContain("Use kebab-case for asset names.");
+    expect(out).not.toContain("# fact:conventions/naming");
+  });
+
+  test("a non-wiki target gets NO wiki schema", () => {
+    writeSchema("research", "Research rule: cite a source.");
+    writeFact("conventions/naming.md", "convention", "Use kebab-case for asset names.");
+
+    const out = resolveStandardsContext("skill:deploy", sb.dir);
+    expect(out).toContain("Use kebab-case for asset names.");
+    expect(out).not.toContain("Research rule: cite a source.");
+  });
+
+  // ── Neither fires ─────────────────────────────────────────────────────────
+
+  test("a wiki raw/ target yields empty standardsContext (neither fires)", () => {
+    writeSchema("research", "Research rule: cite a source.");
+    writeFact("conventions/naming.md", "convention", "Use kebab-case for asset names.");
+
+    expect(resolveStandardsContext("wiki:research/raw/some-source", sb.dir)).toBe("");
+  });
+
+  test("a wiki infra file (schema/index/log) target yields empty (neither fires)", () => {
+    writeSchema("research", "Research rule: cite a source.");
+    expect(resolveStandardsContext("wiki:research/schema", sb.dir)).toBe("");
+    expect(resolveStandardsContext("wiki:research/index", sb.dir)).toBe("");
+    expect(resolveStandardsContext("wiki:research/log", sb.dir)).toBe("");
+  });
+
+  test("a bare wiki ref with no page yields empty (neither fires)", () => {
+    writeSchema("research", "Research rule: cite a source.");
+    expect(resolveStandardsContext("wiki:research", sb.dir)).toBe("");
+  });
+
+  test("a NESTED page whose basename matches an infra name still fires (Feature A)", () => {
+    writeSchema("research", "Research rule: cite a source.");
+    // `wiki:research/analysis/schema` is a genuine nested page, NOT the wiki's
+    // root schema.md — it must inject the wiki schema body, not be suppressed.
+    const out = resolveStandardsContext("wiki:research/analysis/schema", sb.dir);
+    expect(out).toContain("Research rule: cite a source.");
+  });
+});

--- a/tests/standards-prompt-injection.test.ts
+++ b/tests/standards-prompt-injection.test.ts
@@ -1,0 +1,185 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Unit tests for standards PROMPT INJECTION (standards plan,
+ * docs/design/standards-wiki-schema-PLAN.md).
+ *
+ * The resolvers/dispatch are tested in standards-resolvers.test.ts and
+ * standards-dispatch.test.ts. THIS file proves that every LLM prompt that
+ * authors or edits a stash asset actually renders the resolved
+ * `standardsContext` into its output — and omits the section when there are no
+ * standards (so a stash without convention/meta facts pays zero prompt cost).
+ *
+ * Covered authoring prompts:
+ *   - buildReflectPrompt        (improve reflect — edit an asset)
+ *   - buildProposePrompt        (propose — author a new asset)
+ *   - buildSchemaRepairPrompt   (schema-repair — fix frontmatter)
+ *   - buildDistillPrompt        (distill — lesson/knowledge)
+ *   - buildExtractPrompt        (extract — lessons/memories from a session)
+ *   - buildChunkPrompt          (consolidate — merge memories)
+ *   - buildClusterPrompt        (recombine — generalize memories)
+ *   - buildProceduralPrompt     (procedural — workflow from a sequence)
+ *
+ * Plus one tie-through test: the REAL `resolveStashStandards` output (from an
+ * on-disk convention fact) reaches a builder's rendered prompt.
+ *
+ * Pure string assertions + a temp stash for the tie-through. No spawn/serve.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { buildChunkPrompt } from "../src/commands/improve/consolidate";
+import { buildDistillPrompt } from "../src/commands/improve/distill";
+import { buildExtractPrompt } from "../src/commands/improve/extract-prompt";
+import { buildProceduralPrompt } from "../src/commands/improve/procedural";
+import { buildClusterPrompt } from "../src/commands/improve/recombine";
+import { resolveStashStandards } from "../src/core/standards/resolve-stash-standards";
+import { buildProposePrompt, buildReflectPrompt, buildSchemaRepairPrompt } from "../src/integrations/agent/prompts";
+
+/** The lead-in line shared by every authoring prompt's standards section. */
+const LEAD_IN = "Standards to follow (the rulebook for this target)";
+/** A distinctive sentinel that only appears via standards injection. */
+const SENTINEL = "ZZZ_STANDARD_RULE_use_kebab_case";
+
+// Minimal cast fixtures: builders that read member `filePath` degrade safely
+// (try/catch) when the path does not exist, so bogus paths are fine here.
+// biome-ignore lint/suspicious/noExplicitAny: minimal test fixtures for pure prompt builders
+const memoryEntry = (name: string): any => ({
+  name,
+  description: `desc ${name}`,
+  tags: [],
+  filePath: `/nonexistent/${name}.md`,
+});
+// biome-ignore lint/suspicious/noExplicitAny: minimal test fixtures for pure prompt builders
+const clusterMember = (name: string): any => ({
+  entry: { name, description: `desc ${name}` },
+  filePath: `/nonexistent/${name}.md`,
+});
+
+const sessionData = () =>
+  ({
+    ref: {
+      harness: "claude-code",
+      sessionId: "ses_test",
+      filePath: "/tmp/test.jsonl",
+      startedAt: Date.parse("2026-06-21T10:00:00.000Z"),
+      endedAt: Date.parse("2026-06-21T11:00:00.000Z"),
+      projectHint: "test-project",
+      title: "Test session",
+    },
+    events: [],
+    inlineRefs: [],
+    // biome-ignore lint/suspicious/noExplicitAny: minimal SessionData fixture
+  }) as any;
+
+/**
+ * Each builder: a thunk producing the rendered prompt string, given an optional
+ * standardsContext. Keeps the present/absent assertions uniform across all 8.
+ */
+const BUILDERS: Array<{ name: string; render: (standardsContext?: string) => string }> = [
+  {
+    name: "buildReflectPrompt",
+    render: (s) =>
+      buildReflectPrompt({ ref: "skill:foo", type: "skill", name: "foo", assetContent: "body", standardsContext: s })
+        .prompt,
+  },
+  {
+    name: "buildProposePrompt",
+    render: (s) => buildProposePrompt({ type: "skill", name: "foo", task: "do a thing", standardsContext: s }),
+  },
+  {
+    name: "buildSchemaRepairPrompt",
+    render: (s) =>
+      buildSchemaRepairPrompt({
+        ref: "skill:foo",
+        type: "skill",
+        name: "foo",
+        reason: "missing description",
+        assetContent: "body",
+        standardsContext: s,
+      }),
+  },
+  {
+    name: "buildDistillPrompt",
+    render: (s) =>
+      buildDistillPrompt({ inputRef: "skill:foo", assetContent: "body", feedback: [], standardsContext: s }),
+  },
+  {
+    name: "buildExtractPrompt",
+    render: (s) => buildExtractPrompt({ data: sessionData(), events: [], inlineRefs: [], standardsContext: s }),
+  },
+  {
+    name: "buildChunkPrompt",
+    render: (s) => buildChunkPrompt("source", [memoryEntry("m1"), memoryEntry("m2")], 0, 1, 3000, new Set(), s),
+  },
+  {
+    name: "buildClusterPrompt",
+    render: (s) =>
+      buildClusterPrompt({ signature: "tag:alpha", members: [clusterMember("a1"), clusterMember("a2")] }, s),
+  },
+  {
+    name: "buildProceduralPrompt",
+    render: (s) =>
+      buildProceduralPrompt(
+        {
+          groupKey: "k",
+          normalized: ["step one", "step two"],
+          members: [
+            { ref: "workflow:x", entryKey: "e1", outcome: "ok" },
+            { ref: "workflow:y", entryKey: "e2", outcome: "ok" },
+          ],
+        },
+        s,
+      ),
+  },
+];
+
+describe("standards prompt injection", () => {
+  for (const b of BUILDERS) {
+    describe(b.name, () => {
+      test("injects the standards section + body when standardsContext is provided", () => {
+        const out = b.render(SENTINEL);
+        expect(out).toContain(LEAD_IN);
+        expect(out).toContain(SENTINEL);
+      });
+
+      test("omits the standards section when standardsContext is absent", () => {
+        expect(b.render(undefined)).not.toContain(LEAD_IN);
+      });
+
+      test("omits the standards section when standardsContext is empty/whitespace", () => {
+        expect(b.render("   \n  ")).not.toContain(LEAD_IN);
+      });
+    });
+  }
+
+  test("tie-through: real resolveStashStandards output reaches a rendered prompt", () => {
+    const factBody = "ALWAYS_NAME_SKILLS_KEBAB_CASE";
+    const facts = path.join(stashDir, "facts", "conventions");
+    fs.mkdirSync(facts, { recursive: true });
+    fs.writeFileSync(
+      path.join(facts, "naming.md"),
+      `---\ndescription: naming rules\ncategory: convention\n---\n\n${factBody}\n`,
+    );
+
+    const standardsContext = resolveStashStandards(stashDir);
+    expect(standardsContext).toContain(factBody);
+    expect(standardsContext).toContain("# fact:conventions/naming");
+
+    const prompt = buildDistillPrompt({ inputRef: "skill:foo", assetContent: "body", feedback: [], standardsContext });
+    expect(prompt).toContain(LEAD_IN);
+    expect(prompt).toContain(factBody);
+  });
+});
+
+let stashDir: string;
+beforeEach(() => {
+  stashDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-standards-inject-"));
+});
+afterEach(() => {
+  fs.rmSync(stashDir, { recursive: true, force: true });
+});

--- a/tests/standards-resolvers.test.ts
+++ b/tests/standards-resolvers.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for the two standards leaf resolvers (Step 1 of the standards
+ * plan, docs/design/standards-wiki-schema-PLAN.md):
+ *
+ *   - `loadWikiSchema`        (Feature A — wiki schema body delivery)
+ *   - `resolveStashStandards` (Feature B — convention/meta fact bodies)
+ *
+ * Both are pure disk readers that swallow-and-degrade; no spawn/serve, fast.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { resolveStashStandards } from "../src/core/standards/resolve-stash-standards";
+import { loadWikiSchema } from "../src/wiki/wiki";
+import { makeSandboxDir, makeStashDir, type SandboxedDir } from "./_helpers/sandbox";
+
+describe("loadWikiSchema", () => {
+  let sb: SandboxedDir;
+  beforeEach(() => {
+    sb = makeSandboxDir("akm-sb-wikischema");
+  });
+  afterEach(() => sb.cleanup());
+
+  function writeSchema(name: string, contents: string): void {
+    const dir = path.join(sb.dir, "wikis", name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "schema.md"), contents, "utf8");
+  }
+
+  test("returns the markdown body and frontmatter for a valid schema.md", () => {
+    writeSchema(
+      "research",
+      [
+        "---",
+        "description: Research wiki schema",
+        "pageKind: [note, source]",
+        "---",
+        "",
+        "# Page contract",
+        "",
+        "Hard rule: every page MUST cite a source.",
+        "",
+      ].join("\n"),
+    );
+
+    const { body, frontmatter } = loadWikiSchema(sb.dir, "research");
+    expect(body).toContain("# Page contract");
+    expect(body).toContain("Hard rule: every page MUST cite a source.");
+    // Body must NOT include the frontmatter block.
+    expect(body).not.toContain("description: Research wiki schema");
+    expect(frontmatter.description).toBe("Research wiki schema");
+  });
+
+  test("returns empty for a missing schema.md", () => {
+    const result = loadWikiSchema(sb.dir, "does-not-exist");
+    expect(result).toEqual({ body: "", frontmatter: {} });
+  });
+
+  test("returns empty for an invalid wiki name (never throws)", () => {
+    const result = loadWikiSchema(sb.dir, "Not A Valid Name!");
+    expect(result).toEqual({ body: "", frontmatter: {} });
+  });
+
+  test("malformed frontmatter degrades to whole content as body, never throws", () => {
+    // No frontmatter delimiters at all: parseFrontmatter treats the entire
+    // file as body with empty data — a valid prose schema.
+    writeSchema("plain", "# Just prose\n\nNo frontmatter here.\n");
+    const { body, frontmatter } = loadWikiSchema(sb.dir, "plain");
+    expect(body).toContain("# Just prose");
+    expect(frontmatter).toEqual({});
+  });
+});
+
+describe("resolveStashStandards", () => {
+  let sb: SandboxedDir;
+  beforeEach(() => {
+    sb = makeStashDir();
+    fs.mkdirSync(path.join(sb.dir, "facts"), { recursive: true });
+  });
+  afterEach(() => sb.cleanup());
+
+  function writeFact(relPath: string, category: string | null, body: string): void {
+    const abs = path.join(sb.dir, "facts", relPath);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    const fm = category === null ? "" : `category: ${category}\n`;
+    fs.writeFileSync(abs, `---\n${fm}---\n\n${body}\n`, "utf8");
+  }
+
+  test("returns '' when there are no facts", () => {
+    expect(resolveStashStandards(sb.dir)).toBe("");
+  });
+
+  test("returns '' when there is no facts directory at all", () => {
+    const empty = makeSandboxDir("akm-sb-nofacts");
+    try {
+      expect(resolveStashStandards(empty.dir)).toBe("");
+    } finally {
+      empty.cleanup();
+    }
+  });
+
+  test("concatenates convention and meta fact bodies with provenance headers", () => {
+    writeFact("conventions/naming.md", "convention", "Use kebab-case for asset names.");
+    writeFact("meta/projects.md", "meta", "Active project: akm.");
+
+    const out = resolveStashStandards(sb.dir);
+    expect(out).toContain("# fact:conventions/naming");
+    expect(out).toContain("Use kebab-case for asset names.");
+    expect(out).toContain("# fact:meta/projects");
+    expect(out).toContain("Active project: akm.");
+  });
+
+  test("ignores facts in other categories", () => {
+    writeFact("personal/me.md", "personal", "I like tabs.");
+    writeFact("team/stack.md", "team", "We use Bun.");
+    writeFact("project/x.md", "project", "Project detail.");
+    writeFact("uncategorized.md", null, "No category here.");
+
+    expect(resolveStashStandards(sb.dir)).toBe("");
+  });
+
+  test("selects by frontmatter category regardless of subdirectory (flat vs nested)", () => {
+    // A convention fact placed FLAT at facts/ root (not under conventions/).
+    writeFact("flat-rule.md", "convention", "Flat convention body.");
+    // A non-standard fact placed UNDER conventions/ — path says convention,
+    // but frontmatter category does not, so it must be ignored.
+    writeFact("conventions/misfiled.md", "project", "Misfiled, should be skipped.");
+
+    const out = resolveStashStandards(sb.dir);
+    expect(out).toContain("# fact:flat-rule");
+    expect(out).toContain("Flat convention body.");
+    expect(out).not.toContain("Misfiled, should be skipped.");
+  });
+
+  test("preserves stable enumeration order across calls", () => {
+    writeFact("conventions/aaa.md", "convention", "First.");
+    writeFact("conventions/bbb.md", "convention", "Second.");
+    writeFact("meta/ccc.md", "meta", "Third.");
+
+    const first = resolveStashStandards(sb.dir);
+    const second = resolveStashStandards(sb.dir);
+    expect(first).toBe(second);
+    // aaa before bbb before ccc (sorted, depth-first).
+    expect(first.indexOf("# fact:conventions/aaa")).toBeLessThan(first.indexOf("# fact:conventions/bbb"));
+    expect(first.indexOf("# fact:conventions/bbb")).toBeLessThan(first.indexOf("# fact:meta/ccc"));
+  });
+});


### PR DESCRIPTION
## What

Adds a **standards layer** so agents receive the relevant "rulebook" at write-time instead of inventing conventions on every run. Two cleanly **separated** features, selected by target type (never both fire):

- **Feature A — wiki schema:** editing a file under `wikis/<name>/` injects *that wiki's* `schema.md` **body**. New `loadWikiSchema()` returns the body (`readSchemaDescription` only returned the one-line description). Wiki ingest already mandates reading `schema.md` (template step 1), so no extra wiring there.
- **Feature B — stash standards:** creating/editing a non-wiki asset injects the bodies of `category: convention|meta` facts, selected by **frontmatter** (not path).

## Wiring

A single dispatch (`resolveStandardsContext`) feeds `reflect` and `propose`. The same standards are injected into **every other LLM authoring prompt that edits a stash file**: `schema-repair`, `distill`, `extract`, `consolidate`, `recombine`, `procedural` (resolved once per run, gated on non-empty). Analysis-only prompts (judge, triage, dedup, staleness, graph-extract, validate-summary) are intentionally **excluded** — they don't author asset content.

## Design — deliberately lean

Rules are authored as fenced ` ```akm-standards ` / ` ```akm-wiki-schema ` blocks in the markdown body and travel to the agent **as prose** — so the MVP has **no parser, no rule model, no cap, no precedence engine, no lint**. All of those are deferred with explicit triggers in `docs/design/standards-wiki-schema-PLAN.md`.

This plan went through review + adversarial re-review (burden-of-proof flipped onto keeping inferior existing code), a complexity-cut pass, and a three-agent verification that the wiki/stash separation is clean.

## Tests

- `tests/standards-resolvers.test.ts` — `loadWikiSchema` + `resolveStashStandards`
- `tests/standards-dispatch.test.ts` — mutual-exclusion dispatch (wiki page → A, non-wiki → B, raw/infra → none), incl. a nested-page regression
- `tests/standards-prompt-injection.test.ts` — all **8** authoring builders inject/omit the section correctly + an end-to-end tie-through

`bun run check` green: **5122 unit + 1524 integration pass, 0 fail**, 0 type errors, 0 lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)