### PR TITLE
fix(improve): add once-per-asset cooldown to high-salience reflect gate

### DIFF
--- a/src/commands/improve/improve.ts
+++ b/src/commands/improve/improve.ts
@@ -3101,6 +3101,14 @@ async function runImprovePreparationStage(args: {
   // Cap: at most 10% of the effective run limit so the lane cannot crowd out
   // reactive feedback. Requires state.db to have an asset_salience row — refs
   // without a row (pre-#608 assets still on the type-weight stub) are skipped.
+  //
+  // Cooldown: a ref qualifies at most once — when no prior reflect proposal
+  // exists for it (`!lastReflectProposalTs.has`). Without this guard the lane
+  // re-selects the same high-salience refs on EVERY run (auto-accept emits a
+  // `promoted` event, not `feedback`, so the ref never leaves
+  // noFeedbackCandidates), burning LLM calls and churning the asset. This
+  // mirrors the P0-A high-retrieval gate's `!lastReflectProposalTs.has(r.ref)`
+  // guard above so all "rescue" lanes share the same once-per-asset semantics.
   const highSalienceRefs: ImproveEligibleRef[] = [];
   const salienceCfg = (options.config ?? loadConfig()).improve?.salience;
   const salienceThreshold = salienceCfg?.salienceThreshold ?? 0.75;
@@ -3115,7 +3123,7 @@ async function runImprovePreparationStage(args: {
       for (const r of candidates) {
         if (highSalienceRefs.length >= highSalienceCap) break;
         const row = getAssetSalience(dbForHighSalience, r.ref);
-        if (row && row.encoding_salience >= salienceThreshold) {
+        if (row && row.encoding_salience >= salienceThreshold && !lastReflectProposalTs.has(r.ref)) {
           highSalienceRefs.push(r);
         }
       }

--- a/tests/commands/improve/improve-eligibility.test.ts
+++ b/tests/commands/improve/improve-eligibility.test.ts
@@ -19,9 +19,11 @@ import path from "node:path";
 import type { AkmDistillResult } from "../../../src/commands/improve/distill";
 import { akmImprove } from "../../../src/commands/improve/improve";
 import type { AkmReflectResult } from "../../../src/commands/improve/reflect";
+import { upsertAssetSalience } from "../../../src/commands/improve/salience";
 import { saveConfig } from "../../../src/core/config/config";
 import { appendEvent, readEvents } from "../../../src/core/events";
 import { getDbPath } from "../../../src/core/paths";
+import { openStateDatabase } from "../../../src/core/state-db";
 import { closeDatabase, openExistingDatabase } from "../../../src/indexer/db/db";
 import { akmIndex } from "../../../src/indexer/indexer";
 import { insertUsageEvent } from "../../../src/indexer/usage/usage-events";
@@ -651,6 +653,72 @@ describe("P0-A high-retrieval fallback (zero-feedback assets)", () => {
     });
 
     expect(reflected).not.toContain("memory:already");
+  });
+});
+
+// ── Layer 3: high-salience admission gate (#608) ──────────────────────────────
+
+describe("high-salience admission gate (#608)", () => {
+  function seedSalience(ref: string, encoding: number): void {
+    const db = openStateDatabase();
+    try {
+      upsertAssetSalience(db, ref, { encoding, outcome: 0, retrieval: 0, rankScore: 0.2 });
+    } finally {
+      db.close();
+    }
+  }
+
+  test("zero-feedback ref with encoding_salience ≥ threshold and no prior reflect → reflected", async () => {
+    const stash = makeTempDir("akm-hs-rescue-");
+    writeMemory(stash, "salient", "Newly distilled, never surfaced to a user.");
+    await buildIndex(stash);
+    // High encoding_salience, no retrieval, no feedback — only the high-salience
+    // lane can rescue it (memory type-weight fallback is 0.5, below threshold).
+    seedSalience("memory:salient", 0.9);
+
+    const reflected: string[] = [];
+    await akmImprove({
+      scope: "memory",
+      stashDir: stash,
+      minRetrievalCount: 5,
+      ensureIndexFn: async () => false,
+      reindexFn: async () => ({ schemaVersion: 1, ok: true, indexed: 0, warnings: [], errors: [], durationMs: 0 }),
+      reflectFn: async ({ ref }) => {
+        if (ref) reflected.push(ref);
+        return okReflect(ref ?? "");
+      },
+      distillFn: async ({ ref }) => okDistill(ref ?? ""),
+    });
+
+    expect(reflected).toContain("memory:salient");
+  });
+
+  test("high-salience fires at most once per asset (prior reflect proposal blocks re-rescue)", async () => {
+    const stash = makeTempDir("akm-hs-once-");
+    writeMemory(stash, "salient", "High salience but already reflected once.");
+    await buildIndex(stash);
+    seedSalience("memory:salient", 0.9);
+    // A reflect proposal already exists for this ref. Without the cooldown guard
+    // the high-salience lane re-selected it every run (auto-accept emits a
+    // `promoted` event, not `feedback`, so it never leaves noFeedbackCandidates),
+    // burning LLM calls and churning the asset. The guard must block re-rescue.
+    appendEvent({ eventType: "reflect_invoked", ref: "memory:salient" });
+
+    const reflected: string[] = [];
+    await akmImprove({
+      scope: "memory",
+      stashDir: stash,
+      minRetrievalCount: 5,
+      ensureIndexFn: async () => false,
+      reindexFn: async () => ({ schemaVersion: 1, ok: true, indexed: 0, warnings: [], errors: [], durationMs: 0 }),
+      reflectFn: async ({ ref }) => {
+        if (ref) reflected.push(ref);
+        return okReflect(ref ?? "");
+      },
+      distillFn: async ({ ref }) => okDistill(ref ?? ""),
+    });
+
+    expect(reflected).not.toContain("memory:salient");
   });
 });
 


### PR DESCRIPTION
## Problem

A 24h improve-health investigation found two refs each accepted **4 times in 24h** (some proposals with *empty diffs*), all via the `high-salience` eligibility lane. Follow-up diagnosis traced it to a missing cooldown.

The **high-salience admission gate** (#608, `src/commands/improve/improve.ts`) admits zero-feedback refs with `encoding_salience >= threshold` — but, unlike the sibling **P0-A high-retrieval gate**, it has **no `!lastReflectProposalTs.has(r.ref)` cooldown**.

Because auto-accept emits a `promoted` event (not `feedback`), a rescued ref **never leaves `noFeedbackCandidates`**, so the gate re-selects the same refs on **every** improve run — burning LLM calls and churning assets. The population affected is large: ~180 refs are permanently re-eligible (two were observed at 16 and 14 re-promotions since Jun 19).

## Fix

Add the same once-per-asset guard P0-A already uses (`improve.ts:3010`) to the high-salience gate, so all "rescue" lanes share consistent semantics:

```ts
if (row && row.encoding_salience >= salienceThreshold && !lastReflectProposalTs.has(r.ref)) {
```

## Test

New `high-salience admission gate (#608)` block in `improve-eligibility.test.ts`:
- positive control: high-salience + no prior reflect → reflected
- regression: high-salience + prior reflect proposal → **not** re-rescued

Verified the regression test **fails without the guard and passes with it**.

`bun run check` green: 5124 unit + 1526 integration pass, 0 fail, 0 type errors, 0 lint warnings.

## Known follow-up (not in this PR)

The improve run re-derives the `DEFAULT_TYPE_ENCODING_WEIGHTS` stub every run instead of reading back the stored `encoding_salience` — so **180 of 181** "high-salience" refs carry type-weight stubs (0.9/0.8/0.75), not content-derived scores (`scoreEncodingSalience` has only ever run for 4 memory assets). This fix stops the per-run *churn*; correcting the *score source* is a separate change with broader selection-semantics impact and deserves its own design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)