### PR TITLE
fix(config): resolve 0.9.0 config audit — schema/type drift, docs, guards

### DIFF
--- a/docs/akm-eval.md
+++ b/docs/akm-eval.md
@@ -282,7 +282,7 @@ scripts/akm-eval/bin/akm-eval-run --suite judge-calibration \
   --akm /path/to/akm/dist/cli.js --format md
 ```
 
-When `profiles.improve.default.processes.feedbackDistillation.enabled` is
+When `profiles.improve.default.processes.distill.enabled` is
 disabled in the test env the judge returns `skipped` for every probe —
 that's expected; the case scores low but the runner machinery and the
 metrics block still work.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,7 +115,7 @@ in-place rewrite. Set `AKM_NO_AUTO_MIGRATE=1` to suppress the rewrite.
 | `profiles.agent.<name>` | object | — | Named agent profile (`platform: "opencode"\|"claude"\|"opencode-sdk"`). See [Profile types](#profile-types). |
 | `defaults.llm` | string | — | Default LLM profile name. Used when a features entry omits `profile`. Also the target for `AKM_LLM_API_KEY` injection. |
 | `defaults.agent` | string | — | Default agent profile name. Fallback for `mode: "agent"` or `mode: "sdk"` entries that omit `profile`. |
-| `defaults.improve` | string | `"default"` | Default improve profile name. Selects a built-in (`default`, `thorough`, `quick`, `frequent`, `catchup`, `consolidate`, `graph-refresh`, `memory-focus`) or a user-defined entry under `profiles.improve`. Overridden by `--profile <name>`. |
+| `defaults.improve` | string | `"default"` | Default improve profile name. Selects a built-in (`default`, `thorough`, `quick`, `frequent`, `catchup`, `consolidate`, `graph-refresh`, `memory-focus`, `synthesize`) or a user-defined entry under `profiles.improve`. Overridden by `--profile <name>`. |
 | `profiles.improve.<name>` | object | — | Improve profile defining per-process gating, type filters, and run-level `autoAccept` / `limit` / `maxCycles` / `symmetricValence` / `sync` defaults. See [Improve profiles](#improve-profiles). |
 | `profiles.improve.<name>.processes.<process>` | object | — | Per-process binding. Processes: `reflect`, `distill`, `consolidate`, `memoryInference`, `graphExtraction`, `extract`, `validation`, `triage`, `proactiveMaintenance`, `recombine`, `procedural`. Common shape: `{ enabled, mode, profile, timeoutMs, allowedTypes?, qualityGate? }` plus process-specific knobs (see [Known process names](#known-process-names) and the [JSON schema](https://itlackey.github.io/akm/schemas/akm-config.json)). |
 | `index.metadataEnhance.enabled` | boolean | `false` | Toggles the `akm index` metadata-enhancement pass. Replaces the legacy `features.index.metadata_enhance` entry. |
@@ -415,14 +415,15 @@ processes, per-process runner / cooldown overrides, and run-level
 | --- | --- | --- |
 | `default` | Standard pass — reflect, distill, consolidate, memoryInference, graphExtraction, extract; markdown asset types. | Auto-commit + push |
 | `thorough` | Like `default` but also enables the `triage` process (drains the pending-proposal backlog). | Auto-commit + push |
-| `quick` | Reflect-only — distill / consolidate / memoryInference / graphExtraction / extract all disabled. | **Sync disabled** |
+| `quick` | Reflect-only — distill / consolidate / memoryInference / graphExtraction / extract all disabled. | Auto-commit + push |
 | `frequent` | Lightweight recurring pass — reflect + memoryInference + graphExtraction + extract (with `minNewSessions`). | Auto-commit + push |
 | `consolidate` | Consolidate-only, tuned for a dedicated consolidation run (`maxChunkSize` 25, `minPoolSize` 500). | Auto-commit + push |
 | `catchup` | Consolidate (`maxChunkSize` 50, `minPoolSize` 0) + `triage` (queue, `personal-stash` policy) for clearing a backlog. | Auto-commit + push |
 | `graph-refresh` | `graphExtraction` only, with `fullScan: true` — a scheduled full-corpus graph rebuild. | Auto-commit + push |
-| `memory-focus` | Reflect + memoryInference only; restricted to `memory` and `lesson` types. | **Sync disabled** |
+| `memory-focus` | Reflect + memoryInference only; restricted to `memory` and `lesson` types. | Auto-commit + push |
+| `synthesize` | Synthesis-only — `recombine` (cross-episodic generalization) + `procedural` (workflow compilation); all generative/extract passes off. Opt-in periodic pass. | Auto-commit + push |
 
-> Two built-ins ship with `sync.enabled: false`: **`quick`** (reflect-only, fast iteration) and **`memory-focus`**. Note `memory-focus` *produces* proposals but does not auto-commit/push them — commit manually or run a sync-enabled profile if you want them persisted to the git stash.
+> All built-ins now auto-commit (and push when the stash is writable with a remote). `saveGitStash` no-ops a clean working tree, so sync costs nothing when a run writes nothing. Use `--no-sync` / `--no-push` to suppress for a single run.
 
 ### Schema
 
@@ -470,7 +471,7 @@ presence of a `.git` directory in the stash — no remote is required.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `enabled` | boolean | true (default/thorough), false (quick/memory-focus) | Whether to auto-commit at run end |
+| `enabled` | boolean | true (all built-ins) | Whether to auto-commit at run end |
 | `push` | boolean | true | Whether to push after commit (only applies when `enabled: true` and stash is writable) |
 | `message` | string | `"akm improve auto-sync"` | Commit message template; supports `{token}` placeholders |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,12 +9,11 @@ akm stores configuration in a platform-standard config directory:
 
 Override with `AKM_CONFIG_DIR`.
 
-When akm runs inside a project, it also looks for project config files named
-`.akm/config.json` in the current directory and each parent directory, then
-merges them on top of the user config. Closer project directories win for
-scalar/object settings, while project `sources` are appended after user-level
-sources. This makes it easy to add project-specific sources without
-changing your global config.
+akm reads a **single** config layer — the user config above. Project-level
+`.akm/config.json` files are **no longer merged** (multi-layer project config was
+removed after the 0.8.x deprecation). If one is found in the current directory or
+an ancestor, akm prints a one-time deprecation warning and ignores it; move any
+settings you still need into the user config.
 
 For a guided first-run experience, use `akm setup` to choose a stash directory,
 configure embeddings/LLM settings, review registries, and add sources.
@@ -35,7 +34,7 @@ akm config migrate                  # Apply config v2 migration
 ```
 
 `akm config set` / `unset` write the user config in your platform config
-directory. Project config files are meant to be edited directly in the project.
+directory.
 
 ## 0.8.0 Config Shape
 
@@ -76,14 +75,12 @@ in-place rewrite. Set `AKM_NO_AUTO_MIGRATE=1` to suppress the rewrite.
             "enabled": true,
             "mode": "llm",
             "profile": "openai-mini",
-            "timeoutMs": 90000,
-            "cooldownByType": { "memory": 2, "lesson": 7, "knowledge": 30 }
+            "timeoutMs": 90000
           },
           "distill": { "enabled": true, "mode": "llm", "profile": "openai-mini" },
           "consolidate": { "enabled": true, "mode": "llm", "profile": "openai-mini" },
           "memoryInference": { "enabled": true },
-          "graphExtraction": { "enabled": true, "profile": "openai-mini" },
-          "feedbackDistillation": { "enabled": true }
+          "graphExtraction": { "enabled": true, "profile": "openai-mini" }
         }
       }
     }
@@ -118,22 +115,26 @@ in-place rewrite. Set `AKM_NO_AUTO_MIGRATE=1` to suppress the rewrite.
 | `profiles.agent.<name>` | object | — | Named agent profile (`platform: "opencode"\|"claude"\|"opencode-sdk"`). See [Profile types](#profile-types). |
 | `defaults.llm` | string | — | Default LLM profile name. Used when a features entry omits `profile`. Also the target for `AKM_LLM_API_KEY` injection. |
 | `defaults.agent` | string | — | Default agent profile name. Fallback for `mode: "agent"` or `mode: "sdk"` entries that omit `profile`. |
-| `defaults.improve` | string | `"default"` | Default improve profile name. Selects one of the built-ins (`default`, `quick`, `thorough`, `memory-focus`) or a user-defined entry under `profiles.improve`. Overridden by `--profile <name>`. |
-| `profiles.improve.<name>` | object | — | Improve profile defining per-process gating, type filters, cooldowns, and run-level `autoAccept` / `limit` defaults. See [Improve profiles](#improve-profiles). |
-| `profiles.improve.<name>.processes.<process>` | object | — | Per-process binding (`reflect`, `distill`, `consolidate`, `memoryInference`, `graphExtraction`, `feedbackDistillation`, `validation`). Shape: `{ enabled, mode, profile, timeoutMs, qualityGate?, contradictionDetection?, cooldownByType?, allowedTypes? }`. |
+| `defaults.improve` | string | `"default"` | Default improve profile name. Selects a built-in (`default`, `thorough`, `quick`, `frequent`, `catchup`, `consolidate`, `graph-refresh`, `memory-focus`) or a user-defined entry under `profiles.improve`. Overridden by `--profile <name>`. |
+| `profiles.improve.<name>` | object | — | Improve profile defining per-process gating, type filters, and run-level `autoAccept` / `limit` / `maxCycles` / `symmetricValence` / `sync` defaults. See [Improve profiles](#improve-profiles). |
+| `profiles.improve.<name>.processes.<process>` | object | — | Per-process binding. Processes: `reflect`, `distill`, `consolidate`, `memoryInference`, `graphExtraction`, `extract`, `validation`, `triage`, `proactiveMaintenance`, `recombine`, `procedural`. Common shape: `{ enabled, mode, profile, timeoutMs, allowedTypes?, qualityGate? }` plus process-specific knobs (see [Known process names](#known-process-names) and the [JSON schema](https://itlackey.github.io/akm/schemas/akm-config.json)). |
 | `index.metadataEnhance.enabled` | boolean | `false` | Toggles the `akm index` metadata-enhancement pass. Replaces the legacy `features.index.metadata_enhance` entry. |
 | `index.stalenessDetection.enabled` | boolean | `false` | Toggles the `akm index` staleness-detection pass. |
 | `index.stalenessDetection.thresholdDays` | integer | `90` | Days before a memory is re-evaluated for staleness. |
 | `search.curateRerank.enabled` | boolean | `false` | Toggles the `akm curate` LLM-rerank pass. Replaces the legacy `features.search.curate_rerank` entry. |
 | `semanticSearchMode` | `"off"` \| `"auto"` | `"auto"` | Semantic vector search mode. |
 | `embedding` | object | null (local) | Embedding connection settings. Unchanged from v1. |
-| `output.format` | string | `json` | Default output format (`json`, `text`, `yaml`, `jsonl`). |
-| `output.detail` | string | `brief` | Default output detail (`brief`, `normal`, `full`, `summary`, `agent`). |
+| `output.format` | string | `json` | Default output format (`json`, `text`, `yaml`). |
+| `output.detail` | string | `brief` | Default output detail (`brief`, `normal`, `full`). |
 | `sources` | array | `[]` | Source entries — directories, git repos, websites, npm packages. |
 | `defaultWriteTarget` | string | — | Source name for `akm remember` / `akm import` writes when `--target` is omitted. |
 | `writable` | boolean | `false` | Whether the primary stash pushes on `akm sync`. |
-| `stashInheritance` | `"merge"` \| `"replace"` | `"merge"` | How per-project sources compose with global ones. |
 | `registries` | array | official + skills.sh | Configured registries. |
+| `archiveRetentionDays` | number | `90` | Days to retain soft-invalidated memory assets in `.akm/archive/`. `0` disables TTL cleanup. |
+| `feedback.requireReason` | boolean | `true` | When true, negative `akm feedback` without `--reason` errors. |
+| `feedback.allowedFailureModes` | array | curated set | Restrict the accepted `--failure-mode` values. |
+| `improve.utilityDecay` / `calibration` / `exploration` / `salience` | object | — | Improve-pipeline tuning. See [Advanced improve tuning](#advanced-improve-tuning). |
+| `improve.eventRetentionDays` | number | `90` | Retention window (days) for `state.db` `events`. `0` disables purging. |
 | `stashDir` | string | platform default | Path to the working stash. |
 | `search.minScore` | number | `0.2` | Minimum score floor for semantic-only hits. |
 | `search.graphBoost.directBoostPerEntity` | number | `0.25` | Additive direct-match graph boost per matched entity. |
@@ -235,18 +236,18 @@ the full field reference and model alias documentation.
 
 ## Process entry shape
 
-Every `features.<section>.<name>` entry uses the same unified shape. Three
-shorthand forms are accepted:
+Every process entry under `profiles.improve.<name>.processes` uses the same
+unified shape:
 
 ```jsonc
-"X": true                    // enabled, all defaults resolved at load time
-"X": false                   // disabled — caller short-circuits (no runner resolved)
 "X": {
-  "enabled": true,           // optional; default true
+  "enabled": true,           // optional; default depends on the process
   "mode": "llm",             // "llm" | "agent" | "sdk" — optional, inferred if omitted
   "profile": "<name>",       // optional; falls back to defaults.llm or defaults.agent
-  "timeoutMs": 60000,        // optional; null = unlimited
-  "options": { /* ... */ }   // optional; process-specific tuning
+  "timeoutMs": 60000         // optional; null = unlimited
+  // ...plus any process-specific tuning knobs as FLAT sibling fields
+  // (e.g. consolidate.minPoolSize, extract.minNewSessions) — there is no
+  // nested `options` wrapper. See "Known process names" below.
 }
 ```
 
@@ -257,31 +258,35 @@ shorthand forms are accepted:
    `"opencode"` / `"claude"` platform → `"agent"`.
 2. If neither is set: `defaults.llm` is set → `"llm"`; else `defaults.agent` → `"agent"`.
 
-**`options`** holds process-specific tuning that doesn't fit the generic fields.
-Unknown keys under `options` warn-and-ignore.
-
-Reflect/distill cooldowns, per-process type filters, and per-process gating
-all live under [`profiles.improve.<name>.processes.*`](#improve-profiles)
-in 0.8.0.
+Per-process type filters (`allowedTypes`) and per-process gating all live under
+[`profiles.improve.<name>.processes.*`](#improve-profiles).
 
 ## Known process names
 
 ### `profiles.improve.<name>.processes.*`
 
 Each entry under `processes` is either absent (use the built-in default
-for the named profile) or an object of the form
-`{ enabled?, mode?, profile?, timeoutMs?, allowedTypes?, qualityGate?, contradictionDetection?, defaultSince?, maxTotalChars? }`.
-(Not all fields apply to all processes: `allowedTypes` is for reflect/distill; `qualityGate` and `contradictionDetection` for specific processes; `defaultSince` and `maxTotalChars` only for extract.)
+for the named profile) or an object with the common fields
+`{ enabled?, mode?, profile?, timeoutMs?, allowedTypes?, qualityGate? }`
+**plus process-specific tuning knobs as flat fields**. Not all fields apply to
+all processes — the per-knob reference (which process each applies to, its
+default, and range) lives in the field comments of
+[`config-schema.ts`](https://github.com/itlackey/akm/blob/main/src/core/config/config-schema.ts)
+and the published [JSON schema](https://itlackey.github.io/akm/schemas/akm-config.json).
 
-| Process | Default (built-in `default` profile) | Description |
+| Process | Default (built-in `default` profile) | Description & key knobs |
 | --- | --- | --- |
-| `reflect` | enabled, all markdown types | Reflection pass — generates per-asset proposals. Optional `qualityGate.enabled` runs an LLM-as-judge check before queuing. |
-| `distill` | enabled, `memory` only | Turns feedback into lesson proposals. Optional `qualityGate.enabled`. |
-| `consolidate` | enabled, `memory` only | Memory deduplication / promotion. Optional `contradictionDetection.enabled` runs pairwise checks. |
-| `memoryInference` | enabled | Derives structured memories from pending memory files. |
-| `graphExtraction` | enabled | Extracts entities and relations for graph-boosted search. |
-| `extract` | enabled | Reads native session files (Claude Code JSONL, opencode logs) and extracts insight proposals via LLM. Configure `defaultSince` (discovery window, e.g. `"24h"`) and `maxTotalChars` (event-budget, default `80000`) to tune extraction scope. |
-| `validation` | unset → falls back to `defaults.llm` | Lower-tier classifier model used by staleness detection, confidence scoring, and lesson classification. Configure with a smaller/cheaper LLM profile to keep validation cycles cheap. |
+| `reflect` | enabled, all markdown types | Reflection pass — generates per-asset proposals. `qualityGate.enabled` runs an LLM-as-judge check; `lowValueFilter.enabled` defers low-value proposals. |
+| `distill` | enabled, `memory` only | Turns feedback into lesson proposals. `qualityGate.enabled`, `requirePlannedRefs`, `cls`, `fidelityCheck`. |
+| `consolidate` | enabled, `memory` only | Memory dedup / promotion. `minPoolSize`, `incrementalSince`, `dedup`, `judgedCache`, `homeostaticDemotion`, `schemaSimilarity`, `antiCollapse`, `contradictionDetection`. |
+| `memoryInference` | enabled | Derives structured memories from pending memory files. `minPendingCount`, `cls`. |
+| `graphExtraction` | enabled | Extracts entities/relations for graph-boosted search. `fullScan`, `topN`. |
+| `extract` | enabled | Reads native session files and extracts insight proposals via LLM. `defaultSince`, `maxTotalChars`, `minContentChars`, `minNewSessions`, `maxSessionsPerRun`, `indexSessions`, `minSessionDuration`, `triage` (`{enabled, minScore}`), `hotProbation`. |
+| `validation` | disabled → falls back to `defaults.llm` | Lower-tier classifier (staleness/confidence/lesson classification). Point at a smaller/cheaper LLM profile. |
+| `triage` | disabled | Drains the standing pending-proposal backlog via a deterministic policy. `applyMode` (`queue`\|`promote`), `policy`, `maxAcceptsPerRun`, `maxDiffLines`, `rejectEmpty`, `judgment`. |
+| `proactiveMaintenance` | disabled | Surfaces top-N highest-priority *due* assets for refresh on a schedule. `dueDays` (30), `maxPerRun`/`limit` (25). |
+| `recombine` | disabled | Clusters memories by relatedness and induces cross-episodic generalizations. `minClusterSize`, `maxClustersPerRun`, `maxClusterSize`, `excludeTags`, `excludeEntities`, `relatednessSource` (`tags`\|`graph`\|`both`), `confirmThreshold`. |
+| `procedural` | disabled | Compiles recurring successful action sequences into workflow proposals. `minRecurrence`, `maxProposalsPerRun`, `emitAs`. |
 
 #### Configuring the extract process
 
@@ -332,6 +337,46 @@ Leave the section absent to use the previous fixed 30-day formula
 unchanged — the feedback-count query is skipped entirely when `utilityDecay`
 is not configured, so there's zero overhead on the search hot path.
 
+#### Advanced improve tuning
+
+Three optional top-level `improve.*` sub-trees tune the auto-accept gate and the
+salience-weighted selection lanes. **All default OFF** — when absent, improve
+behaves byte-identically to the un-tuned baseline. Enable them only after
+measuring with `scripts/akm-eval` + the health report.
+
+```jsonc
+{
+  "improve": {
+    "calibration": {
+      "autoTune": false,          // master switch for bounded threshold auto-tune (default false)
+      "minThreshold": 50,         // lower bound (0-100) the tuned threshold may never drop below
+      "maxThreshold": 85,         // upper bound (0-100); default 85 (prevents pure exploitation)
+      "maxStep": 5,               // max adjustment per tune step (points)
+      "minSamples": 20,           // min acted-on samples before any adjustment
+      "targetAcceptRate": 0.9     // target realized accept rate [0,1] (default 0.9)
+    },
+    "exploration": {
+      "enabled": false,           // accept a fixed fraction of proposals regardless of confidence
+      "budgetFraction": 0.05      // fraction per run [0,1] (default 0.05 = 5%)
+    },
+    "salience": {
+      "outcomeWeightEnabled": false, // enable the WS-2 outcome-weight term in salience (default false)
+      "salienceThreshold": 0.75,     // min encoding salience for the high-salience lane; 1.0 disables it
+      "replayBudget": 0              // additive per-run top-salience refs to revisit (default 0 = no replay)
+    }
+  }
+}
+```
+
+- **`calibration`** controls the opt-in per-phase auto-tune of the confidence
+  gate (persisted in `state.db`). The reliability summary on `akm health` is
+  always computed; this block only governs whether the threshold is adjusted.
+- **`exploration`** reserves a slice of accepts for below-threshold proposals so
+  the gate can't converge to pure exploitation (which would starve novelty).
+- **`salience`** governs the encoding-salience selection lane and the additive
+  replay budget. Per-knob semantics are documented in
+  [`config-schema.ts`](https://github.com/itlackey/akm/blob/main/src/core/config/config-schema.ts).
+
 ### `index.*`
 
 | Section | Default | Description |
@@ -340,11 +385,21 @@ is not configured, so there's zero overhead on the search hot path.
 | `index.stalenessDetection.enabled` | `false` | Run the staleness-detection validator pass during `akm index`. |
 | `index.stalenessDetection.thresholdDays` | `90` | Days before a memory is re-evaluated for staleness. |
 
+Any **other** key under `index` is treated as a per-pass entry (keyed by pass
+name, e.g. `index.graph`). Per-pass entries accept: `llm` (boolean — set
+`false` to opt a single pass out of its LLM call), `graphExtractionBatchSize`
+(default 4), `graphExtractionIncludeTypes` (array), `memoryInferenceBatchSize`
+(default 1), and `lazyGraphExtraction` (boolean, default false). Per-pass
+alternate-provider configuration is not supported — configure
+provider/model/endpoint under `profiles.llm` only.
+
 ### `search.*`
 
 | Section | Default | Description |
 | --- | --- | --- |
 | `search.curateRerank.enabled` | `false` | LLM re-ranking during `akm curate`. |
+| `search.minScore` | `0.2` | Minimum score floor for semantic-only hits. `0` disables. |
+| `search.defaultExcludeTypes` | `["session"]` | Asset types excluded from default (untyped) `akm search` / `akm curate`. Explicit `[]` disables exclusion; never applies when `--type` is given. |
 
 ## Improve profiles
 
@@ -358,10 +413,16 @@ processes, per-process runner / cooldown overrides, and run-level
 
 | Name | Description | Sync behavior |
 | --- | --- | --- |
-| `default` | Standard improve pass — all sub-processes, markdown asset types. | Auto-commit + push |
-| `quick` | Reflect-only — distill, consolidate, memoryInference, graphExtraction all disabled. | Sync disabled |
-| `thorough` | All sub-processes enabled (currently identical to `default`; reserved for future divergence). | Auto-commit + push |
-| `memory-focus` | Reflect + memoryInference only; restricted to `memory` and `lesson` types. | Sync disabled |
+| `default` | Standard pass — reflect, distill, consolidate, memoryInference, graphExtraction, extract; markdown asset types. | Auto-commit + push |
+| `thorough` | Like `default` but also enables the `triage` process (drains the pending-proposal backlog). | Auto-commit + push |
+| `quick` | Reflect-only — distill / consolidate / memoryInference / graphExtraction / extract all disabled. | **Sync disabled** |
+| `frequent` | Lightweight recurring pass — reflect + memoryInference + graphExtraction + extract (with `minNewSessions`). | Auto-commit + push |
+| `consolidate` | Consolidate-only, tuned for a dedicated consolidation run (`maxChunkSize` 25, `minPoolSize` 500). | Auto-commit + push |
+| `catchup` | Consolidate (`maxChunkSize` 50, `minPoolSize` 0) + `triage` (queue, `personal-stash` policy) for clearing a backlog. | Auto-commit + push |
+| `graph-refresh` | `graphExtraction` only, with `fullScan: true` — a scheduled full-corpus graph rebuild. | Auto-commit + push |
+| `memory-focus` | Reflect + memoryInference only; restricted to `memory` and `lesson` types. | **Sync disabled** |
+
+> Two built-ins ship with `sync.enabled: false`: **`quick`** (reflect-only, fast iteration) and **`memory-focus`**. Note `memory-focus` *produces* proposals but does not auto-commit/push them — commit manually or run a sync-enabled profile if you want them persisted to the git stash.
 
 ### Schema
 
@@ -372,15 +433,15 @@ processes, per-process runner / cooldown overrides, and run-level
       "description": "Human-readable summary (optional).",
       "autoAccept": 90,             // optional — default proposal auto-accept threshold (0-100)
       "limit": 25,                  // optional — default refs per run; overridden by --limit
+      "maxCycles": 1,               // optional — bounded multi-cycle phasing (default 1)
+      "symmetricValence": false,    // optional — weight |valence| (both +/- feedback) in ranking
       "processes": {
         "reflect": {
           "enabled": true,
           "mode": "llm",            // optional — "llm" | "agent" | "sdk"
           "profile": "openai-mini", // optional — runner profile name (profiles.llm.* / profiles.agent.*)
           "timeoutMs": 60000,       // optional
-          "allowedTypes": ["memory", "lesson"],      // optional — whitelist of asset types
-          "cooldownByType": { "memory": 1 },         // optional — per-type cooldown (days)
-          "cooldownDays": 7                          // optional — uniform cooldown
+          "allowedTypes": ["memory", "lesson"]       // optional — whitelist of asset types
         },
         "distill": { "enabled": true, "allowedTypes": ["memory"] },
         "consolidate": { "enabled": true },

--- a/docs/technical/improve-workflow.md
+++ b/docs/technical/improve-workflow.md
@@ -210,7 +210,7 @@ For `skill:*` refs, reflect also reviews related distilled lessons as consolidat
 3. Read feedback events via `readEvents({ ref, type: "feedback" })`. Apply `excludeFeedbackFromRefs` filtering before the LLM sees the events.
 4. Memory promotion fast path: when `proposalKind` is `"auto"` or `"knowledge"` and `assessMemoryKnowledgePromotionCandidate` returns `promote: true`, create a `knowledge:` proposal immediately without an LLM call.
 5. LLM call: `tryLlmFeature("feedback_distillation", config, () => chat(getDefaultLlmConfig(config), messages), null)`.
-   - Feature gate: disabled if `profiles.improve.default.processes.feedbackDistillation.enabled` is `false`.
+   - Feature gate: disabled if `profiles.improve.default.processes.distill.enabled` is `false` (0.8.0 unified the legacy `feedback_distillation` flag into `distill.enabled`).
    - Hard timeout: 30 seconds enforced by `tryLlmFeature`.
    - Returns `null` on gate-disabled, timeout, or error — treated as a graceful skip (exit 0, no proposal).
 6. Strip markdown fences and `<think>` blocks from the raw LLM output.
@@ -330,7 +330,7 @@ Before the per-asset loop, `akm improve` builds Sets of all refs that are curren
 
 | Feature flag (name passed to `isLlmFeatureEnabled` / `tryLlmFeature`) | Config path | Controls |
 |---|---|---|
-| `feedback_distillation` | `profiles.improve.default.processes.feedbackDistillation.enabled` | Whether `akmDistill` issues an LLM call. Disabled → outcome `"skipped"`, no proposal, exit 0. Enforced by `tryLlmFeature` with a 30 s hard timeout. |
+| `feedback_distillation` | `profiles.improve.default.processes.distill.enabled` | Whether `akmDistill` issues an LLM call. Disabled → outcome `"skipped"`, no proposal, exit 0. Enforced by `tryLlmFeature` with a 30 s hard timeout. (Internal flag key is still `feedback_distillation`; the config path was unified into `distill.enabled` in 0.8.0.) |
 | `memory_consolidation` | `profiles.improve.default.processes.consolidate.enabled` | Whether `akmConsolidate` runs Phase A or B at all. Disabled → immediate no-op return with `processed: 0`. Also gates the `generateMergedContent` call inside Phase B via a second `tryLlmFeature` call. |
 
 Agent path vs. HTTP path in consolidate is determined at runtime by resolving the

--- a/docs/technical/manual-testing-checklist.md
+++ b/docs/technical/manual-testing-checklist.md
@@ -501,7 +501,7 @@ Run only inside the sandbox.
 ### 15.3 improve / lesson
 
 - [ ] `akm improve skill:k8s-deploy` returns `outcome: "skipped"` when
-      `profiles.improve.default.processes.feedbackDistillation.enabled` is
+      `profiles.improve.default.processes.distill.enabled` is
       `false`, or queues a lesson proposal when enabled.
 - [ ] `akm improve skill:k8s-deploy --exclude-feedback-from "memory:test-memory"`
       accepts valid refs.

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "lint:devto-posts:fix": "bun scripts/lint-devto-posts.ts --fix",
     "publish:devto": "npx -y @sinedied/devto-cli push \"docs/posts/**/*.md\" --token \"$DEVTO_TOKEN\" --repo \"$GITHUB_REPOSITORY\" --branch \"${GITHUB_REF_NAME:-main}\" --reconcile",
     "release:check": "./tests/release-check.sh",
-    "lint": "bunx biome check src/ tests/ && bun scripts/lint-tests-isolation.ts && bun scripts/lint-license-headers.ts && bun scripts/lint-runtime-boundary.ts && bun scripts/lint-repository-sql.ts",
+    "lint": "bunx biome check src/ tests/ && bun scripts/lint-tests-isolation.ts && bun scripts/lint-license-headers.ts && bun scripts/lint-runtime-boundary.ts && bun scripts/lint-repository-sql.ts && bun scripts/gen-config-schema.ts --check",
     "lint:runtime-boundary": "bun scripts/lint-runtime-boundary.ts",
     "lint:tests-isolation": "bun scripts/lint-tests-isolation.ts",
     "lint:fix": "bunx biome check --write src/ tests/",

--- a/schemas/akm-config.json
+++ b/schemas/akm-config.json
@@ -116,6 +116,17 @@
               "model": {
                 "type": "string",
                 "minLength": 1
+              },
+              "timeoutMs": {
+                "anyOf": [
+                  {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               }
             },
             "required": [
@@ -263,6 +274,22 @@
                       "topN": {
                         "type": "integer",
                         "exclusiveMinimum": 0
+                      },
+                      "fullScan": {
+                        "type": "boolean"
+                      },
+                      "triage": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "minScore": {
+                            "type": "number",
+                            "minimum": 0
+                          }
+                        },
+                        "additionalProperties": true
                       },
                       "minPendingCount": {
                         "type": "integer",
@@ -623,6 +650,22 @@
                         "type": "integer",
                         "exclusiveMinimum": 0
                       },
+                      "fullScan": {
+                        "type": "boolean"
+                      },
+                      "triage": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "minScore": {
+                            "type": "number",
+                            "minimum": 0
+                          }
+                        },
+                        "additionalProperties": true
+                      },
                       "minPendingCount": {
                         "type": "integer",
                         "minimum": 0
@@ -981,6 +1024,22 @@
                       "topN": {
                         "type": "integer",
                         "exclusiveMinimum": 0
+                      },
+                      "fullScan": {
+                        "type": "boolean"
+                      },
+                      "triage": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "minScore": {
+                            "type": "number",
+                            "minimum": 0
+                          }
+                        },
+                        "additionalProperties": true
                       },
                       "minPendingCount": {
                         "type": "integer",
@@ -1341,6 +1400,22 @@
                         "type": "integer",
                         "exclusiveMinimum": 0
                       },
+                      "fullScan": {
+                        "type": "boolean"
+                      },
+                      "triage": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "minScore": {
+                            "type": "number",
+                            "minimum": 0
+                          }
+                        },
+                        "additionalProperties": true
+                      },
                       "minPendingCount": {
                         "type": "integer",
                         "minimum": 0
@@ -1699,6 +1774,397 @@
                       "topN": {
                         "type": "integer",
                         "exclusiveMinimum": 0
+                      },
+                      "fullScan": {
+                        "type": "boolean"
+                      },
+                      "triage": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "minScore": {
+                            "type": "number",
+                            "minimum": 0
+                          }
+                        },
+                        "additionalProperties": true
+                      },
+                      "minPendingCount": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "minNewSessions": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "maxSessionsPerRun": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "indexSessions": {
+                        "type": "boolean"
+                      },
+                      "minSessionDuration": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "p90ChunkSecondsDefault": {
+                        "type": "number",
+                        "exclusiveMinimum": 0
+                      },
+                      "homeostaticDemotion": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "staleDays": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "demotionFactor": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          }
+                        },
+                        "additionalProperties": true
+                      },
+                      "schemaSimilarity": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "epsilon": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "confidencePenalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          }
+                        },
+                        "additionalProperties": true
+                      },
+                      "hotProbation": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": true
+                      },
+                      "antiCollapse": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "maxGeneration": {
+                            "type": "integer",
+                            "minimum": 1
+                          },
+                          "lexicalDiversityCheck": {
+                            "type": "boolean"
+                          },
+                          "randomClusterFraction": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          }
+                        },
+                        "additionalProperties": true
+                      },
+                      "cls": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "adjacentCount": {
+                            "type": "integer",
+                            "minimum": 1
+                          }
+                        },
+                        "additionalProperties": true
+                      },
+                      "fidelityCheck": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": true
+                      },
+                      "minClusterSize": {
+                        "type": "integer",
+                        "minimum": 2
+                      },
+                      "maxClustersPerRun": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "maxClusterSize": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "excludeTags": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "excludeEntities": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "relatednessSource": {
+                        "type": "string",
+                        "enum": [
+                          "tags",
+                          "graph",
+                          "both"
+                        ]
+                      },
+                      "confirmThreshold": {
+                        "type": "integer",
+                        "minimum": 1
+                      },
+                      "minRecurrence": {
+                        "type": "integer",
+                        "minimum": 2
+                      },
+                      "maxProposalsPerRun": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "emitAs": {
+                        "type": "string",
+                        "enum": [
+                          "workflow",
+                          "skill"
+                        ]
+                      },
+                      "lowValueFilter": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": true
+                      },
+                      "proceduralAwareFloor": {
+                        "type": "boolean"
+                      },
+                      "applyMode": {
+                        "type": "string",
+                        "enum": [
+                          "queue",
+                          "promote"
+                        ]
+                      },
+                      "policy": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "maxAcceptsPerRun": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "maxDiffLines": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "rejectEmpty": {
+                        "type": "boolean"
+                      },
+                      "judgment": {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "llm",
+                              "agent",
+                              "sdk"
+                            ]
+                          },
+                          "profile": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "timeoutMs": {
+                            "anyOf": [
+                              {
+                                "type": "integer",
+                                "exclusiveMinimum": 0
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    },
+                    "additionalProperties": true
+                  },
+                  "extract": {
+                    "type": "object",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "llm",
+                          "agent",
+                          "sdk"
+                        ]
+                      },
+                      "profile": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "timeoutMs": {
+                        "anyOf": [
+                          {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "allowedTypes": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "minPoolSize": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "dedup": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "cosineThreshold": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "cosineCandidateLimit": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          }
+                        },
+                        "additionalProperties": true
+                      },
+                      "judgedCache": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": true
+                      },
+                      "qualityGate": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": true
+                      },
+                      "contradictionDetection": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": true
+                      },
+                      "defaultSince": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "maxTotalChars": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "minContentChars": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "maxChunkSize": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 50
+                      },
+                      "incrementalSince": {
+                        "type": "string"
+                      },
+                      "limit": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "neighborsPerChanged": {
+                        "type": "integer",
+                        "minimum": 1
+                      },
+                      "requirePlannedRefs": {
+                        "type": "boolean"
+                      },
+                      "dueDays": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "maxPerRun": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "topN": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "fullScan": {
+                        "type": "boolean"
+                      },
+                      "triage": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "minScore": {
+                            "type": "number",
+                            "minimum": 0
+                          }
+                        },
+                        "additionalProperties": true
                       },
                       "minPendingCount": {
                         "type": "integer",
@@ -2059,6 +2525,22 @@
                         "type": "integer",
                         "exclusiveMinimum": 0
                       },
+                      "fullScan": {
+                        "type": "boolean"
+                      },
+                      "triage": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "minScore": {
+                            "type": "number",
+                            "minimum": 0
+                          }
+                        },
+                        "additionalProperties": true
+                      },
                       "minPendingCount": {
                         "type": "integer",
                         "minimum": 0
@@ -2417,6 +2899,22 @@
                       "topN": {
                         "type": "integer",
                         "exclusiveMinimum": 0
+                      },
+                      "fullScan": {
+                        "type": "boolean"
+                      },
+                      "triage": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "minScore": {
+                            "type": "number",
+                            "minimum": 0
+                          }
+                        },
+                        "additionalProperties": true
                       },
                       "minPendingCount": {
                         "type": "integer",
@@ -2777,6 +3275,22 @@
                         "type": "integer",
                         "exclusiveMinimum": 0
                       },
+                      "fullScan": {
+                        "type": "boolean"
+                      },
+                      "triage": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "minScore": {
+                            "type": "number",
+                            "minimum": 0
+                          }
+                        },
+                        "additionalProperties": true
+                      },
                       "minPendingCount": {
                         "type": "integer",
                         "minimum": 0
@@ -3136,6 +3650,22 @@
                         "type": "integer",
                         "exclusiveMinimum": 0
                       },
+                      "fullScan": {
+                        "type": "boolean"
+                      },
+                      "triage": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "minScore": {
+                            "type": "number",
+                            "minimum": 0
+                          }
+                        },
+                        "additionalProperties": true
+                      },
                       "minPendingCount": {
                         "type": "integer",
                         "minimum": 0
@@ -3494,6 +4024,22 @@
                       "topN": {
                         "type": "integer",
                         "exclusiveMinimum": 0
+                      },
+                      "fullScan": {
+                        "type": "boolean"
+                      },
+                      "triage": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "minScore": {
+                            "type": "number",
+                            "minimum": 0
+                          }
+                        },
+                        "additionalProperties": true
                       },
                       "minPendingCount": {
                         "type": "integer",
@@ -4405,6 +4951,17 @@
                   "model": {
                     "type": "string",
                     "minLength": 1
+                  },
+                  "timeoutMs": {
+                    "anyOf": [
+                      {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "required": [
@@ -4552,6 +5109,22 @@
                           "topN": {
                             "type": "integer",
                             "exclusiveMinimum": 0
+                          },
+                          "fullScan": {
+                            "type": "boolean"
+                          },
+                          "triage": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "minScore": {
+                                "type": "number",
+                                "minimum": 0
+                              }
+                            },
+                            "additionalProperties": true
                           },
                           "minPendingCount": {
                             "type": "integer",
@@ -4912,6 +5485,22 @@
                             "type": "integer",
                             "exclusiveMinimum": 0
                           },
+                          "fullScan": {
+                            "type": "boolean"
+                          },
+                          "triage": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "minScore": {
+                                "type": "number",
+                                "minimum": 0
+                              }
+                            },
+                            "additionalProperties": true
+                          },
                           "minPendingCount": {
                             "type": "integer",
                             "minimum": 0
@@ -5270,6 +5859,22 @@
                           "topN": {
                             "type": "integer",
                             "exclusiveMinimum": 0
+                          },
+                          "fullScan": {
+                            "type": "boolean"
+                          },
+                          "triage": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "minScore": {
+                                "type": "number",
+                                "minimum": 0
+                              }
+                            },
+                            "additionalProperties": true
                           },
                           "minPendingCount": {
                             "type": "integer",
@@ -5630,6 +6235,22 @@
                             "type": "integer",
                             "exclusiveMinimum": 0
                           },
+                          "fullScan": {
+                            "type": "boolean"
+                          },
+                          "triage": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "minScore": {
+                                "type": "number",
+                                "minimum": 0
+                              }
+                            },
+                            "additionalProperties": true
+                          },
                           "minPendingCount": {
                             "type": "integer",
                             "minimum": 0
@@ -5988,6 +6609,397 @@
                           "topN": {
                             "type": "integer",
                             "exclusiveMinimum": 0
+                          },
+                          "fullScan": {
+                            "type": "boolean"
+                          },
+                          "triage": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "minScore": {
+                                "type": "number",
+                                "minimum": 0
+                              }
+                            },
+                            "additionalProperties": true
+                          },
+                          "minPendingCount": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "minNewSessions": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "maxSessionsPerRun": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "indexSessions": {
+                            "type": "boolean"
+                          },
+                          "minSessionDuration": {
+                            "type": "number",
+                            "minimum": 0
+                          },
+                          "p90ChunkSecondsDefault": {
+                            "type": "number",
+                            "exclusiveMinimum": 0
+                          },
+                          "homeostaticDemotion": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "staleDays": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "demotionFactor": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                              }
+                            },
+                            "additionalProperties": true
+                          },
+                          "schemaSimilarity": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "epsilon": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                              },
+                              "confidencePenalty": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                              }
+                            },
+                            "additionalProperties": true
+                          },
+                          "hotProbation": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              }
+                            },
+                            "additionalProperties": true
+                          },
+                          "antiCollapse": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "maxGeneration": {
+                                "type": "integer",
+                                "minimum": 1
+                              },
+                              "lexicalDiversityCheck": {
+                                "type": "boolean"
+                              },
+                              "randomClusterFraction": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                              }
+                            },
+                            "additionalProperties": true
+                          },
+                          "cls": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "adjacentCount": {
+                                "type": "integer",
+                                "minimum": 1
+                              }
+                            },
+                            "additionalProperties": true
+                          },
+                          "fidelityCheck": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              }
+                            },
+                            "additionalProperties": true
+                          },
+                          "minClusterSize": {
+                            "type": "integer",
+                            "minimum": 2
+                          },
+                          "maxClustersPerRun": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          },
+                          "maxClusterSize": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          },
+                          "excludeTags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "excludeEntities": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "relatednessSource": {
+                            "type": "string",
+                            "enum": [
+                              "tags",
+                              "graph",
+                              "both"
+                            ]
+                          },
+                          "confirmThreshold": {
+                            "type": "integer",
+                            "minimum": 1
+                          },
+                          "minRecurrence": {
+                            "type": "integer",
+                            "minimum": 2
+                          },
+                          "maxProposalsPerRun": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          },
+                          "emitAs": {
+                            "type": "string",
+                            "enum": [
+                              "workflow",
+                              "skill"
+                            ]
+                          },
+                          "lowValueFilter": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              }
+                            },
+                            "additionalProperties": true
+                          },
+                          "proceduralAwareFloor": {
+                            "type": "boolean"
+                          },
+                          "applyMode": {
+                            "type": "string",
+                            "enum": [
+                              "queue",
+                              "promote"
+                            ]
+                          },
+                          "policy": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "maxAcceptsPerRun": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          },
+                          "maxDiffLines": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          },
+                          "rejectEmpty": {
+                            "type": "boolean"
+                          },
+                          "judgment": {
+                            "type": "object",
+                            "properties": {
+                              "mode": {
+                                "type": "string",
+                                "enum": [
+                                  "llm",
+                                  "agent",
+                                  "sdk"
+                                ]
+                              },
+                              "profile": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "timeoutMs": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer",
+                                    "exclusiveMinimum": 0
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": true
+                          }
+                        },
+                        "additionalProperties": true
+                      },
+                      "extract": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "llm",
+                              "agent",
+                              "sdk"
+                            ]
+                          },
+                          "profile": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "timeoutMs": {
+                            "anyOf": [
+                              {
+                                "type": "integer",
+                                "exclusiveMinimum": 0
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "allowedTypes": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "minPoolSize": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "dedup": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "cosineThreshold": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                              },
+                              "cosineCandidateLimit": {
+                                "type": "integer",
+                                "exclusiveMinimum": 0
+                              }
+                            },
+                            "additionalProperties": true
+                          },
+                          "judgedCache": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              }
+                            },
+                            "additionalProperties": true
+                          },
+                          "qualityGate": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              }
+                            },
+                            "additionalProperties": true
+                          },
+                          "contradictionDetection": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              }
+                            },
+                            "additionalProperties": true
+                          },
+                          "defaultSince": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "maxTotalChars": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          },
+                          "minContentChars": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "maxChunkSize": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50
+                          },
+                          "incrementalSince": {
+                            "type": "string"
+                          },
+                          "limit": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          },
+                          "neighborsPerChanged": {
+                            "type": "integer",
+                            "minimum": 1
+                          },
+                          "requirePlannedRefs": {
+                            "type": "boolean"
+                          },
+                          "dueDays": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "maxPerRun": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          },
+                          "topN": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          },
+                          "fullScan": {
+                            "type": "boolean"
+                          },
+                          "triage": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "minScore": {
+                                "type": "number",
+                                "minimum": 0
+                              }
+                            },
+                            "additionalProperties": true
                           },
                           "minPendingCount": {
                             "type": "integer",
@@ -6348,6 +7360,22 @@
                             "type": "integer",
                             "exclusiveMinimum": 0
                           },
+                          "fullScan": {
+                            "type": "boolean"
+                          },
+                          "triage": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "minScore": {
+                                "type": "number",
+                                "minimum": 0
+                              }
+                            },
+                            "additionalProperties": true
+                          },
                           "minPendingCount": {
                             "type": "integer",
                             "minimum": 0
@@ -6706,6 +7734,22 @@
                           "topN": {
                             "type": "integer",
                             "exclusiveMinimum": 0
+                          },
+                          "fullScan": {
+                            "type": "boolean"
+                          },
+                          "triage": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "minScore": {
+                                "type": "number",
+                                "minimum": 0
+                              }
+                            },
+                            "additionalProperties": true
                           },
                           "minPendingCount": {
                             "type": "integer",
@@ -7066,6 +8110,22 @@
                             "type": "integer",
                             "exclusiveMinimum": 0
                           },
+                          "fullScan": {
+                            "type": "boolean"
+                          },
+                          "triage": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "minScore": {
+                                "type": "number",
+                                "minimum": 0
+                              }
+                            },
+                            "additionalProperties": true
+                          },
                           "minPendingCount": {
                             "type": "integer",
                             "minimum": 0
@@ -7425,6 +8485,22 @@
                             "type": "integer",
                             "exclusiveMinimum": 0
                           },
+                          "fullScan": {
+                            "type": "boolean"
+                          },
+                          "triage": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "minScore": {
+                                "type": "number",
+                                "minimum": 0
+                              }
+                            },
+                            "additionalProperties": true
+                          },
                           "minPendingCount": {
                             "type": "integer",
                             "minimum": 0
@@ -7783,6 +8859,22 @@
                           "topN": {
                             "type": "integer",
                             "exclusiveMinimum": 0
+                          },
+                          "fullScan": {
+                            "type": "boolean"
+                          },
+                          "triage": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "minScore": {
+                                "type": "number",
+                                "minimum": 0
+                              }
+                            },
+                            "additionalProperties": true
                           },
                           "minPendingCount": {
                             "type": "integer",
@@ -8824,6 +9916,22 @@
           "type": "integer",
           "exclusiveMinimum": 0
         },
+        "fullScan": {
+          "type": "boolean"
+        },
+        "triage": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "minScore": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": true
+        },
         "minPendingCount": {
           "type": "integer",
           "minimum": 0
@@ -9193,6 +10301,22 @@
                   "type": "integer",
                   "exclusiveMinimum": 0
                 },
+                "fullScan": {
+                  "type": "boolean"
+                },
+                "triage": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "minScore": {
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  },
+                  "additionalProperties": true
+                },
                 "minPendingCount": {
                   "type": "integer",
                   "minimum": 0
@@ -9551,6 +10675,22 @@
                 "topN": {
                   "type": "integer",
                   "exclusiveMinimum": 0
+                },
+                "fullScan": {
+                  "type": "boolean"
+                },
+                "triage": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "minScore": {
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  },
+                  "additionalProperties": true
                 },
                 "minPendingCount": {
                   "type": "integer",
@@ -9911,6 +11051,22 @@
                   "type": "integer",
                   "exclusiveMinimum": 0
                 },
+                "fullScan": {
+                  "type": "boolean"
+                },
+                "triage": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "minScore": {
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  },
+                  "additionalProperties": true
+                },
                 "minPendingCount": {
                   "type": "integer",
                   "minimum": 0
@@ -10269,6 +11425,22 @@
                 "topN": {
                   "type": "integer",
                   "exclusiveMinimum": 0
+                },
+                "fullScan": {
+                  "type": "boolean"
+                },
+                "triage": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "minScore": {
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  },
+                  "additionalProperties": true
                 },
                 "minPendingCount": {
                   "type": "integer",
@@ -10629,6 +11801,397 @@
                   "type": "integer",
                   "exclusiveMinimum": 0
                 },
+                "fullScan": {
+                  "type": "boolean"
+                },
+                "triage": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "minScore": {
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "minPendingCount": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "minNewSessions": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "maxSessionsPerRun": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "indexSessions": {
+                  "type": "boolean"
+                },
+                "minSessionDuration": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "p90ChunkSecondsDefault": {
+                  "type": "number",
+                  "exclusiveMinimum": 0
+                },
+                "homeostaticDemotion": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "staleDays": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "demotionFactor": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "schemaSimilarity": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "epsilon": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "confidencePenalty": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "hotProbation": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "antiCollapse": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "maxGeneration": {
+                      "type": "integer",
+                      "minimum": 1
+                    },
+                    "lexicalDiversityCheck": {
+                      "type": "boolean"
+                    },
+                    "randomClusterFraction": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "cls": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "adjacentCount": {
+                      "type": "integer",
+                      "minimum": 1
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "fidelityCheck": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "minClusterSize": {
+                  "type": "integer",
+                  "minimum": 2
+                },
+                "maxClustersPerRun": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                "maxClusterSize": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                "excludeTags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "excludeEntities": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "relatednessSource": {
+                  "type": "string",
+                  "enum": [
+                    "tags",
+                    "graph",
+                    "both"
+                  ]
+                },
+                "confirmThreshold": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "minRecurrence": {
+                  "type": "integer",
+                  "minimum": 2
+                },
+                "maxProposalsPerRun": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                "emitAs": {
+                  "type": "string",
+                  "enum": [
+                    "workflow",
+                    "skill"
+                  ]
+                },
+                "lowValueFilter": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "proceduralAwareFloor": {
+                  "type": "boolean"
+                },
+                "applyMode": {
+                  "type": "string",
+                  "enum": [
+                    "queue",
+                    "promote"
+                  ]
+                },
+                "policy": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "maxAcceptsPerRun": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                "maxDiffLines": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                "rejectEmpty": {
+                  "type": "boolean"
+                },
+                "judgment": {
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "llm",
+                        "agent",
+                        "sdk"
+                      ]
+                    },
+                    "profile": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "timeoutMs": {
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              },
+              "additionalProperties": true
+            },
+            "extract": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "mode": {
+                  "type": "string",
+                  "enum": [
+                    "llm",
+                    "agent",
+                    "sdk"
+                  ]
+                },
+                "profile": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "timeoutMs": {
+                  "anyOf": [
+                    {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "allowedTypes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "minPoolSize": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "dedup": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "cosineThreshold": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "cosineCandidateLimit": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "judgedCache": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "qualityGate": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "contradictionDetection": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "defaultSince": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "maxTotalChars": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                "minContentChars": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "maxChunkSize": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 50
+                },
+                "incrementalSince": {
+                  "type": "string"
+                },
+                "limit": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                "neighborsPerChanged": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "requirePlannedRefs": {
+                  "type": "boolean"
+                },
+                "dueDays": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "maxPerRun": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                "topN": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                "fullScan": {
+                  "type": "boolean"
+                },
+                "triage": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "minScore": {
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  },
+                  "additionalProperties": true
+                },
                 "minPendingCount": {
                   "type": "integer",
                   "minimum": 0
@@ -10987,6 +12550,22 @@
                 "topN": {
                   "type": "integer",
                   "exclusiveMinimum": 0
+                },
+                "fullScan": {
+                  "type": "boolean"
+                },
+                "triage": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "minScore": {
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  },
+                  "additionalProperties": true
                 },
                 "minPendingCount": {
                   "type": "integer",
@@ -11347,6 +12926,22 @@
                   "type": "integer",
                   "exclusiveMinimum": 0
                 },
+                "fullScan": {
+                  "type": "boolean"
+                },
+                "triage": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "minScore": {
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  },
+                  "additionalProperties": true
+                },
                 "minPendingCount": {
                   "type": "integer",
                   "minimum": 0
@@ -11705,6 +13300,22 @@
                 "topN": {
                   "type": "integer",
                   "exclusiveMinimum": 0
+                },
+                "fullScan": {
+                  "type": "boolean"
+                },
+                "triage": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "minScore": {
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  },
+                  "additionalProperties": true
                 },
                 "minPendingCount": {
                   "type": "integer",
@@ -12065,6 +13676,22 @@
                   "type": "integer",
                   "exclusiveMinimum": 0
                 },
+                "fullScan": {
+                  "type": "boolean"
+                },
+                "triage": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "minScore": {
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  },
+                  "additionalProperties": true
+                },
                 "minPendingCount": {
                   "type": "integer",
                   "minimum": 0
@@ -12423,6 +14050,22 @@
                 "topN": {
                   "type": "integer",
                   "exclusiveMinimum": 0
+                },
+                "fullScan": {
+                  "type": "boolean"
+                },
+                "triage": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "minScore": {
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  },
+                  "additionalProperties": true
                 },
                 "minPendingCount": {
                   "type": "integer",

--- a/src/assets/profiles/memory-focus.json
+++ b/src/assets/profiles/memory-focus.json
@@ -8,5 +8,5 @@
     "graphExtraction": { "enabled": false },
     "triage": { "enabled": false }
   },
-  "sync": { "enabled": false }
+  "sync": { "enabled": true, "push": true }
 }

--- a/src/assets/profiles/quick.json
+++ b/src/assets/profiles/quick.json
@@ -12,5 +12,5 @@
     "graphExtraction": { "enabled": false },
     "triage": { "enabled": false }
   },
-  "sync": { "enabled": false }
+  "sync": { "enabled": true, "push": true }
 }

--- a/src/assets/profiles/synthesize.json
+++ b/src/assets/profiles/synthesize.json
@@ -1,0 +1,15 @@
+{
+  "description": "Synthesis-only — cross-episodic recombination (#609) + procedural workflow compilation (#615). Opt-in periodic pass; all generative/extract passes off.",
+  "processes": {
+    "reflect": { "enabled": false },
+    "distill": { "enabled": false },
+    "consolidate": { "enabled": false },
+    "memoryInference": { "enabled": false },
+    "graphExtraction": { "enabled": false },
+    "extract": { "enabled": false },
+    "triage": { "enabled": false },
+    "recombine": { "enabled": true },
+    "procedural": { "enabled": true }
+  },
+  "sync": { "enabled": true, "push": true }
+}

--- a/src/assets/profiles/thorough.json
+++ b/src/assets/profiles/thorough.json
@@ -1,5 +1,5 @@
 {
-  "description": "All sub-processes enabled (currently identical to default; reserved for future divergence).",
+  "description": "Like default, plus the triage process (drains the pending-proposal backlog).",
   "processes": {
     "reflect": {
       "enabled": true,

--- a/src/commands/improve/improve-profiles.ts
+++ b/src/commands/improve/improve-profiles.ts
@@ -9,6 +9,7 @@ import profileFrequent from "../../assets/profiles/frequent.json" with { type: "
 import profileGraphRefresh from "../../assets/profiles/graph-refresh.json" with { type: "json" };
 import profileMemoryFocus from "../../assets/profiles/memory-focus.json" with { type: "json" };
 import profileQuick from "../../assets/profiles/quick.json" with { type: "json" };
+import profileSynthesize from "../../assets/profiles/synthesize.json" with { type: "json" };
 import profileThorough from "../../assets/profiles/thorough.json" with { type: "json" };
 import { parseAssetRef } from "../../core/asset/asset-ref";
 import type { AkmConfig, ImproveProfileConfig } from "../../core/config/config";
@@ -38,6 +39,7 @@ const BUILTIN_PROFILES: Record<string, ImproveProfileConfig> = {
   frequent: profileFrequent as ImproveProfileConfig,
   consolidate: profileConsolidate as ImproveProfileConfig,
   catchup: profileCatchup as ImproveProfileConfig,
+  synthesize: profileSynthesize as ImproveProfileConfig,
 };
 
 /**

--- a/src/core/config/config-schema.ts
+++ b/src/core/config/config-schema.ts
@@ -142,6 +142,10 @@ export const AgentProfileConfigSchema = z
     args: z.array(z.string()).optional(),
     workspace: z.string().min(1).optional(),
     model: z.string().min(1).optional(),
+    // Per-call timeout (ms) used when a command does not pass an explicit
+    // timeout (e.g. `akm wiki ingest` without `--timeout-ms`). null = no
+    // timeout. Honored by resolveAgentProfile (integrations/agent/config.ts).
+    timeoutMs: z.union([positiveInt, z.null()]).optional(),
   })
   .passthrough();
 
@@ -220,6 +224,23 @@ export const ImproveProcessConfigSchema = z
     // high-signal-first sweep). Unset = process all eligible (current
     // behavior). Only meaningful on `graphExtraction`.
     topN: positiveInt.optional(),
+    // graphExtraction process: full-corpus scan. When true, graph extraction
+    // runs on ALL stash files instead of only files touched by actionable refs
+    // in the current run. Used by the `graph-refresh` built-in profile / a
+    // scheduled weekly task. Only meaningful on `graphExtraction`.
+    fullScan: z.boolean().optional(),
+    // #626 — extract process: pre-LLM heuristic triage gate. When enabled, a
+    // deterministic scorer decides BEFORE the extraction LLM call whether a
+    // session carries enough signal to be worth extracting; low-signal sessions
+    // are skipped at zero LLM cost. Default OFF. Only meaningful on `extract`.
+    // `minScore` is the minimum total heuristic score to PASS (default 2).
+    triage: z
+      .object({
+        enabled: z.boolean().optional(),
+        minScore: z.number().min(0).optional(),
+      })
+      .passthrough()
+      .optional(),
     // MemoryInference process: minimum pending memory count to run the pass.
     minPendingCount: z.number().int().min(0).optional(),
     // Extract process: minimum number of new (unseen, in-window) candidate
@@ -397,6 +418,7 @@ const ImproveProfileProcessesSchema = z
     consolidate: ImproveProcessConfigSchema.optional(),
     memoryInference: ImproveProcessConfigSchema.optional(),
     graphExtraction: ImproveProcessConfigSchema.optional(),
+    extract: ImproveProcessConfigSchema.optional(),
     validation: ImproveProcessConfigSchema.optional(),
     triage: ImproveProcessConfigSchema.optional(),
     proactiveMaintenance: ImproveProcessConfigSchema.optional(),

--- a/src/core/config/config-types.ts
+++ b/src/core/config/config-types.ts
@@ -2,6 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+// Type-only imports (erased at runtime → no import cycle with config-schema,
+// which imports VALID_HARNESS_IDS from here at runtime). The improve/agent
+// process shapes are DERIVED from the Zod schema via `z.infer` so the type and
+// the validator cannot drift — the schema in ./config-schema.ts is the single
+// source of truth (see its field comments for per-knob docs).
+import type { z } from "zod";
 // VALID_HARNESS_IDS now derives from the unified HARNESS_REGISTRY (#562), which
 // is the single source of truth replacing the previously-disconnected
 // registries. config ← harnesses is the only import direction (harnesses/ is a
@@ -11,11 +17,15 @@ import { VALID_HARNESS_IDS } from "../../integrations/harnesses";
  * Type definitions for the `AkmConfig` shape and its sub-shapes.
  *
  * The Zod schema in `./config-schema.ts` is the single source of truth for
- * runtime validation; the interfaces here mirror it for consumers that don't
- * want to import Zod just to get a type. Keep the two in sync — `bunx tsc`
- * will surface the drift through call-site errors.
+ * runtime validation. The high-churn improve/agent process shapes
+ * (`ImproveProcessConfig`, `ImproveProfileConfig`, `AgentProfileConfig`) are
+ * DERIVED from that schema via `z.infer`, so they cannot drift. The remaining
+ * hand-written interfaces (connection/source/index/top-level `AkmConfig`) mirror
+ * the schema for consumers that don't want to import Zod; keep those in sync —
+ * `bunx tsc` surfaces drift through call-site errors.
  */
 import type { InstalledStashEntry } from "../../registry/types";
+import type { AgentProfileConfigSchema, ImproveProcessConfigSchema, ImproveProfileConfigSchema } from "./config-schema";
 
 /**
  * Canonical list of valid agent harness / platform ids. Re-exported from the
@@ -119,533 +129,32 @@ export interface LlmProfileConfig extends LlmConnectionConfig {
   supportsJsonSchema?: boolean;
 }
 
-export interface AgentProfileConfig {
-  platform: HarnessId;
-  bin?: string;
-  args?: string[];
-  workspace?: string;
-  model?: string;
-  /**
-   * Per-call timeout (ms) for this agent profile. Used when a command does not
-   * pass an explicit timeout (e.g. `akm wiki ingest` without `--timeout-ms`).
-   * Mirrors `AgentProfileConfigSchema.timeoutMs`. null = no timeout.
-   */
-  timeoutMs?: number | null;
-}
+/**
+ * Per-agent-profile config (`profiles.agent.<name>`). Derived from
+ * {@link AgentProfileConfigSchema}; fields: `platform`, `bin`, `args`,
+ * `workspace`, `model`, `timeoutMs` (null = no timeout).
+ */
+export type AgentProfileConfig = z.infer<typeof AgentProfileConfigSchema>;
 
-export interface ImproveProcessConfig {
-  enabled?: boolean;
-  mode?: "llm" | "agent" | "sdk";
-  /** Named runner profile from profiles.llm or profiles.agent. */
-  profile?: string;
-  timeoutMs?: number | null;
-  /**
-   * Whitelist of asset types for this process. Absent = built-in default.
-   * Only applied by per-ref processes (`reflect`, `distill`); ignored by
-   * full-pass operations.
-   */
-  allowedTypes?: string[];
-  /**
-   * Optional LLM-as-judge quality gate. Fail-open: judge failures always pass.
-   * Replaces the legacy `lesson_quality_gate` / `proposal_quality_gate` flags.
-   */
-  qualityGate?: { enabled?: boolean };
-  /**
-   * Optional contradiction-detection pass (M-1 / #367). Only meaningful on
-   * the `consolidate` process.
-   */
-  contradictionDetection?: { enabled?: boolean };
-  /**
-   * #639 — semantic value-floor filter for the `reflect` process. When
-   * enabled, reflect proposals classified as `"low-value"` by the
-   * deterministic noise gate are deferred (not accepted). DEFAULT OFF:
-   * absent or `{ enabled: false }` = byte-identical behaviour to pre-#639.
-   * Only meaningful on the `reflect` process.
-   */
-  lowValueFilter?: { enabled?: boolean };
-  /**
-   * Default discovery window for the `extract` process when the caller does
-   * not pass an explicit `--since`. Accepts ISO timestamps or duration
-   * strings (`24h`, `7d`, `30m`). Only meaningful on the `extract` process.
-   * Defaults to `24h` when absent.
-   */
-  defaultSince?: string;
-  /**
-   * Pre-filter total-character budget. Once kept events exceed this many
-   * chars, older events are dropped (recency-bias) so the prompt stays
-   * within the model's context window. Only meaningful on the `extract`
-   * process. Defaults to 80_000 when absent — chosen for 32K-token models;
-   * raise it for larger-context models.
-   */
-  maxTotalChars?: number;
-  /**
-   * Minimum raw session character count for the `extract` process. Sessions
-   * whose total content falls below this threshold are skipped before the LLM
-   * call — avoids burning inference capacity on empty sessions (journal files)
-   * that never yield candidates. Checked against pre-filter `inputCount` (raw
-   * size), not `outputCount`, since the pre-filter strips so much boilerplate
-   * that even signal-bearing sessions can have tiny output. Absent = default
-   * 10 (only truly empty sessions are safe to skip — tiny sessions of a few
-   * hundred chars regularly yield candidates). `0` disables the gate. Only
-   * meaningful on the `extract` process.
-   */
-  minContentChars?: number;
-  /**
-   * Max chunk size for the consolidation pass (1–50).
-   * Overrides the computed value derived from the model context window.
-   * Absent = use computed value (capped at 50).
-   */
-  maxChunkSize?: number;
-  /**
-   * Narrows the consolidation candidate pool to memories modified within this
-   * window (e.g. `"1h"`, `"4h"`, `"7d"`) plus their top-k graph neighbours.
-   * Useful when consolidation runs more than once per day — keeps each pass
-   * focused on recent changes. Absent = full-pool sweep. Only meaningful on
-   * the `consolidate` process.
-   */
-  incrementalSince?: string;
-  /**
-   * Hard cap on memories processed per consolidation pass. Absent = no cap
-   * (full pool after incremental narrowing). Only meaningful on the
-   * `consolidate` process. For `reflect`/`distill`: max refs processed (same
-   * semantics as the profile-level `limit` field).
-   */
-  limit?: number;
-  /**
-   * Number of graph neighbours to include per changed memory during
-   * incremental consolidation. Default 5 (hardcoded). Only meaningful on the
-   * `consolidate` process when `incrementalSince` is set.
-   */
-  neighborsPerChanged?: number;
-  /**
-   * When `true`, the distill process is skipped entirely if the reflect phase
-   * produced zero planned refs (i.e. no refs passed the signal gate for
-   * reflect). Prevents the distill loop from running against distill-only refs
-   * and generating hundreds of `distill-skipped` events on quiet passes. Only
-   * meaningful on the `distill` process.
-   */
-  requirePlannedRefs?: boolean;
-  /**
-   * Minimum number of pending split-parent memories below which the memory
-   * inference pass is skipped entirely (zero LLM calls). Absent = always run
-   * when enabled. Only meaningful on the `memoryInference` process.
-   */
-  minPendingCount?: number;
-  /**
-   * Minimum eligible-memory pool size for the consolidation pass. When the
-   * eligible pool is below this threshold the pass skips entirely (emitting an
-   * `improve_skipped` event with `reason: "pool_below_min_size"`) and makes
-   * ZERO LLM calls. `0` disables the guard. Absent = default 500. Only
-   * meaningful on the `consolidate` process.
-   */
-  minPoolSize?: number;
-  /**
-   * Deterministic near-duplicate dedup pre-pass for the `consolidate` process
-   * (#617). A cheap, no-LLM fast path that collapses the obvious duplicates
-   * (`.derived` origin pairs + content twins) in front of the embedding-clustered
-   * LLM consolidation. Default OFF — when absent the consolidate pass behaves
-   * byte-identically to today.
-   *
-   *   - `enabled`: turn the pre-pass on. Default `false`.
-   *   - `cosineThreshold`: strict similarity floor in [0, 1] (default `0.97`)
-   *     for the optional embedding-similarity match. Exact normalized
-   *     content-hash equality always collapses regardless of this value;
-   *     the cosine path only fires when embeddings are configured and a pair's
-   *     similarity is >= this threshold. Genuinely distinct memories fall
-   *     through untouched to the LLM consolidation.
-   *
-   * Only meaningful on the `consolidate` process.
-   */
-  dedup?: {
-    enabled?: boolean;
-    cosineThreshold?: number;
-    /**
-     * Maximum pool size for the O(n²) cosine-similarity twin compare.
-     * Only the first `cosineCandidateLimit` memories (sorted lexicographically)
-     * are cosine-compared; exact-hash matches still run over the full pool.
-     * Default 500 (~125 K comparisons, ≈ 0.1 s). Raise with care — cost is O(n²).
-     */
-    cosineCandidateLimit?: number;
-  };
-  /**
-   * Judged-state cache for the `consolidate` process (#581). When `enabled`,
-   * each memory's frontmatter-stripped content hash is recorded after the LLM
-   * judges its chunk; on a later run a memory whose current hash equals its
-   * cached judged hash is SKIPPED from the LLM pool (judged-unchanged → no
-   * re-judge). This lets a single run sweep the FULL corpus at O(changed/new)
-   * cost rather than narrowing to a recent time-window slice (which leaves a
-   * near-duplicate backlog). Default OFF — when absent the consolidate pass
-   * behaves byte-identically to today and the `incrementalSince` path is
-   * unaffected. Only meaningful on the `consolidate` process.
-   *
-   *   - `enabled`: turn the judged-state cache on. Default `false`.
-   */
-  judgedCache?: {
-    enabled?: boolean;
-  };
-  /**
-   * Minimum number of new (unseen, in-window) candidate sessions for the
-   * `extract` process. When the candidate-session pool is below this threshold
-   * the extract pass skips entirely (emitting an `improve_skipped` event with
-   * `reason: "below_min_new_sessions"`) and makes ZERO LLM calls. `0` disables
-   * the guard. Absent = default 0 (disabled), preserving existing always-run
-   * behaviour. Only meaningful on the `extract` process.
-   */
-  minNewSessions?: number;
-  /**
-   * Maximum number of NEW (unseen) sessions the `extract` pass will process
-   * (make an LLM call for) in a single run. Bounds per-run wall time + LLM cost
-   * so a backlog of accumulated sessions (e.g. after downtime) can't push one
-   * run past its task timeout. Sessions beyond the cap stay unseen and are
-   * picked up by subsequent runs (no coverage loss). `0` disables the cap.
-   * Absent = a built-in default. Only meaningful on the `extract` process.
-   */
-  maxSessionsPerRun?: number;
-  /**
-   * #561 — index agent sessions as a searchable `session` asset. When the
-   * `extract` pass distills memory proposals from a session it ADDITIONALLY
-   * writes `sessions/<harness>/<id>.md` (LLM `## Summary` + `## Key topics`) so
-   * the session becomes discoverable via `akm search` / `akm curate`.
-   *
-   * ADDITIVE + FAIL-OPEN. The summary is generated through the same in-tree LLM
-   * seam as the rest of extract; if no LLM is configured (or the call fails) no
-   * asset is written and extract behaves EXACTLY as before. Absent = default
-   * ON-WHEN-AVAILABLE: because the extract pass only runs at all when an LLM is
-   * configured, defaulting on costs nothing when offline (the summary call
-   * simply fails open) while making sessions searchable for the common
-   * LLM-configured case. Set `false` to opt out entirely (byte-identical
-   * legacy behaviour). Only meaningful on the `extract` process.
-   */
-  indexSessions?: boolean;
-  /**
-   * #561 — minimum session duration (ended_at − started_at) in MINUTES for a
-   * session to be indexed as a `session` asset. Trivially short sessions carry
-   * little reusable signal and are not worth an LLM summary call. Absent =
-   * default 5. `0` disables the gate (index every session). Only meaningful on
-   * the `extract` process when `indexSessions` is enabled.
-   */
-  minSessionDuration?: number;
-  /**
-   * Proactive-maintenance selector (Layer 2): staleness gate in DAYS. An asset
-   * is eligible only when it has never been reflected/distilled OR was last
-   * reflected/distilled more than this many days ago. This same value doubles as
-   * the per-ref rotation cooldown — a freshly-reflected asset is excluded until
-   * it ages back past `dueDays`, so successive runs rotate through the due pool.
-   * Absent = default 30. Only meaningful on the `proactiveMaintenance` process.
-   */
-  dueDays?: number;
-  /**
-   * Proactive-maintenance selector (Layer 2): hard cap on how many due assets
-   * are surfaced into the reflect/distill candidate set per run. Bounds the
-   * blast radius of a scheduled maintenance sweep. Absent = default 25. Alias
-   * for the per-process `limit` field; `maxPerRun` wins when both are set. Only
-   * meaningful on the `proactiveMaintenance` process.
-   */
-  maxPerRun?: number;
-  /**
-   * Full-corpus scan for the `graphExtraction` process.
-   * When `true`, graph extraction runs on ALL stash files instead of only
-   * the files touched by actionable refs in the current run.
-   * Use with the `graph-refresh` built-in profile or a scheduled weekly task.
-   * Has no effect on other processes.
-   */
-  fullScan?: boolean;
-  /**
-   * graphExtraction process: when set, rank eligible files by utility_scores
-   * DESC and process only the top-N per run (incremental high-signal-first
-   * sweep). Unset = process all eligible (current behavior). Only meaningful on
-   * graphExtraction.
-   */
-  topN?: number;
-  /**
-   * Apply mode for drained proposals: `queue` stages only (never promotes),
-   * `promote` accepts matching proposals (commits to git). Defaults to the
-   * safe `queue`. Only meaningful on the `triage` process.
-   */
-  applyMode?: "queue" | "promote";
-  /**
-   * Built-in policy preset name (`personal-stash` | `conservative` | `manual`)
-   * or a path to a custom policy file. Only meaningful on the `triage` process.
-   */
-  policy?: string;
-  /**
-   * Hard per-run accept ceiling. Accepts beyond this land in `skippedByCap`.
-   * Only meaningful on the `triage` process.
-   */
-  maxAcceptsPerRun?: number;
-  /**
-   * Defer (never promote) accepts whose proposed content exceeds this many
-   * lines. Only meaningful on the `triage` process.
-   */
-  maxDiffLines?: number;
-  /**
-   * Reject proposals whose diff is empty. Only meaningful on the `triage`
-   * process.
-   */
-  rejectEmpty?: boolean;
-  /**
-   * Optional judgment tier for mid-band / ambiguous items. Only meaningful on
-   * the `triage` process.
-   */
-  judgment?: {
-    mode?: "llm" | "agent" | "sdk";
-    profile?: string;
-    timeoutMs?: number | null;
-  };
-  /**
-   * Fallback p90 wall-clock time per consolidation chunk in seconds, used for
-   * cold-start budget estimation when no telemetry history exists. The actual
-   * p90 is derived from observed run durations once sufficient history
-   * accumulates; this value is only used on the very first run. Default 30 s.
-   * Only meaningful on the `consolidate` process.
-   */
-  p90ChunkSecondsDefault?: number;
-  /**
-   * WS-3b: Homeostatic demotion (step 0a). Before any LLM merge, demote
-   * `retrievalSalience` (state.db only — file content untouched) for
-   * stale/low-value assets so the merge pool is bounded and high-SNR.
-   * Re-promotable on re-retrieval. Default OFF. Only meaningful on the
-   * `consolidate` process.
-   */
-  homeostaticDemotion?: {
-    enabled?: boolean;
-    /** Days since last retrieval to consider an asset stale. Default 30. */
-    staleDays?: number;
-    /** Multiplicative demotion factor on retrievalSalience (0–1). Default 0.5. */
-    demotionFactor?: number;
-  };
-  /**
-   * WS-3b: Schema-similarity gate (step 0b). At intake, if a new candidate's
-   * body embedding is within epsilon of an existing derived-layer lesson/knowledge
-   * node, mark it schema-consistent and lower its priority. Default OFF.
-   * Only meaningful on the `consolidate` and `extract` processes.
-   */
-  schemaSimilarity?: {
-    enabled?: boolean;
-    /** Cosine similarity epsilon above which a candidate is schema-consistent. Default 0.85. */
-    epsilon?: number;
-    /** Multiplicative factor applied to candidate confidence when schema-consistent. Default 0.5. */
-    confidencePenalty?: number;
-  };
-  /**
-   * WS-3b: Hot-probation intake buffer (#604). New system-generated extractions
-   * enter `captureMode: hot-probation` and spend ONE consolidation cycle in
-   * probation before promotion; dedup + quality second-pass runs against them.
-   * Default OFF. Only meaningful on the `extract` process.
-   */
-  hotProbation?: {
-    enabled?: boolean;
-  };
-  /**
-   * #626: Pre-LLM heuristic triage gate. When enabled, a pure deterministic
-   * scorer decides BEFORE the extraction LLM call whether a session carries
-   * enough signal (decision/outcome/error markers, tool-use / edit / commit
-   * density, substantive-turn ratio) to be worth extracting; low-signal sessions
-   * are skipped (skipReason 'triaged_out') at zero LLM cost.
-   * Default OFF. Only meaningful on the `extract` process.
-   */
-  triage?: {
-    enabled?: boolean;
-    /** Minimum total heuristic score to PASS. Default 2 (DEFAULT_TRIAGE_MIN_SCORE). */
-    minScore?: number;
-  };
-  /**
-   * WS-3b: Anti-collapse guards (step 8). Prevents the consolidation pipeline
-   * from collapsing too aggressively and losing diversity.
-   * Default OFF. Only meaningful on the `consolidate` process.
-   */
-  antiCollapse?: {
-    enabled?: boolean;
-    /** Refuse to merge two assets both above this generation. Default 2. */
-    maxGeneration?: number;
-    /** Low n-gram diversity ⇒ raise merge threshold. Default true when enabled. */
-    lexicalDiversityCheck?: boolean;
-    /** Fraction of pool to fill with random (non-similar) clusters. Default 0.05. */
-    randomClusterFraction?: number;
-  };
-  /**
-   * WS-3b: CLS (Complementary Learning System) interleaving (step 9).
-   * distill/memoryInference prompts include embedding-retrieved adjacent
-   * lessons/knowledge to prevent catastrophic interference. Default OFF.
-   * Only meaningful on `distill` and `memoryInference` processes.
-   */
-  cls?: {
-    enabled?: boolean;
-    /** Number of adjacent lessons/knowledge to include in prompts. Default 3. */
-    adjacentCount?: number;
-  };
-  /**
-   * WS-3b: Distill→source fidelity check (step 10). After a distill proposal,
-   * checks it against its cited source memories; a contradiction flag forces human
-   * review. Default OFF. Only meaningful on the `distill` process.
-   */
-  fidelityCheck?: {
-    enabled?: boolean;
-  };
-  /**
-   * #609 — recombine / synthesize pass: minimum number of related memories a
-   * cluster must contain before it is eligible for an LLM generalization call.
-   * Clusters below this size are skipped (no LLM call). Default 3. Only
-   * meaningful on the `recombine` process.
-   */
-  minClusterSize?: number;
-  /**
-   * #609 — recombine pass: hard cap on the number of clusters processed (one
-   * bounded LLM call each) per run. Bounds cost on stashes with many shared
-   * tags. Clusters are ranked by member-count desc and the top N are kept.
-   * Default 5. Only meaningful on the `recombine` process.
-   */
-  maxClustersPerRun?: number;
-  /**
-   * #632 — recombine pass: maximum number of members a cluster may contain
-   * before it is SKIPPED. Oversized tag/entity buckets (e.g. a generic "akm"
-   * tag shared by hundreds of memories) produce bland, over-broad
-   * generalizations; capping member count keeps clusters tight. When SET, the
-   * largest-first ranking no longer starves smaller, tighter clusters (the
-   * oversized ones are dropped before ranking). UNSET = no cap = identical to
-   * the pre-#632 behaviour. Only meaningful on the `recombine` process.
-   */
-  maxClusterSize?: number;
-  /**
-   * #632 — recombine pass: tags that must NEVER form a tag-based cluster (e.g.
-   * generic project-wide tags). Memories still cluster on their OTHER tags /
-   * graph entities; only the listed tag values are dropped as cluster signals.
-   * UNSET/[] = identical to the pre-#632 behaviour. Only meaningful on the
-   * `recombine` process.
-   */
-  excludeTags?: string[];
-  /**
-   * #632 — recombine pass: entity_norm values that must NEVER form an entity
-   * cluster (user-curated counterpart to the built-in generic-entity filter).
-   * Memories still cluster on their OTHER entities / tags. UNSET/[] = entity
-   * clustering governed by the built-in junk filter alone. Only meaningful on
-   * the `recombine` process.
-   */
-  excludeEntities?: string[];
-  /**
-   * #609 — recombine pass: relatedness signal used to form clusters.
-   *   - `"tags"`  — group memories by each shared frontmatter tag.
-   *   - `"graph"` — group by shared graph entity (`graph_file_entities`);
-   *                 falls back to tags when the graph table is empty.
-   *   - `"both"`  — union of the two grouping keys.
-   * Clustering is by RELATEDNESS, never embedding similarity. Default `"both"`
-   * (#632 — entity clustering surfaces coherent subject-scoped clusters tags
-   * miss; additive over tag clustering). Only meaningful on the `recombine`
-   * process.
-   */
-  relatednessSource?: "tags" | "graph" | "both";
-  /**
-   * #609 — recombine pass: number of consecutive runs a `type: hypothesis`
-   * generalization must be re-induced before a later confirmation run may
-   * promote it to a `type: lesson`. The first pass NEVER emits a lesson
-   * directly (two-pass contract). Default 2. Only meaningful on the
-   * `recombine` process.
-   */
-  confirmThreshold?: number;
-  /**
-   * #615 — procedural-compilation pass: minimum number of distinct assets that
-   * must share the SAME successful normalized ordered-action sequence before it
-   * is compiled into a workflow proposal. Default 3. Only meaningful on the
-   * `procedural` process.
-   */
-  minRecurrence?: number;
-  /**
-   * #615 — procedural pass: hard cap on the number of workflow proposals emitted
-   * per run (one bounded LLM call each). Clusters are ranked by member-count
-   * desc and the top N are kept. Default 3. Only meaningful on the `procedural`
-   * process.
-   */
-  maxProposalsPerRun?: number;
-  /**
-   * #615 — procedural pass: asset type a compiled sequence is emitted as.
-   * Reserved; v1 always emits `"workflow"` (the `"skill"` alternative is
-   * deferred). Only meaningful on the `procedural` process.
-   */
-  emitAs?: "workflow" | "skill";
-}
+/**
+ * Per-process config (`profiles.improve.<profile>.processes.<process>`).
+ * Derived from {@link ImproveProcessConfigSchema} so the type and the runtime
+ * validator cannot drift. Most fields are process-specific — see the field
+ * comments in config-schema.ts for which process each knob applies to and its
+ * default (e.g. `dedup`/`judgedCache`/`minPoolSize` = consolidate;
+ * `minNewSessions`/`indexSessions`/`triage` = extract; `fullScan`/`topN` =
+ * graphExtraction; `minClusterSize`/`relatednessSource` = recombine;
+ * `minRecurrence`/`emitAs` = procedural).
+ */
+export type ImproveProcessConfig = z.infer<typeof ImproveProcessConfigSchema>;
 
-export interface ImproveProfileConfig {
-  description?: string;
-  processes?: {
-    reflect?: ImproveProcessConfig;
-    distill?: ImproveProcessConfig;
-    consolidate?: ImproveProcessConfig;
-    memoryInference?: ImproveProcessConfig;
-    graphExtraction?: ImproveProcessConfig;
-    /** Third-tier classifier runner. Used by staleness/confidence/classification. */
-    validation?: ImproveProcessConfig;
-    /**
-     * Gates the `akm extract` pass that reads native session files via the
-     * session-log harness registry and queues durable-insight proposals.
-     * Default: enabled.
-     */
-    extract?: ImproveProcessConfig;
-    /**
-     * Drains the standing pending proposal backlog using a deterministic
-     * triage policy. Opt-in (default disabled).
-     */
-    triage?: ImproveProcessConfig;
-    /**
-     * Layer 2 — proactive-maintenance selector. On whole-stash / type scope,
-     * surfaces the top-N highest-priority *due* assets (never reflected, or last
-     * reflected > `dueDays` ago) into the reflect/distill candidate set so stable
-     * high-value assets get refreshed on a schedule even without new feedback.
-     * Opt-in (default DISABLED). Knobs: `enabled`, `dueDays` (30),
-     * `maxPerRun`/`limit` (25).
-     */
-    proactiveMaintenance?: ImproveProcessConfig;
-    /**
-     * #609 — recombine / synthesize pass. Clusters memories by relatedness
-     * (shared tags / graph entities) and issues one bounded LLM call per
-     * cluster to induce a cross-episodic generalization, emitting it as a
-     * `type: hypothesis` proposal through the normal queue + quality gate.
-     * Opt-in (default DISABLED).
-     */
-    recombine?: ImproveProcessConfig;
-    /**
-     * #615 — procedural-compilation pass. Detects recurring successful ordered
-     * action sequences (the same normalized step list appearing >=
-     * `minRecurrence` times with a non-failure outcome) and compiles each into a
-     * `type: workflow` proposal through the normal queue + quality gate.
-     * Opt-in (default DISABLED).
-     */
-    procedural?: ImproveProcessConfig;
-  };
-  autoAccept?: number;
-  limit?: number;
-  /**
-   * Bounded multi-cycle phasing (#616). Number of prep->loop->post-loop cycles
-   * per run. Each cycle re-runs ensureIndex + collectEligibleRefs so
-   * gate-accepted output of cycle N is selectable input to cycle N+1. DEFAULT 1
-   * => byte-identical single-pass behavior. A cycle accepting ZERO new
-   * gate-accepted proposals ends the loop (fixed-point). Budget-gated: a cycle
-   * is not started when remainingBudgetMs is exhausted.
-   */
-  maxCycles?: number;
-  /**
-   * #614 — symmetric valence weighting in the improve eligibility sort. The
-   * legacy ranking weights feedback NEGATIVE-ONLY (`negative / total`), so
-   * strong POSITIVE feedback never drives attention. When `true`, the feedback
-   * attention term becomes the |valence| MAGNITUDE — both strong positive and
-   * strong negative feedback lift an asset's attention (utility remains the
-   * dominant ordering factor) — and strongly-signed assets are routed to a
-   * lane: high-negative → fix, high-positive → reinforce.
-   *
-   * DEFAULT OFF. Absent or `false` preserves the legacy negative-only ranking
-   * byte-for-byte.
-   */
-  symmetricValence?: boolean;
-  /**
-   * End-of-run auto-sync: batch-commit (and optionally push) the primary
-   * git-backed stash once an improve run finishes. Default ON for git-backed
-   * stashes; push is gated on `config.writable` + a configured remote.
-   */
-  sync?: {
-    enabled?: boolean;
-    push?: boolean;
-    message?: string;
-  };
-}
+/**
+ * A named improve profile (`profiles.improve.<name>`). Derived from
+ * {@link ImproveProfileConfigSchema}. Holds the per-process `processes` map plus
+ * profile-level knobs (`autoAccept`, `limit`, `maxCycles`, `symmetricValence`,
+ * `sync`). See config-schema.ts for per-field docs.
+ */
+export type ImproveProfileConfig = z.infer<typeof ImproveProfileConfigSchema>;
 
 export interface RegistryConfigEntry {
   /** URL of the registry index */

--- a/src/core/config/config-types.ts
+++ b/src/core/config/config-types.ts
@@ -2,11 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Type-only imports (erased at runtime → no import cycle with config-schema,
-// which imports VALID_HARNESS_IDS from here at runtime). The improve/agent
-// process shapes are DERIVED from the Zod schema via `z.infer` so the type and
-// the validator cannot drift — the schema in ./config-schema.ts is the single
-// source of truth (see its field comments for per-knob docs).
+// The improve/agent process shapes are DERIVED from the Zod schema via
+// `z.infer` so the type and the validator cannot drift — config-schema.ts is the
+// single source of truth (see its field comments for per-knob docs). The schema
+// values are referenced via inline `typeof import("./config-schema").<Schema>`
+// type queries rather than an `import type {...}`: this is unambiguously
+// type-only under any tsconfig/toolchain and creates no runtime import cycle
+// (config-schema imports VALID_HARNESS_IDS from here at runtime).
 import type { z } from "zod";
 // VALID_HARNESS_IDS now derives from the unified HARNESS_REGISTRY (#562), which
 // is the single source of truth replacing the previously-disconnected
@@ -25,7 +27,6 @@ import { VALID_HARNESS_IDS } from "../../integrations/harnesses";
  * `bunx tsc` surfaces drift through call-site errors.
  */
 import type { InstalledStashEntry } from "../../registry/types";
-import type { AgentProfileConfigSchema, ImproveProcessConfigSchema, ImproveProfileConfigSchema } from "./config-schema";
 
 /**
  * Canonical list of valid agent harness / platform ids. Re-exported from the
@@ -134,7 +135,7 @@ export interface LlmProfileConfig extends LlmConnectionConfig {
  * {@link AgentProfileConfigSchema}; fields: `platform`, `bin`, `args`,
  * `workspace`, `model`, `timeoutMs` (null = no timeout).
  */
-export type AgentProfileConfig = z.infer<typeof AgentProfileConfigSchema>;
+export type AgentProfileConfig = z.infer<typeof import("./config-schema").AgentProfileConfigSchema>;
 
 /**
  * Per-process config (`profiles.improve.<profile>.processes.<process>`).
@@ -146,7 +147,7 @@ export type AgentProfileConfig = z.infer<typeof AgentProfileConfigSchema>;
  * graphExtraction; `minClusterSize`/`relatednessSource` = recombine;
  * `minRecurrence`/`emitAs` = procedural).
  */
-export type ImproveProcessConfig = z.infer<typeof ImproveProcessConfigSchema>;
+export type ImproveProcessConfig = z.infer<typeof import("./config-schema").ImproveProcessConfigSchema>;
 
 /**
  * A named improve profile (`profiles.improve.<name>`). Derived from
@@ -154,7 +155,7 @@ export type ImproveProcessConfig = z.infer<typeof ImproveProcessConfigSchema>;
  * profile-level knobs (`autoAccept`, `limit`, `maxCycles`, `symmetricValence`,
  * `sync`). See config-schema.ts for per-field docs.
  */
-export type ImproveProfileConfig = z.infer<typeof ImproveProfileConfigSchema>;
+export type ImproveProfileConfig = z.infer<typeof import("./config-schema").ImproveProfileConfigSchema>;
 
 export interface RegistryConfigEntry {
   /** URL of the registry index */

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -357,9 +357,14 @@ export function saveConfig(config: AkmConfig): void {
 
   const sanitized = sanitizeConfigForWrite(config);
 
-  // Final validation gate before bytes hit disk. Catches schema violations
-  // (unknown keys in registries[] / sources[] / profiles.*; out-of-range
-  // numbers; etc. — closes #462) before we corrupt the user's config.
+  // Final validation gate before bytes hit disk. Runs the FULL schema —
+  // including the cross-field superRefine guards (removed `feedbackDistillation`
+  // process key, `defaultWriteTarget` resolution, writable npm/website sources)
+  // and all type/enum/range checks — so an `akm config set` (leaf OR object
+  // form) cannot persist a guard-violating or mistyped value. NOTE: unknown
+  // keys are intentionally NOT rejected here — object schemas are `.passthrough()`
+  // so cross-version skew round-trips (see config-schema.ts header); the lenient
+  // tolerance is by design, not an oversight.
   const parseResult = AkmConfigSchema.safeParse(sanitized);
   if (!parseResult.success) {
     const lines = parseResult.error.issues.map((i) => `  - ${i.path.join(".") || "(root)"}: ${i.message}`).join("\n");

--- a/tests/commands/default-improve-profiles.test.ts
+++ b/tests/commands/default-improve-profiles.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, test } from "bun:test";
 import profileCatchup from "../../src/assets/profiles/catchup.json";
 import profileConsolidate from "../../src/assets/profiles/consolidate.json";
 import profileFrequent from "../../src/assets/profiles/frequent.json";
+import profileSynthesize from "../../src/assets/profiles/synthesize.json";
 import { resolveImproveProfile } from "../../src/commands/improve/improve-profiles";
 import type { AkmConfig } from "../../src/core/config/config";
 import { ImproveProfileConfigSchema } from "../../src/core/config/config-schema";
@@ -85,6 +86,23 @@ describe("default improve profiles (#552)", () => {
     expect(JSON.stringify(profileFrequent)).not.toContain("minPoolSize");
     expect(JSON.stringify(profileConsolidate)).toContain("minPoolSize");
     expect(JSON.stringify(profileCatchup)).toContain("minPoolSize");
+  });
+
+  test("synthesize: validates against the live schema", () => {
+    expect(() => ImproveProfileConfigSchema.parse(profileSynthesize)).not.toThrow();
+  });
+
+  test("synthesize resolves to recombine + procedural ON, all generative/extract passes OFF", () => {
+    const p = resolveImproveProfile("synthesize", MINIMAL_CONFIG);
+    expect(p.processes?.recombine?.enabled).toBe(true);
+    expect(p.processes?.procedural?.enabled).toBe(true);
+    expect(p.processes?.reflect?.enabled).toBe(false);
+    expect(p.processes?.distill?.enabled).toBe(false);
+    expect(p.processes?.consolidate?.enabled).toBe(false);
+    expect(p.processes?.memoryInference?.enabled).toBe(false);
+    expect(p.processes?.graphExtraction?.enabled).toBe(false);
+    expect(p.processes?.extract?.enabled).toBe(false);
+    expect(p.sync?.push).toBe(true);
   });
 
   test("minNewSessions (#554) lives only on the frequent profile's extract process", () => {

--- a/tests/commands/improve-profiles.test.ts
+++ b/tests/commands/improve-profiles.test.ts
@@ -55,8 +55,10 @@ describe("resolveImproveProfile", () => {
     expect(profile.processes?.consolidate?.enabled).toBe(false);
     expect(profile.processes?.memoryInference?.enabled).toBe(false);
     expect(profile.processes?.graphExtraction?.enabled).toBe(false);
-    // Lightweight pass opts out of end-of-run auto-sync (no surprise commit/push).
-    expect(profile.sync?.enabled).toBe(false);
+    // Sync is enabled (consistent with every built-in): reflect can auto-accept
+    // and write, so the run must commit rather than leave a silent backlog.
+    // saveGitStash no-ops a clean tree, so this is free when nothing is written.
+    expect(profile.sync?.enabled).toBe(true);
   });
 
   test("resolves named built-in 'thorough'", () => {
@@ -75,8 +77,9 @@ describe("resolveImproveProfile", () => {
     expect(profile.processes?.consolidate?.enabled).toBe(false);
     expect(profile.processes?.memoryInference?.enabled).toBe(true);
     expect(profile.processes?.graphExtraction?.enabled).toBe(false);
-    // Limited pass opts out of end-of-run auto-sync (no surprise commit/push).
-    expect(profile.sync?.enabled).toBe(false);
+    // Sync is enabled (consistent with every built-in): reflect + memoryInference
+    // both write, so the run must commit rather than leave a silent backlog.
+    expect(profile.sync?.enabled).toBe(true);
   });
 
   test("unknown name falls back to default built-in", () => {

--- a/tests/config-process-roundtrip.test.ts
+++ b/tests/config-process-roundtrip.test.ts
@@ -481,3 +481,29 @@ describe("config audit 0.9.0: previously-drifted knobs are now schema-validated"
     expect(() => loadConfig()).toThrow(ConfigError);
   });
 });
+
+// saveConfig is the whole-config validation gate that runs the cross-field
+// superRefine GUARDS (not just leaf checks). This is what stops an `akm config
+// set` — leaf OR object form — from persisting a guard-violating value (e.g.
+// re-introducing the removed `feedbackDistillation` process key via an
+// object-valued set, which the per-leaf walker schema alone would let through).
+// Lock that the guard fires at save so it can never silently regress.
+describe("config audit 0.9.0: saveConfig runs superRefine guards (object-form set cannot bypass)", () => {
+  test("saveConfig rejects the removed feedbackDistillation process key with the migration hint", () => {
+    expect(() =>
+      saveConfig({
+        semanticSearchMode: "off",
+        profiles: { improve: { default: { processes: { feedbackDistillation: { enabled: true } } } } },
+      } as unknown as AkmConfig),
+    ).toThrow(/feedbackDistillation was removed/);
+  });
+
+  test("saveConfig rejects writable: true on a non-filesystem/git source (superRefine)", () => {
+    expect(() =>
+      saveConfig({
+        semanticSearchMode: "off",
+        sources: [{ type: "website", name: "docs", url: "https://example.com", writable: true }],
+      } as unknown as AkmConfig),
+    ).toThrow(ConfigError);
+  });
+});

--- a/tests/config-process-roundtrip.test.ts
+++ b/tests/config-process-roundtrip.test.ts
@@ -408,3 +408,76 @@ describe("#598 process-level config fields survive a load→save→load round tr
     expect(() => loadConfig()).toThrow(ConfigError);
   });
 });
+
+// Config audit 0.9.0 — schema/type drift closure. These four knobs previously
+// existed only in the TS type (or only in the schema), riding `.passthrough()`
+// without validation, because the Zod schema and the hand-written interface were
+// two hand-synced sources of truth. The interfaces are now DERIVED from the
+// schema via `z.infer` (config-types.ts) and the missing fields were added to
+// the schema (config-schema.ts). These tests lock that each is a first-class,
+// VALIDATED field — round-tripping when valid AND rejected when mistyped.
+describe("config audit 0.9.0: previously-drifted knobs are now schema-validated", () => {
+  test("graphExtraction.fullScan round-trips (was TS-only)", () => {
+    saveConfig({
+      semanticSearchMode: "off",
+      profiles: { improve: { default: { processes: { graphExtraction: { enabled: true, fullScan: true } } } } },
+    } as unknown as AkmConfig);
+    resetConfigCache();
+    expect(() => loadConfig()).not.toThrow();
+    const gx = loadConfig().profiles?.improve?.default?.processes?.graphExtraction;
+    expect(gx?.fullScan).toBe(true);
+  });
+
+  test("extract.triage { enabled, minScore } round-trips (was TS-only)", () => {
+    saveConfig({
+      semanticSearchMode: "off",
+      profiles: {
+        improve: { default: { processes: { extract: { enabled: true, triage: { enabled: true, minScore: 3 } } } } },
+      },
+    } as unknown as AkmConfig);
+    resetConfigCache();
+    expect(() => loadConfig()).not.toThrow();
+    const extract = loadConfig().profiles?.improve?.default?.processes?.extract;
+    expect(extract?.triage?.enabled).toBe(true);
+    expect(extract?.triage?.minScore).toBe(3);
+  });
+
+  test("processes.extract is now a VALIDATED process — a mistyped known field is rejected (closes C2)", () => {
+    // Before the fix `extract` was absent from ImproveProfileProcessesSchema, so
+    // the whole block rode top-level passthrough and `minNewSessions: "lots"`
+    // was silently accepted. It must now hard-error at load.
+    const configPath = getConfigPath();
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        semanticSearchMode: "off",
+        profiles: { improve: { default: { processes: { extract: { minNewSessions: "lots" } } } } },
+      }),
+    );
+    resetConfigCache();
+    expect(() => loadConfig()).toThrow(ConfigError);
+  });
+
+  test("profiles.agent.<name>.timeoutMs round-trips (number) and rejects a mistyped value", () => {
+    saveConfig({
+      semanticSearchMode: "off",
+      profiles: { agent: { opencode: { platform: "opencode", timeoutMs: 120000 } } },
+    } as unknown as AkmConfig);
+    resetConfigCache();
+    expect(() => loadConfig()).not.toThrow();
+    expect(loadConfig().profiles?.agent?.opencode?.timeoutMs).toBe(120000);
+
+    // A string timeoutMs must now be rejected (it is a known, typed field).
+    const configPath = getConfigPath();
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        semanticSearchMode: "off",
+        profiles: { agent: { opencode: { platform: "opencode", timeoutMs: "soon" } } },
+      }),
+    );
+    resetConfigCache();
+    expect(() => loadConfig()).toThrow(ConfigError);
+  });
+});


### PR DESCRIPTION
Resolves the release-blocker findings from the 0.9.0 configuration audit (full report in `.plans/config-audit-0.9.0.md`). Closes validation gaps and corrects misleading docs. One intentional runtime behavior change: the `quick` and `memory-focus` built-in profiles now auto-commit/push like every other built-in (previously `sync.enabled: false`) — see the synthesize/sync commit and the "sync consistency" note below.

## Root cause: schema/type two-source-of-truth drift
The improve-process and agent-profile shapes were maintained twice — the Zod schema (`config-schema.ts`) and hand-written TS interfaces (`config-types.ts`) — and had drifted. Fields existed in one but not the other, riding `.passthrough()` without validation.

**Fix (subtractive):** added the 3 missing fields to the schema, then derived the types from it via `z.infer` and deleted ~430 lines of hand-synced interface. Drift is now structurally impossible. (Verified `z.infer` of a `.passthrough()` schema adds no index signature, so consumer type-safety is unchanged — `tsc` 0 errors.)

## Findings closed
**Critical**
- **C1** — `docs/configuration.md` minimal example contained `feedbackDistillation`, which the schema *hard-rejects* → paste-the-docs = `INVALID_CONFIG_FILE`. Removed (+ dead `cooldownByType`/`cooldownDays`). Verified the corrected example now validates.
- **C2** — `extract` was absent from `ImproveProfileProcessesSchema`, so the entire default-ON extract process config escaped shape validation. Added it; a mistyped `extract` field now errors at load.
- **C3** — *Downgraded after verification.* The dangerous half (object-form `config set` bypassing superRefine guards) does **not** occur — `saveConfig` already runs the full `safeParse`. The agent had tested the walker in isolation. Fixed the now-false `saveConfig` comment; added regression tests locking that the guards fire. No strict-on-set validator added (it would false-positive on the genuinely-open passthrough objects).

**High**
- **H1/H2/H3** — `AgentProfileConfig.timeoutMs`, `graphExtraction.fullScan` (TS-only → added to schema), `proceduralAwareFloor` (schema-only → now in the inferred type).
- **H4** — fixed `output.format`/`output.detail` enums, deleted dead `stashInheritance`, rewrote the `features.*`/`options:{}` process-shape section, corrected the false "project config is merged" opening.
- **H5** — documented the previously-undocumented `improve.calibration`/`exploration`/`salience` trees, the four processes (triage/proactiveMaintenance/recombine/procedural), per-pass `index.<pass>` keys, `search.defaultExcludeTypes`, `archiveRetentionDays`, `feedback.*`.

**Medium/Nit** — expanded the built-in profiles table from 4 → all 8 (catchup/consolidate/frequent/graph-refresh were undocumented); fixed the false "thorough identical to default" claim; flagged memory-focus's sync-disabled footgun; repointed `processes.feedbackDistillation.enabled` → `processes.distill.enabled` in 3 technical docs.

## Verification
- `tsc --noEmit` → 0 errors
- `gen-config-schema --check` → up to date (regenerated `schemas/akm-config.json`)
- Full unit suite → **5314 pass / 0 fail**
- New regression tests lock each previously-drifted knob (round-trips when valid, rejected when mistyped) and the save-time guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)