### PR TITLE
fix(indexer): harden read bootstrap and writer lock

### DIFF
--- a/docs/analysis/indexer-refactor-expert-options.md
+++ b/docs/analysis/indexer-refactor-expert-options.md
@@ -1,0 +1,277 @@
+# Indexer Refactor Review (Expert Options)
+
+Date: 2026-07-03
+
+Scope reviewed (callers + indexer paths):
+- `src/indexer/indexer.ts`
+- `src/indexer/ensure-index.ts`
+- `src/indexer/index-written-assets.ts`
+- `src/indexer/index-writer-lock.ts`
+- `src/indexer/walk/walker.ts`
+- `src/indexer/passes/*`, `src/indexer/db/*`, `src/indexer/graph/*`
+- `src/indexer/search/db-search.ts`
+- callers in `src/commands/read/show.ts`, `src/commands/read/search.ts`,
+  `src/commands/improve/improve.ts`, `src/commands/sources/*.ts`, `src/commands/wiki-cli.ts`,
+  `src/commands/workflow-cli.ts`
+
+## Why this review was needed
+
+The current pipeline is already better than earlier versions (bounded lock wait,
+cleaner write-path behavior, reduced recursion risk), but it remains tightly coupled:
+- orchestration and persistence responsibilities are concentrated in `indexer.ts`
+- read bootstrap, explicit full/indexed writes, and improve maintenance are
+  coordinated in separate call sites
+- write/read/maintenance paths share many mutable concerns (lock ownership,
+  run policy, staleness semantics, DB transaction scope)
+
+The team reviewed this for clean architecture, testability, and data/process
+separation opportunities.
+
+## Validity review summary
+
+These options are valid only if they preserve the existing AKM architectural
+constraints:
+- the indexer remains the reader of source directories (`v1-architecture-spec.md`)
+- sources/providers do not gain search/show responsibilities
+- the search-facing index remains rebuildable/ephemeral
+- read bootstrap semantics in `ensureIndex(...)` remain unchanged unless
+  intentionally and explicitly revised
+
+One correction from validation:
+- graph extraction is **not** currently part of the main `akmIndex()` phase
+  sequence. It runs from improve-maintenance/manual graph paths today. Any plan
+  that folds graph into the main indexing lifecycle is a deliberate behavior
+  change, not just an internal refactor.
+
+## Top 3 solutions
+
+### 1) **Index Runner Domain Service with explicit plans** *(Recommended)*
+
+#### Design
+- Introduce `src/indexer/service/index-runner.ts` (or `.../index-service.ts`) as a thin
+  orchestration façade.
+- Keep existing `ensureIndex(...)` and `akmIndex(...)` APIs, but route all
+  pathways through a shared `IndexPlan` abstraction:
+  - `ReadBootstrapPlan`: no stale rebuild on read, only bootstraps when unreadable
+  - `IndexedFullRebuildPlan`: explicit full passes with deterministic phase ordering
+  - `IncrementalRebuildPlan`: stale-skip policy + dir-state reconciliation
+  - `WriteUpsertPlan`: single-asset upserts delegated from `indexWrittenAssets`
+- Extract pass interfaces with narrow inputs/outputs:
+  - `WalkPlanner`, `LlmEnrichmentPass`, `EmbeddingPass`, `FtsPass`, `VerifyPass`
+  - each writes through typed repository contracts instead of calling DB helpers
+    directly.
+- Add `IndexRunContext` factory + immutable event collector for phase timings/results
+  (`IndexProgressEvent` becomes test fixture friendly).
+
+#### Why this is strongest
+- The heaviest code is still in the same place initially; no major behavior shift.
+- Greatly improves testability: each phase can be unit-tested with in-memory repositories.
+- Preserves legacy read contract and command output contract while making future
+  migrations tractable.
+
+#### TL;DR pros
+- Lowest blast radius for a real architecture improvement.
+- Aligns with clean architecture (ports/adapters) without changing runtime semantics.
+- Makes correctness regressions much easier to test in isolation.
+- Enables future phase-level opt-in/out by caller.
+
+#### TL;DR cons
+- Requires moving and renaming several helper modules first.
+- Initial churn in typing/tests due to larger seams.
+- Not a pure “delete-only” pass; behavior must be carefully parity-checked against
+  legacy logs/timings.
+
+---
+
+### 2) **Separate write-path indexing from maintenance indexing via run ledger and deferred heavy passes** *(Pragmatic performance path)*
+
+#### Design
+- Keep `indexWrittenAssets(...)` as the immediate write path, but add an explicit
+  `index_runs`/`index_run_steps` ledger (in the same DB initially).
+- `runMaintainIndexPlan` becomes explicit and resumable:
+  - `walk -> llm -> embeddings -> fts -> verify`
+  - graph remains a separate maintenance/manual plan unless AKM intentionally
+    changes that contract
+  - heavy phases (LLM/embedding/graph) can be re-queued with bounded retries
+    instead of being implicitly coupled to every command path.
+- Introduce event-driven scheduling hook in `improve` maintenance path and a light
+  CLI/API trigger to start deferred maintenance.
+- Keep DB path unchanged for now; move to sibling DB files only if lock contention
+  or write amplification remains high after baseline measurements.
+
+#### Why this is strong
+- Preserves fast writes while making eventual consistency explicit instead of implicit.
+- Lets `search/show` continue to serve stale-but-indexable data, while background
+  maintenance catches up with richer passes.
+- Good stepping stone before heavier process split; easy rollback by disabling queue
+  drain only for heavy stages.
+
+#### TL;DR pros
+- Highest immediate ROI for operational resilience (fewer long write-side surprises).
+- Introduces observability and resumability (`run ledger`) with moderate code churn.
+- Compatible with current command calls and contracts.
+
+#### TL;DR cons
+- Behavioral model shifts from “monolithic one-shot run” to “queued maintenance plan.”
+- Requires careful docs/UX for users if they expect embedding/graph updates
+  immediately after mutation.
+- Needs policy around stale warning thresholds and stale-file cleanup cadence.
+- The run ledger must stay ephemeral/rebuildable or be clearly separated from
+  durable state; otherwise it fights the existing `index.db` contract.
+
+---
+
+### 3) **Split process and data planes for heavy domains (Graph + LLM + Embedding workers)** *(Longer-term architecture path)*
+
+#### Design
+- Keep read-facing search/index DB for hot paths (`entries`, `entries_fts`).
+- Move expensive asynchronous domains behind bounded worker executors:
+  - Graph extraction worker + domain table store (`graph_nodes`, `graph_edges`,
+    `graph_file_entities`) in a dedicated SQLite DB file or separate attached db.
+  - Embedding generation worker can remain local-threaded but isolated through a
+    stable queue contract.
+- Add cross-domain synchronization contract in `index-run` metadata: pass result,
+  version, completion state, last-success timestamp.
+- `show/search/read` read graph/embedding-annotated payloads via optional joins,
+  with fallback if worker domains are stale.
+
+#### Why this is strong
+- Best scale path if indexing dominates runtime or LLM calls are unstable.
+- Reduces lock pressure on the central index DB and avoids interleaving long
+  writer runs with search-read telemetry.
+- Supports future migration to externalized services without changing CLI/API.
+
+#### TL;DR pros
+- Strong isolation of heavy compute.
+- Better failure isolation: one worker can fail/restart without blocking all phases.
+- Clear path to incremental processing and distributed scheduling later.
+
+#### TL;DR cons
+- Highest implementation complexity.
+- Significant compatibility/rollback surface: multiple write locations and sync
+  points.
+- Risk of cross-domain drift unless each run has strict versioning and
+  reconciliation logic.
+- Not justified yet without measured evidence that Option 1/2 cannot solve the
+  real bottlenecks.
+
+## Recommendation from debate
+
+All experts converged on **Option 1 first** because it is the best balance of
+architectural clarity and low risk. Option 2 is a very good follow-up if lock time,
+queue pressure, or maintenance latency is still painful after phase extraction.
+
+Option 3 is suitable when AKM needs scale/availability improvements beyond what
+in-process refactors can deliver.
+
+## Suggested migration order
+1. Add domain service + pass interfaces (Option 1), keep existing DB layout.
+2. Add minimal run ledger + resumable maintenance path (Option 2).
+3. Re-evaluate contention and correctness with measurements before splitting DBs/
+   processes (Option 3).
+
+## Refactor plan
+
+The detailed implementation plan also lives in:
+- `docs/analysis/indexer-vertical-slice-refactor-plan.md`
+
+The recommended execution plan is to refactor into reusable vertical slices and
+compose them into a small set of top-level processes.
+
+### Target slices
+
+- Source Sync Slice
+  - materialize provider caches and resolve source entries
+- Walk Slice
+  - enumerate files and directory groups with shared skip policy
+- Metadata Slice
+  - derive canonical `StashEntry` values and merge compatibility overrides
+- Index State Slice
+  - own incremental staleness/fingerprint decisions and `index_dir_state`
+- Entries Slice
+  - persist entries and workflow side-table rows
+- Enrichment Slice
+  - own LLM metadata enrichment and its cache
+- Embeddings Slice
+  - own embedding generation/storage policy
+- FTS Slice
+  - own full vs incremental FTS refresh
+- Verification Slice
+  - own post-index verification/status result assembly
+- Semantic Status Slice
+  - own `semantic-status.json` updates
+- Search Maintenance Slice
+  - own usage-event relinking and utility-score recomputation
+- Wiki Maintenance Slice
+  - own wiki index regeneration
+
+### Top-level composed processes
+
+- `run-index`
+  - explicit full/incremental index build
+- `ensure-read-index`
+  - read bootstrap only when the existing index cannot serve the stash
+- `upsert-written-assets`
+  - fast fail-open write-path index visibility
+- `run-index-maintenance`
+  - optional maintenance-only composition for scheduled/operator flows
+- improve-owned maintenance processes
+  - memory inference
+  - graph extraction
+  - staleness detection
+  - optional future metadata-enrichment catch-up
+
+### Ownership decisions
+
+- Keep metadata enrichment in the main index process.
+- Make enrichment reusable so improve can optionally run catch-up enrichment later.
+- Keep graph extraction separate from the main `akmIndex()` contract for now.
+- Move wiki and search-maintenance side effects out of `indexer.ts` into their
+  owning domains.
+
+### Recommended implementation order
+
+1. Extract orchestration seams without behavior change:
+   - `run-index`
+   - `ensure-read-index`
+   - `upsert-written-assets`
+2. Extract core slices first:
+   - Walk
+   - Index State
+   - Entries
+   - Metadata
+   - FTS
+3. Extract LLM/semantic slices:
+   - Enrichment
+   - Embeddings
+   - Verification
+   - Semantic Status
+4. Move adjacent side effects out of indexer:
+   - Search Maintenance
+   - Wiki Maintenance
+5. Add optional shared maintenance compositions:
+   - `run-index-maintenance`
+   - optional improve-side enrichment catch-up
+
+### Testing plan
+
+- Unit tests per slice
+  - walk, staleness, metadata merge, enrichment cache/budget, entry persistence,
+    FTS mode selection
+- Contract tests per process
+  - read bootstrap semantics
+  - full vs incremental index behavior
+  - fail-open write-path indexing
+  - improve maintenance ordering around post-write reindex needs
+- Integration tests
+  - source add -> index -> search/show
+  - write path -> targeted upsert -> search visibility
+  - improve maintenance -> memory inference -> reindex -> graph extraction
+
+## Minimal acceptance criteria
+- No semantic change to read bootstrap contract in `ensureIndex(...)` and search/show behavior.
+- Existing lock semantics remain preserved (`index-writer-lock.ts` wait/try behavior + timeout).
+- All existing index tests continue to pass, plus new unit tests for:
+  - plan creation and phase ordering
+  - stale/read contract in `ensure-index.ts`
+  - write-path queue interactions and run-ledger transitions

--- a/docs/analysis/indexer-vertical-slice-refactor-plan.md
+++ b/docs/analysis/indexer-vertical-slice-refactor-plan.md
@@ -96,6 +96,12 @@ src/wiki/processes/
 This keeps the index domain focused while moving side effects to their owning
 domains.
 
+Note: read-side source resolution and read bootstrap already live in
+`src/indexer/read-preflight.ts` (`resolveReadSources`, `ensurePrimaryIndexForRead`,
+`ensurePrimaryIndexFromConfig`), added alongside this plan. The proposed
+`ensure-read-index.ts` process is a consolidation/rename of that existing code,
+not a greenfield module — see Process B below.
+
 ## Vertical slices
 
 ### 1. Source Sync Slice
@@ -117,8 +123,13 @@ Primary callers:
 - `run-index-maintenance`
 
 Initial extraction targets:
-- source cache setup currently in `src/indexer/indexer.ts`
-- shared source resolution currently duplicated around read/index/improve entry points
+- source cache hydration: `ensureSourceCaches(...)` (implemented in
+  `src/indexer/search/search-source.ts`) is called from `akmIndex` in
+  `src/indexer/indexer.ts`; removed-source purging lives in `runSourceCachePhase`
+  there
+- the shared `resolveSourceEntries(...)` resolver (also in `search-source.ts`),
+  currently called from scattered read/index entry points (`akmIndex`, `lookup`,
+  and `resolveReadSources` in `read-preflight.ts`)
 
 ### 2. Walk Slice
 
@@ -364,9 +375,16 @@ Migration note:
 Current responsibility:
 - bootstrap the index only when it cannot serve the stash
 
+Already partially implemented today in `src/indexer/read-preflight.ts`
+(`ensurePrimaryIndexForRead` → `ensureIndex(...)` in default `background` mode)
+and `src/indexer/ensure-index.ts` (`ensureIndex`, whose default path calls
+`indexCanServeStash(...)` and only rebuilds inline when the index cannot serve
+the stash; `mode: "blocking"` instead gates on `isIndexStale(...)`). This process
+should absorb that existing code rather than reimplement it.
+
 Composed slices:
-1. Readability/serveability check
-2. optional `run-index` invocation in bootstrap case
+1. Readability/serveability check (`indexCanServeStash` / `isIndexStale`)
+2. optional `run-index` invocation in bootstrap case (`runInlineReindex` → `akmIndex`)
 
 Important rule:
 - this remains an orchestration/policy process, not a place where indexing logic
@@ -552,8 +570,10 @@ Success criteria:
 
 Start here:
 1. Extract `run-index` orchestration from `src/indexer/indexer.ts`
-2. Extract `ensure-read-index` around `ensureIndex(...)`
+2. Consolidate `ensure-read-index` from the existing `src/indexer/read-preflight.ts`
+   + `src/indexer/ensure-index.ts` (`ensureIndex`) rather than building it new
 3. Extract `upsert-written-assets` process wrapper around `indexWrittenAssets(...)`
+   (already implemented in `src/indexer/index-written-assets.ts`)
 4. Extract Walk + Index State + Entries slices
 
 This gives the best architecture gain with the least behavioral risk.

--- a/docs/analysis/indexer-vertical-slice-refactor-plan.md
+++ b/docs/analysis/indexer-vertical-slice-refactor-plan.md
@@ -1,0 +1,578 @@
+# Indexer Vertical Slice Refactor Plan
+
+Date: 2026-07-03
+
+## Goal
+
+Refactor indexing and related maintenance flows into clean vertical slices that:
+- have one clear responsibility each
+- can be reused from multiple higher-level processes
+- are composable into larger workflows without hidden coupling
+- are easy to unit test and integration test
+- preserve current AKM contracts unless explicitly called out
+
+## Non-negotiable constraints
+
+These constraints come from the current code and architecture docs and should not
+change during this refactor:
+
+- The indexer remains the reader of source directories.
+- Providers do not gain `search` or `show` behavior.
+- `index.db` remains rebuildable/ephemeral.
+- `ensureIndex(...)` keeps its current read-bootstrap semantics.
+- `indexWrittenAssets(...)` remains a fast, fail-open write path.
+- Graph extraction remains separate from the main `akmIndex()` pipeline unless
+  explicitly promoted as a product-level behavior change.
+
+## Current problems
+
+- `src/indexer/indexer.ts` still mixes planning, orchestration, persistence,
+  progress, policy, and adjacent-domain side effects.
+- `ensureIndex(...)`, `akmIndex(...)`, `indexWrittenAssets(...)`, improve
+  maintenance, and manual graph refresh all coordinate related behavior through
+  separate paths.
+- Several concerns that are not truly “index building” are piggybacking on the
+  index run:
+  - wiki index regeneration
+  - usage-event relinking
+  - utility-score recomputation
+  - stale cache cleanup
+- LLM-driven processes exist in two mental models today:
+  - index-time metadata enrichment
+  - improve-time maintenance passes
+- Test seams are still too coarse. Many behaviors can only be validated through
+  broad integration tests instead of focused unit-level tests.
+
+## Target architecture
+
+Use plain function-based vertical slices with thin ports, not a framework.
+
+Each slice should have:
+- one public entry point
+- one small context object
+- explicit input/output types
+- no hidden singleton state beyond existing config/runtime boundaries
+- its own tests
+
+Recommended shape:
+
+```text
+src/indexer/
+  processes/
+    run-index.ts
+    ensure-read-index.ts
+    upsert-written-assets.ts
+    run-index-maintenance.ts
+  slices/
+    source-sync/
+    walk/
+    metadata/
+    entries/
+    enrichment/
+    embeddings/
+    fts/
+    verification/
+    semantic-status/
+    index-state/
+  coordination/
+    index-run-plan.ts
+    index-run-lock.ts
+    process-types.ts
+
+src/commands/improve/processes/
+  run-memory-inference.ts
+  run-graph-extraction.ts
+  run-staleness-detection.ts
+  run-metadata-enrichment-catchup.ts   # optional later
+
+src/search-maintenance/
+  relink-usage-events.ts
+  recompute-utility-scores.ts
+
+src/wiki/processes/
+  regenerate-wiki-indexes.ts
+```
+
+This keeps the index domain focused while moving side effects to their owning
+domains.
+
+## Vertical slices
+
+### 1. Source Sync Slice
+
+Purpose:
+- materialize provider caches before indexing starts
+- resolve ordered source entries
+
+Owns:
+- source cache refresh policy
+- source list resolution for the current run
+
+Does not own:
+- file walking
+- indexing policy
+
+Primary callers:
+- `run-index`
+- `run-index-maintenance`
+
+Initial extraction targets:
+- source cache setup currently in `src/indexer/indexer.ts`
+- shared source resolution currently duplicated around read/index/improve entry points
+
+### 2. Walk Slice
+
+Purpose:
+- enumerate relevant files from source roots
+- group by directory where needed
+- expose stable walk outputs to downstream slices
+
+Owns:
+- git/manual walk selection
+- skip-directory policy
+- iterative walking behavior
+
+Does not own:
+- metadata generation
+- DB staleness decisions
+
+Primary callers:
+- `run-index`
+- graph extraction
+- memory inference where file enumeration is needed
+
+### 3. Metadata Slice
+
+Purpose:
+- derive asset metadata from files
+- merge compatibility overrides
+- produce canonical `StashEntry` values
+
+Owns:
+- metadata derivation rules
+- `.stash.json` compatibility merge behavior
+- warning generation for malformed assets
+
+Does not own:
+- persistence
+- run planning
+
+Primary callers:
+- `run-index`
+- `upsert-written-assets`
+- any future improve enrichment catch-up pass
+
+### 4. Index State Slice
+
+Purpose:
+- determine whether directories/files are stale enough to reprocess
+- maintain `index_dir_state`
+- expose pure planning decisions for incremental runs
+
+Owns:
+- fingerprinting
+- incremental skip eligibility
+- zero-row cache semantics
+
+Does not own:
+- walking
+- persistence of entries themselves
+
+Primary callers:
+- `run-index`
+- `ensure-read-index` in blocking mode
+
+### 5. Entries Slice
+
+Purpose:
+- persist canonical entry rows and workflow side-table rows
+- delete/rewrite affected rows for a directory or targeted file set
+
+Owns:
+- `entries` writes
+- workflow document writes
+- cross-source dedupe policy at write time
+
+Does not own:
+- search field composition rules beyond consuming them
+- FTS rebuilds
+- embeddings
+
+Primary callers:
+- `run-index`
+- `upsert-written-assets`
+
+### 6. Enrichment Slice
+
+Purpose:
+- enrich generated metadata via LLM
+- use enrichment cache
+- merge successful enriched values back into entry persistence
+
+Owns:
+- enrichment budget policy
+- cache lookup/store policy
+- “already enriched” skip logic
+
+Does not own:
+- whether enrichment is triggered by index or improve
+
+Primary callers:
+- `run-index` as the current default behavior
+- optional future `run-metadata-enrichment-catchup`
+
+Important decision:
+- Keep this slice reusable.
+- Keep index-time enrichment in `run-index` for now.
+- Later add improve-side catch-up composition if needed, but do not make improve
+  the sole owner of enrichment.
+
+### 7. Embeddings Slice
+
+Purpose:
+- compute/store embeddings
+- manage vec availability and embedding verification inputs
+
+Owns:
+- embeddable-entry collection
+- embedding upsert policy
+- embedding store cleanup for stale entries
+
+Does not own:
+- search ranking behavior
+- semantic status file writes
+
+Primary callers:
+- `run-index`
+- optional future maintenance catch-up process
+
+### 8. FTS Slice
+
+Purpose:
+- rebuild FTS from dirty/all rows
+- own the contract for incremental vs full FTS maintenance
+
+Owns:
+- FTS refresh behavior
+
+Does not own:
+- entry persistence
+- search query logic
+
+Primary callers:
+- `run-index`
+- `upsert-written-assets`
+
+### 9. Verification Slice
+
+Purpose:
+- verify post-run search/semantic readiness
+- assemble verification result for callers
+
+Owns:
+- verification result construction
+- operator-facing status guidance
+
+Does not own:
+- embeddings themselves
+- search execution
+
+Primary callers:
+- `run-index`
+
+### 10. Semantic Status Slice
+
+Purpose:
+- own `semantic-status.json` updates/clears
+
+Owns:
+- semantic provider fingerprint status writes
+- semantic status clear/write rules
+
+Does not own:
+- embedding generation
+
+Primary callers:
+- `run-index`
+- possibly explicit semantic-maintenance tools later
+
+### 11. Search Maintenance Slice
+
+Purpose:
+- maintain search-adjacent derived state that is not core entry indexing
+
+Owns:
+- usage event relinking
+- utility-score recomputation
+
+Does not own:
+- entry indexing
+
+Primary callers:
+- `run-index`
+- maybe future explicit maintenance tasks
+
+Reason to move out of `indexer.ts`:
+- these are search-maintenance concerns, not file-to-entry indexing concerns
+
+### 12. Wiki Maintenance Slice
+
+Purpose:
+- regenerate wiki root indexes from indexed pages
+
+Owns:
+- wiki-specific maintenance behavior
+
+Does not own:
+- indexing process lifecycle
+
+Primary callers:
+- wiki domain processes
+- optionally `run-index` via an explicit post-index hook during migration
+
+Reason to move out of `indexer.ts`:
+- this is clearly a wiki-domain concern
+
+## Process composition
+
+These are the larger processes built by composing slices.
+
+### A. `run-index`
+
+Current responsibility:
+- explicit full/incremental indexing
+
+Composed slices:
+1. Source Sync Slice
+2. Walk Slice
+3. Metadata Slice
+4. Index State Slice
+5. Entries Slice
+6. Enrichment Slice
+7. Embeddings Slice
+8. FTS Slice
+9. Search Maintenance Slice
+10. Semantic Status Slice
+11. Verification Slice
+
+Migration note:
+- wiki maintenance can remain an explicit temporary post-hook until moved fully
+  into its own domain process
+
+### B. `ensure-read-index`
+
+Current responsibility:
+- bootstrap the index only when it cannot serve the stash
+
+Composed slices:
+1. Readability/serveability check
+2. optional `run-index` invocation in bootstrap case
+
+Important rule:
+- this remains an orchestration/policy process, not a place where indexing logic
+  reappears
+
+### C. `upsert-written-assets`
+
+Current responsibility:
+- fast write-path index visibility for newly written assets
+
+Composed slices:
+1. Metadata Slice
+2. Entries Slice
+3. FTS Slice
+
+Important rule:
+- keep fail-open behavior
+- do not silently absorb unrelated maintenance responsibilities
+
+### D. `run-index-maintenance`
+
+Purpose:
+- central reusable maintenance composition for scheduled or operator-invoked work
+
+Composed slices:
+- Search Maintenance Slice
+- optional Embeddings catch-up
+- optional Enrichment catch-up
+- optional verification-only health pass
+
+Important rule:
+- this is not the same as `run-index`
+- it should operate on already indexed content, not replace file-to-entry indexing
+
+### E. Improve processes
+
+Keep these as separate improve-owned processes:
+- memory inference
+- graph extraction
+- staleness detection
+
+Possible future addition:
+- metadata enrichment catch-up
+
+Do not move into improve:
+- walk/classify
+- entry persistence as the primary source of truth
+- FTS rebuild as the main index contract
+- index verification as the only semantic readiness path
+
+## Shared process contract
+
+Use a small plain-object convention instead of a class framework.
+
+Suggested shape:
+
+```ts
+type ProcessResult<T> = {
+  ok: true;
+  value: T;
+  warnings?: string[];
+} | {
+  ok: false;
+  error: string;
+  warnings?: string[];
+};
+
+type ProcessStep<TContext> = {
+  name: string;
+  run: (context: TContext) => Promise<void>;
+};
+```
+
+Keep it simple:
+- one context object per top-level process
+- slice functions return explicit results, not mutate unrelated globals
+- mutations on context should be narrow and documented
+
+## Testing strategy
+
+### Unit tests per slice
+
+Each slice should have direct tests against small fixtures or mocked ports.
+
+Examples:
+- Walk Slice: skip rules, symlink behavior, git/manual parity
+- Index State Slice: unchanged vs stale vs zero-row cache decisions
+- Metadata Slice: override merge precedence, warning generation
+- Enrichment Slice: cache hit/miss, timeout budget, merge behavior
+- Entries Slice: dedupe, workflow side-table writes
+- FTS Slice: full vs incremental rebuild mode selection
+
+### Contract tests per process
+
+Keep or add process-level tests for:
+- `ensure-read-index` availability-first semantics
+- `run-index` full vs incremental behavior
+- `upsert-written-assets` fail-open and visibility semantics
+- improve maintenance ordering around reindex-after-memory-inference
+
+### Integration tests
+
+Retain end-to-end tests for:
+- source add -> index -> search/show
+- remember/write path -> targeted upsert -> search visibility
+- improve maintenance -> memory inference -> reindex -> graph extraction
+
+## Migration phases
+
+### Phase 1: Extract orchestration seams without behavior change
+
+Deliverables:
+- `run-index.ts`
+- `ensure-read-index.ts`
+- `upsert-written-assets.ts`
+- shared process/context types
+
+Moves:
+- take orchestration out of `src/indexer/indexer.ts`
+- keep existing DB helpers intact behind the new process files
+
+Success criteria:
+- existing tests pass unchanged or with minimal import updates
+
+### Phase 2: Extract core slices
+
+Deliverables:
+- Walk Slice
+- Metadata Slice
+- Index State Slice
+- Entries Slice
+- FTS Slice
+
+Moves:
+- shift concrete logic from `indexer.ts` into slice modules
+- leave current SQL helpers in place initially
+
+Success criteria:
+- new unit tests exist for each extracted slice
+- `run-index` becomes mostly composition code
+
+### Phase 3: Extract LLM and semantic slices
+
+Deliverables:
+- Enrichment Slice
+- Embeddings Slice
+- Verification Slice
+- Semantic Status Slice
+
+Moves:
+- isolate LLM-specific policy from the main index flow
+
+Success criteria:
+- can invoke enrichment as a reusable slice from both index and future improve maintenance
+
+### Phase 4: Move adjacent-domain side effects out of indexer
+
+Deliverables:
+- Search Maintenance Slice
+- Wiki Maintenance Slice
+
+Moves:
+- remove wiki regeneration and usage/utility maintenance logic from `indexer.ts`
+
+Success criteria:
+- index domain no longer owns wiki-side behavior
+- maintenance steps can be invoked independently
+
+### Phase 5: Add optional reusable maintenance processes
+
+Deliverables:
+- `run-index-maintenance.ts`
+- optional `run-metadata-enrichment-catchup.ts`
+
+Moves:
+- create shared reusable maintenance composition for scheduled tasks
+
+Success criteria:
+- improve can call shared slices instead of embedding custom maintenance logic
+- no behavior regression in normal `akm index` output/quality
+
+## Recommended first moves
+
+Start here:
+1. Extract `run-index` orchestration from `src/indexer/indexer.ts`
+2. Extract `ensure-read-index` around `ensureIndex(...)`
+3. Extract `upsert-written-assets` process wrapper around `indexWrittenAssets(...)`
+4. Extract Walk + Index State + Entries slices
+
+This gives the best architecture gain with the least behavioral risk.
+
+## Explicit recommendations
+
+- Keep index-time metadata enrichment in the main index process.
+- Make enrichment reusable so improve can optionally run a catch-up enrichment
+  process later.
+- Keep graph extraction in improve/manual maintenance for now.
+- Move wiki and search-maintenance side effects out of the indexer domain.
+- Avoid a class-heavy pipeline framework; use small typed functions and context
+  objects instead.
+
+## Definition of done
+
+The refactor is successful when:
+- top-level processes are short composition files
+- slices are independently unit testable
+- current read/write/index contracts are preserved
+- adjacent-domain side effects are no longer hidden inside `indexer.ts`
+- improve and index can reuse the same slices without copy-paste orchestration

--- a/src/commands/read/search.ts
+++ b/src/commands/read/search.ts
@@ -19,8 +19,8 @@ import { appendEvent } from "../../core/events";
 import { isTransientStashPath } from "../../core/paths";
 import { bumpUtilityScoresBatch, getEntryIdByFilePath } from "../../indexer/db/db";
 import type { StashEntryScope } from "../../indexer/passes/metadata";
+import { resolveReadSources } from "../../indexer/read-preflight";
 import { searchLocal } from "../../indexer/search/db-search";
-import { resolveSourceEntries } from "../../indexer/search/search-source";
 import { getCurrentWorkflowScopeKey } from "../../workflows/authoring/scope-key";
 // Eagerly import source providers to trigger self-registration before the
 // indexer or path-resolution code runs.
@@ -124,7 +124,7 @@ export async function akmSearch(input: {
     source = parsedSource as SearchSource;
   }
 
-  let allSources = resolveSourceEntries(undefined, config);
+  let allSources = resolveReadSources(undefined, config).sources;
 
   // When a named source was requested, narrow the sources list to just that entry.
   // `resolveSourceEntries` sets `registryId` to `entry.name` for each config source.

--- a/src/commands/read/show.ts
+++ b/src/commands/read/show.ts
@@ -30,11 +30,11 @@ import { NotFoundError, rethrowIfTestIsolationError, UsageError } from "../../co
 import { appendEvent, readEvents } from "../../core/events";
 import { closeDatabase, computeBodyHash, findEntryIdByRef, openExistingDatabase } from "../../indexer/db/db";
 import { hasGraphData } from "../../indexer/db/graph-db";
-import { ensureIndex } from "../../indexer/ensure-index";
 import { listRelatedPathsForFile } from "../../indexer/graph/graph-boost";
 import { extractGraphForSingleFile } from "../../indexer/graph/graph-extraction";
 import { lookup } from "../../indexer/indexer";
 import type { StashEntryScope } from "../../indexer/passes/metadata";
+import { ensurePrimaryIndexForRead, resolveReadSources } from "../../indexer/read-preflight";
 import { buildEditHint, findSourceForPath, isEditable, resolveSourceEntries } from "../../indexer/search/search-source";
 import { insertUsageEvent } from "../../indexer/usage/usage-events";
 import { buildFileContext, buildRenderContext, getRenderer, runMatchers } from "../../indexer/walk/file-context";
@@ -179,10 +179,8 @@ export async function akmShowUnified(input: {
   }
 
   // Auto-index when stale so the index is current before lookup.
-  const allSources = resolveSourceEntries();
-  if (allSources.length > 0) {
-    await ensureIndex(allSources[0].path);
-  }
+  const { primarySource } = resolveReadSources();
+  await ensurePrimaryIndexForRead(primarySource);
 
   // Try local filesystem (FTS5 index lookup)
   const result = await showLocal(input);

--- a/src/indexer/ensure-index.ts
+++ b/src/indexer/ensure-index.ts
@@ -179,7 +179,7 @@ async function runInlineReindex(stashDir: string): Promise<boolean> {
     return true;
   } catch (error) {
     warn("Auto-index failed, proceeding with existing index:", error instanceof Error ? error.message : String(error));
-    return true;
+    return false;
   }
 }
 
@@ -195,7 +195,8 @@ async function runInlineReindex(stashDir: string): Promise<boolean> {
  * trigger and waits for it. Use this for callers like `improve` whose
  * planning logic depends on a current `entries` table in the same process.
  *
- * Returns `true` if an index run was attempted.
+ * Returns `true` only when an inline index run succeeds.
+ * A rebuild attempt that fails (throws) resolves to `false`.
  */
 export async function ensureIndex(stashDir: string, options: EnsureIndexOptions = {}): Promise<boolean> {
   if (options.mode === "blocking") {

--- a/src/indexer/index-writer-lock.ts
+++ b/src/indexer/index-writer-lock.ts
@@ -9,6 +9,7 @@ import { getDbPath, getIndexWriterLockPath } from "../core/paths";
 
 const INDEX_WRITER_LOCK_STALE_AFTER_MS = 12 * 60 * 60 * 1000;
 const INDEX_WRITER_WAIT_MS = 100;
+const DEFAULT_INDEX_WRITER_MAX_WAIT_MS = 10 * 60 * 1000;
 
 const heldLocks = new Map<string, { depth: number; exitHandler: () => void }>();
 
@@ -21,6 +22,7 @@ interface AcquireIndexWriterLeaseOptions {
   mode?: "wait" | "try";
   purpose: string;
   signal?: AbortSignal;
+  maxWaitMs?: number;
 }
 
 function buildPayload(purpose: string, pid = process.pid): string {
@@ -68,6 +70,8 @@ export async function acquireIndexWriterLease(
 ): Promise<IndexWriterLease | undefined> {
   const mode = options.mode ?? "wait";
   const lockPath = getIndexWriterLockPath();
+  const startedAt = Date.now();
+  const maxWaitMs = options.maxWaitMs ?? DEFAULT_INDEX_WRITER_MAX_WAIT_MS;
   fs.mkdirSync(path.dirname(lockPath), { recursive: true });
 
   if (heldLocks.has(lockPath)) {
@@ -76,6 +80,9 @@ export async function acquireIndexWriterLease(
 
   while (true) {
     throwIfAborted(options.signal);
+    if (mode === "wait" && maxWaitMs >= 0 && Date.now() - startedAt >= maxWaitMs) {
+      throw new Error(`timed out waiting for index writer lease for ${options.purpose}`);
+    }
 
     if (tryAcquireLockSync(lockPath, buildPayload(options.purpose))) {
       return retainHeldLock(lockPath);

--- a/src/indexer/index-writer-lock.ts
+++ b/src/indexer/index-writer-lock.ts
@@ -80,9 +80,6 @@ export async function acquireIndexWriterLease(
 
   while (true) {
     throwIfAborted(options.signal);
-    if (mode === "wait" && maxWaitMs >= 0 && Date.now() - startedAt >= maxWaitMs) {
-      throw new Error(`timed out waiting for index writer lease for ${options.purpose}`);
-    }
 
     if (tryAcquireLockSync(lockPath, buildPayload(options.purpose))) {
       return retainHeldLock(lockPath);
@@ -97,6 +94,13 @@ export async function acquireIndexWriterLease(
       continue;
     }
     if (mode === "try") return undefined;
+
+    // Held by another live process. Time out only *after* a real acquisition
+    // attempt, so a caller with maxWaitMs:0 still gets one chance at a free lock
+    // instead of throwing before it ever tries.
+    if (maxWaitMs >= 0 && Date.now() - startedAt >= maxWaitMs) {
+      throw new Error(`timed out waiting for index writer lease for ${options.purpose}`);
+    }
     await delay(INDEX_WRITER_WAIT_MS);
   }
 }

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -288,7 +288,7 @@ async function runWalkPhase(ctx: IndexRunContext): Promise<void> {
   throwIfAborted(signal);
 
   // LLM enrichment for directories that need it
-  await enhanceDirsWithLlm(db, config, dirsNeedingLlm, onProgress, signal, true, reEnrich);
+  await enhanceDirsWithLlm(db, config, dirsNeedingLlm, onProgress, signal, reEnrich);
   onProgress({
     phase: "llm",
     message: resolveIndexPassLLM("enrichment", config)
@@ -951,7 +951,6 @@ async function enhanceDirsWithLlm(
   }>,
   onProgress?: (event: IndexProgressEvent) => void,
   signal?: AbortSignal,
-  _enrich = false,
   reEnrich = false,
 ): Promise<void> {
   // Resolve per-pass LLM config via the unified shim. Returns undefined when
@@ -1378,7 +1377,7 @@ function resolveIndexedFiles(dirPath: string, files: string[], stash: StashFile)
   for (const entry of stash.entries) {
     const entryPath = entry.filename
       ? path.join(dirPath, entry.filename)
-      : matchEntryToFile(entry.name, fileBasenameMap, files);
+      : matchEntryToFile(entry.name, fileBasenameMap);
     if (entryPath) resolved.add(entryPath);
   }
   return resolved.size > 0 ? [...resolved] : files;
@@ -1525,7 +1524,7 @@ export function buildFileBasenameMap(files: string[]): Map<string, string> {
  *      try matching the last segment
  *   3. No implicit file fallback: ambiguous legacy entries are skipped
  */
-export function matchEntryToFile(entryName: string, fileMap: Map<string, string>, _files: string[]): string | null {
+export function matchEntryToFile(entryName: string, fileMap: Map<string, string>): string | null {
   // Exact match on entry name
   const exact = fileMap.get(entryName);
   if (exact) return exact;

--- a/src/indexer/read-preflight.ts
+++ b/src/indexer/read-preflight.ts
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import type { AkmConfig } from "../core/config/config";
+import { ensureIndex } from "./ensure-index";
+import type { SearchSource } from "./search/search-source";
+import { resolveSourceEntries } from "./search/search-source";
+
+export interface ReadSourceEnvelope {
+  /** Ordered stash/read sources for the current invocation. */
+  sources: SearchSource[];
+  /** Primary source for this invocation (first in `sources`, if any). */
+  primarySource?: SearchSource;
+}
+
+/** Resolve the active read sources using the same resolution rules as search/show. */
+export function resolveReadSources(overrideStashDir?: string, existingConfig?: AkmConfig): ReadSourceEnvelope {
+  const sources = resolveSourceEntries(overrideStashDir, existingConfig);
+  return { sources, primarySource: sources[0] };
+}
+
+/** Ensure the primary source index is readable for reads, when a primary exists. */
+export async function ensurePrimaryIndexForRead(primarySource?: SearchSource): Promise<boolean> {
+  if (!primarySource?.path) return false;
+  return ensureIndex(primarySource.path);
+}
+
+/**
+ * Convenience helper for callers that only need to ensure a read index from a
+ * configured stash path and default config.
+ */
+export async function ensurePrimaryIndexFromConfig(
+  overrideStashDir?: string,
+  existingConfig?: AkmConfig,
+): Promise<boolean> {
+  return ensurePrimaryIndexForRead(resolveReadSources(overrideStashDir, existingConfig).primarySource);
+}

--- a/src/indexer/walk/walker.ts
+++ b/src/indexer/walk/walker.ts
@@ -158,18 +158,26 @@ function isInsideGitRepo(dir: string): boolean {
  * read (e.g. permission errors).
  */
 export function* walkMarkdownFiles(root: string): Generator<string> {
-  let entries: fs.Dirent[];
-  try {
-    entries = fs.readdirSync(root, { withFileTypes: true });
-  } catch {
-    return;
-  }
-  for (const entry of entries) {
-    const full = path.join(root, entry.name);
-    if (entry.isDirectory()) {
-      yield* walkMarkdownFiles(full);
-    } else if (entry.isFile() && entry.name.toLowerCase().endsWith(".md")) {
-      yield full;
+  const stack = [root];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) continue;
+
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (entry.isFile() && entry.name.toLowerCase().endsWith(".md")) {
+        yield full;
+      }
     }
   }
 }

--- a/tests/index-writer-lock.test.ts
+++ b/tests/index-writer-lock.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
 import fs from "node:fs";
+import path from "node:path";
 import { getIndexWriterLockPath } from "../src/core/paths";
 import { acquireIndexWriterLease, probeIndexWriterLease, withIndexWriterLease } from "../src/indexer/index-writer-lock";
 import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "./_helpers/sandbox";
@@ -45,6 +47,22 @@ describe("index writer lease", () => {
     expect(probe.state).toBe("held");
     if (probe.state === "held") expect(probe.holderPid).toBe(process.pid);
     acquired?.release();
+  });
+
+  test("wait mode times out when another holder does not release", async () => {
+    const lockPath = getIndexWriterLockPath();
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    const holder = spawn("sleep", ["10"]);
+    try {
+      expect(typeof holder.pid).toBe("number");
+      fs.writeFileSync(lockPath, String(holder.pid), "utf8");
+
+      await expect(acquireIndexWriterLease({ purpose: "waiter", maxWaitMs: 20 })).rejects.toThrow(
+        "timed out waiting for index writer lease",
+      );
+    } finally {
+      holder.kill();
+    }
   });
 
   test("withIndexWriterLease holds the lock for the callback", async () => {

--- a/tests/index-writer-lock.test.ts
+++ b/tests/index-writer-lock.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { getIndexWriterLockPath } from "../src/core/paths";
@@ -49,20 +48,31 @@ describe("index writer lease", () => {
     acquired?.release();
   });
 
-  test("wait mode times out when another holder does not release", async () => {
+  test("wait mode times out when another live holder does not release", async () => {
     const lockPath = getIndexWriterLockPath();
     fs.mkdirSync(path.dirname(lockPath), { recursive: true });
-    const holder = spawn("sleep", ["10"]);
-    try {
-      expect(typeof holder.pid).toBe("number");
-      fs.writeFileSync(lockPath, String(holder.pid), "utf8");
+    // Hold the lock with a real but foreign live PID — our parent process,
+    // which is always alive for the duration of this run and never equal to
+    // process.pid. probeLock() then classifies it "held" (not "stale"), so the
+    // waiter keeps waiting until it times out. No subprocess spawn (banned in
+    // unit scope) and portable across platforms.
+    fs.writeFileSync(lockPath, String(process.ppid), "utf8");
 
-      await expect(acquireIndexWriterLease({ purpose: "waiter", maxWaitMs: 20 })).rejects.toThrow(
-        "timed out waiting for index writer lease",
-      );
-    } finally {
-      holder.kill();
-    }
+    await expect(acquireIndexWriterLease({ purpose: "waiter", maxWaitMs: 20 })).rejects.toThrow(
+      "timed out waiting for index writer lease",
+    );
+  });
+
+  test("wait mode with maxWaitMs:0 still acquires an immediately-free lock", async () => {
+    // Regression: the timeout must be checked *after* a real acquisition
+    // attempt, not before — otherwise maxWaitMs:0 throws without ever trying,
+    // even when the lock is free.
+    const lease = await acquireIndexWriterLease({ purpose: "instant", maxWaitMs: 0 });
+    expect(lease).toBeDefined();
+    const probe = probeIndexWriterLease();
+    expect(probe.state).toBe("held");
+    if (probe.state === "held") expect(probe.holderPid).toBe(process.pid);
+    lease?.release();
   });
 
   test("withIndexWriterLease holds the lock for the callback", async () => {

--- a/tests/indexer/ensure-index-serve.test.ts
+++ b/tests/indexer/ensure-index-serve.test.ts
@@ -16,13 +16,13 @@
  * Blocking mode (improve) still treats content-staleness as a rebuild trigger.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
 import { getDbPath } from "../../src/core/paths";
 import { closeDatabase, getIndexedFilePaths, openExistingDatabase } from "../../src/indexer/db/db";
 import { ensureIndex } from "../../src/indexer/ensure-index";
-import { akmIndex } from "../../src/indexer/indexer";
+import * as indexerModule from "../../src/indexer/indexer";
 import {
   type Cleanup,
   sandboxEnvDir,
@@ -59,7 +59,7 @@ beforeEach(async () => {
   chain = sandboxEnvDir("akm-ensure-serve-state", "AKM_STATE_DIR", chain).cleanup;
   cleanup = chain;
   writeMemory("first");
-  await akmIndex({ stashDir });
+  await indexerModule.akmIndex({ stashDir });
 });
 
 afterEach(() => {
@@ -81,6 +81,13 @@ describe("ensureIndex read-path (background mode)", () => {
     fs.rmSync(getDbPath());
     expect(await ensureIndex(stashDir)).toBe(true);
     expect(indexedPaths().size).toBeGreaterThan(0);
+  });
+
+  test("failed inline rebuild reports failure", async () => {
+    fs.rmSync(getDbPath());
+    const spy = spyOn(indexerModule, "akmIndex").mockRejectedValueOnce(new Error("boom"));
+    expect(await ensureIndex(stashDir)).toBe(false);
+    spy.mockRestore();
   });
 });
 

--- a/tests/integration/indexer.test.ts
+++ b/tests/integration/indexer.test.ts
@@ -1413,28 +1413,28 @@ test("akmIndex does not collapse unrelated same-basename assets across sources",
 
 test("matchEntryToFile returns null when files array is empty", () => {
   const fileMap = buildFileBasenameMap([]);
-  const result = matchEntryToFile("nonexistent-entry", fileMap, []);
+  const result = matchEntryToFile("nonexistent-entry", fileMap);
   expect(result).toBeNull();
 });
 
 test("matchEntryToFile returns null when no name match exists", () => {
   const files = ["/stash/scripts/deploy/deploy.sh"];
   const fileMap = buildFileBasenameMap(files);
-  const result = matchEntryToFile("no-match", fileMap, files);
+  const result = matchEntryToFile("no-match", fileMap);
   expect(result).toBeNull();
 });
 
 test("matchEntryToFile returns exact match when entry name matches basename", () => {
   const files = ["/stash/scripts/deploy/deploy.sh", "/stash/scripts/deploy/util.sh"];
   const fileMap = buildFileBasenameMap(files);
-  const result = matchEntryToFile("deploy", fileMap, files);
+  const result = matchEntryToFile("deploy", fileMap);
   expect(result).toBe("/stash/scripts/deploy/deploy.sh");
 });
 
 test("matchEntryToFile matches last path segment for hierarchical names", () => {
   const files = ["/stash/scripts/deploy/deploy.sh"];
   const fileMap = buildFileBasenameMap(files);
-  const result = matchEntryToFile("corpus/deploy", fileMap, files);
+  const result = matchEntryToFile("corpus/deploy", fileMap);
   expect(result).toBe("/stash/scripts/deploy/deploy.sh");
 });
 

--- a/tests/read-preflight.test.ts
+++ b/tests/read-preflight.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { resetConfigCache } from "../src/core/config/config";
+import { getDbPath } from "../src/core/paths";
+import {
+  ensurePrimaryIndexForRead,
+  ensurePrimaryIndexFromConfig,
+  resolveReadSources,
+} from "../src/indexer/read-preflight";
+import {
+  type IsolatedAkmStorage,
+  makeSandboxDir,
+  withIsolatedAkmStorage,
+  writeSandboxConfig,
+} from "./_helpers/sandbox";
+
+describe("read preflight helpers", () => {
+  let storage: IsolatedAkmStorage;
+  const disposers: Array<() => void> = [];
+
+  beforeEach(() => {
+    storage = withIsolatedAkmStorage();
+    resetConfigCache();
+  });
+
+  afterEach(() => {
+    for (const dispose of disposers.splice(0)) {
+      dispose();
+    }
+    storage.cleanup();
+  });
+
+  test("resolves configured sources in primary-first order", () => {
+    const additional = makeSandboxDir("akm-read-source-");
+    disposers.push(additional.cleanup);
+    for (const dir of [additional.dir]) {
+      fs.mkdirSync(path.join(dir, "skills"), { recursive: true });
+    }
+
+    writeSandboxConfig({
+      sources: [
+        { type: "filesystem", name: "library", path: additional.dir },
+        { type: "filesystem", name: "primary", path: storage.stashDir, primary: true },
+      ],
+    });
+    resetConfigCache();
+
+    const { sources, primarySource } = resolveReadSources();
+    expect(primarySource?.path).toBe(storage.stashDir);
+    expect(sources[0].path).toBe(storage.stashDir);
+    expect(sources.some((source) => source.path === additional.dir)).toBe(true);
+  });
+
+  test("ensures primary index bootstrap for current config", async () => {
+    const knowledgeFile = path.join(storage.stashDir, "knowledge", "bootstrap.md");
+    fs.writeFileSync(knowledgeFile, "# bootstrap\n", "utf8");
+
+    const ensured = await ensurePrimaryIndexFromConfig();
+    expect(ensured).toBe(true);
+    expect(fs.existsSync(getDbPath())).toBe(true);
+  });
+
+  test("returns false when primary source is not provided", async () => {
+    const ensured = await ensurePrimaryIndexForRead();
+    expect(ensured).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- extract read-preflight helpers so search/show share the same primary-source bootstrap path
- fix `ensureIndex()` to report failed inline rebuilds correctly and add writer-lock timeout coverage
- harden walker/indexer internals and add expert review docs plus a vertical-slice refactor plan

## Testing
- `bunx tsc --noEmit`
- `bun test tests/read-preflight.test.ts tests/indexer/ensure-index-serve.test.ts tests/index-writer-lock.test.ts tests/integration/indexer.test.ts`