### PR TITLE
fix(graph): salvage array-preferring batch output + retry once before per-asset fallback (#635)

### DIFF
--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -393,6 +393,13 @@ export interface ImproveHealthMetrics {
     htmlErrors: number;
     /** Single bounded retries triggered for transient LLM failures during extraction. */
     retryAttempts: number;
+    /**
+     * Batch extraction calls that stayed non-array even after the stricter
+     * retry, each forcing a per-asset fallback. A rising count signals the
+     * batch→per-asset cost cliff (#635). Sourced from the graph-extraction
+     * telemetry's `nonArrayBatchFailures`.
+     */
+    nonArrayBatchFailures: number;
     durationMs: number;
   };
   /**
@@ -778,6 +785,7 @@ function createUnknownImproveMetrics(): ImproveHealthMetrics {
       failures: 0,
       htmlErrors: 0,
       retryAttempts: 0,
+      nonArrayBatchFailures: 0,
       durationMs: 0,
     },
     sessionExtraction: {
@@ -1077,6 +1085,7 @@ function projectRunMetrics(result: Record<string, unknown>): ImproveHealthMetric
       metrics.graphExtraction.failures += toFiniteNumber(telemetry.failureCount);
       metrics.graphExtraction.htmlErrors += toFiniteNumber(telemetry.htmlErrorCount);
       metrics.graphExtraction.retryAttempts += toFiniteNumber(telemetry.retryAttempts);
+      metrics.graphExtraction.nonArrayBatchFailures += toFiniteNumber(telemetry.nonArrayBatchFailures);
     }
   }
   metrics.graphExtraction.durationMs += toFiniteNumber(result.graphExtractionDurationMs);
@@ -1233,6 +1242,7 @@ function mergeImproveMetrics(dst: ImproveHealthMetrics, src: ImproveHealthMetric
   dst.graphExtraction.truncations += src.graphExtraction.truncations;
   dst.graphExtraction.failures += src.graphExtraction.failures;
   dst.graphExtraction.htmlErrors += src.graphExtraction.htmlErrors;
+  dst.graphExtraction.nonArrayBatchFailures += src.graphExtraction.nonArrayBatchFailures;
   dst.graphExtraction.durationMs += src.graphExtraction.durationMs;
   dst.sessionExtraction.sessionsScanned += src.sessionExtraction.sessionsScanned;
   dst.sessionExtraction.sessionsExtracted += src.sessionExtraction.sessionsExtracted;
@@ -1686,6 +1696,7 @@ const INTERESTING_DELTA_PATHS = [
   "improve.graphExtraction.cacheHitRate",
   "improve.graphExtraction.failures",
   "improve.graphExtraction.htmlErrors",
+  "improve.graphExtraction.nonArrayBatchFailures",
   "improve.sessionExtraction.sessionsScanned",
   "improve.sessionExtraction.proposalsCreated",
   "improve.autoAccept.promoted",
@@ -2445,6 +2456,7 @@ export function renderWindowCompareMd(windows: WindowResult[], deltas: Record<st
     "improve.actions.reflect.failed",
     "improve.actions.distill.llmFailed",
     "improve.graphExtraction.failures",
+    "improve.graphExtraction.nonArrayBatchFailures",
     "improve.wallTime.medianMs",
     "improve.wallTime.p95Ms",
     "improve.memoryInference.skippedNoFacts",

--- a/src/core/parse.ts
+++ b/src/core/parse.ts
@@ -98,22 +98,47 @@ export function parseJsonResponse<T = unknown>(raw: string): T | undefined {
   }
 }
 
+/** Options for {@link parseEmbeddedJsonResponse}. */
+export interface ParseEmbeddedJsonOptions {
+  /**
+   * Which top-level shape the caller expects.
+   *
+   * - `"any"` (default): object-preferring. A `{…}` object found first is
+   *   returned immediately; arrays are only a fallback. Preserves the
+   *   historical behaviour for the many object-expecting callers.
+   * - `"array"`: array-preferring. Only top-level `[…]` arrays are returned;
+   *   leading/example `{…}` objects are ignored. Use this for callers that
+   *   expect a JSON array (e.g. batched graph extraction, #635) so a stray
+   *   object before the array no longer masks a valid array as "non-array".
+   */
+  expect?: "any" | "array";
+}
+
 /**
  * Attempts `parseJsonResponse` first. On failure, scans for the first
  * balanced `{ }` or `[ ]` structure in the text and attempts to parse that
  * substring. Returns `undefined` if no valid JSON structure is found.
  *
- * Non-array results are preferred: if a `{…}` object is found first, it is
- * returned immediately. Arrays (`[…]`) are captured as a fallback and
- * returned only when no object was found.
+ * Shape preference is controlled by {@link ParseEmbeddedJsonOptions.expect}:
+ * - `"any"` (default): non-array results are preferred — a `{…}` object found
+ *   first is returned immediately; arrays (`[…]`) are a fallback.
+ * - `"array"`: only top-level arrays are returned. The direct parse is
+ *   accepted only if it is an array, and the scanner returns the first
+ *   balanced `[…]` while skipping `{…}` openers entirely.
  */
-export function parseEmbeddedJsonResponse<T = unknown>(raw: string): T | undefined {
+export function parseEmbeddedJsonResponse<T = unknown>(raw: string, options?: ParseEmbeddedJsonOptions): T | undefined {
+  const expectArray = options?.expect === "array";
+
   const direct = parseJsonResponse<T>(raw);
-  if (direct !== undefined) return direct;
+  if (direct !== undefined && (!expectArray || Array.isArray(direct))) return direct;
 
   const text = escapeJsonStringControls(stripCodeFences(stripThinkBlocks(raw)));
   let arrayFallback: T | undefined;
 
+  // Scan only *top-level* balanced structures: once a `{…}`/`[…]` is matched we
+  // jump `start` past its closing bracket rather than re-scanning its interior.
+  // This keeps array mode from salvaging an array *nested inside* a leading
+  // object (e.g. the `entities` array of a bare `{entities,relations}` object).
   for (let start = 0; start < text.length; start++) {
     const opener = text[start];
     if (opener !== "{" && opener !== "[") continue;
@@ -122,6 +147,7 @@ export function parseEmbeddedJsonResponse<T = unknown>(raw: string): T | undefin
     let depth = 0;
     let inString = false;
     let escaped = false;
+    let end = -1;
 
     for (let i = start; i < text.length; i++) {
       const ch = text[i];
@@ -143,18 +169,28 @@ export function parseEmbeddedJsonResponse<T = unknown>(raw: string): T | undefin
       if (ch === closer) {
         depth -= 1;
         if (depth === 0) {
-          try {
-            const parsed = JSON.parse(text.slice(start, i + 1)) as T;
-            if (!Array.isArray(parsed)) {
-              return parsed;
-            }
-            arrayFallback ??= parsed;
-            break;
-          } catch {
-            break;
-          }
+          end = i;
+          break;
         }
       }
+    }
+
+    if (end === -1) continue; // never balanced — let the next opener try
+
+    try {
+      const parsed = JSON.parse(text.slice(start, end + 1)) as T;
+      if (Array.isArray(parsed)) {
+        // First valid array wins in array mode; in "any" mode it is the
+        // fallback returned only if no object is found.
+        if (expectArray) return parsed;
+        arrayFallback ??= parsed;
+      } else if (!expectArray) {
+        return parsed;
+      }
+      // Skip past this balanced structure so we don't descend into it.
+      start = end;
+    } catch {
+      // Malformed candidate — advance one char and try the next opener.
     }
   }
 

--- a/src/indexer/graph/graph-extraction.ts
+++ b/src/indexer/graph/graph-extraction.ts
@@ -107,6 +107,13 @@ export interface GraphExtractionTelemetry {
   htmlErrorCount?: number;
   /** Count of single bounded retries triggered for transient LLM failures. */
   retryAttempts: number;
+  /**
+   * Batch graph-extraction calls whose response was not a JSON array even
+   * after the one stricter-reprompt retry — each one cost a wasted batch call
+   * plus a per-asset fallback. Surfaced so a rising batch-fallback rate is
+   * observable instead of silent (#635).
+   */
+  nonArrayBatchFailures?: number;
 }
 
 /** Persisted graph shape loaded from SQLite. */
@@ -562,6 +569,7 @@ export async function runGraphExtractionPass(ctx: GraphExtractionPassContext): P
     failureCount: 0,
     htmlErrorCount: 0,
     retryAttempts: 0,
+    nonArrayBatchFailures: 0,
   };
   const canReusePreviousGraph = previousGraph.telemetry?.extractorId === extractorId;
   const runtimeTelemetry: graphExtract.GraphRuntimeTelemetry = {
@@ -857,6 +865,7 @@ export async function runGraphExtractionPass(ctx: GraphExtractionPassContext): P
   telemetry.failureCount = runtimeTelemetry.failureCount ?? 0;
   telemetry.htmlErrorCount = runtimeTelemetry.htmlErrorCount ?? 0;
   telemetry.retryAttempts = runtimeTelemetry.retryAttempts ?? 0;
+  telemetry.nonArrayBatchFailures = runtimeTelemetry.nonArrayBatchFailures ?? 0;
 
   const qualityConsidered = mergedNodes.length;
   const qualityExtracted = mergedNodes.filter((node) => node.status === "extracted" && node.entities.length > 0).length;

--- a/src/llm/graph-extract.ts
+++ b/src/llm/graph-extract.ts
@@ -517,6 +517,21 @@ function buildBatchSystemPrompt(): string {
   );
 }
 
+/**
+ * Hardened system prompt for the single batch retry (#635). Used only after a
+ * first response failed array salvage — leans harder on "raw array only" so a
+ * model that wrapped the array in prose/fences corrects itself before we pay
+ * the per-asset fallback.
+ */
+function buildBatchRetrySystemPrompt(): string {
+  return (
+    `${buildBatchSystemPrompt()} ` +
+    "Your previous response could NOT be parsed as a JSON array. " +
+    "Respond with ONLY the raw JSON array — start with '[' and end with ']'. " +
+    "No prose, no explanation, no markdown code fences, no preamble."
+  );
+}
+
 function buildBatchUserPrompt(bodies: string[]): string {
   const count = bodies.length;
   const assetBlocks = bodies.map((body, i) => `${BATCH_ASSET_SEPARATOR} ${i + 1} ===\n${body.trim()}`).join("\n\n");
@@ -663,7 +678,25 @@ export async function extractGraphFromBodies(
           },
         );
         if (!raw) return null;
-        const parsed = parseEmbeddedJsonResponse<unknown[]>(raw);
+        // Array-preferring salvage (#635): the batch contract is a top-level
+        // JSON array. A leading/example `{…}` object in the response must not
+        // mask a valid `[…]` array as a false "non-array" failure.
+        let parsed = parseEmbeddedJsonResponse<unknown[]>(raw, { expect: "array" });
+        if (!Array.isArray(parsed)) {
+          // One stricter-reprompt retry before paying the per-asset fallback
+          // (#635). Many genuine non-array responses recover when the model is
+          // told explicitly to emit only the raw array.
+          bumpTelemetry(options.telemetry, "retryAttempts");
+          const retryRaw = await chatCompletion(
+            llmConfig,
+            [
+              { role: "system", content: buildBatchRetrySystemPrompt() },
+              { role: "user", content: userPrompt },
+            ],
+            { temperature: 0, timeoutMs: llmConfig.timeoutMs, signal },
+          );
+          parsed = retryRaw ? parseEmbeddedJsonResponse<unknown[]>(retryRaw, { expect: "array" }) : undefined;
+        }
         if (!Array.isArray(parsed)) {
           nonArrayResponse = true;
           bumpTelemetry(options.telemetry, "nonArrayBatchFailures");
@@ -674,8 +707,9 @@ export async function extractGraphFromBodies(
             }
           }
           warn(
-            `graph extraction (batch): LLM response was not a JSON array for ${nonEmptyBodies.length} asset(s); ` +
-              `will fall back per-asset. promptChars=${userPrompt.length}${formatContextHint(llmConfig)}`,
+            `graph extraction (batch): LLM response was not a JSON array for ${nonEmptyBodies.length} asset(s) ` +
+              `even after a stricter retry; will fall back per-asset. ` +
+              `promptChars=${userPrompt.length}${formatContextHint(llmConfig)}`,
           );
           return null;
         }

--- a/tests/graph-extract-batch.test.ts
+++ b/tests/graph-extract-batch.test.ts
@@ -30,8 +30,8 @@ import type { LlmConnectionConfig } from "../src/core/config/config";
  * individual (single-asset) fallback calls and route to separate queues.
  */
 let chatCallCount = 0;
-/** First batch response to return. Consumed once. */
-let batchRawOnce: string | null = null;
+/** Queue of raw strings for batch calls (the user prompt contains "N="). */
+const batchRawQueue: string[] = [];
 /** Queue of raw strings for individual (single-asset fallback) calls. */
 const singleRawQueue: string[] = [];
 
@@ -44,9 +44,8 @@ const llmServer = Bun.serve({
     };
     const userContent = body.messages?.find((m) => m.role === "user")?.content ?? "";
     let content = "";
-    if (userContent.includes("N=") && batchRawOnce !== null) {
-      content = batchRawOnce;
-      batchRawOnce = null;
+    if (userContent.includes("N=")) {
+      content = batchRawQueue.shift() ?? "";
     } else {
       content = singleRawQueue.shift() ?? "";
     }
@@ -79,7 +78,7 @@ const AKM_CFG_WITH_GATE = {
 
 beforeEach(() => {
   chatCallCount = 0;
-  batchRawOnce = null;
+  batchRawQueue.length = 0;
   singleRawQueue.length = 0;
 });
 
@@ -134,17 +133,19 @@ describe("extractGraphFromBodies — unit", () => {
       "No graph content here.",
     ];
 
-    batchRawOnce = JSON.stringify([
-      {
-        entities: ["ServiceA", "ServiceB"],
-        relations: [{ from: "ServiceA", to: "ServiceB", type: "integrates with" }],
-      },
-      {
-        entities: ["Terraform", "ProdCluster"],
-        relations: [{ from: "Terraform", to: "ProdCluster", type: "provisions" }],
-      },
-      { entities: [], relations: [] },
-    ]);
+    batchRawQueue.push(
+      JSON.stringify([
+        {
+          entities: ["ServiceA", "ServiceB"],
+          relations: [{ from: "ServiceA", to: "ServiceB", type: "integrates with" }],
+        },
+        {
+          entities: ["Terraform", "ProdCluster"],
+          relations: [{ from: "Terraform", to: "ProdCluster", type: "provisions" }],
+        },
+        { entities: [], relations: [] },
+      ]),
+    );
 
     const results = await extractGraphFromBodies(SAMPLE_LLM, bodies, undefined, AKM_CFG_WITH_GATE);
 
@@ -163,11 +164,13 @@ describe("extractGraphFromBodies — unit", () => {
     const bodies = ["Body A mentioning Alpha.", "Body B mentioning Beta.", "Body C mentioning Gamma."];
 
     // Batch returns only 2 items (missing index 2).
-    batchRawOnce = JSON.stringify([
-      { entities: ["Alpha"], relations: [] },
-      { entities: ["Beta"], relations: [] },
-      // index 2 is intentionally omitted — partial failure
-    ]);
+    batchRawQueue.push(
+      JSON.stringify([
+        { entities: ["Alpha"], relations: [] },
+        { entities: ["Beta"], relations: [] },
+        // index 2 is intentionally omitted — partial failure
+      ]),
+    );
 
     // Individual fallback for index 2 (the single-asset prompt does NOT contain "N=").
     singleRawQueue.push(JSON.stringify({ entities: ["Gamma"], relations: [] }));
@@ -238,21 +241,76 @@ describe("extractGraphFromBodies — unit", () => {
     expect(chatCallCount).toBe(0);
   });
 
-  test("(f) LLM returns non-array JSON falls back to individual calls for all assets", async () => {
+  test("(f) genuinely non-array batch retries once, then falls back + surfaces the metric", async () => {
     const bodies = ["Alpha body.", "Beta body."];
-    // Batch call returns an object (not an array) — parse succeeds but not an array.
-    batchRawOnce = JSON.stringify({ oops: true });
+    const telemetry: Record<string, number> = {};
+    // First batch call AND the stricter retry both return a non-array object.
+    batchRawQueue.push(JSON.stringify({ oops: true }));
+    batchRawQueue.push(JSON.stringify({ still: "broken" }));
     // Individual fallback calls for both assets.
     singleRawQueue.push(JSON.stringify({ entities: ["Alpha"], relations: [] }));
     singleRawQueue.push(JSON.stringify({ entities: ["Beta"], relations: [] }));
 
-    const results = await extractGraphFromBodies(SAMPLE_LLM, bodies, undefined, AKM_CFG_WITH_GATE);
+    const results = await extractGraphFromBodies(SAMPLE_LLM, bodies, undefined, AKM_CFG_WITH_GATE, undefined, {
+      telemetry,
+    });
 
     expect(results).toHaveLength(2);
     expect(results[0]?.entities).toEqual(["Alpha"]);
     expect(results[1]?.entities).toEqual(["Beta"]);
-    // 1 batch call + 2 fallback individual calls = 3 total.
-    expect(chatCallCount).toBe(3);
+    // 1 batch call + 1 stricter retry + 2 fallback individual calls = 4 total.
+    expect(chatCallCount).toBe(4);
+    // The failure (after the retry) is counted and observable (#635 item 3).
+    expect(telemetry.nonArrayBatchFailures).toBe(1);
+    expect(telemetry.retryAttempts).toBe(1);
+  });
+
+  test("(g) batch response wrapped in prose with a leading object is salvaged (#635) — no fallback", async () => {
+    const bodies = ["Alpha references Beta.", "Gamma uses Delta."];
+    // Model wraps the valid array in prose AND emits a stray example object
+    // first. Array-preferring salvage must recover the array — no per-asset
+    // fallback, no retry.
+    const validArray = JSON.stringify([
+      { entities: ["Alpha", "Beta"], relations: [{ from: "Alpha", to: "Beta" }] },
+      { entities: ["Gamma", "Delta"], relations: [{ from: "Gamma", to: "Delta" }] },
+    ]);
+    batchRawQueue.push(
+      `Sure! For example {"from":"X","to":"Y"}.\nHere is the result:\n${validArray}\nHope that helps.`,
+    );
+
+    const results = await extractGraphFromBodies(SAMPLE_LLM, bodies, undefined, AKM_CFG_WITH_GATE);
+
+    expect(results).toHaveLength(2);
+    expect(results[0]?.entities).toEqual(["Alpha", "Beta"]);
+    expect(results[1]?.entities).toEqual(["Gamma", "Delta"]);
+    // Only the single batch call — salvage avoided both the retry and fallback.
+    expect(chatCallCount).toBe(1);
+  });
+
+  test("(h) non-array batch recovered by the stricter retry — no per-asset fallback", async () => {
+    const bodies = ["Alpha body.", "Beta body."];
+    const telemetry: Record<string, number> = {};
+    // First batch is non-array prose; the stricter retry returns a clean array.
+    batchRawQueue.push("I cannot produce JSON, sorry.");
+    batchRawQueue.push(
+      JSON.stringify([
+        { entities: ["Alpha"], relations: [] },
+        { entities: ["Beta"], relations: [] },
+      ]),
+    );
+
+    const results = await extractGraphFromBodies(SAMPLE_LLM, bodies, undefined, AKM_CFG_WITH_GATE, undefined, {
+      telemetry,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[0]?.entities).toEqual(["Alpha"]);
+    expect(results[1]?.entities).toEqual(["Beta"]);
+    // 1 batch + 1 stricter retry, no per-asset fallback.
+    expect(chatCallCount).toBe(2);
+    expect(telemetry.retryAttempts).toBe(1);
+    // The retry recovered the batch → no surfaced non-array failure.
+    expect(telemetry.nonArrayBatchFailures ?? 0).toBe(0);
   });
 
   test("normalizes entities/relation types and keeps confidence when provided", async () => {

--- a/tests/graph-extraction-batch.test.ts
+++ b/tests/graph-extraction-batch.test.ts
@@ -370,8 +370,13 @@ describe("runGraphExtractionPass — batch path", () => {
 
       expect(result.considered).toBe(6);
       expect(result.extracted).toBe(6);
-      expect(batchCallCount).toBe(2);
+      // Two batches each fail after one stricter retry (#635): batch + retry =
+      // 2 calls per failing batch, ×2 batches = 4. The 2nd failure trips the
+      // disable threshold so m5/m6 go straight to per-asset (no 3rd batch).
+      expect(batchCallCount).toBe(4);
       expect(singleCallCount).toBe(6);
+      // The two batch→per-asset fallbacks are now observable (#635 item 3).
+      expect(result.telemetry?.nonArrayBatchFailures).toBe(2);
     } finally {
       closeDatabase(db);
     }

--- a/tests/llm-client.test.ts
+++ b/tests/llm-client.test.ts
@@ -654,3 +654,48 @@ describe("parseEmbeddedJsonResponse", () => {
     expect(parseEmbeddedJsonResponse("not json at all")).toBeUndefined();
   });
 });
+
+describe('parseEmbeddedJsonResponse({ expect: "array" })', () => {
+  test("parses a direct top-level array", () => {
+    expect(parseEmbeddedJsonResponse<number[]>("[1,2,3]", { expect: "array" })).toEqual([1, 2, 3]);
+  });
+
+  test("salvages a prose-wrapped array", () => {
+    const raw = 'Here are the results:\n[{"entities":["A"],"relations":[]}]\nDone.';
+    expect(parseEmbeddedJsonResponse<unknown[]>(raw, { expect: "array" })).toEqual([
+      { entities: ["A"], relations: [] },
+    ]);
+  });
+
+  test("salvages a fenced array", () => {
+    const raw = '```json\n[{"entities":[],"relations":[]}]\n```';
+    expect(parseEmbeddedJsonResponse<unknown[]>(raw, { expect: "array" })).toEqual([{ entities: [], relations: [] }]);
+  });
+
+  test("prefers the array even when a leading object precedes it (the #635 bug)", () => {
+    // Default object-preferring mode returns the leading object — a false
+    // "non-array" for the graph batch path. Array mode must return the array.
+    const raw =
+      'For example {"from":"A","to":"B"}.\nNow the answer:\n[{"entities":["A","B"],"relations":[{"from":"A","to":"B"}]}]';
+    expect(parseEmbeddedJsonResponse<unknown[]>(raw, { expect: "array" })).toEqual([
+      { entities: ["A", "B"], relations: [{ from: "A", to: "B" }] },
+    ]);
+  });
+
+  test("skips a malformed leading array and parses the later valid array", () => {
+    const raw = 'Draft: [{"entities":["A",]}]\nFinal: [{"entities":["ServiceA"],"relations":[]}]';
+    expect(parseEmbeddedJsonResponse<unknown[]>(raw, { expect: "array" })).toEqual([
+      { entities: ["ServiceA"], relations: [] },
+    ]);
+  });
+
+  test("returns undefined when only an object is present (no array to salvage)", () => {
+    const raw = 'Here is the result:\n{"entities":["A"],"relations":[]}';
+    expect(parseEmbeddedJsonResponse<unknown[]>(raw, { expect: "array" })).toBeUndefined();
+  });
+
+  test('default ("any") mode still prefers a leading object — regression guard', () => {
+    const raw = 'Note {"ok":true}\n[1,2,3]';
+    expect(parseEmbeddedJsonResponse<{ ok: boolean }>(raw)).toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
Closes #635.

## Root cause
Graph batch extraction expects a top-level JSON array. The shared `parseEmbeddedJsonResponse` was **object-preferring** by design — when a model wrapped the array in prose with any leading `{…}` (wrapper object, inline example, stray brace), it returned that object, so `Array.isArray(parsed)` was `false`: a **false "non-array" failure**. That double-paid (wasted batch call + per-asset re-runs) and, after `NON_ARRAY_BATCH_DISABLE_THRESHOLD = 2` failures, disabled batching for the whole run (the cost cliff). Since beta.44 (#632) recombine clusters on graph entities, so the cascade also degrades hypothesis quality.

## Changes
- **`src/core/parse.ts`** — `parseEmbeddedJsonResponse(raw, { expect: "array" })`. Array mode accepts a direct parse only if it's an array and returns the first balanced top-level `[…]`, skipping leading objects. The scanner now jumps past each balanced top-level structure rather than re-scanning its interior, so array mode never salvages an array *nested inside* a leading object. Default (`"any"`) behaviour preserved for the ~10 object-expecting callers.
- **`src/llm/graph-extract.ts`** — parse the batch with `expect: "array"`; on a genuine non-array, one stricter-reprompt retry ("raw JSON array only") before the disable counter + per-asset fallback.
- **`src/indexer/graph/graph-extraction.ts` + `src/commands/health.ts`** — surface `nonArrayBatchFailures` through the telemetry envelope, health metrics struct/init/aggregation/merge, and the window-compare delta paths (+ bad-if-positive).

## Acceptance (all covered by tests)
- A response with prose around a valid array parses without per-asset fallback.
- A genuinely malformed batch retries once, then falls back, incrementing a surfaced metric.
- Regression tests for the salvage parser + the retry path.

## Verification
Local full gate green: lint (biome + isolation/license/runtime-boundary), `tsc --noEmit`, **5246 unit pass / 0 fail**, **1546 integration pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)