### PR TITLE
fix(release): --external @huggingface/transformers so --compile survives --omit optional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,14 @@ jobs:
       - run: bun install --omit optional
 
       - name: Compile binary
-        run: bun build ./src/cli.ts --compile --target=${{ matrix.target }} --outfile ${{ matrix.artifact }} --define "AKM_VERSION='${{ inputs.version }}'"
+        # @huggingface/transformers is an OPTIONAL dependency, omitted from the
+        # install above, and loaded lazily at runtime via a dynamic import
+        # (src/llm/embedders/local.ts) after `akm setup` installs it. Mark it
+        # --external so `bun build --compile` leaves that import as a runtime
+        # require instead of trying to resolve/bundle the (absent) package —
+        # without this the compile fails "Could not resolve @huggingface/transformers"
+        # (regression surfaced when #693 moved the import to a module-level loader).
+        run: bun build ./src/cli.ts --compile --target=${{ matrix.target }} --external @huggingface/transformers --outfile ${{ matrix.artifact }} --define "AKM_VERSION='${{ inputs.version }}'"
 
       - uses: actions/upload-artifact@v5
         with:


### PR DESCRIPTION
## Problem
The `build` job in `release.yml` (`bun build --compile` after `bun install --omit optional`) started failing on **0.9.0-beta.54** with:

```
error: Could not resolve: "@huggingface/transformers". Maybe you need to "bun install"?
```

This skipped the standalone binaries and the GitHub release (npm publish and `dist/cli.js` were unaffected).

## Root cause
`@huggingface/transformers` is an **optional** dependency (omitted from the release install, installed lazily at runtime by `akm setup`). **#693** moved its dynamic import from an inline `await import(...)` deep in a method to a **module-level loader** (`src/llm/embedders/local.ts:74`). `bun build --compile` now eagerly tries to resolve that module-scope dynamic import at build time — and with `--omit optional` it isn't installed. beta.53 (before #693) built binaries fine.

## Fix
Add `--external @huggingface/transformers` to the compile step so bun leaves the import as a runtime require instead of resolving/bundling the absent package. `better-sqlite3` and `sqlite-vec` (the other optional deps) aren't imported anywhere in `src/`, so they never enter the compile graph and need no change.

## Validation (local)
With the package relocated out of `node_modules` to simulate `--omit optional`:
- plain `--compile` → reproduces `Could not resolve: "@huggingface/transformers"`
- `--compile --external @huggingface/transformers` → `bundle 493 modules`, produces a working binary; `--version` and `--help` run correctly.

Binary-artifact-only change; no source or runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YjU1mGiShdDP4qFW7p4mv