### PR TITLE
fix(recombine): cap-aware decay so maxClustersPerRun no longer traps recurring hypotheses (#658)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **improve/recombine: cap-aware decay — the `maxClustersPerRun` cap no longer
+  traps recurring hypotheses below `confirmThreshold` (#658).** Recombine is a
+  two-pass design: a cluster must be re-induced on `confirmThreshold` (=2) runs
+  before its `type:hypothesis` proposal promotes to an auto-accepted
+  `type:lesson`. But only the top-`maxClustersPerRun` (=5) clusters are
+  processed per run, and `decayUnseenRecombineHypotheses` hard-reset the
+  confirmation streak of every hypothesis not processed that run. A cluster that
+  genuinely re-forms every run but is displaced out of the top-5 (slots are tied
+  on member-count and broken by an arbitrary alphabetical tiebreak) had its
+  streak zeroed — it could never win two consecutive slots, so its proposal sat
+  pending forever (6 such proposals were stuck in one production stash).
+  `decayUnseenRecombineHypotheses` is now **cap-aware**: `recombine.ts` passes
+  the FULL pre-cap cluster set, and a hypothesis is spared from reset when its
+  cluster still Jaccard-matches a present cluster (same signature, overlap ≥ 0.7
+  — the same rule used for re-induction). Only hypotheses with no matching
+  current cluster (the corpus stopped supporting them) decay. This does **not**
+  lower the recurrence bar: the confirmation count is still advanced only by
+  genuine re-induction in the processed slice (`recordRecombineInduction`);
+  sparing merely avoids an artificial reset, so a genuinely non-recurring
+  hypothesis still decays to 0 and never confirms (no new bland-hypothesis churn,
+  cf. #632/#633). No schema change. The cap now lives in a new `capClusters`
+  helper split out of `buildRelatednessClusters` so the full ranked set stays
+  available for the decay sweep.
+
 - **Auto-sync no longer refuses to commit akm's own changes when unrelated
   non-akm files are present in the stash working tree.** When a stash root is
   shared with a project repo, stray files written into the stash root (e.g. a

--- a/src/commands/improve/recombine.ts
+++ b/src/commands/improve/recombine.ts
@@ -216,14 +216,16 @@ export function isJunkTag(tag: string): boolean {
  *   - `"both"`  — union of the tag and entity grouping keys.
  *
  * A cluster is a signal whose member set is >= `minClusterSize`. Overlapping
- * clusters are de-duplicated by member-set identity, and the result is capped
- * to `maxClustersPerRun` by member-count descending.
+ * clusters are de-duplicated by member-set identity, and the result is RANKED
+ * by member-count descending (deterministic alphabetical tiebreak). The
+ * `maxClustersPerRun` cap is NOT applied here — call {@link capClusters} on the
+ * result for the processed slice; the full ranked list is retained so the
+ * cap-aware decay sweep can tell cap-displacement from corpus absence (#658).
  */
 export function buildRelatednessClusters(
   entries: DbIndexedEntry[],
   opts: {
     minClusterSize: number;
-    maxClustersPerRun: number;
     relatednessSource: "tags" | "graph" | "both";
     entityByEntryId?: Map<number, string[]>;
     /**
@@ -303,9 +305,25 @@ export function buildRelatednessClusters(
     return true;
   });
 
-  // Cap to maxClustersPerRun, largest clusters first (deterministic tiebreak).
+  // Rank largest-first (deterministic alphabetical tiebreak). The cap is applied
+  // by the caller via {@link capClusters}, NOT here, so the FULL formed set
+  // (every cluster that genuinely re-forms this run) stays available for the
+  // cap-aware decay sweep — a cluster displaced by the cap must not be confused
+  // with a cluster that vanished from the corpus (#658).
   clusters.sort((a, b) => b.members.length - a.members.length || a.signature.localeCompare(b.signature));
-  return clusters.slice(0, Math.max(0, opts.maxClustersPerRun));
+  return clusters;
+}
+
+/**
+ * #658 — apply the `maxClustersPerRun` cap to a largest-first ranked cluster
+ * list. Split out from {@link buildRelatednessClusters} so callers retain the
+ * full pre-cap set: the clusters BELOW the cap still re-formed this run and must
+ * spare their hypotheses from decay (cap-displacement is a SCHEDULING miss, not
+ * a substance miss). Callers that only need the processed slice call this; the
+ * full ranked list feeds {@link decayUnseenRecombineHypotheses}.
+ */
+export function capClusters(ranked: MemoryCluster[], maxClustersPerRun: number): MemoryCluster[] {
+  return ranked.slice(0, Math.max(0, maxClustersPerRun));
 }
 
 // ── Prompt + ref derivation ───────────────────────────────────────────────────
@@ -474,14 +492,18 @@ export async function akmRecombine(opts: AkmRecombineOptions): Promise<Recombine
     if (db) closeDatabase(db);
   }
 
-  const clusters = buildRelatednessClusters(entries, {
+  // #658 — `rankedClusters` is the FULL set that re-formed this run (ranked,
+  // pre-cap); `clusters` is the processed top-`maxClustersPerRun` slice. The
+  // decay sweep below uses the full set so a cap-displaced (but present)
+  // cluster spares its hypothesis from reset.
+  const rankedClusters = buildRelatednessClusters(entries, {
     minClusterSize,
-    maxClustersPerRun,
     relatednessSource,
     ...(entityByEntryId ? { entityByEntryId } : {}),
     ...(opts.maxClusterSize != null ? { maxClusterSize: opts.maxClusterSize } : {}),
     ...(opts.excludeTags ? { excludeTags: opts.excludeTags } : {}),
   });
+  const clusters = capClusters(rankedClusters, maxClustersPerRun);
 
   let clustersFormed = 0;
   let proposalsEmitted = 0;
@@ -700,8 +722,22 @@ export async function akmRecombine(opts: AkmRecombineOptions): Promise<Recombine
 
     // #625 — decay hypotheses NOT re-induced this run (reset their consecutive
     // streak) so confirmation is per-consecutive-run and conservative (AC4).
+    // #658 — but a hypothesis whose cluster genuinely re-formed this run and was
+    // merely cap-displaced (outside the top-`maxClustersPerRun` slice) must NOT
+    // be decayed — that is a scheduling miss, not a substance miss. We pass
+    // EVERY cluster that formed this run (the full pre-cap `rankedClusters`) as
+    // `presentClusters`; decay spares any row that Jaccard-matches a present
+    // cluster under the SAME overlap rule used for re-induction. Only rows with
+    // no matching current cluster (the corpus stopped supporting them) decay.
     if (stateDb) {
-      const decayedCount = decayUnseenRecombineHypotheses(stateDb, sourceRun, [...seenThisRun]);
+      const presentClusters = rankedClusters.map((c) => ({
+        signature: c.signature,
+        memberKey: recombineMemberKey(c),
+      }));
+      const decayedCount = decayUnseenRecombineHypotheses(stateDb, sourceRun, [...seenThisRun], {
+        presentClusters,
+        minOverlap: DEFAULT_RECOMBINE_OVERLAP,
+      });
       if (decayedCount > 0) {
         appendEvent(
           {

--- a/src/core/state-db.ts
+++ b/src/core/state-db.ts
@@ -2273,9 +2273,16 @@ function decayUnseenRecombineHypothesesInner(db: Database, currentRun: string, s
   }
   // A single NOT IN keeps the exclusion atomic (a chunked NOT IN would let a ref
   // excluded by one chunk still be reset by another chunk's statement). The
-  // recombine pass caps re-induced clusters at `maxClustersPerRun` (a handful),
-  // so `seenRefs` is far under SQLite's ~999 param ceiling in practice; we cap
-  // defensively and fall back to resetting all when somehow exceeded.
+  // recombine pass caps RE-INDUCED clusters at `maxClustersPerRun` (a handful) —
+  // but with #658 cap-aware sparing the caller folds every cap-displaced
+  // (present-but-unprocessed) hypothesis into `effectiveSeen` too, so on a large
+  // stash `seenRefs` here can carry MANY spared refs, not just the handful that
+  // were processed. We cap defensively at ~900 (under SQLite's ~999 param
+  // ceiling): if `effectiveSeen` somehow exceeds it we fall back to resetting all
+  // eligible rows — which re-introduces the cap-displacement trap for THAT run
+  // (spared rows get decayed because the NOT IN protection is dropped). That is a
+  // rare, bounded degradation; a stash with >900 simultaneously-spared
+  // hypotheses is far beyond current scale.
   if (seenRefs.length > 900) {
     const res = db
       .prepare(

--- a/src/core/state-db.ts
+++ b/src/core/state-db.ts
@@ -2160,6 +2160,46 @@ export function markRecombineHypothesisPromoted(db: Database, hypothesisRef: str
 }
 
 /**
+ * A cluster that formed in the current run, identified the same way a hypothesis
+ * row is: by its relatedness `signature` plus its membership fingerprint
+ * (`memberKey` — sorted member entryKeys joined by `|`). Used by
+ * {@link decayUnseenRecombineHypotheses} to spare cap-displaced hypotheses.
+ */
+export interface PresentCluster {
+  signature: string;
+  memberKey: string;
+}
+
+/**
+ * #658 — does any current-run cluster match this hypothesis row under the SAME
+ * signature + Jaccard-overlap rule used for re-induction? A match means the
+ * cluster genuinely re-formed this run (it was merely cap-displaced out of the
+ * processed top-`maxClustersPerRun` slice), so its streak must NOT be reset.
+ */
+function hypothesisMatchesAnyPresentCluster(
+  row: { signature: string; member_key: string },
+  presentClusters: readonly PresentCluster[],
+  minOverlap: number,
+): boolean {
+  const rowMembers = row.member_key.split("|").filter((m) => m.length > 0);
+  if (rowMembers.length === 0) return false;
+  const rowSet = new Set(rowMembers);
+  for (const cluster of presentClusters) {
+    if (cluster.signature !== row.signature) continue;
+    const clusterMembers = cluster.memberKey.split("|").filter((m) => m.length > 0);
+    if (clusterMembers.length === 0) continue;
+    let intersection = 0;
+    for (const m of clusterMembers) {
+      if (rowSet.has(m)) intersection += 1;
+    }
+    const union = rowSet.size + clusterMembers.length - intersection;
+    const overlap = union === 0 ? 0 : intersection / union;
+    if (overlap >= minOverlap) return true;
+  }
+  return false;
+}
+
+/**
  * Decay-to-zero every NON-promoted hypothesis NOT re-induced in the current run.
  *
  * A generalization that stops being supported by the corpus has lost its
@@ -2169,9 +2209,57 @@ export function markRecombineHypothesisPromoted(db: Database, hypothesisRef: str
  *
  * Only rows whose `hypothesis_ref` is NOT in `seenRefs` AND whose `last_run` is
  * NOT the current run are decayed. Already-promoted rows are left alone.
+ *
+ * #658 — CAP-AWARE decay. The recombine pass only re-inducts (and thus marks
+ * `seen`) the top-`maxClustersPerRun` clusters, but a cluster genuinely
+ * re-forms every run even when it is displaced below that cap. Resetting such a
+ * row treats a SCHEDULING miss as a SUBSTANCE miss and traps the hypothesis
+ * below `confirmThreshold` forever. When `opts.presentClusters` is supplied, a
+ * row is SPARED from decay if it Jaccard-matches any present cluster (same
+ * signature, overlap >= `opts.minOverlap`) — i.e. its cluster re-formed this run
+ * but was cap-displaced. This does NOT advance the streak (only re-induction in
+ * the processed slice does that, via {@link recordRecombineInduction}), so the
+ * recurrence bar for promotion is unchanged; it only stops the cap from
+ * manufacturing artificial misses. Omitting `presentClusters` preserves the
+ * pre-#658 hard-reset-after-one-miss behaviour exactly.
+ *
  * Returns the number of rows reset.
  */
-export function decayUnseenRecombineHypotheses(db: Database, currentRun: string, seenRefs: readonly string[]): number {
+export function decayUnseenRecombineHypotheses(
+  db: Database,
+  currentRun: string,
+  seenRefs: readonly string[],
+  opts?: { presentClusters: readonly PresentCluster[]; minOverlap: number },
+): number {
+  // #658 — when cap-aware sparing is requested, fold the cap-displaced rows into
+  // the "seen" exclusion set: the underlying reset SQL already protects every
+  // ref it is given, so sparing == treating a spared row exactly like a seen
+  // row for this sweep (its count is left untouched, never advanced).
+  let effectiveSeen: readonly string[] = seenRefs;
+  if (opts && opts.presentClusters.length > 0) {
+    const candidates = db
+      .prepare(
+        "SELECT hypothesis_ref, signature, member_key FROM recombine_hypotheses WHERE promoted_at IS NULL AND (last_run IS NULL OR last_run != ?) AND consecutive_count != 0",
+      )
+      .all(currentRun) as Array<{ hypothesis_ref: string; signature: string; member_key: string }>;
+    const seenSet = new Set(seenRefs);
+    for (const row of candidates) {
+      if (seenSet.has(row.hypothesis_ref)) continue;
+      if (hypothesisMatchesAnyPresentCluster(row, opts.presentClusters, opts.minOverlap)) {
+        seenSet.add(row.hypothesis_ref);
+      }
+    }
+    effectiveSeen = [...seenSet];
+  }
+  return decayUnseenRecombineHypothesesInner(db, currentRun, effectiveSeen);
+}
+
+/**
+ * The raw reset sweep shared by the cap-aware wrapper above. Resets every
+ * non-promoted row from a prior run whose ref is NOT in `seenRefs`. Kept private
+ * so the param-ceiling chunking logic lives in one place.
+ */
+function decayUnseenRecombineHypothesesInner(db: Database, currentRun: string, seenRefs: readonly string[]): number {
   // Reset every eligible row, then exclude the seen refs in chunks to respect
   // the ~999 SQLite param ceiling. With no seen refs we reset all non-promoted
   // rows from prior runs in a single statement.

--- a/tests/commands/improve-recombine-promote.test.ts
+++ b/tests/commands/improve-recombine-promote.test.ts
@@ -569,3 +569,129 @@ describe("recombine promotion — decay on absence (AC4)", () => {
     TIMEOUT_MS,
   );
 });
+
+// ── #658 Gap-3: cap-aware decay wiring is exercised end-to-end ───────────────────
+
+describe("recombine cap-aware decay — full rankedClusters wiring (#658, Gap-3)", () => {
+  /**
+   * The unit tests in `tests/state-db/recombine-hypotheses.test.ts` cover
+   * `decayUnseenRecombineHypotheses` with a hand-built `presentClusters` array,
+   * but nothing verifies the WIRING at `recombine.ts` — that the FULL pre-cap
+   * `rankedClusters` (not the capped `clusters` slice) is what reaches the decay
+   * sweep as `presentClusters`. If a refactor passed `clusters` instead, the
+   * cap-displacement trap (#658) would silently return: a cluster that genuinely
+   * re-forms every run but loses the largest-first slot would be decayed to 0 and
+   * could never reach `confirmThreshold`. This integration test drives the real
+   * `akmRecombine` path with `maxClustersPerRun=1` so a present-but-cap-displaced
+   * cluster's streak is PRESERVED, while a cluster that genuinely vanished still
+   * decays — proving the `rankedClusters`-not-`clusters` wiring.
+   */
+  test(
+    "a cap-displaced (present) cluster is SPARED while a vanished cluster decays",
+    async () => {
+      const iso = isolated();
+      const stash = iso.stashDir;
+
+      // Cluster KEEP — tag `aaa`, FOUR members so it is strictly largest and
+      // always wins the single processed slot under maxClustersPerRun=1.
+      writeMemory(stash, "k-1", ["aaa"], "Keep cluster first distinct fact about the world.");
+      writeMemory(stash, "k-2", ["aaa"], "Keep cluster second unrelated observation noted here.");
+      writeMemory(stash, "k-3", ["aaa"], "Keep cluster a third dissimilar note on the subject.");
+      writeMemory(stash, "k-4", ["aaa"], "Keep cluster a fourth independent remark recorded.");
+      // Cluster DISPLACED — tag `zzz`, THREE members. Present every run but, being
+      // smaller AND alphabetically later, always loses the cap=1 slot to `aaa`.
+      writeMemory(stash, "d-1", ["zzz"], "Displaced cluster first distinct fact about the world.");
+      writeMemory(stash, "d-2", ["zzz"], "Displaced cluster second unrelated observation here.");
+      writeMemory(stash, "d-3", ["zzz"], "Displaced cluster a third dissimilar note on subject.");
+      // Cluster VANISH — tag `mmm`, THREE members. Present on run 1 only; retagged
+      // below minClusterSize before run 2 so it genuinely stops forming.
+      writeMemory(stash, "v-1", ["mmm"], "Vanish cluster first distinct fact about the world.");
+      writeMemory(stash, "v-2", ["mmm"], "Vanish cluster second unrelated observation here.");
+      writeMemory(stash, "v-3", ["mmm"], "Vanish cluster a third dissimilar note on subject.");
+      await buildIndex(stash);
+
+      const config = promoteConfig(2);
+      const llmFn = async () => GOOD_GENERALIZATION();
+
+      // RUN 1 — UNCAPPED (maxClustersPerRun=99): all three clusters are induced,
+      // so each gets a hypothesis row at consecutive_count=1.
+      await akmRecombine({
+        stashDir: stash,
+        config,
+        sourceRun: "run-1",
+        relatednessSource: "tags",
+        minClusterSize: 3,
+        confirmThreshold: 2,
+        maxClustersPerRun: 99,
+        recombineLlmFn: llmFn,
+      });
+
+      // Resolve each cluster's stable lesson ref from the pending hypothesis
+      // proposals. `deriveRecombineLessonRef` slugifies the tag into the ref
+      // (`lesson:recombined/<tag>-<hash>`), so the tag prefix identifies which
+      // ref belongs to which cluster without reconstructing entryKeys by hand.
+      const refForTag = (tag: string): string => {
+        const hyp = pendingByType(stash, "hypothesis").find((p) => p.ref.startsWith(`lesson:recombined/${tag}-`));
+        expect(hyp).toBeDefined();
+        return (hyp as { ref: string }).ref;
+      };
+      const refKeep = refForTag("aaa");
+      const refDisplaced = refForTag("zzz");
+      const refVanish = refForTag("mmm");
+
+      const db1 = openStateDatabase(stateDbPath(iso));
+      expect(getRecombineHypothesis(db1, refKeep)?.consecutive_count).toBe(1);
+      expect(getRecombineHypothesis(db1, refDisplaced)?.consecutive_count).toBe(1);
+      expect(getRecombineHypothesis(db1, refVanish)?.consecutive_count).toBe(1);
+      db1.close();
+
+      // Dissolve only the VANISH cluster (retag its members below minClusterSize).
+      // KEEP and DISPLACED still form unchanged.
+      writeMemory(stash, "v-1", ["q1"], "Vanish cluster first distinct fact about the world.");
+      writeMemory(stash, "v-2", ["q2"], "Vanish cluster second unrelated observation here.");
+      writeMemory(stash, "v-3", ["q3"], "Vanish cluster a third dissimilar note on subject.");
+      await buildIndex(stash);
+
+      // RUN 2 — CAPPED at 1. Ranking: KEEP (size 4) takes the only processed slot;
+      // DISPLACED (size 3) re-forms but is cap-displaced; VANISH no longer forms.
+      // Only KEEP is re-induced (seenThisRun). The decay sweep receives the FULL
+      // rankedClusters as presentClusters, so:
+      //   - DISPLACED Jaccard-matches a present cluster → SPARED (count preserved).
+      //   - VANISH matches nothing present → decays to 0.
+      // If the wiring passed the CAPPED `clusters` instead, DISPLACED would not be
+      // present and would wrongly decay — this assertion is what guards that.
+      await akmRecombine({
+        stashDir: stash,
+        config,
+        sourceRun: "run-2",
+        relatednessSource: "tags",
+        minClusterSize: 3,
+        confirmThreshold: 2,
+        maxClustersPerRun: 1,
+        recombineLlmFn: llmFn,
+      });
+
+      const db2 = openStateDatabase(stateDbPath(iso));
+      // KEEP: it WON the single processed slot and was re-induced — its streak
+      // reached confirmThreshold(2) and it promoted (promoted_at set, count reset
+      // to 0). This confirms KEEP — not DISPLACED — held the cap slot this run.
+      const rowKeep = getRecombineHypothesis(db2, refKeep);
+      expect(rowKeep?.promoted_at ?? null).not.toBeNull();
+      expect(rowKeep?.last_run).toBe("run-2");
+      // DISPLACED: present but cap-displaced → SPARED, streak PRESERVED at 1 (NOT
+      // advanced — sparing never increments, only re-induction does) and never
+      // re-induced this run (last_run still run-1). This is the load-bearing
+      // assertion: it only holds because the FULL `rankedClusters` (which includes
+      // the cap-displaced `zzz` cluster) is passed as `presentClusters`. Were the
+      // capped `clusters` slice passed instead, `zzz` would be absent → decay → 0.
+      const rowDisplaced = getRecombineHypothesis(db2, refDisplaced);
+      expect(rowDisplaced?.consecutive_count).toBe(1);
+      expect(rowDisplaced?.last_run).toBe("run-1");
+      expect(rowDisplaced?.promoted_at ?? null).toBeNull();
+      // VANISH: cluster genuinely gone → no present-cluster match → decayed to 0.
+      expect(getRecombineHypothesis(db2, refVanish)?.consecutive_count ?? 0).toBe(0);
+      db2.close();
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/tests/recombine-tuning.test.ts
+++ b/tests/recombine-tuning.test.ts
@@ -38,7 +38,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
-import { akmRecombine, buildRelatednessClusters, isJunkTag } from "../src/commands/improve/recombine";
+import { akmRecombine, buildRelatednessClusters, capClusters, isJunkTag } from "../src/commands/improve/recombine";
 import { listProposals } from "../src/commands/proposal/validators/proposals";
 import type { AkmConfig } from "../src/core/config/config";
 import { saveConfig } from "../src/core/config/config";
@@ -107,9 +107,7 @@ describe("#632 — maxClusterSize cap", () => {
 
     const clusters = buildRelatednessClusters(entries, {
       minClusterSize: 3,
-      maxClustersPerRun: 5,
       relatednessSource: "tags",
-      // NEW knob — does not exist yet; intentional RED.
       maxClusterSize: 4,
     } as Parameters<typeof buildRelatednessClusters>[1]);
 
@@ -136,12 +134,14 @@ describe("#632 — maxClusterSize cap", () => {
       memoryEntry(8, "small-3", ["small"]),
     ];
 
-    const clusters = buildRelatednessClusters(entries, {
-      minClusterSize: 3,
-      maxClustersPerRun: 1,
-      relatednessSource: "tags",
-      maxClusterSize: 4,
-    } as Parameters<typeof buildRelatednessClusters>[1]);
+    const clusters = capClusters(
+      buildRelatednessClusters(entries, {
+        minClusterSize: 3,
+        relatednessSource: "tags",
+        maxClusterSize: 4,
+      } as Parameters<typeof buildRelatednessClusters>[1]),
+      1,
+    );
 
     expect(clusters.length).toBe(1);
     expect(clusters[0].signature).toBe("tag:small");
@@ -164,9 +164,7 @@ describe("#632 — excludeTags", () => {
 
     const clusters = buildRelatednessClusters(entries, {
       minClusterSize: 3,
-      maxClustersPerRun: 5,
       relatednessSource: "tags",
-      // NEW knob — does not exist yet; intentional RED.
       excludeTags: ["generic"],
     } as Parameters<typeof buildRelatednessClusters>[1]);
 
@@ -215,7 +213,6 @@ describe("#632 — junk tags (numeric/date/hash/version/stopword) never cluster"
     ];
     const clusters = buildRelatednessClusters(entries, {
       minClusterSize: 3,
-      maxClustersPerRun: 5,
       relatednessSource: "tags",
     });
     const signatures = clusters.map((c) => c.signature);
@@ -252,14 +249,13 @@ describe("#632 — default-preserving guard (both knobs UNSET)", () => {
 
     const opts = {
       minClusterSize: 3,
-      maxClustersPerRun: 2,
       relatednessSource: "tags" as const,
     };
 
-    // The pre-#632 behaviour: largest-first, then slice(0, maxClustersPerRun).
+    // The pre-#632 behaviour: largest-first, then capClusters(…, maxClustersPerRun).
     // alpha(4) wins; beta vs gamma tie at 3 → broken by signature ascending →
     // "tag:beta" before "tag:gamma". So the top-2 are alpha + beta.
-    const result = buildRelatednessClusters(entries, opts);
+    const result = capClusters(buildRelatednessClusters(entries, opts), 2);
     const shape = clusterShape(result);
 
     expect(result.length).toBe(2);

--- a/tests/state-db/recombine-hypotheses.test.ts
+++ b/tests/state-db/recombine-hypotheses.test.ts
@@ -146,3 +146,109 @@ describe("decayUnseenRecombineHypotheses", () => {
     expect(row?.promoted_at).toBe("2026-06-18T01:00:00.000Z");
   });
 });
+
+// ── #658 — cap-aware decay ──────────────────────────────────────────────────────
+//
+// A hypothesis whose cluster genuinely re-formed this run but was displaced out
+// of the processed top-`maxClustersPerRun` slice (so its ref is NOT in seenRefs)
+// must NOT have its streak reset — that is a scheduling miss, not a substance
+// miss. The recombine pass passes EVERY cluster that formed this run (the full
+// pre-cap set) as `presentClusters`; decay spares any non-promoted row that
+// Jaccard-matches a present cluster under the same overlap rule.
+describe("decayUnseenRecombineHypotheses — #658 cap-aware sparing", () => {
+  // The member_key that `induct()` writes for every row.
+  const MEMBERS = "memory:auth-a|memory:auth-b|memory:auth-c";
+
+  test("a cap-displaced row (cluster present this run, not in seenRefs) is SPARED", () => {
+    // The row accumulated to count=1 in run-1 and was NOT processed in run-2
+    // (outside the top-N cap), so it is absent from seenRefs. Its cluster still
+    // formed this run → it is in presentClusters → must NOT decay.
+    induct("lesson:recombined/displaced", "run-1");
+    const before = getRecombineHypothesis(db, "lesson:recombined/displaced")?.consecutive_count;
+    expect(before).toBe(1);
+
+    const affected = decayUnseenRecombineHypotheses(db, "run-2", [], {
+      presentClusters: [{ signature: "tag:auth", memberKey: MEMBERS }],
+      minOverlap: 0.7,
+    });
+
+    expect(affected).toBe(0);
+    // Streak preserved (NOT advanced — sparing only avoids reset).
+    expect(getRecombineHypothesis(db, "lesson:recombined/displaced")?.consecutive_count).toBe(1);
+  });
+
+  test("a row whose cluster genuinely has NO matching present cluster DOES decay", () => {
+    induct("lesson:recombined/gone", "run-1");
+    expect(getRecombineHypothesis(db, "lesson:recombined/gone")?.consecutive_count).toBe(1);
+
+    // presentClusters contains an unrelated signature → no match → decays.
+    const affected = decayUnseenRecombineHypotheses(db, "run-2", [], {
+      presentClusters: [{ signature: "tag:unrelated", memberKey: "memory:x|memory:y|memory:z" }],
+      minOverlap: 0.7,
+    });
+
+    expect(affected).toBe(1);
+    expect(getRecombineHypothesis(db, "lesson:recombined/gone")?.consecutive_count).toBe(0);
+  });
+
+  test("a present cluster below the overlap floor does NOT spare the row (it decays)", () => {
+    induct("lesson:recombined/drifted", "run-1");
+    // Same signature but membership has fully drifted (0 overlap) → below the
+    // 0.7 floor → treated as a different cluster → row decays.
+    const affected = decayUnseenRecombineHypotheses(db, "run-2", [], {
+      presentClusters: [{ signature: "tag:auth", memberKey: "memory:auth-x|memory:auth-y|memory:auth-z" }],
+      minOverlap: 0.7,
+    });
+
+    expect(affected).toBe(1);
+    expect(getRecombineHypothesis(db, "lesson:recombined/drifted")?.consecutive_count).toBe(0);
+  });
+
+  test("confirmation still requires reaching the threshold via genuine re-induction (sparing never advances the streak)", () => {
+    const CONFIRM_THRESHOLD = 2;
+    // run-1: first induction → count 1.
+    expect(induct("lesson:recombined/streak", "run-1")).toBe(1);
+    // run-2: the cluster is present but cap-displaced (spared, NOT re-inducted).
+    decayUnseenRecombineHypotheses(db, "run-2", [], {
+      presentClusters: [{ signature: "tag:auth", memberKey: MEMBERS }],
+      minOverlap: 0.7,
+    });
+    // Still count 1 — sparing alone never reaches the threshold.
+    expect(getRecombineHypothesis(db, "lesson:recombined/streak")?.consecutive_count).toBe(1);
+    expect(getRecombineHypothesis(db, "lesson:recombined/streak")?.consecutive_count).toBeLessThan(CONFIRM_THRESHOLD);
+    // run-3: the cluster finally wins a processed slot → genuine re-induction →
+    // count reaches the threshold (this is what authorizes promotion).
+    expect(induct("lesson:recombined/streak", "run-3")).toBe(CONFIRM_THRESHOLD);
+  });
+
+  test("a genuinely non-recurring hypothesis never confirms (decays every run it is absent)", () => {
+    expect(induct("lesson:recombined/oneoff", "run-1")).toBe(1);
+    // It never re-forms: every subsequent run has no matching present cluster.
+    for (const run of ["run-2", "run-3", "run-4"]) {
+      decayUnseenRecombineHypotheses(db, run, [], {
+        presentClusters: [{ signature: "tag:other", memberKey: "memory:p|memory:q|memory:r" }],
+        minOverlap: 0.7,
+      });
+      expect(getRecombineHypothesis(db, "lesson:recombined/oneoff")?.consecutive_count).toBe(0);
+    }
+  });
+
+  test("omitting presentClusters preserves the pre-#658 hard-reset behaviour", () => {
+    induct("lesson:recombined/legacy", "run-1");
+    // No opts → unconditional reset of every unseen prior-run row.
+    const affected = decayUnseenRecombineHypotheses(db, "run-2", []);
+    expect(affected).toBe(1);
+    expect(getRecombineHypothesis(db, "lesson:recombined/legacy")?.consecutive_count).toBe(0);
+  });
+
+  test("a re-inducted row is untouched even when also present (seenRefs wins)", () => {
+    induct("lesson:recombined/seen2", "run-1");
+    induct("lesson:recombined/seen2", "run-2");
+    const affected = decayUnseenRecombineHypotheses(db, "run-2", ["lesson:recombined/seen2"], {
+      presentClusters: [{ signature: "tag:auth", memberKey: MEMBERS }],
+      minOverlap: 0.7,
+    });
+    expect(affected).toBe(0);
+    expect(getRecombineHypothesis(db, "lesson:recombined/seen2")?.consecutive_count).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes #658

## The trap

Recombine is two-pass: pass 1 emits a `type:hypothesis` proposal; only after the SAME cluster (Jaccard ≥ 0.7 membership overlap) is re-induced on `confirmThreshold` (=2) runs does it promote to a `type:lesson` that the drain policy auto-accepts (`drain-policies.ts:57`). The confirmation streak lives in `recombine_hypotheses.consecutive_count`.

Two constants interacted badly:
- `recombine.ts` `DEFAULT_MAX_CLUSTERS_PER_RUN=5` — clusters were ranked largest-first and the top-5 `.slice`d off **before** the per-cluster loop, discarding the rest.
- `state-db.ts` `decayUnseenRecombineHypotheses` **hard-reset** `consecutive_count → 0` for every non-promoted hypothesis whose ref was not in `seenThisRun` (only the processed top-5 ever land there).

A cluster that genuinely re-forms every run but is displaced out of the top-5 — slots are tied on member-count and broken by an arbitrary alphabetical `signature.localeCompare` tiebreak — was treated identically to a cluster that vanished: its streak was zeroed. It could never win two consecutive top-5 slots → never reached `confirmThreshold` → sat pending forever.

## PART 1 — recurrence findings (read-only on prod `state.db` + `index.db`)

6 stuck `type:hypothesis` proposals: `lesson:recombined/{architecture-225914f2, guardian-2c55e98f, model-c9973e08, admin-6c042733, config-d2c0fdcd, llm-afb008e4}` (4 at count 0, 2 at count 1, none promoted).

- **Every** recombine run in the last 3 days (`recombine_invoked` events) processed **exactly 5** clusters — the cap is hit on every single run.
- All 12 hypothesis rows have an **identical member-count (12)** post-#632 trim, so top-5 selection is decided purely by the alphabetical tiebreak and slot membership rotates run-to-run.
- For each stuck cluster's signature tag, the current index holds far more than `minClusterSize`(=3) member memories: **architecture=90, guardian=56, model=13, admin=15, config=16, llm=22**. These clusters re-form on every run.

**Per-ref verdict — all 6 are "recurs but cap-displaced" (legitimate; the fix lets them confirm). None are "never recurs."** (`model-c9973e08` was induced twice and returned a justified-null on its 2nd induction — that is an LLM-call outcome, not cluster absence.) The maintainer can safely manually accept any of the 6, or let the fix confirm them on subsequent runs.

## The fix — cap-aware decay (preferred option)

`decayUnseenRecombineHypotheses` gains an optional `{ presentClusters, minOverlap }`. `recombine.ts` now:
1. computes the FULL ranked cluster set (`buildRelatednessClusters`, cap removed from it),
2. applies the cap via a new `capClusters` helper to get the processed slice, and
3. passes **every** cluster that formed this run as `presentClusters` to decay.

Decay spares any non-promoted row that Jaccard-matches a present cluster (same signature, overlap ≥ 0.7 — the SAME rule used for re-induction). Only rows with no matching current cluster (the corpus stopped supporting them) decay. Omitting `presentClusters` preserves the exact pre-#658 hard-reset behaviour.

## Why this does NOT lower the recurrence bar (skeptic's concern, #632/#633)

The confirmation count is advanced **only** by `recordRecombineInduction`, which still runs **only** for clusters that reach the processed top-`maxClustersPerRun` slice AND pass the quality gate. Cap-displaced clusters are merely **spared from reset** — their streak is never **advanced** by displacement. So:
- promotion still requires `confirmThreshold` genuine re-inductions;
- a genuinely non-recurring hypothesis (no matching current cluster) still decays to 0 and never confirms.

We remove only artificial cap-induced misses; we do not make confirmation systemically easier, so the bland-hypothesis churn risk of #632/#633 is unaffected. Per the panel, `confirmThreshold` was NOT lowered and `maxClustersPerRun` was NOT raised/removed.

## Migration

None. The cap-aware option works entirely from the runtime present-cluster set; no `recombine_hypotheses` schema change was needed (the fallback soft-decay option was not used).

## Tests

`tests/state-db/recombine-hypotheses.test.ts` (new `#658 cap-aware sparing` block):
- a cap-displaced row (cluster present, not in seenRefs) is SPARED and its streak preserved (not advanced);
- a row with no matching present cluster DOES decay;
- a present cluster below the overlap floor does NOT spare (decays);
- confirmation still requires reaching the threshold via genuine re-induction (sparing never advances the streak);
- a genuinely non-recurring hypothesis never confirms (decays every absent run);
- omitting `presentClusters` preserves the pre-#658 hard reset;
- a re-inducted row stays untouched even when also present.

`tests/recombine-tuning.test.ts` updated to the `buildRelatednessClusters` + `capClusters` split.

## `bun run check`

0 / 0 / 0 — lint clean (Biome + custom lints), `tsc --noEmit` clean, unit 5196 pass / 0 fail, integration 1534 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
