### PR TITLE
fix(env): never surface .env comment text — comments carry credentials

### DIFF
--- a/docs/agents/AGENTS.full.md
+++ b/docs/agents/AGENTS.full.md
@@ -49,7 +49,7 @@ akm show wiki:research                        # Wiki summary (same as akm wiki s
 | knowledge | `content` (with view modes: `full`, `toc`, `frontmatter`, `section`, `lines`) |
 | workflow | `workflowTitle`, `workflowParameters`, `steps` |
 | memory | `content` (recalled context) |
-| env | `keys`, `comments` (values are never returned) |
+| env | `keys` (values and comment text are never returned) |
 | secret | metadata only (the single value is never returned) |
 | wiki | `content` (same view modes as knowledge). For any wiki task, run `akm wiki list`. `akm wiki ingest <name>` dispatches the configured agent (defaults.agent or `--profile`) to execute the ingest workflow. |
 | lesson | `content` plus `when_to_use` from frontmatter — read both before applying the lesson |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,7 +41,7 @@ Useful for streaming consumption by scripts or agents.
 Strips output to only action-relevant fields:
 
 - **search**: keeps `name`, `ref`, `type`, `description`, `action`, `score`, `estimatedTokens`
-- **show**: keeps `type`, `name`, `description`, `action`, `content`, `template`, `prompt`, `run`, `setup`, `cwd`, `toolPolicy`, `modelHint`, `agent`, `parameters`, `workflowTitle`, `workflowParameters`, `steps`, `keys`
+- **show**: keeps `type`, `name`, `description`, `action`, `content`, `template`, `prompt`, `run`, `setup`, `cwd`, `toolPolicy`, `modelHint`, `agent`, `parameters`, `workflowTitle`, `workflowParameters`, `steps`, `keys`, `related`
 
 ### `--shape summary`
 
@@ -50,7 +50,7 @@ with an `INVALID_SHAPE_VALUE` usage error (exit 2) — an honest rejection rathe
 than a silent fallback. It returns a compact view suitable for capability
 discovery:
 
-- **show**: `type`, `name`, `description`, `tags`, `parameters`, `workflowTitle`, `action`, `run`, `origin`, `keys`
+- **show**: `type`, `name`, `description`, `tags`, `parameters`, `workflowTitle`, `action`, `run`, `origin`, `keys`, `related`
 
 ## Exit Codes and Error Envelope
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,7 +41,7 @@ Useful for streaming consumption by scripts or agents.
 Strips output to only action-relevant fields:
 
 - **search**: keeps `name`, `ref`, `type`, `description`, `action`, `score`, `estimatedTokens`
-- **show**: keeps `type`, `name`, `description`, `action`, `content`, `template`, `prompt`, `run`, `setup`, `cwd`, `toolPolicy`, `modelHint`, `agent`, `parameters`, `workflowTitle`, `workflowParameters`, `steps`, `keys`, `comments`
+- **show**: keeps `type`, `name`, `description`, `action`, `content`, `template`, `prompt`, `run`, `setup`, `cwd`, `toolPolicy`, `modelHint`, `agent`, `parameters`, `workflowTitle`, `workflowParameters`, `steps`, `keys`
 
 ### `--shape summary`
 
@@ -50,7 +50,7 @@ with an `INVALID_SHAPE_VALUE` usage error (exit 2) — an honest rejection rathe
 than a silent fallback. It returns a compact view suitable for capability
 discovery:
 
-- **show**: `type`, `name`, `description`, `tags`, `parameters`, `workflowTitle`, `action`, `run`, `origin`, `keys`, `comments`
+- **show**: `type`, `name`, `description`, `tags`, `parameters`, `workflowTitle`, `action`, `run`, `origin`, `keys`
 
 ## Exit Codes and Error Envelope
 
@@ -468,8 +468,7 @@ The default `show` JSON includes the asset body when applicable. Use
 `content`/`template`/`prompt`; `--detail full` adds verbose metadata such as
 `schemaVersion`, `path`, `editable`, and `editHint`; `--shape summary`
 returns a compact view with only `type`, `name`, `description`, `tags`,
-`parameters`, `workflowTitle`, `action`, `run`, `origin`, `keys`, and
-`comments`.
+`parameters`, `workflowTitle`, `action`, `run`, `origin`, and `keys`.
 
 Returns type-specific payloads:
 
@@ -482,7 +481,7 @@ Returns type-specific payloads:
 | knowledge | `content` with view modes: `full`, `toc`, `frontmatter`, `section`, `lines` |
 | workflow | `workflowTitle`, `workflowParameters`, `steps` |
 | memory | `content` |
-| env | `keys`, `comments` (key names + comments only — values never returned) |
+| env | `keys` (key names only — values and comment text never returned) |
 | lesson | `content` plus `when_to_use` surfaced from frontmatter |
 
 Assets from non-writable sources (git clones, npm packages, websites) return
@@ -1337,11 +1336,12 @@ Manage `.env`-backed **environment files** — a group of related **configuratio
 for an app or service (URLs, feature flags, and any credentials it needs),
 loaded together. Each `env` asset is an entire `.env` file stored under `env/`
 in your stash (mode 0600). Values may or may not be sensitive; **akm protects
-them all the same** — key *names* and comments are discoverable, values never
-appear in structured output. akm does **not** manage individual entries — you
-edit the `.env` with your own editor (or ingest one with `--from-file`) and akm
-loads it wholesale. `list` and `show` surface key names + comments only; `run`
-and `export` are the supported value-use paths.
+them all the same** — key *names* are discoverable; values and comment text
+never appear in structured output (comments routinely contain commented-out
+credentials, so they are treated like values). akm does **not** manage
+individual entries — you edit the `.env` with your own editor (or ingest one
+with `--from-file`) and akm loads it wholesale. `list` and `show` surface key
+names only; `run` and `export` are the supported value-use paths.
 
 ```sh
 akm env list

--- a/docs/features/knowledge-management.md
+++ b/docs/features/knowledge-management.md
@@ -123,7 +123,8 @@ akm wiki lint ml-research
 `akm env` manages `.env`-backed groups of configuration (a `.env` file loaded
 wholesale), and `akm secret` manages a single standalone sensitive value. The
 core security guarantee: **values never appear in akm's structured output**.
-Only key names (and `.env` comments) are shown. Values reach processes through
+Only key names are shown — comment text is never surfaced either, since
+comments can contain commented-out credentials. Values reach processes through
 `akm env run` / `akm secret run`, never through akm's JSON output. (The old
 `akm vault` verb was removed in 0.9.0.)
 
@@ -135,7 +136,7 @@ akm env create prod --from-file ./.env    # or ingest an existing .env
 $EDITOR "$(akm env path env:prod --quiet)"
 
 akm env list
-akm show env:prod                         # key names + comments only
+akm show env:prod                         # key names only
 
 # Inject the whole .env into a subprocess (never onto stdout):
 akm env run env:prod -- ./deploy.sh

--- a/docs/migration/v0.8-to-v0.9.md
+++ b/docs/migration/v0.8-to-v0.9.md
@@ -153,8 +153,9 @@ and splits it by **purpose**:
   `vault set <ref> <KEY>` was used to store one credential.
 
 Both protect values identically (never written to stdout, the index, or any
-structured output); env additionally surfaces key names + comments for
-discoverability. Pick `env` for configuration, `secret` for a standalone
+structured output); env additionally surfaces key names for discoverability
+(comment text is never surfaced — comments can contain commented-out
+credentials). Pick `env` for configuration, `secret` for a standalone
 authentication credential.
 
 ## What changed in 0.8.0
@@ -322,7 +323,7 @@ akm env list
 ls -la "$(akm config get stashDir)/vaults/.migrated"
 
 # Values still never leak
-akm show env:prod          # keys + comments only
+akm show env:prod          # key names only
 akm search <a-secret-value> # no hits
 ```
 

--- a/src/assets/hints/cli-hints-full.md
+++ b/src/assets/hints/cli-hints-full.md
@@ -58,7 +58,7 @@ akm show knowledge:my-doc                    # Show content (local or remote)
 | knowledge | `content` (with view modes: `full`, `toc`, `frontmatter`, `section`, `lines`) |
 | workflow | `workflowTitle`, `workflowParameters`, `steps` |
 | memory | `content` (recalled context) |
-| env | `keys`, `comments` (key names + comments only — values never returned) |
+| env | `keys` (key names only — values and comment text never returned) |
 | secret | `name` only (the whole file is the value — never returned) |
 | wiki | `content` (same view modes as knowledge). For any wiki task, run `akm wiki list`. To ingest sources, `akm wiki ingest <name>` dispatches the configured agent (defaults.agent or `--profile`) to execute the ingest workflow. |
 
@@ -122,15 +122,16 @@ search results. No `--llm` anywhere — akm never reasons about page content.
 ## Env files
 
 A group of related CONFIGURATION for an app/service in one `.env` file at
-`<stashDir>/env/<name>.env`, sourced/injected wholesale. Key names + comments
-are discoverable; values stay on disk and never reach stdout or the index. akm
-does not edit entries — you edit the file with your own editor and akm loads it.
+`<stashDir>/env/<name>.env`, sourced/injected wholesale. Key names are
+discoverable; values and comment text stay on disk and never reach stdout or
+the index (comments can contain commented-out credentials). akm does not edit
+entries — you edit the file with your own editor and akm loads it.
 
 ```sh
 akm env create prod                           # Create an empty env file
 akm env create prod --from-file ./.env        # Ingest an existing .env
 akm env list                                  # List all env files across stashes with key names
-akm show env:prod                             # Inspect key names + comments (never values)
+akm show env:prod                             # Inspect key names (never values or comments)
 akm env run env:prod -- ./deploy.sh           # Run a command with the whole .env injected (the safe path)
 akm env run env:prod -- $SHELL                # Open an interactive shell with values injected
 akm env export env:prod --out ./env.sh        # Write a sourceable script to a file (mode 0600)

--- a/src/commands/env/env-cli.ts
+++ b/src/commands/env/env-cli.ts
@@ -11,8 +11,9 @@
  * copy.
  *
  * `akm env` manages whole `.env` files under each stash's env/ directory.
- * Values are NEVER written to stdout or structured output — only key NAMES and
- * start-of-line comments are surfaced. akm does not manage individual entries;
+ * Values and comment text are NEVER written to stdout or structured output —
+ * only key NAMES are surfaced (comments routinely contain commented-out
+ * credentials). akm does not manage individual entries;
  * you edit the `.env` file yourself and akm loads it. Replaced the deprecated
  * `vault` type (removed in 0.9.0).
  */

--- a/src/commands/env/env.ts
+++ b/src/commands/env/env.ts
@@ -19,10 +19,13 @@
  * round-trip through `dotenv`; the shell-load safety guarantee still lives on
  * the READ path (see `buildShellExportScript` + `akm env export`).
  *
- * Invariant: env values must never be written to stdout, returned through the
- * indexer, the `akm show` renderer, or any structured output channel. Key
- * NAMES and start-of-line comments ARE surfaced by design (discoverability) —
- * only values are secret. The supported value-load paths are:
+ * Invariant: nothing from an env file except key NAMES may be written to
+ * stdout, returned through the indexer, the `akm show` renderer, or any
+ * structured output channel. Key NAMES are surfaced for discoverability;
+ * comment text is NOT — real .env files routinely carry commented-out
+ * `KEY=value` lines and free-text notes containing live credentials, so
+ * comments are treated exactly like values. The supported value-load paths
+ * are:
  *
  *   - `akm env run <ref> -- <command>` — values injected into the child
  *     process env (never via a shell), see `injectIntoEnv` / `loadEnv`. This is
@@ -74,74 +77,18 @@ function scanKeys(text: string): string[] {
 }
 
 /**
- * Scan lines and return start-of-line `#` comments (with the leading `#` and
- * any leading whitespace stripped). Inline/trailing `#` after an assignment is
- * never extracted.
- */
-function scanComments(text: string): string[] {
-  const comments: string[] = [];
-  for (const line of text.split(/\r?\n/)) {
-    const trimmed = line.trimStart();
-    if (trimmed.startsWith("#")) {
-      comments.push(trimmed.slice(1).trimStart());
-    }
-  }
-  return comments;
-}
-
-/**
- * Read and return ONLY non-secret metadata (keys + start-of-line comments).
+ * Read and return ONLY non-secret metadata: key names.
  *
  * The function reads the whole file into memory (same as any dotenv parser)
- * but deliberately does not parse values — the LHS-only regex scanners above
- * ensure no value content is retained or returned. The guarantee is that
- * values never leave this function.
+ * but deliberately does not parse values — the LHS-only regex scanner above
+ * ensures no value content is retained or returned. Comment text is never
+ * returned either: comments routinely contain commented-out `KEY=value`
+ * credentials and free-text secrets, so they never leave this function.
  */
-export function listKeys(envPath: string): { keys: string[]; comments: string[] } {
-  if (!fs.existsSync(envPath)) return { keys: [], comments: [] };
+export function listKeys(envPath: string): { keys: string[] } {
+  if (!fs.existsSync(envPath)) return { keys: [] };
   const text = fs.readFileSync(envPath, "utf8");
-  return { keys: scanKeys(text), comments: scanComments(text) };
-}
-
-/**
- * Return structured `entries` pairing each key with the nearest preceding
- * comment line (if any). This is an easier-to-consume shape than the parallel
- * `keys[]` + `comments[]` of `listKeys` (QA #35).
- *
- * Values are never included — the same privacy guarantee as `listKeys`.
- */
-export function listEntries(envPath: string): Array<{ key: string; comment?: string }> {
-  if (!fs.existsSync(envPath)) return [];
-  const text = fs.readFileSync(envPath, "utf8");
-  const lines = text.split(/\r?\n/);
-  const seen = new Set<string>();
-  const entries: Array<{ key: string; comment?: string }> = [];
-  let pendingComment: string | undefined;
-
-  for (const line of lines) {
-    const trimmed = line.trimStart();
-    if (trimmed.startsWith("#")) {
-      // Capture the most recent comment before a key
-      pendingComment = trimmed.slice(1).trimStart() || undefined;
-      continue;
-    }
-    const m = line.match(ASSIGN_RE);
-    if (m) {
-      const key = m[1];
-      if (!seen.has(key)) {
-        seen.add(key);
-        const entry: { key: string; comment?: string } = { key };
-        if (pendingComment) entry.comment = pendingComment;
-        entries.push(entry);
-      }
-      pendingComment = undefined;
-    } else {
-      // Any non-comment, non-assignment line (including blank lines)
-      // breaks "nearest preceding comment line" association.
-      pendingComment = undefined;
-    }
-  }
-  return entries;
+  return { keys: scanKeys(text) };
 }
 
 /**

--- a/src/core/asset/asset-spec.ts
+++ b/src/core/asset/asset-spec.ts
@@ -95,8 +95,9 @@ const ASSET_SPECS_INTERNAL: Record<string, AssetSpec> = {
   script: { stashDir: "scripts", ...scriptSpec },
   memory: { stashDir: "memories", ...markdownSpec },
   // Environment assets — whole `.env` files sourced/injected wholesale. Replaced
-  // the deprecated `vault` type (removed in 0.9.0). Key NAMES + start-of-line
-  // comments are surfaced as metadata; values are never read for indexing.
+  // the deprecated `vault` type (removed in 0.9.0). Only key NAMES are surfaced
+  // as metadata; values and comment text are never read for indexing (comments
+  // routinely contain commented-out credentials).
   env: {
     stashDir: "env",
     isRelevantFile: (fileName) => fileName === ".env" || fileName.endsWith(".env"),

--- a/src/output/renderers.ts
+++ b/src/output/renderers.ts
@@ -439,25 +439,23 @@ const scriptSourceRenderer: AssetRenderer = {
 // ── 8. env-file ───────────────────────────────────────────────────────────────
 
 /**
- * Env renderer. Returns ONLY key names and start-of-line comments — never
- * values. Deliberately omits content/template/prompt so env values cannot leak
- * through `akm show`.
+ * Env renderer. Returns ONLY key names — never values, and never comment
+ * text (comments routinely contain commented-out credentials). Deliberately
+ * omits content/template/prompt so env values cannot leak through `akm show`.
  */
 const envFileRenderer: AssetRenderer = {
   name: "env-file",
 
   buildShowResponse(ctx: RenderContext): ShowResponse {
     const name = deriveName(ctx);
-    const { keys, comments } = listVaultKeys(ctx.absPath);
+    const { keys } = listVaultKeys(ctx.absPath);
     return {
       type: "env",
       name,
       path: ctx.absPath,
       action:
-        "Environment — keys + comments only. Use `akm env run <ref> -- <command>` to run with the whole .env injected; prefer `--clean` to minimize inherited parent env. AKM itself does not print values, but child stdout/stderr is not redacted. `akm env export <ref> --out <file>` writes a sourceable script to a file. Never `source` the raw file. Values stay on disk and are never written to akm's stdout.",
-      description: comments.length > 0 ? comments.join("\n") : undefined,
+        "Environment — key names only. Use `akm env run <ref> -- <command>` to run with the whole .env injected; prefer `--clean` to minimize inherited parent env. AKM itself does not print values, but child stdout/stderr is not redacted. `akm env export <ref> --out <file>` writes a sourceable script to a file. Never `source` the raw file. Values stay on disk and are never written to akm's stdout.",
       keys,
-      comments,
     };
   },
 
@@ -731,12 +729,9 @@ function applyScriptMetadata(entry: StashEntry, ctx: RenderContext): void {
 }
 
 function applyEnvMetadata(entry: StashEntry, ctx: RenderContext): void {
-  const { keys, comments } = listVaultKeys(ctx.absPath);
-  if (comments.length > 0 && !entry.description) {
-    entry.description = comments.join(" ").slice(0, 500);
-    entry.source = "comments";
-    entry.confidence = 0.7;
-  }
+  // Key names only — comment text must never reach description/search_text
+  // (comments routinely contain commented-out credentials).
+  const { keys } = listVaultKeys(ctx.absPath);
   if (keys.length > 0) {
     entry.searchHints = keys;
   }

--- a/src/output/shapes/helpers.ts
+++ b/src/output/shapes/helpers.ts
@@ -430,7 +430,6 @@ export function shapeShowOutput(
       "workflowParameters",
       "steps",
       "keys",
-      "comments",
       "related",
     ]);
   }
@@ -446,7 +445,6 @@ export function shapeShowOutput(
       "run",
       "origin",
       "keys",
-      "comments",
       "related",
     ]);
   }
@@ -473,7 +471,6 @@ export function shapeShowOutput(
     "cwd",
     "activeRun",
     "keys",
-    "comments",
     "related",
     // path and editable are always projected so JSON consumers can locate and
     // edit the asset without needing --detail full (QA #7).

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -325,15 +325,11 @@ export interface ShowResponse {
   /** Actionable guidance when editable is false (omitted when editable) */
   editHint?: string;
   /**
-   * Env-only: list of KEY names defined in the env file (no values).
+   * Env-only: list of KEY names defined in the env file (no values, no
+   * comment text — comments can contain commented-out credentials).
    * Populated by the `env-file` renderer; never set for any other type.
    */
   keys?: string[];
-  /**
-   * Env-only: start-of-line `#` comment lines from the env file (with the
-   * leading `#` stripped). Inline/trailing comments are deliberately omitted.
-   */
-  comments?: string[];
   related?: {
     total: number;
     hits: Array<{ ref?: string; path: string; type: string; sharedEntities: string[]; relationCount: number }>;

--- a/tests/commands/consolidate/consolidate-wave2-e.test.ts
+++ b/tests/commands/consolidate/consolidate-wave2-e.test.ts
@@ -5,14 +5,10 @@
  * #7  — `akm show` JSON shape always includes path + editable.
  * #20 — `akm remember --description` persisted in frontmatter.
  * #28 — `registry search --detail brief` projects name + installRef + score.
- * #35 — Vault list returns entries:[{key,comment}] instead of parallel arrays.
+ * #35 — (deleted) vault listEntries was removed with the env comment-leak fix.
  */
 
 import { describe, expect, test } from "bun:test";
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import { listEntries } from "../../../src/commands/env/env";
 import { buildMemoryFrontmatter } from "../../../src/commands/remember";
 import { shapeSearchHit, shapeShowOutput } from "../../../src/output/shapes";
 
@@ -144,56 +140,9 @@ describe("buildMemoryFrontmatter — description field (#20)", () => {
   });
 });
 
-// ── #35: vault metadata entries shape ────────────────────────────────────────
-
-describe("vault listEntries — entries shape (#35)", () => {
-  function makeTmpVault(content: string): string {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-vault-test-"));
-    const vaultPath = path.join(tmpDir, "test.env");
-    fs.writeFileSync(vaultPath, content);
-    return vaultPath;
-  }
-
-  test("returns empty array for nonexistent vault", () => {
-    const result = listEntries("/tmp/nonexistent-vault-file-xyz.env");
-    expect(result).toEqual([]);
-  });
-
-  test("returns keys without comments for uncommented vault", () => {
-    const vaultPath = makeTmpVault("DB_URL=postgres://localhost\nAPI_KEY=secret\n");
-    const entries = listEntries(vaultPath);
-    expect(entries.map((e) => e.key)).toEqual(["DB_URL", "API_KEY"]);
-    expect(entries.every((e) => e.comment === undefined)).toBe(true);
-  });
-
-  test("associates comment with the following key", () => {
-    const vaultPath = makeTmpVault("# Database connection URL\nDB_URL=postgres://localhost\n");
-    const entries = listEntries(vaultPath);
-    expect(entries).toHaveLength(1);
-    expect(entries[0].key).toBe("DB_URL");
-    expect(entries[0].comment).toBe("Database connection URL");
-  });
-
-  test("returns {key, comment} shape", () => {
-    const vaultPath = makeTmpVault("# API key\nAPI_KEY=secret\n# DB\nDB_URL=pg://localhost\n");
-    const entries = listEntries(vaultPath);
-    expect(entries).toHaveLength(2);
-    expect(entries[0]).toMatchObject({ key: "API_KEY", comment: "API key" });
-    expect(entries[1]).toMatchObject({ key: "DB_URL", comment: "DB" });
-  });
-
-  test("duplicate keys: only first occurrence kept", () => {
-    const vaultPath = makeTmpVault("DB_URL=first\nDB_URL=second\n");
-    const entries = listEntries(vaultPath);
-    expect(entries.map((e) => e.key)).toEqual(["DB_URL"]);
-  });
-
-  test("entry has no comment field when there's no preceding comment", () => {
-    const vaultPath = makeTmpVault("API_KEY=abc\n");
-    const entries = listEntries(vaultPath);
-    expect(entries[0].comment).toBeUndefined();
-  });
-});
+// #35's listEntries ({key, comment} pairs) was DELETED with the env
+// comment-leak fix: comment text can contain commented-out credentials and no
+// production code consumed it. Key-name listing is covered by tests/env.test.ts.
 
 // ── #2: info sourceProviders from stashDir ────────────────────────────────────
 

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -55,7 +55,7 @@ async function runCli(
 // ── listKeys ────────────────────────────────────────────────────────────────
 
 describe("listKeys", () => {
-  test("returns keys + comments only, no values", () => {
+  test("returns key names only — no values, no comment text", () => {
     const dir = tmpDir();
     const fp = path.join(dir, "v.env");
     fs.writeFileSync(
@@ -66,26 +66,31 @@ describe("listKeys", () => {
     );
     const result = listKeys(fp);
     expect(result.keys).toEqual(["DB_URL", "API_TOKEN"]);
-    expect(result.comments).toEqual(["top comment", "bottom comment"]);
-    expect(Object.keys(result).sort()).toEqual(["comments", "keys"]);
+    expect(Object.keys(result)).toEqual(["keys"]);
+    const json = JSON.stringify(result);
+    expect(json).not.toContain("secret-value-do-not-leak");
+    expect(json).not.toContain("top comment");
+    expect(json).not.toContain("bottom comment");
   });
 
-  test("captures only start-of-line comments, never trailing/inline", () => {
+  test("comment text is never extracted — commented-out credentials stay private", () => {
     const dir = tmpDir();
     const fp = path.join(dir, "v.env");
     fs.writeFileSync(
       fp,
       [
-        "# header comment",
-        "  # indented comment",
+        "# OLD_GITEA_TOKEN=zqxcommentedoutcredential",
+        "  # webhook: https://hooks.example.com/services/zqxfreetexttoken",
         "FOO=bar # trailing-comment-not-extracted",
         "BAZ=qux",
-        "# footer comment",
       ].join("\n"),
     );
     const result = listKeys(fp);
-    expect(result.comments).toEqual(["header comment", "indented comment", "footer comment"]);
-    expect(result.comments.join(" ")).not.toContain("trailing-comment-not-extracted");
+    expect(result.keys).toEqual(["FOO", "BAZ"]);
+    const json = JSON.stringify(result);
+    expect(json).not.toContain("zqxcommentedoutcredential");
+    expect(json).not.toContain("zqxfreetexttoken");
+    expect(json).not.toContain("trailing-comment-not-extracted");
   });
 
   test("preserves key order and de-duplicates", () => {
@@ -104,7 +109,7 @@ describe("listKeys", () => {
 
   test("returns empty result for missing file", () => {
     const result = listKeys(path.join(tmpDir(), "missing.env"));
-    expect(result).toEqual({ keys: [], comments: [] });
+    expect(result).toEqual({ keys: [] });
   });
 });
 
@@ -267,8 +272,10 @@ describe("env indexer safety", () => {
       envPath,
       [
         "# Production secrets",
+        "# OLD_TOKEN=zqxoldcredleak",
         `SECRET_TOKEN=${SECRET_VALUE}`,
         "DB_PASSWORD=another-secret-pa55w0rd",
+        "# hook: https://hooks.example.com/services/zqxcommentleak",
         "# Last rotated 2026-04-01",
       ].join("\n"),
     );
@@ -290,27 +297,39 @@ describe("env indexer safety", () => {
       expect(envEntry.entry.searchHints).toContain("SECRET_TOKEN");
       expect(envEntry.entry.searchHints).toContain("DB_PASSWORD");
 
-      // 3. Comments are surfaced in the description
-      expect(envEntry.entry.description).toContain("Production secrets");
+      // 3. CRITICAL: comment text is never surfaced — comments carry
+      // commented-out credentials and free-text secrets
+      expect(envEntry.entry.description ?? "").not.toContain("Production secrets");
 
-      // 4. CRITICAL: the secret value is nowhere in the persisted record
+      // 4. CRITICAL: neither values NOR comment text are anywhere in the
+      // persisted record
       const json = JSON.stringify(envEntry);
       expect(json).not.toContain(SECRET_VALUE);
       expect(json).not.toContain("another-secret-pa55w0rd");
+      expect(json).not.toContain("zqxoldcredleak");
+      expect(json).not.toContain("zqxcommentleak");
+      expect(json).not.toContain("Production secrets");
 
-      // 5. CRITICAL: the secret value is not in entries.search_text
+      // 5. CRITICAL: neither values nor comment text are in entries.search_text
       type Row = { search_text: string | null; entry_json: string };
       const rows = db.prepare("SELECT search_text, entry_json FROM entries WHERE entry_type = ?").all("env") as Row[];
       expect(rows.length).toBe(1);
-      expect(rows[0].search_text ?? "").not.toContain(SECRET_VALUE);
+      const searchText = rows[0].search_text ?? "";
+      expect(searchText).not.toContain(SECRET_VALUE);
+      expect(searchText).not.toContain("zqxoldcredleak");
+      expect(searchText).not.toContain("zqxcommentleak");
       expect(rows[0].entry_json).not.toContain(SECRET_VALUE);
+      expect(rows[0].entry_json).not.toContain("zqxoldcredleak");
+      expect(rows[0].entry_json).not.toContain("zqxcommentleak");
 
-      // 6. CRITICAL: the secret value cannot be retrieved via FTS5 search
+      // 6. CRITICAL: neither values nor comment text can be retrieved via FTS5
       type FtsRow = { c: number };
-      const ftsHit = db
-        .prepare("SELECT count(*) AS c FROM entries_fts WHERE entries_fts MATCH ?")
-        .get("correct") as FtsRow;
-      expect(ftsHit.c).toBe(0);
+      for (const term of ["correct", "zqxoldcredleak", "zqxcommentleak"]) {
+        const ftsHit = db
+          .prepare("SELECT count(*) AS c FROM entries_fts WHERE entries_fts MATCH ?")
+          .get(term) as FtsRow;
+        expect(ftsHit.c).toBe(0);
+      }
     } finally {
       closeDatabase(db);
     }


### PR DESCRIPTION
## Problem

Real `.env` files routinely contain commented-out `KEY=value` lines and free-text notes with live tokens or webhook URLs. The env pipeline treated start-of-line comments as safe discoverability metadata and published them into:

- the search index — `applyEnvMetadata` set `entry.description` from comment text, which flows into `search_text` and FTS (surfaced by `akm search`, truncated at 250 chars)
- the uncapped `akm show` response — `buildShowResponse` returned a `comments[]` field plus a comment-derived `description`
- the `--shape agent`/`summary`/default projections

So any credential sitting in a comment became retrievable by any agent via `akm search` / `akm show` — violating the env module's own invariant that nothing sensitive leaves the file. A filter on assignment-shaped comments would **not** close this: free-text comments (e.g. a pasted webhook URL) leak too. The only safe policy is to treat comment text exactly like values.

## Fix (net −96 LOC)

- `listKeys` returns `{ keys }` only; `scanComments` deleted
- `listEntries` deleted — a `{key, comment}` pairing API with zero production callers
- env renderer: show response is key names only; no `comments` field, no comment-derived `description`; `ShowResponse.comments` removed from the type
- `applyEnvMetadata`: `searchHints` from key names only — nothing comment-derived reaches `description`/`search_text`
- shapes: `comments` dropped from all projections
- `docs/cli.md` + module headers updated to state the new invariant

## Tests

- The env indexer-safety test now writes commented-out credentials and a free-text token URL into the fixture and proves they reach neither `entry_json`, `search_text`, nor FTS
- `listKeys` tests assert comment text never escapes the module
- Gates: biome + custom lints 0 warnings, `tsc --noEmit` clean, 4,966 unit + 108 env/secret/e2e integration tests passing

## Upgrade note

Existing indexes still hold previously-harvested comment text: **reindex after upgrading** (`akm index --full`), and rotate any credential that was ever present in an env-file comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YjU1mGiShdDP4qFW7p4mv