### PR TITLE
fix(improve): high-salience lane requires content-derived encoding_source (#655)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **The high-salience improve admission lane (#608) now requires a
+  content-derived encoding score, not the per-type weight stub (#655,
+  #608/#644 follow-up).** The lane previously admitted any zero-feedback ref
+  whose `asset_salience.encoding_salience >= salienceThreshold` (default 0.75).
+  But for assets distill has not content-scored, `encoding_salience` is just the
+  per-type WEIGHT STUB (skill/agent 0.9, command/workflow 0.8, lesson 0.75), so
+  "high-salience" degenerated into "is a skill/agent/command/lesson" — which
+  selected the type-stub `lore-writer` agent on every run (prod: 1 content-scored
+  / 37 type-stub / 1826 NULL-legacy rows). The gate now also requires
+  `isContentEncodingRow(row, parseAssetRef(ref).type)` (the #644 provenance
+  helper), so only genuinely content-scored assets qualify. This preserves
+  #608's intent — distilled assets, the lane's real targets, keep their real
+  content score and still qualify — while cutting the type-stub waste; type-stub
+  rows must earn retrieval/feedback signal via the other lanes. NULL-legacy rows
+  follow `isContentEncodingRow`'s differs-from-stub heuristic. An aggregated log
+  line now reports how many refs the lane admitted so lane composition is
+  observable. The threshold, type-weight table, 10% cap, and `isContentEncodingRow`
+  are unchanged.
+
 - **Auto-sync no longer refuses to commit akm's own changes when unrelated
   non-akm files are present in the stash working tree.** When a stash root is
   shared with a project repo, stray files written into the stash root (e.g. a

--- a/docs/design/improve-salience-working-reference.md
+++ b/docs/design/improve-salience-working-reference.md
@@ -63,7 +63,7 @@ list the **footguns that have already bitten us** so we don't reintroduce them.
 | signal-delta partition | prep 2-3 | improve.ts:2762 | `eligibleRefs`, `distillOnlyRefs`, `noFeedbackPool` | 30-day window; `--scope` bypasses |
 | high-retrieval (P0-A) | prep 3 | improve.ts:3008 | `highRetrievalRefs` | `retrievalCount>=5`, no prior reflect proposal |
 | proactive maintenance | prep 3 | improve.ts:3035 | `proactiveRefs` | `proactiveMaintenance` enabled (**default OFF**) |
-| high-salience admission (#608) | prep 3 | improve.ts:3112 | `highSalienceRefs` (≤10% of limit) | `encoding_salience>=0.75`, no prior reflect proposal |
+| high-salience admission (#608) | prep 3 | improve.ts:3112 | `highSalienceRefs` (≤10% of limit) | `isContentEncodingRow` (content provenance, #655) AND `encoding_salience>=0.75`, no prior reflect proposal |
 | forgetting-safety | prep | improve.ts:3536 | force-add fallen refs | WS-1 rank-change report (scenario B) |
 | replay | prep | improve.ts:3650 | append refs after `--limit` | `replayBudget>0` (**default 0**) |
 | salience sort + no-op dampen | prep 4 | improve.ts:3782 | `loopRefs` priority order | always |
@@ -286,6 +286,23 @@ content-sourced, passes `encodingSalience` back in so the rank score is computed
 real content score too. The type-weight stub remains the genuine fallback for
 never-content-scored refs. (improve.ts ~3375; salience.ts `upsertAssetSalience` /
 `isContentEncodingRow`; distill.ts:973; state-db.ts migration 015)
+
+**F1-follow-up (#655) — the high-salience gate now REQUIRES content provenance.**
+Fixing the clobber (above) stopped the stub overwriting real scores, but the gate
+itself still admitted on `encoding_salience >= threshold` alone, so any unscored
+asset still qualified on its type-weight stub (skill/agent 0.9, command/workflow
+0.8, lesson 0.75) — "high-salience" = "is an agent/command/skill/lesson" — which
+selected the type-stub `lore-writer` agent every run (prod: 1 content / 37 stub /
+1826 NULL). The gate now ALSO requires
+`isContentEncodingRow(row, parseAssetRef(ref).type)` (improve.ts ~3127), so only
+genuinely content-scored rows (and NULL-legacy rows that differ from their type
+stub) are admitted; type-stub rows must earn signal via the other lanes. This
+preserves #608's intent — distilled assets keep their real content score and
+still qualify. Unchanged: threshold, type-weight table, 10% cap,
+`isContentEncodingRow`. An aggregated `[improve] high-salience lane admitted N
+content-scored ref(s)` log line makes lane composition observable; measure it
+after rollout (the skeptic's caveat — the lane shrinks, by design, until more
+assets carry content scores).
 
 **F2 — the high-salience gate fires exactly once, then never again.**
 `!lastReflectProposalTs.has(r.ref)` (improve.ts:3126, the #643 cooldown) permanently

--- a/src/commands/improve/improve.ts
+++ b/src/commands/improve/improve.ts
@@ -3110,6 +3110,18 @@ async function runImprovePreparationStage(args: {
   // noFeedbackCandidates), burning LLM calls and churning the asset. This
   // mirrors the P0-A high-retrieval gate's `!lastReflectProposalTs.has(r.ref)`
   // guard above so all "rescue" lanes share the same once-per-asset semantics.
+  //
+  // Content-provenance gate (#644 follow-up): the row must ALSO carry a genuine
+  // content-derived encoding score (`isContentEncodingRow`). Otherwise the lane
+  // admits the per-type WEIGHT STUB (skill/agent 0.9, command/workflow 0.8,
+  // lesson 0.75 from DEFAULT_TYPE_ENCODING_WEIGHTS) for every distill-unscored
+  // asset — i.e. "high-salience" degenerates into "is a skill/agent/command/
+  // lesson", which selected the lore-writer type-stub agent on every run. Only
+  // content-scored assets earn the high-salience rescue; type-stub rows must
+  // earn retrieval/feedback signal via the other lanes. This PRESERVES #608's
+  // intent — distilled assets (the lane's real targets) keep their real content
+  // score and still qualify — while cutting the type-stub waste. See §5 F1 of
+  // docs/design/improve-salience-working-reference.md and #608/#644.
   const highSalienceRefs: ImproveEligibleRef[] = [];
   const salienceCfg = (options.config ?? loadConfig()).improve?.salience;
   const salienceThreshold = salienceCfg?.salienceThreshold ?? 0.75;
@@ -3124,7 +3136,12 @@ async function runImprovePreparationStage(args: {
       for (const r of candidates) {
         if (highSalienceRefs.length >= highSalienceCap) break;
         const row = getAssetSalience(dbForHighSalience, r.ref);
-        if (row && row.encoding_salience >= salienceThreshold && !lastReflectProposalTs.has(r.ref)) {
+        if (
+          row &&
+          isContentEncodingRow(row, parseAssetRef(r.ref).type) &&
+          row.encoding_salience >= salienceThreshold &&
+          !lastReflectProposalTs.has(r.ref)
+        ) {
           highSalienceRefs.push(r);
         }
       }
@@ -3133,6 +3150,12 @@ async function runImprovePreparationStage(args: {
       // best-effort: if DB unavailable, highSalienceRefs stays empty
     } finally {
       if (dbForHighSalience) dbForHighSalience.close();
+    }
+    if (highSalienceRefs.length > 0) {
+      info(
+        `[improve] high-salience lane admitted ${highSalienceRefs.length} content-scored ref(s) ` +
+          `(threshold=${salienceThreshold}, requires content-derived encoding_source)`,
+      );
     }
   }
 

--- a/tests/commands/improve/improve-eligibility.test.ts
+++ b/tests/commands/improve/improve-eligibility.test.ts
@@ -19,7 +19,13 @@ import path from "node:path";
 import type { AkmDistillResult } from "../../../src/commands/improve/distill";
 import { akmImprove } from "../../../src/commands/improve/improve";
 import type { AkmReflectResult } from "../../../src/commands/improve/reflect";
-import { upsertAssetSalience } from "../../../src/commands/improve/salience";
+import type { AssetSalienceRow } from "../../../src/commands/improve/salience";
+import {
+  DEFAULT_ENCODING_SALIENCE,
+  DEFAULT_TYPE_ENCODING_WEIGHTS,
+  isContentEncodingRow,
+  upsertAssetSalience,
+} from "../../../src/commands/improve/salience";
 import { saveConfig } from "../../../src/core/config/config";
 import { appendEvent, readEvents } from "../../../src/core/events";
 import { getDbPath } from "../../../src/core/paths";
@@ -659,22 +665,52 @@ describe("P0-A high-retrieval fallback (zero-feedback assets)", () => {
 // ── Layer 3: high-salience admission gate (#608) ──────────────────────────────
 
 describe("high-salience admission gate (#608)", () => {
-  function seedSalience(ref: string, encoding: number): void {
+  // #644 follow-up: the high-salience lane requires a CONTENT-derived encoding
+  // score (`encoding_source = 'content'`), not the per-type weight stub. Default
+  // to "content" here so existing #608 cases model genuinely distilled assets
+  // (the lane's real targets); the type-stub exclusion is asserted separately.
+  function seedSalience(
+    ref: string,
+    encoding: number,
+    encodingSource: "content" | "type-stub" | null = "content",
+  ): void {
     const db = openStateDatabase();
     try {
-      upsertAssetSalience(db, ref, { encoding, outcome: 0, retrieval: 0, rankScore: 0.2 });
+      if (encodingSource === null) {
+        // Legacy NULL-provenance row (pre-#644 migration 015). Write the raw
+        // value with a NULL encoding_source so `isContentEncodingRow`'s
+        // differs-from-stub heuristic governs admission.
+        db.prepare(
+          `INSERT INTO asset_salience
+             (asset_ref, encoding_salience, outcome_salience, retrieval_salience, rank_score, consecutive_no_ops, updated_at, encoding_source)
+           VALUES (?, ?, 0, 0, 0.2, 0, ?, NULL)
+           ON CONFLICT(asset_ref) DO UPDATE SET
+             encoding_salience = excluded.encoding_salience,
+             encoding_source = NULL,
+             updated_at = excluded.updated_at`,
+        ).run(ref, encoding, Date.now());
+      } else {
+        upsertAssetSalience(db, ref, {
+          encoding,
+          outcome: 0,
+          retrieval: 0,
+          rankScore: 0.2,
+          encodingSource,
+        });
+      }
     } finally {
       db.close();
     }
   }
 
-  test("zero-feedback ref with encoding_salience ≥ threshold and no prior reflect → reflected", async () => {
+  test("zero-feedback ref with content encoding_salience ≥ threshold and no prior reflect → reflected", async () => {
     const stash = makeTempDir("akm-hs-rescue-");
     writeMemory(stash, "salient", "Newly distilled, never surfaced to a user.");
     await buildIndex(stash);
-    // High encoding_salience, no retrieval, no feedback — only the high-salience
-    // lane can rescue it (memory type-weight fallback is 0.5, below threshold).
-    seedSalience("memory:salient", 0.9);
+    // High CONTENT-derived encoding_salience, no retrieval, no feedback — only the
+    // high-salience lane can rescue it (memory type-weight fallback is 0.5, below
+    // threshold). This is #608's real target: a distilled, content-scored asset.
+    seedSalience("memory:salient", 0.9, "content");
 
     const reflected: string[] = [];
     await akmImprove({
@@ -697,7 +733,7 @@ describe("high-salience admission gate (#608)", () => {
     const stash = makeTempDir("akm-hs-once-");
     writeMemory(stash, "salient", "High salience but already reflected once.");
     await buildIndex(stash);
-    seedSalience("memory:salient", 0.9);
+    seedSalience("memory:salient", 0.9, "content");
     // A reflect proposal already exists for this ref. Without the cooldown guard
     // the high-salience lane re-selected it every run (auto-accept emits a
     // `promoted` event, not `feedback`, so it never leaves noFeedbackCandidates),
@@ -719,6 +755,87 @@ describe("high-salience admission gate (#608)", () => {
     });
 
     expect(reflected).not.toContain("memory:salient");
+  });
+
+  // #644 follow-up — the lore-writer case. A type-stub row (encoding_salience set
+  // to the per-type WEIGHT STUB, e.g. agent 0.9) must NOT be admitted: before this
+  // fix "high-salience" degenerated into "is a skill/agent/command/lesson", and a
+  // type-stub agent (lore-writer) was selected by the lane on every run. The gate
+  // now requires content-derived provenance, so a `type-stub` row is excluded even
+  // though its `encoding_salience` (0.9) is well above the 0.75 threshold.
+  test("type-stub row (encoding_source='type-stub', 0.9) is NOT admitted — the lore-writer case", async () => {
+    const stash = makeTempDir("akm-hs-typestub-");
+    writeMemory(stash, "stub", "Type-stub asset; never content-scored.");
+    await buildIndex(stash);
+    // Explicit type-stub provenance: isContentEncodingRow returns false outright,
+    // regardless of the value differing from the (memory) stub.
+    seedSalience("memory:stub", 0.9, "type-stub");
+
+    const reflected: string[] = [];
+    await akmImprove({
+      scope: "memory",
+      stashDir: stash,
+      minRetrievalCount: 5,
+      ensureIndexFn: async () => false,
+      reindexFn: async () => ({ schemaVersion: 1, ok: true, indexed: 0, warnings: [], errors: [], durationMs: 0 }),
+      reflectFn: async ({ ref }) => {
+        if (ref) reflected.push(ref);
+        return okReflect(ref ?? "");
+      },
+      distillFn: async ({ ref }) => okDistill(ref ?? ""),
+    });
+
+    expect(reflected).not.toContain("memory:stub");
+  });
+
+  // Legacy NULL-provenance row (pre-#644 migration 015). isContentEncodingRow
+  // applies the differs-from-stub heuristic: a NULL row whose value still differs
+  // from the per-type stub must have been content-written and never re-clobbered,
+  // so it is treated as content and IS admitted. Memory stub is 0.5; 0.9 ≠ 0.5.
+  test("legacy NULL-provenance row that DIFFERS from the type stub IS admitted (differs-from-stub heuristic)", async () => {
+    const stash = makeTempDir("akm-hs-null-diff-");
+    writeMemory(stash, "legacy", "Legacy row, value differs from stub.");
+    await buildIndex(stash);
+    seedSalience("memory:legacy", 0.9, null);
+
+    const reflected: string[] = [];
+    await akmImprove({
+      scope: "memory",
+      stashDir: stash,
+      minRetrievalCount: 5,
+      ensureIndexFn: async () => false,
+      reindexFn: async () => ({ schemaVersion: 1, ok: true, indexed: 0, warnings: [], errors: [], durationMs: 0 }),
+      reflectFn: async ({ ref }) => {
+        if (ref) reflected.push(ref);
+        return okReflect(ref ?? "");
+      },
+      distillFn: async ({ ref }) => okDistill(ref ?? ""),
+    });
+
+    expect(reflected).toContain("memory:legacy");
+  });
+
+  // Legacy NULL-provenance row whose value EQUALS the per-type stub. The
+  // heuristic treats it as a stub (the safe default) → NOT admitted. Asserted at
+  // the helper level (a non-indexed lesson ref would never be a run candidate, so
+  // routing it through akmImprove would be vacuous): the gate calls
+  // `isContentEncodingRow(row, parseAssetRef(ref).type)` and admits only when it
+  // returns true. lesson stub = 0.75; a NULL row at exactly 0.75 returns false.
+  test("legacy NULL-provenance row that EQUALS the type stub is treated as a stub (isContentEncodingRow=false)", () => {
+    const equalsStub: AssetSalienceRow = {
+      asset_ref: "lesson:atstub",
+      encoding_salience: DEFAULT_TYPE_ENCODING_WEIGHTS.lesson ?? DEFAULT_ENCODING_SALIENCE,
+      outcome_salience: 0,
+      retrieval_salience: 0,
+      rank_score: 0.2,
+      consecutive_no_ops: 0,
+      updated_at: Date.now(),
+      encoding_source: null,
+    };
+    // EQUALS stub → not content → excluded from the lane.
+    expect(isContentEncodingRow(equalsStub, "lesson")).toBe(false);
+    // DIFFERS from stub → content (never re-clobbered) → admitted by the lane.
+    expect(isContentEncodingRow({ ...equalsStub, encoding_salience: 0.9 }, "lesson")).toBe(true);
   });
 });
 

--- a/tests/commands/improve/salience-wiring.test.ts
+++ b/tests/commands/improve/salience-wiring.test.ts
@@ -630,7 +630,11 @@ describe("#608 high-salience admission gate", () => {
     writeSkill(stash, "novel-skill", "A genuinely novel skill with critical error handling.");
     await buildIndex(stash);
 
-    // Pre-seed encoding_salience above the default threshold (0.75).
+    // Pre-seed a CONTENT-derived encoding_salience above the default threshold
+    // (0.75). #655: the high-salience lane requires content provenance — a
+    // type-stub row no longer qualifies (that was the lore-writer footgun) — and
+    // this case models a genuinely content-scored novel skill, the lane's real
+    // target.
     const dbSetup = openStateDatabase();
     try {
       upsertAssetSalience(dbSetup, "skill:novel-skill", {
@@ -638,6 +642,7 @@ describe("#608 high-salience admission gate", () => {
         outcome: 0,
         retrieval: 0,
         rankScore: 0.2,
+        encodingSource: "content",
       });
     } finally {
       dbSetup.close();
@@ -685,11 +690,15 @@ describe("#608 high-salience admission gate", () => {
 
     const dbSetup = openStateDatabase();
     try {
+      // Content-provenance so the ONLY thing keeping this ref out of the lane is
+      // the threshold (1.0 > 0.82), not the #655 content gate — this test pins
+      // the threshold knob specifically.
       upsertAssetSalience(dbSetup, "skill:gated-skill", {
         encoding: 0.82,
         outcome: 0,
         retrieval: 0,
         rankScore: 0.2,
+        encodingSource: "content",
       });
     } finally {
       dbSetup.close();


### PR DESCRIPTION
## Problem

The high-salience admission lane (#608) admitted any zero-feedback ref whose `asset_salience.encoding_salience >= salienceThreshold` (default 0.75). But for any asset distill has not content-scored, `encoding_salience` is just the per-type **WEIGHT STUB** (`DEFAULT_TYPE_ENCODING_WEIGHTS`: skill/agent 0.9, command/workflow 0.8, lesson 0.75). Production reality: **1 content-scored / 37 type-stub / 1826 NULL-legacy** rows. So "high-salience" degenerated into "is a skill/agent/command/lesson" — which selected the type-stub `lore-writer` agent on every run.

#644 (merged) added the `encoding_source` provenance column and the `isContentEncodingRow` helper, but the admission gate did not yet use it.

## The fix

In `src/commands/improve/improve.ts` the high-salience gate now ALSO requires content provenance:

```ts
if (
  row &&
  isContentEncodingRow(row, parseAssetRef(r.ref).type) &&
  row.encoding_salience >= salienceThreshold &&
  !lastReflectProposalTs.has(r.ref)
) {
  highSalienceRefs.push(r);
}
```

So only genuinely content-scored rows (and NULL-legacy rows that differ from their type stub, per `isContentEncodingRow`'s heuristic) are admitted; type-stub rows must earn retrieval/feedback signal via the other lanes. Added an aggregated `[improve] high-salience lane admitted N content-scored ref(s)` log line so lane composition is observable.

**Unchanged:** threshold, type-weight table, 10% cap, and `isContentEncodingRow` itself.

## How #608's intent is preserved

#608 exists to rescue newly distilled, never-surfaced assets — those carry real content-derived encoding scores (`encoding_source='content'`), so they still pass the gate. Only the type-stub fallback rows that never earned a content score are excluded.

Skeptic's caveat: this shrinks the lane (few content rows exist today). That is intended (it stops the type-stub waste). The new log line lets us measure lane composition after rollout.

## Tests (`tests/commands/improve/improve-eligibility.test.ts`)

- type-stub row (`encoding_source='type-stub'`, 0.9) is **NOT** admitted — the lore-writer case.
- content row (`encoding_source='content'`, >=0.75) **IS** admitted.
- NULL-legacy row that DIFFERS from the type stub IS admitted (differs-from-stub heuristic, via the real gate).
- NULL-legacy row that EQUALS the type stub is treated as a stub (`isContentEncodingRow=false`) — asserted at the helper level (a non-indexed ref would be a vacuous run candidate).
- Existing content-scored high-salience behavior preserved (the two pre-existing #608 cases now seed `content` provenance).
- Pre-existing `salience-wiring.test.ts` #608 cases updated to seed `content` provenance (they model genuinely content-scored skills).

## Quality

`bun run check`: lint 0, tsc 0, unit **5192 pass / 0 fail**, integration **1537 pass / 0 fail**.

## Docs

- `CHANGELOG.md` `[Unreleased]` updated.
- `docs/design/improve-salience-working-reference.md` §5 F1 (new F1-follow-up note) and the §3 lane table updated to note the gate now requires content provenance.

Closes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)