### PR TITLE
feat(init): seed default per-type SOFT convention templates (#646)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   source of validator-rejecting rules). The general convention/meta resolver now
   excludes `facts/conventions/assets/*` so per-type guidance never leaks
   un-type-scoped into other authoring flows. (#646)
+- **`akm init` now seeds default per-type SOFT convention templates.** Starter
+  `facts/conventions/assets/<type>.md` templates ship in the stash skeleton for
+  the authored types (`lesson, skill, command, agent, knowledge, memory,
+  workflow, script, fact`; `wiki`/`env`/`secret` excluded) so a stash owner has
+  an editable starting point. Each expands the matching built-in `TYPE_HINTS`
+  one-liner into soft starter guidance, carries `category: convention`
+  frontmatter, and states in-body that it is advice, not enforced — it carries
+  **no** validator-rejecting rules, so editing or deleting one cannot weaken the
+  gate (#645). The stash-skeleton copy is now recursive (preserving nested
+  subpaths), and `akm init` seeds **unconditionally** rather than only on first
+  create: re-running it on an existing stash backfills any missing skeleton,
+  convention, or `.meta/index.md` files. Seeding stays absent-only and never
+  overwrites a user-edited file. (#646)
 
 ## [0.9.0-beta.36] — 2026-06-22
 

--- a/docs/design/improve-salience-working-reference.md
+++ b/docs/design/improve-salience-working-reference.md
@@ -243,6 +243,19 @@ equivalent.
   `TYPE_HINTS` fallback (`prompts.ts:54`, NOT removed) for that type. To prevent
   cross-type leakage, `resolveStashStandards` now EXCLUDES `facts/conventions/assets/*`
   so a `command` author never receives the `skill` convention.
+  - **Default templates seeded by `akm init`:** the stash skeleton now ships
+    starter `facts/conventions/assets/<type>.md` templates for the authored types
+    (`lesson, skill, command, agent, knowledge, memory, workflow, script, fact`;
+    `wiki`/`env`/`secret` excluded). They live under
+    `src/assets/stash-skeleton/facts/conventions/assets/` and are mirrored
+    recursively into the stash by `copyStashSkeleton`. `akm init` now seeds
+    UNCONDITIONALLY (not only on first create), so re-running it backfills any
+    missing skeleton/convention/meta files — absent-only, never clobbering a
+    user-edited template. Each template carries `category: convention`, expands
+    the matching `TYPE_HINTS` one-liner into soft starter guidance, and states
+    in-body that it is advice not enforced. The HARD boundary holds: templates
+    carry **no** validator-rejecting rules, so editing/deleting one cannot weaken
+    the gate (#645).
 
 Dispatch: `resolveStandardsContext(ref, stashRoot)` (resolve-standards-context.ts) is
 **mutually exclusive at the A/B boundary**: genuine wiki page → `loadWikiSchema().body`

--- a/src/assets/stash-skeleton/facts/conventions/assets/agent.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/agent.md
@@ -1,0 +1,22 @@
+---
+category: convention
+description: Starter SOFT authoring conventions for agent assets — edit to taste.
+when_to_use: Surfaced to authoring agents when they write or revise an agent asset.
+---
+
+<!--
+  SOFT guidance only — advice, not a contract. Nothing here is enforced by the
+  proposal gate; the validator-rejecting HARD rules live in
+  src/core/authoring-rules.ts (#645) and remain the sole enforced source. Editing
+  or deleting this file cannot weaken the gate.
+-->
+
+# Agent authoring conventions
+
+An agent is markdown whose frontmatter describes a reusable role.
+
+- Frontmatter typically carries `name`, `description`, and optionally `tools` and
+  `model`. Write the `description` so a dispatcher knows exactly when to delegate.
+- The body is the system prompt: establish the role, its scope, and its boundaries.
+- Be explicit about what the agent should and should not do, and what it returns.
+- Prefer a focused single-responsibility persona over a broad do-everything agent.

--- a/src/assets/stash-skeleton/facts/conventions/assets/command.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/command.md
@@ -1,0 +1,22 @@
+---
+category: convention
+description: Starter SOFT authoring conventions for command assets — edit to taste.
+when_to_use: Surfaced to authoring agents when they write or revise a command asset.
+---
+
+<!--
+  SOFT guidance only — advice, not a contract. Nothing here is enforced by the
+  proposal gate; the validator-rejecting HARD rules live in
+  src/core/authoring-rules.ts (#645) and remain the sole enforced source. Editing
+  or deleting this file cannot weaken the gate.
+-->
+
+# Command authoring conventions
+
+A command is a markdown prompt template the user invokes by name.
+
+- Optional frontmatter carries `name` and `description`; the body *is* the prompt.
+- Write the body as the instruction you want the model to follow when invoked.
+- State the task, the expected inputs, and the shape of the desired output up front.
+- Keep it tight and unambiguous — a command is run repeatedly, so vagueness compounds.
+- Use clear placeholders for any arguments the caller will supply.

--- a/src/assets/stash-skeleton/facts/conventions/assets/fact.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/fact.md
@@ -1,0 +1,24 @@
+---
+category: convention
+description: Starter SOFT authoring conventions for fact assets — edit to taste.
+when_to_use: Surfaced to authoring agents when they write or revise a fact asset.
+---
+
+<!--
+  SOFT guidance only — advice, not a contract. Nothing here is enforced by the
+  proposal gate; the validator-rejecting HARD rules live in
+  src/core/authoring-rules.ts (#645) and remain the sole enforced source. Editing
+  or deleting this file cannot weaken the gate.
+-->
+
+# Fact authoring conventions
+
+A fact is durable stash-level context — personal, team, or project details,
+coding conventions, or stash-meta.
+
+- Frontmatter should include a `description` and a `category`
+  (personal | team | project | convention | meta).
+- Set `pinned: true` only for the small always-injected core; most facts stay unpinned.
+- Keep each fact short, high-signal, and self-contained — it is durable context,
+  not an episodic note.
+- Write it as a standing declaration that stays true across sessions.

--- a/src/assets/stash-skeleton/facts/conventions/assets/knowledge.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/knowledge.md
@@ -1,0 +1,22 @@
+---
+category: convention
+description: Starter SOFT authoring conventions for knowledge assets — edit to taste.
+when_to_use: Surfaced to authoring agents when they write or revise a knowledge asset.
+---
+
+<!--
+  SOFT guidance only — advice, not a contract. Nothing here is enforced by the
+  proposal gate; the validator-rejecting HARD rules live in
+  src/core/authoring-rules.ts (#645) and remain the sole enforced source. Editing
+  or deleting this file cannot weaken the gate.
+-->
+
+# Knowledge authoring conventions
+
+A knowledge asset is a reference document meant to be read on demand.
+
+- Open with a top-level `# Title` that names the subject plainly.
+- Organise into concise, well-headed sections so a reader can jump to what they need.
+- Favour accuracy and clarity over completeness; link or cross-reference rather than
+  duplicating other assets.
+- Voice: explanatory and neutral, written to be re-read months later.

--- a/src/assets/stash-skeleton/facts/conventions/assets/lesson.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/lesson.md
@@ -1,0 +1,25 @@
+---
+category: convention
+description: Starter SOFT authoring conventions for lesson assets — edit to taste.
+when_to_use: Surfaced to authoring agents when they write or revise a lesson asset.
+---
+
+<!--
+  SOFT guidance only — advice, not a contract. Nothing here is enforced by the
+  proposal gate; the validator-rejecting HARD rules live in
+  src/core/authoring-rules.ts (#645) and remain the sole enforced source. Editing
+  or deleting this file cannot weaken the gate. Tune the guidance below to match
+  how your stash likes lessons written.
+-->
+
+# Lesson authoring conventions
+
+A lesson captures durable, hard-won judgement about *when* to reach for something
+and *what goes wrong without it* — it is not a restatement of the source asset.
+
+- Lead with the trigger: when should a reader reach for this lesson?
+- Then the failure mode: what breaks, or what gets missed, without it?
+- Then the insight: what did real use reveal that the asset itself does not say?
+- Keep it to one to three short, concrete paragraphs. Prefer specifics over
+  general advice; a lesson earns its keep by being actionable in a real moment.
+- Voice: direct and practical, written for a future agent mid-task.

--- a/src/assets/stash-skeleton/facts/conventions/assets/memory.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/memory.md
@@ -1,0 +1,21 @@
+---
+category: convention
+description: Starter SOFT authoring conventions for memory assets — edit to taste.
+when_to_use: Surfaced to authoring agents when they write or revise a memory asset.
+---
+
+<!--
+  SOFT guidance only — advice, not a contract. Nothing here is enforced by the
+  proposal gate; the validator-rejecting HARD rules live in
+  src/core/authoring-rules.ts (#645) and remain the sole enforced source. Editing
+  or deleting this file cannot weaken the gate.
+-->
+
+# Memory authoring conventions
+
+A memory is a short factual note the user wants persisted across sessions.
+
+- Frontmatter usually includes a `description` that states the fact in one line.
+- Keep the body brief and self-contained — one durable fact or decision per memory.
+- Write it so it still reads clearly with no surrounding conversation for context.
+- Prefer durable, reusable facts over episodic play-by-play of a single session.

--- a/src/assets/stash-skeleton/facts/conventions/assets/script.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/script.md
@@ -1,0 +1,21 @@
+---
+category: convention
+description: Starter SOFT authoring conventions for script assets — edit to taste.
+when_to_use: Surfaced to authoring agents when they write or revise a script asset.
+---
+
+<!--
+  SOFT guidance only — advice, not a contract. Nothing here is enforced by the
+  proposal gate; the validator-rejecting HARD rules live in
+  src/core/authoring-rules.ts (#645) and remain the sole enforced source. Editing
+  or deleting this file cannot weaken the gate.
+-->
+
+# Script authoring conventions
+
+A script is an executable text file stored as-is and run on demand.
+
+- Start with a shebang appropriate to the interpreter (e.g. `#!/usr/bin/env bash`).
+- Follow it with a short usage comment: what the script does and how to invoke it.
+- Keep the script focused on one job; fail loudly and early on bad input.
+- Prefer readable, well-commented logic over cleverness — these get re-run by others.

--- a/src/assets/stash-skeleton/facts/conventions/assets/skill.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/skill.md
@@ -1,0 +1,23 @@
+---
+category: convention
+description: Starter SOFT authoring conventions for skill assets — edit to taste.
+when_to_use: Surfaced to authoring agents when they write or revise a skill asset.
+---
+
+<!--
+  SOFT guidance only — advice, not a contract. Nothing here is enforced by the
+  proposal gate; the validator-rejecting HARD rules live in
+  src/core/authoring-rules.ts (#645) and remain the sole enforced source. Editing
+  or deleting this file cannot weaken the gate.
+-->
+
+# Skill authoring conventions
+
+A skill is a reusable, self-contained capability stored as `skills/<name>/SKILL.md`.
+
+- Frontmatter usually carries `name`, `description`, and `when_to_use`. Write the
+  `description` so a dispatcher can decide *from it alone* whether to load the skill.
+- Open the body with the goal in an imperative voice ("Generate…", "Review…").
+- Structure as: purpose, when to use, then the procedure or guidance as ordered
+  steps or short sections. Favour scannable headings over long prose.
+- Keep it focused on one capability; split unrelated concerns into separate skills.

--- a/src/assets/stash-skeleton/facts/conventions/assets/workflow.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/workflow.md
@@ -1,0 +1,22 @@
+---
+category: convention
+description: Starter SOFT authoring conventions for workflow assets — edit to taste.
+when_to_use: Surfaced to authoring agents when they write or revise a workflow asset.
+---
+
+<!--
+  SOFT guidance only — advice, not a contract. Nothing here is enforced by the
+  proposal gate; the validator-rejecting HARD rules live in
+  src/core/authoring-rules.ts (#645) and remain the sole enforced source. Editing
+  or deleting this file cannot weaken the gate.
+-->
+
+# Workflow authoring conventions
+
+A workflow describes a multi-step process an agent or human follows in order.
+
+- Open with a top-level `# <Title>` naming the workflow's outcome.
+- Lay out the steps as ordered `## Step N` sections, each with a clear action.
+- For each step, state what to do, what it depends on, and how to know it is done.
+- Keep steps atomic and resumable — a reader should be able to stop and pick up midway.
+- Note any branch points or preconditions explicitly rather than burying them in prose.

--- a/src/commands/sources/init.ts
+++ b/src/commands/sources/init.ts
@@ -96,10 +96,13 @@ export async function akmInit(options?: { dir?: string }): Promise<InitResponse>
   // Ensure the default stash is a local git repo (no remote required)
   ensureGitRepo(stashDir);
 
-  if (created) {
-    copyStashSkeleton(stashDir);
-    scaffoldStashMeta(stashDir);
-  }
+  // Run seeding UNCONDITIONALLY (not just when the stash was newly created) so
+  // re-running `akm init` on an existing stash backfills any missing skeleton
+  // files — the README, the per-type SOFT convention templates under
+  // facts/conventions/assets/, and the `.meta/index.md` orientation doc. Both
+  // helpers are absent-only: they never overwrite a file a user has edited.
+  copyStashSkeleton(stashDir);
+  scaffoldStashMeta(stashDir);
 
   // Persist stashDir in config.json
   const configPath = getConfigPath();

--- a/src/commands/sources/stash-skeleton.ts
+++ b/src/commands/sources/stash-skeleton.ts
@@ -9,26 +9,42 @@ import { getDirname } from "../../runtime";
 const SKELETON_DIR = path.join(getDirname(import.meta.url), "../../assets/stash-skeleton");
 
 /**
- * Copy the default stash skeleton into a newly created stash directory.
+ * Copy the default stash skeleton into a stash directory.
  *
- * Each file in src/assets/stash-skeleton/ is written to the stash root only
- * if the destination does not already exist — existing files are never
- * overwritten. Non-fatal: if the skeleton directory is missing or a copy
- * fails the caller continues normally.
+ * The skeleton tree under src/assets/stash-skeleton/ is mirrored **recursively**
+ * into the stash root, preserving relative subpaths (e.g.
+ * `facts/conventions/assets/skill.md` lands at the matching stash subpath).
+ * Each file is written only if the destination does not already exist — existing
+ * (possibly user-edited) files are never overwritten. Intermediate directories
+ * are created as needed.
+ *
+ * Idempotent and absent-only: running it again on an existing stash backfills
+ * any skeleton files that are missing without clobbering present ones. Non-fatal:
+ * if the skeleton directory is missing or a copy fails the caller continues.
  */
 export function copyStashSkeleton(stashDir: string): void {
-  let entries: string[];
+  copySkeletonDir(SKELETON_DIR, stashDir);
+}
+
+/** Recursively mirror `srcDir` into `destDir`, writing files only when absent. */
+function copySkeletonDir(srcDir: string, destDir: string): void {
+  let entries: fs.Dirent[];
   try {
-    entries = fs.readdirSync(SKELETON_DIR);
+    entries = fs.readdirSync(srcDir, { withFileTypes: true });
   } catch {
     return;
   }
 
   for (const entry of entries) {
-    const src = path.join(SKELETON_DIR, entry);
-    const dest = path.join(stashDir, entry);
+    const src = path.join(srcDir, entry.name);
+    const dest = path.join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      copySkeletonDir(src, dest);
+      continue;
+    }
     if (fs.existsSync(dest)) continue;
     try {
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
       fs.copyFileSync(src, dest);
     } catch {
       // Non-fatal — stash is usable without skeleton files

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -12,7 +12,15 @@ import os from "node:os";
 import path from "node:path";
 
 import { akmInit } from "../src/commands/sources/init";
+import { resolveTypeConventions } from "../src/core/standards/resolve-type-conventions";
 import { type Cleanup, sandboxHome, sandboxXdgCacheHome, sandboxXdgConfigHome } from "./_helpers/sandbox";
+
+/** Asset types that ship a default per-type SOFT convention template (#646). */
+const CONVENTION_TYPES = ["lesson", "skill", "command", "agent", "knowledge", "memory", "workflow", "script", "fact"];
+
+function conventionPath(stashDir: string, type: string): string {
+  return path.join(stashDir, "facts", "conventions", "assets", `${type}.md`);
+}
 
 function makeTempDir(prefix: string): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -79,5 +87,83 @@ describe("akm init", () => {
     fs.writeFileSync(readmePath, "custom content", "utf8");
     await akmInit({ dir: stashDir });
     expect(fs.readFileSync(readmePath, "utf8")).toBe("custom content");
+  });
+
+  test("seeds default per-type SOFT convention templates (#646)", async () => {
+    const stashDir = makeTempDir("akm-init-conventions-");
+    fs.rmSync(stashDir, { recursive: true, force: true });
+    await akmInit({ dir: stashDir });
+
+    for (const type of CONVENTION_TYPES) {
+      expect(fs.existsSync(conventionPath(stashDir, type))).toBe(true);
+      // Resolves through the same disk reader the authoring seam uses, with a
+      // non-empty soft body (frontmatter stripped).
+      expect(resolveTypeConventions(stashDir, type).length).toBeGreaterThan(0);
+    }
+  });
+
+  test("convention templates carry category: convention and NO hard-rule phrasing (#645 boundary)", async () => {
+    const stashDir = makeTempDir("akm-init-conv-soft-");
+    fs.rmSync(stashDir, { recursive: true, force: true });
+    await akmInit({ dir: stashDir });
+
+    for (const type of CONVENTION_TYPES) {
+      const raw = fs.readFileSync(conventionPath(stashDir, type), "utf8");
+      expect(raw).toContain("category: convention");
+      // Must not restate the validator's HARD bounds — those live solely in
+      // src/core/authoring-rules.ts. A user editing these must not weaken the gate.
+      expect(raw).not.toContain("20–400");
+      expect(raw).not.toContain("20-400");
+      expect(raw).not.toContain("exactly two");
+      expect(raw).not.toMatch(/\b400\b/);
+    }
+  });
+
+  test("re-init backfills a deleted convention file but does not overwrite an edited one", async () => {
+    const stashDir = makeTempDir("akm-init-conv-backfill-");
+    fs.rmSync(stashDir, { recursive: true, force: true });
+    await akmInit({ dir: stashDir });
+
+    // Delete one convention file and edit another.
+    const skillPath = conventionPath(stashDir, "skill");
+    const factPath = conventionPath(stashDir, "fact");
+    fs.rmSync(skillPath, { force: true });
+    fs.writeFileSync(factPath, "user-edited convention", "utf8");
+    expect(fs.existsSync(skillPath)).toBe(false);
+
+    // Re-init on the EXISTING stash should backfill the missing file...
+    await akmInit({ dir: stashDir });
+    expect(fs.existsSync(skillPath)).toBe(true);
+    expect(resolveTypeConventions(stashDir, "skill").length).toBeGreaterThan(0);
+    // ...but never clobber the user-edited one.
+    expect(fs.readFileSync(factPath, "utf8")).toBe("user-edited convention");
+  });
+
+  test("recursive skeleton copy preserves nested subpaths under the stash root", async () => {
+    const stashDir = makeTempDir("akm-init-conv-subpath-");
+    fs.rmSync(stashDir, { recursive: true, force: true });
+    await akmInit({ dir: stashDir });
+    // The nested asset landed at its mirrored subpath, not flattened to root.
+    expect(fs.existsSync(conventionPath(stashDir, "skill"))).toBe(true);
+    expect(fs.existsSync(path.join(stashDir, "skill.md"))).toBe(false);
+  });
+
+  test("source convention templates ship under src/assets and are picked up by copy-assets", () => {
+    // Build sanity: the embedded source files exist (copy-assets mirrors
+    // src/assets/**/* into dist/assets/ verbatim, so shipping follows).
+    const repoRoot = path.resolve(import.meta.dir, "..");
+    for (const type of CONVENTION_TYPES) {
+      const srcPath = path.join(
+        repoRoot,
+        "src",
+        "assets",
+        "stash-skeleton",
+        "facts",
+        "conventions",
+        "assets",
+        `${type}.md`,
+      );
+      expect(fs.existsSync(srcPath)).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Ships the deferred **"scaffold starter facts"** item from #646: default per-type **SOFT** authoring-convention templates as embedded stash-skeleton assets, seeded by `akm init` into `facts/conventions/assets/<type>.md` — including **backfilling missing files on re-init of an existing stash** (idempotent, absent-only).

The resolver/dispatch half of #646 (`resolveTypeConventions`, type-scoped injection, `getAssetTypes()` validation, `TYPE_HINTS` fallback) already shipped in beta.38; this PR provides the editable starting point a stash owner gets out of the box.

## Templates added

New embedded assets under `src/assets/stash-skeleton/facts/conventions/assets/`, each mirrored to the stash at `facts/conventions/assets/<type>.md`:

`lesson`, `skill`, `command`, `agent`, `knowledge`, `memory`, `workflow`, `script`, `fact`

Excluded by design: `wiki` (Feature A schema path, not per-type conventions), `env`/`secret` (config/credentials, not authored prose). Every basename is a `getAssetTypes()`-validated type, so `resolveTypeConventions` loads each one.

Each template:
- Carries `category: convention` frontmatter + `description` + `when_to_use`.
- Body expands the matching built-in `TYPE_HINTS` one-liner into soft starter guidance (voice, structure, length *preference*, section conventions).
- States in an HTML comment that it is soft guidance, **not enforced** — an owner is expected to edit it.

## #645 HARD boundary (held)

Templates carry **no** validator-rejecting rules (no "20–400 char" bounds, no "exactly two `---` fences", etc.). Those remain solely in `src/core/authoring-rules.ts`. A user editing or deleting a template **cannot weaken the gate**. A test pins this by asserting the templates contain none of the validator-bound phrasing.

## init behavior change

- `copyStashSkeleton` is now **recursive** — it mirrors nested skeleton subpaths (so `facts/conventions/assets/*.md` land at the right stash subpath), creating intermediate dirs, writing **absent-only** (never overwriting an existing/user-edited file).
- `akmInit` now runs `copyStashSkeleton` + `scaffoldStashMeta` **unconditionally** (previously only `if (created)`). Re-running `akm init` on an existing stash now **backfills** any missing skeleton README, per-type convention templates, and `.meta/index.md`. Implication: re-init is a safe top-up — idempotent, non-destructive, never clobbers.

## Tests (tests/init.test.ts)

- Fresh init seeds all 9 templates and `resolveTypeConventions(stash, <type>)` returns a non-empty soft body.
- Re-init **backfills** a deleted convention file and does **not** overwrite a user-edited one.
- Templates carry `category: convention` and contain no hard-rule phrasing (#645 boundary).
- Recursive copy preserves nested subpaths (not flattened to root).
- Source templates exist under `src/assets/...` (build-ship sanity; `copy-assets` mirrors `src/assets/**/*` verbatim).

## Verification

- `bun run check`: passes for all touched code. The full parallel run shows the single **known host-state flake** `tests/migrate-storage-differential.test.ts` (snapshot/fixture-stash differential) — it **passes in isolation** (`14 pass, 0 fail`) and is in no file this PR touches. All other suites green; biome/tsc clean.
- `bun run build`: succeeds; the 9 templates ship to `dist/assets/stash-skeleton/facts/conventions/assets/` (verified: `agent.md command.md fact.md knowledge.md lesson.md memory.md script.md skill.md workflow.md`).

## Docs

- `docs/design/improve-salience-working-reference.md` §4 + `CHANGELOG.md` (`[Unreleased]`) updated to describe the shipped default templates and unconditional/recursive init seeding.

Part of #646 (resolver/dispatch shipped in beta.38; the optional `FactLinter` lint item remains deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)