### PR TITLE
fix(agent): config-only ingest timeout + remove legacy v1 agent-config

### DIFF
--- a/src/core/config/config-types.ts
+++ b/src/core/config/config-types.ts
@@ -20,9 +20,9 @@ import type { InstalledStashEntry } from "../../registry/types";
 /**
  * Canonical list of valid agent harness / platform ids. Re-exported from the
  * unified harness registry (#562) so the Zod `AgentPlatformSchema` enum, the
- * `AgentProfileConfigV2` platform union, `parseAgentProfilesMapV2`'s membership
- * check, and setup's `DetectedHarness` union all derive from one place and
- * cannot drift. Add a harness in `src/integrations/harnesses/index.ts`.
+ * `AgentProfileConfig` platform union, and setup's `DetectedHarness` union all
+ * derive from one place and cannot drift. Add a harness in
+ * `src/integrations/harnesses/index.ts`.
  */
 export { VALID_HARNESS_IDS };
 
@@ -119,12 +119,18 @@ export interface LlmProfileConfig extends LlmConnectionConfig {
   supportsJsonSchema?: boolean;
 }
 
-export interface AgentProfileConfigV2 {
+export interface AgentProfileConfig {
   platform: HarnessId;
   bin?: string;
   args?: string[];
   workspace?: string;
   model?: string;
+  /**
+   * Per-call timeout (ms) for this agent profile. Used when a command does not
+   * pass an explicit timeout (e.g. `akm wiki ingest` without `--timeout-ms`).
+   * Mirrors `AgentProfileConfigSchema.timeoutMs`. null = no timeout.
+   */
+  timeoutMs?: number | null;
 }
 
 export interface ImproveProcessConfig {
@@ -898,7 +904,7 @@ export interface AkmConfig {
   /** Named LLM and agent profiles. */
   profiles?: {
     llm?: Record<string, LlmProfileConfig>;
-    agent?: Record<string, AgentProfileConfigV2>;
+    agent?: Record<string, AgentProfileConfig>;
     improve?: Record<string, ImproveProfileConfig>;
   };
   /** Default profile names and improve pipeline defaults. */

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -28,7 +28,7 @@ export type { AgentConfig } from "../../integrations/agent/config";
 // Re-export type surface from config-types.ts so call sites don't need to
 // move (the runtime values live here; the types are documentation-only).
 export type {
-  AgentProfileConfigV2,
+  AgentProfileConfig,
   AkmConfig,
   BaseConnectionConfig,
   ConfiguredSource,

--- a/src/integrations/agent/config.ts
+++ b/src/integrations/agent/config.ts
@@ -13,14 +13,10 @@
  * No LLM SDK is imported here. The runtime path is shell-out only (see
  * `./spawn.ts`).
  */
-import type { AgentProfileConfigV2, AkmConfig } from "../../core/config/config";
-import { VALID_HARNESS_IDS } from "../../core/config/config";
+import type { AgentProfileConfig, AkmConfig } from "../../core/config/config";
 import { ConfigError } from "../../core/errors";
-import { warn } from "../../core/warn";
 import {
-  type AgentParseMode,
   type AgentProfile,
-  type AgentStdioMode,
   BUILTIN_AGENT_PROFILE_NAMES,
   getBuiltinAgentProfile,
   listBuiltinAgentProfiles,
@@ -31,31 +27,6 @@ import {
  * `docs/configuration.md`).
  */
 export const DEFAULT_AGENT_TIMEOUT_MS = 60_000;
-
-/**
- * Persisted form of `profiles.agent[<name>]` after the 0.8.0 migration.
- * Every field is optional so users can override one piece of a built-in
- * without re-stating the rest.
- */
-export interface AgentProfileConfig {
-  bin?: string;
-  args?: string[];
-  stdio?: AgentStdioMode;
-  env?: Record<string, string>;
-  envPassthrough?: string[];
-  timeoutMs?: number;
-  parseOutput?: AgentParseMode;
-  /** Model to use when the platform is opencode-sdk. */
-  model?: string;
-  /** OpenAI-compatible endpoint when platform is opencode-sdk. */
-  endpoint?: string;
-  /** API key when platform is opencode-sdk. */
-  apiKey?: string;
-  /** Override which builder handles argv construction for this profile. */
-  commandBuilder?: string;
-  /** User-defined model aliases for this platform. Keys are lowercase alias strings. */
-  modelAliases?: Record<string, string>;
-}
 
 /**
  * Backwards-compatible alias type. After 0.8.0, the "agent config" lives on
@@ -69,7 +40,7 @@ export type AgentConfig = AkmConfig;
  * user override (`profiles.agent[name]`) on top of the built-in profile (if
  * any). Returns `undefined` when neither yields a usable profile.
  */
-export function resolveAgentProfile(name: string, overrides?: AgentProfileConfigV2): AgentProfile | undefined {
+export function resolveAgentProfile(name: string, overrides?: AgentProfileConfig): AgentProfile | undefined {
   const builtin = getBuiltinAgentProfile(name);
   const platform = overrides?.platform;
   // For opencode-sdk profiles, allow synthesizing without a built-in.
@@ -97,7 +68,12 @@ export function resolveAgentProfile(name: string, overrides?: AgentProfileConfig
     stdio: base.stdio,
     env: base.env,
     envPassthrough: base.envPassthrough,
-    timeoutMs: base.timeoutMs,
+    // Honor a user-configured `profiles.agent.<name>.timeoutMs` override; fall
+    // back to the built-in profile's value. (Previously always used base, so
+    // the documented config override was silently ignored — callers had to pass
+    // a CLI flag like `--timeout-ms`.) runAgent (spawn.ts) reads profile.timeoutMs
+    // when no per-call timeout is supplied, so this makes the config knob work.
+    timeoutMs: overrides.timeoutMs ?? base.timeoutMs,
     parseOutput: base.parseOutput,
     ...(sdkMode ? { sdkMode: true } : {}),
     model: overrides.model ?? base.model,
@@ -206,54 +182,4 @@ export function listResolvedAgentProfiles(config?: AkmConfig): AgentProfile[] {
     if (profile) resolved.push(profile);
   }
   return resolved;
-}
-
-/**
- * Parse the v2 `profiles.agent` map (AgentProfileConfigV2 shape with required
- * `platform` field). Returns a map of profile name → AgentProfileConfigV2.
- */
-export function parseAgentProfilesMapV2(value: unknown): Record<string, AgentProfileConfigV2> | undefined {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
-  const out: Record<string, AgentProfileConfigV2> = {};
-  // Derives from the canonical harness-id source of truth (#565).
-  const VALID_PLATFORMS = VALID_HARNESS_IDS;
-  for (const [name, raw] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
-      warn(`[akm] Ignoring profiles.agent["${name}"]: expected an object.`);
-      continue;
-    }
-    const obj = raw as Record<string, unknown>;
-    if (!VALID_PLATFORMS.includes(obj.platform as (typeof VALID_PLATFORMS)[number])) {
-      warn(
-        `[akm] Ignoring profiles.agent["${name}"]: missing or invalid "platform" (must be one of: ${VALID_PLATFORMS.join(", ")}).`,
-      );
-      continue;
-    }
-    const profile: AgentProfileConfigV2 = {
-      platform: obj.platform as (typeof VALID_PLATFORMS)[number],
-    };
-    if (typeof obj.bin === "string" && obj.bin.trim()) profile.bin = obj.bin.trim();
-    if (Array.isArray(obj.args) && obj.args.every((a) => typeof a === "string")) {
-      profile.args = obj.args as string[];
-    }
-    if (typeof obj.workspace === "string" && obj.workspace.trim()) profile.workspace = obj.workspace.trim();
-    if (typeof obj.model === "string" && obj.model.trim()) profile.model = obj.model.trim();
-    out[name] = profile;
-  }
-  return Object.keys(out).length > 0 ? out : undefined;
-}
-
-/**
- * Stub kept for source-compat with callers that previously used the v1 agent
- * config parser. After 0.8.0 there is no separate `agent` block to parse — the
- * loaded `AkmConfig` already carries the agent data on `profiles.agent` and
- * `defaults.agent`. This function is a no-op alias for those callers.
- *
- * @deprecated v0.8.0 — the unified `AkmConfig` IS the agent config. Use the
- * profile/defaults accessors above instead.
- */
-export function parseAgentConfig(_value: unknown): AgentConfig | undefined {
-  // No-op: there is no separate agent block in 0.8.0. Callers should pass
-  // their loaded `AkmConfig` directly to `requireAgentProfile` etc.
-  return undefined;
 }

--- a/src/integrations/agent/index.ts
+++ b/src/integrations/agent/index.ts
@@ -10,7 +10,7 @@
  * Surface:
  *   • Types: AgentProfile, AgentConfig, AgentRunResult, AgentFailureReason.
  *   • Profiles: getBuiltinAgentProfile, listBuiltinAgentProfiles, BUILTIN_AGENT_PROFILE_NAMES.
- *   • Config: parseAgentConfig, resolveProfileFromConfig, requireAgentProfile, listResolvedAgentProfiles, listAgentProfileNames.
+ *   • Config: resolveProfileFromConfig, requireAgentProfile, listResolvedAgentProfiles, listAgentProfileNames.
  *   • Spawn: runAgent. Builders: getCommandBuilder, AgentCommandBuilder, AgentDispatchRequest — platform-specific argv construction.
  *   • Detection: detectAgentCliProfiles, pickDefaultAgentProfile, defaultWhich.
  */
@@ -21,15 +21,11 @@
 export { runAgentSdk } from "../harnesses/opencode-sdk";
 export type { AgentCommandBuilder, AgentDispatchRequest, BuiltCommand } from "./builders";
 export { getCommandBuilder } from "./builders";
-export type {
-  AgentConfig,
-  AgentProfileConfig,
-} from "./config";
+export type { AgentConfig } from "./config";
 export {
   DEFAULT_AGENT_TIMEOUT_MS,
   listAgentProfileNames,
   listResolvedAgentProfiles,
-  parseAgentConfig,
   requireAgentProfile,
   resolveAgentProfile,
   resolveDefaultProfileName,

--- a/src/integrations/harnesses/index.ts
+++ b/src/integrations/harnesses/index.ts
@@ -67,9 +67,8 @@ const HARNESS_BY_ANY_ID: ReadonlyMap<string, AkmHarness> = (() => {
 
 /**
  * Canonical, ordered list of valid harness / platform ids. The Zod
- * `AgentPlatformSchema` enum, the `AgentProfileConfigV2` platform union,
- * `parseAgentProfilesMapV2`'s membership check, and setup's `DetectedHarness`
- * union all derive from this so they cannot drift.
+ * `AgentPlatformSchema` enum, the `AgentProfileConfig` platform union, and
+ * setup's `DetectedHarness` union all derive from this so they cannot drift.
  */
 export const VALID_HARNESS_IDS = Object.freeze(HARNESS_REGISTRY.map((h) => h.id)) as unknown as readonly [
   (typeof HARNESS_REGISTRY)[number]["id"],

--- a/tests/agent/agent-config.test.ts
+++ b/tests/agent/agent-config.test.ts
@@ -34,6 +34,15 @@ describe("built-in profile resolution", () => {
     expect(merged?.envPassthrough).toContain("PATH"); // built-in retained
   });
 
+  test("user-configured timeoutMs override is honored (config-only timeout, no CLI flag)", async () => {
+    const { resolveAgentProfile } = await import("../../src/integrations/agent/config");
+    // profiles.agent.<name>.timeoutMs must flow onto the resolved profile so
+    // runAgent (spawn.ts) picks it up when no per-call timeout is passed —
+    // e.g. `akm wiki ingest` without `--timeout-ms`.
+    const merged = resolveAgentProfile("opencode", { platform: "opencode", timeoutMs: 6_000_000 });
+    expect(merged?.timeoutMs).toBe(6_000_000);
+  });
+
   test("user-defined profile (no built-in) requires bin", async () => {
     const { resolveAgentProfile } = await import("../../src/integrations/agent/config");
     expect(resolveAgentProfile("rover", undefined)).toBeUndefined();

--- a/tests/harnesses-registry.test.ts
+++ b/tests/harnesses-registry.test.ts
@@ -46,7 +46,7 @@ describe("HARNESS_REGISTRY membership", () => {
   });
 
   it("config-types re-exports the SAME derived id list (single source of truth)", () => {
-    // The Zod schema, the AgentProfileConfigV2 platform union, and setup's
+    // The Zod schema, the AgentProfileConfig platform union, and setup's
     // DetectedHarness all derive from this exact array.
     expect([...CONFIG_VALID_HARNESS_IDS]).toEqual([...VALID_HARNESS_IDS]);
   });


### PR DESCRIPTION
## 1. Set the wiki-ingest timeout via config (no `--timeout-ms`)

`akm wiki ingest` only applied a timeout when `--timeout-ms` was passed; the documented config knob `profiles.agent.<name>.timeoutMs` was **silently ignored**. Root cause: `resolveAgentProfile` merged `timeoutMs: base.timeoutMs`, dropping the user override. `runAgent` (spawn.ts) already falls back to `profile.timeoutMs`, so the one-line fix makes the config path work end-to-end. Also added the missing `timeoutMs` field to the `AgentProfileConfig` type (it was already in the zod schema).

**Usage** (default agent profile is `opencode`):
```jsonc
"profiles": { "agent": { "opencode": { "platform": "opencode", "timeoutMs": 6000000 } } }
```
Default stays 60s when unset.

## 2. Remove legacy v1 agent-config (the "why is there a V2?" answer)

The 0.8.0 migration left duplicates behind:
- **`AgentProfileConfig` (v1 interface)** — orphaned; only defined + re-exported, never used as a type.
- **`parseAgentProfilesMapV2`** — dead; config loads via the zod schema, not this manual parser. Zero callers.
- **`parseAgentConfig`** — a `@deprecated` no-op stub; zero callers.

Removed all three (+ now-orphaned imports), and renamed the live `AgentProfileConfigV2` → `AgentProfileConfig` so there's **one** canonical agent-profile config type and no confusing `V2` suffix. `AgentConfig` (the `AkmConfig` alias) is kept — it has real callers.

## Verification
- lint 0/0 · `tsc` 0 · unit **5311/0**
- New test: `profiles.agent.<name>.timeoutMs` override is honored by `resolveAgentProfile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)