### PR TITLE
fix(indexer): relink origin-qualified usage refs + kill O(n×m) finalize scan

### DIFF
--- a/src/indexer/db/db.ts
+++ b/src/indexer/db/db.ts
@@ -1675,16 +1675,19 @@ export function relinkUsageEvents(db: Database): void {
       .all() as { ref: string }[];
 
     const update = db.prepare("UPDATE usage_events SET entry_id = ? WHERE entry_ref = ? AND entry_id IS NULL");
-    for (const { ref } of refs) {
-      let id: number | undefined;
-      try {
-        id = findEntryIdByRef(db, ref);
-      } catch {
-        // Malformed ref (parseAssetRef throws): leave null, ages out via retention.
-        continue;
+    const relinkTx = db.transaction(() => {
+      for (const { ref } of refs) {
+        let id: number | undefined;
+        try {
+          id = findEntryIdByRef(db, ref);
+        } catch (err) {
+          if (err instanceof Error && err.name === "UsageError") continue;
+          throw err;
+        }
+        if (id !== undefined) update.run(id, ref);
       }
-      if (id !== undefined) update.run(id, ref);
-    }
+    });
+    relinkTx();
   }, "usage_events table may not exist yet during entry_id re-resolution");
 }
 

--- a/src/indexer/db/db.ts
+++ b/src/indexer/db/db.ts
@@ -1643,9 +1643,8 @@ export function applyFeedbackToUtilityScore(
 /**
  * Re-link detached usage_events to their current entry_ids via entry_ref.
  *
- * After a full rebuild, entry IDs change. This query matches events to their
- * new entry rows using the stable `entry_ref` ("type:name") column so usage
- * history survives a full reindex.
+ * After a full rebuild, entry IDs change. This restores each event's link
+ * using the stable `entry_ref` column so usage history survives a reindex.
  */
 export function relinkUsageEvents(db: Database): void {
   bestEffort(() => {
@@ -1663,17 +1662,29 @@ export function relinkUsageEvents(db: Database): void {
         AND entry_id NOT IN (SELECT id FROM entries)
     `);
 
-    // Step 2: re-resolve any null entry_id from entry_ref against the
-    // current entries table. Picks up entries that were re-created with
-    // the same ref (e.g. an asset moved between sources).
-    db.exec(`
-      UPDATE usage_events SET entry_id = (
-        SELECT e.id FROM entries e
-        WHERE substr(e.entry_key, length(e.entry_key) - length(usage_events.entry_ref)) = ':' || usage_events.entry_ref
-        LIMIT 1
-      )
-      WHERE entry_id IS NULL AND entry_ref IS NOT NULL
-    `);
+    // Step 2: re-resolve any null entry_id from entry_ref against the current
+    // entries table, reusing the SAME canonical resolver the read path uses at
+    // insert time (`findEntryIdByRef` → `parseAssetRef`). Resolving per DISTINCT
+    // ref keeps this O(distinct-refs) indexed lookups instead of the previous
+    // O(events × entries) non-indexable `substr(entry_key, …)` scan. It also
+    // fixes a silent correctness bug: the old suffix match compared the RAW
+    // `entry_ref`, so origin-qualified refs ("source//type:name") never matched
+    // an `entry_key` and lost their usage history on every full rebuild.
+    const refs = db
+      .prepare("SELECT DISTINCT entry_ref AS ref FROM usage_events WHERE entry_id IS NULL AND entry_ref IS NOT NULL")
+      .all() as { ref: string }[];
+
+    const update = db.prepare("UPDATE usage_events SET entry_id = ? WHERE entry_ref = ? AND entry_id IS NULL");
+    for (const { ref } of refs) {
+      let id: number | undefined;
+      try {
+        id = findEntryIdByRef(db, ref);
+      } catch {
+        // Malformed ref (parseAssetRef throws): leave null, ages out via retention.
+        continue;
+      }
+      if (id !== undefined) update.run(id, ref);
+    }
   }, "usage_events table may not exist yet during entry_id re-resolution");
 }
 

--- a/tests/indexer/relink-usage-events.test.ts
+++ b/tests/indexer/relink-usage-events.test.ts
@@ -1,0 +1,109 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, test } from "bun:test";
+import { relinkUsageEvents } from "../../src/indexer/db/db";
+import { ensureUsageEventsSchema } from "../../src/indexer/usage/usage-events";
+import type { Database as AkmDatabase } from "../../src/storage/database";
+
+/**
+ * Focused tests for {@link relinkUsageEvents}.
+ *
+ * Regression guard for the finalize-phase slowness + silent link-loss bug:
+ * the previous hand-rolled `substr(entry_key, ...)` suffix query matched the
+ * RAW `entry_ref`, so origin-qualified refs (`source//type:name`) never
+ * relinked and were re-scanned (non-indexably) on every index. The fix reuses
+ * the canonical `findEntryIdByRef` resolver, which strips the `origin//`
+ * qualifier via `parseAssetRef`.
+ */
+describe("relinkUsageEvents", () => {
+  let db: AkmDatabase;
+
+  /** Minimal `entries` schema — only the columns the resolver reads. */
+  function seedEntry(entryKey: string, entryType: string, name: string): number {
+    const info = db
+      .prepare("INSERT INTO entries (entry_key, entry_type, entry_json) VALUES (?, ?, ?)")
+      .run(entryKey, entryType, JSON.stringify({ type: entryType, name }));
+    return Number(info.lastInsertRowid);
+  }
+
+  function insertEvent(entryRef: string, entryId: number | null): void {
+    db.prepare("INSERT INTO usage_events (event_type, entry_id, entry_ref) VALUES ('show', ?, ?)").run(
+      entryId,
+      entryRef,
+    );
+  }
+
+  function entryIdFor(entryRef: string): number | null {
+    const row = db.prepare("SELECT entry_id FROM usage_events WHERE entry_ref = ?").get(entryRef) as {
+      entry_id: number | null;
+    };
+    return row.entry_id;
+  }
+
+  beforeEach(() => {
+    db = new Database(":memory:") as unknown as AkmDatabase;
+    db.exec(`
+      CREATE TABLE entries (
+        id         INTEGER PRIMARY KEY AUTOINCREMENT,
+        entry_key  TEXT NOT NULL,
+        entry_type TEXT NOT NULL,
+        entry_json TEXT NOT NULL
+      );
+    `);
+    ensureUsageEventsSchema(db);
+  });
+
+  test("relinks a BARE type:name ref after entry ids change (existing behaviour)", () => {
+    const id = seedEntry("/home/u/akm:skill:deploy", "skill", "deploy");
+    insertEvent("skill:deploy", null); // detached (e.g. after a full rebuild)
+
+    relinkUsageEvents(db);
+
+    expect(entryIdFor("skill:deploy")).toBe(id);
+  });
+
+  test("relinks an ORIGIN-QUALIFIED source//type:name ref (regression: was silently dropped)", () => {
+    const id = seedEntry(
+      "/home/u/.cache/akm/registry/git-github-getsentry-skills/abc/extracted:knowledge:skills/skill-writer/references/workflow-routing",
+      "knowledge",
+      "skills/skill-writer/references/workflow-routing",
+    );
+    insertEvent("github:getsentry/skills//knowledge:skills/skill-writer/references/workflow-routing", null);
+
+    relinkUsageEvents(db);
+
+    expect(entryIdFor("github:getsentry/skills//knowledge:skills/skill-writer/references/workflow-routing")).toBe(id);
+  });
+
+  test("leaves a genuinely-orphaned ref null (no matching entry)", () => {
+    seedEntry("/home/u/akm:skill:deploy", "skill", "deploy");
+    insertEvent("script:does-not-exist", null);
+
+    relinkUsageEvents(db);
+
+    expect(entryIdFor("script:does-not-exist")).toBeNull();
+  });
+
+  test("nulls entry_ids pointing at deleted entries, then re-resolves via ref", () => {
+    const id = seedEntry("/home/u/akm:skill:deploy", "skill", "deploy");
+    // Event points at a stale id (99) that no longer exists, but carries a
+    // resolvable ref.
+    insertEvent("skill:deploy", 99);
+
+    relinkUsageEvents(db);
+
+    expect(entryIdFor("skill:deploy")).toBe(id);
+  });
+
+  test("does not clobber already-correct links", () => {
+    const id = seedEntry("/home/u/akm:skill:deploy", "skill", "deploy");
+    insertEvent("skill:deploy", id);
+
+    relinkUsageEvents(db);
+
+    expect(entryIdFor("skill:deploy")).toBe(id);
+  });
+});


### PR DESCRIPTION
## Summary

Investigated a reported *"akm index performance regression"* where finalize blocked other writer commands for minutes. Verified everything against a **read-only snapshot of the live 684 MB `index.db`** rather than accepting the initial report — which turned out to be directionally right about the slow phase but to have **missed a silent correctness bug**, and whose proposed rewrite would have made a *wrong* query fast.

## Root cause

`relinkUsageEvents` step 2 hand-rolled a `substr(entry_key, …)` suffix query that matched the **raw** `entry_ref`, diverging from the codebase's canonical resolver `findEntryIdByRef` (which calls `parseAssetRef` to strip the `origin//` qualifier and handle `.md` variants). Two bugs fell out:

1. **Correctness (silent):** origin-qualified refs (`github:org/repo//knowledge:…`, `agent-stash//script:…`) carry a `source//` prefix that never appears in `entry_key`, so they never relinked. On the live index this dropped the `entry_id` of **13,591 usage events** for registry / multi-stash assets on **every full rebuild**, corrupting their utility scores. Verified: raw-ref matches = 0, `//`-stripped matches = 13,591.
2. **Performance:** the correlated subquery is non-indexable → O(events × entries). Measured **2m22s** during finalize, holding the single writer lease (10-min default wait for queued commands).

The existing test only exercised bare `type:name` refs — the one case the buggy query *did* handle — which is why the bug hid.

## Fix

Re-resolve per **distinct** null `entry_ref` using the canonical `findEntryIdByRef` resolver (the same one the read path uses at insert time). Deletes the divergent SQL instead of layering a temp-table / gate on top of it. Net +25 / −14.

## Verified metrics (live snapshot, full-detach simulation)

| | Old substr | New resolver |
|---|---|---|
| Links restored | 3,179 (**wrong**) | **16,782 (correct)** |
| Time (full rebuild) | **2m 52s** | **3.46s** (~50×) |
| Steady-state re-run | 2m 22s | **1.8s** |

## Tests

- New `tests/indexer/relink-usage-events.test.ts` (5 cases). The origin-qualified case **fails on old code** (`null` vs id) and **passes on new** — a real regression guard.
- Existing integration relink test + 50 usage/utility tests green. `tsc` + full `bun run lint` clean.

## Known residual (follow-up, not in this PR)

Steady-state relink is now ~1.8s, spent re-resolving ~201 permanently-orphaned refs (usage recorded for assets never indexed) that never match. No longer blocks writers. Optional follow-ups: gate relink when entries didn't change this run, or a set-based one-pass resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YjU1mGiShdDP4qFW7p4mv