### PR TITLE
fix(improve): unify authoring rules into one validator-sourced seam; fix stuck-proposal loop

### DIFF
--- a/src/assets/prompts/distill-lesson-system.md
+++ b/src/assets/prompts/distill-lesson-system.md
@@ -15,7 +15,7 @@ when_to_use: <one complete sentence describing the concrete trigger condition>
 <lesson body — plain markdown, 1–3 short paragraphs of practical guidance>
 
 ## description field (MANDATORY)
-- A single complete sentence in present tense, 80-200 chars, NO markdown.
+- A single complete sentence in present tense, 20–400 chars, NO markdown.
 - Self-contained: a reviewer must understand the lesson from this field alone.
 - DO NOT start with "When ", "If ", or a connector word — that belongs in when_to_use.
 - DO NOT copy a section heading ("Key takeaways", "For example", "Key pitfalls").

--- a/src/commands/improve/distill.ts
+++ b/src/commands/improve/distill.ts
@@ -60,6 +60,7 @@ import { parseAssetRef } from "../../core/asset/asset-ref";
 import { assembleAssetFromString } from "../../core/asset/asset-serialize";
 import { parseFrontmatter, writeSalienceToFrontmatter } from "../../core/asset/frontmatter";
 import { stripMarkdownFences } from "../../core/asset/markdown";
+import { authoringRulesForType } from "../../core/authoring-rules";
 import { resolveStashDir, timestampForFilename } from "../../core/common";
 import type { AkmConfig, LlmConnectionConfig } from "../../core/config/config";
 import { getDefaultLlmConfig, loadConfig } from "../../core/config/config";
@@ -539,6 +540,13 @@ export function buildDistillPrompt(input: BuildPromptInput): string {
     lines.push("Standards to follow (the rulebook for this target):");
     lines.push(input.standardsContext.trim());
     lines.push("");
+  }
+  {
+    const authoringRules = authoringRulesForType(input.proposalKind ?? "lesson");
+    if (authoringRules) {
+      lines.push(authoringRules);
+      lines.push("");
+    }
   }
   lines.push("Asset content:");
   if (input.assetContent) {

--- a/src/commands/proposal/drain.ts
+++ b/src/commands/proposal/drain.ts
@@ -591,6 +591,13 @@ export async function drainProposals(
   const needsJudge = new Set<string>();
 
   for (const proposal of pending) {
+    // Do NOT reclassify a proposal that was already conclusively stamped
+    // `auto-rejected` by a prior gate run (e.g. the improve confidence gate).
+    // Overwriting an authoritative rejection with `auto-accepted` would corrupt
+    // the audit trail and silently promote content the gate explicitly rejected.
+    // Such proposals remain pending for manual review (or TTL expiry).
+    if (proposal.gateDecision?.outcome === "auto-rejected") continue;
+
     const decision = classifyProposal(proposal, opts.policy, opts.maxDiffLines);
     if (decision === null) continue;
     // #577: stamp the gate's verdict onto the proposal so `akm proposal show`

--- a/src/commands/proposal/validators/proposal-quality-validators.ts
+++ b/src/commands/proposal/validators/proposal-quality-validators.ts
@@ -62,6 +62,12 @@
 // ── Reflect-size guard ───────────────────────────────────────────────────────
 
 import { parseFrontmatter } from "../../../core/asset/frontmatter";
+import {
+  DESCRIPTION_MAX_CHARS,
+  DESCRIPTION_MIN_CHARS,
+  WHEN_TO_USE_MAX_CHARS,
+  WHEN_TO_USE_MIN_CHARS,
+} from "../../../core/authoring-rules";
 import { detectTruncatedDescription, TRUNCATION_TRAILING_WORDS } from "../../../core/text-truncation";
 import type { ProposalValidator } from "./proposal-validators";
 
@@ -100,8 +106,10 @@ export function isValidDescription(
   if (typeof value !== "string") return { ok: false, reason: "description is not a string" };
   const v = value.trim();
   if (!v) return { ok: false, reason: "description is empty" };
-  if (v.length < 20) return { ok: false, reason: `description is too short (${v.length} chars; need ≥20)` };
-  if (v.length > 400) return { ok: false, reason: `description is too long (${v.length} chars; max 400)` };
+  if (v.length < DESCRIPTION_MIN_CHARS)
+    return { ok: false, reason: `description is too short (${v.length} chars; need ≥${DESCRIPTION_MIN_CHARS})` };
+  if (v.length > DESCRIPTION_MAX_CHARS)
+    return { ok: false, reason: `description is too long (${v.length} chars; max ${DESCRIPTION_MAX_CHARS})` };
   if (/^\s*[\d#*\->`]/.test(v)) return { ok: false, reason: "description starts with a digit or markdown marker" };
   const last = v.slice(-1);
   if (last === ":" || last === ";" || last === ",")
@@ -152,8 +160,10 @@ export function isValidWhenToUse(value: unknown, inputRef: string): { ok: true }
   if (typeof value !== "string") return { ok: false, reason: "when_to_use is not a string" };
   const v = value.trim();
   if (!v) return { ok: false, reason: "when_to_use is empty" };
-  if (v.length < 15) return { ok: false, reason: `when_to_use is too short (${v.length} chars; need ≥15)` };
-  if (v.length > 400) return { ok: false, reason: `when_to_use is too long (${v.length} chars; max 400)` };
+  if (v.length < WHEN_TO_USE_MIN_CHARS)
+    return { ok: false, reason: `when_to_use is too short (${v.length} chars; need ≥${WHEN_TO_USE_MIN_CHARS})` };
+  if (v.length > WHEN_TO_USE_MAX_CHARS)
+    return { ok: false, reason: `when_to_use is too long (${v.length} chars; max ${WHEN_TO_USE_MAX_CHARS})` };
   if (/^when working with\b/i.test(v))
     return { ok: false, reason: "when_to_use is the circular 'When working with ...' fallback" };
   const refTail = inputRef.split(":").pop()?.toLowerCase() ?? "";

--- a/src/commands/proposal/validators/proposals.ts
+++ b/src/commands/proposal/validators/proposals.ts
@@ -68,6 +68,7 @@ import {
   upsertProposal,
   withImmediateTransaction,
 } from "../../../core/state-db";
+import { repairTruncatedDescription } from "../../../core/text-truncation";
 import { warn } from "../../../core/warn";
 import {
   commitWriteTargetBoundary,
@@ -1147,6 +1148,118 @@ export function validateProposal(proposal: Proposal): ProposalValidationReport {
   return runProposalValidators(proposal);
 }
 
+// ── Content repair ──────────────────────────────────────────────────────────
+
+/**
+ * Attempt bounded, deterministic repair of mechanically-fixable defects in a
+ * proposal's markdown content. NEVER fabricates text — only strips known-bad
+ * structure and applies {@link repairTruncatedDescription} to a truncated
+ * description when one is detected.
+ *
+ * Repairs performed (in order):
+ *   1. Strip body lines that restate frontmatter fields as pseudo-frontmatter
+ *      (e.g. `**description**: …` or `when_to_use: …` in the body).
+ *   2. Remove stray body `---` horizontal-rule lines (leaving exactly the two
+ *      frontmatter fences when the content has a valid frontmatter block).
+ *   3. Apply {@link repairTruncatedDescription} to a truncated/hanging
+ *      `description` field in the frontmatter.
+ *
+ * Returns the repaired content string. When no repairs apply the input is
+ * returned byte-identical so callers can use strict equality to detect
+ * whether a repair actually happened.
+ *
+ * CRITICAL: This function is CONTENT-PRESERVING. Callers MUST re-validate the
+ * repaired output via {@link validateProposal} / {@link runProposalValidators}
+ * before promotion — a repair that makes things *worse* (or is simply
+ * insufficient) must be caught by the existing gate.
+ */
+export function repairProposalContent(content: string): string {
+  if (typeof content !== "string" || content.trim() === "") return content;
+
+  // Determine whether the content has a frontmatter block so we know how
+  // many `---` fence lines are expected.
+  const hasFrontmatter = /^---\r?\n[\s\S]*?\r?\n---/.test(content);
+
+  // Split into lines for structural repairs.
+  const lines = content.split(/\r?\n/);
+
+  // Track whether we are inside the opening frontmatter block so we can
+  // leave it untouched and only repair the body.
+  let inFrontmatter = false;
+
+  // Frontmatter fence index tracking: first fence opens FM, second closes it.
+  let fmOpenSeen = false;
+  let fmCloseSeen = false;
+
+  const repairedLines: string[] = [];
+
+  for (const line of lines) {
+    const isFence = /^---\s*$/.test(line);
+
+    // Track frontmatter fences (first two `---` fences delimit the FM block).
+    if (isFence && !fmCloseSeen) {
+      if (!fmOpenSeen) {
+        fmOpenSeen = true;
+        inFrontmatter = true;
+        repairedLines.push(line);
+        continue;
+      }
+      if (inFrontmatter) {
+        fmCloseSeen = true;
+        inFrontmatter = false;
+        repairedLines.push(line);
+        continue;
+      }
+    }
+
+    // We are now in the body (past the frontmatter or no frontmatter).
+    if (inFrontmatter) {
+      // Still inside the frontmatter — keep as-is.
+      repairedLines.push(line);
+      continue;
+    }
+
+    // Repair 1: Strip pseudo-frontmatter restatements in the body.
+    // Matches lines like `**description**: …` or `when_to_use: …`.
+    if (/^\s*(\*\*|__)?\s*(description|when_to_use)\s*(\*\*|__)?\s*:/i.test(line)) {
+      // Drop the line — it is a structural defect, not user content.
+      continue;
+    }
+
+    // Repair 2: Remove stray `---` horizontal-rule lines in the body.
+    // We keep these only when the content has NO frontmatter (in that case
+    // `---` is a legitimate thematic break in plain-body content).
+    if (isFence && hasFrontmatter) {
+      // Drop: these are extra `---` fences beyond the two frontmatter delimiters.
+      continue;
+    }
+
+    repairedLines.push(line);
+  }
+
+  let repaired = repairedLines.join("\n");
+
+  // Repair 3: Apply repairTruncatedDescription to the description field.
+  // We operate on the raw text rather than re-parsing YAML to avoid
+  // reformatting unrelated frontmatter keys.
+  if (hasFrontmatter) {
+    // Extract the body text (after the second `---`) so we can pass it to
+    // repairTruncatedDescription as context for the swap-in heuristic.
+    const bodyMatch = repaired.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?([\s\S]*)$/);
+    const bodyText = bodyMatch?.[1] ?? "";
+
+    repaired = repaired.replace(
+      /^(description:\s*)(.*?)(\r?\n)/m,
+      (_match, prefix: string, rawDesc: string, nl: string) => {
+        const fixed = repairTruncatedDescription(rawDesc.trim(), bodyText);
+        return `${prefix}${fixed}${nl}`;
+      },
+    );
+  }
+
+  return repaired;
+}
+
 // ── Promotion ──────────────────────────────────────────────────────────────
 
 export interface PromoteResult {
@@ -1184,7 +1297,19 @@ export async function promoteProposal(
     );
   }
 
-  const report = validateProposal(proposal);
+  // Attempt bounded auto-repair of mechanically-fixable structural defects
+  // (pseudo-frontmatter-in-body, stray `---` fences, truncated description)
+  // BEFORE running validation. If the repair produces valid content, we
+  // promote the repaired version; if validation still fails, the original
+  // error path throws as before. The repair is content-preserving and
+  // deterministic — it never invents text.
+  const repairedContent = repairProposalContent(proposal.payload.content);
+  const proposalToValidate: Proposal =
+    repairedContent !== proposal.payload.content
+      ? { ...proposal, payload: { ...proposal.payload, content: repairedContent } }
+      : proposal;
+
+  const report = validateProposal(proposalToValidate);
   if (!report.ok) {
     const message = report.findings.map((f) => `[${f.kind}] ${f.message}`).join("\n");
     throw new UsageError(
@@ -1194,7 +1319,17 @@ export async function promoteProposal(
     );
   }
 
-  const ref = parseAssetRef(proposal.ref);
+  // Use the (possibly repaired) payload for the promotion write. Persist the
+  // repaired content back onto the DB row so the audit trail reflects the
+  // final promoted payload (not the defective original).
+  if (repairedContent !== proposal.payload.content) {
+    withProposalsDb(stashDir, ctx, (db) => {
+      const updated: Proposal = { ...proposal, payload: { ...proposal.payload, content: repairedContent } };
+      upsertProposal(db, updated, stashDir);
+    });
+  }
+
+  const ref = parseAssetRef(proposalToValidate.ref);
   if (!TYPE_DIRS[ref.type]) {
     throw new UsageError(`Proposal ${id} targets unknown asset type "${ref.type}".`, "INVALID_FLAG_VALUE");
   }
@@ -1220,7 +1355,7 @@ export async function promoteProposal(
     );
   }
 
-  const written = await writeAssetToSource(target.source, target.config, ref, proposal.payload.content);
+  const written = await writeAssetToSource(target.source, target.config, ref, repairedContent);
   // 0.9.0 (issue #507): single batch commit at the write boundary for git
   // targets. No-op for filesystem/primary-stash targets.
   commitWriteTargetBoundary(target, `Update ${formatRefForMessage(ref)}`);

--- a/src/commands/sources/schema-repair.ts
+++ b/src/commands/sources/schema-repair.ts
@@ -19,6 +19,7 @@ import path from "node:path";
 import { parseAssetRef } from "../../core/asset/asset-ref";
 import { assembleAsset } from "../../core/asset/asset-serialize";
 import { parseFrontmatter } from "../../core/asset/frontmatter";
+import { authoringRulesForType } from "../../core/authoring-rules";
 import type { LlmConnectionConfig } from "../../core/config/config";
 import { appendEvent, readEvents } from "../../core/events";
 import { resolveStandardsContext } from "../../core/standards/resolve-standards-context";
@@ -177,6 +178,9 @@ export async function runSchemaRepairPass(
       const standardsSection = standardsContext.trim()
         ? `\n\nStandards to follow (the rulebook for this target):\n${standardsContext.trim()}`
         : "";
+      const assetType = parseAssetRef(failure.ref).type;
+      const authoringRules = authoringRulesForType(assetType);
+      const authoringRulesSection = authoringRules ? `\n\n${authoringRules}` : "";
       const llmResponse = await chatFn(llmConfig, [
         {
           role: "system",
@@ -184,7 +188,7 @@ export async function runSchemaRepairPass(
         },
         {
           role: "user",
-          content: `Generate the missing frontmatter fields (${fieldList}) for this ${parseAssetRef(failure.ref).type} asset. Return ONLY valid JSON like {"description": "...", "when_to_use": "..."}${standardsSection}\n\n${bodyPreview}`,
+          content: `Generate the missing frontmatter fields (${fieldList}) for this ${assetType} asset. Return ONLY valid JSON like {"description": "...", "when_to_use": "..."}${standardsSection}${authoringRulesSection}\n\n${bodyPreview}`,
         },
       ]);
 

--- a/src/core/authoring-rules.ts
+++ b/src/core/authoring-rules.ts
@@ -1,0 +1,91 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Canonical HARD authoring rules — the single source of truth shared by the
+ * proposal validators (which REJECT violations) and the improve/authoring
+ * prompts (which must TELL the agent the same rules, in the same words).
+ *
+ * Why this module exists: authoring rules were duplicated and drifted across
+ * prompt templates. `distill-lesson-system.md` told the model "80–200 chars"
+ * while the validator enforced 20–400; reflect's prompt omitted the
+ * no-pseudo-frontmatter / single-fence rules entirely, so reflect generated
+ * proposals that the gate then rejected and that got stuck in the queue.
+ *
+ * The fix: the numeric bounds live HERE and are imported by both the validators
+ * (`isValidDescription` / `isValidWhenToUse` in proposal-quality-validators.ts)
+ * and the prompt text (`authoringRulesForType`). The agent-facing rule prose
+ * sits next to the bounds it describes, so a developer changing a validator
+ * sees the prompt copy that must change with it. `tests/authoring-rules-*`
+ * asserts the two representations stay consistent.
+ *
+ * SCOPE: only HARD rules (a validator rejects the proposal if violated) belong
+ * here. Soft/style conventions (voice, paragraph count, "include a # Title")
+ * are user-editable and flow through the separate `standardsContext` seam
+ * (stash `category: convention` facts) — NOT this module.
+ */
+
+// ── Canonical numeric bounds (imported by the validators — do not duplicate) ──
+
+/** `description` length bounds (chars). Enforced by `isValidDescription`. */
+export const DESCRIPTION_MIN_CHARS = 20;
+export const DESCRIPTION_MAX_CHARS = 400;
+
+/** `when_to_use` length bounds (chars). Enforced by `isValidWhenToUse`. */
+export const WHEN_TO_USE_MIN_CHARS = 15;
+export const WHEN_TO_USE_MAX_CHARS = 400;
+
+// ── Agent-facing rule prose (mirrors the validator checks one-for-one) ────────
+
+/**
+ * Rules that apply to any markdown asset authored with YAML frontmatter + a
+ * body. Enforced by `detectDoubleFrontmatter` (currently fires for lesson
+ * proposals, but the rules are universally correct, so we state them for every
+ * type to prevent the same defect class elsewhere).
+ */
+const FRONTMATTER_BODY_RULES: readonly string[] = [
+  "Emit EXACTLY TWO `---` fence lines — the opening and closing of the YAML frontmatter. Do NOT use `---` as a horizontal rule anywhere in the body.",
+  "Do NOT restate `description:` or `when_to_use:` inside the body (no `**description:** …` or `**when_to_use:** …` lines). Those keys belong in the frontmatter ONLY.",
+];
+
+/** Rules for the `description` frontmatter field. Enforced by `isValidDescription`. */
+const DESCRIPTION_RULES: readonly string[] = [
+  `\`description\` must be ${DESCRIPTION_MIN_CHARS}–${DESCRIPTION_MAX_CHARS} characters of plain-prose sentence — no leading digit or markdown marker, balanced backticks, and it must NOT end with \`:\`, \`;\`, or \`,\` (those read as truncation).`,
+  '`description` must NOT be a section-heading fragment (e.g. "Overview", "Key points", "Summary"), a code fragment (must not start with `def`/`function`/`class`/`const`/…), or end on a hanging connector word ("a", "the", "and", "to", …).',
+  "`description` must NOT merely restate the asset's ref/name; write what the asset actually does.",
+  '`description` should NOT start with "When" — that phrasing belongs in `when_to_use`.',
+];
+
+/** Rules for the `when_to_use` frontmatter field. Enforced by `isValidWhenToUse`. */
+const WHEN_TO_USE_RULES: readonly string[] = [
+  `\`when_to_use\` is REQUIRED and must be ${WHEN_TO_USE_MIN_CHARS}–${WHEN_TO_USE_MAX_CHARS} characters describing a concrete trigger. Never write the circular fallback "When working with <name>".`,
+  "`description` and `when_to_use` must be different from each other.",
+];
+
+/**
+ * Asset types that carry a `description` and a body where the
+ * frontmatter/body rules apply. (Types without those — if any are added later —
+ * simply fall through to the cross-cutting block.)
+ */
+const DESCRIPTION_TYPES = new Set(["lesson", "knowledge", "memory", "skill", "command", "agent", "workflow", "fact"]);
+
+/** Types where `when_to_use` is a HARD requirement (validator rejects if absent). */
+const WHEN_TO_USE_TYPES = new Set(["lesson"]);
+
+/**
+ * Build the hard-rules block for a given asset type, ready to inject as a prompt
+ * section. Returns `""` for an unknown type (no over-claiming). The block is
+ * deterministic so prompt snapshots stay stable.
+ *
+ * Inject this VERBATIM into every improve/authoring prompt that creates or edits
+ * an asset of `type`, so the agent is told exactly what the gate will reject.
+ */
+export function authoringRulesForType(type: string): string {
+  const rules: string[] = [...FRONTMATTER_BODY_RULES];
+  if (DESCRIPTION_TYPES.has(type)) rules.push(...DESCRIPTION_RULES);
+  if (WHEN_TO_USE_TYPES.has(type)) rules.push(...WHEN_TO_USE_RULES);
+  if (rules.length === 0) return "";
+  const heading = `Hard authoring rules for ${type} assets (the validator REJECTS proposals that violate these):`;
+  return [heading, ...rules.map((r) => `- ${r}`)].join("\n");
+}

--- a/src/integrations/agent/prompts.ts
+++ b/src/integrations/agent/prompts.ts
@@ -28,6 +28,7 @@
  */
 
 import { TYPE_DIRS } from "../../core/asset/asset-spec";
+import { authoringRulesForType } from "../../core/authoring-rules";
 import { parseEmbeddedJsonResponse, stripCodeFences, stripThinkBlocks } from "../../core/parse";
 
 /** Agent-returned proposal payload (after JSON parse). */
@@ -264,6 +265,14 @@ export function buildReflectPrompt(input: ReflectPromptInput): ReflectPromptResu
     sections.push(input.standardsContext.trim());
   }
 
+  {
+    const resolvedType = input.type ?? (input.ref?.includes(":") ? input.ref.split(":")[0] : "");
+    const authoringRules = resolvedType ? authoringRulesForType(resolvedType) : "";
+    if (authoringRules) {
+      sections.push(authoringRules);
+    }
+  }
+
   if (input.assetContent?.trim()) {
     // Cap at 12 000 chars to stay well under OS ARG_MAX when the prompt is
     // passed as a CLI argument to opencode/claude. Large assets (wiki snapshots,
@@ -446,6 +455,12 @@ export function buildProposePrompt(input: ProposePromptInput): string {
     sections.push("Standards to follow (the rulebook for this target):");
     sections.push(input.standardsContext.trim());
   }
+  {
+    const authoringRules = authoringRulesForType(input.type);
+    if (authoringRules) {
+      sections.push(authoringRules);
+    }
+  }
   sections.push("Produce a single proposal that, if accepted, would land as the asset described above.");
   sections.push(input.draftFilePath ? fileWriteContract(input.draftFilePath) : RESPONSE_CONTRACT_JSON);
   return sections.join("\n\n");
@@ -490,6 +505,12 @@ export function buildSchemaRepairPrompt(input: SchemaRepairPromptInput): string 
   if (input.standardsContext?.trim()) {
     sections.push("Standards to follow (the rulebook for this target):");
     sections.push(input.standardsContext.trim());
+  }
+  {
+    const authoringRules = authoringRulesForType(input.type);
+    if (authoringRules) {
+      sections.push(authoringRules);
+    }
   }
   const CONTENT_CAP = 3000;
   const body = input.assetContent.trimEnd();

--- a/tests/authoring-rules-injection.test.ts
+++ b/tests/authoring-rules-injection.test.ts
@@ -1,0 +1,164 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Unit tests proving that `authoringRulesForType` is injected as its own
+ * prompt section into every improve/authoring prompt that creates or edits
+ * an asset. Uses a lesson target so the full set of hard rules (frontmatter,
+ * description, when_to_use) is exercised.
+ *
+ * Tests are pure string assertions — no spawn/serve/disk required.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { buildDistillPrompt } from "../src/commands/improve/distill";
+import { buildProposePrompt, buildReflectPrompt, buildSchemaRepairPrompt } from "../src/integrations/agent/prompts";
+
+/**
+ * Distinctive substrings from FRONTMATTER_BODY_RULES in authoring-rules.ts.
+ * Each one only appears in a prompt if authoringRulesForType was called and
+ * its output injected. We pick two from different rule groups:
+ *   - from FRONTMATTER_BODY_RULES (applies to ALL types including lesson)
+ *   - from WHEN_TO_USE_RULES (applies to lesson only)
+ */
+const HARD_RULE_FRONTMATTER = "Do NOT restate `description:`";
+const HARD_RULE_FENCE = "EXACTLY TWO `---` fence";
+const HARD_RULE_WHEN_TO_USE = "when_to_use` is REQUIRED";
+
+describe("authoring-rules injection", () => {
+  describe("buildReflectPrompt (lesson type, type provided directly)", () => {
+    const rendered = buildReflectPrompt({
+      ref: "lesson:foo-lesson",
+      type: "lesson",
+      name: "foo-lesson",
+      assetContent: "Some lesson body content here.",
+    }).prompt;
+
+    test("contains FRONTMATTER_BODY_RULES snippet", () => {
+      expect(rendered).toContain(HARD_RULE_FRONTMATTER);
+    });
+
+    test("contains fence rule snippet", () => {
+      expect(rendered).toContain(HARD_RULE_FENCE);
+    });
+
+    test("contains when_to_use REQUIRED rule", () => {
+      expect(rendered).toContain(HARD_RULE_WHEN_TO_USE);
+    });
+  });
+
+  describe("buildReflectPrompt (lesson type, type derived from ref prefix)", () => {
+    // input.type is undefined — type must be derived from ref prefix "lesson"
+    const rendered = buildReflectPrompt({
+      ref: "lesson:foo-lesson",
+      // type intentionally omitted
+      assetContent: "Some lesson body content here.",
+    }).prompt;
+
+    test("contains FRONTMATTER_BODY_RULES snippet even when type is derived from ref", () => {
+      expect(rendered).toContain(HARD_RULE_FRONTMATTER);
+    });
+
+    test("contains when_to_use REQUIRED rule even when type is derived from ref", () => {
+      expect(rendered).toContain(HARD_RULE_WHEN_TO_USE);
+    });
+  });
+
+  describe("buildProposePrompt (lesson type)", () => {
+    const rendered = buildProposePrompt({
+      type: "lesson",
+      name: "foo-lesson",
+      task: "Document what we learned about foos.",
+    });
+
+    test("contains FRONTMATTER_BODY_RULES snippet", () => {
+      expect(rendered).toContain(HARD_RULE_FRONTMATTER);
+    });
+
+    test("contains fence rule snippet", () => {
+      expect(rendered).toContain(HARD_RULE_FENCE);
+    });
+
+    test("contains when_to_use REQUIRED rule", () => {
+      expect(rendered).toContain(HARD_RULE_WHEN_TO_USE);
+    });
+  });
+
+  describe("buildSchemaRepairPrompt (lesson type)", () => {
+    const rendered = buildSchemaRepairPrompt({
+      ref: "lesson:foo-lesson",
+      type: "lesson",
+      name: "foo-lesson",
+      reason: "missing description",
+      assetContent: "---\nwhen_to_use: When foo is used.\n---\n\nBody text.",
+    });
+
+    test("contains FRONTMATTER_BODY_RULES snippet", () => {
+      expect(rendered).toContain(HARD_RULE_FRONTMATTER);
+    });
+
+    test("contains fence rule snippet", () => {
+      expect(rendered).toContain(HARD_RULE_FENCE);
+    });
+
+    test("contains when_to_use REQUIRED rule", () => {
+      expect(rendered).toContain(HARD_RULE_WHEN_TO_USE);
+    });
+  });
+
+  describe("buildDistillPrompt (lesson proposalKind, default)", () => {
+    const rendered = buildDistillPrompt({
+      inputRef: "skill:foo",
+      assetContent: "Some skill body content.",
+      feedback: [],
+      // proposalKind omitted — defaults to "lesson" per the injection logic
+    });
+
+    test("contains FRONTMATTER_BODY_RULES snippet", () => {
+      expect(rendered).toContain(HARD_RULE_FRONTMATTER);
+    });
+
+    test("contains fence rule snippet", () => {
+      expect(rendered).toContain(HARD_RULE_FENCE);
+    });
+
+    test("contains when_to_use REQUIRED rule", () => {
+      expect(rendered).toContain(HARD_RULE_WHEN_TO_USE);
+    });
+  });
+
+  describe("buildDistillPrompt (lesson proposalKind, explicit)", () => {
+    const rendered = buildDistillPrompt({
+      inputRef: "skill:foo",
+      assetContent: "Some skill body content.",
+      feedback: [],
+      proposalKind: "lesson",
+    });
+
+    test("contains FRONTMATTER_BODY_RULES snippet", () => {
+      expect(rendered).toContain(HARD_RULE_FRONTMATTER);
+    });
+
+    test("contains when_to_use REQUIRED rule", () => {
+      expect(rendered).toContain(HARD_RULE_WHEN_TO_USE);
+    });
+  });
+
+  describe("non-lesson type: buildProposePrompt (knowledge)", () => {
+    const rendered = buildProposePrompt({
+      type: "knowledge",
+      name: "foo-knowledge",
+      task: "Document foo reference material.",
+    });
+
+    // knowledge has FRONTMATTER_BODY_RULES + DESCRIPTION_RULES but NOT when_to_use
+    test("contains FRONTMATTER_BODY_RULES snippet for knowledge type", () => {
+      expect(rendered).toContain(HARD_RULE_FRONTMATTER);
+    });
+
+    test("does NOT contain when_to_use REQUIRED rule for knowledge type", () => {
+      expect(rendered).not.toContain(HARD_RULE_WHEN_TO_USE);
+    });
+  });
+});

--- a/tests/authoring-rules.test.ts
+++ b/tests/authoring-rules.test.ts
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Drift guard for the canonical hard-authoring-rules seam.
+ *
+ * The whole point of src/core/authoring-rules.ts is that the prompt text and
+ * the validators share ONE source for the bounds, so they can't drift (the bug
+ * was distill telling the model "80–200 chars" while the gate enforced 20–400).
+ * These tests pin that the bounds constants actually drive the validators AND
+ * that the agent-facing rule text states the same numbers — if someone changes
+ * one without the other, this fails.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { isValidDescription, isValidWhenToUse } from "../src/commands/proposal/validators/proposal-quality-validators";
+import {
+  authoringRulesForType,
+  DESCRIPTION_MAX_CHARS,
+  DESCRIPTION_MIN_CHARS,
+  WHEN_TO_USE_MAX_CHARS,
+  WHEN_TO_USE_MIN_CHARS,
+} from "../src/core/authoring-rules";
+
+const ref = "lesson:example";
+
+describe("authoring-rules bounds drive the validators", () => {
+  test("description below DESCRIPTION_MIN_CHARS is rejected; at the bound is accepted", () => {
+    const tooShort = "x".repeat(DESCRIPTION_MIN_CHARS - 1);
+    const atMin = "a real sentence ".repeat(2).slice(0, DESCRIPTION_MIN_CHARS);
+    expect(isValidDescription(tooShort, ref).ok).toBe(false);
+    expect(atMin.length).toBe(DESCRIPTION_MIN_CHARS);
+    expect(isValidDescription(atMin, ref).ok).toBe(true);
+  });
+
+  test("description above DESCRIPTION_MAX_CHARS is rejected", () => {
+    const tooLong = `A valid sentence start ${"word ".repeat(DESCRIPTION_MAX_CHARS)}`.slice(
+      0,
+      DESCRIPTION_MAX_CHARS + 1,
+    );
+    expect(tooLong.length).toBeGreaterThan(DESCRIPTION_MAX_CHARS);
+    expect(isValidDescription(tooLong, ref).ok).toBe(false);
+  });
+
+  test("when_to_use below WHEN_TO_USE_MIN_CHARS is rejected; at the bound is accepted", () => {
+    const tooShort = "x".repeat(WHEN_TO_USE_MIN_CHARS - 1);
+    // No leading/trailing whitespace (the validator trims before measuring).
+    const atMin = "reach for it!".padEnd(WHEN_TO_USE_MIN_CHARS, "x");
+    expect(isValidWhenToUse(tooShort, ref).ok).toBe(false);
+    expect(atMin.length).toBe(WHEN_TO_USE_MIN_CHARS);
+    expect(isValidWhenToUse(atMin, ref).ok).toBe(true);
+  });
+});
+
+describe("authoringRulesForType states the canonical bounds (no prompt/validator drift)", () => {
+  test("lesson block names the description AND when_to_use bounds", () => {
+    const block = authoringRulesForType("lesson");
+    expect(block).toContain(`${DESCRIPTION_MIN_CHARS}–${DESCRIPTION_MAX_CHARS}`);
+    expect(block).toContain(`${WHEN_TO_USE_MIN_CHARS}–${WHEN_TO_USE_MAX_CHARS}`);
+  });
+
+  test("lesson block covers every hard rule that has a validator", () => {
+    const block = authoringRulesForType("lesson").toLowerCase();
+    // pseudo-frontmatter + single-fence (detectDoubleFrontmatter)
+    expect(block).toContain("exactly two `---` fence");
+    expect(block).toContain("do not restate");
+    // when_to_use required + circular guard + differ (isValidWhenToUse / lessonContentQualityValidator)
+    expect(block).toContain("when working with");
+    expect(block).toContain("must be different from each other");
+    // description shape (isValidDescription)
+    expect(block).toContain("section-heading fragment");
+    expect(block).toContain('start with "when"');
+  });
+
+  test("knowledge block has the frontmatter/description rules but NOT the when_to_use requirement", () => {
+    const block = authoringRulesForType("knowledge").toLowerCase();
+    expect(block).toContain("`description`");
+    expect(block).toContain("exactly two `---` fence");
+    expect(block).not.toContain("`when_to_use` is required");
+  });
+
+  test("unknown type still gets the universally-safe frontmatter/body rules, never empty over-claim", () => {
+    // A type with no description/when_to_use mapping still must not silently
+    // promise nothing; cross-cutting frontmatter rules always apply.
+    const block = authoringRulesForType("script").toLowerCase();
+    expect(block).toContain("exactly two `---` fence");
+  });
+});

--- a/tests/proposal-stuck-repair.test.ts
+++ b/tests/proposal-stuck-repair.test.ts
@@ -1,0 +1,413 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Tests for Bug 1 (drain masking) and Bug 2 (bounded auto-repair).
+ *
+ * Bug 1: drainProposals must SKIP proposals already stamped auto-rejected —
+ *        it must never overwrite the rejection with auto-accepted.
+ *
+ * Bug 2: repairProposalContent strips pseudo-frontmatter-in-body, stray
+ *        `---` fences, and truncated descriptions, then re-validates.
+ *        Genuinely-unrepairable proposals (e.g. description too short) must
+ *        remain pending (not promoted, not fabricated).
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type DrainOptions, drainProposals } from "../src/commands/proposal/drain";
+import { PERSONAL_STASH } from "../src/commands/proposal/drain-policies";
+import type { ProposalAcceptResult, ProposalRejectResult } from "../src/commands/proposal/proposal";
+import {
+  createProposal,
+  getProposal,
+  isProposalSkipped,
+  type Proposal,
+  recordGateDecision,
+  repairProposalContent,
+} from "../src/commands/proposal/validators/proposals";
+import type { EventsContext } from "../src/core/events";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeStashDir(): string {
+  const stash = makeTempDir("akm-stuck-repair-stash-");
+  for (const sub of ["lessons", "skills", "memories", "knowledge"]) {
+    fs.mkdirSync(path.join(stash, sub), { recursive: true });
+  }
+  return stash;
+}
+
+function eventsCtx(): EventsContext {
+  return { dbPath: path.join(makeTempDir("akm-stuck-repair-db-"), "state.db") };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function seedProposal(stash: string, ref: string, content: string): Proposal {
+  const result = createProposal(stash, {
+    ref,
+    source: "extract",
+    force: true,
+    sourceRun: "run-test",
+    payload: { content, frontmatter: { description: "test fixture" } },
+  });
+  if (isProposalSkipped(result)) throw new Error(`unexpected skip: ${result.message}`);
+  return result;
+}
+
+function fakeAccept() {
+  return mock(
+    async (opts: { id: string }): Promise<ProposalAcceptResult> => ({
+      schemaVersion: 1,
+      ok: true,
+      id: opts.id,
+      ref: "lesson:fake",
+      assetPath: "/tmp/fake.md",
+      proposal: { id: opts.id } as Proposal,
+    }),
+  );
+}
+
+function fakeReject() {
+  return mock(
+    (opts: { id: string; reason?: string }): ProposalRejectResult => ({
+      schemaVersion: 1,
+      ok: true,
+      id: opts.id,
+      ref: "lesson:fake",
+      ...(opts.reason !== undefined ? { reason: opts.reason } : {}),
+      proposal: { id: opts.id } as Proposal,
+    }),
+  );
+}
+
+function baseOpts(stash: string, overrides: Partial<DrainOptions> = {}): DrainOptions {
+  return {
+    stashDir: stash,
+    policy: PERSONAL_STASH,
+    applyMode: "promote",
+    maxAccepts: 25,
+    dryRun: false,
+    eventsCtx: eventsCtx(),
+    ...overrides,
+  };
+}
+
+// A valid extract proposal that PERSONAL_STASH would auto-accept.
+const VALID_EXTRACT = `---\ndescription: Use ripgrep before grep for speed\nwhen_to_use: Searching large repos for patterns\n---\n\nPrefer rg over grep when scanning large code repositories.\n`;
+
+// ── Bug 1: Drain masking ──────────────────────────────────────────────────────
+
+describe("Bug 1 — drain skips auto-rejected proposals", () => {
+  test("drain does NOT reclassify a proposal stamped auto-rejected to auto-accepted", async () => {
+    const stash = makeStashDir();
+    const proposal = seedProposal(stash, "lesson:drain-skip-test", VALID_EXTRACT);
+
+    // Stamp the proposal as auto-rejected (as the improve confidence gate would).
+    recordGateDecision(stash, proposal.id, {
+      outcome: "auto-rejected",
+      reason: "validation:invalid-description",
+      gate: "improve:reflect",
+    });
+
+    // Verify the stamp is in place.
+    const before = getProposal(stash, proposal.id);
+    expect(before.gateDecision?.outcome).toBe("auto-rejected");
+    expect(before.status).toBe("pending");
+
+    const acceptFn = fakeAccept();
+    const rejectFn = fakeReject();
+
+    await drainProposals(baseOpts(stash), acceptFn, rejectFn);
+
+    // The proposal must NOT have been reclassified to auto-accepted.
+    const after = getProposal(stash, proposal.id);
+    expect(after.status).toBe("pending");
+    expect(after.gateDecision?.outcome).toBe("auto-rejected"); // unchanged
+
+    // acceptFn must never have been called for this proposal.
+    expect(acceptFn).not.toHaveBeenCalledWith(expect.objectContaining({ id: proposal.id }));
+  });
+
+  test("drain accepts normal pending extract proposal (no auto-rejected stamp)", async () => {
+    const stash = makeStashDir();
+    const proposal = seedProposal(stash, "lesson:normal-drain-test", VALID_EXTRACT);
+
+    // No gateDecision stamp — drain should accept it normally.
+    const acceptFn = fakeAccept();
+    const rejectFn = fakeReject();
+
+    const result = await drainProposals(baseOpts(stash), acceptFn, rejectFn);
+
+    // The proposal should appear in promoted list.
+    expect(result.promoted).toContain(proposal.id);
+    expect(acceptFn).toHaveBeenCalledWith(expect.objectContaining({ id: proposal.id }));
+  });
+
+  test("drain skips auto-rejected and accepts clean proposal in same batch", async () => {
+    const stash = makeStashDir();
+
+    const rejected = seedProposal(stash, "lesson:skip-me", VALID_EXTRACT);
+    recordGateDecision(stash, rejected.id, {
+      outcome: "auto-rejected",
+      reason: "validation:truncated",
+      gate: "improve:reflect",
+    });
+
+    const clean = seedProposal(stash, "lesson:accept-me", VALID_EXTRACT);
+
+    const acceptFn = fakeAccept();
+    const rejectFn = fakeReject();
+
+    const result = await drainProposals(baseOpts(stash), acceptFn, rejectFn);
+
+    // Clean proposal promoted; rejected proposal skipped.
+    expect(result.promoted).toContain(clean.id);
+    expect(result.promoted).not.toContain(rejected.id);
+
+    // The auto-rejected stamp must still be `auto-rejected` (not overwritten).
+    const rejectedAfter = getProposal(stash, rejected.id);
+    expect(rejectedAfter.gateDecision?.outcome).toBe("auto-rejected");
+  });
+});
+
+// ── Bug 2: repairProposalContent ─────────────────────────────────────────────
+
+describe("Bug 2 — repairProposalContent", () => {
+  // ── Pseudo-frontmatter-in-body repair ────────────────────────────────────
+
+  test("strips pseudo-frontmatter restatement from body", () => {
+    const content = [
+      "---",
+      "description: A good description of the thing.",
+      "when_to_use: When you need it",
+      "---",
+      "",
+      "Some body text here.",
+      "**description**: A good description of the thing.",
+      "More body text.",
+    ].join("\n");
+
+    const repaired = repairProposalContent(content);
+
+    // The pseudo-frontmatter line must be gone from the body.
+    expect(repaired).not.toMatch(/\*\*description\*\*:/);
+    // The frontmatter description must still be intact.
+    expect(repaired).toContain("description: A good description of the thing.");
+    // The legitimate body content must remain.
+    expect(repaired).toContain("Some body text here.");
+    expect(repaired).toContain("More body text.");
+  });
+
+  test("strips `when_to_use:` restatement from body", () => {
+    const content = [
+      "---",
+      "description: A good description here.",
+      "when_to_use: When you need it daily",
+      "---",
+      "",
+      "when_to_use: When you need it daily",
+      "Real content.",
+    ].join("\n");
+
+    const repaired = repairProposalContent(content);
+    // Body pseudo-frontmatter line stripped.
+    const bodyLines = repaired.split("\n").slice(5); // skip fm
+    expect(bodyLines.every((l) => !/^when_to_use:/.test(l))).toBe(true);
+    expect(repaired).toContain("Real content.");
+  });
+
+  // ── Stray `---` in body repair ────────────────────────────────────────────
+
+  test("removes extra `---` horizontal rule lines from body, keeps fm fences", () => {
+    const content = [
+      "---",
+      "description: A good description of the test.",
+      "when_to_use: When testing body fences",
+      "---",
+      "",
+      "First paragraph.",
+      "---",
+      "Second paragraph.",
+    ].join("\n");
+
+    const repaired = repairProposalContent(content);
+
+    const lines = repaired.split("\n");
+    // Only 2 `---` lines must remain (the frontmatter fences).
+    const fenceLines = lines.filter((l) => /^---\s*$/.test(l));
+    expect(fenceLines.length).toBe(2);
+
+    // Content must be preserved.
+    expect(repaired).toContain("First paragraph.");
+    expect(repaired).toContain("Second paragraph.");
+  });
+
+  // ── Truncated description repair ──────────────────────────────────────────
+
+  test("repairs truncated description ending with ':'", () => {
+    // "description" ending with ':' is detected as truncated.
+    const content = [
+      "---",
+      "description: This explains how to configure the",
+      "when_to_use: When setting up configuration files",
+      "---",
+      "",
+      "Use this approach for configuration management in large projects.",
+    ].join("\n");
+
+    const repaired = repairProposalContent(content);
+
+    // The trailing truncated fragment must be removed or fixed.
+    const descMatch = repaired.match(/^description:\s*(.+)$/m);
+    expect(descMatch).toBeTruthy();
+    const desc = descMatch?.[1] ?? "";
+    // Must not end with a truncation indicator word or `:`.
+    expect(desc.endsWith(":")).toBe(false);
+    expect(desc.endsWith(",")).toBe(false);
+    // Must not end with hanging connector word "the".
+    expect(desc.trim().toLowerCase().endsWith(" the")).toBe(false);
+  });
+
+  // ── Unrepairable: description too short ───────────────────────────────────
+
+  test("does NOT fabricate or alter content when description is too short to repair", () => {
+    // 11-char description — too short to be repairable (MIN is 20).
+    const content = ["---", "description: Short txt", "when_to_use: When needed", "---", "", "Body text."].join("\n");
+
+    // repairProposalContent must return something (possibly unchanged or lightly
+    // repaired), but must NOT fabricate a description.
+    const repaired = repairProposalContent(content);
+
+    // The description must not have been replaced with invented text.
+    const descMatch = repaired.match(/^description:\s*(.+)$/m);
+    const desc = descMatch?.[1] ?? "";
+    // It must still be the short original (or trimmed equivalent).
+    expect(desc.length).toBeLessThan(20);
+    // Must not contain text not from the original.
+    expect(desc).not.toMatch(/configuration|project|approach/i);
+  });
+});
+
+// ── Promote boundary: repair + re-validate integration ───────────────────────
+
+describe("Bug 2 — promote boundary re-validate after repair", () => {
+  // These tests call repairProposalContent directly and then verify that the
+  // repaired content is valid according to the same validators used by
+  // promoteProposal. We test the repair function standalone here because
+  // promoteProposal requires a full stash + config setup.
+
+  test("repaired pseudo-frontmatter content passes validators", async () => {
+    const { runProposalValidators } = await import("../src/commands/proposal/validators/proposal-validators");
+
+    const raw = [
+      "---",
+      "description: A reliable method for configuring deployment pipelines.",
+      "when_to_use: When automating deployment steps in CI/CD.",
+      "---",
+      "",
+      "**description**: A reliable method for configuring deployment pipelines.",
+      "Use this when you need repeatable deployments.",
+    ].join("\n");
+
+    const repaired = repairProposalContent(raw);
+
+    // The pseudo-frontmatter line must be gone.
+    expect(repaired).not.toMatch(/\*\*description\*\*:/);
+
+    // Build a minimal proposal and validate.
+    const proposal = {
+      id: "test-pseudo-fm",
+      ref: "lesson:deploy-pipelines",
+      status: "pending" as const,
+      source: "extract",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      payload: { content: repaired },
+    };
+    const report = runProposalValidators(proposal as Parameters<typeof runProposalValidators>[0]);
+    expect(report.ok).toBe(true);
+  });
+
+  test("repaired double-`---` content passes validators", async () => {
+    const { runProposalValidators } = await import("../src/commands/proposal/validators/proposal-validators");
+
+    const raw = [
+      "---",
+      "description: A solid guide for repository management practices.",
+      "when_to_use: When managing code repositories at scale.",
+      "---",
+      "",
+      "Key practices for repository management.",
+      "---",
+      "Additional notes on branching strategy.",
+    ].join("\n");
+
+    const repaired = repairProposalContent(raw);
+
+    // Only 2 fence lines remain.
+    const fences = repaired.split("\n").filter((l) => /^---\s*$/.test(l));
+    expect(fences.length).toBe(2);
+
+    const proposal = {
+      id: "test-double-fence",
+      ref: "lesson:repo-management",
+      status: "pending" as const,
+      source: "extract",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      payload: { content: repaired },
+    };
+    const report = runProposalValidators(proposal as Parameters<typeof runProposalValidators>[0]);
+    expect(report.ok).toBe(true);
+  });
+
+  test("unrepairable (too short description) stays invalid after repair", async () => {
+    const { runProposalValidators } = await import("../src/commands/proposal/validators/proposal-validators");
+
+    // 11 chars — too short for DESCRIPTION_MIN_CHARS (20).
+    const raw = [
+      "---",
+      "description: Short txt",
+      "when_to_use: When needed for the task at hand.",
+      "---",
+      "",
+      "Body content.",
+    ].join("\n");
+
+    const repaired = repairProposalContent(raw);
+
+    const proposal = {
+      id: "test-too-short",
+      ref: "lesson:short-desc",
+      status: "pending" as const,
+      source: "extract",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      payload: { content: repaired },
+    };
+    const report = runProposalValidators(proposal as Parameters<typeof runProposalValidators>[0]);
+
+    // Must still be invalid — repair cannot fabricate a longer description.
+    expect(report.ok).toBe(false);
+    const kinds = report.findings.map((f) => f.kind);
+    // Should have a description-related finding.
+    expect(kinds.some((k) => k.includes("description"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

A 24h improve-health investigation found proposals that pass the confidence gate but **fail validation** and get stuck `pending` forever (pseudo-frontmatter-in-body, double-`---`-fence, truncated/short descriptions). Root cause: **authoring rules were scattered and drifted** across prompt templates. `distill`'s system prompt stated the no-pseudo-frontmatter / single-fence / description rules; **reflect, propose, and schema-repair did not** — so they generated content the gate then rejected. `distill` even told the model "80–200 chars" while the validator enforced 20–400.

Per owner direction, this fixes the *class* of bug via a single seam, sourced from the **validators** (so prompt and gate can't drift) — not just patching reflect.

## Single source of truth

- **`src/core/authoring-rules.ts`** owns the canonical numeric bounds (`DESCRIPTION_MIN/MAX_CHARS`, `WHEN_TO_USE_MIN/MAX_CHARS`). The validators (`isValidDescription` / `isValidWhenToUse`) now **import** them — the prompt text physically cannot disagree with what the gate enforces.
- **`authoringRulesForType(type)`** emits the agent-facing hard-rule block, injected into every authoring prompt: `buildReflectPrompt`, `buildProposePrompt`, `buildSchemaRepairPrompt` (+ the inline schema-repair message), and `buildDistillPrompt`.
- `extract` / `consolidate` / `recombine` / `procedural` emit schema-gated JSON (not inline markdown) — intentionally skipped.
- Fixed the `distill-lesson-system.md` 80–200 → 20–400 drift.

**Layering (unchanged):** hard rules → this seam (validator-sourced, code); soft conventions → the shipped `standardsContext` seam (stash `category: convention` facts); structural hints → `TYPE_HINTS`.

## Stuck-proposal lifecycle — fixed without short-circuiting downstream

Investigation confirmed leaving a validation-failure `pending` is intentional ("manual review"), so the state machine is **unchanged**. Two real bugs fixed:

- **Drain masking:** `drainProposals` no longer overwrites an `auto-rejected` gate stamp with `auto-accepted` in queue mode — the failure stays truthful and visible.
- **Bounded auto-repair** at the promote boundary: deterministically strips pseudo-frontmatter / stray `---` and applies the existing `repairTruncatedDescription`, then **re-runs the same `validateProposal`**. Fixable → promoted; genuinely unrepairable (e.g. description too short) → stays `pending`, nothing fabricated, validation never bypassed. Net: fresh fixable proposals never stick; the existing backlog is visible and clearable via `akm proposal accept` (which now auto-repairs).

## Tests

- Drift guard: bounds drive the validators AND the prompt states the same numbers (fails if either changes alone).
- Seam injection across all 4 builders (incl. type derived from ref).
- Drain skips `auto-rejected`; repair promotes fixable defects; **too-short description stays pending (not fabricated, not promoted)**.

`bun run check` exits 0. Two intermittent failures (a WAL-concurrency proposal test and a storage-migration differential) are pre-existing host-state flakes — both pass in isolation and neither is in a file this PR changes.

## Follow-up

The deferred per-type **soft** convention facts (`facts/conventions/assets/<type>.md`) remain a separate, optional enhancement — this PR deliberately keeps hard rules in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)