### PR TITLE
feat(wiki): add pluggable snapshot fetchers

### DIFF
--- a/docs/features/wiki-snapshot-fetchers.md
+++ b/docs/features/wiki-snapshot-fetchers.md
@@ -3,6 +3,9 @@
 `akm wiki stash <url>` and every other URL-based knowledge read path now pass
 through a pluggable fetcher seam before the built-in website scraper.
 
+akm currently ships one built-in fetcher: `youtube-transcript`, which extracts
+the video description and transcript when captions are available.
+
 ## Why
 
 Some sites need custom extraction logic that the generic HTML-to-markdown path
@@ -102,3 +105,5 @@ export default {
   knowledge reads that use `fetchWebsiteMarkdownSnapshot()`.
 - The built-in website scraper remains the default path when no custom fetcher
   matches.
+- Stash-local fetchers are loaded before built-ins, so you can override the
+  built-in YouTube behavior for your own workflow when needed.

--- a/docs/features/wiki-snapshot-fetchers.md
+++ b/docs/features/wiki-snapshot-fetchers.md
@@ -1,0 +1,104 @@
+# Wiki Snapshot Fetchers
+
+`akm wiki stash <url>` and every other URL-based knowledge read path now pass
+through a pluggable fetcher seam before the built-in website scraper.
+
+## Why
+
+Some sites need custom extraction logic that the generic HTML-to-markdown path
+cannot provide well.
+
+Examples:
+
+- YouTube: fetch the transcript instead of the video description page chrome
+- GitHub issues: fetch the issue body plus comments instead of the repository shell
+- PDF-heavy sites: extract the underlying text instead of scraping an embed page
+
+## Discovery
+
+Drop fetcher modules into:
+
+```text
+<stashDir>/scripts/wiki-fetchers/
+```
+
+`<stashDir>` is the active stash for the current operation. When a command has a
+resolved write target (for example `akm wiki stash --target ...`), akm loads
+fetchers from that target stash before falling back to the built-in website
+scraper.
+
+Files ending in `.ts`, `.js`, or `.mjs` are loaded in alphabetical order.
+The first fetcher whose `matches()` returns `true` gets a chance to handle the
+URL.
+
+If a fetcher:
+
+- returns `null`, akm falls through to the next fetcher or the built-in website scraper
+- throws, akm logs a warning and falls through to the next fetcher or the built-in website scraper
+
+## Interface
+
+Fetchers should export a default object with this shape:
+
+```ts
+export interface WikiSnapshotResult {
+  url: string;
+  title: string;
+  markdown: string;
+  preferredName?: string;
+  tags?: string[];
+}
+
+export interface FetcherContext {
+  stashDir: string;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}
+
+export interface WikiSnapshotFetcher {
+  name: string;
+  matches(url: URL, context: FetcherContext): boolean;
+  fetch(url: URL, context: FetcherContext): Promise<WikiSnapshotResult | null>;
+}
+```
+
+`markdown` should contain only the body content. akm still wraps the result in
+the standard raw snapshot frontmatter (`name`, `description`, `sourceUrl`,
+`title`, `tags`) so downstream wiki tooling continues to work normally.
+
+Custom `tags` are appended to the default snapshot tags (`website` and the
+resolved hostname). They do not replace those defaults.
+
+## Example
+
+```ts
+export default {
+  name: "youtube-transcript",
+  matches(url: URL) {
+    return (
+      (url.hostname === "www.youtube.com" && url.pathname === "/watch") ||
+      url.hostname === "youtu.be"
+    );
+  },
+  async fetch(url: URL) {
+    const videoId = url.hostname === "youtu.be" ? url.pathname.slice(1) : url.searchParams.get("v");
+    if (!videoId) return null;
+
+    const transcript = await getTranscript(videoId);
+    return {
+      url: url.toString(),
+      title: `Video ${videoId}`,
+      markdown: `## Transcript\n\n${transcript}`,
+      preferredName: `videos/${videoId}`,
+      tags: ["video", "transcript"],
+    };
+  },
+};
+```
+
+## Notes
+
+- The fetcher seam is shared by `akm wiki stash <url>` and other URL-based
+  knowledge reads that use `fetchWebsiteMarkdownSnapshot()`.
+- The built-in website scraper remains the default path when no custom fetcher
+  matches.

--- a/docs/features/wiki-snapshot-fetchers.md
+++ b/docs/features/wiki-snapshot-fetchers.md
@@ -77,13 +77,13 @@ resolved hostname). They do not replace those defaults.
 ```ts
 export default {
   name: "youtube-transcript",
-  matches(url: URL) {
+  matches(url: URL, _context: FetcherContext) {
     return (
       (url.hostname === "www.youtube.com" && url.pathname === "/watch") ||
       url.hostname === "youtu.be"
     );
   },
-  async fetch(url: URL) {
+  async fetch(url: URL, _context: FetcherContext) {
     const videoId = url.hostname === "youtu.be" ? url.pathname.slice(1) : url.searchParams.get("v");
     if (!videoId) return null;
 

--- a/src/commands/read/knowledge.ts
+++ b/src/commands/read/knowledge.ts
@@ -116,9 +116,12 @@ export function readKnowledgeContent(source: string): { content: string; preferr
  * URLs are fetched via `fetchWebsiteMarkdownSnapshot`; local sources delegate
  * to `readKnowledgeContent`.
  */
-export async function readKnowledgeInput(source: string): Promise<{ content: string; preferredName?: string }> {
+export async function readKnowledgeInput(
+  source: string,
+  options?: { stashDir?: string },
+): Promise<{ content: string; preferredName?: string }> {
   if (!isHttpUrl(source)) return readKnowledgeContent(source);
-  const snapshot = await fetchWebsiteMarkdownSnapshot(source);
+  const snapshot = await fetchWebsiteMarkdownSnapshot(source, { stashDir: options?.stashDir });
   return { content: snapshot.content, preferredName: snapshot.preferredName };
 }
 

--- a/src/commands/sources/stash-cli.ts
+++ b/src/commands/sources/stash-cli.ts
@@ -32,10 +32,12 @@ import { defineCommand } from "citty";
 import { defineJsonCommand, output, runWithJsonErrors } from "../../cli/shared";
 import { assertFlatAssetName } from "../../core/asset/asset-create";
 import { isHttpUrl } from "../../core/common";
+import { loadConfig } from "../../core/config/config";
 import { UsageError } from "../../core/errors";
 import { appendEvent } from "../../core/events";
 import { getCacheDir } from "../../core/paths";
 import { clearLogFile, info, isVerbose, setLogFile } from "../../core/warn";
+import { resolveWriteTarget } from "../../core/write-source";
 import { akmIndex } from "../../indexer/indexer";
 import { getHyphenatedBoolean, getOutputMode, parseFlagValue } from "../../output/context";
 import { readKnowledgeInput, writeMarkdownAsset } from "../read/knowledge";
@@ -199,7 +201,8 @@ export const importKnowledgeCommand = defineJsonCommand({
   async run({ args }) {
     // `--name` is a flat name; subdirectory placement is `--path`'s job.
     assertFlatAssetName(args.name);
-    const { content, preferredName } = await readKnowledgeInput(args.source);
+    const stashDir = resolveWriteTarget(loadConfig(), args.target).source.path;
+    const { content, preferredName } = await readKnowledgeInput(args.source, { stashDir });
     const result = await writeMarkdownAsset({
       type: "knowledge",
       content,

--- a/src/commands/wiki-cli.ts
+++ b/src/commands/wiki-cli.ts
@@ -15,7 +15,7 @@
 import { defineCommand } from "citty";
 import { getStringArg, parsePositiveIntFlag } from "../cli/parse-args";
 import { defineGroupCommand, defineJsonCommand, output, runWithJsonErrors } from "../cli/shared";
-import { isHttpUrl, resolveStashDir } from "../core/common";
+import { resolveStashDir } from "../core/common";
 import { loadConfig, resolveConfiguredSources } from "../core/config/config";
 import { ConfigError, UsageError } from "../core/errors";
 import { getHyphenatedArg, getHyphenatedBoolean } from "../output/context";
@@ -184,13 +184,6 @@ const wikiStashCommand = defineJsonCommand({
   },
   async run({ args }) {
     const { stashRaw } = await import("../wiki/wiki.js");
-    const { content, preferredName } = await (async () => {
-      if (!isHttpUrl(args.source)) return readKnowledgeInput(args.source);
-      const { fetchWebsiteMarkdownSnapshot } = await import("../sources/website-ingest");
-      const snapshot = await fetchWebsiteMarkdownSnapshot(args.source);
-      return { content: snapshot.content, preferredName: args.as ?? snapshot.preferredName };
-    })();
-
     let stashDir: string;
     if (args.target) {
       // Resolve the named source to its filesystem path.
@@ -215,6 +208,8 @@ const wikiStashCommand = defineJsonCommand({
     } else {
       stashDir = resolveStashDir();
     }
+
+    const { content, preferredName } = await readKnowledgeInput(args.source, { stashDir });
 
     const result = stashRaw({
       stashDir,

--- a/src/sources/website-ingest.ts
+++ b/src/sources/website-ingest.ts
@@ -5,12 +5,13 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { fetchWithRetry, ResponseTooLargeError, readBodyWithByteCap } from "../core/common";
+import { fetchWithRetry, ResponseTooLargeError, readBodyWithByteCap, resolveStashDir } from "../core/common";
 import type { SourceConfigEntry } from "../core/config/config";
 import { ConfigError, UsageError } from "../core/errors";
 import { getRegistryIndexCacheDir } from "../core/paths";
 import { warn } from "../core/warn";
 import { isExpired, sanitizeString } from "./providers/provider-utils";
+import { type FetcherContext, loadWikiSnapshotFetchers, type WikiSnapshotResult } from "./wiki-fetchers/registry";
 
 /** Refresh website snapshots every 12 hours to balance freshness with scraping load. */
 const CACHE_REFRESH_INTERVAL_MS = 12 * 60 * 60 * 1000;
@@ -50,6 +51,21 @@ export interface WebsiteMarkdownSnapshot {
   markdown: string;
   preferredName: string;
   content: string;
+}
+
+export interface FetchSnapshotOptions {
+  stashDir?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+function resolveFetcherStashDir(explicitStashDir?: string): string | null {
+  if (explicitStashDir) return explicitStashDir;
+  try {
+    return resolveStashDir({ readOnly: true });
+  } catch {
+    return null;
+  }
 }
 
 export function getWebsiteCachePaths(siteUrl: string): {
@@ -155,21 +171,66 @@ async function scrapeWebsiteToStash(
   }
 }
 
-export async function fetchWebsiteMarkdownSnapshot(rawUrl: string): Promise<WebsiteMarkdownSnapshot> {
+export async function fetchWebsiteMarkdownSnapshot(
+  rawUrl: string,
+  options?: FetchSnapshotOptions,
+): Promise<WebsiteMarkdownSnapshot> {
   const normalizedUrl = validateWebsiteInputUrl(rawUrl);
+  const parsedUrl = new URL(normalizedUrl);
+  const stashDir = resolveFetcherStashDir(options?.stashDir);
+  if (stashDir) {
+    const context: FetcherContext = {
+      stashDir,
+      timeoutMs: options?.timeoutMs ?? 15_000,
+      signal: options?.signal,
+    };
+
+    for (const fetcher of await loadWikiSnapshotFetchers(stashDir)) {
+      try {
+        if (!fetcher.matches(parsedUrl, context)) continue;
+        const snapshot = await fetcher.fetch(parsedUrl, context);
+        if (!snapshot) continue;
+        return websiteMarkdownSnapshotFromResult(snapshot);
+      } catch (error) {
+        warn(
+          "[akm] wiki-fetcher %s threw on %s: %s",
+          fetcher.name,
+          normalizedUrl,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
+  }
+
   const fetched = await fetchWebsitePage(normalizedUrl);
   if (!fetched) {
     throw new UsageError(`No content could be fetched from ${normalizedUrl}`);
   }
 
-  const preferredName = deriveImportPath(fetched.page.url);
-  const slug = preferredName.split("/").pop() ?? preferredName;
-  return {
+  return websiteMarkdownSnapshotFromResult({
     url: fetched.page.url,
     title: fetched.page.title,
     markdown: fetched.page.markdown,
+  });
+}
+
+function websiteMarkdownSnapshotFromResult(snapshot: WikiSnapshotResult): WebsiteMarkdownSnapshot {
+  const preferredName = snapshot.preferredName ?? deriveImportPath(snapshot.url);
+  const slug = preferredName.split("/").pop() ?? preferredName;
+  return {
+    url: snapshot.url,
+    title: snapshot.title,
+    markdown: snapshot.markdown,
     preferredName,
-    content: buildMarkdownSnapshot(fetched.page, slug || "website"),
+    content: buildMarkdownSnapshot(
+      {
+        url: snapshot.url,
+        title: snapshot.title,
+        markdown: snapshot.markdown,
+      },
+      slug || "website",
+      snapshot.tags,
+    ),
   };
 }
 
@@ -269,11 +330,12 @@ async function fetchWebsitePage(pageUrl: string): Promise<{ page: WebsitePage; l
   };
 }
 
-function buildMarkdownSnapshot(page: WebsitePage, slug: string): string {
+function buildMarkdownSnapshot(page: WebsitePage, slug: string, tags?: string[]): string {
   const title = sanitizeString(page.title, 200) || slug;
   const description = sanitizeString(`Snapshot of ${page.url}`, 500);
   const host = sanitizeString(new URL(page.url).hostname, 120);
   const content = page.markdown.trim() || `Source: ${page.url}`;
+  const normalizedTags = Array.from(new Set(["website", host, ...(tags ?? [])]));
 
   return [
     "---",
@@ -282,8 +344,7 @@ function buildMarkdownSnapshot(page: WebsitePage, slug: string): string {
     `sourceUrl: ${JSON.stringify(page.url)}`,
     `title: ${JSON.stringify(title)}`,
     "tags:",
-    `  - ${JSON.stringify("website")}`,
-    `  - ${JSON.stringify(host)}`,
+    ...normalizedTags.map((tag) => `  - ${JSON.stringify(tag)}`),
     "---",
     "",
     `# ${title}`,

--- a/src/sources/website-ingest.ts
+++ b/src/sources/website-ingest.ts
@@ -178,27 +178,25 @@ export async function fetchWebsiteMarkdownSnapshot(
   const normalizedUrl = validateWebsiteInputUrl(rawUrl);
   const parsedUrl = new URL(normalizedUrl);
   const stashDir = resolveFetcherStashDir(options?.stashDir);
-  if (stashDir) {
-    const context: FetcherContext = {
-      stashDir,
-      timeoutMs: options?.timeoutMs ?? 15_000,
-      signal: options?.signal,
-    };
+  const context: FetcherContext = {
+    stashDir: stashDir ?? "",
+    timeoutMs: options?.timeoutMs ?? 15_000,
+    signal: options?.signal,
+  };
 
-    for (const fetcher of await loadWikiSnapshotFetchers(stashDir)) {
-      try {
-        if (!fetcher.matches(parsedUrl, context)) continue;
-        const snapshot = await fetcher.fetch(parsedUrl, context);
-        if (!snapshot) continue;
-        return websiteMarkdownSnapshotFromResult(snapshot);
-      } catch (error) {
-        warn(
-          "[akm] wiki-fetcher %s threw on %s: %s",
-          fetcher.name,
-          normalizedUrl,
-          error instanceof Error ? error.message : String(error),
-        );
-      }
+  for (const fetcher of await loadWikiSnapshotFetchers(stashDir)) {
+    try {
+      if (!fetcher.matches(parsedUrl, context)) continue;
+      const snapshot = await fetcher.fetch(parsedUrl, context);
+      if (!snapshot) continue;
+      return websiteMarkdownSnapshotFromResult(snapshot);
+    } catch (error) {
+      warn(
+        "[akm] wiki-fetcher %s threw on %s: %s",
+        fetcher.name,
+        normalizedUrl,
+        error instanceof Error ? error.message : String(error),
+      );
     }
   }
 

--- a/src/sources/wiki-fetchers/registry.ts
+++ b/src/sources/wiki-fetchers/registry.ts
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { warn } from "../../core/warn";
+import youtubeFetcher from "./youtube";
 
 export interface WikiSnapshotResult {
   url: string;
@@ -29,6 +30,7 @@ export interface WikiSnapshotFetcher {
 
 const FETCHER_DIR = path.join("scripts", "wiki-fetchers");
 const FETCHER_FILE_PATTERN = /\.(?:ts|js|mjs)$/i;
+const BUILTIN_FETCHERS: readonly WikiSnapshotFetcher[] = [youtubeFetcher];
 
 function isWikiSnapshotFetcher(value: unknown): value is WikiSnapshotFetcher {
   if (!value || typeof value !== "object") return false;
@@ -40,30 +42,36 @@ function isWikiSnapshotFetcher(value: unknown): value is WikiSnapshotFetcher {
   );
 }
 
-export async function loadWikiSnapshotFetchers(stashDir: string): Promise<WikiSnapshotFetcher[]> {
-  const fetcherDir = path.join(stashDir, FETCHER_DIR);
+export async function loadWikiSnapshotFetchers(stashDir?: string | null): Promise<WikiSnapshotFetcher[]> {
   const fetchers: WikiSnapshotFetcher[] = [];
 
-  try {
-    const entries = fs.readdirSync(fetcherDir).sort();
-    for (const entry of entries) {
-      if (!FETCHER_FILE_PATTERN.test(entry)) continue;
+  if (stashDir) {
+    const fetcherDir = path.join(stashDir, FETCHER_DIR);
+    try {
+      const entries = fs.readdirSync(fetcherDir).sort();
+      for (const entry of entries) {
+        if (!FETCHER_FILE_PATTERN.test(entry)) continue;
 
-      try {
-        const fileUrl = pathToFileURL(path.join(fetcherDir, entry)).toString();
-        const mod = await import(fileUrl);
-        if (isWikiSnapshotFetcher(mod.default)) {
-          fetchers.push(mod.default);
-        } else {
-          warn("[akm] wiki-fetcher %s skipped: missing { name, matches, fetch }", entry);
+        try {
+          const fileUrl = pathToFileURL(path.join(fetcherDir, entry)).toString();
+          const mod = await import(fileUrl);
+          if (isWikiSnapshotFetcher(mod.default)) {
+            fetchers.push(mod.default);
+          } else {
+            warn("[akm] wiki-fetcher %s skipped: missing { name, matches, fetch }", entry);
+          }
+        } catch (error) {
+          warn(
+            "[akm] wiki-fetcher %s failed to load: %s",
+            entry,
+            error instanceof Error ? error.message : String(error),
+          );
         }
-      } catch (error) {
-        warn("[akm] wiki-fetcher %s failed to load: %s", entry, error instanceof Error ? error.message : String(error));
       }
+    } catch {
+      // Missing directory means no custom fetchers.
     }
-  } catch {
-    // Missing directory means no custom fetchers.
   }
 
-  return fetchers;
+  return [...fetchers, ...BUILTIN_FETCHERS];
 }

--- a/src/sources/wiki-fetchers/registry.ts
+++ b/src/sources/wiki-fetchers/registry.ts
@@ -68,7 +68,16 @@ export async function loadWikiSnapshotFetchers(stashDir?: string | null): Promis
           );
         }
       }
-    } catch {
+    } catch (error) {
+      const code =
+        typeof error === "object" && error && "code" in error ? (error as { code?: unknown }).code : undefined;
+      if (code !== "ENOENT") {
+        warn(
+          "[akm] wiki-fetcher directory %s could not be read: %s",
+          fetcherDir,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
       // Missing directory means no custom fetchers.
     }
   }

--- a/src/sources/wiki-fetchers/registry.ts
+++ b/src/sources/wiki-fetchers/registry.ts
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { warn } from "../../core/warn";
+
+export interface WikiSnapshotResult {
+  url: string;
+  title: string;
+  markdown: string;
+  preferredName?: string;
+  tags?: string[];
+}
+
+export interface FetcherContext {
+  stashDir: string;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}
+
+export interface WikiSnapshotFetcher {
+  name: string;
+  matches(url: URL, context: FetcherContext): boolean;
+  fetch(url: URL, context: FetcherContext): Promise<WikiSnapshotResult | null>;
+}
+
+const FETCHER_DIR = path.join("scripts", "wiki-fetchers");
+const FETCHER_FILE_PATTERN = /\.(?:ts|js|mjs)$/i;
+
+function isWikiSnapshotFetcher(value: unknown): value is WikiSnapshotFetcher {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<WikiSnapshotFetcher>;
+  return (
+    typeof candidate.name === "string" &&
+    typeof candidate.matches === "function" &&
+    typeof candidate.fetch === "function"
+  );
+}
+
+export async function loadWikiSnapshotFetchers(stashDir: string): Promise<WikiSnapshotFetcher[]> {
+  const fetcherDir = path.join(stashDir, FETCHER_DIR);
+  const fetchers: WikiSnapshotFetcher[] = [];
+
+  try {
+    const entries = fs.readdirSync(fetcherDir).sort();
+    for (const entry of entries) {
+      if (!FETCHER_FILE_PATTERN.test(entry)) continue;
+
+      try {
+        const fileUrl = pathToFileURL(path.join(fetcherDir, entry)).toString();
+        const mod = await import(fileUrl);
+        if (isWikiSnapshotFetcher(mod.default)) {
+          fetchers.push(mod.default);
+        } else {
+          warn("[akm] wiki-fetcher %s skipped: missing { name, matches, fetch }", entry);
+        }
+      } catch (error) {
+        warn("[akm] wiki-fetcher %s failed to load: %s", entry, error instanceof Error ? error.message : String(error));
+      }
+    }
+  } catch {
+    // Missing directory means no custom fetchers.
+  }
+
+  return fetchers;
+}

--- a/src/sources/wiki-fetchers/youtube.ts
+++ b/src/sources/wiki-fetchers/youtube.ts
@@ -48,9 +48,18 @@ function canonicalWatchUrl(videoId: string): string {
 }
 
 function decodeEntities(value: string): string {
+  const safeFromCodePoint = (codePoint: number, fallback: string) => {
+    if (!Number.isFinite(codePoint) || codePoint < 0 || codePoint > 0x10ffff) return fallback;
+    try {
+      return String.fromCodePoint(codePoint);
+    } catch {
+      return fallback;
+    }
+  };
+
   return value
-    .replace(/&#x([0-9a-f]+);/gi, (_m, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
-    .replace(/&#([0-9]+);/g, (_m, dec) => String.fromCodePoint(Number.parseInt(dec, 10)))
+    .replace(/&#x([0-9a-f]+);/gi, (m, hex) => safeFromCodePoint(Number.parseInt(hex, 16), m))
+    .replace(/&#([0-9]+);/g, (m, dec) => safeFromCodePoint(Number.parseInt(dec, 10), m))
     .replace(/&quot;/g, '"')
     .replace(/&#39;|&apos;/g, "'")
     .replace(/&lt;/g, "<")

--- a/src/sources/wiki-fetchers/youtube.ts
+++ b/src/sources/wiki-fetchers/youtube.ts
@@ -1,0 +1,201 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { fetchWithRetry } from "../../core/common";
+import type { WikiSnapshotFetcher, WikiSnapshotResult } from "./registry";
+
+type YoutubeCaptionTrack = {
+  baseUrl?: unknown;
+  languageCode?: unknown;
+  kind?: unknown;
+};
+
+type YoutubePlayerResponse = {
+  videoDetails?: {
+    title?: unknown;
+    shortDescription?: unknown;
+  };
+  captions?: {
+    playerCaptionsTracklistRenderer?: {
+      captionTracks?: YoutubeCaptionTrack[];
+    };
+  };
+};
+
+const YOUTUBE_HOSTS = new Set(["www.youtube.com", "youtube.com", "m.youtube.com", "youtu.be"]);
+const WATCH_HOST = "https://www.youtube.com/watch?v=";
+
+function extractVideoId(url: URL): string | null {
+  if (!YOUTUBE_HOSTS.has(url.hostname)) return null;
+  if (url.hostname === "youtu.be") {
+    const id = url.pathname.replace(/^\/+/, "").split("/")[0]?.trim();
+    return id || null;
+  }
+  if (url.pathname === "/watch") {
+    const id = url.searchParams.get("v")?.trim();
+    return id || null;
+  }
+  if (url.pathname.startsWith("/shorts/")) {
+    const id = url.pathname.slice("/shorts/".length).split("/")[0]?.trim();
+    return id || null;
+  }
+  return null;
+}
+
+function canonicalWatchUrl(videoId: string): string {
+  return `${WATCH_HOST}${encodeURIComponent(videoId)}`;
+}
+
+function decodeEntities(value: string): string {
+  return value
+    .replace(/&#x([0-9a-f]+);/gi, (_m, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+    .replace(/&#([0-9]+);/g, (_m, dec) => String.fromCodePoint(Number.parseInt(dec, 10)))
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+function stripTags(value: string): string {
+  return value.replace(/<[^>]+>/g, "");
+}
+
+function extractJsonObjectAfter(marker: string, source: string): string | null {
+  const markerIndex = source.indexOf(marker);
+  if (markerIndex === -1) return null;
+  const start = source.indexOf("{", markerIndex + marker.length);
+  if (start === -1) return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < source.length; i += 1) {
+    const char = source[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+function parsePlayerResponse(html: string): YoutubePlayerResponse | null {
+  const jsonText = extractJsonObjectAfter("ytInitialPlayerResponse =", html);
+  if (!jsonText) return null;
+  try {
+    return JSON.parse(jsonText) as YoutubePlayerResponse;
+  } catch {
+    return null;
+  }
+}
+
+function chooseCaptionTrack(tracks: YoutubeCaptionTrack[]): string | null {
+  const normalized = tracks
+    .map((track) => ({
+      baseUrl: typeof track.baseUrl === "string" ? track.baseUrl : "",
+      languageCode: typeof track.languageCode === "string" ? track.languageCode : "",
+      kind: typeof track.kind === "string" ? track.kind : "",
+    }))
+    .filter((track) => track.baseUrl);
+  if (normalized.length === 0) return null;
+
+  const preferred =
+    normalized.find((track) => track.languageCode === "en" && track.kind !== "asr") ??
+    normalized.find((track) => track.languageCode.startsWith("en") && track.kind !== "asr") ??
+    normalized.find((track) => track.languageCode.startsWith("en")) ??
+    normalized[0];
+  return preferred.baseUrl;
+}
+
+async function fetchText(url: string, timeoutMs: number, signal?: AbortSignal): Promise<string | null> {
+  const response = await fetchWithRetry(
+    url,
+    {
+      headers: {
+        Accept: "text/html,application/json,application/xml,text/xml,text/plain;q=0.9,*/*;q=0.1",
+        "User-Agent": "akm-cli youtube fetcher",
+      },
+      signal,
+    },
+    { timeout: timeoutMs, retries: 1 },
+  );
+  if (!response.ok) return null;
+  return response.text();
+}
+
+function parseTranscript(xml: string): string | null {
+  const texts = [...xml.matchAll(/<text\b[^>]*>([\s\S]*?)<\/text>/g)]
+    .map((match) => decodeEntities(stripTags(match[1] ?? "")).trim())
+    .filter(Boolean);
+  if (texts.length === 0) return null;
+  return texts.join("\n");
+}
+
+const youtubeFetcher: WikiSnapshotFetcher = {
+  name: "youtube-transcript",
+  matches(url) {
+    return extractVideoId(url) !== null;
+  },
+  async fetch(url, context): Promise<WikiSnapshotResult | null> {
+    const videoId = extractVideoId(url);
+    if (!videoId) return null;
+
+    const watchUrl = canonicalWatchUrl(videoId);
+    const watchHtml = await fetchText(watchUrl, context.timeoutMs, context.signal);
+    if (!watchHtml) return null;
+
+    const playerResponse = parsePlayerResponse(watchHtml);
+    if (!playerResponse) return null;
+
+    const title =
+      typeof playerResponse.videoDetails?.title === "string" ? playerResponse.videoDetails.title.trim() : "";
+    const description =
+      typeof playerResponse.videoDetails?.shortDescription === "string"
+        ? playerResponse.videoDetails.shortDescription.trim()
+        : "";
+    const sections: string[] = [];
+    let hasTranscript = false;
+    if (description) {
+      sections.push("## Description", "", description);
+    }
+
+    const tracks = playerResponse.captions?.playerCaptionsTracklistRenderer?.captionTracks ?? [];
+    const captionUrl = chooseCaptionTrack(tracks);
+    if (captionUrl) {
+      const transcriptXml = await fetchText(captionUrl, context.timeoutMs, context.signal);
+      const transcript = transcriptXml ? parseTranscript(transcriptXml) : null;
+      if (transcript) {
+        hasTranscript = true;
+        sections.push("## Transcript", "", transcript);
+      }
+    }
+
+    if (sections.length === 0) return null;
+
+    return {
+      url: watchUrl,
+      title: title || `YouTube ${videoId}`,
+      markdown: sections.join("\n"),
+      preferredName: `youtube/${videoId}`,
+      tags: hasTranscript ? ["youtube", "video", "transcript"] : ["youtube", "video"],
+    };
+  },
+};
+
+export default youtubeFetcher;

--- a/tests/source-providers/website.test.ts
+++ b/tests/source-providers/website.test.ts
@@ -22,6 +22,7 @@ import {
   sandboxStashDir,
   sandboxXdgCacheHome,
   sandboxXdgConfigHome,
+  withEnv,
   withMockedFetch,
   writeSandboxConfig,
 } from "../_helpers/sandbox";
@@ -197,6 +198,193 @@ describe("WebsiteSourceProvider", () => {
       },
       (_url) => {
         throw new Error("default fetch should not run when a custom fetcher handles the URL");
+      },
+    );
+  });
+
+  test("fetchWebsiteMarkdownSnapshot uses the built-in YouTube fetcher to return description and transcript markdown", async () => {
+    await withMockedFetch(
+      async () => {
+        const snapshot = await fetchWebsiteMarkdownSnapshot("https://youtu.be/abc123");
+        expect(snapshot.url).toBe("https://www.youtube.com/watch?v=abc123");
+        expect(snapshot.title).toBe("Transcript Title");
+        expect(snapshot.preferredName).toBe("youtube/abc123");
+        expect(snapshot.content).toContain("## Description");
+        expect(snapshot.content).toContain("Line one\nLine two");
+        expect(snapshot.content).toContain("## Transcript");
+        expect(snapshot.content).toContain("Hello & welcome");
+        expect(snapshot.content).toContain("Second line");
+        expect(snapshot.content).toContain('  - "youtube"');
+        expect(snapshot.content).toContain('  - "video"');
+        expect(snapshot.content).toContain('  - "transcript"');
+      },
+      (url) => {
+        if (url === "https://www.youtube.com/watch?v=abc123") {
+          return new Response(
+            [
+              "<html><head><title>ignored</title></head><body>",
+              "<script>",
+              'var ytInitialPlayerResponse = {"videoDetails":{"title":"Transcript Title","shortDescription":"Line one\\nLine two"},"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":"https://www.youtube.com/api/timedtext?v=abc123&lang=en","languageCode":"en","name":{"simpleText":"English"}}]}}};',
+              "</script>",
+              "</body></html>",
+            ].join(""),
+            {
+              status: 200,
+              headers: { "Content-Type": "text/html; charset=utf-8" },
+            },
+          );
+        }
+        if (url === "https://www.youtube.com/api/timedtext?v=abc123&lang=en") {
+          return new Response(
+            '<transcript><text start="0" dur="1">Hello &amp; welcome</text><text start="1" dur="1">Second line</text></transcript>',
+            {
+              status: 200,
+              headers: { "Content-Type": "application/xml; charset=utf-8" },
+            },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+  });
+
+  test("built-in YouTube fetcher still runs when no stash directory is available to load custom fetchers", async () => {
+    await withEnv({ AKM_STASH_DIR: undefined }, async () => {
+      await withMockedFetch(
+        async () => {
+          const snapshot = await fetchWebsiteMarkdownSnapshot("https://youtu.be/abc123");
+          expect(snapshot.title).toBe("Transcript Title");
+          expect(snapshot.content).toContain("## Transcript");
+        },
+        (url) => {
+          if (url === "https://www.youtube.com/watch?v=abc123") {
+            return new Response(
+              [
+                "<html><body><script>",
+                'var ytInitialPlayerResponse = {"videoDetails":{"title":"Transcript Title","shortDescription":"Line one"},"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":"https://www.youtube.com/api/timedtext?v=abc123&lang=en","languageCode":"en"}]}}};',
+                "</script></body></html>",
+              ].join(""),
+              {
+                status: 200,
+                headers: { "Content-Type": "text/html; charset=utf-8" },
+              },
+            );
+          }
+          if (url === "https://www.youtube.com/api/timedtext?v=abc123&lang=en") {
+            return new Response("<transcript><text>Transcript body</text></transcript>", {
+              status: 200,
+              headers: { "Content-Type": "application/xml; charset=utf-8" },
+            });
+          }
+          return new Response("not found", { status: 404 });
+        },
+      );
+    });
+  });
+
+  test("built-in YouTube fetcher returns a description-only snapshot when captions are unavailable", async () => {
+    await withMockedFetch(
+      async () => {
+        const snapshot = await fetchWebsiteMarkdownSnapshot("https://www.youtube.com/watch?v=abc123");
+        expect(snapshot.title).toBe("Description Only");
+        expect(snapshot.content).toContain("## Description");
+        expect(snapshot.content).toContain("Only the description is available.");
+        expect(snapshot.content).not.toContain("## Transcript");
+        expect(snapshot.content).toContain('  - "youtube"');
+        expect(snapshot.content).toContain('  - "video"');
+        expect(snapshot.content).not.toContain('  - "transcript"');
+      },
+      (url) => {
+        if (url === "https://www.youtube.com/watch?v=abc123") {
+          return new Response(
+            [
+              "<html><body><script>",
+              'var ytInitialPlayerResponse = {"videoDetails":{"title":"Description Only","shortDescription":"Only the description is available."}};',
+              "</script></body></html>",
+            ].join(""),
+            {
+              status: 200,
+              headers: { "Content-Type": "text/html; charset=utf-8" },
+            },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+  });
+
+  test("built-in YouTube fetcher prefers manual English tracks over ASR tracks", async () => {
+    await withMockedFetch(
+      async () => {
+        const snapshot = await fetchWebsiteMarkdownSnapshot("https://www.youtube.com/watch?v=abc123");
+        expect(snapshot.content).toContain("Manual transcript");
+        expect(snapshot.content).not.toContain("ASR transcript");
+      },
+      (url) => {
+        if (url === "https://www.youtube.com/watch?v=abc123") {
+          return new Response(
+            [
+              "<html><body><script>",
+              'var ytInitialPlayerResponse = {"videoDetails":{"title":"Track Choice","shortDescription":"desc"},"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":"https://www.youtube.com/api/timedtext?v=abc123&lang=en-asr","languageCode":"en","kind":"asr"},{"baseUrl":"https://www.youtube.com/api/timedtext?v=abc123&lang=en-us","languageCode":"en-US"}]}}};',
+              "</script></body></html>",
+            ].join(""),
+            {
+              status: 200,
+              headers: { "Content-Type": "text/html; charset=utf-8" },
+            },
+          );
+        }
+        if (url === "https://www.youtube.com/api/timedtext?v=abc123&lang=en-asr") {
+          return new Response("<transcript><text>ASR transcript</text></transcript>", {
+            status: 200,
+            headers: { "Content-Type": "application/xml; charset=utf-8" },
+          });
+        }
+        if (url === "https://www.youtube.com/api/timedtext?v=abc123&lang=en-us") {
+          return new Response("<transcript><text>Manual transcript</text></transcript>", {
+            status: 200,
+            headers: { "Content-Type": "application/xml; charset=utf-8" },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+  });
+
+  test("stash-local fetchers override the built-in YouTube fetcher", async () => {
+    const fetcherDir = path.join(process.env.AKM_STASH_DIR ?? "", "scripts", "wiki-fetchers");
+    fs.mkdirSync(fetcherDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(fetcherDir, "youtube-override.ts"),
+      [
+        "export default {",
+        '  name: "youtube-override",',
+        '  matches(url) { return url.hostname === "www.youtube.com" || url.hostname === "youtu.be"; },',
+        "  async fetch(url) {",
+        "    return {",
+        "      url: url.toString(),",
+        '      title: "Custom YouTube Override",',
+        '      markdown: "custom body",',
+        '      preferredName: "youtube/custom-override",',
+        '      tags: ["custom-youtube"],',
+        "    };",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await withMockedFetch(
+      async () => {
+        const snapshot = await fetchWebsiteMarkdownSnapshot("https://www.youtube.com/watch?v=abc123");
+        expect(snapshot.title).toBe("Custom YouTube Override");
+        expect(snapshot.preferredName).toBe("youtube/custom-override");
+        expect(snapshot.content).toContain("custom body");
+        expect(snapshot.content).toContain('  - "custom-youtube"');
+      },
+      (_url) => {
+        throw new Error("built-in YouTube fetcher should not run when a stash-local fetcher overrides it");
       },
     );
   });

--- a/tests/source-providers/website.test.ts
+++ b/tests/source-providers/website.test.ts
@@ -14,7 +14,17 @@ import {
 
 // Trigger self-registration
 import "../../src/sources/providers/website";
-import { type Cleanup, sandboxStashDir, sandboxXdgCacheHome, sandboxXdgConfigHome } from "../_helpers/sandbox";
+import { createWiki } from "../../src/wiki/wiki";
+import { runCliCapture } from "../_helpers/cli";
+import {
+  type Cleanup,
+  makeStashDir,
+  sandboxStashDir,
+  sandboxXdgCacheHome,
+  sandboxXdgConfigHome,
+  withMockedFetch,
+  writeSandboxConfig,
+} from "../_helpers/sandbox";
 
 let cleanup: Cleanup = () => {};
 
@@ -126,30 +136,253 @@ describe("WebsiteSourceProvider", () => {
   });
 
   test("fetchWebsiteMarkdownSnapshot fetches one page and derives a URL-path name", async () => {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async (input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url === "https://docs.example.test/guide/getting-started") {
-        return new Response(
-          "<html><head><title>Getting Started</title></head><body><h1>Getting Started</h1><p>Run setup first.</p></body></html>",
-          {
+    await withMockedFetch(
+      async () => {
+        const snapshot = await fetchWebsiteMarkdownSnapshot("https://docs.example.test/guide/getting-started");
+        expect(snapshot.url).toBe("https://docs.example.test/guide/getting-started");
+        expect(snapshot.preferredName).toBe("guide/getting-started");
+        expect(snapshot.title).toBe("Getting Started");
+        expect(snapshot.content).toContain('sourceUrl: "https://docs.example.test/guide/getting-started"');
+        expect(snapshot.content).toContain("# Getting Started");
+      },
+      (url) => {
+        if (url === "https://docs.example.test/guide/getting-started") {
+          return new Response(
+            "<html><head><title>Getting Started</title></head><body><h1>Getting Started</h1><p>Run setup first.</p></body></html>",
+            {
+              status: 200,
+              headers: { "Content-Type": "text/html; charset=utf-8" },
+            },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+  });
+
+  test("fetchWebsiteMarkdownSnapshot uses a matching custom fetcher before the default website fetch", async () => {
+    const fetcherDir = path.join(process.env.AKM_STASH_DIR ?? "", "scripts", "wiki-fetchers");
+    fs.mkdirSync(fetcherDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(fetcherDir, "youtube.ts"),
+      [
+        "export default {",
+        '  name: "youtube-transcript",',
+        '  matches(url) { return url.hostname === "video.example.test"; },',
+        "  async fetch(url) {",
+        "    return {",
+        "      url: url.toString(),",
+        '      title: "Transcript Title",',
+        '      markdown: "## Transcript\\n\\nHello from transcript.",',
+        '      preferredName: "videos/transcript-title",',
+        '      tags: ["video", "transcript"],',
+        "    };",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await withMockedFetch(
+      async () => {
+        const snapshot = await fetchWebsiteMarkdownSnapshot("https://video.example.test/watch?v=abc123");
+        expect(snapshot.title).toBe("Transcript Title");
+        expect(snapshot.preferredName).toBe("videos/transcript-title");
+        expect(snapshot.content).toContain("## Transcript");
+        expect(snapshot.content).toContain('  - "website"');
+        expect(snapshot.content).toContain('  - "video.example.test"');
+        expect(snapshot.content).toContain('  - "video"');
+        expect(snapshot.content).toContain('  - "transcript"');
+      },
+      (_url) => {
+        throw new Error("default fetch should not run when a custom fetcher handles the URL");
+      },
+    );
+  });
+
+  test("fetchWebsiteMarkdownSnapshot falls through to the default website fetch when a custom fetcher returns null", async () => {
+    const fetcherDir = path.join(process.env.AKM_STASH_DIR ?? "", "scripts", "wiki-fetchers");
+    fs.mkdirSync(fetcherDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(fetcherDir, "null-fetcher.ts"),
+      [
+        "export default {",
+        '  name: "null-fetcher",',
+        '  matches(url) { return url.hostname === "docs.example.test"; },',
+        "  async fetch() { return null; },",
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await withMockedFetch(
+      async () => {
+        const snapshot = await fetchWebsiteMarkdownSnapshot("https://docs.example.test/fallback");
+        expect(snapshot.title).toBe("Fallback");
+        expect(snapshot.content).toContain("# Fallback");
+      },
+      (url) => {
+        if (url === "https://docs.example.test/fallback") {
+          return new Response("<html><head><title>Fallback</title></head><body><p>default path</p></body></html>", {
             status: 200,
             headers: { "Content-Type": "text/html; charset=utf-8" },
-          },
-        );
-      }
-      return new Response("not found", { status: 404 });
-    }) as typeof fetch;
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+  });
 
-    try {
-      const snapshot = await fetchWebsiteMarkdownSnapshot("https://docs.example.test/guide/getting-started");
-      expect(snapshot.url).toBe("https://docs.example.test/guide/getting-started");
-      expect(snapshot.preferredName).toBe("guide/getting-started");
-      expect(snapshot.title).toBe("Getting Started");
-      expect(snapshot.content).toContain('sourceUrl: "https://docs.example.test/guide/getting-started"');
-      expect(snapshot.content).toContain("# Getting Started");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+  test("fetchWebsiteMarkdownSnapshot falls through to the default website fetch when a custom fetcher throws", async () => {
+    const fetcherDir = path.join(process.env.AKM_STASH_DIR ?? "", "scripts", "wiki-fetchers");
+    fs.mkdirSync(fetcherDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(fetcherDir, "throwing-fetcher.ts"),
+      [
+        "export default {",
+        '  name: "throwing-fetcher",',
+        '  matches(url) { return url.hostname === "docs.example.test"; },',
+        '  async fetch() { throw new Error("boom"); },',
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await withMockedFetch(
+      async () => {
+        const snapshot = await fetchWebsiteMarkdownSnapshot("https://docs.example.test/throws");
+        expect(snapshot.title).toBe("Recovered");
+        expect(snapshot.content).toContain("# Recovered");
+      },
+      (url) => {
+        if (url === "https://docs.example.test/throws") {
+          return new Response("<html><head><title>Recovered</title></head><body><p>default path</p></body></html>", {
+            status: 200,
+            headers: { "Content-Type": "text/html; charset=utf-8" },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+  });
+
+  test("fetchWebsiteMarkdownSnapshot falls through to the default website fetch when fetcher.matches throws", async () => {
+    const fetcherDir = path.join(process.env.AKM_STASH_DIR ?? "", "scripts", "wiki-fetchers");
+    fs.mkdirSync(fetcherDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(fetcherDir, "throwing-matches-fetcher.ts"),
+      [
+        "export default {",
+        '  name: "throwing-matches-fetcher",',
+        '  matches() { throw new Error("boom"); },',
+        "  async fetch() { return null; },",
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await withMockedFetch(
+      async () => {
+        const snapshot = await fetchWebsiteMarkdownSnapshot("https://docs.example.test/matches-throws");
+        expect(snapshot.title).toBe("Matches Recovered");
+        expect(snapshot.content).toContain("# Matches Recovered");
+      },
+      (url) => {
+        if (url === "https://docs.example.test/matches-throws") {
+          return new Response(
+            "<html><head><title>Matches Recovered</title></head><body><p>default path</p></body></html>",
+            {
+              status: 200,
+              headers: { "Content-Type": "text/html; charset=utf-8" },
+            },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+  });
+
+  test("wiki stash --target resolves custom fetchers from the target stash", async () => {
+    const targetStash = makeStashDir();
+    const priorCleanup = cleanup;
+    cleanup = () => {
+      targetStash.cleanup();
+      priorCleanup();
+    };
+
+    writeSandboxConfig({
+      sources: [
+        {
+          name: "target",
+          type: "filesystem",
+          path: targetStash.dir,
+          writable: true,
+        },
+      ],
+    });
+
+    createWiki(targetStash.dir, "articles");
+
+    const defaultFetcherDir = path.join(process.env.AKM_STASH_DIR ?? "", "scripts", "wiki-fetchers");
+    fs.mkdirSync(defaultFetcherDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(defaultFetcherDir, "default-fetcher.ts"),
+      [
+        "export default {",
+        '  name: "default-fetcher",',
+        '  matches(url) { return url.hostname === "video.example.test"; },',
+        '  async fetch(url) { return { url: url.toString(), title: "Wrong Fetcher", markdown: "wrong" }; },',
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const targetFetcherDir = path.join(targetStash.dir, "scripts", "wiki-fetchers");
+    fs.mkdirSync(targetFetcherDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(targetFetcherDir, "target-fetcher.ts"),
+      [
+        "export default {",
+        '  name: "target-fetcher",',
+        '  matches(url) { return url.hostname === "video.example.test"; },',
+        '  async fetch(url) { return { url: url.toString(), title: "Target Fetcher", markdown: "target body" }; },',
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await withMockedFetch(
+      async () => {
+        const result = await runCliCapture([
+          "wiki",
+          "stash",
+          "articles",
+          "https://video.example.test/watch?v=abc123",
+          "--target",
+          "target",
+          "--format",
+          "json",
+        ]);
+
+        expect(result.code).toBe(0);
+        const rawFiles = fs.readdirSync(path.join(targetStash.dir, "wikis", "articles", "raw"));
+        expect(rawFiles.some((name) => name.endsWith(".md"))).toBe(true);
+        const rawDoc = fs.readFileSync(
+          path.join(targetStash.dir, "wikis", "articles", "raw", rawFiles.find((name) => name.endsWith(".md")) ?? ""),
+          "utf8",
+        );
+        expect(rawDoc).toContain("# Target Fetcher");
+        expect(rawDoc).not.toContain("Wrong Fetcher");
+      },
+      (_url) => {
+        throw new Error("default website fetch should not run when the target stash provides a custom fetcher");
+      },
+    );
   });
 });

--- a/tests/source-providers/wiki-fetchers.test.ts
+++ b/tests/source-providers/wiki-fetchers.test.ts
@@ -18,12 +18,12 @@ afterEach(() => {
 });
 
 describe("wiki fetcher registry", () => {
-  test("returns an empty list when the fetcher directory does not exist", async () => {
+  test("includes built-in fetchers when the stash has no custom fetcher directory", async () => {
     const fetchers = await loadWikiSnapshotFetchers(process.env.AKM_STASH_DIR ?? "");
-    expect(fetchers).toEqual([]);
+    expect(fetchers.map((fetcher) => fetcher.name)).toContain("youtube-transcript");
   });
 
-  test("loads valid fetchers in alphabetical filename order and skips invalid modules", async () => {
+  test("loads valid custom fetchers before built-ins and skips invalid modules", async () => {
     const fetcherDir = path.join(process.env.AKM_STASH_DIR ?? "", "scripts", "wiki-fetchers");
     fs.mkdirSync(fetcherDir, { recursive: true });
     fs.writeFileSync(
@@ -39,6 +39,7 @@ describe("wiki fetcher registry", () => {
     fs.writeFileSync(path.join(fetcherDir, "broken.ts"), 'export default { name: "broken" };\n', "utf8");
 
     const fetchers = await loadWikiSnapshotFetchers(process.env.AKM_STASH_DIR ?? "");
-    expect(fetchers.map((fetcher) => fetcher.name)).toEqual(["a", "b"]);
+    expect(fetchers.slice(0, 2).map((fetcher) => fetcher.name)).toEqual(["a", "b"]);
+    expect(fetchers.map((fetcher) => fetcher.name)).toContain("youtube-transcript");
   });
 });

--- a/tests/source-providers/wiki-fetchers.test.ts
+++ b/tests/source-providers/wiki-fetchers.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { loadWikiSnapshotFetchers } from "../../src/sources/wiki-fetchers/registry";
+import { type Cleanup, sandboxStashDir, sandboxXdgConfigHome } from "../_helpers/sandbox";
+
+let cleanup: Cleanup = () => {};
+
+beforeEach(() => {
+  const cfgResult = sandboxXdgConfigHome();
+  const stashResult = sandboxStashDir(cfgResult.cleanup);
+  cleanup = stashResult.cleanup;
+});
+
+afterEach(() => {
+  cleanup();
+  cleanup = () => {};
+});
+
+describe("wiki fetcher registry", () => {
+  test("returns an empty list when the fetcher directory does not exist", async () => {
+    const fetchers = await loadWikiSnapshotFetchers(process.env.AKM_STASH_DIR ?? "");
+    expect(fetchers).toEqual([]);
+  });
+
+  test("loads valid fetchers in alphabetical filename order and skips invalid modules", async () => {
+    const fetcherDir = path.join(process.env.AKM_STASH_DIR ?? "", "scripts", "wiki-fetchers");
+    fs.mkdirSync(fetcherDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(fetcherDir, "b.ts"),
+      'export default { name: "b", matches() { return false; }, async fetch() { return null; } };\n',
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(fetcherDir, "a.ts"),
+      'export default { name: "a", matches() { return false; }, async fetch() { return null; } };\n',
+      "utf8",
+    );
+    fs.writeFileSync(path.join(fetcherDir, "broken.ts"), 'export default { name: "broken" };\n', "utf8");
+
+    const fetchers = await loadWikiSnapshotFetchers(process.env.AKM_STASH_DIR ?? "");
+    expect(fetchers.map((fetcher) => fetcher.name)).toEqual(["a", "b"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a stash-local wiki snapshot fetcher registry under `scripts/wiki-fetchers/` plus a built-in `youtube-transcript` fetcher
- route `fetchWebsiteMarkdownSnapshot()` through matching custom/built-in fetchers before the generic website scraper
- extract YouTube descriptions and transcripts into clean markdown, while preserving target-stash resolution, fallback behavior, and overrideability

## Testing
- `bun test tests/source-providers/website.test.ts tests/source-providers/wiki-fetchers.test.ts`
- `bunx tsc --noEmit`
- `bun run build`

## Review
- implemented test-first with failing registry and website snapshot tests before each seam/fetcher change
- ran repeated review passes and fixed issues around missing-stash fallback, target-stash plumbing, `matches()` exceptions, captionless-video behavior, manual-vs-ASR caption selection, and preserving default website/host tags
