### PR TITLE
feat(standards): per-type SOFT authoring conventions (#646)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Per-type SOFT authoring conventions are now user-editable stash facts.** A
+  third authoring-guidance layer joins the hard rules (#645) and general stash
+  standards (#642): a stash owner can author
+  `facts/conventions/assets/<type>.md` (e.g. `…/skill.md`, `…/command.md`) to
+  capture soft, type-specific guidance — voice, structure, length *preference*,
+  naming style. When an agent authors a `skill:x`, the body of
+  `fact:conventions/assets/skill` is injected (type-scoped — authoring
+  `command:y` pulls the `command` convention, never the `skill` one), labeled
+  as soft guidance and kept separate from the validator-enforced hard rules.
+  The basename must be a `getAssetTypes()`-validated asset type; facts are read
+  straight from disk (no index rebuild) and degrade to empty safely. When no
+  per-type fact exists, the built-in `TYPE_HINTS` fallback is unchanged (no
+  regression). These facts carry soft conventions only and can never weaken the
+  authoring contract the gate enforces (`authoringRulesForType` remains the sole
+  source of validator-rejecting rules). The general convention/meta resolver now
+  excludes `facts/conventions/assets/*` so per-type guidance never leaks
+  un-type-scoped into other authoring flows. (#646)
+
 ## [0.9.0-beta.36] — 2026-06-22
 
 ### Added

--- a/docs/design/improve-salience-working-reference.md
+++ b/docs/design/improve-salience-working-reference.md
@@ -227,20 +227,31 @@ equivalent.
 
 ## 4. Standards & authoring-rules seam (HARD vs SOFT)
 
-Two layers, deliberately separate:
+**Three** layers now, deliberately separate (one HARD, two SOFT):
 
 - **HARD rules** (validator-rejecting, code-sourced): `src/core/authoring-rules.ts` →
   `authoringRulesForType()` injected verbatim into reflect/propose/distill/consolidate/
   recombine/procedural/extract/schema-repair prompts. Cannot drift from the gate (#645).
-- **SOFT conventions** (user-editable, advice-only): stash `fact` assets with
-  `category: convention|meta` → `resolveStashStandards(stashRoot)` (resolve-stash-
-  standards.ts:63). No enforcement — prose only.
+  Injected as its own block, AFTER `standardsContext`, in every prompt builder.
+- **SOFT general conventions** (user-editable, advice-only, cross-type): stash `fact`
+  assets with `category: convention|meta` → `resolveStashStandards(stashRoot)`
+  (resolve-stash-standards.ts:63). No enforcement — prose only. **Un-type-scoped.**
+- **SOFT per-type conventions** (user-editable, advice-only, type-scoped, #646):
+  `facts/conventions/assets/<type>.md` → `resolveTypeConventions(stashRoot, type)`
+  (resolve-type-conventions.ts). Basename MUST be a `getAssetTypes()`-validated type;
+  read straight from disk (no index rebuild); degrades to `""`. Augments the built-in
+  `TYPE_HINTS` fallback (`prompts.ts:54`, NOT removed) for that type. To prevent
+  cross-type leakage, `resolveStashStandards` now EXCLUDES `facts/conventions/assets/*`
+  so a `command` author never receives the `skill` convention.
 
-Dispatch: `resolveStandardsContext(ref, stashRoot)` (resolve-standards-context.ts:34) is
-**mutually exclusive**: genuine wiki page → `loadWikiSchema().body` (Feature A);
-non-wiki → `resolveStashStandards()` (Feature B); wiki `raw/`/infra files → `""`.
-Shipped #642 (beta.36). Per-type soft conventions (`facts/conventions/assets/<type>.md`)
-are the open follow-up **#646**.
+Dispatch: `resolveStandardsContext(ref, stashRoot)` (resolve-standards-context.ts) is
+**mutually exclusive at the A/B boundary**: genuine wiki page → `loadWikiSchema().body`
+(Feature A); non-wiki → `resolveStashStandards()` (general SOFT) **plus the type-scoped
+per-type SOFT section appended after it, clearly labeled "soft … guidance, not
+enforced"**; wiki `raw/`/infra files → `""`. The per-type layer never fires for wiki
+targets. Shipped #642 (beta.36); per-type conventions #646 (beta.38, fixed pending merge).
+The HARD/SOFT boundary is intact: per-type facts are advice only and CANNOT weaken the
+gate — `authoringRulesForType` remains the sole validator-enforced source.
 
 ---
 
@@ -345,7 +356,7 @@ rewrites.
 | issue | state | one-liner |
 |---|---|---|
 | **#644** | FIXED (pending merge) | high-salience gate selected on type-weight stub, not content score (F1). Fixed via `encoding_source` provenance (migration 015) + non-lowering `upsertAssetSalience` + loop read-back. |
-| **#646** | OPEN | per-type SOFT convention facts (`facts/conventions/assets/<type>.md`); keep TYPE_HINTS fallback; soft-only. |
+| **#646** | FIXED (pending merge) | per-type SOFT convention facts (`facts/conventions/assets/<type>.md`) via `resolveTypeConventions`, type-scoped, validated by `getAssetTypes()`; built-in TYPE_HINTS fallback kept; general resolver now excludes `conventions/assets/*` to stop cross-type leak; soft-only (HARD rules stay in #645). |
 | #642 | MERGED b36 | standards delivery (Feature A wiki schema + Feature B stash conventions). |
 | #645 | MERGED b36 | unify authoring rules into validator-sourced seam; fix stuck-proposal loop + drain masking. |
 | #643 | MERGED b36 | once-per-asset cooldown on high-salience gate (F2). |

--- a/src/core/standards/resolve-standards-context.ts
+++ b/src/core/standards/resolve-standards-context.ts
@@ -19,9 +19,24 @@
 
 import { extractWikiNameFromRef, INDEX_MD, LOG_MD, loadWikiSchema, SCHEMA_MD } from "../../wiki/wiki";
 import { resolveStashStandards } from "./resolve-stash-standards";
+import { resolveTypeConventions, typeConventionRef } from "./resolve-type-conventions";
 
 /** Wiki infra files that are not authored pages (relative to the wiki root). */
 const WIKI_INFRA_BASENAMES: ReadonlySet<string> = new Set([SCHEMA_MD, INDEX_MD, LOG_MD]);
+
+/**
+ * Extract the asset type from a canonical ref (`[origin//]type:name`) without
+ * throwing. Returns `undefined` for refs that have no `type:` prefix. Kept local
+ * and lenient — the per-type resolver validates the result against
+ * `getAssetTypes()`, so a bogus prefix here simply yields no convention.
+ */
+function refType(ref: string | undefined): string | undefined {
+  if (!ref) return undefined;
+  const body = ref.includes("//") ? ref.slice(ref.indexOf("//") + 2) : ref;
+  const colon = body.indexOf(":");
+  if (colon <= 0) return undefined;
+  return body.slice(0, colon).trim() || undefined;
+}
 
 /**
  * Resolve the standards context for a write target identified by its asset ref.
@@ -34,8 +49,25 @@ const WIKI_INFRA_BASENAMES: ReadonlySet<string> = new Set([SCHEMA_MD, INDEX_MD, 
 export function resolveStandardsContext(ref: string | undefined, stashRoot: string): string {
   const wikiName = ref ? extractWikiNameFromRef(ref) : undefined;
   if (!wikiName) {
-    // Non-wiki asset target → Feature B (stash authoring standards).
-    return resolveStashStandards(stashRoot);
+    // Non-wiki asset target → Feature B (general stash standards) plus the
+    // per-type SOFT conventions layer (#646), type-scoped to the write target.
+    const general = resolveStashStandards(stashRoot);
+
+    const type = refType(ref);
+    // A non-empty body here guarantees `type` is a `getAssetTypes()`-validated
+    // string (the resolver returns "" otherwise).
+    const typeConventions = type ? resolveTypeConventions(stashRoot, type) : "";
+    if (!typeConventions || !type) return general;
+
+    // Soft, type-scoped guidance — clearly labeled and kept separate from the
+    // HARD (validator-enforced) rules that `authoringRulesForType` injects
+    // downstream. These facts are advice only; they never weaken the gate.
+    const softSection = [
+      `# ${typeConventionRef(type)} (soft per-type conventions — guidance, not enforced)`,
+      typeConventions,
+    ].join("\n");
+
+    return general ? `${general}\n\n${softSection}` : softSection;
   }
 
   // Wiki target. Extract the page path after `wiki:<name>/`.

--- a/src/core/standards/resolve-stash-standards.ts
+++ b/src/core/standards/resolve-stash-standards.ts
@@ -27,6 +27,14 @@ const STANDARD_CATEGORIES = new Set(["convention", "meta"]);
 const FACTS_SUBDIR = "facts";
 
 /**
+ * Per-type SOFT convention facts (`facts/conventions/assets/<type>.md`, #646)
+ * are surfaced **type-scoped** through `resolveTypeConventions`, so they must
+ * NOT leak into this un-type-scoped general layer (authoring a `command` must
+ * not pull the `skill` convention). Excluded by relative path (POSIX form).
+ */
+const TYPE_CONVENTIONS_REL = "conventions/assets/";
+
+/**
  * Recursively collect `.md` files under `dir` in stable (sorted) enumeration
  * order. Returns absolute paths. Missing dir → `[]`.
  */
@@ -65,6 +73,11 @@ export function resolveStashStandards(stashRoot: string): string {
   const sections: string[] = [];
 
   for (const absPath of collectMarkdownFiles(factsRoot)) {
+    // Per-type SOFT conventions are delivered type-scoped (#646); skip them
+    // here so they never leak un-type-scoped into every authoring flow.
+    const relPosix = path.relative(factsRoot, absPath).split(path.sep).join("/");
+    if (relPosix.startsWith(TYPE_CONVENTIONS_REL)) continue;
+
     let raw: string;
     try {
       raw = fs.readFileSync(absPath, "utf8");

--- a/src/core/standards/resolve-type-conventions.ts
+++ b/src/core/standards/resolve-type-conventions.ts
@@ -1,0 +1,71 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Resolve **per-type SOFT authoring conventions** (#646) — the third and final
+ * authoring-guidance layer:
+ *
+ *   1. HARD rules (validator-rejecting, code-sourced) → `authoringRulesForType()`
+ *      (`src/core/authoring-rules.ts`, #645). Never editable; the gate enforces them.
+ *   2. General stash standards (cross-type naming/tag conventions) →
+ *      `resolveStashStandards()` `category: convention|meta` facts (#642).
+ *   3. **Per-type SOFT conventions** (voice, structure, length *preference* for
+ *      *this* asset type) → user-editable `facts/conventions/assets/<type>.md`
+ *      (THIS module). Augments the built-in `TYPE_HINTS` fallback for display.
+ *
+ * These facts are **soft only** — advice, not contract. They MUST NOT carry
+ * hard, validator-rejecting rules: a user editing or deleting one must never be
+ * able to weaken the authoring contract the gate enforces (#645 boundary).
+ *
+ * Selection is by a `getAssetTypes()`-validated basename: only
+ * `facts/conventions/assets/<known-type>.md` resolves. Read directly from disk
+ * (no index rebuild); any missing dir/file, unknown type, or read error degrades
+ * to `""` and never throws.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { getAssetTypes } from "../asset/asset-spec";
+import { parseFrontmatter } from "../asset/frontmatter";
+
+/** Sub-path (under the stash root) for per-type SOFT convention facts. */
+export const TYPE_CONVENTIONS_SUBDIR = path.join("facts", "conventions", "assets");
+
+/** The `fact:` ref prefix for a per-type convention, e.g. `fact:conventions/assets/skill`. */
+export function typeConventionRef(type: string): string {
+  return `fact:conventions/assets/${type}`;
+}
+
+/**
+ * Read the SOFT authoring-convention body for asset type `type`, if a stash
+ * owner has authored `facts/conventions/assets/<type>.md`.
+ *
+ * @returns the trimmed markdown body (frontmatter stripped), or `""` when the
+ *          type is unknown, the file is absent, or anything goes wrong.
+ */
+export function resolveTypeConventions(stashRoot: string, type: string | undefined): string {
+  if (!stashRoot || !type) return "";
+
+  // Basename MUST be a known asset type — never resolve an arbitrary file.
+  if (!getAssetTypes().includes(type)) return "";
+
+  const abs = path.join(stashRoot, TYPE_CONVENTIONS_SUBDIR, `${type}.md`);
+  let raw: string;
+  try {
+    raw = fs.readFileSync(abs, "utf8");
+  } catch {
+    return ""; // missing dir/file or read error → degrade to empty
+  }
+
+  let body = "";
+  try {
+    body = parseFrontmatter(raw).content;
+  } catch {
+    // Malformed frontmatter: fall back to the whole file (parseFrontmatter
+    // normally returns whole content as body, but guard defensively).
+    body = raw;
+  }
+
+  return body.trim();
+}

--- a/tests/standards-type-conventions.test.ts
+++ b/tests/standards-type-conventions.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for the per-type SOFT authoring-convention layer (#646):
+ *
+ *   - `resolveTypeConventions(stashRoot, type)` — reads
+ *     `facts/conventions/assets/<type>.md` directly from disk, validated by
+ *     `getAssetTypes()`, degrading to "" on any miss.
+ *   - `resolveStandardsContext(ref, stashRoot)` — type-scoped dispatch: a
+ *     `skill:x` target pulls the `skill` convention, a `command:y` target pulls
+ *     the `command` convention (never the other), the built-in `TYPE_HINTS`
+ *     fallback is untouched, and the un-type-scoped general layer no longer
+ *     leaks per-type facts.
+ *
+ * Pure disk reads through the same resolver the reflect/propose call sites use;
+ * no spawn/serve, fast.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { resolveStandardsContext } from "../src/core/standards/resolve-standards-context";
+import { resolveStashStandards } from "../src/core/standards/resolve-stash-standards";
+import { resolveTypeConventions } from "../src/core/standards/resolve-type-conventions";
+import { makeSandboxDir, makeStashDir, type SandboxedDir } from "./_helpers/sandbox";
+
+function writeTypeConvention(stashRoot: string, type: string, body: string, category = "convention"): void {
+  const abs = path.join(stashRoot, "facts", "conventions", "assets", `${type}.md`);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  const fm = category === "" ? "" : `category: ${category}\n`;
+  fs.writeFileSync(abs, `---\n${fm}---\n\n${body}\n`, "utf8");
+}
+
+function writeFact(stashRoot: string, relPath: string, category: string, body: string): void {
+  const abs = path.join(stashRoot, "facts", relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, `---\ncategory: ${category}\n---\n\n${body}\n`, "utf8");
+}
+
+describe("resolveTypeConventions", () => {
+  let sb: SandboxedDir;
+  beforeEach(() => {
+    sb = makeStashDir();
+  });
+  afterEach(() => sb.cleanup());
+
+  test("returns the body of facts/conventions/assets/<type>.md for a known type", () => {
+    writeTypeConvention(sb.dir, "skill", "Skills should open with an imperative verb.");
+    expect(resolveTypeConventions(sb.dir, "skill")).toBe("Skills should open with an imperative verb.");
+  });
+
+  test("returns '' when the per-type fact is absent", () => {
+    expect(resolveTypeConventions(sb.dir, "skill")).toBe("");
+  });
+
+  test("returns '' when the whole facts dir is missing (degrades safely)", () => {
+    const empty = makeSandboxDir("akm-sb-noconv");
+    try {
+      expect(resolveTypeConventions(empty.dir, "skill")).toBe("");
+    } finally {
+      empty.cleanup();
+    }
+  });
+
+  test("returns '' for a basename that is not a known asset type", () => {
+    // A file exists, but `bogus` is not in getAssetTypes() → never resolved.
+    writeTypeConvention(sb.dir, "bogus", "Some prose for a non-type basename.");
+    expect(resolveTypeConventions(sb.dir, "bogus")).toBe("");
+  });
+
+  test("returns '' for an undefined/empty type", () => {
+    writeTypeConvention(sb.dir, "skill", "Body.");
+    expect(resolveTypeConventions(sb.dir, undefined)).toBe("");
+    expect(resolveTypeConventions(sb.dir, "")).toBe("");
+  });
+
+  test("strips frontmatter, returns only the body", () => {
+    writeTypeConvention(sb.dir, "command", "Command body guidance here.");
+    const out = resolveTypeConventions(sb.dir, "command");
+    expect(out).toContain("Command body guidance here.");
+    expect(out).not.toContain("category:");
+  });
+});
+
+describe("resolveStandardsContext — per-type SOFT conventions (#646)", () => {
+  let sb: SandboxedDir;
+  beforeEach(() => {
+    sb = makeStashDir();
+  });
+  afterEach(() => sb.cleanup());
+
+  test("authoring skill:x injects the skill convention, not the command one (type-scoped)", () => {
+    writeTypeConvention(sb.dir, "skill", "SKILL CONVENTION: keep skills imperative.");
+    writeTypeConvention(sb.dir, "command", "COMMAND CONVENTION: body is the prompt.");
+
+    const skillOut = resolveStandardsContext("skill:deploy", sb.dir);
+    expect(skillOut).toContain("SKILL CONVENTION: keep skills imperative.");
+    expect(skillOut).not.toContain("COMMAND CONVENTION: body is the prompt.");
+    // Labeled clearly as soft guidance.
+    expect(skillOut).toContain("# fact:conventions/assets/skill");
+    expect(skillOut.toLowerCase()).toContain("soft");
+
+    const cmdOut = resolveStandardsContext("command:ship", sb.dir);
+    expect(cmdOut).toContain("COMMAND CONVENTION: body is the prompt.");
+    expect(cmdOut).not.toContain("SKILL CONVENTION: keep skills imperative.");
+  });
+
+  test("when no per-type fact exists, the general layer is returned unchanged (TYPE_HINTS fallback path untouched)", () => {
+    // No per-type fact authored. The dispatch must return exactly the general
+    // stash standards (which is "" here) — the built-in TYPE_HINTS fallback in
+    // prompts.ts is then used downstream, unchanged.
+    expect(resolveStandardsContext("skill:deploy", sb.dir)).toBe("");
+
+    writeFact(sb.dir, "conventions/naming.md", "convention", "Use kebab-case for asset names.");
+    const out = resolveStandardsContext("skill:deploy", sb.dir);
+    expect(out).toContain("Use kebab-case for asset names.");
+    expect(out).not.toContain("conventions/assets");
+  });
+
+  test("general + per-type compose: both appear, per-type clearly separated", () => {
+    writeFact(sb.dir, "conventions/naming.md", "convention", "Use kebab-case for asset names.");
+    writeTypeConvention(sb.dir, "skill", "SKILL CONVENTION: keep skills imperative.");
+
+    const out = resolveStandardsContext("skill:deploy", sb.dir);
+    expect(out).toContain("Use kebab-case for asset names.");
+    expect(out).toContain("SKILL CONVENTION: keep skills imperative.");
+    // The general layer comes first, the per-type soft section after.
+    expect(out.indexOf("kebab-case")).toBeLessThan(out.indexOf("SKILL CONVENTION"));
+  });
+
+  test("per-type facts do NOT leak un-type-scoped through the general layer", () => {
+    // A per-type convention fact carries category: convention, so without the
+    // exclusion it would also be picked up un-type-scoped by resolveStashStandards.
+    writeTypeConvention(sb.dir, "skill", "SKILL CONVENTION should not leak to command.");
+
+    // The general resolver must ignore facts/conventions/assets/*.
+    expect(resolveStashStandards(sb.dir)).toBe("");
+
+    // Authoring a different type must NOT receive the skill convention.
+    const cmdOut = resolveStandardsContext("command:ship", sb.dir);
+    expect(cmdOut).not.toContain("SKILL CONVENTION should not leak to command.");
+  });
+
+  test("a fact under conventions/assets/ with an unknown-type basename is never injected", () => {
+    writeTypeConvention(sb.dir, "bogus", "Junk under a non-type basename.");
+    // Not via the general layer (excluded), and not via the type-scoped layer
+    // (basename not a known type).
+    expect(resolveStashStandards(sb.dir)).toBe("");
+    expect(resolveStandardsContext("bogus:thing" as string, sb.dir)).toBe("");
+  });
+
+  test("wiki targets are unaffected — no per-type convention leaks into Feature A", () => {
+    const dir = path.join(sb.dir, "wikis", "research");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "schema.md"),
+      ["---", "description: research wiki schema", "---", "", "Research rule: cite a source.", ""].join("\n"),
+      "utf8",
+    );
+    writeTypeConvention(sb.dir, "skill", "SKILL CONVENTION: keep skills imperative.");
+
+    const out = resolveStandardsContext("wiki:research/foo", sb.dir);
+    expect(out).toContain("Research rule: cite a source.");
+    expect(out).not.toContain("SKILL CONVENTION: keep skills imperative.");
+  });
+});


### PR DESCRIPTION
## Summary

Adds the third authoring-guidance layer: **per-type SOFT conventions** as user-editable stash facts at `facts/conventions/assets/<type>.md`, surfaced to authoring agents through the existing standards seam. Implements the issue's "cheap alternative" (plan §4) — **not** a `TYPE_HINTS` removal.

Closes #646.

## Layering (one HARD, two SOFT)

| Layer | Source | Editable | Scope |
|---|---|---|---|
| HARD rules (validator-rejecting) | `authoringRulesForType()` (#645) | No | per-type, code |
| General SOFT standards | `resolveStashStandards()` `category: convention\|meta` facts (#642) | Yes | un-type-scoped |
| **Per-type SOFT conventions (THIS PR)** | `facts/conventions/assets/<type>.md` → `resolveTypeConventions()` | Yes | **type-scoped** |

## Design implemented

- **New `resolveTypeConventions(stashRoot, type)`** (`src/core/standards/resolve-type-conventions.ts`): validates the basename against `getAssetTypes()`, reads `facts/conventions/assets/<type>.md` straight from disk (no index rebuild), strips frontmatter, returns the trimmed body or `""` on any miss (unknown type, missing dir/file, read/parse error). Never throws.
- **`resolveStandardsContext`** parses the asset type from the write target's ref and, for non-wiki targets, **appends** the type-scoped soft section after the general stash standards — clearly labeled `# fact:conventions/assets/<type> (soft per-type conventions — guidance, not enforced)`. So `skill:x` injects the `skill` convention and `command:y` injects the `command` one (never the other). The HARD `authoringRulesForType` block is still injected separately and afterward in each prompt builder, preserving the HARD/SOFT separation.
- **`resolveStashStandards` now excludes `facts/conventions/assets/*`** so a per-type fact (which carries `category: convention`) never leaks un-type-scoped into other authoring flows.
- **`TYPE_HINTS` fallback untouched** — when no per-type fact exists, the dispatch returns exactly the general layer and the built-in hint is used downstream as before (no regression).

## Hard boundary (does NOT regress #645)

These facts carry **soft** conventions only and can never weaken the gate. `src/core/authoring-rules.ts` / `authoringRulesForType` is left untouched and remains the sole source of validator-enforced rules. The injected section is explicitly labeled "guidance, not enforced" and is separate from the hard-rules block.

## Deferred (nice-to-haves from the issue, not implemented)

- TYPE_HINTS-derived **starter scaffold** facts.
- The optional **FactLinter** check (flag a `conventions/assets/<basename>.md` whose basename is not a known type / whose `category` isn't `convention`).

These were optional; skipped to keep the change focused. The runtime resolver already validates the basename against `getAssetTypes()` and silently ignores unknown-type / mis-categorized files, so there is no correctness gap — only the authoring-time warning is deferred.

## Tests added

`tests/standards-type-conventions.test.ts`:
- type-scoped injection (skill fact for skill, not for command, and vice versa);
- TYPE_HINTS fallback path when no per-type fact exists;
- safe degradation (missing facts dir / file / unknown type / undefined type);
- basename validation against `getAssetTypes()` (a `bogus.md` is never injected);
- general + per-type compose with the per-type section appearing after;
- no cross-type leak through the general resolver;
- wiki targets unaffected (per-type layer never fires for Feature A).

## Verification

`bun run check` green: biome lint (incl. isolation / license / runtime-boundary lints) clean, `tsc --noEmit` clean, unit `5180 pass / 0 fail`, integration `1534 pass / 0 fail`. (One intermittent host-state flake appeared in an early unit run, did not recur in a clean re-run, and is in no file touched here.)

Working reference doc §4 + §7 updated to reflect the new layer (#646 fixed-pending-merge); CHANGELOG `[Unreleased]` entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)