### PR TITLE
feat(wiki): YouTube /embed/ URLs + raw-queue-driven ingest workflow

### DIFF
--- a/src/assets/wiki/ingest-workflow-template.md
+++ b/src/assets/wiki/ingest-workflow-template.md
@@ -6,20 +6,27 @@ Schema: {{SCHEMA_PATH}}
 Follow these steps. akm commands handle the invariants; use your native
 Read/Write/Edit tools for page edits.
 
+This workflow is for ingesting sources that are ALREADY present under
+`{{WIKI_DIR}}/raw/`. Do not ask the user for a source unless the raw queue is
+empty and the caller explicitly asked for interactive ingest.
+
 1. **Read the schema.** Open `{{SCHEMA_PATH}}`. It defines the voice, page
    kinds, contradiction policy, and any wiki-specific conventions. Do not
    skip this step even on familiar wikis — the schema may have changed.
 
-2. **File the source under `raw/`.**
+2. **Discover the pending raw queue.**
    ```sh
-   akm wiki stash {{WIKI_NAME}} <path-or-url-to-source>
-   # or: cat <source> | akm wiki stash {{WIKI_NAME}} -
+   akm wiki lint {{WIKI_NAME}}
    ```
-   Returns `{ slug, path, ref }`. The raw copy is immutable — never edit it.
+   Focus on `uncited-raw` findings: those raw files exist under `raw/` but are
+   not yet cited by any authored page. Treat each `uncited-raw` finding as a
+   pending ingest item. If there are no `uncited-raw` findings, exit cleanly
+   after a final `akm index` + `akm wiki lint {{WIKI_NAME}}` verification.
 
-3. **Find related existing pages.**
+3. **For each pending raw file, read the source and find related pages.**
+   Open the raw file directly from `{{WIKI_DIR}}/raw/`, then search:
    ```sh
-   akm wiki search {{WIKI_NAME}} "<key terms from the source>"
+   akm wiki search {{WIKI_NAME}} "<key terms from the raw source>"
    ```
    Read the top hits with `akm show wiki:{{WIKI_NAME}}/<page>`. Use
    `akm show wiki:{{WIKI_NAME}}/<page> toc` for large pages.
@@ -39,8 +46,8 @@ Read/Write/Edit tools for page edits.
 6. **Update xrefs both ways.** If page A now xrefs page B, page B must xref
    page A. `akm wiki lint {{WIKI_NAME}}` will flag violations.
 
-7. **Append to `log.md`.** One entry per ingest: date, source slug, one-line
-   summary, refs to created/edited pages. Newest at the top.
+7. **Append to `log.md`.** One entry per ingested raw source: date, raw slug,
+   one-line summary, refs to created/edited pages. Newest at the top.
 
 8. **Regenerate the index + verify.**
    ```sh
@@ -50,5 +57,5 @@ Read/Write/Edit tools for page edits.
    Resolve any lint findings before calling the ingest done.
 
 That's it. `akm` never calls an LLM — reasoning is your job; it just owns
-the invariants (raw immutability, unique slugs, ref validation, index
-regeneration, structural lint).
+the invariants (raw immutability, ref validation, index regeneration,
+structural lint).

--- a/src/sources/wiki-fetchers/youtube.ts
+++ b/src/sources/wiki-fetchers/youtube.ts
@@ -40,6 +40,10 @@ function extractVideoId(url: URL): string | null {
     const id = url.pathname.slice("/shorts/".length).split("/")[0]?.trim();
     return id || null;
   }
+  if (url.pathname.startsWith("/embed/")) {
+    const id = url.pathname.slice("/embed/".length).split("/")[0]?.trim();
+    return id || null;
+  }
   return null;
 }
 

--- a/tests/source-providers/website.test.ts
+++ b/tests/source-providers/website.test.ts
@@ -248,6 +248,74 @@ describe("WebsiteSourceProvider", () => {
     );
   });
 
+  test("built-in YouTube fetcher canonicalizes watch URLs with extra query params", async () => {
+    await withMockedFetch(
+      async () => {
+        const snapshot = await fetchWebsiteMarkdownSnapshot(
+          "https://www.youtube.com/watch?is=abc123&v=abc123&feature=youtu.be",
+        );
+        expect(snapshot.url).toBe("https://www.youtube.com/watch?v=abc123");
+        expect(snapshot.preferredName).toBe("youtube/abc123");
+        expect(snapshot.content).toContain("## Transcript");
+      },
+      (url) => {
+        if (url === "https://www.youtube.com/watch?v=abc123") {
+          return new Response(
+            [
+              "<html><body><script>",
+              'var ytInitialPlayerResponse = {"videoDetails":{"title":"Transcript Title","shortDescription":"Line one"},"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":"https://www.youtube.com/api/timedtext?v=abc123&lang=en","languageCode":"en"}]}}};',
+              "</script></body></html>",
+            ].join(""),
+            {
+              status: 200,
+              headers: { "Content-Type": "text/html; charset=utf-8" },
+            },
+          );
+        }
+        if (url === "https://www.youtube.com/api/timedtext?v=abc123&lang=en") {
+          return new Response("<transcript><text>Transcript body</text></transcript>", {
+            status: 200,
+            headers: { "Content-Type": "application/xml; charset=utf-8" },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+  });
+
+  test("built-in YouTube fetcher handles embed URLs", async () => {
+    await withMockedFetch(
+      async () => {
+        const snapshot = await fetchWebsiteMarkdownSnapshot("https://www.youtube.com/embed/abc123");
+        expect(snapshot.url).toBe("https://www.youtube.com/watch?v=abc123");
+        expect(snapshot.preferredName).toBe("youtube/abc123");
+        expect(snapshot.content).toContain("## Transcript");
+      },
+      (url) => {
+        if (url === "https://www.youtube.com/watch?v=abc123") {
+          return new Response(
+            [
+              "<html><body><script>",
+              'var ytInitialPlayerResponse = {"videoDetails":{"title":"Embed Title","shortDescription":"Line one"},"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":"https://www.youtube.com/api/timedtext?v=abc123&lang=en","languageCode":"en"}]}}};',
+              "</script></body></html>",
+            ].join(""),
+            {
+              status: 200,
+              headers: { "Content-Type": "text/html; charset=utf-8" },
+            },
+          );
+        }
+        if (url === "https://www.youtube.com/api/timedtext?v=abc123&lang=en") {
+          return new Response("<transcript><text>Embed transcript</text></transcript>", {
+            status: 200,
+            headers: { "Content-Type": "application/xml; charset=utf-8" },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+  });
+
   test("built-in YouTube fetcher still runs when no stash directory is available to load custom fetchers", async () => {
     await withEnv({ AKM_STASH_DIR: undefined }, async () => {
       await withMockedFetch(

--- a/tests/wiki.test.ts
+++ b/tests/wiki.test.ts
@@ -586,10 +586,12 @@ describe("buildIngestWorkflow", () => {
     expect(result.wiki).toBe("research");
     expect(result.path).toBe(path.join(stash, WIKIS_SUBDIR, "research"));
     expect(result.schemaPath).toBe(path.join(stash, WIKIS_SUBDIR, "research", SCHEMA_MD));
-    expect(result.workflow).toContain("akm wiki stash research");
+    expect(result.workflow).toContain("ALREADY present under");
+    expect(result.workflow).toContain("uncited-raw");
     expect(result.workflow).toContain("akm wiki lint research");
     expect(result.workflow).toContain("akm wiki search research");
     expect(result.workflow).toContain("akm index");
+    expect(result.workflow).not.toContain("akm wiki stash research");
   });
 });
 


### PR DESCRIPTION
## What

Two related wiki improvements that were sitting uncommitted in the working tree. **Verified absent from main** before committing (the related YouTube fetcher landed earlier in `c61cdb90`, but this extension was never committed — no duplication):

- **YouTube `/embed/` URLs** — `extractVideoId` now handles `/embed/<id>` in addition to watch/shorts/youtu.be. New tests cover embed URLs and watch-URL canonicalization (strips extra query params down to `?v=<id>`).
- **Raw-queue-driven ingest workflow** — the `ingest-workflow-template.md` now drives off the existing raw queue: discover `uncited-raw` lint findings already under `raw/`, process each, and exit cleanly (index + lint) when empty — instead of prompting the user for a source to `akm wiki stash`. `buildIngestWorkflow` test updated accordingly.

## Verification

- lint 0/0 · `tsc` 0 · unit **5309/0**
- affected suites (`tests/wiki.test.ts`, `tests/source-providers/website.test.ts`) **61/0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)