### PR TITLE
fix(sync): scope auto-sync staging to akm paths instead of refusing on stray files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Auto-sync no longer refuses to commit akm's own changes when unrelated
+  non-akm files are present in the stash working tree.** When a stash root is
+  shared with a project repo, stray files written into the stash root (e.g. a
+  `tasks.bak-…` backup dir or report artifacts like `data.js`,
+  `akm-health-report.html`, `reports/`) previously tripped the #476 safety
+  guard, which threw `refusing to push: … has uncommitted non-akm changes` on
+  **every** `akm improve` end-of-run auto-sync, `akm sync`, and `akm push`. In
+  one production incident this silently blocked all commits for ~1.5 days while
+  akm kept accepting proposals it never persisted. `saveGitStash` now **scopes
+  what it stages** instead of refusing: (1) an explicit modified-file list when
+  the caller passes `opts.paths`, else (2) the akm-managed pathspecs
+  (`TYPE_DIRS` values + `.akm`) that exist on disk — which by construction never
+  stages non-akm WIP, preserving the #476 protection without an all-or-nothing
+  refusal — and only as a last resort (3) `git add -A` when no managed pathspec
+  can be resolved. If nothing akm-managed is staged the run returns
+  `nothing to commit` (no empty commit, no throw). Unrelated non-akm files are
+  left untouched and uncommitted.
+
 ### Changed
 
 - **BEHAVIOR CHANGE — `akm init --dir <path>` no longer silently repoints your

--- a/src/sources/providers/git.ts
+++ b/src/sources/providers/git.ts
@@ -506,7 +506,7 @@ export function saveGitStash(
   name?: string,
   message?: string,
   writableOverride?: boolean,
-  options?: { push?: boolean; repoDir?: string },
+  options?: { push?: boolean; repoDir?: string; paths?: string[] },
 ): SaveGitStashResult {
   // `push: false` (from `akm sync --no-push`) commits but never pushes, even
   // when the stash is writable with a remote configured.
@@ -559,31 +559,34 @@ export function saveGitStash(
     return { committed: false, pushed: false, skipped: false, output: "nothing to commit, working tree clean" };
   }
 
-  // Safety check (#476): when the stash dir is shared with a non-akm project
-  // (stash root == project repo root), `git add -A` would stage every dirty
-  // file in the user's working tree and push their unrelated WIP to the
-  // stash's remote. Refuse if any dirty path is outside the known akm-
-  // managed subtrees (TYPE_DIRS + `.akm/` state).
-  const nonAkmDirty = collectNonAkmDirtyPaths(statusResult.stdout);
-  if (nonAkmDirty.length > 0) {
-    const sample = nonAkmDirty.slice(0, 10);
-    const more = nonAkmDirty.length > sample.length ? `\n  ...and ${nonAkmDirty.length - sample.length} more` : "";
-    throw new Error(
-      `refusing to push: stash repo at ${repoDir} has uncommitted non-akm changes:\n` +
-        sample.map((p) => `  ${p}`).join("\n") +
-        more +
-        `\nCommit or stash these manually before running an akm push. ` +
-        `Akm-managed paths are: ${Object.values(TYPE_DIRS).join(", ")}, .akm/`,
-    );
+  // Scoped staging (#476 + the auto-sync incident): NEVER refuse akm's commit
+  // because unrelated non-akm files exist in the working tree. When the stash
+  // dir is shared with a non-akm project (stash root == project repo root), a
+  // blunt `git add -A` would sweep the user's unrelated WIP into the stash's
+  // remote. We avoid that by SCOPING what we stage, not by refusing the commit.
+  //
+  // Precedence:
+  //   1. Explicit modified-file list (`options.paths`) — stage exactly those.
+  //   2. Managed pathspecs (TYPE_DIRS values + `.akm`) that exist on disk —
+  //      stages everything akm owns and, by construction, never stages non-akm
+  //      WIP. This preserves the #476 protection WITHOUT refusing.
+  //   3. Last-resort `git add -A` — ONLY when neither an explicit list nor any
+  //      managed pathspec can be resolved. This is the maintainer-approved
+  //      "or all files if we cannot determine the exact file list" fallback and
+  //      is the one (rare) path that could include unrelated non-akm files.
+  if (!stageScopedChanges(repoDir, options?.paths)) {
+    throw new Error(`git add failed while staging akm changes in ${repoDir}`);
   }
 
-  // Stage and commit — supply fallback identity so fresh environments without
-  // user.name/user.email configured can always commit to the default stash.
-  // `add -A` is safe here because nonAkmDirty was just verified empty.
-  const addResult = runGit(["-C", repoDir, "add", "-A"]);
-  if (addResult.status !== 0) {
-    throw new Error(`git add failed: ${addResult.stderr?.trim() || "unknown error"}`);
+  // Nothing actually staged → don't create an empty commit. This happens when
+  // only non-akm files were dirty (precedence 2 staged nothing).
+  const stagedResult = runGit(["-C", repoDir, "diff", "--cached", "--quiet"]);
+  if (stagedResult.status === 0) {
+    return { committed: false, pushed: false, skipped: false, output: "nothing to commit" };
   }
+
+  // Commit — supply fallback identity so fresh environments without
+  // user.name/user.email configured can always commit to the default stash.
   const commitResult = runGit([
     "-C",
     repoDir,
@@ -621,6 +624,54 @@ export function saveGitStash(
     skipped: false,
     output: (commitResult.stdout + pushResult.stdout).trim() || "changes committed and pushed",
   };
+}
+
+/**
+ * Stage akm's changes in `repoDir` using the scoped-staging precedence
+ * documented at the call site (#476). Returns `false` only when a `git add`
+ * subprocess fails; returns `true` otherwise (including when nothing matched —
+ * the caller then detects "nothing staged" via `git diff --cached --quiet`).
+ *
+ * @param paths Optional explicit repo-relative paths akm wrote this run. When
+ *   provided and non-empty, exactly those are staged (chunked to stay under
+ *   argv length limits). Otherwise we fall back to the managed pathspecs, and
+ *   finally to `git add -A` only if no managed pathspec exists on disk.
+ */
+function stageScopedChanges(repoDir: string, paths?: string[]): boolean {
+  // Precedence 1: explicit modified-file list.
+  const explicit = (paths ?? []).filter((p) => typeof p === "string" && p.length > 0);
+  if (explicit.length > 0) {
+    return addPathspecsChunked(repoDir, explicit);
+  }
+
+  // Precedence 2: managed pathspecs that exist on disk (TYPE_DIRS + `.akm`).
+  const managed = [...Object.values(TYPE_DIRS), ".akm"].filter((dir) => fs.existsSync(path.join(repoDir, dir)));
+  if (managed.length > 0) {
+    return addPathspecsChunked(repoDir, managed);
+  }
+
+  // Precedence 3 (last resort): nothing akm-managed resolved on disk. Stage
+  // everything. This is the ONLY branch that can include unrelated non-akm
+  // files — it is the explicit, maintainer-approved "or all files if we cannot
+  // determine the exact file list" fallback and should be rare/never in
+  // practice (a git-backed stash always has at least one managed subtree once
+  // akm has written to it).
+  const addAll = runGit(["-C", repoDir, "add", "-A"]);
+  return addAll.status === 0;
+}
+
+/**
+ * Run `git add -- <pathspec>...` in chunks so a very large path list never
+ * exceeds the OS argv-length limit. Each chunk must succeed.
+ */
+function addPathspecsChunked(repoDir: string, pathspecs: string[]): boolean {
+  const CHUNK = 500;
+  for (let i = 0; i < pathspecs.length; i += CHUNK) {
+    const chunk = pathspecs.slice(i, i + CHUNK);
+    const result = runGit(["-C", repoDir, "add", "--", ...chunk]);
+    if (result.status !== 0) return false;
+  }
+  return true;
 }
 
 function findGitStashByTarget(stashes: SourceConfigEntry[], target: string): SourceConfigEntry | undefined {
@@ -730,45 +781,7 @@ export function classifyCloneFailure(
   return `Failed to clone ${url}: ${detail}`;
 }
 
-// ── Stash-safety helpers (#476) ──────────────────────────────────────────────
-
-/**
- * Inspect `git status --porcelain` output and return every dirty path that is
- * NOT inside an akm-managed subtree. Used by `runUpstreamPush` to refuse
- * pushing unrelated WIP when a writable stash shares its root with a project
- * repo.
- *
- * Porcelain v1 format: `XY <path>` or `XY <orig> -> <new>` for renames. We
- * key off the post-rename path (or the only path) — that is the working-tree
- * file at risk of being staged by `git add -A`.
- */
-function collectNonAkmDirtyPaths(porcelainOutput: string): string[] {
-  const akmDirs = new Set<string>(Object.values(TYPE_DIRS));
-  const result: string[] = [];
-  for (const rawLine of porcelainOutput.split("\n")) {
-    const line = rawLine.replace(/\r$/, "");
-    if (line.length === 0) continue;
-    // Skip the 2-char status code + 1 space.
-    let p = line.length > 3 ? line.slice(3) : "";
-    // Renames / copies: `from -> to`. Stage decision applies to `to`.
-    const arrow = p.lastIndexOf(" -> ");
-    if (arrow !== -1) {
-      p = p.slice(arrow + 4);
-    }
-    // Strip surrounding quotes for paths with special chars.
-    if (p.startsWith('"') && p.endsWith('"') && p.length >= 2) {
-      p = p.slice(1, -1);
-    }
-    if (!p) continue;
-    const segments = p.split("/");
-    const top = segments[0];
-    if (top === ".akm" || akmDirs.has(top)) continue;
-    result.push(p);
-  }
-  return result;
-}
-
 // ── Exports ─────────────────────────────────────────────────────────────────
 
-export { collectNonAkmDirtyPaths, ensureGitMirror, GitSourceProvider, getCachePaths, parseGitRepoUrl };
+export { ensureGitMirror, GitSourceProvider, getCachePaths, parseGitRepoUrl };
 // resolveWritableOverride is exported at its declaration above.

--- a/tests/git-source-safety.test.ts
+++ b/tests/git-source-safety.test.ts
@@ -2,59 +2,208 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Regression suite for #476 — `akm save` git add -A clobbering WIP.
-// runUpstreamPush previously ran `git add -A` unconditionally, so any
-// dirty file in the working tree was staged and pushed. The fix refuses
-// the push when any dirty path is outside akm-managed subtrees (TYPE_DIRS
-// + `.akm/`). This file tests the path-classifier in isolation; the
-// integration path is exercised in git-provider tests.
+// Regression suite for the auto-sync staging behaviour (#476 + the auto-sync
+// incident where stray non-akm files in the stash root refused EVERY commit
+// for ~1.5 days). `saveGitStash` no longer refuses when unrelated non-akm
+// files are dirty; instead it SCOPES what it stages:
+//   1. explicit `options.paths` → exactly those
+//   2. fallback → akm-managed pathspecs (TYPE_DIRS + `.akm`) that exist
+//   3. last resort → `git add -A` (only when no managed pathspec exists)
+// The non-akm files must be left untouched/uncommitted.
 
-import { describe, expect, it } from "bun:test";
-import { collectNonAkmDirtyPaths } from "../src/sources/providers/git";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { saveGitStash } from "../src/sources/providers/git";
+import { type Cleanup, sandboxStashDir, sandboxXdgCacheHome, sandboxXdgConfigHome } from "./_helpers/sandbox";
 
-describe("collectNonAkmDirtyPaths (#476)", () => {
-  it("returns empty when only akm-managed subtrees are dirty", () => {
-    const porcelain = [
-      " M skills/foo/skill.md",
-      "A  commands/bar.md",
-      "?? agents/new.md",
-      " M .akm/state/index.lock",
-    ].join("\n");
-    expect(collectNonAkmDirtyPaths(porcelain)).toEqual([]);
+function initRepo(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  for (const args of [
+    ["init", "--initial-branch=main"],
+    ["config", "user.email", "test@akm.local"],
+    ["config", "user.name", "akm-test"],
+    ["config", "commit.gpgsign", "false"],
+  ] as string[][]) {
+    const result = spawnSync("git", ["-C", dir, ...args], { encoding: "utf8" });
+    if (result.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
+  }
+}
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+/** Files (relative paths) touched by the most recent commit on HEAD. */
+function committedFiles(repoDir: string): string[] {
+  const out = spawnSync("git", ["-C", repoDir, "show", "--name-only", "--format=", "HEAD"], { encoding: "utf8" });
+  return out.stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+/** Porcelain status lines (still-dirty working-tree paths). */
+function status(repoDir: string): string {
+  return spawnSync("git", ["-C", repoDir, "status", "--porcelain"], { encoding: "utf8" }).stdout;
+}
+
+let envCleanup: Cleanup = () => {};
+
+beforeEach(() => {
+  const cacheResult = sandboxXdgCacheHome();
+  const cfgResult = sandboxXdgConfigHome(cacheResult.cleanup);
+  const stashResult = sandboxStashDir(cfgResult.cleanup);
+  envCleanup = stashResult.cleanup;
+});
+
+afterEach(() => {
+  envCleanup();
+  envCleanup = () => {};
+});
+
+describe("saveGitStash — scoped staging (auto-sync incident regression)", () => {
+  test("commits akm-managed files and leaves unrelated non-akm files dirty/untouched", () => {
+    const stashDir = process.env.AKM_STASH_DIR as string;
+    initRepo(stashDir);
+
+    // akm-managed dirty files.
+    writeFile(path.join(stashDir, "memories", "x.md"), "memory x\n");
+    writeFile(path.join(stashDir, "knowledge", "y.md"), "knowledge y\n");
+    // Unrelated non-akm files (the exact shapes that caused the incident).
+    writeFile(path.join(stashDir, "data.js"), "window.data = {};\n");
+    writeFile(path.join(stashDir, "akm-health-report.html"), "<html></html>\n");
+    writeFile(path.join(stashDir, "reports", "summary.txt"), "report\n");
+    writeFile(path.join(stashDir, "tasks.bak-123", "z"), "backup\n");
+
+    const result = saveGitStash(undefined, "scoped commit");
+    expect(result.committed).toBe(true);
+    expect(result.skipped).toBe(false);
+
+    // The commit contains ONLY managed paths.
+    const files = committedFiles(stashDir);
+    expect(files).toContain("memories/x.md");
+    expect(files).toContain("knowledge/y.md");
+    expect(files.some((f) => f.startsWith("data.js"))).toBe(false);
+    expect(files.some((f) => f.startsWith("akm-health-report.html"))).toBe(false);
+    expect(files.some((f) => f.startsWith("reports/"))).toBe(false);
+    expect(files.some((f) => f.startsWith("tasks.bak-123/"))).toBe(false);
+
+    // The non-akm files are STILL dirty afterward (untouched). Untracked
+    // directories are collapsed to "<dir>/" by git porcelain.
+    const after = status(stashDir);
+    expect(after).toContain("data.js");
+    expect(after).toContain("akm-health-report.html");
+    expect(after).toContain("reports/");
+    expect(after).toContain("tasks.bak-123/");
   });
 
-  it("flags top-level non-akm paths", () => {
-    const porcelain = [
-      " M skills/foo/skill.md", // akm — skip
-      " M package.json", // not akm
-      "?? README-DRAFT.md", // not akm
-    ].join("\n");
-    expect(collectNonAkmDirtyPaths(porcelain)).toEqual(["package.json", "README-DRAFT.md"]);
+  test("does NOT throw the old 'refusing to push' error when non-akm files are present", () => {
+    const stashDir = process.env.AKM_STASH_DIR as string;
+    initRepo(stashDir);
+    writeFile(path.join(stashDir, "facts", "a.md"), "fact a\n");
+    writeFile(path.join(stashDir, "scratch.tmp"), "stray\n");
+
+    let threw: unknown;
+    try {
+      saveGitStash(undefined, "no refuse");
+    } catch (err) {
+      threw = err;
+    }
+    expect(threw).toBeUndefined();
   });
 
-  it("flags non-akm subtree paths", () => {
-    const porcelain = [" M src/index.ts", "?? docs/scratch.md", "A  vendor/lib.js"].join("\n");
-    expect(collectNonAkmDirtyPaths(porcelain)).toEqual(["src/index.ts", "docs/scratch.md", "vendor/lib.js"]);
+  test("explicit options.paths stages only the listed subset", () => {
+    const stashDir = process.env.AKM_STASH_DIR as string;
+    initRepo(stashDir);
+    writeFile(path.join(stashDir, "memories", "keep.md"), "keep\n");
+    writeFile(path.join(stashDir, "memories", "skip.md"), "skip\n");
+    writeFile(path.join(stashDir, "lessons", "also-skip.md"), "skip\n");
+
+    const result = saveGitStash(undefined, "subset", undefined, { paths: ["memories/keep.md"] });
+    expect(result.committed).toBe(true);
+
+    const files = committedFiles(stashDir);
+    expect(files).toEqual(["memories/keep.md"]);
+
+    const after = status(stashDir);
+    expect(after).toContain("memories/skip.md");
+    // lessons/ is entirely untracked → porcelain collapses it to "lessons/".
+    expect(after).toContain("lessons/");
   });
 
-  it("uses the post-rename path for renames", () => {
-    const porcelain = "R  src/old.ts -> src/new.ts";
-    // src/new.ts is non-akm → should be flagged.
-    expect(collectNonAkmDirtyPaths(porcelain)).toEqual(["src/new.ts"]);
+  test("only non-akm files dirty → nothing committed, no commit created, no throw", () => {
+    const stashDir = process.env.AKM_STASH_DIR as string;
+    initRepo(stashDir);
+    // Seed an initial commit so HEAD exists, then add only non-akm dirt.
+    writeFile(path.join(stashDir, "knowledge", "seed.md"), "seed\n");
+    saveGitStash(undefined, "seed");
+    const headBefore = spawnSync("git", ["-C", stashDir, "rev-parse", "HEAD"], { encoding: "utf8" }).stdout.trim();
+
+    writeFile(path.join(stashDir, "data.js"), "only non-akm\n");
+    writeFile(path.join(stashDir, "tasks.bak-9", "z"), "backup\n");
+
+    const result = saveGitStash(undefined, "should not commit");
+    expect(result.committed).toBe(false);
+    expect(result.skipped).toBe(false);
+    expect(result.output).toBe("nothing to commit");
+
+    // No new commit was created.
+    const headAfter = spawnSync("git", ["-C", stashDir, "rev-parse", "HEAD"], { encoding: "utf8" }).stdout.trim();
+    expect(headAfter).toBe(headBefore);
+
+    // Non-akm files still dirty.
+    const after = status(stashDir);
+    expect(after).toContain("data.js");
+    // tasks.bak-9/ is entirely untracked → porcelain collapses it.
+    expect(after).toContain("tasks.bak-9/");
   });
 
-  it("strips surrounding quotes for paths with special characters", () => {
-    const porcelain = ' M "skills/has space/file.md"\n M "external/with quote.txt"';
-    expect(collectNonAkmDirtyPaths(porcelain)).toEqual(["external/with quote.txt"]);
+  test("clean tree → nothing to commit, working tree clean", () => {
+    const stashDir = process.env.AKM_STASH_DIR as string;
+    initRepo(stashDir);
+    writeFile(path.join(stashDir, "facts", "seed.md"), "seed\n");
+    saveGitStash(undefined, "seed");
+
+    const result = saveGitStash(undefined, "nothing left");
+    expect(result.committed).toBe(false);
+    expect(result.output).toBe("nothing to commit, working tree clean");
   });
 
-  it("handles trailing carriage returns (git on Windows)", () => {
-    const porcelain = " M src/cli.ts\r\n M skills/ok.md\r";
-    expect(collectNonAkmDirtyPaths(porcelain)).toEqual(["src/cli.ts"]);
-  });
+  test("committed change pushes when a remote is configured and stash is writable", () => {
+    const stashDir = process.env.AKM_STASH_DIR as string;
+    // Bare remote to push into.
+    const remoteDir = `${stashDir}-remote.git`;
+    spawnSync("git", ["init", "--bare", "--initial-branch=main", remoteDir], { encoding: "utf8" });
 
-  it("ignores empty lines", () => {
-    expect(collectNonAkmDirtyPaths("")).toEqual([]);
-    expect(collectNonAkmDirtyPaths("\n\n")).toEqual([]);
+    initRepo(stashDir);
+    spawnSync("git", ["-C", stashDir, "remote", "add", "origin", remoteDir], { encoding: "utf8" });
+    // Seed an initial commit and set the branch upstream so `git push` (no args)
+    // resolves a target — mirrors a cloned writable stash's tracking config.
+    writeFile(path.join(stashDir, "knowledge", "seed.md"), "seed\n");
+    spawnSync("git", ["-C", stashDir, "add", "-A"], { encoding: "utf8" });
+    spawnSync("git", ["-C", stashDir, "-c", "user.name=akm", "-c", "user.email=akm@local", "commit", "-m", "seed"], {
+      encoding: "utf8",
+    });
+    spawnSync("git", ["-C", stashDir, "push", "-u", "origin", "main"], { encoding: "utf8" });
+
+    writeFile(path.join(stashDir, "memories", "pushed.md"), "pushed\n");
+    // Stray non-akm file must NOT block the push.
+    writeFile(path.join(stashDir, "data.js"), "stray\n");
+
+    const result = saveGitStash(undefined, "push it", /* writableOverride */ true);
+    expect(result.committed).toBe(true);
+    expect(result.pushed).toBe(true);
+
+    // The remote received exactly the managed file.
+    const remoteFiles = spawnSync("git", ["-C", remoteDir, "show", "--name-only", "--format=", "HEAD"], {
+      encoding: "utf8",
+    }).stdout;
+    expect(remoteFiles).toContain("memories/pushed.md");
+    expect(remoteFiles).not.toContain("data.js");
+
+    fs.rmSync(remoteDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## The production incident

For ~1.5 days, `akm improve`'s end-of-run auto-sync **refused to commit on every run**. The stash at `~/akm` had a few stray non-akm files in its root — a `tasks.bak-…` backup dir plus recurring report artifacts (`data.js`, `akm-health-report.html`, `reports/`). akm accepted hundreds of proposals (writing under `memories/`, `knowledge/`, `lessons/`, `facts/`, …) but **never committed any of them**, because one unrelated file in the working tree blocked the whole commit. Every `stash_synced` event recorded `committed:false, skipped:true, reason:"refusing to push…"`.

## Root cause

`saveGitStash` (the function `akm improve` auto-sync, `akm sync`, and `akm push` all call) did a blunt `git add -A`, guarded by the #476 safety check `collectNonAkmDirtyPaths`: if **any** dirty path was outside the akm-managed subtrees (`TYPE_DIRS` + `.akm/`), it **threw** `refusing to push: stash repo … has uncommitted non-akm changes`. The #476 concern was legitimate (don't sweep a user's unrelated WIP into the stash's remote when stash-root == project-repo-root) but the all-or-nothing refusal was the wrong remedy — it blocked akm's own commits too.

## The fix — scoped staging

Stage **only akm's own changes**, never refuse because stray files exist. New precedence in `saveGitStash`:

1. **Explicit modified-file list** — new optional `opts.paths?: string[]`. When provided and non-empty, stage exactly those (`git add -- <path>…`, chunked to stay under argv limits).
2. **Managed pathspecs (default fallback)** — `git add -- <each TYPE_DIRS value> .akm`, restricted to those that exist on disk. By construction this never stages non-akm WIP, so it **preserves the #476 protection by scoping rather than refusing**. This is the path `akm sync` and `akm improve` use.
3. **Last resort `git add -A`** — only when neither an explicit list nor any managed pathspec can be resolved (rare/never once akm has written to the stash). This is the explicit, maintainer-approved "or all files if we cannot determine the exact file list" fallback and is the one branch that could include unrelated files; it's documented as such in a comment.

After staging, `git diff --cached --quiet` short-circuits: if nothing akm-managed is staged, return `{committed:false, skipped:false, output:"nothing to commit"}` — no empty commit, no throw. The `refusing to push …` throw and the now-dead `collectNonAkmDirtyPaths` helper are removed. Push logic is unchanged except it's no longer gated behind the refusal — and since staging is scoped, only akm's commits ever get pushed.

### Does `improve` thread an explicit path list?

No — `improve`'s `result` does not already carry a flat written-paths set, so wiring an exact list would be more than a modest change. Per the maintainer's guidance, `improve` (and `akm sync`) use the **managed-pathspec fallback (path 2)**, which already guarantees only akm-owned files are committed. The `opts.paths` parameter is exposed on `saveGitStash` for correctness and future use.

## Tests

Rewrote `tests/git-source-safety.test.ts` (the old file only unit-tested the now-removed classifier) into real-temp-repo integration tests:

- **Main regression**: akm-managed (`memories/x.md`, `knowledge/y.md`) **and** non-akm dirty (`data.js`, `akm-health-report.html`, `reports/`, `tasks.bak-123/z`) → commit contains **only** managed paths; non-akm files remain dirty/untouched afterward.
- Explicit `opts.paths` subset → only listed paths committed.
- Only non-akm files dirty → `nothing to commit`, no commit created, no throw, files stay dirty.
- Clean tree → `nothing to commit, working tree clean`.
- Committed change pushes to a configured bare remote when writable (stray non-akm file does not block it; remote receives only the managed file).
- Asserts the old `refusing to push` error is **no longer thrown** when non-akm files are present.

## Quality

`bun run check` clean: biome lint 0, `tsc --noEmit` 0, unit 5189 pass / 0 fail, integration 1534 pass / 0 fail. The known `migrate-storage` host-state flake did not appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)