### PR TITLE
fix(init): --dir no longer silently clobbers the default stash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **BEHAVIOR CHANGE — `akm init --dir <path>` no longer silently repoints your
+  default stash.** Previously, `akm init --dir X` unconditionally wrote
+  `stashDir: X` to `config.json` whenever `X` differed from the configured
+  default — so initializing a throwaway or secondary stash (e.g.
+  `akm init --dir /tmp/scratch`) would hijack the user's real default stash
+  pointer (the footgun documented in `memory:akm-init-persists-stashdir-warning`).
+  Now `init` persists `stashDir` to config **only** when one of the following
+  holds: (a) **no `--dir`** was provided (the default `~/akm` setup flow —
+  unchanged), (b) `--dir` was provided and **no `stashDir` exists in config yet**
+  (first-time bootstrap), or (c) `--dir` was provided **with the new
+  `--set-default` flag** (explicit opt-in). Otherwise `init` still scaffolds and
+  backfills the target dir exactly as before, but **leaves your default stash
+  pointer untouched** and prints:
+  `Your default stash is unchanged (<existing>). Re-run with --set-default to make <dir> the default.`
+  The `InitResponse` JSON gains `defaultStashUpdated: boolean` and an optional
+  `previousStashDir`. To make a `--dir` target your default, pass
+  `akm init --dir <path> --set-default`. (`akm setup` is unaffected — it remains
+  the explicit configuration flow and always sets the default.)
+
 ### Added
 
 - **Per-type SOFT authoring conventions are now user-editable stash facts.** A

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -97,6 +97,21 @@ Creates one subdirectory per asset type under the stash path — currently
 `memories/`, `env/`, `secrets/`, `wikis/`, and `lessons/`. See
 [technical/filesystem.md](technical/filesystem.md) for config file locations.
 
+```sh
+akm init                              # Initialize the default stash (~/akm) and set it as default
+akm init --dir ~/scratch-stash        # Scaffold a secondary stash WITHOUT changing your default
+akm init --dir ~/scratch-stash --set-default  # Scaffold AND make it the default stash
+```
+
+**`--dir <path>`** scaffolds (and backfills) the target directory. By design it
+does **not** change your configured default stash unless you ask: `init` writes
+`stashDir` to `config.json` only when (a) no `--dir` is given, (b) no default is
+configured yet (first-time bootstrap), or (c) you pass **`--set-default`**. When
+a `--dir` is given and a default already exists without `--set-default`, your
+default stash pointer is left untouched and `init` prints a note telling you so.
+This prevents `akm init --dir /tmp/throwaway` from silently hijacking your real
+default stash.
+
 ### setup
 
 Run the interactive first-run wizard.

--- a/src/commands/sources/init.ts
+++ b/src/commands/sources/init.ts
@@ -60,6 +60,19 @@ export interface InitResponse {
   stashDir: string;
   created: boolean;
   configPath: string;
+  /**
+   * Whether this init wrote `stashDir` to the user's config.json (i.e. changed
+   * the default stash pointer). False when `--dir` targeted a secondary stash
+   * and the existing default was deliberately left untouched.
+   */
+  defaultStashUpdated: boolean;
+  /**
+   * The `stashDir` that was configured BEFORE this init ran, when it differs
+   * from the dir we scaffolded and was left in place. Only set when a `--dir`
+   * was provided, an existing default already existed, and `--set-default` was
+   * NOT passed — so the CLI can tell the user their default is unchanged.
+   */
+  previousStashDir?: string;
   ripgrep?: {
     rgPath: string;
     installed: boolean;
@@ -67,7 +80,9 @@ export interface InitResponse {
   };
 }
 
-export async function akmInit(options?: { dir?: string }): Promise<InitResponse> {
+export async function akmInit(options?: { dir?: string; setDefault?: boolean }): Promise<InitResponse> {
+  const dirExplicitlyProvided = options?.dir != null;
+  const setDefault = options?.setDefault === true;
   const stashDir = options?.dir ? path.resolve(options.dir) : getDefaultStashDir();
 
   // Safety check (#473): refuse stashDir at /, $HOME, /etc, ~/.config, etc.
@@ -78,7 +93,7 @@ export async function akmInit(options?: { dir?: string }): Promise<InitResponse>
 
   // Defense-in-depth: refuse to persist an explicit --dir /tmp/... stashDir
   // to config under a test runner. Default HOME-resolved paths are exempt.
-  assertInitSandbox(stashDir, options?.dir != null);
+  assertInitSandbox(stashDir, dirExplicitlyProvided);
 
   let created = false;
   if (!fs.existsSync(stashDir)) {
@@ -104,11 +119,33 @@ export async function akmInit(options?: { dir?: string }): Promise<InitResponse>
   copyStashSkeleton(stashDir);
   scaffoldStashMeta(stashDir);
 
-  // Persist stashDir in config.json
+  // Persist stashDir in config.json — but ONLY when the user is actually
+  // setting up / opting into a default. A bare `akm init --dir <secondary>`
+  // must NOT silently repoint the user's real default stash (the footgun
+  // documented in memory:akm-init-persists-stashdir-warning).
+  //
+  // Decision matrix — persist when ANY of:
+  //   (a) no --dir provided           → default HOME-resolved setup flow
+  //   (b) --dir AND no existing stashDir in config → first-time bootstrap
+  //   (c) --dir AND --set-default      → explicit opt-in
+  // Otherwise (--dir + existing default + no --set-default) leave the default
+  // pointer alone; the target dir is still scaffolded above.
   const configPath = getConfigPath();
   const existing = loadUserConfig();
-  if (!existing.stashDir || existing.stashDir !== stashDir) {
-    saveConfig({ ...existing, stashDir });
+  const existingStashDir = existing.stashDir;
+  const shouldPersist = !dirExplicitlyProvided || !existingStashDir || setDefault;
+
+  let defaultStashUpdated = false;
+  let previousStashDir: string | undefined;
+  if (shouldPersist) {
+    if (!existingStashDir || existingStashDir !== stashDir) {
+      saveConfig({ ...existing, stashDir });
+      defaultStashUpdated = true;
+    }
+    // else: already pointed here — no-op, no spurious rewrite.
+  } else {
+    // Default left untouched; surface it so the CLI can inform the user.
+    previousStashDir = existingStashDir;
   }
 
   // Ensure ripgrep is available (install to cache/bin if needed)
@@ -121,7 +158,7 @@ export async function akmInit(options?: { dir?: string }): Promise<InitResponse>
     // Non-fatal: ripgrep is optional, search works without it
   }
 
-  return { stashDir, created, configPath, ripgrep };
+  return { stashDir, created, configPath, defaultStashUpdated, previousStashDir, ripgrep };
 }
 
 /** Initialise `dir` as a git repository if it is not already one. */

--- a/src/commands/sources/stash-cli.ts
+++ b/src/commands/sources/stash-cli.ts
@@ -51,12 +51,21 @@ export const initCommand = defineJsonCommand({
   },
   args: {
     dir: { type: "string", description: "Custom stash directory path (default: ~/akm)" },
+    "set-default": {
+      type: "boolean",
+      description:
+        "Make --dir the default stash (write stashDir to config.json). Without this, `akm init --dir X` scaffolds X but leaves your existing default stash unchanged.",
+      default: false,
+    },
   },
   async run({ args }) {
     // Accept both historical spellings for backwards compatibility with
     // older docs/scripts that used `--stashDir`.
     const legacyDir = parseFlagValue(process.argv, "--stashDir") ?? parseFlagValue(process.argv, "--stash-dir");
-    const result = await akmInit({ dir: args.dir ?? legacyDir });
+    const result = await akmInit({
+      dir: args.dir ?? legacyDir,
+      setDefault: getHyphenatedBoolean(args, "set-default"),
+    });
     output("init", result);
   },
 });

--- a/src/output/text/helpers.ts
+++ b/src/output/text/helpers.ts
@@ -1055,7 +1055,13 @@ export function formatCuratePlain(r: Record<string, unknown>, detail: DetailLeve
 
 export function formatInitPlain(r: Record<string, unknown>): string {
   let out = `Stash initialized at ${r.stashDir ?? "unknown"}`;
-  if (r.configPath) out += `\nConfig saved to ${r.configPath}`;
+  // When --dir scaffolded a secondary stash but the default was deliberately
+  // left untouched, tell the user instead of silently repointing their default.
+  if (r.defaultStashUpdated === false && typeof r.previousStashDir === "string" && r.previousStashDir) {
+    out += `\nYour default stash is unchanged (${r.previousStashDir}). Re-run with --set-default to make ${r.stashDir} the default.`;
+  } else if (r.configPath) {
+    out += `\nConfig saved to ${r.configPath}`;
+  }
   return out;
 }
 

--- a/src/setup/setup.ts
+++ b/src/setup/setup.ts
@@ -2218,7 +2218,7 @@ export async function runSetupWizard(opts?: { dir?: string; noInit?: boolean }):
   // Bootstrap directory structure before any prompts so the stash exists
   // even if the wizard is interrupted after this point.
   if (!opts?.noInit) {
-    await akmInit({ dir: resolvedStashDir });
+    await akmInit({ dir: resolvedStashDir, setDefault: true });
   }
 
   // Quick connectivity check — skip network-dependent steps when offline
@@ -2446,7 +2446,7 @@ export async function runSetupWithDefaults(opts: {
   // Bootstrap directory structure first
   let initResult: InitResponse | undefined;
   if (!opts.noInit) {
-    initResult = await akmInit({ dir: stashDir });
+    initResult = await akmInit({ dir: stashDir, setDefault: true });
   }
 
   // Run steps in non-interactive mode (applies defaults, skips prompts)
@@ -2783,7 +2783,7 @@ export async function runSetupFromConfig(opts: {
   // Bootstrap directory structure
   let initResult: InitResponse | undefined;
   if (!opts.noInit) {
-    initResult = await akmInit({ dir: stashDir });
+    initResult = await akmInit({ dir: stashDir, setDefault: true });
   }
 
   // Optional probe

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -12,6 +12,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { akmInit } from "../src/commands/sources/init";
+import { loadUserConfig, saveConfig } from "../src/core/config/config";
 import { resolveTypeConventions } from "../src/core/standards/resolve-type-conventions";
 import { type Cleanup, sandboxHome, sandboxXdgCacheHome, sandboxXdgConfigHome } from "./_helpers/sandbox";
 
@@ -146,6 +147,67 @@ describe("akm init", () => {
     // The nested asset landed at its mirrored subpath, not flattened to root.
     expect(fs.existsSync(conventionPath(stashDir, "skill"))).toBe(true);
     expect(fs.existsSync(path.join(stashDir, "skill.md"))).toBe(false);
+  });
+
+  // ── Default-stash persist decision matrix (#footgun: --dir must not clobber) ──
+  describe("default stash persist decision matrix", () => {
+    test("no --dir, no existing stashDir → default-path init persists stashDir", async () => {
+      expect(loadUserConfig().stashDir).toBeUndefined();
+      const result = await akmInit();
+      expect(result.defaultStashUpdated).toBe(true);
+      expect(result.previousStashDir).toBeUndefined();
+      expect(loadUserConfig().stashDir).toBe(result.stashDir);
+    });
+
+    test("--dir X, NO existing stashDir → first-time bootstrap persists X", async () => {
+      const dirX = makeTempDir("akm-init-bootstrap-");
+      fs.rmSync(dirX, { recursive: true, force: true });
+      expect(loadUserConfig().stashDir).toBeUndefined();
+      const result = await akmInit({ dir: dirX });
+      expect(result.defaultStashUpdated).toBe(true);
+      expect(loadUserConfig().stashDir).toBe(dirX);
+    });
+
+    test("--dir X, existing stashDir=Y, NO --set-default → Y preserved, X scaffolded", async () => {
+      const dirY = makeTempDir("akm-init-existing-Y-");
+      saveConfig({ ...loadUserConfig(), stashDir: dirY });
+
+      const dirX = makeTempDir("akm-init-secondary-X-");
+      fs.rmSync(dirX, { recursive: true, force: true });
+      const result = await akmInit({ dir: dirX });
+
+      // Config still points at Y — default pointer left alone.
+      expect(loadUserConfig().stashDir).toBe(dirY);
+      expect(result.stashDir).toBe(dirX);
+      expect(result.defaultStashUpdated).toBe(false);
+      expect(result.previousStashDir).toBe(dirY);
+
+      // ...but X is still fully scaffolded (regression for the non-persist case).
+      expect(fs.existsSync(path.join(dirX, "lessons"))).toBe(true);
+      expect(fs.existsSync(path.join(dirX, "facts"))).toBe(true);
+      expect(fs.existsSync(conventionPath(dirX, "skill"))).toBe(true);
+    });
+
+    test("--dir X, existing stashDir=Y, WITH --set-default → config now points at X", async () => {
+      const dirY = makeTempDir("akm-init-setdefault-Y-");
+      saveConfig({ ...loadUserConfig(), stashDir: dirY });
+
+      const dirX = makeTempDir("akm-init-setdefault-X-");
+      fs.rmSync(dirX, { recursive: true, force: true });
+      const result = await akmInit({ dir: dirX, setDefault: true });
+
+      expect(loadUserConfig().stashDir).toBe(dirX);
+      expect(result.defaultStashUpdated).toBe(true);
+      expect(result.previousStashDir).toBeUndefined();
+    });
+
+    test("--dir X where X equals existing stashDir → no-op, no spurious rewrite", async () => {
+      const dirX = makeTempDir("akm-init-equal-");
+      saveConfig({ ...loadUserConfig(), stashDir: dirX });
+      const result = await akmInit({ dir: dirX });
+      expect(result.defaultStashUpdated).toBe(false);
+      expect(loadUserConfig().stashDir).toBe(dirX);
+    });
   });
 
   test("source convention templates ship under src/assets and are picked up by copy-assets", () => {


### PR DESCRIPTION
## The footgun

`akm init --dir <path>` **silently persisted `stashDir` to the user's `config.json`**, repointing their default stash. The offending block in `src/commands/sources/init.ts` wrote `stashDir` unconditionally whenever the resolved dir differed from config:

```ts
if (!existing.stashDir || existing.stashDir !== stashDir) {
  saveConfig({ ...existing, stashDir });
}
```

So `akm init --dir /tmp/throwaway` (or any secondary/test stash) hijacked the user's real configured default. This bit us twice — see `memory:akm-init-persists-stashdir-warning` and the `assertInitSandbox` guard (which only covered the under-test-runner + `/tmp` case; the general footgun remained for normal use).

## The fix

### New `--set-default` flag

`akm init` gains a boolean `--set-default` flag, wired through `akmInit(options.setDefault)`.

### Persist decision matrix (as implemented)

`init` writes `stashDir` to config **only** when one of these holds:

| Case | Condition | Persist? |
|------|-----------|----------|
| (a) | No `--dir` provided (default `~/akm` setup flow) | ✅ yes (unchanged) |
| (b) | `--dir` provided AND no existing `stashDir` in config | ✅ yes (first-time bootstrap) |
| (c) | `--dir` provided AND `--set-default` passed | ✅ yes (explicit opt-in) |
| — | `--dir` provided, existing `stashDir` set, `--set-default` NOT passed | ❌ no — default left untouched |
| — | `--dir` equals existing `stashDir` | ❌ no-op (no spurious rewrite) |

In the non-persist case the target dir is **still scaffolded/backfilled** exactly as before (recursive skeleton copy + unconditional convention/`.meta` backfill); only the default pointer is left alone.

### New response fields + CLI note

`InitResponse` gains:
- `defaultStashUpdated: boolean`
- `previousStashDir?: string`

When `--dir` was provided but the default was left unchanged, the text formatter prints:

```
Your default stash is unchanged (<existing>). Re-run with --set-default to make <dir> the default.
```

When the default WAS updated, the existing `Config saved to <path>` messaging is preserved.

### `akm setup` unaffected

The three `akmInit` call sites in `src/setup/setup.ts` now pass `setDefault: true` — `setup` remains the explicit "configure my default stash" flow and always sets the default.

### Safety guard retained

`assertInitSandbox` is kept as defense-in-depth (not weakened); the new logic makes the common footgun impossible regardless of test runner. `assertSafeStashDir` untouched.

## Tests added

In `tests/init.test.ts` (isolated config via the XDG sandbox helpers — never touches the real `~/.config/akm/config.json`), a new `default stash persist decision matrix` block covers:

- No `--dir`, no existing stashDir → persists (existing behavior preserved)
- `--dir X`, no existing stashDir → bootstrap persists X
- `--dir X`, existing stashDir=Y, no `--set-default` → config still points at Y; X still scaffolded (`facts/`, `lessons/`, `conventions/skill.md` exist); response `defaultStashUpdated:false`, `previousStashDir:Y`
- `--dir X`, existing stashDir=Y, with `--set-default` → config now points at X; `defaultStashUpdated:true`
- `--dir X` equals existing stashDir → no-op, no spurious rewrite

## Docs

- `CHANGELOG.md` `[Unreleased] → ### Changed` documents the behavior change.
- `docs/cli.md` `init` section + the citty `--help` text document `--dir` / `--set-default`.

## `bun run check`

`0 lint errors / 0 type errors / 0 test failures` — 5190 unit + 1534 integration pass (9+34 skip). The known `migrate-storage fixture-stash differential` host-state flake did not appear.

Background: `memory:akm-init-persists-stashdir-warning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)