### PR TITLE
fix(improve): preserve content-derived encoding_salience across runs (#644)

### DIFF
--- a/docs/design/improve-salience-working-reference.md
+++ b/docs/design/improve-salience-working-reference.md
@@ -1,0 +1,379 @@
+# Improve Pipeline & Salience — Working Reference
+
+> **Status:** living document. Last synthesized 2026-06-22 from a 4-agent code audit
+> (improve control flow, salience system, proposal lifecycle, design intent + issues).
+> Keep this open when modifying anything under `src/commands/improve/`,
+> `src/commands/proposal/`, or `src/core/salience*`/`state-db`. Update it when the
+> facts below change — every claim carries a `file:line` so it can be re-verified.
+
+This is the end-to-end mental model for how `akm improve` evolves the stash and how
+salience steers it. It exists to stop us re-deriving the pipeline from scratch and to
+list the **footguns that have already bitten us** so we don't reintroduce them.
+
+---
+
+## 0. TL;DR — the things most likely to trip you up
+
+1. **The high-salience lane selects on a *type-weight stub*, not a real score.**
+   `encoding_salience` *was* re-asserted to a per-type constant on *every* improve run, so
+   the `>= 0.75` admission gate effectively meant "reflect every feedback-less agent /
+   command / skill / lesson once." This is **#644** — **fixed pending merge**: migration
+   015 adds an `encoding_source` provenance column (`content` vs `type-stub`),
+   `upsertAssetSalience` no longer lowers a `content` score to a `type-stub`, and the
+   improve loop reads the stored content score back and passes it to `computeSalience`.
+   The single most important thing to understand before touching salience. (§2, §5-F1)
+
+2. **LOOK vs CHANGE must stay separated.** Selecting an asset to *look at* (liberal,
+   proactive) is a different decision from deciding to *change* it (gated, default
+   no-op). Collapsing them caused 96% of assets to go permanently invisible. Do not
+   re-gate LOOK behind the signal-delta gate. (§6, design principle #1)
+
+3. **`gateDecision` is metadata, not status.** `deferred`/`auto-rejected`/`auto-accepted`
+   live on `proposal.gateDecision`; the lifecycle state is `proposal.status`. A
+   `deferred` proposal is still `pending`. Manual `accept` does **not** consult
+   `gateDecision` — only `drain` skips `auto-rejected`. (§3)
+
+4. **`force: true` bypasses all dedup/cooldown guards** and the `create` CLI path always
+   sets it. Loop callers can flood the queue. Use `createProposal` with `force:false` if
+   dedup matters. (§3-Guards)
+
+5. **Several wired-but-dead fields**: `review_pressure`, `feedbackLane`, the proactive
+   `recencyDecay` term, and `outcome_salience`'s weight (`outcomeWeightEnabled` default
+   OFF). They compute and persist but don't influence selection yet. Don't assume they're
+   live. (§5, §7)
+
+---
+
+## 1. Pass inventory (what runs, in order)
+
+`akmImprove` (improve.ts:1094) → multi-cycle loop (improve.ts:1483), each cycle =
+**preparation → loop → post-loop**, under three independent locks
+(`triage.lock`, `consolidate.lock`, `reflect-distill.lock`). Cycle stops early when
+`gateAcceptedThisCycle === 0` (fixed-point).
+
+| Pass | Stage | file:line | Produces | Gating |
+|---|---|---|---|---|
+| triage drain | pre | improve.ts:1293 | promote/reject/defer of **backlog** proposals | `triage` enabled, `scope.mode!=="ref"`, `triage.lock` |
+| ensureIndex + collectEligibleRefs | pre-cycle | improve.ts:1187 | `plannedRefs` | always |
+| consolidation | prep 0.3 | improve.ts:2424 | merge/delete memories → proposals | pool-delta mtime gate, `minPoolSize` (default **500**), `consolidate.lock` |
+| session extract | prep 0.4 | improve.ts:2491 | candidate proposals from session logs | `extract` enabled, `minNewSessions` gate |
+| extract backlog drain | prep | improve.ts:2576 | promote/fail extract proposals | `autoAccept!==undefined`, not dryRun |
+| validation + schema-repair | prep 1 | improve.ts:2643/2679 | `schemaRepairs` | LLM available |
+| akmLint | prep 0.5 | improve.ts:2703 | fixed/flagged | always, non-fatal |
+| signal-delta partition | prep 2-3 | improve.ts:2762 | `eligibleRefs`, `distillOnlyRefs`, `noFeedbackPool` | 30-day window; `--scope` bypasses |
+| high-retrieval (P0-A) | prep 3 | improve.ts:3008 | `highRetrievalRefs` | `retrievalCount>=5`, no prior reflect proposal |
+| proactive maintenance | prep 3 | improve.ts:3035 | `proactiveRefs` | `proactiveMaintenance` enabled (**default OFF**) |
+| high-salience admission (#608) | prep 3 | improve.ts:3112 | `highSalienceRefs` (≤10% of limit) | `encoding_salience>=0.75`, no prior reflect proposal |
+| forgetting-safety | prep | improve.ts:3536 | force-add fallen refs | WS-1 rank-change report (scenario B) |
+| replay | prep | improve.ts:3650 | append refs after `--limit` | `replayBudget>0` (**default 0**) |
+| salience sort + no-op dampen | prep 4 | improve.ts:3782 | `loopRefs` priority order | always |
+| reflect loop | loop | improve.ts:4178 | proposals (per ref) | non-derived, non-distillOnly, budget |
+| self-consistency multi-sample | loop | improve.ts:4222 | majority-vote winner | `utilityScore>=0.7` and `SC_N>=2` |
+| distill loop | loop | improve.ts:4478 | proposals | `isDistillCandidateRef`, cooldown, pending-dedup |
+| memory inference | post | improve.ts:4886 | `.derived` memory facts on disk | `memoryInference` enabled |
+| recombine | post | improve.ts:4692 | `type:hypothesis`→`type:lesson` proposals | `recombine` enabled, `scope.mode!=="ref"` |
+| procedural | post | improve.ts:4736 | `type:workflow` proposals | `procedural` enabled (**default OFF**, #634) |
+| orphan purge / expiry / log purge | post | improve.ts:5025/5059/5094 | reject/expire/delete | retention config |
+
+**Order gotchas:**
+- **Consolidation runs BEFORE extract** (improve.ts:2424, intentional): extract's
+  auto-accepted writes must not re-trip consolidation's mtime gate in the same run.
+  Reordering breaks the pool-delta gate.
+- **Graph extraction reindexes only when `consolidationRan` AND inference didn't already
+  reindex** (improve.ts:4950). `consolidationRan` is true only when `processed>0`.
+
+---
+
+## 2. Salience — the data model and the formulas
+
+Two SQLite tables in `state.db`:
+
+**`asset_salience`** (state-db.ts:633, migration `009`):
+`encoding_salience` (def 0.5), `outcome_salience` (def 0.0), `retrieval_salience`
+(def 0.0), `rank_score` (def 0.0), `consecutive_no_ops` (int), `updated_at`,
+`homeostatic_demoted_at` (migration 011). Index on `rank_score DESC`.
+
+**`asset_outcome`** (state-db.ts:682, migration `010`):
+`last_retrieved_at`, `retrieval_count`, `expected_retrieval_rate`,
+`negative_feedback_count`, `accepted_change_count`, `review_pressure`, `outcome_score`.
+
+Upsert: `upsertAssetSalience` (salience.ts:355) overwrites all four score columns +
+`updated_at` on every call; **does NOT touch `consecutive_no_ops`**.
+
+### The three components (`computeSalience`, salience.ts:229)
+
+**encoding** (salience.ts:239):
+- If `inputs.encodingSalience` supplied → clamp & use.
+- Else → `DEFAULT_TYPE_ENCODING_WEIGHTS[type] ?? 0.5`.
+- The *content-based* score `scoreEncodingSalience` (`0.40·novelty + 0.35·magnitude +
+  0.25·predictionError`, encoding-salience.ts:249) is computed at distill time
+  (distill.ts:951-975) and persisted with `encoding_source='content'`. **Since #644**
+  (fixed pending merge) the improve loop READS that stored content score back and passes
+  it as `encodingSalience` to `computeSalience` (improve.ts ~3375), and
+  `upsertAssetSalience` refuses to lower it to the type-stub. A ref that has never been
+  content-scored still gets the type-weight stub fallback (`encoding_source='type-stub'`).
+  ⚠️ See §5-F1.
+
+**retrieval** (salience.ts:276): `rawRetrieval = log(1+freq)·recencyDecay`, soft-capped
+to `[0,1)`. `recencyDecay = 0.1 + 0.5^(ageDays/21)` — **21-day half-life, floor 0.1**
+(never zero). This is the *only* component with genuine time decay.
+
+**outcome** (salience.ts:255): WS-2 row → pass-through; else warm-start from
+`min(utilityScore, 0.3)`. EMA update α=0.3 (outcome-loop.ts:250).
+
+**rankScore** (salience.ts:313):
+- Default (`outcomeWeightEnabled=false`): `(0.30·enc + 0.00·out + 0.70·ret) / log10(size)`
+- WS-2 opt-in: `(0.25·enc + 0.15·out + 0.60·ret) / log10(size)`
+
+Size penalty `1/log10(max(200,bytes))`. **`outcome` has zero weight by default** — it is
+observed but doesn't steer ranking until an operator runs the Part-V baseline and sets
+`outcomeWeightEnabled:true`.
+
+### Type weights (`DEFAULT_TYPE_ENCODING_WEIGHTS`, salience.ts:119)
+
+| type | weight | ≥0.75 gate? |
+|---|---|---|
+| skill | 0.9 | ✅ |
+| agent | 0.9 | ✅ |
+| command | 0.8 | ✅ |
+| workflow | 0.8 | ✅ |
+| lesson | 0.75 | ✅ |
+| knowledge | 0.7 | ❌ |
+| script | 0.6 | ❌ |
+| memory | 0.5 | ❌ |
+| *(default)* | 0.5 | ❌ |
+
+→ Every skill/agent/command/workflow/lesson clears the default `salienceThreshold=0.75`
+on the stub alone. This is why 180/181 "high-salience" assets are type-selected, not
+content-selected (#644).
+
+---
+
+## 3. Proposal lifecycle (the bridge from "improve generated it" to "it landed")
+
+**Status state machine** (`ProposalStatus`, proposals.ts:198):
+`pending → accepted | rejected`, and `accepted → reverted`. Single `proposals` table,
+status is authoritative, archival = status flip on the same row. Only `pending` can be
+promoted/archived; only `accepted` can be reverted (else `UsageError`).
+
+| transition | fn | file:line |
+|---|---|---|
+| →pending | createProposal | proposals.ts:630 |
+| pending→accepted | promoteProposal→archiveProposal | proposals.ts:1363 |
+| pending→rejected (explicit/orphan/TTL) | archiveProposal / purgeOrphanProposals / expireStaleProposals | 917 / 1025 / 1094 |
+| accepted→reverted | revertProposal | 1443 |
+
+**`status` vs `gateDecision`** (proposals.ts:236): `gateDecision.outcome` ∈
+{`auto-accepted`,`deferred`,`auto-rejected`} is *adjudication metadata* written by
+`recordGateDecision` (proposals.ts:964) — a no-op if not pending, and it **never flips
+status**. A `deferred` proposal stays `pending`.
+
+**`eligibilitySource`** (improve-types.ts:60) — the lane that selected the ref, stamped
+at partition time and threaded to proposal creation. Full vocabulary: `signal-delta`,
+`high-retrieval`, **`high-salience`**, `proactive`, `scope`, `forgetting-safety`,
+`replay`, `exploration`, `recombine`, `procedural`, `unknown`. Precedence (improve.ts:3191):
+`scope > signal-delta > high-retrieval > proactive > high-salience`, with
+forgetting-safety overlaid last (improve.ts:3614).
+*(Note: `high-salience` IS present and IS stamped — improve.ts:3197/3614. An earlier
+audit claimed it was missing; that was wrong.)*
+
+### Guards (createProposal, proposals.ts:630 — `force:true` bypasses the last three)
+
+| guard | kind | blocks |
+|---|---|---|
+| invalid_ref / unknown_type / empty_content | hard reject | throws `UsageError`, emits `proposal_creation_rejected` |
+| missing_description (consolidate only) | hard reject | same |
+| duplicate_pending | dedup | pending exists for same ref+source |
+| content_hash_match | dedup | SHA-256 matches pending or most-recent rejected |
+| cooldown | cooldown | recent rejected within window (reflect 14d, distill 30d, default 7d) |
+
+⚠️ `akmProposalCreate` (proposal.ts:275) **always passes `force:true`** → CLI `create`
+skips all three dedup/cooldown guards.
+
+### Validators (`runProposalValidators`, proposal-validators.ts:91)
+
+Run in order: generic → lesson → descriptionQuality → lessonContentQuality →
+sourceNotSuperseded → reflectSizeGuard. **Error-level findings throw and block; only
+`severity:"warn"` passes** (`ok = findings.every(f=>f.severity==="warn")`). The only
+current warn is "description starts with When" (proposal-quality-validators.ts:148).
+
+**Hard bounds** live in `src/core/authoring-rules.ts` and are imported by the validators
+(single source of truth, #645): `DESCRIPTION 20–400`, `WHEN_TO_USE 15–400`.
+`authoringRulesForType(type)` emits the matching agent-facing prose so prompt and gate
+cannot drift. `DESCRIPTION_TYPES` = lesson/knowledge/memory/skill/command/agent/workflow/
+fact; `WHEN_TO_USE_TYPES` = lesson only.
+
+**Repair before validate** (`repairProposalContent`, proposals.ts:1176; called from
+`promoteProposal` at 1306): strips pseudo-frontmatter body lines, drops stray `---`
+fences, repairs truncated `description`. Then **re-runs full validation** — never a
+bypass. ⚠️ It persists the repaired content to the DB row *before* the asset write
+(proposals.ts:1325); if the subsequent write fails, the row holds repaired content the
+audit trail no longer matches.
+
+### Drain (`drainProposals`, drain.ts:574)
+
+Backlog-only (`excludeIds` removes this-run's fresh proposals). `classifyProposal`
+(drain.ts:208): rejectEmpty → policy.accept rule (with `max-diff-lines` /
+`min-content-lines` defer bands) → policy.defer → null (leave pending). Optional judgment
+tier (LLM/agent runner) resolves deferred items; the runner only judges, the engine
+writes.
+
+⚠️ **`auto-rejected` masking** (drain.ts:599): `if (gateDecision?.outcome ===
+"auto-rejected") continue;` — prevents a prior concrete rejection being overwritten with
+an accept. This guard exists in drain only; the judgment tier and manual `accept` have no
+equivalent.
+
+---
+
+## 4. Standards & authoring-rules seam (HARD vs SOFT)
+
+Two layers, deliberately separate:
+
+- **HARD rules** (validator-rejecting, code-sourced): `src/core/authoring-rules.ts` →
+  `authoringRulesForType()` injected verbatim into reflect/propose/distill/consolidate/
+  recombine/procedural/extract/schema-repair prompts. Cannot drift from the gate (#645).
+- **SOFT conventions** (user-editable, advice-only): stash `fact` assets with
+  `category: convention|meta` → `resolveStashStandards(stashRoot)` (resolve-stash-
+  standards.ts:63). No enforcement — prose only.
+
+Dispatch: `resolveStandardsContext(ref, stashRoot)` (resolve-standards-context.ts:34) is
+**mutually exclusive**: genuine wiki page → `loadWikiSchema().body` (Feature A);
+non-wiki → `resolveStashStandards()` (Feature B); wiki `raw/`/infra files → `""`.
+Shipped #642 (beta.36). Per-type soft conventions (`facts/conventions/assets/<type>.md`)
+are the open follow-up **#646**.
+
+---
+
+## 5. The footgun list (things that have already cost us)
+
+**F1 — encoding_salience is clobbered every run (THE big one, #644). FIXED pending merge.**
+distill writes a real content score; before the fix the improve loop omitted
+`encodingSalience`, recomputed the type-stub, and `upsertAssetSalience` overwrote the real
+score, so the `#608` high-salience gate read the stub ("high-salience" = "is an
+agent/command/skill/lesson").
+**Fix (migration 015 + salience.ts + improve.ts):**
+(1) `asset_salience.encoding_source` records provenance — `"content"` (from
+`scoreEncodingSalience` at distill) vs `"type-stub"` (the type-weight fallback); legacy
+NULL rows are judged by the differs-from-stub heuristic in `isContentEncodingRow`.
+(2) `upsertAssetSalience` refuses to lower a stored `content` score to a `type-stub` (the
+`CASE` guards on encoding_salience + encoding_source).
+(3) the improve loop reads the stored row before `computeSalience` and, when it is
+content-sourced, passes `encodingSalience` back in so the rank score is computed on the
+real content score too. The type-weight stub remains the genuine fallback for
+never-content-scored refs. (improve.ts ~3375; salience.ts `upsertAssetSalience` /
+`isContentEncodingRow`; distill.ts:973; state-db.ts migration 015)
+
+**F2 — the high-salience gate fires exactly once, then never again.**
+`!lastReflectProposalTs.has(r.ref)` (improve.ts:3126, the #643 cooldown) permanently
+excludes a ref after its first reflect proposal. Auto-accept emits `promoted`, not
+`feedback`, so the ref never re-enters via signal-delta. It must accumulate
+`retrievalCount>=5` to return via high-retrieval. Newly-distilled high-salience assets
+get one pass, then freeze out.
+
+**F3 — the no-op dampener can't fire on a churning ref.**
+`resetConsecutiveNoOps` is called on `reflectResult.ok` (improve.ts:4335) = "a proposal
+was generated," not "accepted." A ref that keeps generating rejected proposals keeps
+resetting its counter and never hits the `>=3` dampen threshold (salience.ts:460). Only
+genuinely *silent* assets (no-change) accumulate it.
+
+**F4 — `force:true` on the create CLI path** bypasses dedup/cooldown (§3).
+
+**F5 — repair persists before the write** (§3) — write failure leaves repaired content
+with no matching asset.
+
+**F6 — `reflectSizeGuardValidator` is inert at manual-accept time** — its `appliesTo`
+needs `ctx.source.content`, which the `accept` path never populates
+(proposal-quality-validators.ts:405). A ballooned reflect proposal can be hand-accepted
+without tripping the shrink/expand guard.
+
+**F7 — wired-but-dead signals:** `review_pressure` (computed, persisted, not read into
+admission — outcome-loop.ts:54), `feedbackLane` (set improve.ts:2842, never consumed),
+proactive `recencyDecay` (proactive-maintenance.ts:186 — caller never passes `lastUseMs`,
+pinned to floor), `outcome_salience` weight (`outcomeWeightEnabled` default OFF).
+Don't assume any of these influence behavior.
+
+**F8 — `minPoolSize` default 500** silently skips consolidation on small stashes
+(improve.ts:2184). Set `consolidate.minPoolSize:0` to force it.
+
+**F9 — `archiveRetentionDays:0` disables proposal expiry** → unbounded pending queue
+(proposals.ts:1094).
+
+**F10 — multi-cycle stop depends on `gateAcceptedThisCycle`** (improve.ts:1483). A new
+pass whose proposals are not auto-accepted never contributes to termination — cycles run
+to `maxCycles`.
+
+---
+
+## 6. The brain model (why the pipeline is shaped this way)
+
+`akm improve` is modeled as offline sleep-phase consolidation. Master reference:
+`docs/design/improve-vs-brain-analysis.md`. Mapping (abridged):
+
+| brain stage | AKM analog | status |
+|---|---|---|
+| sensory firehose | session logs → extract | aligned |
+| attention gate | curate/search top-K | aligned |
+| hippocampal encoding | extract → pending proposal | aligned |
+| **amygdala salience tagging** | feedback + retrieval + utility | **Gap 1** (exogenous & sparse; #608/#644) |
+| NREM replay (episodic→semantic) | consolidate + distill | aligned |
+| REM divergent recombination | recombine (#625), graph/inference | Gap 4 (gated, weak) |
+| glymphatic clearance | cleanup / archive / forgetting | Gap 6 (under-powered) |
+| procedural/implicit | procedural pass | Gap 5 (default-OFF, over-fits, #634) |
+| **predictive model / prediction-error** | passive retrieval; WS-2 outcome loop | **Gap 2** (biggest; outcome weight OFF) |
+| closed reconsolidation loop | usage→proactive eligibility | Gap 2/3 |
+
+**The one intentional divergence to PRESERVE: no lossy reconsolidation.** The brain
+rewrites memories on recall (drift, confabulation); AKM preserves raw assets + additive
+distill + the #580 no-op gate + git history. Backed by research showing iterated LLM
+rewriting failed 54% of previously-solved tasks. **Do not** introduce in-place lossy
+rewrites.
+
+**Design principles that are load-bearing — don't undo them:**
+1. **LOOK/CHANGE separation** — liberal selection, gated change. (improve-proactive-
+   maintenance.md; the budget-cap design was tried and removed in 4c1700b2.)
+2. **Signal-delta gate stays** — fixed the 2026-05-26 synchronized-wave incident
+   (6a5e0ca4). "Usage is the gate; rate control is the scheduler's job."
+3. **Salience is a 3-vector, scalarized only for ranking** — three independent reviews
+   rejected a single scalar.
+4. **Success metric = coverage + accepted-change rate, NOT promotion volume.** Promotion
+   volume rewards churn and risks the 54% drift. (akm-improve-success-metric memory.)
+
+---
+
+## 7. Open issues map (as of beta.36)
+
+| issue | state | one-liner |
+|---|---|---|
+| **#644** | FIXED (pending merge) | high-salience gate selected on type-weight stub, not content score (F1). Fixed via `encoding_source` provenance (migration 015) + non-lowering `upsertAssetSalience` + loop read-back. |
+| **#646** | OPEN | per-type SOFT convention facts (`facts/conventions/assets/<type>.md`); keep TYPE_HINTS fallback; soft-only. |
+| #642 | MERGED b36 | standards delivery (Feature A wiki schema + Feature B stash conventions). |
+| #645 | MERGED b36 | unify authoring rules into validator-sourced seam; fix stuck-proposal loop + drain masking. |
+| #643 | MERGED b36 | once-per-asset cooldown on high-salience gate (F2). |
+| #608 | CLOSED→0.10 | automatic encoding-time salience scoring (Gap 1 origin; only partially realized). |
+| #632 | OPEN | recombine clusters = whole-stash tag buckets → bland hypotheses (junk-tag filter shipped; graph-entity clustering pending). |
+| #633 | OPEN (fix shipped b30) | recombine confirmation loop was structurally dead (member-set hash reset streak); Jaccard match fixed it — likely closeable. |
+| #634 | OPEN | procedural over-fits single-project sequences; default-OFF until cross-project gate + identifier-stripping land. |
+| #636 | OPEN | reflect emits proposals missing `description` for source docs lacking one (14/16 rejects in one pass). |
+| #637 | CLOSED (reverted) | "skip improve-review sessions" — built on a bad number (386 sessions = ONE Workflow run). Verify per-day counts before sizing fixes. |
+| #638 | OPEN/superseded | accept-boundary cooldown; superseded by select-time `filterProactiveDue` (cooldown belongs at SELECT, before the wasted LLM call). |
+| #611 | OPEN→0.10 | hierarchical abstraction for lesson clusters (Gap 4 continuation). |
+
+---
+
+## 8. When you modify improve/salience code — checklist
+
+- [ ] Does your change read or write `encoding_salience`? Remember it's clobbered every
+      run (F1). Don't build on the stored value without fixing the overwrite.
+- [ ] New eligibility lane? Add it to `EligibilitySource` (improve-types.ts:60), stamp it
+      at partition time, AND add it to the post-lock cooldown re-filter (improve.ts:1568).
+- [ ] New auto-accepting pass? It must feed `gateAcceptedThisCycle` or multi-cycle
+      termination breaks (F10).
+- [ ] Touching consolidation/extract order? Consolidation MUST precede extract (§1).
+- [ ] New validator finding? Decide error vs `warn` explicitly — default (no severity) is
+      blocking.
+- [ ] New hard bound? Put it in `authoring-rules.ts` and assert prompt↔validator parity in
+      `tests/authoring-rules*`.
+- [ ] Verify with `bun run check` (0 errors / 0 warnings / 0 failures) before commit.
+- [ ] Sizing a fix from session/proposal counts? Verify **per-day generation** counts and
+      session file paths first (`workflows/wf_*` = Workflow tool, not recurring CLI). See
+      akm-verify-impact-against-artifacts.

--- a/src/commands/improve/improve.ts
+++ b/src/commands/improve/improve.ts
@@ -123,6 +123,7 @@ import {
   getAssetSalience,
   getConsecutiveNoOps,
   getLastUseMsByRef,
+  isContentEncodingRow,
   recordNoOp,
   resetConsecutiveNoOps,
   SALIENCE_NO_OP_DAMPEN_FACTOR,
@@ -3372,6 +3373,36 @@ async function runImprovePreparationStage(args: {
   const outcomeWeightEnabled = salienceConfig?.outcomeWeightEnabled === true;
   const salienceMap = new Map<string, ReturnType<typeof computeSalience>>();
   const nowForSalience = Date.now();
+
+  // #644 — preserve content-derived encoding scores across runs.
+  //
+  // Before computing the salience vector, load each ref's stored encoding score
+  // and its provenance. When the stored row carries a genuine content-derived
+  // score (written by the distill path via `scoreEncodingSalience`), pass that
+  // value back in as `inputs.encodingSalience` so `computeSalience` does NOT fall
+  // back to the type-weight stub — keeping both the persisted `encoding_salience`
+  // AND the derived `rank_score` keyed on real novelty/magnitude/prediction-error.
+  // Refs that have never been content-scored keep the type-weight stub fallback.
+  const storedEncodingByRef = new Map<string, number>();
+  {
+    let dbForStoredEncoding: import("../../storage/database").Database | undefined;
+    try {
+      dbForStoredEncoding = openStateDatabase(eventsCtx?.dbPath);
+      for (const r of mergedRefs) {
+        const type = r.ref.includes(":") ? r.ref.slice(0, r.ref.indexOf(":")) : "";
+        const row = getAssetSalience(dbForStoredEncoding, r.ref);
+        if (row && isContentEncodingRow(row, type)) {
+          storedEncodingByRef.set(r.ref, row.encoding_salience);
+        }
+      }
+    } catch (err) {
+      rethrowIfTestIsolationError(err);
+      // best-effort: if DB unavailable, fall back to type-weight stub (prior behaviour)
+    } finally {
+      if (dbForStoredEncoding) dbForStoredEncoding.close();
+    }
+  }
+
   for (const r of mergedRefs) {
     const type = r.ref.includes(":") ? r.ref.slice(0, r.ref.indexOf(":")) : "";
     const sizeBytes = (() => {
@@ -3383,9 +3414,13 @@ async function runImprovePreparationStage(args: {
         return undefined;
       }
     })();
+    const storedEncoding = storedEncodingByRef.get(r.ref);
     const vector = computeSalience({
       ref: r.ref,
       type,
+      // #644: pass the stored content-derived score (if any) so the type-weight
+      // stub is NOT re-asserted over a real distill-written encoding score.
+      ...(storedEncoding !== undefined ? { encodingSalience: storedEncoding } : {}),
       retrievalFreq: retrievalCounts.get(r.ref) ?? 0,
       lastUseMs: lastUseMsByRef.get(r.ref),
       utilityScore: utilityMap.get(r.ref),

--- a/src/commands/improve/salience.ts
+++ b/src/commands/improve/salience.ts
@@ -217,7 +217,25 @@ export interface SalienceVector {
    * normalized to [0,1]. Used for ranking by every selector.
    */
   rankScore: number;
+  /**
+   * Provenance of the `encoding` sub-score (#644):
+   *   "content"   — `inputs.encodingSalience` was supplied (a real content-derived
+   *                 score from `scoreEncodingSalience`).
+   *   "type-stub" — fell back to `DEFAULT_TYPE_ENCODING_WEIGHTS` (no content score).
+   *
+   * `computeSalience` always sets this. Optional only so hand-built vectors (in
+   * tests and ad-hoc callers) need not specify it — `upsertAssetSalience` defaults
+   * an absent value to `"type-stub"`, which is the correct semantics for a vector
+   * built without a content-derived score.
+   *
+   * Persisted to `asset_salience.encoding_source` so a later improve run's
+   * type-stub fallback can no longer clobber a real content-derived score.
+   */
+  encodingSource?: EncodingSource;
 }
+
+/** Provenance tag for a stored `encoding_salience` value. */
+export type EncodingSource = "content" | "type-stub";
 
 // ── Core computation ─────────────────────────────────────────────────────────
 
@@ -236,6 +254,7 @@ export function computeSalience(inputs: SalienceInputs): SalienceVector {
   // Fall back to the type-importance stub only when the caller has not yet
   // computed a content-based score (e.g. on older assets before the first
   // staleness refresh runs).
+  const encodingSource: EncodingSource = inputs.encodingSalience !== undefined ? "content" : "type-stub";
   const encoding =
     inputs.encodingSalience !== undefined
       ? Math.min(1, Math.max(0, inputs.encodingSalience))
@@ -329,7 +348,7 @@ export function computeSalience(inputs: SalienceInputs): SalienceVector {
   const rawRankScore = (we * encoding + wo * outcome + wr * retrieval) * sizePenalty;
   const rankScore = Math.min(1, Math.max(0, rawRankScore));
 
-  return { encoding, outcome, retrieval, rankScore };
+  return { encoding, outcome, retrieval, rankScore, encodingSource };
 }
 
 // ── state.db persistence ─────────────────────────────────────────────────────
@@ -345,26 +364,89 @@ export interface AssetSalienceRow {
   rank_score: number;
   consecutive_no_ops: number;
   updated_at: number;
+  /**
+   * Provenance of `encoding_salience` (#644). `"content"` = real content-derived
+   * score; `"type-stub"` = type-weight fallback; `null` = legacy row (pre-#644
+   * migration 015) of unknown provenance. See {@link isContentEncodingRow}.
+   */
+  encoding_source: EncodingSource | null;
+}
+
+/**
+ * Does this row carry a genuine content-derived `encoding_salience` (#644)?
+ *
+ * Returns true when the provenance flag is `"content"`. For legacy rows
+ * (`encoding_source === null`, written before migration 015) we apply a
+ * conservative heuristic: treat the stored value as content-derived only when it
+ * does NOT equal the pure type-weight stub for the asset's type — because before
+ * the #644 fix every run overwrote real scores with the stub, a value that still
+ * differs from the stub must have been content-written and never re-clobbered.
+ * When the type cannot be determined (no `type` given) a null-provenance row is
+ * treated as a stub (the safe default).
+ */
+export function isContentEncodingRow(row: AssetSalienceRow, type?: string): boolean {
+  if (row.encoding_source === "content") return true;
+  if (row.encoding_source === "type-stub") return false;
+  // Legacy NULL provenance: differ-from-stub heuristic.
+  if (!type) return false;
+  const stub = DEFAULT_TYPE_ENCODING_WEIGHTS[type] ?? DEFAULT_ENCODING_SALIENCE;
+  return Math.abs(row.encoding_salience - stub) > 1e-9;
 }
 
 /**
  * Upsert salience scores for one asset into state.db.
  *
- * Idempotent: safe to call every run; updates all columns on conflict.
+ * Idempotent: safe to call every run; updates the outcome / retrieval / rank
+ * columns on conflict.
+ *
+ * #644 — encoding provenance guard: the `encoding_salience` + `encoding_source`
+ * columns are NOT lowered from a real content-derived score to a type-weight
+ * stub. When the stored row is `encoding_source = 'content'` and the incoming
+ * vector is a `type-stub` fallback, the stored encoding score and its provenance
+ * are preserved (only the other sub-scores and `rank_score` advance). A `content`
+ * write always wins; a `type-stub` write only seeds a row that has no content
+ * score yet. This stops the improve loop's type-weight fallback re-asserting the
+ * stub over a distill-written score on every run.
+ *
+ * NOTE: when the guard preserves the stored encoding score, the incoming
+ * `vector.rankScore` (computed from the stub encoding) is still written. Callers
+ * that want the rank_score to reflect the preserved content score should pass the
+ * stored content score back in as `inputs.encodingSalience` to `computeSalience`
+ * — which the improve loop does. The guard here is the defensive backstop.
  */
 export function upsertAssetSalience(db: Database, ref: string, vector: SalienceVector, now?: number): void {
   const ts = now ?? Date.now();
   db.prepare(
     `INSERT INTO asset_salience
-       (asset_ref, encoding_salience, outcome_salience, retrieval_salience, rank_score, consecutive_no_ops, updated_at)
-     VALUES (?, ?, ?, ?, ?, 0, ?)
+       (asset_ref, encoding_salience, outcome_salience, retrieval_salience, rank_score, consecutive_no_ops, updated_at, encoding_source)
+     VALUES (?, ?, ?, ?, ?, 0, ?, ?)
      ON CONFLICT(asset_ref) DO UPDATE SET
-       encoding_salience  = excluded.encoding_salience,
+       -- #644: never lower a real content-derived score to a type-weight stub.
+       -- Keep the stored encoding score + provenance when the stored row is
+       -- 'content' and the incoming write is a 'type-stub' fallback.
+       encoding_salience  = CASE
+         WHEN asset_salience.encoding_source = 'content' AND excluded.encoding_source = 'type-stub'
+           THEN asset_salience.encoding_salience
+           ELSE excluded.encoding_salience
+       END,
+       encoding_source    = CASE
+         WHEN asset_salience.encoding_source = 'content' AND excluded.encoding_source = 'type-stub'
+           THEN asset_salience.encoding_source
+           ELSE excluded.encoding_source
+       END,
        outcome_salience   = excluded.outcome_salience,
        retrieval_salience = excluded.retrieval_salience,
        rank_score         = excluded.rank_score,
        updated_at         = excluded.updated_at`,
-  ).run(ref, vector.encoding, vector.outcome, vector.retrieval, vector.rankScore, ts);
+  ).run(
+    ref,
+    vector.encoding,
+    vector.outcome,
+    vector.retrieval,
+    vector.rankScore,
+    ts,
+    vector.encodingSource ?? "type-stub",
+  );
 }
 
 /**
@@ -374,7 +456,7 @@ export function getAssetSalience(db: Database, ref: string): AssetSalienceRow | 
   const row = db
     .prepare(
       `SELECT asset_ref, encoding_salience, outcome_salience, retrieval_salience,
-              rank_score, consecutive_no_ops, updated_at
+              rank_score, consecutive_no_ops, updated_at, encoding_source
        FROM asset_salience WHERE asset_ref = ?`,
     )
     .get(ref);

--- a/src/core/state-db.ts
+++ b/src/core/state-db.ts
@@ -820,6 +820,31 @@ const MIGRATIONS: Migration[] = [
         ON recombine_hypotheses(last_seen_at);
     `,
   },
+  // ── Migration 015 — asset_salience: encoding_source provenance column (#644) ──
+  //
+  // Records HOW the stored `encoding_salience` was derived so an improve run's
+  // type-weight fallback can no longer clobber a real content-derived score:
+  //
+  //   "content"   — written by the distill path from `scoreEncodingSalience`
+  //                 (novelty·0.40 + magnitude·0.35 + predictionError·0.25).
+  //   "type-stub" — written by `computeSalience`'s `DEFAULT_TYPE_ENCODING_WEIGHTS`
+  //                 fallback (no content-based score available for this ref yet).
+  //   NULL        — legacy row written before this migration; provenance unknown.
+  //                 Treated as a stub by readers UNLESS its stored value differs
+  //                 from the pure type-weight (best-effort heuristic for old data).
+  //
+  // Why a column rather than inference: before #644, every improve run overwrote
+  // the distill-written content score with the type-weight stub, so the stored
+  // value alone cannot distinguish a real score from a stub. The provenance flag
+  // is the single source of truth going forward; `upsertAssetSalience` refuses to
+  // lower a "content" row to a "type-stub" so the high-salience gate (#608) keys
+  // on genuine novelty/magnitude/prediction-error, not the asset type.
+  {
+    id: "015-asset-salience-encoding-source",
+    up: `
+      ALTER TABLE asset_salience ADD COLUMN encoding_source TEXT DEFAULT NULL;
+    `,
+  },
 ];
 
 /**

--- a/tests/commands/improve/salience.test.ts
+++ b/tests/commands/improve/salience.test.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_TYPE_ENCODING_WEIGHTS,
   getAssetSalience,
   getConsecutiveNoOps,
+  isContentEncodingRow,
   recordNoOp,
   resetConsecutiveNoOps,
   upsertAssetSalience,
@@ -464,6 +465,178 @@ describe("state.db persistence: upsertAssetSalience / getAssetSalience", () => {
       upsertAssetSalience(db, "lesson:beta", vector, NOW);
       const row = getAssetSalience(db, "lesson:beta");
       expect(row?.consecutive_no_ops).toBe(2);
+    } finally {
+      db.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── #644 — encoding provenance: content scores survive the type-stub fallback ──
+
+describe("#644 encoding_salience provenance (content vs type-stub)", () => {
+  // A genuine content-derived score for an agent. The agent type stub is 0.9
+  // (DEFAULT_TYPE_ENCODING_WEIGHTS.agent); 0.65 mimics the issue's measured
+  // community-manager value (content formula ~0.65 < stub 0.9).
+  const CONTENT_SCORE = 0.65;
+
+  test("computeSalience tags encodingSource 'content' when encodingSalience is supplied", () => {
+    const v = computeSalience({ ref: "agent:x", type: "agent", retrievalFreq: 0, encodingSalience: CONTENT_SCORE });
+    expect(v.encoding).toBeCloseTo(CONTENT_SCORE, 6);
+    expect(v.encodingSource).toBe("content");
+  });
+
+  test("computeSalience tags encodingSource 'type-stub' when encodingSalience is absent", () => {
+    const v = computeSalience({ ref: "agent:x", type: "agent", retrievalFreq: 0 });
+    expect(v.encoding).toBeCloseTo(DEFAULT_TYPE_ENCODING_WEIGHTS.agent, 6);
+    expect(v.encodingSource).toBe("type-stub");
+  });
+
+  test("upsert persists encoding_source provenance", () => {
+    const { db, tmpDir } = openTestStateDb();
+    try {
+      const content = computeSalience({
+        ref: "agent:c",
+        type: "agent",
+        retrievalFreq: 0,
+        encodingSalience: CONTENT_SCORE,
+      });
+      upsertAssetSalience(db, "agent:c", content, NOW);
+      expect(getAssetSalience(db, "agent:c")?.encoding_source).toBe("content");
+
+      const stub = computeSalience({ ref: "agent:s", type: "agent", retrievalFreq: 0 });
+      upsertAssetSalience(db, "agent:s", stub, NOW);
+      expect(getAssetSalience(db, "agent:s")?.encoding_source).toBe("type-stub");
+    } finally {
+      db.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("a later type-stub upsert does NOT clobber a stored content-derived score (THE #644 bug)", () => {
+    const { db, tmpDir } = openTestStateDb();
+    try {
+      // 1. Distill writes a real content score (0.65, below the agent stub 0.9).
+      const distillVector = computeSalience({
+        ref: "agent:community-manager",
+        type: "agent",
+        retrievalFreq: 0,
+        encodingSalience: CONTENT_SCORE,
+      });
+      upsertAssetSalience(db, "agent:community-manager", distillVector, NOW - DAY_MS);
+      expect(getAssetSalience(db, "agent:community-manager")?.encoding_salience).toBeCloseTo(CONTENT_SCORE, 6);
+
+      // 2. A later improve run with NO encodingSalience would recompute the
+      //    type-weight stub (0.9). Pre-#644 this overwrote the real score.
+      const stubVector = computeSalience({ ref: "agent:community-manager", type: "agent", retrievalFreq: 0 });
+      expect(stubVector.encoding).toBeCloseTo(0.9, 6); // the stub
+      upsertAssetSalience(db, "agent:community-manager", stubVector, NOW);
+
+      // 3. The stored content score and provenance MUST survive.
+      const row = getAssetSalience(db, "agent:community-manager");
+      expect(row?.encoding_salience).toBeCloseTo(CONTENT_SCORE, 6);
+      expect(row?.encoding_source).toBe("content");
+    } finally {
+      db.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("a content upsert DOES overwrite a prior type-stub row (real score wins)", () => {
+    const { db, tmpDir } = openTestStateDb();
+    try {
+      // 1. First seen as a stub (never content-scored).
+      upsertAssetSalience(
+        db,
+        "agent:a",
+        computeSalience({ ref: "agent:a", type: "agent", retrievalFreq: 0 }),
+        NOW - DAY_MS,
+      );
+      expect(getAssetSalience(db, "agent:a")?.encoding_salience).toBeCloseTo(0.9, 6);
+
+      // 2. Distill later computes a real score → it must replace the stub.
+      upsertAssetSalience(
+        db,
+        "agent:a",
+        computeSalience({ ref: "agent:a", type: "agent", retrievalFreq: 0, encodingSalience: CONTENT_SCORE }),
+        NOW,
+      );
+      const row = getAssetSalience(db, "agent:a");
+      expect(row?.encoding_salience).toBeCloseTo(CONTENT_SCORE, 6);
+      expect(row?.encoding_source).toBe("content");
+    } finally {
+      db.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("a content upsert is updated by a newer content upsert (content→content always wins)", () => {
+    const { db, tmpDir } = openTestStateDb();
+    try {
+      upsertAssetSalience(
+        db,
+        "agent:a",
+        computeSalience({ ref: "agent:a", type: "agent", retrievalFreq: 0, encodingSalience: 0.65 }),
+        NOW - DAY_MS,
+      );
+      upsertAssetSalience(
+        db,
+        "agent:a",
+        computeSalience({ ref: "agent:a", type: "agent", retrievalFreq: 0, encodingSalience: 0.42 }),
+        NOW,
+      );
+      const row = getAssetSalience(db, "agent:a");
+      expect(row?.encoding_salience).toBeCloseTo(0.42, 6);
+      expect(row?.encoding_source).toBe("content");
+    } finally {
+      db.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("isContentEncodingRow: 'content' true, 'type-stub' false", () => {
+    const { db, tmpDir } = openTestStateDb();
+    try {
+      upsertAssetSalience(
+        db,
+        "agent:c",
+        computeSalience({ ref: "agent:c", type: "agent", retrievalFreq: 0, encodingSalience: CONTENT_SCORE }),
+        NOW,
+      );
+      upsertAssetSalience(db, "agent:s", computeSalience({ ref: "agent:s", type: "agent", retrievalFreq: 0 }), NOW);
+      const contentRow = getAssetSalience(db, "agent:c");
+      const stubRow = getAssetSalience(db, "agent:s");
+      expect(contentRow && isContentEncodingRow(contentRow, "agent")).toBe(true);
+      expect(stubRow && isContentEncodingRow(stubRow, "agent")).toBe(false);
+    } finally {
+      db.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("isContentEncodingRow legacy NULL-provenance heuristic: differs-from-stub ⇒ content", () => {
+    const { db, tmpDir } = openTestStateDb();
+    try {
+      // Simulate a legacy row written before migration 015 (encoding_source NULL)
+      // whose stored value differs from the type stub — i.e. a real score that was
+      // never re-clobbered. The heuristic must treat it as content.
+      db.prepare(
+        `INSERT INTO asset_salience
+           (asset_ref, encoding_salience, outcome_salience, retrieval_salience, rank_score, consecutive_no_ops, updated_at, encoding_source)
+         VALUES (?, ?, 0, 0, 0, 0, ?, NULL)`,
+      ).run("memory:legacy-real", 0.83, NOW);
+      // And a legacy row sitting exactly on the type stub — treat as a stub.
+      db.prepare(
+        `INSERT INTO asset_salience
+           (asset_ref, encoding_salience, outcome_salience, retrieval_salience, rank_score, consecutive_no_ops, updated_at, encoding_source)
+         VALUES (?, ?, 0, 0, 0, 0, ?, NULL)`,
+      ).run("agent:legacy-stub", DEFAULT_TYPE_ENCODING_WEIGHTS.agent, NOW);
+
+      const realRow = getAssetSalience(db, "memory:legacy-real");
+      const stubRow = getAssetSalience(db, "agent:legacy-stub");
+      expect(realRow?.encoding_source).toBeNull();
+      expect(realRow && isContentEncodingRow(realRow, "memory")).toBe(true);
+      expect(stubRow && isContentEncodingRow(stubRow, "agent")).toBe(false);
     } finally {
       db.close();
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/storage/__snapshots__/sqlite-migrations.characterization.test.ts.snap
+++ b/tests/storage/__snapshots__/sqlite-migrations.characterization.test.ts.snap
@@ -17,6 +17,7 @@ exports[`SQLite migration runner characterization state.db: fresh-DB migration r
     "012-improve-gate-thresholds",
     "013-extract-sessions-content-hash",
     "014-recombine-hypotheses",
+    "015-asset-salience-encoding-source",
   ],
   "schema": [
     {
@@ -198,7 +199,7 @@ exports[`SQLite migration runner characterization state.db: fresh-DB migration r
         rank_score         REAL    NOT NULL DEFAULT 0.0,
         consecutive_no_ops INTEGER NOT NULL DEFAULT 0,
         updated_at         INTEGER NOT NULL DEFAULT 0
-      , homeostatic_demoted_at INTEGER DEFAULT NULL)"
+      , homeostatic_demoted_at INTEGER DEFAULT NULL, encoding_source TEXT DEFAULT NULL)"
 ,
       "type": "table",
     },

--- a/tests/storage/sqlite-migrations.characterization.test.ts
+++ b/tests/storage/sqlite-migrations.characterization.test.ts
@@ -80,6 +80,7 @@ describe("SQLite migration runner characterization", () => {
         "012-improve-gate-thresholds",
         "013-extract-sessions-content-hash",
         "014-recombine-hypotheses",
+        "015-asset-salience-encoding-source",
       ]);
 
       // The set of durable objects the migrations create.


### PR DESCRIPTION
## Root cause

The `akm improve` high-salience reflect-eligibility gate (#608) admits zero-feedback refs whose `encoding_salience >= salienceThreshold` (default 0.75). But the stored value was almost never the content-derived score from `scoreEncodingSalience` (computed **only at distill time**, `distill.ts:951-975`). It was the `DEFAULT_TYPE_ENCODING_WEIGHTS` **type stub**, re-asserted on every improve run:

1. The improve loop called `computeSalience` **without** `encodingSalience`, so it fell back to the type-weight stub (`salience.ts` encoding branch), and
2. `upsertAssetSalience` then **overwrote** the distill-written content score with that stub on every run — no decay, no provenance.

Net effect: **180/181** "high-salience" refs were selected by asset **type** (skill/agent=0.9, command/workflow=0.8, lesson=0.75 — all clear the 0.75 gate on the stub alone), not by real novelty/magnitude/prediction-error. The gate effectively meant "reflect every feedback-less agent/command/skill/lesson once."

## Approach chosen, and why

The issue listed four candidate directions. The blocker for the smallest one (#1, "load the stored score in the loop") is its own open question: *with no provenance, you cannot tell a real distill-written row from a stub-overwritten one*, because before this fix every run overwrote real scores with the stub.

I therefore implemented a **provenance-based** combination of the issue's #1 + #3, which resolves that open question directly:

1. **Migration 015** adds `asset_salience.encoding_source` — `"content"` (from `scoreEncodingSalience`) vs `"type-stub"` (the type-weight fallback); `NULL` for legacy rows.
2. **`computeSalience`** tags `encodingSource` on its returned vector (`"content"` when `inputs.encodingSalience` is supplied, else `"type-stub"`). **`upsertAssetSalience`** persists it and **refuses to lower a stored `"content"` score to a `"type-stub"`** (a `CASE` guard on both encoding columns). A genuine `"content"` write still always wins; a `"type-stub"` write only seeds a row with no content score yet.
3. The **improve loop** reads each ref's stored row before `computeSalience` and, when it is content-sourced (`isContentEncodingRow`, with a conservative differs-from-stub heuristic for legacy `NULL` rows), passes its `encoding_salience` back in as `inputs.encodingSalience` — so both the persisted `encoding_salience` AND the derived `rank_score` are keyed on the real content score.

**Why not the alternatives:**
- *Run `scoreEncodingSalience` during the improve loop for every ref* (issue #2) would re-derive scores for the whole pool every run — extra cost, and it duplicates the distill path's vocabulary build. The distill path already writes the real score; the bug was purely that improve *clobbered* it. Reading it back is cheaper and principled.
- *Skip stub rows from the gate / change the threshold or type table* (issue #4) masks the bug — the fix is about the score **source**, not the gate's cutoff. The `salienceThreshold` and `DEFAULT_TYPE_ENCODING_WEIGHTS` are **unchanged**.

The type-weight stub remains the genuine fallback for never-content-scored refs. LOOK/CHANGE separation, lane precedence, and the #643 once-per-asset cooldown (F2) are untouched.

## Tests added

New `#644 encoding_salience provenance` block in `tests/commands/improve/salience.test.ts`:
- `computeSalience` tags `encodingSource` `"content"` vs `"type-stub"` correctly.
- `upsertAssetSalience` persists provenance.
- **THE bug:** a later type-stub upsert does NOT clobber a stored content-derived score (content `0.65` survives a stub `0.9` overwrite).
- A `"content"` upsert DOES overwrite a prior `"type-stub"` row (real score wins).
- content→content always updates (newer real score wins).
- `isContentEncodingRow`: `"content"` true / `"type-stub"` false, plus the legacy-`NULL` differs-from-stub heuristic.

Also updated `tests/storage/sqlite-migrations.characterization.test.ts` (+snapshot) for migration 015.

## Verification

`bun run check` (biome lint + `tsc --noEmit` + unit + integration) is green:
- lint: 0 errors / 0 warnings; tsc: clean.
- integration (`tests/commands` incl. all salience/improve tests): **1534 pass, 0 fail**.
- unit: the only full-suite red is the pre-existing `migrate-storage fixture-stash differential` concurrency flake — an **untouched** file that **passes in isolation** (consistent with the known concurrent-workflow flake). All migration/salience tests pass.

## Docs

Updated `docs/design/improve-salience-working-reference.md` (§0 item 1, §2 encoding component, §5-F1, §7) to mark #644 fixed-pending-merge and describe the new provenance behavior.

Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)