### PR TITLE
fix(ci): self-heal Bun --isolate epoll_ctl EEXIST crash in shard retry wrapper

### DIFF
--- a/scripts/run-test-shard.sh
+++ b/scripts/run-test-shard.sh
@@ -1,9 +1,22 @@
 #!/usr/bin/env bash
 #
-# Run one test shard sequentially, retrying ONLY on a hang (timeout / SIGKILL),
-# NEVER on a real test failure — so genuine red tests fail fast and are never
-# masked, while the rare Bun 1.3.x --isolate busy-spin hang (a worker parked
-# forever in ep_poll; see release.yml header) self-heals on a fresh process.
+# Run one test shard sequentially, retrying ONLY on the Bun 1.3.x --isolate
+# fd/epoll race, NEVER on a real test failure — so genuine red tests fail fast
+# and are never masked, while this known runtime bug self-heals on a fresh
+# process.
+#
+# The same race (an fd recycled into a still-registered epoll slot; see
+# release.yml header) has TWO manifestations, both retried here:
+#   1. HANG  — a worker parks forever in ep_poll. `timeout` kills it (exit
+#              124, or 137 from --kill-after SIGKILL).
+#   2. CRASH — the runtime aborts with `EEXIST: file already exists, epoll_ctl`
+#              and the runner then reports `Cannot call <hook>() after the test
+#              run has completed`. The process exits non-zero with an ordinary
+#              code (e.g. 1), so it is detected by the signature in the output,
+#              NOT by exit code.
+# Both strings are emitted by the Bun runtime itself, never by a failed
+# expect(), so retrying on them cannot mask a genuine red test. A real
+# assertion failure (no signature, non-timeout exit) fails fast immediately.
 #
 # Usage:  SHARD=k/N scripts/run-test-shard.sh <unit|integration>
 #
@@ -35,30 +48,52 @@ MAX_ATTEMPTS="${SHARD_MAX_ATTEMPTS:-3}"
 
 bun run sweep:tmp >/dev/null 2>&1 || true
 
+# Signature of the Bun --isolate fd/epoll race in captured output. Emitted by
+# the runtime, never by a failed expect() — so matching it cannot mask a real
+# red test. The post-completion hook error is the corruption that follows the
+# EEXIST abort.
+RACE_SIGNATURE='EEXIST: file already exists, epoll_ctl|Cannot call (beforeEach|afterEach|beforeAll|afterAll)\(\) after the test run has completed'
+
+ec=1
 for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
   echo "::group::shard $SHARD $suite — attempt $attempt/$MAX_ATTEMPTS"
+  out_file="$(mktemp)"
+  # Tee so we can inspect the output for the race signature while still
+  # streaming it to the CI log live. PIPESTATUS[0] is bun's real exit code.
   timeout --kill-after=15s "$PER_ATTEMPT_TIMEOUT" \
-    bun test --parallel=1 --timeout=30000 "${paths[@]}" --shard="$SHARD"
-  ec=$?
+    bun test --parallel=1 --timeout=30000 "${paths[@]}" --shard="$SHARD" 2>&1 | tee "$out_file"
+  ec="${PIPESTATUS[0]}"
   echo "::endgroup::"
 
   if [ "$ec" -eq 0 ]; then
+    rm -f "$out_file"
     exit 0
   fi
 
-  # 124 = `timeout` expired; 137 = SIGKILL (128+9) from --kill-after. Both mean
-  # the run hung, not that a test asserted false. Only these are retried.
+  # 124 = `timeout` expired; 137 = SIGKILL (128+9) from --kill-after → the hang
+  # manifestation. The crash manifestation exits with an ordinary code but
+  # leaves the race signature in the output. Either is the known runtime bug.
+  is_race=false
   if [ "$ec" -eq 124 ] || [ "$ec" -eq 137 ]; then
-    echo "shard $SHARD $suite HUNG (exit $ec) — Bun --isolate epoll busy-spin; retrying on a fresh process"
-    # Reap any orphan from the killed attempt before retrying. Guarded to CI so a
-    # local run never kills a developer's other `bun test` processes.
+    echo "shard $SHARD $suite HUNG (exit $ec) — Bun --isolate epoll busy-spin"
+    is_race=true
+  elif grep -qE "$RACE_SIGNATURE" "$out_file"; then
+    echo "shard $SHARD $suite hit the Bun --isolate epoll_ctl EEXIST race (exit $ec)"
+    is_race=true
+  fi
+  rm -f "$out_file"
+
+  if [ "$is_race" = true ]; then
+    echo "  → known Bun runtime race (not an assertion failure); retrying on a fresh process"
+    # Reap any orphan from the killed/aborted attempt before retrying. Guarded to
+    # CI so a local run never kills a developer's other `bun test` processes.
     [ -n "${CI:-}" ] && pkill -9 -f 'bun test ' 2>/dev/null || true
     continue
   fi
 
-  echo "shard $SHARD $suite FAILED with a real test error (exit $ec) — not a hang, not retrying"
+  echo "shard $SHARD $suite FAILED with a real test error (exit $ec) — not a hang/race, not retrying"
   exit "$ec"
 done
 
-echo "shard $SHARD $suite still hung after $MAX_ATTEMPTS attempts"
-exit 124
+echo "shard $SHARD $suite still failing after $MAX_ATTEMPTS attempts (Bun epoll race did not clear)"
+exit "$ec"


### PR DESCRIPTION
## Problem
The Bun 1.3.x `--isolate` fd/epoll race has **two** manifestations:
1. **Hang** — worker parks in `ep_poll` → `timeout` kills it (exit 124/137). Already retried.
2. **Crash** — runtime aborts with `EEXIST: file already exists, epoll_ctl`, then `Cannot call beforeEach() after the test run has completed`; exits with an ordinary code (e.g. 1). **Not** retried — slipped past the 124/137 check and was misreported as a real test failure.

Observed **deterministically** on release run `28067662432`, shard 5/8 (`tests/core/write-source.test.ts`, heavy `spawnSync` git fd churn). That file passes clean locally and on every other shard — no assertion failed; the runtime crashed.

## Fix
`scripts/run-test-shard.sh` now captures each attempt's output (`tee` + `PIPESTATUS`) and retries on a fresh process when **either** the hang exit code **or** the runtime-only race signature is present.

Both signature strings are emitted by the Bun runtime, never by a failed `expect()` — so this **cannot mask a genuine red test**: a real assertion failure has no signature and a non-timeout exit, so it still fails fast on attempt 1. If the race never clears across all attempts, the shard still exits non-zero (build stays red).

## Verification
Stubbed-`bun` harness across all four paths: success (exit 0, 1 attempt), real failure (fail-fast, no retry), race signature (retry → red after max attempts), hang (retry on 124). All correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)