### PR TITLE
test: ban mock.module (Rule 6) + fix registry-cache port-reuse flake

### DIFF
--- a/scripts/lint-tests-isolation.ts
+++ b/scripts/lint-tests-isolation.ts
@@ -44,6 +44,15 @@
  * setup lines are not flagged. Existing spawners are grandfathered in
  * SPAWN_ALLOWED (shrink-only).
  *
+ * Rule 6 (mock.module ban): flag ANY `mock.module(` call in tests/. Bun's
+ * mock.module is process-global and its registrations are NOT cleared by
+ * mock.restore(), so a mocked module leaks into every later test file in the
+ * same process — proven by a two-file probe during the DI-seam workstream.
+ * The suite runs WITHOUT --isolate precisely because mock.module reached
+ * zero (PR #689); one reintroduced call silently re-opens cross-file
+ * poisoning. Use the swap-and-restore seams instead (tests/_helpers/seams.ts;
+ * pattern: docs/design/di-seams-plan.md). No allowlist — zero is the invariant.
+ *
  * Exit codes:
  *   0 — no violations
  *   1 — violations found (or internal error)
@@ -302,7 +311,7 @@ export function collectTestFiles(dir: string): string[] {
   return results;
 }
 
-type Rule = "mkdtemp-env" | "unguarded-env" | "elapsed-assertion" | "raw-akm-mkdtemp" | "unit-real-spawn";
+type Rule = "mkdtemp-env" | "unguarded-env" | "elapsed-assertion" | "raw-akm-mkdtemp" | "unit-real-spawn" | "mock-module";
 
 interface Violation {
   file: string;
@@ -427,6 +436,26 @@ function lintFile(filePath: string): Violation[] {
     }
   }
 
+  // ── Rule 6: mock.module ban ─────────────────────────────────────────────────
+  // Process-global, not cleared by mock.restore(), leaks across files without
+  // --isolate (which the suite no longer uses). Zero-tolerance, no allowlist.
+  {
+    const lines = src.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const l = lines[i];
+      if (/^\s*(\/\/|\*)/.test(l)) continue;
+      if (/\bmock\.module\s*\(/.test(l)) {
+        violations.push({
+          file: rel,
+          rule: "mock-module",
+          detail:
+            "mock.module is banned — it leaks across test files now that the suite runs without --isolate; use the swap-and-restore seams (tests/_helpers/seams.ts)",
+          line: i + 1,
+        });
+      }
+    }
+  }
+
   // ── Rule 3: wall-clock elapsed-time assertion ──────────────────────────────
   // Targets the precise flaky shape: a LOCAL variable assigned a measured
   // wall-clock delta (`const elapsed = Date.now() - start`) then bounded with
@@ -495,6 +524,7 @@ if (import.meta.main) {
     "elapsed-assertion": "wall-clock elapsed-time assertion",
     "raw-akm-mkdtemp": "raw mkdtempSync(…akm-test…) outside tests/_helpers/",
     "unit-real-spawn": "real process spawn in unit-scope test",
+    "mock-module": "mock.module call (banned — suite runs without --isolate)",
   };
 
   console.error(`lint-tests-isolation: ${violations.length} violation(s) found\n`);

--- a/scripts/run-test-shard.sh
+++ b/scripts/run-test-shard.sh
@@ -10,8 +10,9 @@
 # probe proved a `mock.module` in file A IS visible in file B and
 # `mock.restore()` does NOT clear module mocks — so de-isolation is only
 # sound with no `mock.module` at all. Verified by repeated green full-suite
-# runs without `--isolate`, including concurrent runs under CPU contention. Dropping `--isolate` also drops the Bun 1.3.x isolate/worker
-# epoll_ctl EEXIST race that used to require a signature-gated retry here.
+# runs without `--isolate`, including concurrent runs under CPU contention.
+# Dropping `--isolate` also drops the Bun 1.3.x isolate/worker epoll_ctl
+# EEXIST race that used to require a signature-gated retry here.
 # `--parallel` must never be passed either: per `bun test --help` it "implies
 # --isolate" (re-adding the racy path) even at N=1.
 #

--- a/tests/integration/registry-index-v2.test.ts
+++ b/tests/integration/registry-index-v2.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import type { RegistryIndex } from "../../src/commands/read/registry-search";
 import { searchRegistry } from "../../src/commands/read/registry-search";
-import { type Cleanup, sandboxXdgCacheHome } from "../_helpers/sandbox";
+import { type Cleanup, sandboxEnvDir, sandboxXdgCacheHome } from "../_helpers/sandbox";
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -109,7 +109,11 @@ let envCleanup: Cleanup = () => {};
 
 beforeEach(() => {
   const cacheResult = sandboxXdgCacheHome();
-  envCleanup = cacheResult.cleanup;
+  // Registry indexes are disk-cached in index.db KEYED BY URL. The local test
+  // servers get OS-assigned ports, and a recycled port would resurrect a
+  // previous test's cached index (observed: a v2 query returning a stale v1
+  // index — duplicate hits). A per-test AKM_DATA_DIR keeps the cache empty.
+  envCleanup = sandboxEnvDir("akm-registry-v2-data", "AKM_DATA_DIR", cacheResult.cleanup).cleanup;
   delete process.env.AKM_REGISTRY_URL;
 });
 


### PR DESCRIPTION
Follow-ups from the #689 review. (1) Rule 6: `mock.module(` is now a lint error anywhere in tests/ — the de-isolation soundness invariant (zero mock.module) becomes a gate instead of a comment; probe-verified. (2) The transient integration flake seen twice today is root-caused: registry index disk-cache keyed by URL + OS port reuse in registry-index-v2's local servers resurrected a stale v1 index; per-test AKM_DATA_DIR sandbox fixes it structurally. Gate green: lint 0/0, tsc clean, unit 4966/0, integration 775/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkfTXQ3QUXKLZhETdPioC3