### PR TITLE
fix(improve): reflect synthesizes description when source lacks one (#636)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`improve` reflect no longer emits proposals doomed to fail the
+  `invalid-description` gate when the source asset has no frontmatter
+  `description` (#636).** Reflect echoed the source frontmatter, so for assets
+  that carry other keys but no `description` (notably scraped docs:
+  `source`/`title`/`scraped`) the proposal inherited the missing/empty
+  description and the promote-time validator (`isValidDescription`, 20–400
+  chars) rejected it — observed as ~14/16 rejects in one triage pass, blocking
+  the whole scraped-doc/knowledge cluster from reflect improvement. The fix is
+  **generation-time only**: (1) `buildReflectPrompt` now injects an explicit
+  "synthesize a `description`" instruction whenever the source lacks a non-empty
+  `description` and the asset type requires one (per `authoring-rules.ts`
+  `DESCRIPTION_TYPES`), telling the model it MUST author a valid 20–400-char
+  plain-prose description from the asset's `title:`/first `# Heading`/opening
+  body; and (2) a deterministic reflect-side belt-and-suspenders in
+  `sanitizeReflectPayload` — if a source that already had frontmatter still ends
+  up with a missing/empty description after generation, reflect derives one
+  deterministically from `title:`/first heading (validated against
+  `isValidDescription`, never free-form invention) **before** the proposal is
+  created. The validator, `authoring-rules.ts` bounds, `repairProposalContent`,
+  and the drain are unchanged — nothing in the validator/promote path fabricates
+  content to pass itself.
+
 - **Auto-sync no longer refuses to commit akm's own changes when unrelated
   non-akm files are present in the stash working tree.** When a stash root is
   shared with a project repo, stray files written into the stash root (e.g. a

--- a/src/commands/improve/reflect.ts
+++ b/src/commands/improve/reflect.ts
@@ -596,30 +596,38 @@ function deriveDescriptionFromAsset(
   sourceBody: string,
   targetRef: string,
 ): string | undefined {
-  const candidates: string[] = [];
+  // Each candidate is tagged with its kind. A title or `# Heading` is a bare
+  // fragment ("Paged.js — Named Page") that reads poorly as a description even
+  // when it is long enough to pass the length gate, so for those we prefer the
+  // padded sentence form. A prose sentence is already a sentence, so it is used
+  // as-is (padding it would double-wrap an already-complete sentence).
+  const candidates: Array<{ text: string; kind: "fragment" | "prose" }> = [];
 
   // 1. title: frontmatter
-  if (typeof title === "string" && title.trim()) candidates.push(title.trim());
+  if (typeof title === "string" && title.trim()) candidates.push({ text: title.trim(), kind: "fragment" });
 
   // 2. first `# Heading` (proposed body first, then source body)
   for (const body of [proposedBody, sourceBody]) {
     const headingMatch = body.match(/^#{1,6}\s+(.+?)\s*$/m);
-    if (headingMatch?.[1]) candidates.push(headingMatch[1].trim());
+    if (headingMatch?.[1]) candidates.push({ text: headingMatch[1].trim(), kind: "fragment" });
   }
 
   // 3. first sentence of the opening prose paragraph (skip headings, fences,
   //    list markers, blockquotes — those are not prose).
   for (const body of [proposedBody, sourceBody]) {
     const firstSentence = firstProseSentence(body);
-    if (firstSentence) candidates.push(firstSentence);
+    if (firstSentence) candidates.push({ text: firstSentence, kind: "prose" });
   }
 
-  for (const raw of candidates) {
-    const normalized = normalizeDescriptionCandidate(raw);
+  for (const { text, kind } of candidates) {
+    const normalized = normalizeDescriptionCandidate(text);
     if (!normalized) continue;
-    // A bare title/heading often reads as a fragment; pad it into a sentence so
-    // it satisfies the prose/length rules without inventing new facts.
-    const variants = [normalized, `Reference notes on ${normalized}.`];
+    // For a title/heading fragment, try the padded sentence form FIRST so the
+    // result reads as a sentence rather than a bare fragment — a short but valid
+    // title like "Paged.js — Named Page" (21 chars) would otherwise be returned
+    // verbatim. Fall back to the bare form only if the padded form fails the
+    // gate. A prose candidate is already a sentence, so it is used as-is.
+    const variants = kind === "fragment" ? [`Reference notes on ${normalized}.`, normalized] : [normalized];
     for (const v of variants) {
       const clamped = v.length > DESCRIPTION_MAX_CHARS ? v.slice(0, DESCRIPTION_MAX_CHARS).trimEnd() : v;
       if (isValidDescription(clamped, targetRef, { skipRefTailCheck: true }).ok) return clamped;

--- a/src/commands/improve/reflect.ts
+++ b/src/commands/improve/reflect.ts
@@ -31,6 +31,7 @@ import { type AssetRef, parseAssetRef } from "../../core/asset/asset-ref";
 import { assembleAssetFromString, serializeFrontmatter } from "../../core/asset/asset-serialize";
 import { parseFrontmatter } from "../../core/asset/frontmatter";
 import { stripMarkdownFences } from "../../core/asset/markdown";
+import { DESCRIPTION_MAX_CHARS, requiresDescription } from "../../core/authoring-rules";
 import { resolveStashDir } from "../../core/common";
 import type { LlmConnectionConfig } from "../../core/config/config";
 import { loadConfig } from "../../core/config/config";
@@ -71,7 +72,7 @@ import {
   loadAgentConfigFromDisk,
   resolveAgentProfile,
 } from "../agent/agent-support";
-import { checkReflectSize } from "../proposal/validators/proposal-quality-validators";
+import { checkReflectSize, isValidDescription } from "../proposal/validators/proposal-quality-validators";
 import {
   type CreateProposalInput,
   createProposal,
@@ -535,7 +536,7 @@ function looksLikeAssetContent(value: string, sdkMode = false, targetType?: stri
 }
 
 /** Outcome of {@link sanitizeReflectPayload}. */
-interface ReflectSanitizeResult {
+export interface ReflectSanitizeResult {
   /** Sanitized content (frontmatter preserved + identity fields restored). */
   content: string;
   /** Sanitized frontmatter object suitable for {@link CreateProposalInput.payload.frontmatter}. */
@@ -576,6 +577,79 @@ function stripAppendedFrontmatter(body: string): string {
 }
 
 /**
+ * #636 — deterministically derive a valid `description` from an asset's existing
+ * metadata when one is missing. Sources, in priority order: the `title:`
+ * frontmatter field, the first `# Heading` in the (proposed or source) body, and
+ * the first sentence of the opening body paragraph. The candidate is normalized
+ * (whitespace collapsed, trailing punctuation/markdown stripped, clamped to the
+ * description max) and only returned if it PASSES `isValidDescription` — so this
+ * never produces a heading-fragment, truncated, or otherwise gate-failing value.
+ * Returns `undefined` when nothing usable can be derived (caller leaves the
+ * proposal as-is rather than fabricating prose).
+ *
+ * This is intentionally deterministic and lives in the reflect proposal-build
+ * path — it does NOT touch the validators or the promote-time repair.
+ */
+function deriveDescriptionFromAsset(
+  title: unknown,
+  proposedBody: string,
+  sourceBody: string,
+  targetRef: string,
+): string | undefined {
+  const candidates: string[] = [];
+
+  // 1. title: frontmatter
+  if (typeof title === "string" && title.trim()) candidates.push(title.trim());
+
+  // 2. first `# Heading` (proposed body first, then source body)
+  for (const body of [proposedBody, sourceBody]) {
+    const headingMatch = body.match(/^#{1,6}\s+(.+?)\s*$/m);
+    if (headingMatch?.[1]) candidates.push(headingMatch[1].trim());
+  }
+
+  // 3. first sentence of the opening prose paragraph (skip headings, fences,
+  //    list markers, blockquotes — those are not prose).
+  for (const body of [proposedBody, sourceBody]) {
+    const firstSentence = firstProseSentence(body);
+    if (firstSentence) candidates.push(firstSentence);
+  }
+
+  for (const raw of candidates) {
+    const normalized = normalizeDescriptionCandidate(raw);
+    if (!normalized) continue;
+    // A bare title/heading often reads as a fragment; pad it into a sentence so
+    // it satisfies the prose/length rules without inventing new facts.
+    const variants = [normalized, `Reference notes on ${normalized}.`];
+    for (const v of variants) {
+      const clamped = v.length > DESCRIPTION_MAX_CHARS ? v.slice(0, DESCRIPTION_MAX_CHARS).trimEnd() : v;
+      if (isValidDescription(clamped, targetRef, { skipRefTailCheck: true }).ok) return clamped;
+    }
+  }
+  return undefined;
+}
+
+/** Extract the first prose sentence from a markdown body, or `""` if none. */
+function firstProseSentence(body: string): string {
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (/^(#{1,6}\s|```|~~~|[-*+]\s|\d+\.\s|>|\||<!--)/.test(line)) continue;
+    const sentenceMatch = line.match(/^(.+?[.!?])(\s|$)/);
+    return (sentenceMatch?.[1] ?? line).trim();
+  }
+  return "";
+}
+
+/** Normalize a description candidate: strip markdown markers, collapse space. */
+function normalizeDescriptionCandidate(raw: string): string {
+  return raw
+    .replace(/`/g, "")
+    .replace(/^[#>*\-\s]+/, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
  * Reflect post-processor — enforces the safety rails described at the top of
  * this file:
  *
@@ -600,7 +674,7 @@ function stripAppendedFrontmatter(body: string): string {
  * from `payload.frontmatter` so identity fields can be enforced. Size guard
  * is skipped because there is no source to compare against.
  */
-function sanitizeReflectPayload(
+export function sanitizeReflectPayload(
   payload: { content: string; frontmatter?: Record<string, unknown> },
   sourceContent: string | undefined,
   targetRef: string,
@@ -651,6 +725,37 @@ function sanitizeReflectPayload(
   }
 
   const cleanedBody = stripAppendedFrontmatter(rawLlmBody.replace(/^\s+/, ""));
+
+  // #636 — deterministic description fallback (reflect-side belt-and-suspenders).
+  // If the type requires a `description` and the merged frontmatter is still
+  // MISSING one (source had none AND the model didn't author one), derive a
+  // description DETERMINISTICALLY from the existing `title:` frontmatter or the
+  // first `# Heading` / opening body sentence — never free-form invention. This
+  // runs in the reflect proposal-build path, BEFORE the proposal is created, so
+  // the validator/promote path is left untouched (no gate fabricates content).
+  //
+  // Scope is the issue's target: a source asset that ALREADY carries frontmatter
+  // (e.g. scraped docs: `source`/`title`/`scraped`) but has a MISSING/empty
+  // `description`. We deliberately do NOT fire when:
+  //   - the source has no frontmatter block at all (injecting one would be a
+  //     structural change and would defeat the #580 no-op/cosmetic noise gate
+  //     for a pure body echo), or
+  //   - a present-but-otherwise-invalid description exists (too short, a heading
+  //     fragment) — overwriting authored content is out of scope; the prompt
+  //     instruction handles improving it instead.
+  const refType = targetRef.includes(":") ? (targetRef.split(":")[0] ?? "") : "";
+  const mergedDesc = mergedFm.description;
+  const descIsMissing = typeof mergedDesc !== "string" || mergedDesc.trim().length === 0;
+  const sourceHadFrontmatter = sourceFmText !== null && Object.keys(sourceFm).length > 0;
+  if (refType && requiresDescription(refType) && descIsMissing && sourceHadFrontmatter) {
+    const derived = deriveDescriptionFromAsset(mergedFm.title, cleanedBody, sourceBody, targetRef);
+    if (derived) {
+      mergedFm.description = derived;
+      warnings.push(
+        "Synthesized a deterministic `description` from title/heading (#636) — source and proposal lacked one.",
+      );
+    }
+  }
 
   // Size guard — only when source body is meaningfully large. The pure
   // predicate lives in `core/proposal-quality-validators` so the same check

--- a/src/core/authoring-rules.ts
+++ b/src/core/authoring-rules.ts
@@ -81,6 +81,16 @@ const WHEN_TO_USE_TYPES = new Set(["lesson"]);
  * Inject this VERBATIM into every improve/authoring prompt that creates or edits
  * an asset of `type`, so the agent is told exactly what the gate will reject.
  */
+/**
+ * Whether an asset of `type` carries a `description` that the validator
+ * (`isValidDescription` / `validateProposalFrontmatter`) treats as required.
+ * Reflect uses this to decide when a description-synthesis instruction (and the
+ * deterministic reflect-side fallback) must fire for a description-less source.
+ */
+export function requiresDescription(type: string): boolean {
+  return DESCRIPTION_TYPES.has(type);
+}
+
 export function authoringRulesForType(type: string): string {
   const rules: string[] = [...FRONTMATTER_BODY_RULES];
   if (DESCRIPTION_TYPES.has(type)) rules.push(...DESCRIPTION_RULES);

--- a/src/integrations/agent/prompts.ts
+++ b/src/integrations/agent/prompts.ts
@@ -28,7 +28,12 @@
  */
 
 import { TYPE_DIRS } from "../../core/asset/asset-spec";
-import { authoringRulesForType } from "../../core/authoring-rules";
+import {
+  authoringRulesForType,
+  DESCRIPTION_MAX_CHARS,
+  DESCRIPTION_MIN_CHARS,
+  requiresDescription,
+} from "../../core/authoring-rules";
 import { parseEmbeddedJsonResponse, stripCodeFences, stripThinkBlocks } from "../../core/parse";
 
 /** Agent-returned proposal payload (after JSON parse). */
@@ -198,6 +203,28 @@ export interface ReflectPromptInput {
   priorDraft?: string;
 }
 
+/**
+ * Whether the source asset content has a non-empty `description:` key in its
+ * YAML frontmatter. Used by {@link buildReflectPrompt} (#636) to decide whether
+ * to inject the synthesize-a-description instruction. Uses an inline regex to
+ * avoid pulling the full YAML parser into the prompt module (mirrors the
+ * existing inline frontmatter handling here).
+ */
+function sourceHasNonEmptyDescription(assetContent: string | undefined): boolean {
+  if (!assetContent) return false;
+  const fmMatch = assetContent.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!fmMatch) return false;
+  const fmBlock = fmMatch[1] ?? "";
+  // Match a top-level `description:` line and capture its inline value.
+  const descMatch = fmBlock.match(/^description\s*:\s*(.*)$/m);
+  if (!descMatch) return false;
+  const value = (descMatch[1] ?? "")
+    .trim()
+    .replace(/^['"]|['"]$/g, "")
+    .trim();
+  return value.length > 0;
+}
+
 /** Result of {@link buildReflectPrompt}. */
 export interface ReflectPromptResult {
   /** Full prompt string to forward to the agent/LLM. */
@@ -270,6 +297,26 @@ export function buildReflectPrompt(input: ReflectPromptInput): ReflectPromptResu
     const authoringRules = resolvedType ? authoringRulesForType(resolvedType) : "";
     if (authoringRules) {
       sections.push(authoringRules);
+    }
+
+    // #636 — synthesize-a-description instruction. Many source assets (notably
+    // scraped docs: `source`/`title`/`scraped`) carry frontmatter but NO
+    // `description`. Reflect echoes the source frontmatter, so the proposal
+    // inherits the missing description and the promote-time validator
+    // (isValidDescription, 20–400 chars) rejects it. The fix is at GENERATION
+    // time: when the source lacks a non-empty `description` and the type
+    // requires one, tell the model — unmissably — that it MUST author a valid
+    // `description`. (The validator/promote path is NOT changed: it must never
+    // fabricate content to pass itself.)
+    if (resolvedType && requiresDescription(resolvedType) && !sourceHasNonEmptyDescription(input.assetContent)) {
+      sections.push(
+        [
+          "REQUIRED — synthesize a `description` (the source asset has none):",
+          `- The source frontmatter does NOT include a non-empty \`description\`, but a ${resolvedType} asset REQUIRES one or the proposal will be rejected at promote time.`,
+          `- You MUST author a valid \`description\` in the proposal frontmatter: ${DESCRIPTION_MIN_CHARS}–${DESCRIPTION_MAX_CHARS} characters of plain-prose sentence summarizing what this asset is about.`,
+          '- Synthesize it from the asset\'s `title:` frontmatter, its first `# Heading`, or the opening body sentence. Do NOT copy a bare heading fragment (e.g. "Overview", "Named Page", "Key Insight") and do NOT emit a truncated phrase that ends on `:`/`;`/`,` or a hanging connector word.',
+        ].join("\n"),
+      );
     }
   }
 

--- a/tests/issue-636-reflect-synthesize-description.test.ts
+++ b/tests/issue-636-reflect-synthesize-description.test.ts
@@ -139,6 +139,30 @@ describe("#636 sanitizeReflectPayload — deterministic description fallback", (
     expect(check.ok).toBe(true);
   });
 
+  test("short title yields the SENTENCE form, not the bare title fragment", () => {
+    // The source title "Paged.js — Named Page" is 21 chars — long enough to pass
+    // the 20-char floor on its own, so the OLD ordering returned it verbatim as a
+    // bare fragment. The fix prefers the padded sentence form for title/heading
+    // candidates, reserving the bare form for prose sentences.
+    const result = sanitizeReflectPayload(
+      // Body has NO usable heading/prose sentence that would win over the title,
+      // so the derivation must come from the `title:` frontmatter.
+      { content: "- a bullet item\n- another bullet item\n- a third bullet item for body size" },
+      SCRAPED_SOURCE,
+      "knowledge:pagedjs_named_page",
+    );
+    expect(result.reject).toBeUndefined();
+    const fm = parseFrontmatter(result.content).data;
+    const desc = fm.description as string;
+    // It must NOT be the bare title fragment...
+    expect(desc).not.toBe("Paged.js — Named Page");
+    // ...it must read as a sentence (the padded form) and still name the topic.
+    expect(desc).toBe("Reference notes on Paged.js — Named Page.");
+    expect(desc.endsWith(".")).toBe(true);
+    // And it must still pass the promote-time gate.
+    expect(isValidDescription(desc, "knowledge:pagedjs_named_page", { skipRefTailCheck: true }).ok).toBe(true);
+  });
+
   test("proposal that ALREADY has a valid description is NOT overridden", () => {
     const existing = "A precise, human-authored description of the named-page feature in Paged.js print layouts.";
     const result = sanitizeReflectPayload(

--- a/tests/issue-636-reflect-synthesize-description.test.ts
+++ b/tests/issue-636-reflect-synthesize-description.test.ts
@@ -1,0 +1,167 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * #636 — reflect must not emit proposals that fail the promote-time
+ * `description` gate just because the SOURCE asset had no frontmatter
+ * `description` (e.g. scraped docs: `source`/`title`/`scraped` but no
+ * `description`).
+ *
+ * The fix is GENERATION-TIME only:
+ *   1. `buildReflectPrompt` injects a synthesize-a-description instruction when
+ *      the source lacks a non-empty `description` and the type requires one.
+ *   2. `sanitizeReflectPayload` (reflect proposal-build path) derives a valid
+ *      `description` DETERMINISTICALLY from `title`/heading when the proposal
+ *      still lacks one — BEFORE the proposal is created. The validator /
+ *      promote / repair path is unchanged.
+ *
+ * These tests are pure string/object assertions — no spawn/serve/LLM/disk.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { sanitizeReflectPayload } from "../src/commands/improve/reflect";
+import { isValidDescription } from "../src/commands/proposal/validators/proposal-quality-validators";
+import { parseFrontmatter } from "../src/core/asset/frontmatter";
+import { buildReflectPrompt } from "../src/integrations/agent/prompts";
+
+// Distinctive substring of the #636 synthesize-a-description instruction.
+const SYNTH_INSTRUCTION = "synthesize a `description`".toLowerCase();
+const SYNTH_HEADER = "REQUIRED — synthesize a `description`";
+
+// A scraped-doc shape: frontmatter with source/title/scraped but NO description.
+const SCRAPED_SOURCE = [
+  "---",
+  "source: https://pagedjs.org/en/documentation/8-named-page/",
+  "title: Paged.js — Named Page",
+  "scraped: 2025-11-07T00:00:00Z",
+  "language: en",
+  "status: active",
+  "---",
+  "# Named Page",
+  "> **When to use:** you need a differently-sized page in a print layout.",
+  "",
+  "Named pages let you assign a specific page size and margins to a section of content.",
+].join("\n");
+
+describe("#636 buildReflectPrompt — synthesize-description instruction", () => {
+  test("knowledge source WITHOUT description → instruction is injected", () => {
+    const { prompt } = buildReflectPrompt({
+      ref: "knowledge:documentation/pagedjs/pagedjs_named_page",
+      type: "knowledge",
+      name: "documentation/pagedjs/pagedjs_named_page",
+      assetContent: SCRAPED_SOURCE,
+    });
+    expect(prompt).toContain(SYNTH_HEADER);
+    expect(prompt.toLowerCase()).toContain(SYNTH_INSTRUCTION);
+    // The bounds are spelled out so the model knows the gate it must satisfy.
+    expect(prompt).toContain("20–400 characters");
+  });
+
+  test("type derived from ref prefix (type omitted) still injects instruction", () => {
+    const { prompt } = buildReflectPrompt({
+      ref: "knowledge:documentation/pagedjs/pagedjs_named_page",
+      assetContent: SCRAPED_SOURCE,
+    });
+    expect(prompt).toContain(SYNTH_HEADER);
+  });
+
+  test("source that ALREADY has a valid description → no instruction (no double-injection)", () => {
+    const withDesc = [
+      "---",
+      "title: Paged.js — Named Page",
+      "description: Named pages assign a specific page size and margins to a section of print content.",
+      "---",
+      "# Named Page",
+      "Body text.",
+    ].join("\n");
+    const { prompt } = buildReflectPrompt({
+      ref: "knowledge:documentation/pagedjs/pagedjs_named_page",
+      type: "knowledge",
+      name: "documentation/pagedjs/pagedjs_named_page",
+      assetContent: withDesc,
+    });
+    expect(prompt).not.toContain(SYNTH_HEADER);
+  });
+
+  test("empty-string description in source IS treated as missing → instruction injected", () => {
+    const emptyDesc = ["---", "title: Foo", "description: ", "---", "# Foo", "Body."].join("\n");
+    const { prompt } = buildReflectPrompt({
+      ref: "knowledge:foo",
+      type: "knowledge",
+      name: "foo",
+      assetContent: emptyDesc,
+    });
+    expect(prompt).toContain(SYNTH_HEADER);
+  });
+
+  test("type that does NOT require a description → no instruction", () => {
+    // `script` is not in DESCRIPTION_TYPES (requiresDescription === false).
+    const { prompt } = buildReflectPrompt({
+      ref: "script:foo",
+      type: "script",
+      name: "foo",
+      assetContent: "---\ntitle: Foo\n---\n# Foo\nBody.",
+    });
+    expect(prompt).not.toContain(SYNTH_HEADER);
+  });
+});
+
+describe("#636 sanitizeReflectPayload — deterministic description fallback", () => {
+  test("proposal lacking a description gets a valid one derived from source title/heading", () => {
+    // The model echoed the description-less source frontmatter and a body.
+    const result = sanitizeReflectPayload(
+      { content: "# Named Page\n\nNamed pages assign a specific page size and margins to a section of content." },
+      SCRAPED_SOURCE,
+      "knowledge:documentation/pagedjs/pagedjs_named_page",
+    );
+    expect(result.reject).toBeUndefined();
+    const fm = parseFrontmatter(result.content).data;
+    expect(typeof fm.description).toBe("string");
+    expect(
+      isValidDescription(fm.description, "knowledge:documentation/pagedjs/pagedjs_named_page", {
+        skipRefTailCheck: true,
+      }).ok,
+    ).toBe(true);
+    // Derived deterministically from the title (not free-form invention).
+    expect((fm.description as string).toLowerCase()).toContain("named page");
+    expect(result.warnings.some((w) => w.includes("#636"))).toBe(true);
+  });
+
+  test("derived description PASSES isValidDescription (the gate that was rejecting before)", () => {
+    const result = sanitizeReflectPayload(
+      { content: "# Named Page\n\nBody describing named pages in detail across several useful sentences." },
+      SCRAPED_SOURCE,
+      "knowledge:pagedjs_named_page",
+    );
+    const fm = parseFrontmatter(result.content).data;
+    const check = isValidDescription(fm.description, "knowledge:pagedjs_named_page", { skipRefTailCheck: true });
+    expect(check.ok).toBe(true);
+  });
+
+  test("proposal that ALREADY has a valid description is NOT overridden", () => {
+    const existing = "A precise, human-authored description of the named-page feature in Paged.js print layouts.";
+    const result = sanitizeReflectPayload(
+      {
+        content: "# Named Page\n\nBody.",
+        frontmatter: { description: existing },
+      },
+      SCRAPED_SOURCE,
+      "knowledge:pagedjs_named_page",
+    );
+    const fm = parseFrontmatter(result.content).data;
+    expect(fm.description).toBe(existing);
+    expect(result.warnings.some((w) => w.includes("#636"))).toBe(false);
+  });
+
+  test("type that does not require a description → no fallback injected", () => {
+    // No description, type does not require one; nothing is fabricated.
+    const result = sanitizeReflectPayload(
+      { content: "echo hello" },
+      "---\ntitle: A Script\n---\necho hi",
+      "script:foo",
+    );
+    const fm = parseFrontmatter(result.content).data;
+    expect(fm.description).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #636

## The bug

`akm improve`'s **reflect** pass emits proposals by echoing the source asset's frontmatter. For source assets that carry other frontmatter (notably scraped docs: `source`/`title`/`scraped`) but **no `description`**, the proposal inherits the missing/empty description and the promote-time validator (`isValidDescription`, bounds 20–400 chars in `authoring-rules.ts`) rejects it with `invalid-description`. Observed as ~14/16 rejects in one triage pass — the whole scraped-doc/knowledge cluster was permanently blocked from reflect improvement.

## The fix — GENERATION TIME ONLY

Per the unanimous 3-person debate panel: fix at reflect generation time; the validator/promote path must never fabricate content to pass itself.

1. **Primary — reflect prompt instruction.** `buildReflectPrompt` (`src/integrations/agent/prompts.ts`) now injects an explicit "REQUIRED — synthesize a `description`" section whenever the resolved type requires a description (per `authoring-rules.ts` `DESCRIPTION_TYPES`, via the new exported `requiresDescription()` helper) **and** the source `assetContent` frontmatter lacks a non-empty `description`. It tells the model it MUST author a valid 20–400-char plain-prose description synthesized from `title:`/first `# Heading`/opening body, and not to emit a heading fragment or truncated phrase.

2. **Deterministic belt-and-suspenders — reflect-side, NOT validator-side.** Added to `sanitizeReflectPayload` (`src/commands/improve/reflect.ts`), at the point where reflect builds the proposal content (BEFORE `createProposal`). If, after generation, the merged frontmatter still has a missing/empty `description`, reflect derives one **deterministically** from the existing `title:`/first `# Heading`/first prose sentence, normalizes it, and accepts it only if it passes `isValidDescription` (never free-form invention). Scoped tightly to avoid behavior changes:
   - fires only when the description is **missing/empty** (a present-but-short/invalid description is left alone),
   - fires only when the **source already had a frontmatter block** (so injecting a description into a frontmatter-less body can't defeat the #580 no-op/cosmetic noise gate).

## What I did NOT touch

No changes to the validators (`isValidDescription`/`validateProposalFrontmatter`), the `authoring-rules.ts` numeric bounds, `repairProposalContent`, or the drain. Nothing in the validator or promote path synthesizes content.

## Tests

New `tests/issue-636-reflect-synthesize-description.test.ts` (9 tests, pure string/object assertions — no LLM/spawn/disk):
- Source without `description` → prompt contains the synthesize instruction (incl. type-derived-from-ref and empty-string-description cases).
- Source that already has a valid `description` → no instruction injected (no double-injection).
- Type that does not require a description (`script`) → no instruction.
- `sanitizeReflectPayload`: a description-less proposal from a frontmatter-bearing scraped-doc source gets a valid description derived from `title`/heading, and it **passes `isValidDescription`**.
- A proposal that already has a valid description is not overridden; a type that doesn't require one gets no fallback.

Existing reflect tests (`reflect-pipeline-fixes`, `reflect-noise-gate`, etc.) remain green — the scoping above was tuned against them.

## `bun run check`

- lint (biome + custom lints): 0 errors / 0 warnings
- `tsc --noEmit`: 0 errors
- unit: **5198 pass, 0 fail**, 9 skip
- integration: **1534 pass, 0 fail**, 34 skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)