### PR TITLE
meta-review 05: delete churn-rewarding signals, filter machine traffic, two-tailed monitors, minting rollup

### DIFF
--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -491,6 +491,44 @@ export interface ImproveHealthMetrics {
     /** Total stash assets at the time of the most recent run (whole-stash snapshot). */
     totalAssets: number;
   };
+  /**
+   * Enrichment-vs-minting policy rollup (reporting-only). Enrichment-classed
+   * lanes are ratified to EDIT existing assets, not mint new ones; this
+   * surfaces the split so drift is visible without a manual DB query.
+   * Absent when no lane-attributed accepted proposals exist in the window.
+   */
+  enrichmentMinting?: EnrichmentMintingRollup;
+}
+
+/**
+ * Lanes ratified as ENRICHMENT-ONLY: they may propose edits to existing
+ * assets (metadata, relations, content refresh) but must not mint new ones.
+ * New-asset generation belongs to the signal-gated minting lanes
+ * (extract/distill/memory-inference/recombine).
+ */
+export const ENRICHMENT_LANES: readonly string[] = ["proactive", "high-salience", "high-retrieval", "signal-delta"];
+
+/** Minted share of enrichment-lane accepts that triggers a WARN advisory. */
+export const ENRICHMENT_MINTED_WARN_SHARE = 0.05;
+
+/** Minted share of enrichment-lane accepts that triggers a FAIL advisory. */
+export const ENRICHMENT_MINTED_FAIL_SHARE = 0.15;
+
+/**
+ * The enrichment-vs-minting split over the health window's accepted,
+ * lane-attributed proposals. Create-vs-update is discriminated by
+ * `metadata_json.backupContent`: apply captures the prior content for
+ * updates, so its absence means a genuinely new asset was minted.
+ */
+export interface EnrichmentMintingRollup {
+  /** Accepted enrichment-lane proposals that MINTED a new asset (no backupContent). */
+  minted: number;
+  /** Accepted enrichment-lane proposals that UPDATED an existing asset. */
+  updated: number;
+  /** minted / (minted + updated) across enrichment lanes. NaN when they decided nothing. */
+  share: number;
+  /** Per-lane minted/updated split for every lane-attributed accepted proposal. */
+  byLane: Record<string, { minted: number; updated: number }>;
 }
 
 /**
@@ -1928,6 +1966,67 @@ function computeDenominatorFixedCoverage(
 }
 
 /**
+ * Compute the enrichment-vs-minting rollup over the window's accepted,
+ * lane-attributed proposals (reporting-only; see {@link EnrichmentMintingRollup}).
+ *
+ * SQL-side `json_extract` keeps the (potentially large) `backupContent` blobs
+ * out of process memory. Pre-Phase-6C rows without an `eligibilitySource`
+ * cannot be lane-classified and are excluded. Fails open (undefined) when the
+ * proposals table is absent.
+ */
+export function computeEnrichmentMintingRollup(
+  db: Database,
+  since: string,
+  until?: string,
+): EnrichmentMintingRollup | undefined {
+  try {
+    const rows = db
+      .prepare(
+        `SELECT
+           json_extract(metadata_json, '$.eligibilitySource') AS lane,
+           CASE WHEN json_extract(metadata_json, '$.backupContent') IS NULL THEN 1 ELSE 0 END AS is_minted,
+           COUNT(*) AS cnt
+         FROM proposals
+         WHERE status = 'accepted'
+           AND updated_at >= ?
+           AND (? IS NULL OR updated_at < ?)
+           AND json_extract(metadata_json, '$.eligibilitySource') IS NOT NULL
+           AND json_extract(metadata_json, '$.eligibilitySource') != ''
+         GROUP BY lane, is_minted`,
+      )
+      .all(since, until ?? null, until ?? null) as Array<{ lane: string; is_minted: number; cnt: number }>;
+    if (rows.length === 0) return undefined;
+
+    const byLane: Record<string, { minted: number; updated: number }> = {};
+    for (const row of rows) {
+      byLane[row.lane] ??= { minted: 0, updated: 0 };
+      const entry = byLane[row.lane];
+      if (row.is_minted === 1) entry.minted += row.cnt;
+      else entry.updated += row.cnt;
+    }
+
+    let minted = 0;
+    let updated = 0;
+    for (const lane of ENRICHMENT_LANES) {
+      const entry = byLane[lane];
+      if (!entry) continue;
+      minted += entry.minted;
+      updated += entry.updated;
+    }
+    const decided = minted + updated;
+    return {
+      minted,
+      updated,
+      share: decided > 0 ? roundRate(minted / decided) : Number.NaN,
+      byLane,
+    };
+  } catch {
+    // Fail open: proposals table may not exist on older installs.
+    return undefined;
+  }
+}
+
+/**
  * Compute WS-5 per-run degradation metrics (Part V §4).
  *
  * Health VIEWS only — reads from state.db tables populated by prior improve
@@ -2253,6 +2352,7 @@ export function akmHealth(options: AkmHealthOptions = {}): AkmHealthResult {
     if (degradationMain) {
       improveSummary.degradation = degradationMain;
     }
+    improveSummary.enrichmentMinting = computeEnrichmentMintingRollup(db, since, until);
 
     // WS-2 proxy-adequacy tripwire: surface any outcome_proxy_inverted events
     // in the health window as an advisory so operators know when the 0.10+
@@ -2308,6 +2408,23 @@ export function akmHealth(options: AkmHealthOptions = {}): AkmHealthResult {
           `Salience distribution collapsed toward uniform: top-100 retrieval_salience Gini = ` +
           `${improveSummary.degradation.corpusCentroidDistance} < 0.08 (uniform baseline ≈ 0.1). ` +
           "Ranking currently carries little to no discrimination between assets.",
+      });
+    }
+
+    // Enrichment-vs-minting policy: enrichment lanes edit existing assets;
+    // a rising minted share means a lane is generating new content instead.
+    const minting = improveSummary.enrichmentMinting;
+    if (minting && Number.isFinite(minting.share) && minting.share > ENRICHMENT_MINTED_WARN_SHARE) {
+      advisories.push({
+        name: "enrichment-lane-minting",
+        status: minting.share > ENRICHMENT_MINTED_FAIL_SHARE ? "fail" : "warn",
+        kind: "deterministic",
+        confidence: "high",
+        message:
+          `Enrichment lanes minted ${minting.minted} NEW asset(s) vs ${minting.updated} update(s) ` +
+          `(${Math.round(minting.share * 100)}% minted, threshold ${Math.round(ENRICHMENT_MINTED_WARN_SHARE * 100)}%). ` +
+          "Enrichment-classed lanes (proactive/high-salience/high-retrieval/signal-delta) are ratified to edit " +
+          "existing assets only — new-asset generation belongs to the signal-gated minting lanes.",
       });
     }
 

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -466,18 +466,28 @@ export interface ImproveHealthMetrics {
   degradation?: ImproveDegradationMetrics;
   /**
    * WS-5 denominator-fixed coverage (Part V §3).
-   * `coverage = accepted_proposals / total_assets` (denominator is fixed at
-   * total stash size, not the moving eligible set). `eligibleFraction` is
-   * reported separately so narrowing eligibility doesn't spuriously inflate
-   * coverage. Both are NaN when total_assets=0 (empty stash).
+   * `coverage = distinct_accepted_refs / total_assets` (denominator is fixed
+   * at total stash size, not the moving eligible set). The numerator counts
+   * DISTINCT refs, not proposals — repeated accepted rewrites of one asset
+   * are churn, not coverage, and previously inflated this rate.
+   * `eligibleFraction` is reported separately so narrowing eligibility doesn't
+   * spuriously inflate coverage. Rates are NaN when total_assets=0 (empty stash).
    */
   coverage: {
-    /** accepted_proposals / total_assets (fixed denominator). NaN when total=0. */
+    /** distinct_accepted_refs / total_assets (fixed denominator). NaN when total=0. */
     rate: number;
     /** eligible_assets / total_assets. NaN when total=0. */
     eligibleFraction: number;
-    /** Total proposals accepted (window-scoped, from state.db). */
+    /** Total proposals accepted (window-scoped, from state.db). Raw volume — includes churn. */
     acceptedProposals: number;
+    /** Distinct asset refs among the window's accepted proposals. */
+    distinctRefs: number;
+    /**
+     * acceptedProposals / distinctRefs. 1.0 = every accepted proposal touched
+     * a different asset; values above ~1.5 mean the loop is repeatedly
+     * rewriting the same assets (churn). NaN when distinctRefs=0.
+     */
+    churnRatio: number;
     /** Total stash assets at the time of the most recent run (whole-stash snapshot). */
     totalAssets: number;
   };
@@ -528,18 +538,21 @@ export interface ImproveDegradationMetrics {
    */
   entrenchmentFlagged?: boolean;
   /**
+   * Low-tail Gini flag: `true` when the top-100 retrieval_salience Gini is
+   * below 0.08 — the salience distribution has collapsed toward uniform and
+   * no longer discriminates between assets (ranking carries no signal).
+   * The uniform baseline for this formula is ~0.1, so a healthy distribution
+   * sits above it; the old one-tailed check (>0.35 entrenchment only)
+   * rendered a fully collapsed distribution as healthy.
+   * `undefined` when the metric is NaN.
+   */
+  salienceUniformityFlagged?: boolean;
+  /**
    * Merge fidelity: fraction of accepted merge proposals in the window whose
    * result was later contradicted (a proxy for "the merge degraded content").
    * 0 = no contradictions detected; higher = potential fidelity loss.
    */
   mergeFidelityContradictionRate: number;
-  /**
-   * Generation distribution: fraction of stash assets (memories) that are
-   * generation ≥ 2 (have been through at least one LLM-merge round).
-   * A healthy corpus has a low high-generation fraction; a rising fraction
-   * signals over-consolidation eroding original content.
-   */
-  highGenerationFraction: number;
   /**
    * Oracle spot-check: up to 5 recently accepted proposals sampled from the
    * window, surfaced for human eyeballing in the health report.
@@ -825,6 +838,8 @@ function createUnknownImproveMetrics(): ImproveHealthMetrics {
       rate: Number.NaN,
       eligibleFraction: Number.NaN,
       acceptedProposals: 0,
+      distinctRefs: 0,
+      churnRatio: Number.NaN,
       totalAssets: 0,
     },
   };
@@ -1869,6 +1884,7 @@ function computeDenominatorFixedCoverage(
   stashDir?: string,
 ): ImproveHealthMetrics["coverage"] {
   let acceptedProposals = 0;
+  let distinctRefs = 0;
   try {
     const proposals = listStateProposals(db, {
       status: "accepted",
@@ -1880,23 +1896,33 @@ function computeDenominatorFixedCoverage(
       return true;
     });
     acceptedProposals = proposals.length;
+    // Coverage counts DISTINCT refs: N accepted rewrites of one asset are
+    // churn, not coverage. The raw proposal count is kept alongside so the
+    // churn ratio (proposals ÷ distinct refs) stays visible.
+    distinctRefs = new Set(proposals.map((p) => p.ref)).size;
   } catch {
     // Fail open: table may not exist on older installs.
   }
+
+  const churnRatio = distinctRefs > 0 ? roundRate(acceptedProposals / distinctRefs) : Number.NaN;
 
   if (totalAssets === 0) {
     return {
       rate: Number.NaN,
       eligibleFraction: Number.NaN,
       acceptedProposals,
+      distinctRefs,
+      churnRatio,
       totalAssets: 0,
     };
   }
 
   return {
-    rate: roundRate(acceptedProposals / totalAssets),
+    rate: roundRate(distinctRefs / totalAssets),
     eligibleFraction: roundRate(eligibleAssets / totalAssets),
     acceptedProposals,
+    distinctRefs,
+    churnRatio,
     totalAssets,
   };
 }
@@ -1911,7 +1937,11 @@ function computeDenominatorFixedCoverage(
  * @param since - Window start (ISO-8601).
  * @param until - Window end (ISO-8601).
  */
-function computeDegradationMetrics(db: Database, since: string, until: string): ImproveDegradationMetrics | undefined {
+export function computeDegradationMetrics(
+  db: Database,
+  since: string,
+  until: string,
+): ImproveDegradationMetrics | undefined {
   // (a) Corpus diversity — salience rank distribution of the top-100 assets.
   // We use the Gini coefficient of retrieval_salience scores as an intra-corpus
   // diversity proxy. A Gini close to 1 = highly concentrated (entrenched top
@@ -1919,6 +1949,7 @@ function computeDegradationMetrics(db: Database, since: string, until: string): 
   // consecutive-run centroid distance requires cross-run history not yet stored.
   let corpusCentroidDistance = Number.NaN;
   let entrenchmentFlagged: boolean | undefined;
+  let salienceUniformityFlagged: boolean | undefined;
   try {
     const rows = db
       .prepare(
@@ -1939,9 +1970,13 @@ function computeDegradationMetrics(db: Database, since: string, until: string): 
       // corpusCentroidDistance approximation: gini is "distance from uniform".
       // Note: retrieval_salience values are in [0,1], so the max achievable Gini
       // with this formula is ~0.5 (when one asset dominates and others are near 0).
-      // Threshold: >0.35 flags entrenchment (robustly above the ~0.1 uniform baseline).
+      // Two-tailed: >0.35 flags entrenchment (robustly above the ~0.1 uniform
+      // baseline); <0.08 flags uniformity collapse — the distribution no longer
+      // discriminates between assets (live 2026-07 value 0.040 sat unflagged
+      // in this tail under the old one-tailed check).
       corpusCentroidDistance = roundRate(gini);
       entrenchmentFlagged = gini > 0.35;
+      salienceUniformityFlagged = gini < 0.08;
     }
   } catch {
     // Table not present (pre-WS-1 install) — leave NaN.
@@ -1979,24 +2014,11 @@ function computeDegradationMetrics(db: Database, since: string, until: string): 
     // Fail open.
   }
 
-  // (c) Generation distribution — fraction of asset_salience rows with
-  // generation >= 2. Generation is NOT currently stored in asset_salience
-  // (it's in frontmatter). We approximate using consecutive_no_ops as a
-  // maturity proxy: assets that have never been no-op'd are "fresh".
-  // TODO(0.10+): store generation in asset_salience for proper tracking.
-  let highGenerationFraction = Number.NaN;
-  try {
-    const genRows = db.prepare("SELECT consecutive_no_ops FROM asset_salience").all() as Array<{
-      consecutive_no_ops: number;
-    }>;
-    if (genRows.length > 0) {
-      // Use consecutive_no_ops >= 2 as a proxy for "has been through merge cycles".
-      const highGen = genRows.filter((r) => r.consecutive_no_ops >= 2).length;
-      highGenerationFraction = roundRate(highGen / genRows.length);
-    }
-  } catch {
-    // Table not present.
-  }
+  // (c) highGenerationFraction was DELETED (meta-review 05 DRIFT-3): it
+  // approximated "LLM-merge generations" from consecutive_no_ops — which counts
+  // the opposite condition (cycles where nothing was changed) — and its own
+  // in-code TODO admitted the proxy. Display-only, never actionable; removed
+  // rather than instrumented.
 
   // (d) Oracle spot-check — up to 5 recently accepted proposals in the window.
   const oracleSpotCheck: OracleSpotCheckEntry[] = [];
@@ -2025,8 +2047,8 @@ function computeDegradationMetrics(db: Database, since: string, until: string): 
   return {
     corpusCentroidDistance,
     entrenchmentFlagged,
+    salienceUniformityFlagged,
     mergeFidelityContradictionRate,
-    highGenerationFraction,
     oracleSpotCheck,
   };
 }
@@ -2251,6 +2273,57 @@ export function akmHealth(options: AkmHealthOptions = {}): AkmHealthResult {
           "Popular assets are also the most-needing-improvement assets — " +
           "the retrieval-based proxy is inverted. " +
           "The 0.10+ rich in-session outcome signal is no longer deferrable. See plan §WS-2.",
+      });
+    }
+
+    // Two-tailed companion: a proxy that decays to noise (|corr| < 0.1 at scale)
+    // is as much a failure as an inverted one — it just fails silently.
+    const proxyDeadEvents = readEvents({ since, type: "outcome_proxy_dead" }, { dbPath: stateDbPath, db }).events;
+    if (proxyDeadEvents.length > 0) {
+      const lastEvent = proxyDeadEvents[proxyDeadEvents.length - 1];
+      const correlation =
+        typeof lastEvent.metadata?.correlation === "number" ? lastEvent.metadata.correlation.toFixed(3) : "unknown";
+      advisories.push({
+        name: "outcome-proxy-dead",
+        status: "warn",
+        kind: "deterministic",
+        confidence: "high",
+        message:
+          `WS-2 outcome proxy is DEAD (${proxyDeadEvents.length} event(s) in window). ` +
+          `|corr(outcome_score, accepted_change_rate)| = ${correlation} < 0.1 at n ≥ 500. ` +
+          "outcome_score is statistically unrelated to improvement outcomes — " +
+          "treat outcome-derived rank contributions as noise until a real usage/outcome signal lands.",
+      });
+    }
+
+    // Salience-distribution collapse: Gini below the uniform baseline means
+    // ranking no longer discriminates between assets.
+    if (improveSummary.degradation?.salienceUniformityFlagged) {
+      advisories.push({
+        name: "salience-uniformity-collapse",
+        status: "warn",
+        kind: "deterministic",
+        confidence: "high",
+        message:
+          `Salience distribution collapsed toward uniform: top-100 retrieval_salience Gini = ` +
+          `${improveSummary.degradation.corpusCentroidDistance} < 0.08 (uniform baseline ≈ 0.1). ` +
+          "Ranking currently carries little to no discrimination between assets.",
+      });
+    }
+
+    // Churn: accepted proposals far exceeding distinct touched refs means the
+    // loop is repeatedly rewriting the same assets, not covering the corpus.
+    if (Number.isFinite(improveSummary.coverage.churnRatio) && improveSummary.coverage.churnRatio > 1.5) {
+      advisories.push({
+        name: "improve-churn-ratio",
+        status: "warn",
+        kind: "deterministic",
+        confidence: "high",
+        message:
+          `Improve churn ratio ${improveSummary.coverage.churnRatio} > 1.5: ` +
+          `${improveSummary.coverage.acceptedProposals} accepted proposals touched only ` +
+          `${improveSummary.coverage.distinctRefs} distinct assets in the window — ` +
+          "repeated rewrites of the same refs count as churn, not coverage.",
       });
     }
 

--- a/src/commands/health/html-report.ts
+++ b/src/commands/health/html-report.ts
@@ -757,7 +757,7 @@ export function buildHealthHtmlReplacements(
         "Coverage rate",
         pct(coverage.rate, 1),
         "flat",
-        "Accepted proposals / total stash assets (denominator-fixed). Shows what fraction of the corpus has been touched.",
+        "Distinct accepted refs / total stash assets (denominator-fixed). Shows what fraction of the corpus has been touched.",
       ],
       [
         "Eligible fraction",
@@ -768,8 +768,14 @@ export function buildHealthHtmlReplacements(
       [
         "Coverage accepted",
         num(coverage.acceptedProposals),
-        "up",
-        "Total accepted proposals used for the denominator-fixed coverage rate.",
+        "flat",
+        "Total accepted proposals in the window (raw volume — includes repeated rewrites of the same asset).",
+      ],
+      [
+        "Churn ratio",
+        Number.isFinite(coverage.churnRatio) ? num(coverage.churnRatio) : "—",
+        Number.isFinite(coverage.churnRatio) && coverage.churnRatio > 1.5 ? "down" : "flat",
+        "Accepted proposals / distinct refs touched. >1.5 = the loop is repeatedly rewriting the same assets (churn, not coverage).",
       ],
     );
   }
@@ -818,20 +824,14 @@ export function buildHealthHtmlReplacements(
       [
         "Corpus diversity (Gini)",
         num(degradation.corpusCentroidDistance),
-        degradation.entrenchmentFlagged ? "down" : "flat",
-        "Gini coefficient of retrieval_salience for top-100 ranked assets. High Gini (>0.35) = entrenchment risk.",
+        degradation.entrenchmentFlagged || degradation.salienceUniformityFlagged ? "down" : "flat",
+        "Gini coefficient of retrieval_salience for top-100 ranked assets. Two-tailed: >0.35 = entrenchment risk; <0.08 = collapsed toward uniform (ranking no longer discriminates).",
       ],
       [
         "Merge fidelity contradiction rate",
         pct(degradation.mergeFidelityContradictionRate, 1),
         "flat",
         "Fraction of consolidated proposals that involved a contradiction, from consolidation result envelopes.",
-      ],
-      [
-        "High-generation fraction",
-        pct(degradation.highGenerationFraction, 1),
-        "flat",
-        "Fraction of assets with consecutive_no_ops >= 2 (proxy for high-generation assets in the salience table).",
       ],
     );
   }
@@ -947,6 +947,21 @@ export function buildHealthHtmlReplacements(
       descHtml:
         "A small set of assets dominates retrieval — retrieval diversity is low. " +
         "Review top-ranked assets for stale or over-represented content. " +
+        `Corpus diversity proxy: ${esc(String(degradation.corpusCentroidDistance))}.`,
+      remedy: "akm health --format json | jq '.improve.degradation'",
+    });
+  }
+
+  // Low-tail companion: salience distribution collapsed toward uniform.
+  if (degradation?.salienceUniformityFlagged) {
+    pushItem({
+      key: "salience-uniformity-collapse",
+      prio: "P2",
+      cls: "warn",
+      title: "Salience distribution collapsed: retrieval_salience Gini < 0.08",
+      descHtml:
+        "The top-100 salience scores are near-uniform (uniform baseline ≈ 0.1) — " +
+        "ranking currently carries little to no discrimination between assets. " +
         `Corpus diversity proxy: ${esc(String(degradation.corpusCentroidDistance))}.`,
       remedy: "akm health --format json | jq '.improve.degradation'",
     });

--- a/src/commands/health/html-report.ts
+++ b/src/commands/health/html-report.ts
@@ -422,6 +422,7 @@ export function buildHealthHtmlReplacements(
   };
   const coverage = improve.coverage;
   const degradation: ImproveDegradationMetrics | undefined = improve.degradation;
+  const minting = improve.enrichmentMinting;
   // #576: real per-stage LLM token/time accounting (replaces the GPU-time
   // proxy). Optional-guarded so reports built from older health JSON without
   // the aggregate still render.
@@ -778,6 +779,16 @@ export function buildHealthHtmlReplacements(
         "Accepted proposals / distinct refs touched. >1.5 = the loop is repeatedly rewriting the same assets (churn, not coverage).",
       ],
     );
+  }
+
+  // Enrichment-vs-minting policy rollup (reporting-only).
+  if (minting && Number.isFinite(minting.share)) {
+    summaryRows.push([
+      "Enrichment-lane minted share",
+      pct(minting.share, 1),
+      minting.share > 0.05 ? "down" : "flat",
+      `New assets minted by enrichment lanes / their accepted total (${minting.minted} minted vs ${minting.updated} updated). Enrichment lanes are ratified to edit existing assets only; WARN >5%, FAIL >15%.`,
+    ]);
   }
 
   // WS-5: perf telemetry rows (only when at least one run reported telemetry).

--- a/src/commands/improve/outcome-loop.ts
+++ b/src/commands/improve/outcome-loop.ts
@@ -8,20 +8,26 @@
  * One per-asset "was this retrieval useful" signal, differential
  * (prediction-error-shaped), persisted in `state.db :: asset_outcome`.
  *
- * ## Signal formula (v1)
+ * ## Signal formula (v2)
  *
  * ```
  * outcome_score =
  *   (retrieval_delta − expected_retrieval_delta)
- *   − PENALTY × retrieval_delta × (1 − accepted_change_rate)
  *   + valence
  * ```
  *
  * - `retrieval_delta`: retrievals gained since the last window.
  * - `expected_retrieval_delta`: rolling mean of per-cycle retrieval DELTA.
- * - `PENALTY`: weight on the "retrieved-but-never-improved" penalty.
- * - `accepted_change_rate`: accepted_change_count / max(1, retrieval_count).
  * - `valence`: normalised net feedback valence in [−1, +1].
+ *
+ * The v1 "retrieved-but-never-improved" penalty term
+ * (`PENALTY × retrieval_delta × (1 − accepted_change_rate)`) was DELETED (#691):
+ * measured corr(outcome_score, accepted_change_rate) was 0.0069 across 5,601 live
+ * rows (noise), and because the unclamped rate exceeds 1 whenever accepted
+ * changes outnumber retrievals, the term paid a live *bonus* for churn —
+ * an asset's score could rise by being rewritten under auto-accept.
+ * `accepted_change_count` remains persisted as raw telemetry only; it must
+ * never re-enter the score (pinned by tests/commands/improve/outcome-invariance.test.ts).
  *
  * ## Eligibility-trace decay
  *
@@ -41,11 +47,14 @@
  * at DIVERSITY_FLOOR_FRACTION of the maximum observed score, so rare-but-correct
  * assets cannot be permanently outcompeted by high-retrieval ones.
  *
- * ## Proxy-adequacy tripwire (health)
+ * ## Proxy-adequacy tripwire (health) — two-tailed
  *
- * We monitor `corr(outcome_score, accepted_change_rate)` across all rows. If
- * it goes negative, "popular assets" and "assets that need improvement" are
- * the same set — the proxy is inverted and surfaced in the health report.
+ * We monitor `corr(outcome_score, accepted_change_rate)` across all rows.
+ * If it goes below −0.3, "popular assets" and "assets that need improvement"
+ * are the same set — the proxy is inverted and surfaced in the health report.
+ * If |corr| < 0.1 at n ≥ 500, the proxy is DEAD — outcome_score carries no
+ * information about improvement need at all (the live 2026-07 state: +0.0104
+ * at n=5,706 rendered as healthy under the old one-tailed check).
  *
  * ## #613 review_pressure
  *
@@ -67,13 +76,6 @@
 import type { Database } from "../../core/state-db";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
-
-/**
- * Weight on the "retrieved-but-never-improved" penalty term. Setting this to
- * 0 degrades to a pure prediction-error score (no quality filter); setting it
- * to 1 heavily penalises assets whose retrievals never led to accepted changes.
- */
-export const OUTCOME_PENALTY_WEIGHT = 0.3;
 
 /**
  * EMA decay factor for the expected-retrieval rolling mean (α).
@@ -162,7 +164,8 @@ export interface OutcomeUpdateInputs {
   lastRetrievedAt: number;
   /**
    * Number of ACCEPTED proposals for this ref since inception.
-   * Used to compute `accepted_change_rate`.
+   * Persisted as raw telemetry ONLY — it does not participate in the
+   * outcome_score formula (#691: the derived rate rewarded churn).
    */
   acceptedChangeCount: number;
   /**
@@ -234,13 +237,8 @@ export function updateAssetOutcome(db: Database, inputs: OutcomeUpdateInputs): O
     // retrieval_delta = current − stored (non-negative — we never go backwards)
     const retrievalDelta = Math.max(0, inputs.currentRetrievalCount - existing.retrieval_count);
 
-    // accepted_change_rate = accepted_count / max(1, retrieval_count)
-    const acceptedChangeRate = inputs.acceptedChangeCount / Math.max(1, inputs.currentRetrievalCount);
-
     // Differential prediction-error term:
-    // outcome = (retrieval_delta − expected_delta)
-    //           − PENALTY × retrieval_delta × (1 − accepted_change_rate)
-    //           + valence
+    // outcome = (retrieval_delta − expected_delta) + valence
     //
     // Prediction error is computed against the PRIOR stored EMA (before folding
     // in this cycle's observation), so the current delta cannot leak into its own
@@ -252,11 +250,10 @@ export function updateAssetOutcome(db: Database, inputs: OutcomeUpdateInputs): O
     // expected' = α × delta + (1−α) × prior_expected
     expectedRetrievalRate =
       OUTCOME_EMA_ALPHA * retrievalDelta + (1 - OUTCOME_EMA_ALPHA) * existing.expected_retrieval_rate;
-    const penalty = OUTCOME_PENALTY_WEIGHT * retrievalDelta * (1 - acceptedChangeRate);
 
     // Running sum (EMA approach): new score = α × update + (1−α) × old
     // so the score tracks the moving signal, not the cumulative sum.
-    const rawUpdate = predictionError - penalty + valence;
+    const rawUpdate = predictionError + valence;
     const newScore = OUTCOME_EMA_ALPHA * rawUpdate + (1 - OUTCOME_EMA_ALPHA) * existing.outcome_score;
 
     // Clip to [OUTCOME_SCORE_MIN, OUTCOME_SCORE_MAX] — the ceiling is the RPE
@@ -392,6 +389,18 @@ export function outcomeScoreToSalience(outcomeScore: number, maxScore: number): 
 
 // ── Proxy-adequacy tripwire ───────────────────────────────────────────────────
 
+/**
+ * Dead-proxy threshold: |corr| below this means outcome_score carries no
+ * information about improvement need (pure noise).
+ */
+export const PROXY_DEAD_CORR_THRESHOLD = 0.1;
+
+/**
+ * Minimum sample size before the dead-proxy check fires. Below this, a
+ * near-zero correlation is indistinguishable from small-sample noise.
+ */
+export const PROXY_DEAD_MIN_N = 500;
+
 export interface ProxyAdequacyResult {
   /**
    * Pearson correlation between outcome_score and accepted_change_rate.
@@ -405,6 +414,14 @@ export interface ProxyAdequacyResult {
    * signal is no longer deferrable, and the health report should warn.
    */
   isInverted: boolean;
+  /**
+   * When `true`, the proxy is DEAD: |correlation| < PROXY_DEAD_CORR_THRESHOLD
+   * at n ≥ PROXY_DEAD_MIN_N — outcome_score is statistically unrelated to
+   * improvement outcomes and must not be treated as a health signal. The old
+   * one-tailed check (inverted only) let the proxy decay from informative to
+   * random without ever alarming.
+   */
+  isDead: boolean;
 }
 
 /**
@@ -421,7 +438,7 @@ export interface ProxyAdequacyResult {
  */
 export function computeProxyAdequacy(rows: AssetOutcomeRow[]): ProxyAdequacyResult {
   const n = rows.length;
-  if (n < 3) return { correlation: Number.NaN, n, isInverted: false };
+  if (n < 3) return { correlation: Number.NaN, n, isInverted: false, isDead: false };
 
   // accepted_change_rate per row.
   const xs = rows.map((r) => r.outcome_score);
@@ -445,11 +462,13 @@ export function computeProxyAdequacy(rows: AssetOutcomeRow[]): ProxyAdequacyResu
   varY /= n;
 
   const denom = Math.sqrt(varX) * Math.sqrt(varY);
-  if (denom < 1e-12) return { correlation: Number.NaN, n, isInverted: false };
+  if (denom < 1e-12) return { correlation: Number.NaN, n, isInverted: false, isDead: false };
 
   const correlation = covXY / denom;
   // Inverted proxy: negative correlation between outcome and accepted_change_rate
   // means high-outcome assets are also high-need — the opposite of "useful".
   const isInverted = correlation < -0.3;
-  return { correlation, n, isInverted };
+  // Dead proxy: near-zero correlation at scale — the score is noise.
+  const isDead = n >= PROXY_DEAD_MIN_N && Math.abs(correlation) < PROXY_DEAD_CORR_THRESHOLD;
+  return { correlation, n, isInverted, isDead };
 }

--- a/src/commands/improve/preparation.ts
+++ b/src/commands/improve/preparation.ts
@@ -55,6 +55,7 @@ import {
   computeProxyAdequacy,
   getAllAssetOutcomes,
   getOutcomeScoresByRef,
+  OUTCOME_SCORE_MAX,
   outcomeScoreToSalience,
   updateAssetOutcome,
 } from "./outcome-loop";
@@ -1571,9 +1572,14 @@ export async function runImprovePreparationStage(args: {
           for (const row of allOutcomes) {
             if (row.outcome_score > maxOutcomeScore) maxOutcomeScore = row.outcome_score;
           }
+          // Read-clip: legacy rows written before the OUTCOME_SCORE_MAX write-clip
+          // existed can sit above the ceiling (live max was 3.13). Without this
+          // clip they inflate the normalisation denominator and floor everyone
+          // else's outcomeSalience (#691 follow-up).
+          maxOutcomeScore = Math.min(maxOutcomeScore, OUTCOME_SCORE_MAX);
 
-          // Proxy-adequacy tripwire: emit a health event if outcome_score is
-          // negatively correlated with accepted_change_rate (inverted proxy).
+          // Proxy-adequacy tripwire (two-tailed): inverted (corr < −0.3) and
+          // dead (|corr| < 0.1 at n ≥ 500) both emit health events.
           const adequacy = computeProxyAdequacy(allOutcomes);
           if (adequacy.isInverted) {
             appendEvent(
@@ -1584,6 +1590,20 @@ export async function runImprovePreparationStage(args: {
                   correlation: adequacy.correlation,
                   n: adequacy.n,
                   note: "corr(outcome_score, accepted_change_rate) < −0.3: high-outcome_score assets have LOW accepted-change rates — the proxy's 'doing well' signal is inverted, so the coarse retrieval-delta signal is no longer trustworthy and the 0.10+ rich in-session signal is no longer deferrable. See plan §WS-2 proxy-adequacy tripwire.",
+                },
+              },
+              eventsCtx,
+            );
+          }
+          if (adequacy.isDead) {
+            appendEvent(
+              {
+                eventType: "outcome_proxy_dead",
+                ref: undefined,
+                metadata: {
+                  correlation: adequacy.correlation,
+                  n: adequacy.n,
+                  note: "|corr(outcome_score, accepted_change_rate)| < 0.1 at n ≥ 500: outcome_score is statistically unrelated to improvement outcomes — the proxy is noise, not signal. Rank contributions derived from it are not currently informative.",
                 },
               },
               eventsCtx,

--- a/src/commands/read/curate.ts
+++ b/src/commands/read/curate.ts
@@ -24,7 +24,7 @@ import { appendEvent } from "../../core/events";
 import { computeBodyHash } from "../../indexer/db/db";
 import { enqueueGraphExtraction, hasGraphData } from "../../indexer/db/graph-db";
 import { findSourceForPath, resolveSourceEntries } from "../../indexer/search/search-source";
-import { insertUsageEvent } from "../../indexer/usage/usage-events";
+import { insertUsageEvent, type UsageEventSource } from "../../indexer/usage/usage-events";
 import { truncateDescription } from "../../output/shapes";
 import type { RegistrySearchResultHit, SearchResponse, ShowResponse, SourceSearchHit } from "../../sources/types";
 import { TELEMETRY_BUSY_TIMEOUT_MS, withIndexDb } from "../../storage/repositories/index-db";
@@ -84,6 +84,12 @@ export interface CurateOptions {
    * `akmCurate` skips its IO and curates this fixture directly.
    */
   searchResponse?: SearchResponse;
+  /**
+   * Usage-event provenance for telemetry. Defaults to `"user"`. The CLI passes
+   * the AKM_EVENT_SOURCE-derived value so pipeline/task-runner curates are not
+   * recorded as user demand (was previously hardcoded to "user").
+   */
+  eventSource?: UsageEventSource;
 }
 
 const CURATE_FALLBACK_FILTER_WORDS = new Set([
@@ -142,7 +148,7 @@ const CURATE_REFERENCE_QUERY_RE = /\b(?:reference|docs?|guide|how|explain|learn|
  * Fire-and-forget: log a curate event to the usage_events table and events.jsonl.
  * Never blocks the caller; errors are silently ignored.
  */
-function logCurateEvent(query: string, result: CurateResponse): void {
+function logCurateEvent(query: string, result: CurateResponse, eventSource: UsageEventSource = "user"): void {
   const itemRefs = result.items.map((item) => ("ref" in item ? item.ref : `registry:${item.id}`));
   appendEvent({
     eventType: "curate",
@@ -159,7 +165,7 @@ function logCurateEvent(query: string, result: CurateResponse): void {
             itemCount: result.items.length,
             itemRefs,
           }),
-          source: "user",
+          source: eventSource,
         });
         for (const item of result.items) {
           if (!("ref" in item) || typeof item.ref !== "string") continue;
@@ -167,7 +173,7 @@ function logCurateEvent(query: string, result: CurateResponse): void {
             event_type: "curate",
             query,
             entry_ref: item.ref,
-            source: "user",
+            source: eventSource,
           });
         }
       },
@@ -198,7 +204,7 @@ export async function akmCurate(options: CurateOptions): Promise<CurateResponse>
       source,
     }));
   const result = await curateSearchResults(options.query, searchResponse, limit, options.type);
-  logCurateEvent(options.query, result);
+  logCurateEvent(options.query, result, options.eventSource);
   return result;
 }
 

--- a/src/commands/read/search-cli.ts
+++ b/src/commands/read/search-cli.ts
@@ -19,18 +19,20 @@ import { defineJsonCommand, output, parseAllFlagValues } from "../../cli/shared"
 import { parseAssetRef } from "../../core/asset/asset-ref";
 import { parseMetaRef } from "../../core/asset/stash-meta";
 import { UsageError } from "../../core/errors";
+import type { UsageEventSource } from "../../indexer/usage/usage-events";
 import { getHyphenatedBoolean, getOutputMode, parseFlagValue } from "../../output/context";
 import type { KnowledgeView, ShowDetailLevel } from "../../sources/types";
 import { akmCurate } from "./curate";
 import { akmSearch, parseBeliefFilterMode, parseScopeFilterFlags, parseSearchSource } from "./search";
 import { akmShowUnified } from "./show";
 
-// AKM_EVENT_SOURCE attributes a query to a `user` invocation or the internal
-// `improve` loop so the event log can distinguish them; any other value is
-// treated as unset.
-function resolveEventSource(): "user" | "improve" | undefined {
+// AKM_EVENT_SOURCE attributes a query to a `user` invocation, the internal
+// `improve` loop, or the `task` runner so the event log can distinguish
+// genuine demand from machine traffic; any other value is treated as unset.
+function resolveEventSource(): UsageEventSource | undefined {
   const raw = process.env.AKM_EVENT_SOURCE;
   if (raw === "improve") return "improve";
+  if (raw === "task") return "task";
   if (raw === "user") return "user";
   return undefined;
 }
@@ -147,7 +149,7 @@ export const curateCommand = defineJsonCommand({
     const limitParsed = parsePositiveIntFlag(args.limit ?? undefined);
     const limit = limitParsed && limitParsed > 0 ? limitParsed : 4;
     const source = parseSearchSource(args.source ?? "stash");
-    const curated = await akmCurate({ query: args.query, type, limit, source });
+    const curated = await akmCurate({ query: args.query, type, limit, source, eventSource: resolveEventSource() });
     output("curate", curated);
   },
 });

--- a/src/commands/read/search.ts
+++ b/src/commands/read/search.ts
@@ -25,7 +25,7 @@ import { getCurrentWorkflowScopeKey } from "../../workflows/authoring/scope-key"
 // Eagerly import source providers to trigger self-registration before the
 // indexer or path-resolution code runs.
 import "../../sources/providers/index";
-import { insertUsageEvent } from "../../indexer/usage/usage-events";
+import { insertUsageEvent, type UsageEventSource } from "../../indexer/usage/usage-events";
 import type {
   AkmSearchType,
   BeliefFilterMode,
@@ -89,7 +89,7 @@ export async function akmSearch(input: {
    * `"improve"` when called from improve's reflect/distill agents
    * so events can be filtered out of user-facing history.
    */
-  eventSource?: "user" | "improve";
+  eventSource?: UsageEventSource;
 }): Promise<SearchResponse> {
   const t0 = Date.now();
   const query = input.query.trim();
@@ -306,7 +306,7 @@ function logSearchEvent(
   query: string,
   response: SearchResponse,
   mode: "semantic" | "keyword" = "keyword",
-  eventSource: "user" | "improve" = "user",
+  eventSource: UsageEventSource = "user",
   disableScopedUtility = false,
 ): void {
   // Emit a structured event to events.jsonl so workflow-trace consumers
@@ -338,7 +338,12 @@ function logSearchEvent(
         }
         // Bump utility scores for all resolved entries (MemRL retrieval signal).
         // The indexer overwrites these at next reindex; bumps are temporary hints.
-        const resolvedIds = resolved.map((r) => r.entryId).filter((id): id is number => id !== undefined);
+        // Gated to user-sourced events: pipeline searches (improve probes, task
+        // runner) must not feed the utility signal (meta-review 05 DRIFT-6 —
+        // the bump previously fired unconditionally, so even correctly-tagged
+        // machine traffic inflated utility).
+        const resolvedIds =
+          eventSource === "user" ? resolved.map((r) => r.entryId).filter((id): id is number => id !== undefined) : [];
         if (resolvedIds.length > 0) {
           let scopeKey: string | undefined;
           try {

--- a/src/commands/read/show.ts
+++ b/src/commands/read/show.ts
@@ -36,7 +36,7 @@ import { lookup } from "../../indexer/indexer";
 import type { StashEntryScope } from "../../indexer/passes/metadata";
 import { ensurePrimaryIndexForRead, resolveReadSources } from "../../indexer/read-preflight";
 import { buildEditHint, findSourceForPath, isEditable, resolveSourceEntries } from "../../indexer/search/search-source";
-import { insertUsageEvent } from "../../indexer/usage/usage-events";
+import { insertUsageEvent, type UsageEventSource } from "../../indexer/usage/usage-events";
 import { buildFileContext, buildRenderContext, getRenderer, runMatchers } from "../../indexer/walk/file-context";
 import { resolveAssetPath } from "../../indexer/walk/path-resolver";
 import { resolveIndexPassLLM } from "../../llm/index-passes";
@@ -139,7 +139,7 @@ export async function akmShowUnified(input: {
    * `"improve"` when called from improve's reflect/distill agents
    * so events can be filtered out of user-facing history.
    */
-  eventSource?: "user" | "improve";
+  eventSource?: UsageEventSource;
 }): Promise<ShowResponse> {
   const ref = input.ref.trim();
 
@@ -298,7 +298,7 @@ function recentShowCount(ref: string): number {
   }
 }
 
-function logShowEvent(ref: string, eventSource: "user" | "improve" = "user"): void {
+function logShowEvent(ref: string, eventSource: UsageEventSource = "user"): void {
   // Emit a structured event to events.jsonl so workflow-trace consumers
   // detect akm show invocations without relying on stdout scraping.
   const parsed = parseAssetRef(ref);

--- a/src/indexer/db/db.ts
+++ b/src/indexer/db/db.ts
@@ -2011,6 +2011,11 @@ function bareRef(ref: string): string {
  * entry_ref populated (see logCurateEvent), so curation is a real retrieval
  * signal here. Legacy summary-only curate rows with a NULL entry_ref simply
  * contribute nothing.
+ *
+ * Machine-sourced events (`source` = 'improve' or 'task') are EXCLUDED: this
+ * count feeds salience/ranking, and pipeline probe traffic counting as demand
+ * creates a self-reinforcing loop (meta-review 05 DRIFT-6). NULL sources
+ * (pre-column rows) count as user demand.
  */
 export function getRetrievalCounts(db: Database, refs: string[]): Map<string, number> {
   if (refs.length === 0) return new Map();
@@ -2049,6 +2054,7 @@ export function getRetrievalCounts(db: Database, refs: string[]): Map<string, nu
          FROM usage_events
          WHERE event_type IN ('search','show','curate')
            AND entry_ref IS NOT NULL
+           AND (source IS NULL OR source NOT IN ('improve','task'))
            AND CASE
                  WHEN instr(entry_ref, '//') > 0
                    THEN substr(entry_ref, instr(entry_ref, '//') + 2)

--- a/src/indexer/usage/usage-events.ts
+++ b/src/indexer/usage/usage-events.ts
@@ -13,6 +13,17 @@ import type { Database, SqlValue } from "../../storage/database";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
+/**
+ * Provenance of a usage event. `"user"` = interactive/direct invocation
+ * (including agent sessions acting for the user); `"improve"` = the improve
+ * pipeline's own retrievals (reflect/distill agents); `"task"` = the task
+ * runner (scheduled/cron work). Non-`"user"` sources are machine demand and
+ * are excluded from retrieval-derived ranking signals (`getRetrievalCounts`,
+ * utility bumps) so pipeline traffic cannot inflate them (meta-review 05
+ * DRIFT-6). Propagated across process boundaries via `AKM_EVENT_SOURCE`.
+ */
+export type UsageEventSource = "user" | "improve" | "task";
+
 export interface UsageEvent {
   event_type: string;
   query?: string;
@@ -20,12 +31,8 @@ export interface UsageEvent {
   entry_ref?: string;
   signal?: string;
   metadata?: string;
-  /**
-   * Event source: `"user"` for direct CLI invocations, `"improve"` for
-   * operations triggered by `akm improve` (reflect/distill agents).
-   * Defaults to `"user"` when omitted.
-   */
-  source?: "user" | "improve";
+  /** Event source (see {@link UsageEventSource}). Defaults to `"user"` when omitted. */
+  source?: UsageEventSource;
 }
 
 export interface UsageEventRow {
@@ -43,7 +50,7 @@ export interface UsageEventRow {
 export interface UsageEventFilters {
   event_type?: string;
   entry_ref?: string;
-  source?: "user" | "improve";
+  source?: UsageEventSource;
   /**
    * Inclusive lower bound on `created_at` (SQLite `YYYY-MM-DD HH:MM:SS`
    * timestamp). When set, only events with `created_at >= since` are returned.

--- a/src/tasks/runner.ts
+++ b/src/tasks/runner.ts
@@ -193,6 +193,11 @@ async function runCommandTask(input: {
       stdout: "pipe",
       stderr: "pipe",
       cwd: process.env.HOME ?? "/tmp",
+      // Stamp task-runner provenance so any akm invocation in the command tree
+      // records usage events as machine traffic, not user demand (DRIFT-6).
+      // A more specific stamp already in the environment (e.g. improve's
+      // AKM_EVENT_SOURCE=improve on its child spawns) still wins in children.
+      env: { ...process.env, AKM_EVENT_SOURCE: process.env.AKM_EVENT_SOURCE ?? "task" },
     });
 
     let timer: ReturnType<typeof setTimeout> | undefined;
@@ -442,6 +447,10 @@ async function runPromptTask(input: {
     timeoutMs: agentTimeoutMs,
     cwd: stashDir,
     ...agentOptions,
+    // Stamp task-runner provenance for any akm invocation the agent makes
+    // (DRIFT-6: agent-task traffic must not be recorded as user demand).
+    // Caller-supplied env still wins on conflicts.
+    env: { AKM_EVENT_SOURCE: "task", ...agentOptions?.env },
   });
 
   const finishedAt = now();

--- a/tests/commands/health-minting-rollup.test.ts
+++ b/tests/commands/health-minting-rollup.test.ts
@@ -1,0 +1,122 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Enrichment-vs-minting rollup pins (meta-review 05, DRIFT-5 refutation).
+ *
+ * The create-vs-update sensor already exists in proposals.metadata_json
+ * (`backupContent` captured at apply time; `eligibilitySource` = lane) — the
+ * rollup only derives the split so policy drift is visible in `akm health`
+ * without a manual DB query. These tests pin the classification rules:
+ * backupContent absent (or null) = minted; non-enrichment lanes appear in
+ * byLane but not in the enrichment share; unattributed rows are excluded.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { computeEnrichmentMintingRollup, ENRICHMENT_LANES } from "../../src/commands/health";
+import type { Database as AkmDatabase } from "../../src/storage/database";
+
+const SINCE = "2026-01-01T00:00:00.000Z";
+const UNTIL = "2026-12-31T00:00:00.000Z";
+const IN_WINDOW = "2026-06-15T00:00:00.000Z";
+
+let db: AkmDatabase;
+
+beforeEach(() => {
+  db = new Database(":memory:") as unknown as AkmDatabase;
+  db.exec(`
+    CREATE TABLE proposals (
+      id               TEXT    PRIMARY KEY,
+      stash_dir        TEXT    NOT NULL,
+      ref              TEXT    NOT NULL,
+      status           TEXT    NOT NULL DEFAULT 'pending',
+      source           TEXT    NOT NULL,
+      created_at       TEXT    NOT NULL,
+      updated_at       TEXT    NOT NULL,
+      content          TEXT    NOT NULL DEFAULT '',
+      frontmatter_json TEXT,
+      metadata_json    TEXT    NOT NULL DEFAULT '{}'
+    );
+  `);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+let idCounter = 0;
+function seedProposal(input: {
+  status?: string;
+  updatedAt?: string;
+  lane?: string;
+  backupContent?: string | null;
+}): void {
+  const metadata: Record<string, unknown> = {};
+  if (input.lane !== undefined) metadata.eligibilitySource = input.lane;
+  if (input.backupContent !== undefined) metadata.backupContent = input.backupContent;
+  db.prepare(
+    `INSERT INTO proposals (id, stash_dir, ref, status, source, created_at, updated_at, metadata_json)
+     VALUES (?, '/tmp/stash', ?, ?, 'reflect', ?, ?, ?)`,
+  ).run(
+    `p-${idCounter++}`,
+    `knowledge:asset-${idCounter}`,
+    input.status ?? "accepted",
+    input.updatedAt ?? IN_WINDOW,
+    input.updatedAt ?? IN_WINDOW,
+    JSON.stringify(metadata),
+  );
+}
+
+describe("computeEnrichmentMintingRollup", () => {
+  test("splits minted (no backupContent) from updated per lane and computes the enrichment share", () => {
+    seedProposal({ lane: "proactive", backupContent: "prior content" }); // updated
+    seedProposal({ lane: "proactive", backupContent: "prior content" }); // updated
+    seedProposal({ lane: "proactive" }); // minted — policy violation
+    seedProposal({ lane: "extract" }); // minted, but extract is a minting lane
+
+    const rollup = computeEnrichmentMintingRollup(db, SINCE, UNTIL);
+    expect(rollup?.byLane.proactive).toEqual({ minted: 1, updated: 2 });
+    expect(rollup?.byLane.extract).toEqual({ minted: 1, updated: 0 });
+    // Share counts ONLY enrichment lanes: 1 minted / 3 decided.
+    expect(rollup?.minted).toBe(1);
+    expect(rollup?.updated).toBe(2);
+    expect(rollup?.share).toBeCloseTo(1 / 3, 3); // roundRate rounds to 4 decimals
+  });
+
+  test("an explicit null backupContent classifies as minted (absence semantics)", () => {
+    seedProposal({ lane: "high-retrieval", backupContent: null });
+    const rollup = computeEnrichmentMintingRollup(db, SINCE, UNTIL);
+    expect(rollup?.byLane["high-retrieval"]).toEqual({ minted: 1, updated: 0 });
+  });
+
+  test("excludes unattributed rows, non-accepted rows, and rows outside the window", () => {
+    seedProposal({}); // no eligibilitySource (pre-Phase-6C) — excluded
+    seedProposal({ lane: "proactive", status: "pending" }); // not accepted
+    seedProposal({ lane: "proactive", updatedAt: "2025-01-01T00:00:00.000Z" }); // before window
+    seedProposal({ lane: "proactive", updatedAt: "2027-01-01T00:00:00.000Z" }); // after window
+
+    expect(computeEnrichmentMintingRollup(db, SINCE, UNTIL)).toBeUndefined();
+  });
+
+  test("share is NaN when only non-enrichment lanes decided", () => {
+    seedProposal({ lane: "extract" });
+    const rollup = computeEnrichmentMintingRollup(db, SINCE, UNTIL);
+    expect(rollup).toBeDefined();
+    expect(Number.isNaN(rollup?.share)).toBe(true);
+  });
+
+  test("fails open when the proposals table is absent", () => {
+    const bare = new Database(":memory:") as unknown as AkmDatabase;
+    try {
+      expect(computeEnrichmentMintingRollup(bare, SINCE, UNTIL)).toBeUndefined();
+    } finally {
+      bare.close();
+    }
+  });
+
+  test("the ratified enrichment lane set is pinned", () => {
+    expect([...ENRICHMENT_LANES].sort()).toEqual(["high-retrieval", "high-salience", "proactive", "signal-delta"]);
+  });
+});

--- a/tests/commands/improve/monitor-liveness.test.ts
+++ b/tests/commands/improve/monitor-liveness.test.ts
@@ -1,0 +1,154 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Two-tailed monitor pins (meta-review 05, DRIFT-3).
+ *
+ * The watchdogs previously fired on only one tail: proxy-adequacy alarmed only
+ * when corr < −0.3 (a proxy decaying to pure noise passed forever), and the
+ * salience Gini check flagged only entrenchment (> 0.35) while a distribution
+ * collapsed toward uniform (live value 0.040, below the ~0.1 uniform baseline)
+ * rendered as healthy. These tests pin both new tails.
+ */
+
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { computeDegradationMetrics } from "../../../src/commands/health";
+import {
+  type AssetOutcomeRow,
+  computeProxyAdequacy,
+  PROXY_DEAD_MIN_N,
+} from "../../../src/commands/improve/outcome-loop";
+import type { Database as AkmDatabase } from "../../../src/storage/database";
+
+// ── proxy adequacy ───────────────────────────────────────────────────────────
+
+function outcomeRow(ref: string, outcomeScore: number, acceptedCount: number, retrievalCount: number): AssetOutcomeRow {
+  return {
+    asset_ref: ref,
+    last_retrieved_at: 0,
+    retrieval_count: retrievalCount,
+    expected_retrieval_rate: 0,
+    negative_feedback_count: 0,
+    accepted_change_count: acceptedCount,
+    review_pressure: 0,
+    outcome_score: outcomeScore,
+    updated_at: 0,
+  };
+}
+
+/**
+ * Rows with exactly zero correlation between outcome_score and
+ * accepted_change_rate: outcome alternates with period 2, rate with period 4,
+ * so over any multiple of 4 rows the two are orthogonal.
+ */
+function uncorrelatedRows(n: number): AssetOutcomeRow[] {
+  const rows: AssetOutcomeRow[] = [];
+  for (let i = 0; i < n; i++) {
+    rows.push(outcomeRow(`x:${i}`, i % 2, (i >> 1) % 2, 1));
+  }
+  return rows;
+}
+
+describe("computeProxyAdequacy — two-tailed", () => {
+  test("DEAD: |corr| < 0.1 at n ≥ PROXY_DEAD_MIN_N fires isDead", () => {
+    const rows = uncorrelatedRows(PROXY_DEAD_MIN_N); // 500 = 125 × 4 → corr exactly 0
+    const result = computeProxyAdequacy(rows);
+    expect(Math.abs(result.correlation)).toBeLessThan(0.1);
+    expect(result.isDead).toBe(true);
+    expect(result.isInverted).toBe(false);
+  });
+
+  test("below the n threshold, zero correlation is NOT flagged dead (small-sample noise)", () => {
+    const rows = uncorrelatedRows(496); // 124 × 4, still corr 0, but n < 500
+    const result = computeProxyAdequacy(rows);
+    expect(result.isDead).toBe(false);
+  });
+
+  test("INVERTED tail still fires and is not confused with dead", () => {
+    // Perfect negative correlation: outcome ascends while accepted rate descends.
+    const n = 600;
+    const rows: AssetOutcomeRow[] = [];
+    for (let i = 0; i < n; i++) {
+      rows.push(outcomeRow(`x:${i}`, i / n, n - i, n));
+    }
+    const result = computeProxyAdequacy(rows);
+    expect(result.correlation).toBeLessThan(-0.3);
+    expect(result.isInverted).toBe(true);
+    expect(result.isDead).toBe(false);
+  });
+
+  test("a genuinely informative proxy passes both tails", () => {
+    const n = 600;
+    const rows: AssetOutcomeRow[] = [];
+    for (let i = 0; i < n; i++) {
+      rows.push(outcomeRow(`x:${i}`, i / n, i, n));
+    }
+    const result = computeProxyAdequacy(rows);
+    expect(result.correlation).toBeGreaterThan(0.3);
+    expect(result.isInverted).toBe(false);
+    expect(result.isDead).toBe(false);
+  });
+});
+
+// ── salience Gini ────────────────────────────────────────────────────────────
+
+function salienceDb(retrievalSaliences: number[]): AkmDatabase {
+  const db = new Database(":memory:") as unknown as AkmDatabase;
+  db.exec(`
+    CREATE TABLE asset_salience (
+      asset_ref          TEXT    PRIMARY KEY,
+      encoding_salience  REAL    NOT NULL DEFAULT 0.5,
+      outcome_salience   REAL    NOT NULL DEFAULT 0.0,
+      retrieval_salience REAL    NOT NULL DEFAULT 0.0,
+      rank_score         REAL    NOT NULL DEFAULT 0.0,
+      consecutive_no_ops INTEGER NOT NULL DEFAULT 0,
+      updated_at         INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+  const stmt = db.prepare("INSERT INTO asset_salience (asset_ref, retrieval_salience, rank_score) VALUES (?, ?, ?)");
+  retrievalSaliences.forEach((v, i) => {
+    stmt.run(`x:${i}`, v, v);
+  });
+  return db;
+}
+
+const SINCE = "2026-01-01T00:00:00.000Z";
+const UNTIL = "2026-12-31T00:00:00.000Z";
+
+describe("computeDegradationMetrics — Gini two-tailed", () => {
+  test("collapsed-toward-uniform distribution (Gini < 0.08) flags uniformity, not entrenchment", () => {
+    // Near-identical scores: Gini ≈ 0.005 — the live 2026-07 failure shape.
+    const values = Array.from({ length: 10 }, (_, i) => (i % 2 === 0 ? 0.49 : 0.51));
+    const db = salienceDb(values);
+    const result = computeDegradationMetrics(db, SINCE, UNTIL);
+    expect(result?.salienceUniformityFlagged).toBe(true);
+    expect(result?.entrenchmentFlagged).toBe(false);
+  });
+
+  test("healthy spread (Gini between 0.08 and 0.35) flags neither tail", () => {
+    // Alternating 0.25/0.75 → Gini 0.125 under the top-100 formula.
+    const values = Array.from({ length: 10 }, (_, i) => (i % 2 === 0 ? 0.25 : 0.75));
+    const db = salienceDb(values);
+    const result = computeDegradationMetrics(db, SINCE, UNTIL);
+    expect(result?.salienceUniformityFlagged).toBe(false);
+    expect(result?.entrenchmentFlagged).toBe(false);
+  });
+
+  test("entrenched distribution (Gini > 0.35) still flags entrenchment, not uniformity", () => {
+    // One dominant asset, nine near-zero → Gini ≈ 0.41.
+    const values = [1.0, ...Array.from({ length: 9 }, () => 0.01)];
+    const db = salienceDb(values);
+    const result = computeDegradationMetrics(db, SINCE, UNTIL);
+    expect(result?.entrenchmentFlagged).toBe(true);
+    expect(result?.salienceUniformityFlagged).toBe(false);
+  });
+
+  test("fewer than 5 salience rows leaves both flags undefined (insufficient data)", () => {
+    const db = salienceDb([0.5, 0.5, 0.5]);
+    const result = computeDegradationMetrics(db, SINCE, UNTIL);
+    expect(result?.entrenchmentFlagged).toBeUndefined();
+    expect(result?.salienceUniformityFlagged).toBeUndefined();
+  });
+});

--- a/tests/commands/improve/outcome-invariance.test.ts
+++ b/tests/commands/improve/outcome-invariance.test.ts
@@ -1,0 +1,153 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * #691 invariance pins (meta-review 05, DRIFT-2).
+ *
+ * The v1 "retrieved-but-never-improved" penalty term was DELETED from the
+ * outcome formula: its accepted_change_rate factor had corr ≈ 0.007 with
+ * outcome_score across live data (noise), and because the unclamped rate
+ * exceeds 1 whenever accepted changes outnumber retrievals, it paid a live
+ * BONUS for churn — an asset's score could rise by being rewritten under
+ * auto-accept.
+ *
+ * These tests pin the post-deletion invariants:
+ *   1. outcome_score is INVARIANT to acceptedChangeCount.
+ *   2. The old churn-bonus shape (accepted > retrievals on a positive delta)
+ *      produces the same score as zero accepted changes.
+ *   3. accepted_change_count is still persisted as raw telemetry.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  DIVERSITY_FLOOR_FRACTION,
+  getAssetOutcome,
+  OUTCOME_SCORE_MAX,
+  outcomeScoreToSalience,
+  updateAssetOutcome,
+} from "../../../src/commands/improve/outcome-loop";
+import type { Database } from "../../../src/core/state-db";
+import { openStateDatabase } from "../../../src/core/state-db";
+
+const NOW = Date.parse("2026-07-02T00:00:00.000Z");
+
+function openTestDb() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-outcome-invariance-test-"));
+  const db = openStateDatabase(path.join(tmpDir, "state.db"));
+  return { db, tmpDir };
+}
+
+/** Seed an existing row so updateAssetOutcome takes the differential-update path. */
+function seedRow(db: Database, ref: string, retrievalCount: number, expectedRate: number, outcomeScore: number): void {
+  db.prepare(
+    `INSERT INTO asset_outcome
+       (asset_ref, last_retrieved_at, retrieval_count, expected_retrieval_rate,
+        negative_feedback_count, accepted_change_count, review_pressure,
+        outcome_score, updated_at)
+     VALUES (?, 0, ?, ?, 0, 0, 0, ?, ?)`,
+  ).run(ref, retrievalCount, expectedRate, outcomeScore, NOW);
+}
+
+describe("outcome_score is invariant to acceptedChangeCount (#691)", () => {
+  test("identical updates differing only in acceptedChangeCount produce identical scores", () => {
+    const { db } = openTestDb();
+    try {
+      seedRow(db, "skill:a", 10, 2.0, 0.2);
+      seedRow(db, "skill:b", 10, 2.0, 0.2);
+
+      const a = updateAssetOutcome(db, {
+        ref: "skill:a",
+        currentRetrievalCount: 15,
+        lastRetrievedAt: NOW,
+        acceptedChangeCount: 0,
+        negativeFeedbackCount: 0,
+        valence: 0.1,
+        now: NOW + 1000,
+      });
+      const b = updateAssetOutcome(db, {
+        ref: "skill:b",
+        currentRetrievalCount: 15,
+        lastRetrievedAt: NOW,
+        acceptedChangeCount: 500,
+        negativeFeedbackCount: 0,
+        valence: 0.1,
+        now: NOW + 1000,
+      });
+
+      expect(b.outcomeScore).toBe(a.outcomeScore);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("the old churn-bonus shape (accepted > retrievals, positive delta) earns nothing", () => {
+    const { db } = openTestDb();
+    try {
+      // The live flip case from the meta-review: 7 accepted changes on 3
+      // retrievals (rate 2.33 > 1) — under v1 the penalty term went negative
+      // and PAID for churn on any positive retrieval delta.
+      seedRow(db, "command:churned", 1, 0.5, 0.0);
+      seedRow(db, "command:untouched", 1, 0.5, 0.0);
+
+      const churned = updateAssetOutcome(db, {
+        ref: "command:churned",
+        currentRetrievalCount: 3,
+        lastRetrievedAt: NOW,
+        acceptedChangeCount: 7,
+        negativeFeedbackCount: 0,
+        valence: 0,
+        now: NOW + 1000,
+      });
+      const untouched = updateAssetOutcome(db, {
+        ref: "command:untouched",
+        currentRetrievalCount: 3,
+        lastRetrievedAt: NOW,
+        acceptedChangeCount: 0,
+        negativeFeedbackCount: 0,
+        valence: 0,
+        now: NOW + 1000,
+      });
+
+      expect(churned.outcomeScore).toBe(untouched.outcomeScore);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("accepted_change_count is still persisted as raw telemetry", () => {
+    const { db } = openTestDb();
+    try {
+      seedRow(db, "lesson:telemetry", 5, 1.0, 0.1);
+      updateAssetOutcome(db, {
+        ref: "lesson:telemetry",
+        currentRetrievalCount: 6,
+        lastRetrievedAt: NOW,
+        acceptedChangeCount: 42,
+        negativeFeedbackCount: 0,
+        valence: 0,
+        now: NOW + 1000,
+      });
+      expect(getAssetOutcome(db, "lesson:telemetry")?.accepted_change_count).toBe(42);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe("outcomeSalience normalisation contract", () => {
+  test("normalises against the provided max and applies the diversity floor", () => {
+    // Callers clip the stash-wide max to OUTCOME_SCORE_MAX before normalising
+    // (preparation.ts) so legacy >MAX rows can't floor everyone else: with the
+    // clipped ceiling as reference, a mid-range score keeps its spread.
+    expect(outcomeScoreToSalience(OUTCOME_SCORE_MAX / 2, OUTCOME_SCORE_MAX)).toBe(0.5);
+    // Negative scores clip to 0 and land on the diversity floor.
+    expect(outcomeScoreToSalience(-0.4, OUTCOME_SCORE_MAX)).toBe(DIVERSITY_FLOOR_FRACTION);
+    // Un-clipped legacy reference (the pre-fix behaviour) would have produced
+    // 0.75/3.13 ≈ 0.24 instead of 0.5 — the clip is what keeps spread meaningful.
+    expect(outcomeScoreToSalience(OUTCOME_SCORE_MAX / 2, 3.1302)).toBeLessThan(0.25);
+  });
+});

--- a/tests/feedback-command.test.ts
+++ b/tests/feedback-command.test.ts
@@ -8,7 +8,7 @@ import { closeDatabase, openIndexDatabase } from "../src/indexer/db/db";
 import { akmIndex } from "../src/indexer/indexer";
 import type { SourceSearchHit } from "../src/sources/types";
 import { runCliCapture } from "./_helpers/cli";
-import { type Cleanup, sandboxStashDir, sandboxXdgCacheHome, sandboxXdgConfigHome } from "./_helpers/sandbox";
+import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "./_helpers/sandbox";
 
 // Migrated from spawnSync("bun", [CLI, ...]) to the shared in-process harness
 // (tests/_helpers/cli.ts). beforeEach already sandboxes AKM_STASH_DIR and the
@@ -36,20 +36,21 @@ function isLocalHit(hit: { type: string }): hit is SourceSearchHit {
   return hit.type !== "registry";
 }
 
+// Full composite isolation (incl. XDG_DATA_HOME): this file asserts EXACT
+// usage_events row counts against getDbPath(), so it must own its index.db.
+// The previous 3-helper chain left the data dir on the process-shared suite
+// sandbox, where any shard-mate's feedback events leaked into the assertions
+// (the leak surfaced whenever adding a test file reshuffled bun's shards).
+let storage: IsolatedAkmStorage;
 let stashDir = "";
-let envCleanup: Cleanup = () => {};
 
 beforeEach(() => {
-  const cacheResult = sandboxXdgCacheHome();
-  const cfgResult = sandboxXdgConfigHome(cacheResult.cleanup);
-  const stashResult = sandboxStashDir(cfgResult.cleanup);
-  stashDir = stashResult.dir;
-  envCleanup = stashResult.cleanup;
+  storage = withIsolatedAkmStorage();
+  stashDir = storage.stashDir;
 });
 
 afterEach(() => {
-  envCleanup();
-  envCleanup = () => {};
+  storage.cleanup();
   stashDir = "";
 });
 

--- a/tests/get-retrieval-counts.test.ts
+++ b/tests/get-retrieval-counts.test.ts
@@ -16,6 +16,9 @@ import type { Database as AkmDatabase } from "../src/storage/database";
  *      entry_ref spellings both match a bare input ref (and aggregate together).
  *   2. `curate` events count alongside `search` / `show`.
  *   3. NULL entry_ref rows (legacy curate summary rows) contribute nothing.
+ *   4. Machine-sourced events (source = 'improve' or 'task') are EXCLUDED —
+ *      this count feeds salience/ranking and pipeline probe traffic must not
+ *      register as demand (meta-review 05 DRIFT-6).
  */
 describe("getRetrievalCounts", () => {
   let db: AkmDatabase;
@@ -29,10 +32,11 @@ describe("getRetrievalCounts", () => {
     db.close();
   });
 
-  function seed(eventType: string, entryRef: string | null): void {
-    db.prepare("INSERT INTO usage_events (event_type, entry_ref, source) VALUES (?, ?, 'user')").run(
+  function seed(eventType: string, entryRef: string | null, source = "user"): void {
+    db.prepare("INSERT INTO usage_events (event_type, entry_ref, source) VALUES (?, ?, ?)").run(
       eventType,
       entryRef,
+      source,
     );
   }
 
@@ -79,5 +83,30 @@ describe("getRetrievalCounts", () => {
 
   test("empty input returns an empty map", () => {
     expect(getRetrievalCounts(db, []).size).toBe(0);
+  });
+
+  test("excludes machine-sourced events (improve, task) from counts", () => {
+    seed("search", "skill:probe", "user");
+    seed("search", "skill:probe", "improve"); // improve-loop probe — excluded
+    seed("curate", "skill:probe", "task"); // task-runner traffic — excluded
+
+    const counts = getRetrievalCounts(db, ["skill:probe"]);
+    expect(counts.get("skill:probe")).toBe(1);
+  });
+
+  test("a ref retrieved ONLY by the pipeline registers no demand at all", () => {
+    seed("search", "lesson:machine-only", "improve");
+    seed("show", "lesson:machine-only", "task");
+
+    const counts = getRetrievalCounts(db, ["lesson:machine-only"]);
+    expect(counts.has("lesson:machine-only")).toBe(false);
+  });
+
+  test("unknown future sources count as demand (exclusion list, not allowlist)", () => {
+    // e.g. a later 'hook' source for agent-session traffic must keep counting.
+    seed("show", "agent:reviewer", "hook");
+
+    const counts = getRetrievalCounts(db, ["agent:reviewer"]);
+    expect(counts.get("agent:reviewer")).toBe(1);
   });
 });


### PR DESCRIPTION
Implements the owner-adjudicated implementation items from meta-review 05 (metrics & evals): subtraction first, then provenance filters and invariant pins, plus the reporting-only enrichment-vs-minting rollup.

## What changed

**Deletions (0a/0b, closes #691's code side)**
- The R1 outcome churn-penalty term is gone: `accepted_change_rate` had corr ≈ 0.007 with `outcome_score` (noise), and because the unclamped rate exceeds 1 when accepted changes outnumber retrievals, the "penalty" paid a live **bonus** for churn — a score could rise by being rewritten under auto-accept. `outcome_score` is now `(prediction_error + valence)`; `accepted_change_count` stays as raw telemetry, pinned by `tests/commands/improve/outcome-invariance.test.ts`. The normalisation max is read-clipped to `OUTCOME_SCORE_MAX` so legacy >1.5 rows stop flooring everyone else's outcomeSalience.
- `highGenerationFraction` deleted: it approximated "LLM-merge generations" from `consecutive_no_ops` — the opposite condition — per its own in-code TODO. Display-only; deleted rather than instrumented.

**G5 event provenance (DRIFT-6)**
- `getRetrievalCounts` excludes machine-sourced usage events (`source IN ('improve','task')`) — pipeline probes no longer count as demand in salience.
- `curate` honours `AKM_EVENT_SOURCE` (was hardcoded `source:"user"`); the task runner stamps `AKM_EVENT_SOURCE=task` on command and agent spawns.
- The search-path utility bump fires only for user-sourced searches (previously unconditional, so even correctly-tagged machine traffic inflated utility).

**G1 two-tailed monitors (DRIFT-3)**
- Proxy-adequacy adds `outcome_proxy_dead` (|corr| < 0.1 at n ≥ 500) — a proxy decaying to noise previously passed forever.
- Salience Gini flags the low tail (< 0.08 uniformity collapse) alongside > 0.35 entrenchment.
- Coverage counts **distinct** accepted refs; raw proposal count and a churn ratio (WARN > 1.5) are reported alongside.

**Enrichment-vs-minting rollup (reporting-only)**
- `akm health` now derives the minted-vs-updated split per lane from existing `proposals.metadata_json` columns (`backupContent`, `eligibilitySource`) via SQL-side `json_extract`; advisory WARN > 5% / FAIL > 15% minted share across the ratified enrichment-only lanes. No schema change, no lane behavior change.

**Test-isolation fix (first commit)**
- `feedback-command.test.ts` asserted exact row counts against the process-shared suite data dir; any shard reshuffle (i.e. any PR adding a test file) made two unrelated feedback tests fail. Now uses the composite `withIsolatedAkmStorage()` fixture.

## Verification
- `bun run lint` clean (biome + isolation + license + runtime-boundary + repository-sql + config-schema)
- `tsc --noEmit` clean
- unit: 4993 pass / 0 fail (sharded, multiple consecutive runs)
- integration: 775 tests / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YjU1mGiShdDP4qFW7p4mv