### PR TITLE
fix(index): writers index their writes; delete read-triggered background reindex

### DIFF
--- a/docs/design/read-path-reindex-contention-findings.md
+++ b/docs/design/read-path-reindex-contention-findings.md
@@ -91,9 +91,12 @@ lints 0/0, tsc clean, unit 4964/0, integration 1935/0):
 
 ## 5. Remaining work
 
-None on this branch. Follow-ups (separate issues if wanted): a "index last
-built N days ago" hint on search for cron-less installs; the `akm health`
-embedding-endpoint advisory (§6.2).
+None. Both follow-ups also shipped on this branch:
+- search emits a "last built N day(s) ago — run 'akm index'" warning when the
+  index is older than 7 days (`db-search.ts`, `STALE_INDEX_HINT_MS`).
+- the `akm health` semantic-search-runtime advisory names the configured
+  embedding endpoint when blocked with a remote-* reason and lists the fixes
+  (§6.2 resolved).
 
 ## 6. Open questions for the owner
 

--- a/docs/design/read-path-reindex-contention-findings.md
+++ b/docs/design/read-path-reindex-contention-findings.md
@@ -1,0 +1,211 @@
+# Read-path reindex contention — findings & fix state
+
+> **Status:** Direction changed 2026-07-02 (owner decision): the read-triggered
+> background reindex is the footgun; the real fix is **write-path indexing**
+> (§7). §3-F1 (cooldown) is SUPERSEDED and will be deleted, not shipped.
+> §3-F2 (telemetry busy timeout) stands.
+> Branch: `fix/read-path-reindex-contention` (off main @ `78bada9a`, post-#682;
+> does NOT include the R5 branch — separate concern).
+> **Uncommitted changes exist on the working tree** — see §4 for exactly what
+> is done and §5 for what remains before this can be committed/PR'd.
+
+## 1. The reported issue (verified)
+
+`akm search` / `akm curate` are slow (fresh queries >20s, timeouts at 35/60/90s)
+because reads repeatedly trigger background reindex work, and those reindex jobs
+contend on the same SQLite `index.db` that search/curate also touch.
+
+## 2. Verification of each claim against the code
+
+| # | Claim | Verdict | Evidence |
+|---|---|---|---|
+| 1a | `searchLocal()` always calls `ensureIndex()` before searching | **Confirmed** | `src/indexer/search/db-search.ts` read path |
+| 1b | `ensureIndex()` spawns a background reindex whenever stale-but-servable | **Confirmed** | `src/indexer/ensure-index.ts:239-265` (pre-fix). There IS a single-flight writer lease (`acquireIndexWriterLease`, try-mode) so only one background reindex runs at a time — but nothing stops the *next* read from spawning a new one the moment the previous finishes. |
+| 1c | `seen-urls.txt` keeps the index stale | **Refuted** | The wiki asset spec uses `markdownSpec` → `isRelevantFile` accepts only `.md` (`src/core/asset/asset-spec.ts:36,139-144`), and `getIndexableFiles` applies that filter before the staleness check. A `.txt` state file can never trigger staleness. |
+| 1d | Session memory files keep the index stale | **Confirmed — this is the real trigger** | `memories/opencode-session-*.md` is indexable and written continuously during active sessions. Every completed background reindex is followed by renewed staleness, so near-every read spawns another reindex. |
+| 2 | Background reindexes collide with reads; 30s busy_timeout amplifies | **Confirmed** | `PRAGMA busy_timeout = 30000` (`src/storage/sqlite-pragmas.ts`). Under WAL, *readers* don't block — the stalls are on the read path's **synchronous telemetry writes** (below), which queue behind the reindex writer for up to 30s each. `database is locked` in `index-background.log` = writer-vs-writer contention (background indexer vs. read-path usage-event inserts, both directions). |
+| 3 | Search telemetry is synchronous and blocks the command | **Confirmed** | `logSearchEvent` (`src/commands/read/search.ts:305-369`) does up to 52 `insertUsageEvent` writes + utility bumps through the synchronous `withIndexDb` (`src/storage/repositories/index-db.ts` — "intentionally synchronous"). Even `--source registry` writes a summary usage event to the local index.db. The reporter's `skipLogging: true` returning in ~2.7s is consistent. |
+| 4 | curate amplifies: multiple searches + per-item show + its own event log | **Confirmed** | `searchForCuration` fallback tokens, `akmShowUnified` per item, `logCurateEvent` opens index.db directly (raw `openExistingDatabase`, 30s timeout). Each hop can independently stall behind the reindex writer. |
+| 5 | Semantic/embedding is a secondary cost | **Agreed, deprioritized** | Background log shows "Embedding generation failed... Unable to connect" — the configured `localhost:1234` endpoint is down, adding noise/latency to *reindex* runs but failing fast. Not addressed in this fix. |
+
+**Root cause in one sentence:** staleness-on-read + continuously-written session
+memories = a background reindex per read; the reindex holds index.db write
+locks; the reads' own synchronous usage-logging writes then wait up to 30s per
+DB open on those locks; curate multiplies this by N searches + M shows + its
+own log.
+
+## 3. Fix design (three small changes, no new machinery)
+
+**F1 — Cooldown on read-triggered background reindex** (`ensure-index.ts`).
+A marker file (`<dataDir>/logs/index-background.last`) is touched on every
+background spawn; while it is younger than `BACKGROUND_REINDEX_COOLDOWN_MS`
+(5 min) AND the index can serve the stash, `ensureIndex()` in background mode
+returns immediately — skipping even the staleness walk. Reads serve the
+slightly-stale index; the improve cron / explicit `akm index` still refresh on
+their own schedule. Blocking-mode callers (improve) are unaffected. Rejected
+alternative: debouncing on mtime deltas — the session files change continuously,
+so any mtime-based rule re-arms instantly.
+
+**F2 — Telemetry writes get a 250ms busy timeout instead of 30s**
+(`withIndexDb(fn, { busyTimeoutMs })` + `TELEMETRY_BUSY_TIMEOUT_MS = 250`).
+Usage-event inserts are fire-and-forget hints (the indexer overwrites utility
+scores on the next reindex anyway); under contention they should be *dropped*,
+not waited on. Applied at: `logSearchEvent` (search.ts), the `show` usage-event
+insert and graph-enqueue (show.ts), `logCurateEvent` and graph-enqueue
+(curate.ts — also converted from a raw `openExistingDatabase` to the shared
+`withIndexDb` helper). All sites already had fire-and-forget catch blocks, so a
+busy-timeout expiry is silently skipped.
+
+**F3 — (implicitly fixed by F1+F2)** curate's amplification: each of its N
+searches now hits the cooldown fast-path instead of the staleness walk + spawn,
+and each telemetry hop caps at 250ms instead of 30s.
+
+Explicitly NOT done (with reasons):
+- No async/queued telemetry — new machinery; the 250ms cap achieves the goal.
+- No change to `busy_timeout` for real writers (indexer, feedback) — they should wait.
+- No embedding-path changes — secondary issue; the endpoint being down is an
+  environment problem (`semanticSearchMode: "auto"` fails open).
+- No change to the #607 inline-rebuild-when-can't-serve behavior.
+
+## 4. Implementation state — DONE (this branch)
+
+Shipped on `fix/read-path-reindex-contention` (full gate green: biome+custom
+lints 0/0, tsc clean, unit 4964/0, integration 1935/0):
+
+- **F2** (telemetry 250ms busy timeout) as described in §3.
+- **§7 write-path indexing**: `src/indexer/index-written-assets.ts`
+  (`indexWrittenAssets`), wired into `writeMarkdownAsset`
+  (`src/commands/read/knowledge.ts`) and extract's session-asset write
+  (`src/commands/improve/extract.ts`).
+- **§7 read-path subtraction**: `ensureIndex()` rewritten — background mode is
+  serve-if-servable / inline-rebuild-if-not; blocking mode unchanged. Deleted:
+  the per-read staleness walk, `spawnBackgroundReindex`, the writer-lease
+  handoff (`handoffIndexWriterLeaseToPid`), the `AKM_CLI_ENTRY` marker
+  (cli.ts), and the never-shipped F1 cooldown.
+- Tests: `tests/indexer/index-written-assets.test.ts`,
+  `tests/indexer/ensure-index-serve.test.ts`, busy-timeout pragma test in
+  `tests/storage/index-db-loan.characterization.test.ts`.
+- End-to-end verified in a sandbox: `akm remember` → hit on the very next
+  `akm search`; a hand-edited file is served stale by reads (no reindex
+  spawned) and appears after an explicit `akm index`.
+
+## 5. Remaining work
+
+None on this branch. Follow-ups (separate issues if wanted): a "index last
+built N days ago" hint on search for cron-less installs; the `akm health`
+embedding-endpoint advisory (§6.2).
+
+## 6. Open questions for the owner
+
+1. **Cooldown length**: 5 min chosen (improve cron reindexes every 20-30 min
+   anyway). Happy to make it a config key (`index.autoRefresh.cooldownMs`) if
+   you want it tunable — kept a constant to avoid new config surface.
+2. The reporter's environment has `embedding.endpoint: localhost:1234` DOWN
+   ("Unable to connect" in the background log). Worth a separate advisory in
+   `akm health` (embedding endpoint unreachable while semanticSearchMode=auto)?
+   Not part of this fix.
+
+## 7. Write-path indexing design (the actual fix — owner-approved direction)
+
+### 7.1 Root cause, restated structurally
+
+The index is maintained **eagerly** by every first-class mutation command
+(`source add`, `stash install`, `wiki`, `workflow`, `setup` all call
+`akmIndex()` after writing) — but **lazily at read time** for the two memory
+write paths:
+
+| Writer | Where | Indexes its write? | Frequency |
+|---|---|---|---|
+| `writeMarkdownAsset` (memory/knowledge) | `src/commands/read/knowledge.ts:141` | **No** | Continuous — the plugin session-checkpoint hook funnels through `akm remember` (live files carry `captureMode: hot`); 3,810 files in `memories/` today |
+| `writeSessionAsset` (session assets) | `src/commands/improve/session-asset.ts` ← `extract.ts:588` | **No** | Per session-end hook |
+| improve internals (distill/dedup/consolidate) | various | **Yes** — post-loop `reindexFn` under the writer lease (`loop-stages.ts:926`) | n/a |
+
+Read-triggered auto-reindex exists solely to compensate for the first two
+rows. Fixing the writers deletes the reason the footgun exists.
+
+### 7.2 New primitive: `indexWrittenAssets(stashDir, filePaths)`
+
+A targeted single-file incremental index. All building blocks already exist —
+no new machinery, just a thin composition:
+
+```
+indexWrittenAssets(stashDir: string, filePaths: string[]): Promise<void>
+  // FAIL-OPEN at every step: any error → warnVerbose + return.
+  // A skipped upsert degrades to today's behavior (visible after the
+  // next full reindex); it must never break remember/extract.
+  1. If index.db absent or has no populated `entries` table → return.
+     (Bootstrap belongs to the first read/`akm index`, not here.)
+  2. Open index.db with a SHORT busy timeout (5s, not 30s): a real write,
+     but `akm remember` must not hang behind a running full reindex.
+  3. Per file: generateMetadataFlat(stashDir, [file])   // passes/metadata.ts:1139
+       → entryKey `${stashDir}:${type}:${name}`, buildSearchText(entry),
+         attachFileSize(entry, path)
+       → upsertEntry(...)                                // db.ts:676, marks FTS-dirty
+  4. rebuildFts(db, { incremental: true })               // dirty-rows only, db.ts:1114
+  5. Close. NO builtAt bump, NO dir-state update, NO embedding/LLM/graph.
+```
+
+Step 5 is deliberate and ADR-blessed (`docs/technical/index-consistency-adr.md`,
+opportunistic recovery): embeddings/graph for the new entry are healed by the
+next full run (improve cron / explicit `akm index`). The per-dir mtime cache is
+untouched — writing the file changed the dir mtime, so the next full walk
+rescans that dir anyway; no drift.
+
+Known minor divergence (accepted, self-healing): the single-file path skips the
+cross-source shadowing dedup (`indexedAssetIdentities`), so a write that a
+higher-priority stash root shadows could appear until the next full run.
+
+### 7.3 Call sites (two lines of integration)
+
+1. `writeMarkdownAsset` — after `writeAssetToSource` succeeds:
+   `await indexWrittenAssets(source.path, [result.path])`.
+   Covers `akm remember` (including the plugin's continuous session
+   checkpoints — the dominant staleness source) and `stash-cli` writes.
+2. `extract.ts:588` — after `writeSessionAsset` returns `written: true`:
+   index `result.filePath`. Covers standalone `akm extract --session-id`
+   (session-end hook). Extract inside improve is additionally covered by the
+   post-loop reindex.
+
+No change to improve internals (already covered) or to the mutation commands
+(already call `akmIndex`).
+
+### 7.4 Read-path subtraction (deletions)
+
+`ensureIndex()` background mode stops compensating:
+
+- **Delete** the read-path staleness walk (the O(N-files) stat sweep per
+  read), `spawnBackgroundReindex`, the writer-lease handoff to the detached
+  child, the `AKM_CLI_ENTRY` guard, and this branch's §3-F1 cooldown
+  (constant, marker helpers, fast-path — never ships).
+- New background-mode behavior: `indexCanServeStash()` → serve as-is;
+  otherwise inline rebuild (bootstrap, unchanged from #607 semantics).
+- Blocking mode (`improve`) unchanged: `isIndexStale()` → inline rebuild.
+  (`isIndexStale`/`hasNewerIndexableFiles`/`getIndexableFiles` stay for this.)
+- If `akm index --background` and `handoffIndexWriterLeaseToPid` have no other
+  callers after this, delete them too (verify at implementation time).
+- §3-F2 (250ms telemetry busy timeout) stays — telemetry writes remain
+  fire-and-forget hints regardless of who maintains the index.
+
+### 7.5 Behavior changes (the honest tradeoff)
+
+| Scenario | Before | After |
+|---|---|---|
+| `akm remember` → search for it | Invisible until next background reindex completes | **Visible immediately** (FTS keyword; semantic after next full run) |
+| Session checkpoint writes during active session | Perpetual reindex loop, 20–90s read stalls | No read-side reindex at all |
+| Hand-edit / `git pull` a stash file → search | Eventually auto-reindexed (with the contention cost) | **Stale until** improve cron / explicit `akm index` / any mutation command |
+| First-ever search (no index) | Inline build | Inline build (unchanged) |
+
+The third row is the price. Mitigations considered: a "index last built N
+days ago — run `akm index`" hint on search (cheap, honest; can be added later
+if real users hit it), or a time-based re-arm of background reindex (rejected:
+re-adds the machinery being deleted).
+
+### 7.6 Tests
+
+- New: `remember` (via `writeMarkdownAsset`) → entry immediately present in
+  `entries` + FTS-searchable; fail-open when index.db absent; short-timeout
+  skip under a held write lock leaves the command successful.
+- New: `ensureIndex` background = serve-when-servable / inline-when-not;
+  blocking still rebuilds on stale.
+- Replace this branch's cooldown tests (behavior deleted).
+- Existing search/curate/show/extract suites stay green; full gate before commit.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -604,13 +604,6 @@ const EXIT_HEALTH_WARN = EXIT_CODES.HEALTH_WARN;
 // The wrapper sets `AKM_NODE_ENTRY=1` to opt into the startup block. The test
 // harness never sets it, so importing cli.ts under Bun stays inert as before.
 if (import.meta.main || process.env.AKM_NODE_ENTRY === "1") {
-  // Mark that this process is the real akm CLI: its `process.argv[1]` is the
-  // akm entrypoint, so the background auto-reindex may safely re-invoke it as a
-  // detached child. Hosts that merely import this module (the in-process test
-  // harness, library embeddings) never reach this block, so they fall back to
-  // an inline reindex instead of spawning the wrong program. See
-  // `ensureIndex` in src/indexer/ensure-index.ts.
-  process.env.AKM_CLI_ENTRY = "1";
   // citty reads process.argv directly and does not accept a custom argv array,
   // so we must replace process.argv with the normalized version before runMain.
   process.argv = normalizeShowArgv(process.argv);

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import fs from "node:fs";
+import { loadConfig } from "../core/config/config";
 import { ConfigError, UsageError } from "../core/errors";
 import { appendEvent, readEvents } from "../core/events";
 import { buildTaskRunId, getLoggedRunIds, openLogsDatabase } from "../core/logs-db";
@@ -2187,6 +2188,17 @@ export function akmHealth(options: AkmHealthOptions = {}): AkmHealthResult {
     const agentFailureRate = promptRows.length === 0 ? 0 : promptFailures.length / promptRows.length;
 
     const semanticStatus = readSemanticStatus();
+    // For the embedding-endpoint advisory. Best-effort: an unloadable config
+    // leaves both undefined and the check falls back to its generic message.
+    let semanticSearchMode: string | undefined;
+    let embeddingEndpoint: string | undefined;
+    try {
+      const config = loadConfig();
+      semanticSearchMode = config.semanticSearchMode;
+      embeddingEndpoint = config.embedding?.endpoint;
+    } catch {
+      // fall through with undefined
+    }
 
     const improveInvoked = readEvents({ since, type: "improve_invoked" }, { dbPath: stateDbPath }).events.length;
     const improveCompletedEvents = readEvents({ since, type: IMPROVE_COMPLETED_EVENT }, { dbPath: stateDbPath }).events;
@@ -2270,6 +2282,8 @@ export function akmHealth(options: AkmHealthOptions = {}): AkmHealthResult {
       logBackingRate,
       stuckActiveRuns,
       semanticStatus,
+      semanticSearchMode,
+      embeddingEndpoint,
       sessionLogEntries,
       sessionExtraction: improveSummary.sessionExtraction,
       autoAccept: improveSummary.autoAccept,

--- a/src/commands/health/checks.ts
+++ b/src/commands/health/checks.ts
@@ -38,6 +38,10 @@ export interface HealthCheckContext {
   /** Active runs older than the stale threshold. */
   stuckActiveRuns: number;
   semanticStatus: SemanticSearchStatus | undefined;
+  /** Effective `semanticSearchMode` from config (for the embedding advisory). */
+  semanticSearchMode: string | undefined;
+  /** Configured remote embedding endpoint, when one is set. */
+  embeddingEndpoint: string | undefined;
   sessionLogEntries: SessionLogAdvisory[];
   sessionExtraction: ImproveHealthMetrics["sessionExtraction"];
   autoAccept: ImproveHealthMetrics["autoAccept"];
@@ -252,22 +256,36 @@ export const HEALTH_CHECKS: readonly HealthCheck[] = [
   {
     name: "semantic-search-runtime",
     channel: "advisory",
-    run: (ctx) => ({
-      name: "semantic-search-runtime",
-      kind: "deterministic",
-      status:
-        !ctx.semanticStatus ||
-        ctx.semanticStatus.status === "pending" ||
-        ctx.semanticStatus.status === "ready-js" ||
-        ctx.semanticStatus.status === "ready-vec"
-          ? "pass"
-          : "warn",
-      confidence: "medium",
-      message: ctx.semanticStatus
-        ? `Semantic search status: ${ctx.semanticStatus.status}`
-        : "No semantic-search runtime status recorded yet.",
-      evidence: ctx.semanticStatus ? { ...ctx.semanticStatus } : undefined,
-    }),
+    run: (ctx) => {
+      const blocked = ctx.semanticStatus?.status === "blocked";
+      // The generic "status: blocked" line is not actionable when the real
+      // problem is a configured remote embedding endpoint that is down while
+      // semanticSearchMode leaves semantic search enabled — every index run
+      // burns time failing against it and searches silently degrade to
+      // keyword-only. Name the endpoint and the two ways out.
+      const remoteReason = ctx.semanticStatus?.reason?.startsWith("remote-") === true;
+      const endpointAdvisory =
+        blocked && remoteReason && ctx.embeddingEndpoint
+          ? `Configured embedding endpoint ${ctx.embeddingEndpoint} is failing ` +
+            `(${ctx.semanticStatus?.reason}${ctx.semanticStatus?.message ? `: ${ctx.semanticStatus.message}` : ""}) ` +
+            `while semanticSearchMode is "${ctx.semanticSearchMode ?? "auto"}". Searches fall back to keyword-only. ` +
+            `Restore the endpoint, or set semanticSearchMode to "off" (or remove embedding.endpoint to use the local model).`
+          : undefined;
+      return {
+        name: "semantic-search-runtime",
+        kind: "deterministic",
+        status: !ctx.semanticStatus || !blocked ? "pass" : "warn",
+        confidence: "medium",
+        message:
+          endpointAdvisory ??
+          (ctx.semanticStatus
+            ? `Semantic search status: ${ctx.semanticStatus.status}`
+            : "No semantic-search runtime status recorded yet."),
+        evidence: ctx.semanticStatus
+          ? { ...ctx.semanticStatus, ...(ctx.embeddingEndpoint ? { embeddingEndpoint: ctx.embeddingEndpoint } : {}) }
+          : undefined,
+      };
+    },
   },
   {
     // session-log-failures: demoted to informational — the ERROR_PATTERNS regex

--- a/src/commands/improve/extract.ts
+++ b/src/commands/improve/extract.ts
@@ -47,6 +47,7 @@ import {
 } from "../../core/state-db";
 import { repairTruncatedDescription } from "../../core/text-truncation";
 import { warn } from "../../core/warn";
+import { indexWrittenAssets } from "../../indexer/index-written-assets";
 import { resolveImproveProcessRunnerFromProfile, runnerIsLlm } from "../../integrations/agent/runner";
 import { normalizeHarnessId } from "../../integrations/harnesses";
 import { getAvailableHarnesses } from "../../integrations/session-logs";
@@ -587,6 +588,9 @@ async function processSession(
     try {
       const result = await writeSessionAsset(data, stashDir, sessionIndexing.generate);
       if (result.written) {
+        // Write-path indexing (itself fail-open): standalone `akm extract`
+        // (session-end hook) has no post-loop reindex to pick this file up.
+        if (result.filePath) await indexWrittenAssets(stashDir, [result.filePath]);
         return {
           ...(result.ref ? { sessionAssetRef: result.ref } : {}),
           ...(result.logPath ? { sessionLogPath: result.logPath } : {}),

--- a/src/commands/read/curate.ts
+++ b/src/commands/read/curate.ts
@@ -21,13 +21,13 @@ import { parseFrontmatter } from "../../core/asset/frontmatter";
 import { getIndexPassConfig, loadConfig } from "../../core/config/config";
 import { rethrowIfTestIsolationError, UsageError } from "../../core/errors";
 import { appendEvent } from "../../core/events";
-import { closeDatabase, computeBodyHash, openExistingDatabase } from "../../indexer/db/db";
+import { computeBodyHash } from "../../indexer/db/db";
 import { enqueueGraphExtraction, hasGraphData } from "../../indexer/db/graph-db";
 import { findSourceForPath, resolveSourceEntries } from "../../indexer/search/search-source";
 import { insertUsageEvent } from "../../indexer/usage/usage-events";
 import { truncateDescription } from "../../output/shapes";
 import type { RegistrySearchResultHit, SearchResponse, ShowResponse, SourceSearchHit } from "../../sources/types";
-import { withIndexDb } from "../../storage/repositories/index-db";
+import { TELEMETRY_BUSY_TIMEOUT_MS, withIndexDb } from "../../storage/repositories/index-db";
 import { akmSearch, parseSearchSource } from "./search";
 import { akmShowUnified } from "./show";
 
@@ -150,29 +150,29 @@ function logCurateEvent(query: string, result: CurateResponse): void {
   });
 
   try {
-    const db = openExistingDatabase();
-    try {
-      insertUsageEvent(db, {
-        event_type: "curate",
-        query,
-        metadata: JSON.stringify({
-          itemCount: result.items.length,
-          itemRefs,
-        }),
-        source: "user",
-      });
-      for (const item of result.items) {
-        if (!("ref" in item) || typeof item.ref !== "string") continue;
+    withIndexDb(
+      (db) => {
         insertUsageEvent(db, {
           event_type: "curate",
           query,
-          entry_ref: item.ref,
+          metadata: JSON.stringify({
+            itemCount: result.items.length,
+            itemRefs,
+          }),
           source: "user",
         });
-      }
-    } finally {
-      closeDatabase(db);
-    }
+        for (const item of result.items) {
+          if (!("ref" in item) || typeof item.ref !== "string") continue;
+          insertUsageEvent(db, {
+            event_type: "curate",
+            query,
+            entry_ref: item.ref,
+            source: "user",
+          });
+        }
+      },
+      { busyTimeoutMs: TELEMETRY_BUSY_TIMEOUT_MS },
+    );
   } catch (err) {
     rethrowIfTestIsolationError(err);
   }
@@ -309,11 +309,14 @@ function maybeEnqueueLazyGraph(assetPath: string): void {
     if (!body) return;
     const bodyHash = computeBodyHash(body);
 
-    withIndexDb((db) => {
-      if (!hasGraphData(db, stashRoot, assetPath)) {
-        enqueueGraphExtraction(db, stashRoot, assetPath, bodyHash, 0);
-      }
-    });
+    withIndexDb(
+      (db) => {
+        if (!hasGraphData(db, stashRoot, assetPath)) {
+          enqueueGraphExtraction(db, stashRoot, assetPath, bodyHash, 0);
+        }
+      },
+      { busyTimeoutMs: TELEMETRY_BUSY_TIMEOUT_MS },
+    );
   } catch (err) {
     rethrowIfTestIsolationError(err);
   }

--- a/src/commands/read/knowledge.ts
+++ b/src/commands/read/knowledge.ts
@@ -23,6 +23,7 @@ import {
   resolveWriteTarget,
   writeAssetToSource,
 } from "../../core/write-source";
+import { indexWrittenAssets } from "../../indexer/index-written-assets";
 import { fetchWebsiteMarkdownSnapshot, shouldAllowPrivateWebsiteUrlForTests } from "../../sources/website-ingest";
 
 const MAX_CAPTURED_ASSET_SLUG_LENGTH = 64;
@@ -186,6 +187,9 @@ export async function writeMarkdownAsset(options: {
   // 0.9.0 (issue #507): single batch commit at the write boundary for git
   // targets. No-op for filesystem/primary-stash targets.
   commitWriteTargetBoundary(target, `Update ${formatRefForMessage(ref)}`);
+  // Write-path indexing: the asset is searchable immediately. Fail-open; reads
+  // no longer trigger reindexes, so keeping the index current is the writer's job.
+  await indexWrittenAssets(source.path, [result.path]);
   return {
     ref: result.ref,
     path: result.path,

--- a/src/commands/read/search.ts
+++ b/src/commands/read/search.ts
@@ -35,7 +35,7 @@ import type {
   SearchSource,
   SourceSearchHit,
 } from "../../sources/types";
-import { withIndexDb } from "../../storage/repositories/index-db";
+import { TELEMETRY_BUSY_TIMEOUT_MS, withIndexDb } from "../../storage/repositories/index-db";
 import { searchRegistry } from "./registry-search";
 
 const DEFAULT_LIMIT = 20;
@@ -321,48 +321,54 @@ function logSearchEvent(
   });
 
   try {
-    withIndexDb((db) => {
-      const resolved = resolveEntryIds(db, stashHits.slice(0, 50));
-      for (const { entryId, ref } of resolved) {
+    // Short busy timeout: telemetry must never stall the search result behind
+    // a background reindex holding the index.db write lock (30s default wait).
+    // Under contention these usage hints are skipped, not waited for.
+    withIndexDb(
+      (db) => {
+        const resolved = resolveEntryIds(db, stashHits.slice(0, 50));
+        for (const { entryId, ref } of resolved) {
+          insertUsageEvent(db, {
+            event_type: "search",
+            query,
+            entry_id: entryId,
+            entry_ref: ref,
+            source: eventSource,
+          });
+        }
+        // Bump utility scores for all resolved entries (MemRL retrieval signal).
+        // The indexer overwrites these at next reindex; bumps are temporary hints.
+        const resolvedIds = resolved.map((r) => r.entryId).filter((id): id is number => id !== undefined);
+        if (resolvedIds.length > 0) {
+          let scopeKey: string | undefined;
+          try {
+            const stashPath = response.stashDir;
+            const disabled = disableScopedUtility || (stashPath && isTransientStashPath(stashPath));
+            scopeKey = disabled ? undefined : getCurrentWorkflowScopeKey();
+          } catch {
+            // Non-fatal — fall back to global-only bumps on any error.
+          }
+          bumpUtilityScoresBatch(db, resolvedIds, 1.0, 0.1, scopeKey);
+        }
+        // Count registry hits separately so registry-only searches record a
+        // non-zero resultCount. response.hits is always [] when source="registry".
+        const stashHitCount = response.hits.length;
+        const registryHitCount = Array.isArray(response.registryHits) ? response.registryHits.length : 0;
         insertUsageEvent(db, {
           event_type: "search",
           query,
-          entry_id: entryId,
-          entry_ref: ref,
+          metadata: JSON.stringify({
+            resultCount: stashHitCount + registryHitCount,
+            stashHitCount,
+            registryHitCount,
+            resolvedCount: resolved.length,
+            mode,
+          }),
           source: eventSource,
         });
-      }
-      // Bump utility scores for all resolved entries (MemRL retrieval signal).
-      // The indexer overwrites these at next reindex; bumps are temporary hints.
-      const resolvedIds = resolved.map((r) => r.entryId).filter((id): id is number => id !== undefined);
-      if (resolvedIds.length > 0) {
-        let scopeKey: string | undefined;
-        try {
-          const stashPath = response.stashDir;
-          const disabled = disableScopedUtility || (stashPath && isTransientStashPath(stashPath));
-          scopeKey = disabled ? undefined : getCurrentWorkflowScopeKey();
-        } catch {
-          // Non-fatal — fall back to global-only bumps on any error.
-        }
-        bumpUtilityScoresBatch(db, resolvedIds, 1.0, 0.1, scopeKey);
-      }
-      // Count registry hits separately so registry-only searches record a
-      // non-zero resultCount. response.hits is always [] when source="registry".
-      const stashHitCount = response.hits.length;
-      const registryHitCount = Array.isArray(response.registryHits) ? response.registryHits.length : 0;
-      insertUsageEvent(db, {
-        event_type: "search",
-        query,
-        metadata: JSON.stringify({
-          resultCount: stashHitCount + registryHitCount,
-          stashHitCount,
-          registryHitCount,
-          resolvedCount: resolved.length,
-          mode,
-        }),
-        source: eventSource,
-      });
-    });
+      },
+      { busyTimeoutMs: TELEMETRY_BUSY_TIMEOUT_MS },
+    );
   } catch (err) {
     rethrowIfTestIsolationError(err);
     /* fire-and-forget */

--- a/src/commands/read/show.ts
+++ b/src/commands/read/show.ts
@@ -42,7 +42,7 @@ import { resolveAssetPath } from "../../indexer/walk/path-resolver";
 import { resolveIndexPassLLM } from "../../llm/index-passes";
 import { resolveSourcesForOrigin } from "../../registry/origin-resolve";
 import { resolveStorageLocations } from "../../storage/locations";
-import { withIndexDb } from "../../storage/repositories/index-db";
+import { TELEMETRY_BUSY_TIMEOUT_MS, withIndexDb } from "../../storage/repositories/index-db";
 // Eagerly import source providers to trigger self-registration.
 import "../../sources/providers/index";
 import type { KnowledgeView, ShowDetailLevel, ShowResponse } from "../../sources/types";
@@ -335,14 +335,17 @@ function logShowEvent(ref: string, eventSource: "user" | "improve" = "user"): vo
   }
 
   try {
-    withIndexDb((db) => {
-      insertUsageEvent(db, {
-        event_type: "show",
-        entry_ref: ref,
-        entry_id: findEntryIdByRef(db, ref),
-        source: eventSource,
-      });
-    });
+    withIndexDb(
+      (db) => {
+        insertUsageEvent(db, {
+          event_type: "show",
+          entry_ref: ref,
+          entry_id: findEntryIdByRef(db, ref),
+          source: eventSource,
+        });
+      },
+      { busyTimeoutMs: TELEMETRY_BUSY_TIMEOUT_MS },
+    );
   } catch (err) {
     rethrowIfTestIsolationError(err);
     /* fire-and-forget */
@@ -504,9 +507,12 @@ async function maybeExtractGraphInline(
       return; // file gone/unreadable ⇒ nothing to extract
     }
 
-    withIndexDb((db) => {
-      alreadyGraphed = hasGraphData(db, sourceStashDir, assetPath);
-    });
+    withIndexDb(
+      (db) => {
+        alreadyGraphed = hasGraphData(db, sourceStashDir, assetPath);
+      },
+      { busyTimeoutMs: TELEMETRY_BUSY_TIMEOUT_MS },
+    );
     if (alreadyGraphed) return;
 
     // Open the db for the async extraction ourselves: `withIndexDb` is

--- a/src/indexer/ensure-index.ts
+++ b/src/indexer/ensure-index.ts
@@ -3,24 +3,30 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 /**
- * Auto-index: silently run an incremental `akm index` when the local index
- * is stale or absent, so that `search`, `show`, and `feedback` always operate
- * against current on-disk state without requiring the user to manually run
- * `akm index` first.
+ * Auto-index bootstrap: silently build the local index inline when it cannot
+ * serve the caller's stash at all (missing DB, no `entries` table, zero rows,
+ * or built for a different stash), so `search`, `show`, and `feedback` work
+ * on first use without a manual `akm index`.
  *
- * This replaces the old filesystem fallbacks that were scattered across
- * `searchLocal()` and `show.ts`, centralizing the "indexed yet?" gap handling
- * behind a single entry point.
+ * Content FRESHNESS is intentionally not this module's job on the read path.
+ * Writers maintain the index (`indexWrittenAssets` for `remember`/extract
+ * session assets; the mutation commands run `akmIndex()` themselves), and the
+ * improve cron / explicit `akm index` do full refreshes. Reads serve whatever
+ * populated index exists. The previous design — a staleness walk plus a
+ * detached background reindex per read — made every read on an actively
+ * written stash spawn a writer that the read's own telemetry then queued
+ * behind (see docs/design/read-path-reindex-contention-findings.md).
+ *
+ * `mode: "blocking"` (improve) still checks staleness and rebuilds inline,
+ * because its planning logic needs a current `entries` table in-process.
  */
 
-import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { ASSET_SPECS, type AssetSpec, TYPE_DIRS } from "../core/asset/asset-spec";
-import { getDataDir, getDbPath } from "../core/paths";
+import { getDbPath } from "../core/paths";
 import { warn } from "../core/warn";
 import { closeDatabase, getEntryCount, getIndexedFilePaths, getMeta, openExistingDatabase } from "./db/db";
-import { acquireIndexWriterLease, handoffIndexWriterLeaseToPid } from "./index-writer-lock";
 
 export interface EnsureIndexOptions {
   mode?: "background" | "blocking";
@@ -137,12 +143,9 @@ export function isIndexStale(stashDir: string): boolean {
  * i.e. the DB file exists, the `entries` table holds rows, and those rows were
  * built for this stash (it is the stored primary stash or appears in the
  * stored `stashDirs` set). When this is true the index is at worst
- * content-stale, so the `#607` background-reindex optimization is safe: the
- * caller gets slightly-stale-but-relevant results immediately. When it is
- * false the existing index has nothing relevant to return (no DB, no `entries`
- * table, zero rows, or built for a different stash), so a background reindex
- * would leave the caller empty until the next read — those cases must rebuild
- * inline.
+ * content-stale, so read paths serve it as-is. When it is false the existing
+ * index has nothing relevant to return (no DB, no `entries` table, zero rows,
+ * or built for a different stash), so those cases must rebuild inline.
  */
 function indexCanServeStash(stashDir: string): boolean {
   const dbPath = getDbPath();
@@ -169,46 +172,6 @@ function indexCanServeStash(stashDir: string): boolean {
   }
 }
 
-/**
- * Spawn a background `akm index` process. Non-blocking — returns immediately.
- * Background callers share the same global index-writer lease as foreground
- * writers, so stale-read-triggered auto-index attempts coalesce safely.
- */
-async function spawnBackgroundReindex(_stashDir: string): Promise<void> {
-  const dataDir = getDataDir();
-  const logFile = path.join(dataDir, "logs", "index-background.log");
-
-  fs.mkdirSync(path.dirname(logFile), { recursive: true });
-
-  const lease = await acquireIndexWriterLease({ mode: "try", purpose: "background-reindex-spawn" });
-  if (!lease) return;
-
-  const akmBin = process.argv[0];
-  const akmScript = process.argv[1];
-  try {
-    const child = spawn(akmBin, [akmScript, "index", "--background"], {
-      detached: true,
-      stdio: ["ignore", fs.openSync(logFile, "a"), fs.openSync(logFile, "a")],
-      env: { ...process.env },
-    });
-
-    if (!child.pid) {
-      lease.release();
-      return;
-    }
-
-    handoffIndexWriterLeaseToPid(lease, child.pid, "background-reindex");
-    try {
-      child.unref();
-    } catch {
-      // ignore
-    }
-  } catch (error) {
-    lease.release();
-    throw error;
-  }
-}
-
 async function runInlineReindex(stashDir: string): Promise<boolean> {
   try {
     const { akmIndex } = await import("./indexer.js");
@@ -221,53 +184,24 @@ async function runInlineReindex(stashDir: string): Promise<boolean> {
 }
 
 /**
- * Ensure the local index exists and is fresh enough for the caller's needs.
+ * Ensure the local index exists and can serve the caller.
  *
- * Default mode is `background`, which preserves the low-latency behavior used
- * by read paths (`search`, `show`, `feedback`): when a populated index is
- * merely stale, spawn a detached reindex and proceed against the existing
- * index. When the index is entirely absent (no DB / no `entries` table / zero
- * rows) the rebuild runs inline regardless of mode, since there is nothing to
- * proceed against.
+ * Default mode is `background` — the read-path contract (`search`, `show`,
+ * `feedback`): a populated index built for this stash is served as-is (its
+ * freshness is the writers' job, see module doc); an unusable index rebuilds
+ * inline, since there is nothing to proceed against.
  *
- * `mode: "blocking"` waits for the rebuild to finish before returning. Use
- * this for callers like `improve` whose planning logic depends on a populated
- * `entries` table in the same process.
+ * `mode: "blocking"` additionally treats content-staleness as a rebuild
+ * trigger and waits for it. Use this for callers like `improve` whose
+ * planning logic depends on a current `entries` table in the same process.
  *
  * Returns `true` if an index run was attempted.
  */
 export async function ensureIndex(stashDir: string, options: EnsureIndexOptions = {}): Promise<boolean> {
-  if (!isIndexStale(stashDir)) return false;
-
-  // Blocking when explicitly requested, or whenever the existing index cannot
-  // serve this stash (absent DB, no `entries` table, zero rows, or built for a
-  // different stash): a background reindex returns immediately and would leave
-  // a first-time caller (search, curate, wiki, show, feedback) with empty
-  // results. Building inline is a one-off cost; a populated index for this
-  // stash that is merely content-stale still refreshes in the background.
-  if (options.mode === "blocking" || !indexCanServeStash(stashDir)) {
+  if (options.mode === "blocking") {
+    if (!isIndexStale(stashDir)) return false;
     return runInlineReindex(stashDir);
   }
-
-  // The background path re-invokes the akm CLI as a detached child via
-  // `process.argv[1]`. That is only the akm entrypoint when THIS process is the
-  // akm CLI itself — which the CLI startup block signals with AKM_CLI_ENTRY=1.
-  // In any other host (the in-process test runner, a library embedding akm),
-  // argv[1] points at the host (e.g. the test runner), so spawning it would
-  // launch the wrong program and orphan it. Build inline there instead — same
-  // resulting index, no detached process.
-  if (process.env.AKM_CLI_ENTRY !== "1") {
-    return runInlineReindex(stashDir);
-  }
-
-  try {
-    await spawnBackgroundReindex(stashDir);
-    return true;
-  } catch (error) {
-    warn(
-      "Background reindex spawn failed, proceeding with existing index:",
-      error instanceof Error ? error.message : String(error),
-    );
-    return true;
-  }
+  if (indexCanServeStash(stashDir)) return false;
+  return runInlineReindex(stashDir);
 }

--- a/src/indexer/index-writer-lock.ts
+++ b/src/indexer/index-writer-lock.ts
@@ -63,13 +63,6 @@ function retainHeldLock(lockPath: string): IndexWriterLease {
   return { lockPath, release: () => releaseHeldLock(lockPath) };
 }
 
-function detachHeldLock(lockPath: string): void {
-  const held = heldLocks.get(lockPath);
-  if (!held) return;
-  heldLocks.delete(lockPath);
-  process.off("exit", held.exitHandler);
-}
-
 export async function acquireIndexWriterLease(
   options: AcquireIndexWriterLeaseOptions,
 ): Promise<IndexWriterLease | undefined> {
@@ -114,11 +107,6 @@ export async function withIndexWriterLease<T>(
   } finally {
     lease.release();
   }
-}
-
-export function handoffIndexWriterLeaseToPid(lease: IndexWriterLease, pid: number, purpose: string): void {
-  fs.writeFileSync(lease.lockPath, buildPayload(purpose, pid), "utf8");
-  detachHeldLock(lease.lockPath);
 }
 
 export function probeIndexWriterLease() {

--- a/src/indexer/index-written-assets.ts
+++ b/src/indexer/index-written-assets.ts
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Write-path indexing: targeted single-file index updates for asset writers.
+ *
+ * The index is maintained eagerly by every first-class mutation command
+ * (`source add`, `wiki`, `workflow`, `setup` all run `akmIndex()` after
+ * writing). The memory write paths — `akm remember` / `writeMarkdownAsset`
+ * and extract's session assets — historically did not, which is why reads
+ * used to compensate with stale-triggered background reindexes (the
+ * lock-contention footgun removed alongside this module's introduction; see
+ * docs/design/read-path-reindex-contention-findings.md §7).
+ *
+ * This is NOT a general reindex. It upserts exactly the files the caller just
+ * wrote: frontmatter/metadata via the shared matcher pipeline, the `entries`
+ * row, and an incremental FTS refresh. Embeddings, index-time LLM passes,
+ * graph extraction, `builtAt`, and the per-dir walk cache are all deliberately
+ * untouched — the next full run heals them (the opportunistic-recovery
+ * strategy of docs/technical/index-consistency-adr.md).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { getDbPath } from "../core/paths";
+import { warnVerbose } from "../core/warn";
+import { closeDatabase, getEntryCount, openExistingDatabase, rebuildFts, upsertEntry } from "./db/db";
+import { generateMetadataFlat } from "./passes/metadata";
+import { buildSearchText } from "./search/search-fields";
+
+/**
+ * Busy-timeout (ms) for write-path index upserts. A real write — unlike the
+ * 250ms telemetry inserts — but it must not hang `akm remember` for the full
+ * default 30s behind a running full reindex. When it times out, the upsert is
+ * skipped and the asset becomes searchable after that reindex instead.
+ */
+export const WRITE_PATH_INDEX_BUSY_TIMEOUT_MS = 5_000;
+
+/**
+ * Index the given just-written asset files into the existing local index.
+ *
+ * FAIL-OPEN at every step: any error (index.db absent, empty, locked past the
+ * busy timeout, unparseable file) is reduced to a verbose-only warning and the
+ * write command succeeds untouched. The degraded outcome is exactly the
+ * pre-write-path-indexing behavior: the asset appears after the next full
+ * `akm index` / improve-cron run.
+ *
+ * An absent or empty index is skipped on purpose — bootstrap belongs to the
+ * first read (`ensureIndex`) or an explicit `akm index`, which also cover
+ * embeddings and the other passes this fast path skips.
+ */
+export async function indexWrittenAssets(stashDir: string, filePaths: string[]): Promise<void> {
+  try {
+    const dbPath = getDbPath();
+    if (!fs.existsSync(dbPath)) return;
+
+    // The full walk never descends into dot-directories (they hold state like
+    // `.meta/`, `.stash.json`), and `shouldIndexStashFile` relies on the walker
+    // for that — mirror it here so this fast path indexes exactly what a full
+    // run would.
+    const files = filePaths.filter((f) => {
+      if (!fs.existsSync(f)) return false;
+      const rel = path.relative(stashDir, f);
+      return !rel.split(/[\\/]+/).some((segment) => segment.startsWith("."));
+    });
+    if (files.length === 0) return;
+
+    // Generate metadata BEFORE opening the DB so the write window stays
+    // short. One call per file keeps the entry↔path pairing exact.
+    const pairs: Array<{ file: string; entry: Awaited<ReturnType<typeof generateMetadataFlat>>["entries"][number] }> =
+      [];
+    for (const file of files) {
+      const generated = await generateMetadataFlat(stashDir, [file]);
+      const entry = generated.entries[0];
+      // Workflows carry a side-table document upsert this fast path doesn't
+      // do; no current caller writes them, but guard so one never lands
+      // half-indexed.
+      if (entry && entry.type !== "workflow") pairs.push({ file, entry });
+    }
+    if (pairs.length === 0) return;
+
+    const db = openExistingDatabase(dbPath);
+    try {
+      db.exec(`PRAGMA busy_timeout = ${WRITE_PATH_INDEX_BUSY_TIMEOUT_MS}`);
+      if (getEntryCount(db) === 0) return;
+      for (const { file, entry } of pairs) {
+        const entryKey = `${stashDir}:${entry.type}:${entry.name}`;
+        let entryWithSize = entry;
+        try {
+          entryWithSize = { ...entry, fileSize: fs.statSync(file).size };
+        } catch {
+          // stat raced a delete — index without the size, like the full walk does.
+        }
+        upsertEntry(db, entryKey, path.dirname(file), file, stashDir, entryWithSize, buildSearchText(entry));
+      }
+      rebuildFts(db, { incremental: true });
+    } finally {
+      closeDatabase(db);
+    }
+  } catch (error) {
+    warnVerbose(
+      "Write-path index update skipped (asset appears after the next full index):",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}

--- a/src/indexer/search/db-search.ts
+++ b/src/indexer/search/db-search.ts
@@ -57,6 +57,28 @@ import {
   readSemanticStatus,
 } from "./semantic-status";
 
+/**
+ * Age past which search surfaces a "run akm index" hint. Reads serve the
+ * existing index as-is (freshness is the writers' job — `indexWrittenAssets`
+ * plus full runs), so on installs with no improve cron a hand-edited or
+ * git-pulled file stays invisible until someone reindexes. The hint makes that
+ * actionable without re-introducing read-triggered reindexing.
+ */
+const STALE_INDEX_HINT_MS = 7 * 24 * 60 * 60 * 1000;
+
+function buildStaleIndexHint(db: Database): string | undefined {
+  try {
+    const builtAt = getMeta(db, "builtAt");
+    if (!builtAt) return undefined;
+    const ageMs = Date.now() - new Date(builtAt).getTime();
+    if (!Number.isFinite(ageMs) || ageMs < STALE_INDEX_HINT_MS) return undefined;
+    const days = Math.floor(ageMs / (24 * 60 * 60 * 1000));
+    return `Search index was last built ${days} day(s) ago. Files added or edited outside akm since then are not searchable — run 'akm index' to refresh.`;
+  } catch {
+    return undefined;
+  }
+}
+
 export function buildLocalAction(
   type: string,
   ref: string,
@@ -188,7 +210,9 @@ export async function searchLocal(input: {
     );
   }
 
-  // Auto-index when stale so the DB is always current before querying.
+  // Bootstrap-only: builds the index inline when it cannot serve this stash.
+  // Content freshness is the writers' job (indexWrittenAssets + full runs);
+  // reads serve the existing index as-is.
   await ensureIndex(stashDir);
 
   const dbPath = getDbPath();
@@ -212,6 +236,9 @@ export async function searchLocal(input: {
         mode: "keyword",
       };
     }
+
+    const staleHint = buildStaleIndexHint(db);
+    if (staleHint) warnings.push(staleHint);
 
     const { hits, embedMs, rankMs } = await searchDatabase(
       db,

--- a/src/storage/repositories/index-db.ts
+++ b/src/storage/repositories/index-db.ts
@@ -7,6 +7,24 @@ import type { Database } from "../database";
 import { resolveStorageLocations } from "../locations";
 
 /**
+ * Busy-timeout (ms) for read-path telemetry writers. Small on purpose: a
+ * usage-event insert contending with a background reindex should be dropped,
+ * not waited on for the default 30s.
+ */
+export const TELEMETRY_BUSY_TIMEOUT_MS = 250;
+
+export interface WithIndexDbOptions {
+  /**
+   * Override the connection's `busy_timeout` (the standard pragmas set 30s).
+   * Read-path TELEMETRY writers pass a small value (e.g. 250) so a usage-event
+   * insert can never stall a `search`/`show`/`curate` command behind a
+   * background reindex holding the write lock — under contention the write is
+   * skipped (fire-and-forget) instead of waited for.
+   */
+  busyTimeoutMs?: number;
+}
+
+/**
  * Scoped-resource (loan pattern) helper for the index database (`index.db`).
  *
  * This is the `index.db` twin of {@link ../../workflows/db withWorkflowDb} /
@@ -35,9 +53,12 @@ import { resolveStorageLocations } from "../locations";
  * @param fn Receives the open index database; must finish all DB work before returning.
  * @returns Whatever `fn` returns.
  */
-export function withIndexDb<T>(fn: (db: Database) => T): T {
+export function withIndexDb<T>(fn: (db: Database) => T, opts?: WithIndexDbOptions): T {
   const db = openExistingDatabase(resolveStorageLocations().indexDb);
   try {
+    if (opts?.busyTimeoutMs !== undefined) {
+      db.exec(`PRAGMA busy_timeout = ${Math.max(0, Math.floor(opts.busyTimeoutMs))}`);
+    }
     return fn(db);
   } finally {
     closeDatabase(db);

--- a/tests/health-checks-characterization.test.ts
+++ b/tests/health-checks-characterization.test.ts
@@ -227,3 +227,50 @@ describe("health checks characterization (WS9)", () => {
     expect(result.status).toBe("fail");
   });
 });
+
+describe("semantic-search-runtime embedding-endpoint advisory", () => {
+  test("blocked remote endpoint while semanticSearchMode=auto names the endpoint and the fixes", async () => {
+    const { resetConfigCache, saveConfig } = await import("../src/core/config/config");
+    const { deriveSemanticProviderFingerprint, writeSemanticStatus } = await import(
+      "../src/indexer/search/semantic-status"
+    );
+    resetConfigCache();
+    const embedding = { endpoint: "http://localhost:1234/v1/embeddings", model: "test-embed" };
+    saveConfig({ semanticSearchMode: "auto", embedding });
+    writeSemanticStatus({
+      status: "blocked",
+      reason: "remote-network",
+      message: "Unable to connect",
+      providerFingerprint: deriveSemanticProviderFingerprint(embedding),
+      lastCheckedAt: new Date().toISOString(),
+    });
+
+    const result = akmHealth({ since: "7d", getExecutionLogCandidatesFn: () => [] });
+    const advisory = findCheck(result.advisories, "semantic-search-runtime");
+    expect(advisory.status).toBe("warn");
+    expect(advisory.message).toContain("http://localhost:1234/v1/embeddings");
+    expect(advisory.message).toContain("remote-network");
+    expect(advisory.message).toContain('semanticSearchMode is "auto"');
+    expect(advisory.message).toContain("keyword-only");
+  });
+
+  test("non-remote blocked reason keeps the generic message", async () => {
+    const { resetConfigCache, saveConfig } = await import("../src/core/config/config");
+    const { deriveSemanticProviderFingerprint, writeSemanticStatus } = await import(
+      "../src/indexer/search/semantic-status"
+    );
+    resetConfigCache();
+    saveConfig({ semanticSearchMode: "auto" });
+    writeSemanticStatus({
+      status: "blocked",
+      reason: "missing-package",
+      providerFingerprint: deriveSemanticProviderFingerprint(undefined),
+      lastCheckedAt: new Date().toISOString(),
+    });
+
+    const result = akmHealth({ since: "7d", getExecutionLogCandidatesFn: () => [] });
+    const advisory = findCheck(result.advisories, "semantic-search-runtime");
+    expect(advisory.status).toBe("warn");
+    expect(advisory.message).toBe("Semantic search status: blocked");
+  });
+});

--- a/tests/indexer/ensure-index-serve.test.ts
+++ b/tests/indexer/ensure-index-serve.test.ts
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Tests for the read-vs-blocking `ensureIndex()` contract.
+ *
+ * Read paths (default/background mode) serve any populated index built for
+ * this stash AS-IS — content freshness is the writers' job
+ * (`indexWrittenAssets`) plus full runs (improve cron / explicit `akm index`).
+ * They rebuild inline only when the index cannot serve at all (missing DB,
+ * zero rows, different stash). This replaced the stale-triggered background
+ * reindex that made every read on an actively-written stash spawn a writer
+ * (docs/design/read-path-reindex-contention-findings.md §7).
+ *
+ * Blocking mode (improve) still treats content-staleness as a rebuild trigger.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { getDbPath } from "../../src/core/paths";
+import { closeDatabase, getIndexedFilePaths, openExistingDatabase } from "../../src/indexer/db/db";
+import { ensureIndex } from "../../src/indexer/ensure-index";
+import { akmIndex } from "../../src/indexer/indexer";
+import {
+  type Cleanup,
+  sandboxEnvDir,
+  sandboxStashDir,
+  sandboxXdgCacheHome,
+  sandboxXdgConfigHome,
+} from "../_helpers/sandbox";
+
+let stashDir = "";
+let cleanup: Cleanup = () => {};
+
+function writeMemory(name: string): string {
+  const filePath = path.join(stashDir, "memories", `${name}.md`);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `---\ndescription: ${name}\n---\n\n# ${name}\n\nBody.\n`, "utf8");
+  return filePath;
+}
+
+function indexedPaths(): Set<string> {
+  const db = openExistingDatabase(getDbPath());
+  try {
+    return getIndexedFilePaths(db);
+  } finally {
+    closeDatabase(db);
+  }
+}
+
+beforeEach(async () => {
+  const stash = sandboxStashDir();
+  stashDir = stash.dir;
+  let chain = sandboxXdgConfigHome(stash.cleanup).cleanup;
+  chain = sandboxXdgCacheHome(chain).cleanup;
+  chain = sandboxEnvDir("akm-ensure-serve-data", "AKM_DATA_DIR", chain).cleanup;
+  chain = sandboxEnvDir("akm-ensure-serve-state", "AKM_STATE_DIR", chain).cleanup;
+  cleanup = chain;
+  writeMemory("first");
+  await akmIndex({ stashDir });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ensureIndex read-path (background mode)", () => {
+  test("fresh servable index: no-op", async () => {
+    expect(await ensureIndex(stashDir)).toBe(false);
+  });
+
+  test("content-stale but servable index is served AS-IS (no reindex)", async () => {
+    const added = writeMemory("second");
+    expect(await ensureIndex(stashDir)).toBe(false);
+    expect(indexedPaths().has(added)).toBe(false);
+  });
+
+  test("missing index rebuilds inline", async () => {
+    fs.rmSync(getDbPath());
+    expect(await ensureIndex(stashDir)).toBe(true);
+    expect(indexedPaths().size).toBeGreaterThan(0);
+  });
+});
+
+describe("ensureIndex blocking mode (improve)", () => {
+  test("content-stale index rebuilds inline", async () => {
+    const added = writeMemory("second");
+    expect(await ensureIndex(stashDir, { mode: "blocking" })).toBe(true);
+    expect(indexedPaths().has(added)).toBe(true);
+  });
+
+  test("fresh index: no-op", async () => {
+    expect(await ensureIndex(stashDir, { mode: "blocking" })).toBe(false);
+  });
+});

--- a/tests/indexer/index-written-assets.test.ts
+++ b/tests/indexer/index-written-assets.test.ts
@@ -1,0 +1,111 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Tests for `indexWrittenAssets` — the write-path single-file index update
+ * used by `writeMarkdownAsset` (akm remember / knowledge writes) and extract's
+ * session assets, so just-written assets are searchable immediately without
+ * any read-triggered reindex.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { getDbPath } from "../../src/core/paths";
+import { closeDatabase, openExistingDatabase } from "../../src/indexer/db/db";
+import { indexWrittenAssets } from "../../src/indexer/index-written-assets";
+import { akmIndex } from "../../src/indexer/indexer";
+import {
+  type Cleanup,
+  sandboxEnvDir,
+  sandboxStashDir,
+  sandboxXdgCacheHome,
+  sandboxXdgConfigHome,
+} from "../_helpers/sandbox";
+
+let stashDir = "";
+let cleanup: Cleanup = () => {};
+
+function writeMemory(name: string, body: string): string {
+  const filePath = path.join(stashDir, "memories", `${name}.md`);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `---\ndescription: ${name}\n---\n\n# ${name}\n\n${body}\n`, "utf8");
+  return filePath;
+}
+
+function queryIndex(ftsTerm?: string): { entryNames: string[]; ftsCount: number } {
+  const db = openExistingDatabase(getDbPath());
+  try {
+    const entryNames = (db.prepare("SELECT entry_json FROM entries").all() as Array<{ entry_json: string }>).map(
+      (r) => (JSON.parse(r.entry_json) as { name: string }).name,
+    );
+    const ftsCount = ftsTerm
+      ? (db.prepare("SELECT COUNT(*) AS c FROM entries_fts WHERE entries_fts MATCH ?").get(ftsTerm) as { c: number }).c
+      : 0;
+    return { entryNames, ftsCount };
+  } finally {
+    closeDatabase(db);
+  }
+}
+
+beforeEach(async () => {
+  const stash = sandboxStashDir();
+  stashDir = stash.dir;
+  let chain = sandboxXdgConfigHome(stash.cleanup).cleanup;
+  chain = sandboxXdgCacheHome(chain).cleanup;
+  chain = sandboxEnvDir("akm-written-data", "AKM_DATA_DIR", chain).cleanup;
+  chain = sandboxEnvDir("akm-written-state", "AKM_STATE_DIR", chain).cleanup;
+  cleanup = chain;
+  writeMemory("seed-memory", "Seed body.");
+  await akmIndex({ stashDir });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("indexWrittenAssets", () => {
+  test("a just-written memory becomes visible in entries AND keyword (FTS) search", async () => {
+    const filePath = writeMemory("zanzibar-note", "Notes about the zanzibar deployment quirk.");
+    await indexWrittenAssets(stashDir, [filePath]);
+
+    const idx = queryIndex("zanzibar");
+    expect(idx.entryNames).toContain("zanzibar-note");
+    expect(idx.ftsCount).toBeGreaterThan(0);
+  });
+
+  test("re-indexing an edited file updates its entry (idempotent upsert)", async () => {
+    const filePath = writeMemory("evolving-note", "Original body.");
+    await indexWrittenAssets(stashDir, [filePath]);
+    // FTS covers metadata fields (name/description/tags/hints), not the raw
+    // body — same as the full walk — so the edit changes the description.
+    fs.writeFileSync(
+      filePath,
+      "---\ndescription: now covers the quokka deployment\n---\n\n# evolving-note\n\nUpdated body.\n",
+      "utf8",
+    );
+    await indexWrittenAssets(stashDir, [filePath]);
+
+    const idx = queryIndex("quokka");
+    expect(idx.entryNames.filter((n) => n === "evolving-note")).toHaveLength(1);
+    expect(idx.ftsCount).toBeGreaterThan(0);
+  });
+
+  test("fail-open: absent index.db is a silent no-op (no DB created)", async () => {
+    fs.rmSync(getDbPath());
+    const filePath = writeMemory("orphan-note", "Body.");
+    await indexWrittenAssets(stashDir, [filePath]);
+    expect(fs.existsSync(getDbPath())).toBe(false);
+  });
+
+  test("fail-open: missing file and non-indexable path are silent no-ops", async () => {
+    await indexWrittenAssets(stashDir, [path.join(stashDir, "memories", "never-written.md")]);
+    const statePath = path.join(stashDir, "memories", ".hidden", "state.md");
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, "not an asset", "utf8");
+    await indexWrittenAssets(stashDir, [statePath]);
+    const idx = queryIndex();
+    expect(idx.entryNames).toEqual(["seed-memory"]);
+  });
+});

--- a/tests/indexer/search-stale-index-hint.test.ts
+++ b/tests/indexer/search-stale-index-hint.test.ts
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Tests for the stale-index hint on search. Reads serve the existing index
+ * as-is (no read-triggered reindex), so when the index was last built more
+ * than a week ago the search response carries an actionable warning pointing
+ * at `akm index` — the escape hatch for installs with no improve cron whose
+ * hand-edited files would otherwise silently never appear.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import type { AkmConfig } from "../../src/core/config/config";
+import { getDbPath } from "../../src/core/paths";
+import { closeDatabase, openExistingDatabase, setMeta } from "../../src/indexer/db/db";
+import { akmIndex } from "../../src/indexer/indexer";
+import { searchLocal } from "../../src/indexer/search/db-search";
+import {
+  type Cleanup,
+  sandboxEnvDir,
+  sandboxStashDir,
+  sandboxXdgCacheHome,
+  sandboxXdgConfigHome,
+} from "../_helpers/sandbox";
+
+let stashDir = "";
+let cleanup: Cleanup = () => {};
+
+function runSearch() {
+  const config: AkmConfig = { semanticSearchMode: "off" };
+  return searchLocal({
+    query: "seed",
+    searchType: "any",
+    limit: 5,
+    stashDir,
+    sources: [{ path: stashDir }],
+    config,
+  });
+}
+
+function backdateBuiltAt(days: number): void {
+  const db = openExistingDatabase(getDbPath());
+  try {
+    setMeta(db, "builtAt", new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString());
+  } finally {
+    closeDatabase(db);
+  }
+}
+
+beforeEach(async () => {
+  const stash = sandboxStashDir();
+  stashDir = stash.dir;
+  let chain = sandboxXdgConfigHome(stash.cleanup).cleanup;
+  chain = sandboxXdgCacheHome(chain).cleanup;
+  chain = sandboxEnvDir("akm-stale-hint-data", "AKM_DATA_DIR", chain).cleanup;
+  chain = sandboxEnvDir("akm-stale-hint-state", "AKM_STATE_DIR", chain).cleanup;
+  cleanup = chain;
+  const memoryPath = path.join(stashDir, "memories", "seed.md");
+  fs.writeFileSync(memoryPath, "---\ndescription: seed memory\n---\n\n# seed\n\nBody.\n", "utf8");
+  await akmIndex({ stashDir });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("search stale-index hint", () => {
+  test("fresh index: no hint", async () => {
+    const result = await runSearch();
+    expect((result.warnings ?? []).join(" ")).not.toContain("last built");
+  });
+
+  test("index built >7 days ago: warning names the age and akm index", async () => {
+    backdateBuiltAt(8);
+    const result = await runSearch();
+    const combined = (result.warnings ?? []).join(" ");
+    expect(combined).toContain("last built 8 day(s) ago");
+    expect(combined).toContain("akm index");
+  });
+
+  test("index built <7 days ago: no hint", async () => {
+    backdateBuiltAt(6);
+    const result = await runSearch();
+    expect((result.warnings ?? []).join(" ")).not.toContain("last built");
+  });
+});

--- a/tests/storage/index-db-loan.characterization.test.ts
+++ b/tests/storage/index-db-loan.characterization.test.ts
@@ -82,6 +82,17 @@ describe("withIndexDb loan helper (WS5)", () => {
     }
   });
 
+  test("busyTimeoutMs option overrides the connection's busy_timeout pragma", () => {
+    // Default connections get the standard 30s pragma.
+    const standard = withIndexDb((db) => (db.prepare("PRAGMA busy_timeout").get() as { timeout: number }).timeout);
+    expect(standard).toBe(30000);
+    // Telemetry callers pass a small value so contended writes drop fast.
+    const short = withIndexDb((db) => (db.prepare("PRAGMA busy_timeout").get() as { timeout: number }).timeout, {
+      busyTimeoutMs: 250,
+    });
+    expect(short).toBe(250);
+  });
+
   test("propagates throws from fn (the connection still closes exactly once)", () => {
     const sentinel = new Error("boom");
     expect(() =>


### PR DESCRIPTION
## Problem

`akm search`/`akm curate` on an actively-used stash stalled 20–90s (reported with timeouts at 35/60/90s). Every read's staleness check spawned a detached background reindex; the continuously-written session-checkpoint memories re-staled the index the moment each reindex finished; and the reads' own **synchronous telemetry writes** then queued up to 30s per DB open behind the reindex writer's `index.db` lock. Curate multiplied this by N searches + M shows + its own event log.

## Root cause

The memory write paths — `akm remember` (`writeMarkdownAsset`, which is also how the plugin's session checkpoints land) and extract's session assets — never indexed what they wrote. Every other mutation command (`source add`, `wiki`, `workflow`, `setup`) already runs `akmIndex()` after writing. The read-triggered background reindex existed solely to compensate, and was the contention footgun.

## Fix

1. **Write-path indexing** — new `indexWrittenAssets()`: targeted single-file upsert (matcher metadata → `entries` row → incremental FTS), fail-open at every step, 5s busy timeout. Embeddings/graph/`builtAt` deliberately untouched — the next full run heals them per the index-consistency ADR. Wired into `writeMarkdownAsset` and extract's session-asset write. **A remembered memory is now searchable immediately** (previously: only after the next reindex).
2. **Read-path subtraction** — `ensureIndex()` reads serve any populated index built for the stash as-is; inline rebuild only when the index cannot serve at all (unchanged #607 bootstrap). Blocking mode (improve) keeps the staleness check. Deleted: the per-read O(N-files) staleness walk, `spawnBackgroundReindex`, the writer-lease PID handoff, and the `AKM_CLI_ENTRY` entrypoint marker.
3. **Telemetry 250ms busy timeout** — search/show/curate usage events + graph enqueues are fire-and-forget hints; under contention they are dropped, not waited on.

## Operator note / tradeoff

Hand-edited or git-pulled stash files stay stale until an explicit `akm index`, the improve cron, or any mutation command — reads no longer repair content freshness. Full analysis and design: `docs/design/read-path-reindex-contention-findings.md`.

## Verification

- Full gate green: biome + custom lints 0/0, `tsc` clean, unit 4964/0 (sharded), integration 1935/0.
- New tests: `index-written-assets.test.ts` (immediate visibility, idempotent re-upsert, fail-open on absent DB / non-indexable paths), `ensure-index-serve.test.ts` (serve-vs-bootstrap, blocking semantics), busy-timeout pragma characterization.
- Sandbox end-to-end: `akm remember` → hit on the very next `akm search`; hand-edited file served stale by reads (no reindex spawned), appears after explicit `akm index`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkfTXQ3QUXKLZhETdPioC3