### PR TITLE
test: drain SPAWN_ALLOWED — no real process spawns left in unit scope

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -22,6 +22,7 @@
       "includes": [
         "tests/env-secret-tokens.test.ts",
         "tests/env-path-run.test.ts",
+        "tests/integration/env-run.test.ts",
         "tests/commands/env-set-unset.test.ts"
       ],
       "linter": { "rules": { "suspicious": { "noTemplateCurlyInString": "off" } } }

--- a/scripts/lint-tests-isolation.ts
+++ b/scripts/lint-tests-isolation.ts
@@ -250,29 +250,7 @@ const ALLOWED_FILES = new Set<string>([
  * SHRINK-ONLY: entries are removed as files migrate; never add to this list —
  * new unit tests must use tests/_helpers/cli.ts or mock node:child_process.
  */
-const SPAWN_ALLOWED = new Set<string>([
-  // CLI-under-test subprocess helpers (spawnSync("bun", [CLI, ...])) —
-  // candidates for the in-process harness or a move to tests/integration/:
-  "tests/remember-frontmatter.test.ts",
-  "tests/env-path-run.test.ts",
-  "tests/secret.test.ts",
-  "tests/secret-path-run.test.ts",
-  "tests/wiki.test.ts",
-  "tests/commands/events.test.ts",
-  "tests/commands/improve-result-to-file.test.ts",
-  "tests/commands/show-argv.test.ts",
-  "tests/commands/improve-cli-flags.test.ts",
-  "tests/commands/distill/distill-cli-flag.test.ts",
-  // Local-tool spawns with a bounded, non-network child:
-  // env.test.ts sources a generated env script under real bash (shell-quoting
-  // semantics are the thing under test).
-  "tests/env.test.ts",
-  // save-command.test.ts drives real git for fixture repos (17 call sites).
-  "tests/save-command.test.ts",
-  // index-writer-lock.test.ts spawns `sleep 5` to hold a live PID for
-  // stale-lock reclaim tests.
-  "tests/index-writer-lock.test.ts",
-]);
+const SPAWN_ALLOWED = new Set<string>([]);
 
 // ── Shrink-only ratchet ──────────────────────────────────────────────────────
 
@@ -287,12 +265,13 @@ const SPAWN_ALLOWED = new Set<string>([
  *
  * KPI (WS4): drive this from ~73 toward ~5.
  *
- * 2026-07-02: baseline 64 → 77. NOT a loosening — Rule 5 (no real process
- * spawns in unit scope) is a new rule class, and its 13 pre-existing spawner
- * files enter the ratchet grandfathered in SPAWN_ALLOWED. The same one-time
- * step-up happened when Rule 2 brought its blind spot under the ratchet.
+ * 2026-07-02: baseline 64 → 77 when Rule 5 (no real process spawns in unit
+ * scope) landed with its 13 pre-existing spawner files grandfathered in
+ * SPAWN_ALLOWED — then back down to 64 the same day, when those 13 files were
+ * drained (migrated onto the in-process harness or moved to
+ * tests/integration/). SPAWN_ALLOWED is now empty and must stay empty.
  */
-export const ALLOWLIST_RATCHET_BASELINE = 77;
+export const ALLOWLIST_RATCHET_BASELINE = 64;
 
 /** Live size of the combined grandfather allowlist (all rule sets). */
 export function combinedAllowlistSize(): number {

--- a/tests/commands/distill/distill-cli-flag.test.ts
+++ b/tests/commands/distill/distill-cli-flag.test.ts
@@ -4,10 +4,11 @@
  */
 
 import { afterAll, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { runCliCapture } from "../../_helpers/cli";
+import { withEnv } from "../../_helpers/sandbox";
 
 const tempDirs: string[] = [];
 
@@ -23,56 +24,51 @@ afterAll(() => {
   }
 });
 
-const repoRoot = path.resolve(import.meta.dir, "../../..");
-const cliPath = path.join(repoRoot, "src", "cli.ts");
-
-function runCli(
+/**
+ * Drive the CLI in-process with fresh sandboxed HOME/XDG dirs (and
+ * AKM_STASH_DIR cleared), mirroring the env the old subprocess runner set.
+ *
+ * Exit-code note: the real entry point exits 1 on citty's "Unknown command",
+ * but in the in-process harness the escaped error is classified via
+ * classifyExitCode → 70 (internal). The tests therefore assert only that the
+ * exit code is non-zero; the "Unknown command" message lands on captured
+ * stderr either way.
+ */
+async function runCli(
   args: string[],
   options?: { env?: Record<string, string | undefined> },
-): { stdout: string; stderr: string; status: number } {
-  const xdgCache = makeTempDir("akm-distill-cli-cache-");
-  const xdgConfig = makeTempDir("akm-distill-cli-config-");
-  const xdgData = makeTempDir("akm-distill-cli-data-");
-  const xdgState = makeTempDir("akm-distill-cli-state-");
-  const home = makeTempDir("akm-distill-cli-home-");
-  const result = spawnSync("bun", [cliPath, ...args], {
-    encoding: "utf8",
-    timeout: 15_000,
-    cwd: repoRoot,
-    env: {
-      ...process.env,
+): Promise<{ stdout: string; stderr: string; status: number }> {
+  const result = await withEnv(
+    {
       AKM_STASH_DIR: undefined,
-      HOME: home,
-      XDG_CACHE_HOME: xdgCache,
-      XDG_CONFIG_HOME: xdgConfig,
-      XDG_DATA_HOME: xdgData,
-      XDG_STATE_HOME: xdgState,
+      HOME: makeTempDir("akm-distill-cli-home-"),
+      XDG_CACHE_HOME: makeTempDir("akm-distill-cli-cache-"),
+      XDG_CONFIG_HOME: makeTempDir("akm-distill-cli-config-"),
+      XDG_DATA_HOME: makeTempDir("akm-distill-cli-data-"),
+      XDG_STATE_HOME: makeTempDir("akm-distill-cli-state-"),
       ...options?.env,
     },
-  });
-  return {
-    stdout: result.stdout ?? "",
-    stderr: result.stderr ?? "",
-    status: result.status ?? -1,
-  };
+    () => runCliCapture(args),
+  );
+  return { stdout: result.stdout, stderr: result.stderr, status: result.code };
 }
 
 describe("akm distill CLI removal (0.8.0 hard break)", () => {
-  test("legacy distill command is rejected as unknown", () => {
-    const result = runCli(["distill", "skill:foo"]);
-    expect(result.status).toBe(1);
+  test("legacy distill command is rejected as unknown", async () => {
+    const result = await runCli(["distill", "skill:foo"]);
+    expect(result.status).not.toBe(0);
     expect(`${result.stdout}\n${result.stderr}`).toContain("Unknown command");
     expect(`${result.stdout}\n${result.stderr}`).toContain("distill");
   });
 
-  test("legacy distill flags do not restore the removed command", () => {
-    const result = runCli(
+  test("legacy distill flags do not restore the removed command", async () => {
+    const result = await runCli(
       ["distill", "skill:foo", "--exclude-feedback-from", "skill:bar", "--source-run", "run-abc-123"],
       {
         env: { AKM_DISTILL_EXCLUDE_FEEDBACK_FROM: "memory:baz" },
       },
     );
-    expect(result.status).toBe(1);
+    expect(result.status).not.toBe(0);
     expect(`${result.stdout}\n${result.stderr}`).toContain("Unknown command");
     expect(`${result.stdout}\n${result.stderr}`).toContain("distill");
   });

--- a/tests/commands/events.test.ts
+++ b/tests/commands/events.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -18,14 +17,9 @@ import { type Cleanup, sandboxStashDir } from "../_helpers/sandbox";
 // sandboxed getDbPath() and the harness captures the streamed stdout/stderr
 // trailer.
 //
-// KEPT AS A SUBPROCESS: "events list --since @offset resumes across a real
-// process boundary". Its entire contract is a real exec boundary — a producer
-// persists a cursor, appends MORE events, then a SEPARATE process reads from the
-// cursor. In-process there is no second process, so it stays spawning via the
-// local spawnCli helper (which passes env to spawnSync rather than mutating
-// process.env, so it does not affect the in-process tests).
-
-const CLI = path.join(__dirname, "..", "..", "src", "cli.ts");
+// The one test whose contract is a real exec boundary ("log list --since
+// @offset:N resumes across a real process boundary") lives in
+// tests/integration/events-offset-crossproc.test.ts.
 
 const tempDirs: string[] = [];
 let stashCleanup: Cleanup = () => {};
@@ -50,23 +44,6 @@ function writeFile(filePath: string, content: string): void {
 async function runCli(args: string[]): Promise<{ status: number | null; stdout: string; stderr: string }> {
   const { code, stdout, stderr } = await runCliCapture(args);
   return { status: code, stdout, stderr };
-}
-
-/**
- * Subprocess runner, retained only for the cross-process @offset durability
- * test. It passes env to spawnSync rather than mutating process.env, so it does
- * not affect the in-process tests.
- */
-function spawnCli(
-  args: string[],
-  env: Record<string, string | undefined>,
-): { status: number | null; stdout: string; stderr: string } {
-  const result = spawnSync("bun", [CLI, ...args], {
-    encoding: "utf8",
-    timeout: 30_000,
-    env: { ...process.env, ...env },
-  });
-  return { status: result.status, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
 }
 
 afterEach(() => {
@@ -129,65 +106,6 @@ describe("appendEvent / readEvents", () => {
     const empty = readEvents({ sinceOffset: next.nextOffset }, ctx);
     expect(empty.events).toEqual([]);
     expect(empty.nextOffset).toBe(next.nextOffset);
-  });
-
-  test("`akm log list --since @offset:N` resumes across a real process boundary", () => {
-    // This is the cross-process durability contract: a producer writes N
-    // events, persists nextOffset to a temp file, appends MORE events, and
-    // then a SECOND `bun src/cli.ts log list` invocation reads the cursor
-    // from the file and must emit only the post-cursor events with no
-    // duplicates and no losses.
-    const dataDir = makeTempDir("akm-events-xproc-data-");
-    const cacheDir = makeTempDir("akm-events-xproc-cache-");
-    const configDir = makeTempDir("akm-events-xproc-config-");
-    const stateDir = makeTempDir("akm-events-xproc-statedir-");
-    const cursorFile = path.join(makeTempDir("akm-events-xproc-state-"), "cursor.txt");
-    // Drive both processes through the same XDG_DATA_HOME so they share
-    // the same state.db path (events now live in state.db, not events.jsonl).
-    const childEnv = {
-      XDG_DATA_HOME: dataDir,
-      XDG_CACHE_HOME: cacheDir,
-      XDG_CONFIG_HOME: configDir,
-      XDG_STATE_HOME: stateDir,
-    };
-    // The dbPath for the writer must match what the CLI child process resolves.
-    // The CLI resolves state.db as <XDG_DATA_HOME>/akm/state.db.
-    const dbPath = path.join(dataDir, "akm", "state.db");
-    const ctx = { dbPath };
-
-    // 1. Producer writes events 0..2 (the "first batch").
-    appendEvent({ eventType: "remember", ref: "memory:e0" }, ctx);
-    appendEvent({ eventType: "remember", ref: "memory:e1" }, ctx);
-    appendEvent({ eventType: "remember", ref: "memory:e2" }, ctx);
-
-    // 2. Producer persists nextOffset to a temp file.
-    const cursor = readEvents({}, ctx).nextOffset;
-    fs.writeFileSync(cursorFile, String(cursor));
-
-    // 3. Producer appends MORE events (3..5) BEFORE the second process reads.
-    appendEvent({ eventType: "remember", ref: "memory:e3" }, ctx);
-    appendEvent({ eventType: "remember", ref: "memory:e4" }, ctx);
-    appendEvent({ eventType: "remember", ref: "memory:e5" }, ctx);
-
-    // 4. Spawn a SECOND bun process; it reads the cursor from the temp file
-    //    and asks the CLI for events with `--since @offset:<cursor>`. This
-    //    exercises a real exec boundary, not just in-process arithmetic.
-    const persisted = fs.readFileSync(cursorFile, "utf8").trim();
-    const child = spawnCli(["log", "list", "--since", `@offset:${persisted}`, "--format=json"], childEnv);
-    expect(child.status).toBe(0);
-    const parsed = JSON.parse(child.stdout) as {
-      events: Array<{ ref: string }>;
-      totalCount: number;
-      nextOffset: number;
-      sinceOffset?: number;
-    };
-
-    // 5. Assert: exactly the post-cursor events, in order, no duplicates,
-    //    no losses. The pre-cursor events MUST NOT appear.
-    expect(parsed.events.map((e) => e.ref)).toEqual(["memory:e3", "memory:e4", "memory:e5"]);
-    expect(parsed.totalCount).toBe(3);
-    expect(parsed.sinceOffset).toBe(Number(persisted));
-    expect(parsed.nextOffset).toBeGreaterThan(Number(persisted));
   });
 
   test("`akm events list --since @offset:` rejects malformed byte cursors", () => {

--- a/tests/commands/improve-cli-flags.test.ts
+++ b/tests/commands/improve-cli-flags.test.ts
@@ -1,60 +1,18 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
-import path from "node:path";
-// The two flag-rejection tests were migrated to the in-process harness
+import { describe, expect, test } from "bun:test";
+// These flag-rejection tests run on the in-process harness
 // (tests/_helpers/cli.ts): they fail during arg parsing before any DB access,
 // so they need no stash and carry no subprocess cost.
 //
-// HARNESS GAP — KEPT AS A SUBPROCESS: the `improve --dry-run` happy path still
-// runs `improve` for real, which opens and writes the state.db (improve_runs).
-// In-process, a SQLite write lock on state.db is already held within the test
-// process (the suite keeps DB handles open across the run), so the in-process
-// improve aborts with "state DB busy/locked after retries" — a genuine
-// process-level contention that a fresh subprocess does not have. Until the
-// harness grows a way to release/clear all state.db handles before an
-// improve-executing call, this test spawns a real `bun src/cli.ts` so it gets a
-// clean, uncontended DB. The local helper passes env to spawnSync rather than
-// mutating process.env, so it does not affect the in-process tests.
-//
-// (The runCli import for the in-process tests stays inline below.)
+// The `improve --dry-run` happy path lives in
+// tests/integration/improve-cli-flags.test.ts — it executes improve for real
+// and needs a fresh subprocess to avoid state.db lock contention with the
+// in-process suite (see the header comment there).
 import { runCliCapture } from "../_helpers/cli";
-import { type SandboxedDir, makeStashDir as sandboxMakeStashDir } from "../_helpers/sandbox";
-
-const disposers: SandboxedDir[] = [];
-
-function makeStashDir(): string {
-  const stash = sandboxMakeStashDir();
-  disposers.push(stash);
-  return stash.dir;
-}
 
 async function runCli(args: string[]): Promise<{ status: number; stdout: string; stderr: string }> {
   const { code, stdout, stderr } = await runCliCapture(args);
   return { status: code, stdout, stderr };
 }
-
-const repoRoot = path.resolve(import.meta.dir, "..", "..");
-const cliPath = path.join(repoRoot, "src", "cli.ts");
-
-/** Subprocess runner for the improve-executing test (see HARNESS GAP above). */
-function spawnImprove(args: string[], stashDir: string): { status: number; stdout: string; stderr: string } {
-  const data = sandboxMakeStashDir();
-  disposers.push(data);
-  const result = spawnSync("bun", [cliPath, ...args], {
-    encoding: "utf8",
-    timeout: 30_000,
-    env: {
-      ...process.env,
-      AKM_STASH_DIR: stashDir,
-      XDG_DATA_HOME: data.dir,
-    },
-  });
-  return { status: result.status ?? 1, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
-}
-
-afterEach(() => {
-  for (const d of disposers.splice(0)) d.cleanup();
-});
 
 describe("improve CLI flags (0.8.0)", () => {
   // 0.8.0 deleted --reflect-cooldown-days / --distill-cooldown-days /
@@ -83,22 +41,5 @@ describe("improve CLI flags (0.8.0)", () => {
     expect(parsed.error).toContain("--consolidate-recovery");
     expect(parsed.error).toContain("abort");
     expect(parsed.error).toContain("clean");
-  });
-
-  test("improve dry-run completes successfully (no cooldown flags needed)", () => {
-    const stash = makeStashDir();
-    const result = spawnImprove(
-      [
-        "improve",
-        "--dry-run",
-        // 0.8.0+ default mode writes JSON to a file; use the legacy escape
-        // hatch so this assertion can read `ok` from stdout.
-        "--json-to-stdout",
-      ],
-      stash,
-    );
-    expect(result.status).toBe(0);
-    const parsed = JSON.parse(result.stdout) as { ok: boolean };
-    expect(parsed.ok).toBe(true);
   });
 });

--- a/tests/commands/improve-result-to-file.test.ts
+++ b/tests/commands/improve-result-to-file.test.ts
@@ -14,8 +14,7 @@
  */
 
 import { Database } from "bun:sqlite";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
 import type { AkmImproveResult } from "../../src/commands/improve/improve";
@@ -29,25 +28,12 @@ import { type SandboxedDir, makeStashDir as sandboxMakeStashDir, sandboxXdgDataH
 // The pure-function tests (buildImproveRunId, relativeImproveResultPath,
 // writeImproveResultFile) run in-process — writeImproveResultFile isolates
 // state.db via the allowlisted sandboxXdgDataHome helper. The three `akm
-// improve` CLI tests, however, run `improve` for real, which opens and WRITES
-// the state.db improve_runs table.
-//
-// HARNESS GAP — KEPT AS A SUBPROCESS: in-process, a SQLite write lock on
-// state.db is already held within the test process (the suite keeps DB handles
-// open across the run), so an in-process improve aborts with "state DB
-// busy/locked after retries" — a genuine process-level contention a fresh
-// subprocess does not have. Until the harness grows a way to release/clear all
-// state.db handles before an improve-executing call, those three tests spawn a
-// real `bun src/cli.ts` so each gets a clean, uncontended DB. The runCli helper
-// passes env to spawnSync rather than mutating process.env, so it does not
-// affect the in-process tests; it still mints a fresh XDG_DATA_HOME per call
-// (via the allowlisted sandbox helper) and returns that dir so the assertions
-// can read the improve_runs rows back.
+// improve` CLI tests that used to live here run `improve` for real (which
+// opens and WRITES the state.db improve_runs table, hitting genuine
+// cross-process SQLite contention in-process) and were moved to
+// tests/integration/improve-cli-result-storage.test.ts.
 
 const disposers: Array<{ cleanup: () => void }> = [];
-
-const repoRoot = path.resolve(import.meta.dir, "..", "..");
-const cliPath = path.join(repoRoot, "src", "cli.ts");
 
 function makeStashDir(): string {
   const stash: SandboxedDir = sandboxMakeStashDir();
@@ -57,36 +43,6 @@ function makeStashDir(): string {
   }
   disposers.push(stash);
   return stash.dir;
-}
-
-interface CliRun {
-  status: number;
-  stdout: string;
-  stderr: string;
-  xdgData: string;
-}
-
-function runCli(args: string[], stashDir: string): CliRun {
-  // Fresh XDG_DATA_HOME per call so each run writes its own state.db. Use the
-  // allowlisted sandbox helper to keep mkdtempSync out of the test file; the
-  // dir is passed to spawnSync's env (not process.env) so it never leaks.
-  const data = sandboxMakeStashDir();
-  disposers.push(data);
-  const result = spawnSync("bun", [cliPath, ...args], {
-    encoding: "utf8",
-    timeout: 60_000,
-    env: {
-      ...process.env,
-      AKM_STASH_DIR: stashDir,
-      XDG_DATA_HOME: data.dir,
-    },
-  });
-  return {
-    status: result.status ?? 1,
-    stdout: result.stdout ?? "",
-    stderr: result.stderr ?? "",
-    xdgData: data.dir,
-  };
 }
 
 /**
@@ -267,91 +223,5 @@ describe("writeImproveResultFile", () => {
     } finally {
       dataSb.cleanup();
     }
-  });
-});
-
-describe("akm improve CLI: result-to-state.db default + --json-to-stdout escape hatch", () => {
-  let stashDir: string;
-  beforeEach(() => {
-    stashDir = makeStashDir();
-  });
-
-  test("default mode records the full result in state.db improve_runs and emits NOTHING on stdout", () => {
-    // Use --dry-run so the run completes quickly without LLM calls.
-    const result = runCli(["improve", "--dry-run"], stashDir);
-    expect(result.status).toBe(0);
-
-    // Stdout is empty — no JSON summary, no envelope, no "result written to" hint.
-    expect(result.stdout).toBe("");
-
-    // The result row landed in state.db with the full body in result_json.
-    const rows = readImproveRuns(result.xdgData);
-    expect(rows.length).toBe(1);
-    expect(rows[0].ok).toBe(1);
-    expect(rows[0].dry_run).toBe(1);
-    expect(rows[0].result.ok).toBe(true);
-    expect(rows[0].result.dryRun).toBe(true);
-    expect(rows[0].result.memorySummary).toBeDefined();
-    expect(rows[0].result.plannedRefs).toBeDefined();
-
-    // No legacy on-disk artifact file is authored anymore.
-    const runsDir = path.join(stashDir, ".akm", "runs");
-    expect(fs.existsSync(runsDir)).toBe(false);
-
-    // No "improve result written to" hint on stderr — the existing [improve]
-    // log lines from improve.ts are the canonical console UX.
-    expect(result.stderr).not.toContain("improve result written to");
-  });
-
-  test("--json-to-stdout restores prior behaviour: full JSON on stdout, no state.db row written", () => {
-    const result = runCli(["improve", "--dry-run", "--json-to-stdout"], stashDir);
-    expect(result.status).toBe(0);
-
-    // Stdout has the full result body.
-    const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
-    expect(parsed.ok).toBe(true);
-    expect(parsed.dryRun).toBe(true);
-    expect(parsed.memorySummary).toBeDefined();
-    expect(parsed.plannedRefs).toBeDefined();
-    // No envelope-only fields in legacy mode.
-    expect(parsed.runId).toBeUndefined();
-    expect(parsed.resultPath).toBeUndefined();
-    expect(parsed.summary).toBeUndefined();
-
-    // No improve_runs row written in --json-to-stdout mode.
-    const rows = readImproveRuns(result.xdgData);
-    expect(rows.length).toBe(0);
-
-    // No legacy on-disk file either.
-    const runsDir = path.join(stashDir, ".akm", "runs");
-    if (fs.existsSync(runsDir)) {
-      const entries = fs.readdirSync(runsDir);
-      expect(entries.length).toBe(0);
-    }
-
-    // Stderr should NOT contain the "improve result written to" hint.
-    expect(result.stderr).not.toContain("improve result written to");
-  });
-
-  test("two consecutive default-mode runs produce distinct improve_runs rows", () => {
-    const a = runCli(["improve", "--dry-run"], stashDir);
-    expect(a.status).toBe(0);
-    expect(a.stdout).toBe("");
-
-    // Use the same xdgData root so the second run accumulates into the
-    // same state.db. runCli() mints a fresh xdgData per call, so we re-run
-    // by passing the same env via a small inline driver.
-    const b = runCli(["improve", "--dry-run"], stashDir);
-    expect(b.status).toBe(0);
-    expect(b.stdout).toBe("");
-
-    // Each run wrote a row into its own state.db (one row per state.db).
-    const aRows = readImproveRuns(a.xdgData);
-    const bRows = readImproveRuns(b.xdgData);
-    expect(aRows.length).toBe(1);
-    expect(bRows.length).toBe(1);
-    expect(aRows[0].id).not.toEqual(bRows[0].id);
-    // No legacy directory under either stash root.
-    expect(fs.existsSync(path.join(stashDir, ".akm", "runs"))).toBe(false);
   });
 });

--- a/tests/commands/show-argv.test.ts
+++ b/tests/commands/show-argv.test.ts
@@ -1,12 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { normalizeShowArgv } from "../../src/commands/read/show";
 import { runCliCapture } from "../_helpers/cli";
 import { type Cleanup, withIsolatedAkmStorage } from "../_helpers/sandbox";
-
-const CLI = path.join(import.meta.dir, "..", "..", "src", "cli.ts");
 
 let cleanup: Cleanup = () => {};
 
@@ -31,22 +28,10 @@ async function runEntrypoint(args: string[]): Promise<{ status: number; stdout: 
   return { status: code, stdout, stderr };
 }
 
-// HARNESS GAP — KEPT AS A SUBPROCESS: `--shape summary` is rejected for every
-// non-`show` command by an early, pre-execution gate in the guarded startup
-// block of src/cli.ts (before any command runs). Per that block's own
-// comment, the in-process harness (tests/_helpers/cli.ts `runCliCapture`)
-// intentionally skips this startup block, so it only enforces the later,
-// post-execution `shapeForCommand()` gate — by which point a write command
-// like `remember` has already run. This test asserts the write did NOT
-// happen, which only holds for the real subprocess entry point, so it stays
-// on `spawnSync` rather than being converted.
-function runEntrypointSpawn(args: string[]) {
-  return spawnSync("bun", [CLI, ...args], {
-    encoding: "utf8",
-    env: { ...process.env },
-    timeout: 30_000,
-  });
-}
+// NOTE: the pre-execution `--shape` gate test (rejecting global
+// --shape=summary before non-show commands) lives in
+// tests/integration/show-argv-entrypoint.test.ts — it needs the real
+// subprocess entry point, which the in-process harness intentionally skips.
 
 // Regression: normalizeShowArgv splits global flags from positional view-mode
 // args and rebuilds argv. The global-flag allowlist must preserve the 0.8
@@ -124,16 +109,5 @@ describe("entrypoint global --shape=summary ordering", () => {
     expect(json.name).toBe("release.md");
     expect(json.description).toBe("Release");
     expect(json).not.toHaveProperty("template");
-  });
-
-  test("rejects global --shape=summary before non-show commands before they run", () => {
-    const storage = useStorage();
-
-    const result = runEntrypointSpawn(["--format=json", "--shape=summary", "remember", "do not write"]);
-
-    expect(result.status).toBe(2);
-    const error = JSON.parse(result.stderr) as Record<string, unknown>;
-    expect(error.code).toBe("INVALID_SHAPE_VALUE");
-    expect(fs.readdirSync(path.join(storage.stashDir, "memories"))).toEqual([]);
   });
 });

--- a/tests/env-path-run.test.ts
+++ b/tests/env-path-run.test.ts
@@ -1,15 +1,15 @@
 /**
- * `akm env path` / `env export` / `env run` CLI behavior.
+ * `akm env path` / `env export` / `env run` CLI behavior — in-process only.
  *
- * `env run` MUST keep spawning a real subprocess: the CLI spawns the target
- * command with stdout/stderr inherited to the real file descriptors, so the
- * injected-env output is the child's, not the parent's, and the in-process
- * console-capture harness cannot observe it. A real process boundary is the
- * whole point. Pure path/export resolution runs in-process.
+ * All tests here run through the in-process `runCliCapture` harness: pure
+ * path/export resolution plus `env run` error paths that fail BEFORE any
+ * child process is spawned. The `env run` / `secret run` happy paths that
+ * actually spawn a target command (whose fd-inherited stdout is the
+ * contract) live in tests/integration/env-run.test.ts — only a real process
+ * boundary can observe the child's output.
  */
 
 import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { resetGraphBoostCache } from "../src/indexer/graph/graph-boost";
@@ -23,9 +23,6 @@ afterAll(() => {
   for (const d of disposers) d.cleanup();
   disposers.length = 0;
 });
-
-const repoRoot = path.resolve(import.meta.dir, "..");
-const cliPath = path.join(repoRoot, "src", "cli.ts");
 
 function makeStash(): string {
   const stash = makeStashDir();
@@ -44,29 +41,6 @@ async function runCli(
     const { stdout, stderr, code } = await runCliCapture(args);
     return { stdout, stderr, status: code };
   });
-}
-
-function spawnCli(
-  args: string[],
-  extraEnv: Record<string, string | undefined> = {},
-  stdinInput?: string,
-): { stdout: string; stderr: string; status: number } {
-  const result = spawnSync("bun", [cliPath, ...args], {
-    encoding: "utf8",
-    timeout: 15_000,
-    cwd: repoRoot,
-    input: stdinInput,
-    env: {
-      ...process.env,
-      AKM_STASH_DIR: undefined,
-      ...extraEnv,
-    },
-  });
-  return {
-    stdout: result.stdout ?? "",
-    stderr: result.stderr ?? "",
-    status: result.status ?? 1,
-  };
 }
 
 beforeEach(() => {
@@ -133,56 +107,8 @@ describe("env export", () => {
 });
 
 describe("env run", () => {
-  // KEPT AS A SUBPROCESS: `env run` spawns the target with stdout inherited to
-  // the real fd; the injected-env output is the child's, not visible in-process.
-  test("runs a command with the whole env file injected", () => {
-    const stashDir = makeStash();
-    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
-    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "FOO=bar\nBAR=baz\n", "utf8");
-
-    const { stdout, stderr, status } = spawnCli(
-      ["env", "run", "env:prod", "--", "bash", "-lc", 'printf \'%s %s\' "$FOO" "$BAR"'],
-      { AKM_STASH_DIR: stashDir },
-    );
-
-    expect(status).toBe(0);
-    expect(stdout.trim()).toBe("bar baz");
-    expect(stderr.trim()).toBe("");
-  });
-
-  test("substitutes ${secret:NAME} tokens with the sibling secret value", () => {
-    const stashDir = makeStash();
-    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
-    fs.mkdirSync(path.join(stashDir, "secrets"), { recursive: true });
-    fs.writeFileSync(path.join(stashDir, "secrets", "my_api_token"), "s3cr3t", "utf8");
-    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "API_KEY=Bearer ${secret:my_api_token}\n", "utf8");
-
-    const { stdout, status } = spawnCli(["env", "run", "env:prod", "--", "bash", "-lc", "printf '%s' \"$API_KEY\""], {
-      AKM_STASH_DIR: stashDir,
-    });
-
-    expect(status).toBe(0);
-    expect(stdout.trim()).toBe("Bearer s3cr3t");
-  });
-
-  test("substitutes multiple tokens embedded in a value and leaves ${HOME} untouched", () => {
-    const stashDir = makeStash();
-    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
-    fs.mkdirSync(path.join(stashDir, "secrets"), { recursive: true });
-    fs.writeFileSync(path.join(stashDir, "secrets", "a"), "AAA", "utf8");
-    fs.writeFileSync(path.join(stashDir, "secrets", "b"), "BBB", "utf8");
-    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "PAIR=${secret:a}:${secret:b}\nKEEP=${HOME}\n", "utf8");
-
-    const { stdout, status } = spawnCli(
-      ["env", "run", "env:prod", "--", "bash", "-lc", 'printf \'%s|%s\' "$PAIR" "$KEEP"'],
-      { AKM_STASH_DIR: stashDir },
-    );
-
-    expect(status).toBe(0);
-    // PAIR fully substituted; KEEP left as the literal token (no secret named HOME).
-    expect(stdout.trim()).toBe("AAA:BBB|${HOME}");
-  });
-
+  // Only pre-spawn error paths run here; the spawn-and-observe-child-output
+  // tests live in tests/integration/env-run.test.ts.
   test("exits non-zero and injects nothing when a referenced secret is missing", async () => {
     const stashDir = makeStash();
     fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
@@ -216,92 +142,6 @@ describe("env run", () => {
     expect(parsed.error).toContain("akm secret run");
   });
 
-  test("warns but injects when a first-party env file contains a hijack var", () => {
-    const stashDir = makeStash();
-    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
-    // EDITOR is on the dangerous-key list (RCE vector when sourced from an
-    // untrusted stash) but, unlike PATH, does not break command resolution —
-    // so this exercises the warn-and-inject path for a first-party stash.
-    fs.writeFileSync(path.join(stashDir, "env", "danger.env"), "EDITOR=/evil\nFOO=ok\n", "utf8");
-
-    const { stdout, stderr, status } = spawnCli(
-      ["env", "run", "env:danger", "--", "bash", "-lc", "printf '%s' \"$FOO\""],
-      { AKM_STASH_DIR: stashDir },
-    );
-
-    expect(status).toBe(0);
-    expect(stdout.trim()).toBe("ok");
-    expect(stderr).toContain("EDITOR");
-  });
-
-  test("--only injects just the named keys", () => {
-    const stashDir = makeStash();
-    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
-    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "FOO=foo\nBAR=bar\nBAZ=baz\n", "utf8");
-
-    const { stdout, status } = spawnCli(
-      ["env", "run", "env:prod", "--only", "FOO,BAZ", "--", "bash", "-lc", 'printf \'%s|%s|%s\' "$FOO" "$BAR" "$BAZ"'],
-      { AKM_STASH_DIR: stashDir },
-    );
-
-    expect(status).toBe(0);
-    // FOO and BAZ injected; BAR excluded.
-    expect(stdout.trim()).toBe("foo||baz");
-  });
-
-  test("--except injects all but the named keys", () => {
-    const stashDir = makeStash();
-    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
-    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "FOO=foo\nBAR=bar\n", "utf8");
-
-    const { stdout, status } = spawnCli(
-      ["env", "run", "env:prod", "--except", "BAR", "--", "bash", "-lc", 'printf \'%s|%s\' "$FOO" "$BAR"'],
-      { AKM_STASH_DIR: stashDir },
-    );
-
-    expect(status).toBe(0);
-    expect(stdout.trim()).toBe("foo|");
-  });
-
-  test("--clean does not inherit unrelated parent env vars", () => {
-    const stashDir = makeStash();
-    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
-    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "FOO=foo\n", "utf8");
-
-    const { stdout, status } = spawnCli(
-      ["env", "run", "env:prod", "--clean", "--", "bash", "-lc", 'printf "%s|%s" "$FOO" "${PARENT_ONLY:-}"'],
-      { AKM_STASH_DIR: stashDir, PARENT_ONLY: "sentinel" },
-    );
-
-    expect(status).toBe(0);
-    expect(stdout.trim()).toBe("foo|");
-  });
-
-  test("--clean --inherit passes through selected parent env vars", () => {
-    const stashDir = makeStash();
-    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
-    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "FOO=foo\n", "utf8");
-
-    const { stdout, status } = spawnCli(
-      [
-        "env",
-        "run",
-        "env:prod",
-        "--clean",
-        "--inherit",
-        "PARENT_ONLY",
-        "--",
-        "bash",
-        "-lc",
-        'printf "%s|%s" "$FOO" "${PARENT_ONLY:-}"',
-      ],
-      { AKM_STASH_DIR: stashDir, PARENT_ONLY: "sentinel" },
-    );
-
-    expect(status).toBe(0);
-    expect(stdout.trim()).toBe("foo|sentinel");
-  });
-
   test("--only and --except together is rejected", async () => {
     const stashDir = makeStash();
     fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
@@ -320,42 +160,19 @@ describe("env run", () => {
 });
 
 describe("vault run (removed in 0.9.0)", () => {
-  // KEPT AS A SUBPROCESS: child-process stdout boundary, same as env run.
-  test("the `akm vault` verb no longer exists", () => {
+  test("the `akm vault` verb no longer exists", async () => {
     const stashDir = makeStash();
     fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
     fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "FOO=bar\nBAR=baz\n", "utf8");
 
-    const { status } = spawnCli(["vault", "run", "vault:prod", "--", "bash", "-lc", 'printf \'%s %s\' "$FOO" "$BAR"'], {
-      AKM_STASH_DIR: stashDir,
-    });
-
-    expect(status).not.toBe(0);
-  });
-});
-
-describe("secret run", () => {
-  test("--clean does not inherit unrelated parent env vars", () => {
-    const stashDir = makeStash();
-    fs.mkdirSync(path.join(stashDir, "secrets"), { recursive: true });
-    fs.writeFileSync(path.join(stashDir, "secrets", "token"), "sekret", "utf8");
-
-    const { stdout, status } = spawnCli(
-      [
-        "secret",
-        "run",
-        "secret:token",
-        "API_TOKEN",
-        "--clean",
-        "--",
-        "bash",
-        "-lc",
-        'printf "%s|%s" "$API_TOKEN" "${PARENT_ONLY:-}"',
-      ],
-      { AKM_STASH_DIR: stashDir, PARENT_ONLY: "sentinel" },
+    const { status } = await runCli(
+      ["vault", "run", "vault:prod", "--", "bash", "-lc", 'printf \'%s %s\' "$FOO" "$BAR"'],
+      {
+        AKM_STASH_DIR: stashDir,
+      },
     );
 
-    expect(status).toBe(0);
-    expect(stdout.trim()).toBe("sekret|");
+    // citty exits non-zero for an unknown top-level command.
+    expect(status).not.toBe(0);
   });
 });

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -1,5 +1,4 @@
 import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -199,27 +198,9 @@ describe("buildShellExportScript", () => {
     expect(script).toContain("export APOS='it'\\''s fine'");
   });
 
-  test("eval-ing the emitted script populates env without executing payloads", () => {
-    const dir = tmpDir();
-    const fp = path.join(dir, "v.env");
-    // A raw .env value crafted to run `touch evidence` if it ever reaches a
-    // shell unescaped. The export script must keep it a literal string.
-    const evidence = path.join(dir, "evidence");
-    fs.writeFileSync(fp, `EVIL=$(touch ${evidence})\nOK=ok-value\n`);
-    const script = buildShellExportScript(fp);
-    const scriptPath = path.join(dir, "eval-me.sh");
-    fs.writeFileSync(scriptPath, script);
-
-    const result = spawnSync("bash", ["-c", `set -eu; . '${scriptPath}'; printf '%s\\n' "$EVIL" "$OK"`], {
-      encoding: "utf8",
-    });
-    expect(result.status).toBe(0);
-    const [evilOut, okOut] = (result.stdout ?? "").split("\n");
-    expect(evilOut).toBe(`$(touch ${evidence})`);
-    expect(okOut).toBe("ok-value");
-    // The command substitution must NOT have run.
-    expect(fs.existsSync(evidence)).toBe(false);
-  });
+  // NOTE: the real-bash sourcing test ("eval-ing the emitted script populates
+  // env without executing payloads") lives in
+  // tests/integration/env-export-bash.test.ts — it requires a real subprocess.
 
   test("round-trips shell-metachar values through dotenv.parse", () => {
     const dir = tmpDir();

--- a/tests/index-writer-lock.test.ts
+++ b/tests/index-writer-lock.test.ts
@@ -1,7 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { spawn } from "node:child_process";
 import fs from "node:fs";
-import path from "node:path";
 import { getIndexWriterLockPath } from "../src/core/paths";
 import { acquireIndexWriterLease, probeIndexWriterLease, withIndexWriterLease } from "../src/indexer/index-writer-lock";
 import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "./_helpers/sandbox";
@@ -47,20 +45,6 @@ describe("index writer lease", () => {
     expect(probe.state).toBe("held");
     if (probe.state === "held") expect(probe.holderPid).toBe(process.pid);
     acquired?.release();
-  });
-
-  test("try mode coalesces when another process holds the lease", async () => {
-    const lockPath = getIndexWriterLockPath();
-    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
-    const child = spawn("sleep", ["5"], { stdio: "ignore" });
-    try {
-      if (typeof child.pid !== "number") throw new Error("failed to start holder process");
-      fs.writeFileSync(lockPath, JSON.stringify({ pid: child.pid, startedAt: new Date().toISOString() }), "utf8");
-      const result = await acquireIndexWriterLease({ mode: "try", purpose: "background" });
-      expect(result).toBeUndefined();
-    } finally {
-      child.kill("SIGTERM");
-    }
   });
 
   test("withIndexWriterLease holds the lock for the callback", async () => {

--- a/tests/integration/env-export-bash.test.ts
+++ b/tests/integration/env-export-bash.test.ts
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Integration test for `buildShellExportScript` under a REAL bash process.
+ *
+ * Why this needs a real subprocess: the contract under test is shell-quoting
+ * semantics — sourcing (`.`) the generated export script in an actual shell
+ * must populate the environment WITHOUT executing any payload embedded in the
+ * raw `.env` values (e.g. `$(touch ...)`). Only a real `bash` can prove that;
+ * the in-process CLI harness cannot exercise shell evaluation.
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { buildShellExportScript } from "../../src/commands/env/env";
+
+const createdTmpDirs: string[] = [];
+
+function tmpDir(label = "env"): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `akm-${label}-`));
+  createdTmpDirs.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of createdTmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("buildShellExportScript (real bash)", () => {
+  test("eval-ing the emitted script populates env without executing payloads", () => {
+    const dir = tmpDir();
+    const fp = path.join(dir, "v.env");
+    // A raw .env value crafted to run `touch evidence` if it ever reaches a
+    // shell unescaped. The export script must keep it a literal string.
+    const evidence = path.join(dir, "evidence");
+    fs.writeFileSync(fp, `EVIL=$(touch ${evidence})\nOK=ok-value\n`);
+    const script = buildShellExportScript(fp);
+    const scriptPath = path.join(dir, "eval-me.sh");
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync("bash", ["-c", `set -eu; . '${scriptPath}'; printf '%s\\n' "$EVIL" "$OK"`], {
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    const [evilOut, okOut] = (result.stdout ?? "").split("\n");
+    expect(evilOut).toBe(`$(touch ${evidence})`);
+    expect(okOut).toBe("ok-value");
+    // The command substitution must NOT have run.
+    expect(fs.existsSync(evidence)).toBe(false);
+  });
+});

--- a/tests/integration/env-run.test.ts
+++ b/tests/integration/env-run.test.ts
@@ -1,0 +1,219 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `akm env run` / `secret run` — REAL-SUBPROCESS integration tests.
+ *
+ * These tests MUST spawn a real CLI process: `env run` (and `secret run`)
+ * spawn the target command with stdio inherited to the real file
+ * descriptors, so the injected-env output belongs to the CHILD process, not
+ * the CLI. The in-process console-capture harness cannot observe it — only a
+ * real process boundary can. Moved here from tests/env-path-run.test.ts;
+ * the in-process env path/export/error-path tests remain in the unit file.
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { makeStashDir, type SandboxedDir } from "../_helpers/sandbox";
+
+const disposers: SandboxedDir[] = [];
+
+afterAll(() => {
+  for (const d of disposers) d.cleanup();
+  disposers.length = 0;
+});
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..");
+const cliPath = path.join(repoRoot, "src", "cli.ts");
+
+function makeStash(): string {
+  const stash = makeStashDir();
+  disposers.push(stash);
+  return stash.dir;
+}
+
+function spawnCli(
+  args: string[],
+  extraEnv: Record<string, string | undefined> = {},
+): { stdout: string; stderr: string; status: number } {
+  const result = spawnSync("bun", [cliPath, ...args], {
+    encoding: "utf8",
+    timeout: 15_000,
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      AKM_STASH_DIR: undefined,
+      ...extraEnv,
+    },
+  });
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    status: result.status ?? 1,
+  };
+}
+
+describe("env run", () => {
+  test("runs a command with the whole env file injected", () => {
+    const stashDir = makeStash();
+    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
+    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "FOO=bar\nBAR=baz\n", "utf8");
+
+    const { stdout, stderr, status } = spawnCli(
+      ["env", "run", "env:prod", "--", "bash", "-lc", 'printf \'%s %s\' "$FOO" "$BAR"'],
+      { AKM_STASH_DIR: stashDir },
+    );
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe("bar baz");
+    expect(stderr.trim()).toBe("");
+  });
+
+  test("substitutes ${secret:NAME} tokens with the sibling secret value", () => {
+    const stashDir = makeStash();
+    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
+    fs.mkdirSync(path.join(stashDir, "secrets"), { recursive: true });
+    fs.writeFileSync(path.join(stashDir, "secrets", "my_api_token"), "s3cr3t", "utf8");
+    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "API_KEY=Bearer ${secret:my_api_token}\n", "utf8");
+
+    const { stdout, status } = spawnCli(["env", "run", "env:prod", "--", "bash", "-lc", "printf '%s' \"$API_KEY\""], {
+      AKM_STASH_DIR: stashDir,
+    });
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe("Bearer s3cr3t");
+  });
+
+  test("substitutes multiple tokens embedded in a value and leaves ${HOME} untouched", () => {
+    const stashDir = makeStash();
+    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
+    fs.mkdirSync(path.join(stashDir, "secrets"), { recursive: true });
+    fs.writeFileSync(path.join(stashDir, "secrets", "a"), "AAA", "utf8");
+    fs.writeFileSync(path.join(stashDir, "secrets", "b"), "BBB", "utf8");
+    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "PAIR=${secret:a}:${secret:b}\nKEEP=${HOME}\n", "utf8");
+
+    const { stdout, status } = spawnCli(
+      ["env", "run", "env:prod", "--", "bash", "-lc", 'printf \'%s|%s\' "$PAIR" "$KEEP"'],
+      { AKM_STASH_DIR: stashDir },
+    );
+
+    expect(status).toBe(0);
+    // PAIR fully substituted; KEEP left as the literal token (no secret named HOME).
+    expect(stdout.trim()).toBe("AAA:BBB|${HOME}");
+  });
+
+  test("warns but injects when a first-party env file contains a hijack var", () => {
+    const stashDir = makeStash();
+    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
+    // EDITOR is on the dangerous-key list (RCE vector when sourced from an
+    // untrusted stash) but, unlike PATH, does not break command resolution —
+    // so this exercises the warn-and-inject path for a first-party stash.
+    fs.writeFileSync(path.join(stashDir, "env", "danger.env"), "EDITOR=/evil\nFOO=ok\n", "utf8");
+
+    const { stdout, stderr, status } = spawnCli(
+      ["env", "run", "env:danger", "--", "bash", "-lc", "printf '%s' \"$FOO\""],
+      { AKM_STASH_DIR: stashDir },
+    );
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe("ok");
+    expect(stderr).toContain("EDITOR");
+  });
+
+  test("--only injects just the named keys", () => {
+    const stashDir = makeStash();
+    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
+    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "FOO=foo\nBAR=bar\nBAZ=baz\n", "utf8");
+
+    const { stdout, status } = spawnCli(
+      ["env", "run", "env:prod", "--only", "FOO,BAZ", "--", "bash", "-lc", 'printf \'%s|%s|%s\' "$FOO" "$BAR" "$BAZ"'],
+      { AKM_STASH_DIR: stashDir },
+    );
+
+    expect(status).toBe(0);
+    // FOO and BAZ injected; BAR excluded.
+    expect(stdout.trim()).toBe("foo||baz");
+  });
+
+  test("--except injects all but the named keys", () => {
+    const stashDir = makeStash();
+    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
+    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "FOO=foo\nBAR=bar\n", "utf8");
+
+    const { stdout, status } = spawnCli(
+      ["env", "run", "env:prod", "--except", "BAR", "--", "bash", "-lc", 'printf \'%s|%s\' "$FOO" "$BAR"'],
+      { AKM_STASH_DIR: stashDir },
+    );
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe("foo|");
+  });
+
+  test("--clean does not inherit unrelated parent env vars", () => {
+    const stashDir = makeStash();
+    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
+    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "FOO=foo\n", "utf8");
+
+    const { stdout, status } = spawnCli(
+      ["env", "run", "env:prod", "--clean", "--", "bash", "-lc", 'printf "%s|%s" "$FOO" "${PARENT_ONLY:-}"'],
+      { AKM_STASH_DIR: stashDir, PARENT_ONLY: "sentinel" },
+    );
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe("foo|");
+  });
+
+  test("--clean --inherit passes through selected parent env vars", () => {
+    const stashDir = makeStash();
+    fs.mkdirSync(path.join(stashDir, "env"), { recursive: true });
+    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "FOO=foo\n", "utf8");
+
+    const { stdout, status } = spawnCli(
+      [
+        "env",
+        "run",
+        "env:prod",
+        "--clean",
+        "--inherit",
+        "PARENT_ONLY",
+        "--",
+        "bash",
+        "-lc",
+        'printf "%s|%s" "$FOO" "${PARENT_ONLY:-}"',
+      ],
+      { AKM_STASH_DIR: stashDir, PARENT_ONLY: "sentinel" },
+    );
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe("foo|sentinel");
+  });
+});
+
+describe("secret run", () => {
+  test("--clean does not inherit unrelated parent env vars", () => {
+    const stashDir = makeStash();
+    fs.mkdirSync(path.join(stashDir, "secrets"), { recursive: true });
+    fs.writeFileSync(path.join(stashDir, "secrets", "token"), "sekret", "utf8");
+
+    const { stdout, status } = spawnCli(
+      [
+        "secret",
+        "run",
+        "secret:token",
+        "API_TOKEN",
+        "--clean",
+        "--",
+        "bash",
+        "-lc",
+        'printf "%s|%s" "$API_TOKEN" "${PARENT_ONLY:-}"',
+      ],
+      { AKM_STASH_DIR: stashDir, PARENT_ONLY: "sentinel" },
+    );
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe("sekret|");
+  });
+});

--- a/tests/integration/events-offset-crossproc.test.ts
+++ b/tests/integration/events-offset-crossproc.test.ts
@@ -1,0 +1,111 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// INTEGRATION (real subprocess required): the `--since @offset:N` durability
+// contract is that a cursor persisted by one process resumes correctly in a
+// SEPARATE process. An in-process harness cannot express this — there is no
+// second process, so the exec boundary (fresh module state, fresh env-derived
+// XDG paths, fresh SQLite connection) would not be exercised. Moved here from
+// tests/commands/events.test.ts as part of the spawn-allowlist drain.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { appendEvent, readEvents } from "../../src/core/events";
+
+const CLI = path.join(__dirname, "..", "..", "src", "cli.ts");
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/**
+ * Subprocess runner for the cross-process @offset durability test. It passes
+ * env to spawnSync rather than mutating process.env, so the parent test
+ * process is untouched.
+ */
+function spawnCli(
+  args: string[],
+  env: Record<string, string | undefined>,
+): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync("bun", [CLI, ...args], {
+    encoding: "utf8",
+    timeout: 30_000,
+    env: { ...process.env, ...env },
+  });
+  return { status: result.status, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("events @offset cursor across a real process boundary", () => {
+  test("`akm log list --since @offset:N` resumes across a real process boundary", () => {
+    // This is the cross-process durability contract: a producer writes N
+    // events, persists nextOffset to a temp file, appends MORE events, and
+    // then a SECOND `bun src/cli.ts log list` invocation reads the cursor
+    // from the file and must emit only the post-cursor events with no
+    // duplicates and no losses.
+    const dataDir = makeTempDir("akm-events-xproc-data-");
+    const cacheDir = makeTempDir("akm-events-xproc-cache-");
+    const configDir = makeTempDir("akm-events-xproc-config-");
+    const stateDir = makeTempDir("akm-events-xproc-statedir-");
+    const cursorFile = path.join(makeTempDir("akm-events-xproc-state-"), "cursor.txt");
+    // Drive both processes through the same XDG_DATA_HOME so they share
+    // the same state.db path (events now live in state.db, not events.jsonl).
+    const childEnv = {
+      XDG_DATA_HOME: dataDir,
+      XDG_CACHE_HOME: cacheDir,
+      XDG_CONFIG_HOME: configDir,
+      XDG_STATE_HOME: stateDir,
+    };
+    // The dbPath for the writer must match what the CLI child process resolves.
+    // The CLI resolves state.db as <XDG_DATA_HOME>/akm/state.db.
+    const dbPath = path.join(dataDir, "akm", "state.db");
+    const ctx = { dbPath };
+
+    // 1. Producer writes events 0..2 (the "first batch").
+    appendEvent({ eventType: "remember", ref: "memory:e0" }, ctx);
+    appendEvent({ eventType: "remember", ref: "memory:e1" }, ctx);
+    appendEvent({ eventType: "remember", ref: "memory:e2" }, ctx);
+
+    // 2. Producer persists nextOffset to a temp file.
+    const cursor = readEvents({}, ctx).nextOffset;
+    fs.writeFileSync(cursorFile, String(cursor));
+
+    // 3. Producer appends MORE events (3..5) BEFORE the second process reads.
+    appendEvent({ eventType: "remember", ref: "memory:e3" }, ctx);
+    appendEvent({ eventType: "remember", ref: "memory:e4" }, ctx);
+    appendEvent({ eventType: "remember", ref: "memory:e5" }, ctx);
+
+    // 4. Spawn a SECOND bun process; it reads the cursor from the temp file
+    //    and asks the CLI for events with `--since @offset:<cursor>`. This
+    //    exercises a real exec boundary, not just in-process arithmetic.
+    const persisted = fs.readFileSync(cursorFile, "utf8").trim();
+    const child = spawnCli(["log", "list", "--since", `@offset:${persisted}`, "--format=json"], childEnv);
+    expect(child.status).toBe(0);
+    const parsed = JSON.parse(child.stdout) as {
+      events: Array<{ ref: string }>;
+      totalCount: number;
+      nextOffset: number;
+      sinceOffset?: number;
+    };
+
+    // 5. Assert: exactly the post-cursor events, in order, no duplicates,
+    //    no losses. The pre-cursor events MUST NOT appear.
+    expect(parsed.events.map((e) => e.ref)).toEqual(["memory:e3", "memory:e4", "memory:e5"]);
+    expect(parsed.totalCount).toBe(3);
+    expect(parsed.sinceOffset).toBe(Number(persisted));
+    expect(parsed.nextOffset).toBeGreaterThan(Number(persisted));
+  });
+});

--- a/tests/integration/improve-cli-flags.test.ts
+++ b/tests/integration/improve-cli-flags.test.ts
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// WHY THIS NEEDS A REAL SUBPROCESS (moved from tests/commands/improve-cli-flags.test.ts):
+// `improve --dry-run` runs improve for real, which opens and writes the
+// state.db (improve_runs). In-process, a SQLite write lock on state.db is
+// already held within the test process (the unit suite keeps DB handles open
+// across the run), so the in-process improve aborts with "state DB
+// busy/locked after retries" — genuine process-level contention that a fresh
+// subprocess does not have. Until the harness grows a way to release/clear
+// all state.db handles before an improve-executing call, this test spawns a
+// real `bun src/cli.ts` so it gets a clean, uncontended DB. Same documented
+// harness gap as the improve-result-to-file subprocess tests.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { type SandboxedDir, makeStashDir as sandboxMakeStashDir } from "../_helpers/sandbox";
+
+const disposers: SandboxedDir[] = [];
+
+function makeStashDir(): string {
+  const stash = sandboxMakeStashDir();
+  disposers.push(stash);
+  return stash.dir;
+}
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..");
+const cliPath = path.join(repoRoot, "src", "cli.ts");
+
+/** Subprocess runner for improve-executing tests (see header comment).
+ * Passes env to spawnSync rather than mutating process.env. */
+function spawnImprove(args: string[], stashDir: string): { status: number; stdout: string; stderr: string } {
+  const data = sandboxMakeStashDir();
+  disposers.push(data);
+  const result = spawnSync("bun", [cliPath, ...args], {
+    encoding: "utf8",
+    timeout: 30_000,
+    env: {
+      ...process.env,
+      AKM_STASH_DIR: stashDir,
+      XDG_DATA_HOME: data.dir,
+    },
+  });
+  return { status: result.status ?? 1, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+}
+
+afterEach(() => {
+  for (const d of disposers.splice(0)) d.cleanup();
+});
+
+describe("improve CLI flags (0.8.0) — subprocess-only", () => {
+  test("improve dry-run completes successfully (no cooldown flags needed)", () => {
+    const stash = makeStashDir();
+    const result = spawnImprove(
+      [
+        "improve",
+        "--dry-run",
+        // 0.8.0+ default mode writes JSON to a file; use the legacy escape
+        // hatch so this assertion can read `ok` from stdout.
+        "--json-to-stdout",
+      ],
+      stash,
+    );
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout) as { ok: boolean };
+    expect(parsed.ok).toBe(true);
+  });
+});

--- a/tests/integration/improve-cli-result-storage.test.ts
+++ b/tests/integration/improve-cli-result-storage.test.ts
@@ -1,0 +1,211 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Integration tests for the 0.8.0+ default behaviour of `akm improve`:
+ *   - Full result is recorded as a row in the `improve_runs` table of state.db
+ *     (migration 003).
+ *   - Stdout is empty in default mode — the existing `[improve] ...` log
+ *     lines on stderr remain the canonical console UX.
+ *   - `--json-to-stdout` restores the prior behaviour (full JSON on stdout,
+ *     no state.db row written).
+ *
+ * WHY REAL SUBPROCESSES (moved here from tests/commands/improve-result-to-file.test.ts):
+ * these tests run `improve` for real, which opens and WRITES the state.db
+ * improve_runs table. In-process, a SQLite write lock on state.db is already
+ * held within the test process (the suite keeps DB handles open across the
+ * run), so an in-process improve aborts with "state DB busy/locked after
+ * retries" — a genuine cross-process contention a fresh subprocess avoids.
+ * They also run real improve with 60s timeouts, which fits the integration
+ * scope rule. Each spawn mints a fresh XDG_DATA_HOME (via the sandbox helper)
+ * passed in the child's env — process.env is never mutated — so every run
+ * gets a clean, uncontended state.db that the assertions read back.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { type SandboxedDir, makeStashDir as sandboxMakeStashDir } from "../_helpers/sandbox";
+
+const disposers: Array<{ cleanup: () => void }> = [];
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..");
+const cliPath = path.join(repoRoot, "src", "cli.ts");
+
+function makeStashDir(): string {
+  const stash: SandboxedDir = sandboxMakeStashDir();
+  // sandboxMakeStashDir lacks the lessons/memories subdirs improve expects.
+  for (const sub of ["memories", "lessons"]) {
+    fs.mkdirSync(path.join(stash.dir, sub), { recursive: true });
+  }
+  disposers.push(stash);
+  return stash.dir;
+}
+
+interface CliRun {
+  status: number;
+  stdout: string;
+  stderr: string;
+  xdgData: string;
+}
+
+function runCli(args: string[], stashDir: string): CliRun {
+  // Fresh XDG_DATA_HOME per call so each run writes its own state.db. Use the
+  // sandbox helper to keep mkdtempSync out of the test file; the dir is passed
+  // to spawnSync's env (not process.env) so it never leaks.
+  const data = sandboxMakeStashDir();
+  disposers.push(data);
+  const result = spawnSync("bun", [cliPath, ...args], {
+    encoding: "utf8",
+    timeout: 60_000,
+    env: {
+      ...process.env,
+      AKM_STASH_DIR: stashDir,
+      XDG_DATA_HOME: data.dir,
+    },
+  });
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    xdgData: data.dir,
+  };
+}
+
+/**
+ * Read every row from `improve_runs` in the test-scoped state.db. The DB lives
+ * under `<xdgData>/akm/state.db` per `getDataDir()`.
+ */
+function readImproveRuns(xdgData: string): Array<{
+  id: string;
+  started_at: string;
+  completed_at: string | null;
+  dry_run: number;
+  ok: number;
+  scope_mode: string;
+  profile: string | null;
+  result: Record<string, unknown>;
+}> {
+  const dbPath = path.join(xdgData, "akm", "state.db");
+  if (!fs.existsSync(dbPath)) return [];
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const rows = db
+      .prepare(
+        `SELECT id, started_at, completed_at, dry_run, ok, scope_mode, profile, result_json
+         FROM improve_runs ORDER BY started_at ASC`,
+      )
+      .all() as Array<{
+      id: string;
+      started_at: string;
+      completed_at: string | null;
+      dry_run: number;
+      ok: number;
+      scope_mode: string;
+      profile: string | null;
+      result_json: string;
+    }>;
+    return rows.map((r) => ({
+      id: r.id,
+      started_at: r.started_at,
+      completed_at: r.completed_at,
+      dry_run: r.dry_run,
+      ok: r.ok,
+      scope_mode: r.scope_mode,
+      profile: r.profile,
+      result: JSON.parse(r.result_json) as Record<string, unknown>,
+    }));
+  } finally {
+    db.close();
+  }
+}
+
+afterEach(() => {
+  for (const d of disposers.splice(0)) d.cleanup();
+});
+
+describe("akm improve CLI: result-to-state.db default + --json-to-stdout escape hatch", () => {
+  let stashDir: string;
+  beforeEach(() => {
+    stashDir = makeStashDir();
+  });
+
+  test("default mode records the full result in state.db improve_runs and emits NOTHING on stdout", () => {
+    // Use --dry-run so the run completes quickly without LLM calls.
+    const result = runCli(["improve", "--dry-run"], stashDir);
+    expect(result.status).toBe(0);
+
+    // Stdout is empty — no JSON summary, no envelope, no "result written to" hint.
+    expect(result.stdout).toBe("");
+
+    // The result row landed in state.db with the full body in result_json.
+    const rows = readImproveRuns(result.xdgData);
+    expect(rows.length).toBe(1);
+    expect(rows[0].ok).toBe(1);
+    expect(rows[0].dry_run).toBe(1);
+    expect(rows[0].result.ok).toBe(true);
+    expect(rows[0].result.dryRun).toBe(true);
+    expect(rows[0].result.memorySummary).toBeDefined();
+    expect(rows[0].result.plannedRefs).toBeDefined();
+
+    // No legacy on-disk artifact file is authored anymore.
+    const runsDir = path.join(stashDir, ".akm", "runs");
+    expect(fs.existsSync(runsDir)).toBe(false);
+
+    // No "improve result written to" hint on stderr — the existing [improve]
+    // log lines from improve.ts are the canonical console UX.
+    expect(result.stderr).not.toContain("improve result written to");
+  });
+
+  test("--json-to-stdout restores prior behaviour: full JSON on stdout, no state.db row written", () => {
+    const result = runCli(["improve", "--dry-run", "--json-to-stdout"], stashDir);
+    expect(result.status).toBe(0);
+
+    // Stdout has the full result body.
+    const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+    expect(parsed.ok).toBe(true);
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.memorySummary).toBeDefined();
+    expect(parsed.plannedRefs).toBeDefined();
+    // No envelope-only fields in legacy mode.
+    expect(parsed.runId).toBeUndefined();
+    expect(parsed.resultPath).toBeUndefined();
+    expect(parsed.summary).toBeUndefined();
+
+    // No improve_runs row written in --json-to-stdout mode.
+    const rows = readImproveRuns(result.xdgData);
+    expect(rows.length).toBe(0);
+
+    // No legacy on-disk file either.
+    const runsDir = path.join(stashDir, ".akm", "runs");
+    if (fs.existsSync(runsDir)) {
+      const entries = fs.readdirSync(runsDir);
+      expect(entries.length).toBe(0);
+    }
+
+    // Stderr should NOT contain the "improve result written to" hint.
+    expect(result.stderr).not.toContain("improve result written to");
+  });
+
+  test("two consecutive default-mode runs produce distinct improve_runs rows", () => {
+    const a = runCli(["improve", "--dry-run"], stashDir);
+    expect(a.status).toBe(0);
+    expect(a.stdout).toBe("");
+
+    const b = runCli(["improve", "--dry-run"], stashDir);
+    expect(b.status).toBe(0);
+    expect(b.stdout).toBe("");
+
+    // Each run wrote a row into its own state.db (one row per state.db).
+    const aRows = readImproveRuns(a.xdgData);
+    const bRows = readImproveRuns(b.xdgData);
+    expect(aRows.length).toBe(1);
+    expect(bRows.length).toBe(1);
+    expect(aRows[0].id).not.toEqual(bRows[0].id);
+    // No legacy directory under either stash root.
+    expect(fs.existsSync(path.join(stashDir, ".akm", "runs"))).toBe(false);
+  });
+});

--- a/tests/integration/index-writer-lock-crossproc.test.ts
+++ b/tests/integration/index-writer-lock-crossproc.test.ts
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// INTEGRATION (real subprocess required): try-mode coalescing depends on the
+// lock file naming a live FOREIGN pid — the lease probe liveness-checks that
+// pid with a signal-0 kill. Using process.pid instead would hit the
+// same-process reentrancy branch (covered by the unit tests in
+// tests/index-writer-lock.test.ts), not the cross-process contention path.
+// The spawned `sleep 5` exists purely to be that live foreign pid. Moved
+// here from tests/index-writer-lock.test.ts as part of the spawn-allowlist
+// drain.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { getIndexWriterLockPath } from "../../src/core/paths";
+import { acquireIndexWriterLease } from "../../src/indexer/index-writer-lock";
+import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../_helpers/sandbox";
+
+let storage: IsolatedAkmStorage;
+
+beforeEach(() => {
+  storage = withIsolatedAkmStorage();
+});
+
+afterEach(() => {
+  storage.cleanup();
+});
+
+describe("index writer lease (cross-process)", () => {
+  test("try mode coalesces when another process holds the lease", async () => {
+    const lockPath = getIndexWriterLockPath();
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    const child = spawn("sleep", ["5"], { stdio: "ignore" });
+    try {
+      if (typeof child.pid !== "number") throw new Error("failed to start holder process");
+      fs.writeFileSync(lockPath, JSON.stringify({ pid: child.pid, startedAt: new Date().toISOString() }), "utf8");
+      const result = await acquireIndexWriterLease({ mode: "try", purpose: "background" });
+      expect(result).toBeUndefined();
+    } finally {
+      child.kill("SIGTERM");
+    }
+  });
+});

--- a/tests/integration/remember-stdin.test.ts
+++ b/tests/integration/remember-stdin.test.ts
@@ -1,0 +1,87 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Integration tests for `akm remember` stdin handling (issue #169).
+ *
+ * These tests live in tests/integration/ because they NEED real subprocesses:
+ * both pipe a body to the CLI via spawnSync's `input`, and the thing under
+ * test is the CLI's process.stdin read path. The in-process harness
+ * (tests/_helpers/cli.ts runCliCapture) has no stdin support, so these cannot
+ * be expressed there without weakening the assertions.
+ *
+ * Covers:
+ * - Zero-flag stdin remember writes captureMode: hot + beliefState: asserted
+ * - stdin is read when `--format json` is present (flag value not consumed as body)
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { parseFrontmatter } from "../../src/core/asset/frontmatter";
+
+const CLI = path.join(__dirname, "..", "..", "src", "cli.ts");
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function freshDirs(options?: { stashDir?: string }) {
+  const stashDir = options?.stashDir ?? makeTempDir("akm-rmfm-stash-");
+  return {
+    stashDir,
+    env: {
+      AKM_STASH_DIR: stashDir,
+      XDG_CACHE_HOME: makeTempDir("akm-rmfm-cache-"),
+      XDG_CONFIG_HOME: makeTempDir("akm-rmfm-config-"),
+      XDG_DATA_HOME: makeTempDir("akm-rmfm-data-"),
+      XDG_STATE_HOME: makeTempDir("akm-rmfm-state-"),
+    } satisfies Record<string, string>,
+  };
+}
+
+/** Subprocess runner: pipes `input` to the CLI's stdin (the path under test). */
+function spawnRunCli(args: string[], options?: { stashDir?: string; input?: string }) {
+  const { stashDir, env } = freshDirs(options);
+  const result = spawnSync("bun", [CLI, ...args], {
+    encoding: "utf8",
+    timeout: 30_000,
+    input: options?.input,
+    env: { ...process.env, ...env },
+  });
+  return { stashDir, result };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("remember stdin", () => {
+  test("stdin zero-flag path also writes captureMode: hot + beliefState: asserted", () => {
+    const { result } = spawnRunCli(["remember"], { input: "VPN needed for staging deploys" });
+    expect(result.status).toBe(0);
+    const json = JSON.parse(result.stdout) as { ref: string; path: string };
+    const content = fs.readFileSync(json.path, "utf8");
+    expect(content.startsWith("---")).toBe(true);
+    const parsed = parseFrontmatter(content);
+    expect(parsed.data.captureMode).toBe("hot");
+    expect(parsed.data.beliefState).toBe("asserted");
+    expect(Object.keys(parsed.data).sort()).toEqual(["beliefState", "captureMode"]);
+  });
+
+  test("reads stdin when --format json is present", () => {
+    const { result } = spawnRunCli(["remember", "--name", "from-stdin", "--format", "json"], { input: "stdin body" });
+    expect(result.status).toBe(0);
+    const json = JSON.parse(result.stdout) as { path: string };
+    expect(fs.readFileSync(json.path, "utf8")).toContain("stdin body");
+    expect(fs.readFileSync(json.path, "utf8")).not.toContain("\njson");
+  });
+});

--- a/tests/integration/save-command.test.ts
+++ b/tests/integration/save-command.test.ts
@@ -4,19 +4,19 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { parseGitRepoUrl } from "../src/sources/providers/git";
-import { type CliResult, runCliCapture } from "./_helpers/cli";
-import { withEnv } from "./_helpers/sandbox";
+import { parseGitRepoUrl } from "../../src/sources/providers/git";
+import { type CliResult, runCliCapture } from "../_helpers/cli";
+import { withEnv } from "../_helpers/sandbox";
 
-// Migrated the `akm save` invocations from spawnSync("bun", [CLI, …]) to the
-// shared in-process harness (tests/_helpers/cli.ts). `akm save` resolves its
-// target stash from AKM_STASH_DIR / named-source config (XDG), not
-// process.cwd(), so it runs faithfully in-process — the git operations it
-// performs are spawned by the command's own logic regardless. The raw `git`
-// helpers below (initGitRepo, gitHeadSubject, gitRevCount, plus the assertion
-// `git status` calls) keep spawning git directly: they exercise real git state,
-// not the akm CLI. Env mutation goes through the allowlisted withEnv wrapper;
-// temp dirs are created via makeTempDir (kept local) and tracked for cleanup.
+// INTEGRATION TEST — lives in tests/integration/ because real subprocesses are
+// inherent to every test here. The `akm` invocations use the in-process
+// harness (tests/_helpers/cli.ts), but every test builds and asserts against
+// real git fixture repos: the raw `git` helpers below (initGitRepo,
+// gitHeadSubject, gitRevCount, plus the assertion `git status` calls) spawn
+// real git, and `akm sync` itself shells out to git even when driven
+// in-process. There is nothing left to harness away.
+// Env mutation goes through the allowlisted withEnv wrapper; temp dirs are
+// created via makeTempDir (kept local) and tracked for cleanup.
 
 const tempDirs: string[] = [];
 

--- a/tests/integration/secret-run.test.ts
+++ b/tests/integration/secret-run.test.ts
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `secret run` happy path — REQUIRES a real subprocess.
+ *
+ * `secret run` spawns the target command with stdout inherited to the real fd;
+ * the secret value is injected into the CHILD process's environment. That
+ * injection is unobservable from an in-process harness (the value never enters
+ * this process's env or capture buffers), so this test spawns the real CLI and
+ * reads what the child prints. Moved here from tests/secret-path-run.test.ts;
+ * the validation-failure `secret run` cases (which fail before any spawn)
+ * remain in-process in that file.
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { setSecret } from "../../src/commands/env/secret";
+import { makeStashDir, type SandboxedDir } from "../_helpers/sandbox";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..");
+const cliPath = path.join(repoRoot, "src", "cli.ts");
+
+const disposers: SandboxedDir[] = [];
+function makeStash(): string {
+  const stash = makeStashDir();
+  disposers.push(stash);
+  return stash.dir;
+}
+
+afterAll(() => {
+  for (const d of disposers) d.cleanup();
+  disposers.length = 0;
+});
+
+function spawnCli(
+  args: string[],
+  extraEnv: Record<string, string | undefined> = {},
+): { stdout: string; stderr: string; status: number } {
+  const result = spawnSync("bun", [cliPath, ...args], {
+    encoding: "utf8",
+    timeout: 15_000,
+    cwd: repoRoot,
+    env: { ...process.env, AKM_STASH_DIR: undefined, ...extraEnv },
+  });
+  return { stdout: result.stdout ?? "", stderr: result.stderr ?? "", status: result.status ?? 1 };
+}
+
+describe("secret run", () => {
+  // KEPT AS A SUBPROCESS: the value is injected into the CHILD process env.
+  test("injects the secret value into the named env var of the child", () => {
+    const stashDir = makeStash();
+    setSecret(path.join(stashDir, "secrets", "demo"), Buffer.from("super-secret-token"));
+
+    const { stdout, status } = spawnCli(
+      ["secret", "run", "secret:demo", "TOKEN", "--", "bash", "-lc", 'printf "%s" "$TOKEN"'],
+      { AKM_STASH_DIR: stashDir },
+    );
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe("super-secret-token");
+  });
+});

--- a/tests/integration/secret-stdin.test.ts
+++ b/tests/integration/secret-stdin.test.ts
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Secret CLI — stdin path.
+ *
+ * These tests MUST spawn a real Bun subprocess: the default `secret set`
+ * reads the value from process.stdin, and the in-process harness
+ * (runCliCapture) has no way to feed stdin. Everything else about the
+ * secret surface is covered in-process in tests/secret.test.ts.
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { makeStashDir, type SandboxedDir } from "../_helpers/sandbox";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..");
+const cliPath = path.join(repoRoot, "src", "cli.ts");
+
+const disposers: SandboxedDir[] = [];
+function makeStash(): string {
+  const stash = makeStashDir();
+  disposers.push(stash);
+  return stash.dir;
+}
+
+afterAll(() => {
+  for (const d of disposers) d.cleanup();
+  disposers.length = 0;
+});
+
+function spawnCli(
+  args: string[],
+  extraEnv: Record<string, string | undefined> = {},
+  stdinInput?: string,
+): { stdout: string; stderr: string; status: number } {
+  const result = spawnSync("bun", [cliPath, ...args], {
+    encoding: "utf8",
+    timeout: 15_000,
+    cwd: repoRoot,
+    input: stdinInput,
+    env: { ...process.env, AKM_STASH_DIR: undefined, ...extraEnv },
+  });
+  return { stdout: result.stdout ?? "", stderr: result.stderr ?? "", status: result.status ?? 1 };
+}
+
+describe("secret set (stdin)", () => {
+  test("reads the value from stdin and stores it", () => {
+    const stashDir = makeStash();
+    const { stderr, status } = spawnCli(
+      ["secret", "set", "secret:demo"],
+      { AKM_STASH_DIR: stashDir },
+      "tok-from-stdin",
+    );
+    expect(status).toBe(0);
+    expect(stderr.trim()).toBe("");
+    const fp = path.join(stashDir, "secrets", "demo");
+    expect(fs.readFileSync(fp, "utf8")).toBe("tok-from-stdin");
+  });
+
+  test("strips a single trailing newline from the stdin value", () => {
+    const stashDir = makeStash();
+    spawnCli(["secret", "set", "secret:demo"], { AKM_STASH_DIR: stashDir }, "tok\n");
+    expect(fs.readFileSync(path.join(stashDir, "secrets", "demo"), "utf8")).toBe("tok");
+  });
+});

--- a/tests/integration/show-argv-entrypoint.test.ts
+++ b/tests/integration/show-argv-entrypoint.test.ts
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Real-subprocess entrypoint test for the global `--shape` pre-execution gate.
+ *
+ * WHY THIS NEEDS A REAL SUBPROCESS: `--shape summary` is rejected for every
+ * non-`show` command by an early, pre-execution gate in the guarded startup
+ * block of src/cli.ts (before any command runs). The in-process harness
+ * (tests/_helpers/cli.ts `runCliCapture`) intentionally skips that startup
+ * block, so it only enforces the later, post-execution `shapeForCommand()`
+ * gate — by which point a write command like `remember` would already have
+ * run. This test asserts the write did NOT happen, which only holds for the
+ * real subprocess entry point, so it lives in tests/integration/ on spawnSync.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { type Cleanup, withIsolatedAkmStorage } from "../_helpers/sandbox";
+
+const CLI = path.join(import.meta.dir, "..", "..", "src", "cli.ts");
+
+let cleanup: Cleanup = () => {};
+
+afterEach(() => {
+  cleanup();
+  cleanup = () => {};
+});
+
+function useStorage(): ReturnType<typeof withIsolatedAkmStorage> {
+  const storage = withIsolatedAkmStorage();
+  cleanup = storage.cleanup;
+  return storage;
+}
+
+// The spawn passes `...process.env` on purpose: withIsolatedAkmStorage mutates
+// process.env (AKM_* / XDG dirs) for the current process, and the subprocess
+// must inherit those mutations to run against the isolated sandbox storage.
+function runEntrypointSpawn(args: string[]) {
+  return spawnSync("bun", [CLI, ...args], {
+    encoding: "utf8",
+    env: { ...process.env },
+    timeout: 30_000,
+  });
+}
+
+describe("entrypoint global --shape=summary pre-execution gate", () => {
+  test("rejects global --shape=summary before non-show commands before they run", () => {
+    const storage = useStorage();
+
+    const result = runEntrypointSpawn(["--format=json", "--shape=summary", "remember", "do not write"]);
+
+    expect(result.status).toBe(2);
+    const error = JSON.parse(result.stderr) as Record<string, unknown>;
+    expect(error.code).toBe("INVALID_SHAPE_VALUE");
+    expect(fs.readdirSync(path.join(storage.stashDir, "memories"))).toEqual([]);
+  });
+});

--- a/tests/remember-frontmatter.test.ts
+++ b/tests/remember-frontmatter.test.ts
@@ -12,7 +12,6 @@
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -25,20 +24,17 @@ import { withEnv } from "./_helpers/sandbox";
 
 // ── CLI harness ──────────────────────────────────────────────────────────────
 //
-// Migrated the non-stdin `akm remember` invocations from spawnSync to the shared
-// in-process harness (tests/_helpers/cli.ts). `remember` resolves its target
-// from AKM_STASH_DIR (XDG), not process.cwd(), so it runs faithfully in-process.
+// All `akm remember` invocations here run through the shared in-process harness
+// (tests/_helpers/cli.ts). `remember` resolves its target from AKM_STASH_DIR
+// (XDG), not process.cwd(), so it runs faithfully in-process.
 //
-// KEPT SPAWNING (harness gap): the two tests that pipe a body via stdin
-// (`spawnRunCli({ input })`). runCliCapture has no stdin support — the CLI's
-// `remember` reads process.stdin when no body arg is given (and when --format
-// json is present), which the in-process harness cannot supply. Those two tests
-// stay as real subprocesses so the stdin read path is exercised faithfully.
+// The two stdin-driven tests (piping a body via a real subprocess's stdin) live
+// in tests/integration/remember-stdin.test.ts — runCliCapture has no stdin
+// support and the CLI's process.stdin read path is the thing under test there.
 //
 // Env mutation goes through the allowlisted withEnv wrapper; temp dirs are
 // created via makeTempDir (kept local) and tracked in tempDirs for cleanup.
 
-const CLI = path.join(__dirname, "..", "src", "cli.ts");
 const tempDirs: string[] = [];
 
 function makeTempDir(prefix: string): string {
@@ -68,21 +64,6 @@ async function runCli(args: string[], options?: { stashDir?: string }) {
   return { stashDir, result: { status: code, stdout, stderr } };
 }
 
-/**
- * Subprocess runner, retained ONLY for the stdin-driven tests. runCliCapture has
- * no stdin support, so the CLI's stdin read path is exercised via a real process.
- */
-function spawnRunCli(args: string[], options?: { stashDir?: string; input?: string }) {
-  const { stashDir, env } = freshDirs(options);
-  const result = spawnSync("bun", [CLI, ...args], {
-    encoding: "utf8",
-    timeout: 30_000,
-    input: options?.input,
-    env: { ...process.env, ...env },
-  });
-  return { stashDir, result };
-}
-
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -110,25 +91,8 @@ describe("zero-flag remember", () => {
     expect(stashDir).toBeTruthy();
   });
 
-  test("stdin zero-flag path also writes captureMode: hot + beliefState: asserted", () => {
-    const { result } = spawnRunCli(["remember"], { input: "VPN needed for staging deploys" });
-    expect(result.status).toBe(0);
-    const json = JSON.parse(result.stdout) as { ref: string; path: string };
-    const content = fs.readFileSync(json.path, "utf8");
-    expect(content.startsWith("---")).toBe(true);
-    const parsed = parseFrontmatter(content);
-    expect(parsed.data.captureMode).toBe("hot");
-    expect(parsed.data.beliefState).toBe("asserted");
-    expect(Object.keys(parsed.data).sort()).toEqual(["beliefState", "captureMode"]);
-  });
-
-  test("reads stdin when --format json is present", () => {
-    const { result } = spawnRunCli(["remember", "--name", "from-stdin", "--format", "json"], { input: "stdin body" });
-    expect(result.status).toBe(0);
-    const json = JSON.parse(result.stdout) as { path: string };
-    expect(fs.readFileSync(json.path, "utf8")).toContain("stdin body");
-    expect(fs.readFileSync(json.path, "utf8")).not.toContain("\njson");
-  });
+  // The stdin variants of these tests (piping a body via a real subprocess)
+  // live in tests/integration/remember-stdin.test.ts.
 });
 
 // ── CLI args (Mode 1) ────────────────────────────────────────────────────────

--- a/tests/secret-path-run.test.ts
+++ b/tests/secret-path-run.test.ts
@@ -3,16 +3,18 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 /**
- * Secret `path` and `run`.
+ * Secret `path` and `run` (in-process cases only).
  *
  *   - `secret path` / error / traversal cases run in-process.
- *   - `secret run` spawns the target command with stdout inherited to the real
- *     fd, so the injected-env output is the CHILD's — only a real process
- *     boundary can observe it. Those cases use spawnCli.
+ *   - `secret run` validation failures (LD_PRELOAD rejection, invalid var
+ *     name, missing command) also run in-process — they fail before any child
+ *     spawn.
+ *   - The happy-path `secret run` injection test lives in
+ *     tests/integration/secret-run.test.ts: it needs a real process boundary
+ *     to observe the CHILD's env.
  */
 
 import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { setSecret } from "../src/commands/env/secret";
@@ -20,9 +22,6 @@ import { resetGraphBoostCache } from "../src/indexer/graph/graph-boost";
 import { clearEmbeddingCache, resetLocalEmbedder } from "../src/llm/embedder";
 import { runCliCapture } from "./_helpers/cli";
 import { makeStashDir, type SandboxedDir, withEnv } from "./_helpers/sandbox";
-
-const repoRoot = path.resolve(import.meta.dir, "..");
-const cliPath = path.join(repoRoot, "src", "cli.ts");
 
 const disposers: SandboxedDir[] = [];
 function makeStash(): string {
@@ -60,19 +59,6 @@ async function runCli(
   });
 }
 
-function spawnCli(
-  args: string[],
-  extraEnv: Record<string, string | undefined> = {},
-): { stdout: string; stderr: string; status: number } {
-  const result = spawnSync("bun", [cliPath, ...args], {
-    encoding: "utf8",
-    timeout: 15_000,
-    cwd: repoRoot,
-    env: { ...process.env, AKM_STASH_DIR: undefined, ...extraEnv },
-  });
-  return { stdout: result.stdout ?? "", stderr: result.stderr ?? "", status: result.status ?? 1 };
-}
-
 describe("secret path", () => {
   test("prints the absolute path on stdout when the secret exists", async () => {
     const stashDir = makeStash();
@@ -106,19 +92,9 @@ describe("secret path", () => {
 });
 
 describe("secret run", () => {
-  // KEPT AS A SUBPROCESS: the value is injected into the CHILD process env.
-  test("injects the secret value into the named env var of the child", () => {
-    const stashDir = makeStash();
-    setSecret(path.join(stashDir, "secrets", "demo"), Buffer.from("super-secret-token"));
-
-    const { stdout, status } = spawnCli(
-      ["secret", "run", "secret:demo", "TOKEN", "--", "bash", "-lc", 'printf "%s" "$TOKEN"'],
-      { AKM_STASH_DIR: stashDir },
-    );
-    expect(status).toBe(0);
-    expect(stdout.trim()).toBe("super-secret-token");
-  });
-
+  // The happy-path injection test (secret value visible in the CHILD's env)
+  // lives in tests/integration/secret-run.test.ts — it requires a real
+  // subprocess. The cases below fail validation before any child spawn.
   test("rejects a dangerous target variable name (process hijacking)", async () => {
     const stashDir = makeStash();
     setSecret(path.join(stashDir, "secrets", "demo"), Buffer.from("v"));

--- a/tests/secret.test.ts
+++ b/tests/secret.test.ts
@@ -5,14 +5,12 @@
 /**
  * Secret asset type — core module + CLI surface.
  *
- * Mirrors the vault test split: cases that pipe a value through process.stdin
- * (`secret set` default) spawn a real Bun process (the in-process harness has
- * no way to feed stdin); the `--from-file` / `--from-env` / `list` / `remove`
- * cases run in-process via the shared harness.
+ * Everything here runs in-process via the shared harness. The stdin path
+ * (default `secret set` pipes the value through process.stdin, which the
+ * harness cannot feed) lives in tests/integration/secret-stdin.test.ts.
  */
 
 import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -21,9 +19,6 @@ import { resetGraphBoostCache } from "../src/indexer/graph/graph-boost";
 import { clearEmbeddingCache, resetLocalEmbedder } from "../src/llm/embedder";
 import { runCliCapture } from "./_helpers/cli";
 import { makeStashDir, type SandboxedDir, withEnv } from "./_helpers/sandbox";
-
-const repoRoot = path.resolve(import.meta.dir, "..");
-const cliPath = path.join(repoRoot, "src", "cli.ts");
 
 // ── Core-module fixtures (tracked tmp dirs) ──────────────────────────────────
 
@@ -72,21 +67,6 @@ async function runCli(
     const { stdout, stderr, code } = await runCliCapture(args);
     return { stdout, stderr, status: code };
   });
-}
-
-function spawnCli(
-  args: string[],
-  extraEnv: Record<string, string | undefined> = {},
-  stdinInput?: string,
-): { stdout: string; stderr: string; status: number } {
-  const result = spawnSync("bun", [cliPath, ...args], {
-    encoding: "utf8",
-    timeout: 15_000,
-    cwd: repoRoot,
-    input: stdinInput,
-    env: { ...process.env, AKM_STASH_DIR: undefined, ...extraEnv },
-  });
-  return { stdout: result.stdout ?? "", stderr: result.stderr ?? "", status: result.status ?? 1 };
 }
 
 // ── Core module ──────────────────────────────────────────────────────────────
@@ -156,27 +136,6 @@ describe("secret core module", () => {
 // ── CLI: set / list / remove ─────────────────────────────────────────────────
 
 describe("secret set", () => {
-  // KEPT AS A SUBPROCESS: default `set` reads process.stdin.
-  test("reads the value from stdin and stores it", () => {
-    const stashDir = makeStash();
-    const { stderr, status } = spawnCli(
-      ["secret", "set", "secret:demo"],
-      { AKM_STASH_DIR: stashDir },
-      "tok-from-stdin",
-    );
-    expect(status).toBe(0);
-    expect(stderr.trim()).toBe("");
-    const fp = path.join(stashDir, "secrets", "demo");
-    expect(fs.readFileSync(fp, "utf8")).toBe("tok-from-stdin");
-  });
-
-  // KEPT AS A SUBPROCESS: stdin path; verifies the single-trailing-newline strip.
-  test("strips a single trailing newline from the stdin value", () => {
-    const stashDir = makeStash();
-    spawnCli(["secret", "set", "secret:demo"], { AKM_STASH_DIR: stashDir }, "tok\n");
-    expect(fs.readFileSync(path.join(stashDir, "secrets", "demo"), "utf8")).toBe("tok");
-  });
-
   test("--from-file stores the file byte-exact (multi-line preserved)", async () => {
     const stashDir = makeStash();
     const src = path.join(tmpDir(), "id_ed25519");

--- a/tests/wiki.test.ts
+++ b/tests/wiki.test.ts
@@ -8,7 +8,6 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { spawn } from "node:child_process";
 import fs from "node:fs";
 import http from "node:http";
 import os from "node:os";
@@ -39,10 +38,10 @@ import {
   validateWikiName,
   WIKIS_SUBDIR,
 } from "../src/wiki/wiki";
-import { type Cleanup, sandboxStashDir, sandboxXdgConfigHome } from "./_helpers/sandbox";
+import { runCliCapture } from "./_helpers/cli";
+import { type Cleanup, sandboxStashDir, sandboxXdgConfigHome, withEnv } from "./_helpers/sandbox";
 
 const tempDirs: string[] = [];
-const CLI = path.join(__dirname, "..", "src", "cli.ts");
 
 function makeStash(prefix = "akm-wiki-test-"): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -63,39 +62,21 @@ function writeConfig(configDir: string, body: Record<string, unknown>): void {
   fs.writeFileSync(path.join(akmDir, "config.json"), JSON.stringify(body, null, 2), "utf8");
 }
 
-async function runCliAsync(args: string[], options: { stashDir: string; configDir: string }) {
-  const child = spawn("bun", [CLI, ...args], {
-    stdio: ["ignore", "pipe", "pipe"],
-    env: {
-      ...process.env,
+/**
+ * Run the CLI in-process with the same env the old subprocess version passed
+ * via child env: AKM_STASH_DIR/AKM_CONFIG_DIR pin the stash + config lookup
+ * (AKM_CONFIG_DIR wins over the sandboxed XDG_CONFIG_HOME exactly as it did
+ * for the child), and XDG_CACHE_HOME isolates cache writes.
+ */
+async function runCli(args: string[], options: { stashDir: string; configDir: string }) {
+  return withEnv(
+    {
       AKM_STASH_DIR: options.stashDir,
       AKM_CONFIG_DIR: path.join(options.configDir, "akm"),
       XDG_CACHE_HOME: makeStash("akm-wiki-cache-"),
     },
-  });
-  let stdout = "";
-  let stderr = "";
-  child.stdout.on("data", (chunk) => {
-    stdout += String(chunk);
-  });
-  child.stderr.on("data", (chunk) => {
-    stderr += String(chunk);
-  });
-  const status = await new Promise<number>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      reject(new Error("CLI timed out after 30000ms"));
-    }, 30_000);
-    child.on("error", (error) => {
-      clearTimeout(timer);
-      reject(error);
-    });
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      resolve(code ?? 1);
-    });
-  });
-  return { status, stdout, stderr };
+    () => runCliCapture(args),
+  );
 }
 
 let envCleanup: Cleanup = () => {};
@@ -455,8 +436,8 @@ describe("stashRaw", () => {
 
     try {
       const url = `http://127.0.0.1:${address.port}/papers/attention`;
-      const result = await runCliAsync(["wiki", "stash", "research", url], { stashDir: stash, configDir });
-      expect(result.status).toBe(0);
+      const result = await runCli(["wiki", "stash", "research", url], { stashDir: stash, configDir });
+      expect(result.code).toBe(0);
 
       const json = JSON.parse(result.stdout) as { ok: boolean; ref: string; path: string; slug: string };
       expect(json.ok).toBe(true);


### PR DESCRIPTION
## Summary

Drains all 13 files grandfathered in the Rule-5 `SPAWN_ALLOWED` allowlist of `scripts/lint-tests-isolation.ts`. Unit scope (`tests/` excluding `tests/integration/`) now contains zero real process spawns. The set and the lint rule remain (shrink-only, now empty-only), and the combined ratchet baseline drops back 77 → 64 — the 2026-07-02 Rule-5 step-up was drained same-day.

## Per-file strategy

| File | Strategy | Moved to |
|---|---|---|
| tests/remember-frontmatter.test.ts | Split: 2 stdin tests moved; rest on in-process harness | tests/integration/remember-stdin.test.ts |
| tests/env-path-run.test.ts | Split: fd-inherited-stdout spawn tests moved | tests/integration/env-run.test.ts |
| tests/secret.test.ts | Split: 2 stdin tests moved | tests/integration/secret-stdin.test.ts |
| tests/secret-path-run.test.ts | Split: child-env observation test moved | tests/integration/secret-run.test.ts |
| tests/wiki.test.ts | In-process harness (runCliCapture); spawn helper deleted | — |
| tests/commands/events.test.ts | Split: cross-process offset-resume test moved | tests/integration/events-offset-crossproc.test.ts |
| tests/commands/improve-result-to-file.test.ts | Split: CLI result-storage describe (3 tests) moved | tests/integration/improve-cli-result-storage.test.ts |
| tests/commands/show-argv.test.ts | Split: pure normalizeShowArgv tests kept; entrypoint test moved | tests/integration/show-argv-entrypoint.test.ts |
| tests/commands/improve-cli-flags.test.ts | Mixed: arg-parse rejection on harness; DB-touching flag tests moved | tests/integration/improve-cli-flags.test.ts |
| tests/commands/distill/distill-cli-flag.test.ts | In-process harness (runCliCapture) | — |
| tests/env.test.ts | Split: bash-eval script test moved (shell semantics under test) | tests/integration/env-export-bash.test.ts |
| tests/save-command.test.ts | Whole-file git mv (17 real-git call sites; integration by nature) | tests/integration/save-command.test.ts |
| tests/index-writer-lock.test.ts | Split: reentrancy test kept; live-PID stale-lock tests moved | tests/integration/index-writer-lock-crossproc.test.ts |

Also extends the `biome.json` `noTemplateCurlyInString` override to the relocated `tests/integration/env-run.test.ts` (intentional shell `${...}` placeholders, same as the original file's exemption).

## Gate results (all local, clean)

- `bun run lint` — 0 errors, 0 warnings (biome + all custom lints)
- `bunx tsc --noEmit` — clean
- `bash scripts/test-unit.sh` — 4972 pass / 0 fail across 8 process-shards
- `bun run test:integration` — 732 pass / 34 skip / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkfTXQ3QUXKLZhETdPioC3