### PR TITLE
test(coverage): harden shallow-test gaps across 6 subsystems (245 tests)

### DIFF
--- a/tests/coverage-hardening/core-asset-ref-branches.test.ts
+++ b/tests/coverage-hardening/core-asset-ref-branches.test.ts
@@ -1,0 +1,109 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//
+// Coverage-hardening: parseAssetRef special-cased branches.
+//
+// The existing tests/asset-ref.test.ts exercises the happy path plus the
+// generic invalid-type path (widget:/tool:). But two SPECIAL branches in
+// parseAssetRef — the `environment:` → `env` alias (TYPE_ALIASES) and the
+// `vault:` removed-type migration error — are never exercised. A regression
+// that deleted the alias or changed the migration message would keep every
+// committed test green. These tests lock in the exact behaviour of those
+// branches plus a cluster of name-normalization shapes that the happy-path
+// tests skip (the relink-class "only the easy input is tested" gap).
+//
+
+import { describe, expect, test } from "bun:test";
+import { makeAssetRef, parseAssetRef, refToString } from "../../src/core/asset/asset-ref";
+
+describe("parseAssetRef — environment→env alias (TYPE_ALIASES)", () => {
+  test("bare `environment:` resolves to the canonical `env` type", () => {
+    const ref = parseAssetRef("environment:prod");
+    expect(ref.type).toBe("env");
+    expect(ref.name).toBe("prod");
+    expect(ref.origin).toBeUndefined();
+  });
+
+  test("origin-qualified `environment:` also aliases to `env`", () => {
+    const ref = parseAssetRef("local//environment:prod");
+    expect(ref.type).toBe("env");
+    expect(ref.origin).toBe("local");
+    expect(ref.name).toBe("prod");
+  });
+
+  test("the alias canonicalizes — it does NOT round-trip to `environment:`", () => {
+    // refToString on an aliased parse must emit the canonical `env:` form, not
+    // the spelling the caller typed. This is the observable contract of an
+    // alias vs a distinct type.
+    expect(refToString(parseAssetRef("environment:prod"))).toBe("env:prod");
+  });
+});
+
+describe("parseAssetRef — removed `vault` type migration branch", () => {
+  test("`vault:` throws the 0.9.0 migration message (not the generic invalid-type error)", () => {
+    // Must point the caller at env:/secret:, and must NOT be the generic
+    // "Invalid asset type" message the widget:/tool: cases produce.
+    expect(() => parseAssetRef("vault:secret")).toThrow(/vault. asset type was removed in 0.9.0/);
+    expect(() => parseAssetRef("vault:secret")).toThrow(/env:/);
+    expect(() => parseAssetRef("vault:secret")).not.toThrow(/Invalid asset type/);
+  });
+
+  test("origin-qualified `vault` ref still hits the migration branch", () => {
+    expect(() => parseAssetRef("local//vault:secret")).toThrow(/removed in 0.9.0/);
+  });
+});
+
+describe("parseAssetRef — name normalization shapes (beyond the tested `../`)", () => {
+  test("a name that normalizes to a bare `.` is rejected as a relative segment", () => {
+    expect(() => parseAssetRef("script:.")).toThrow(/relative path segments|Path traversal/);
+  });
+
+  test("leading `./` is stripped by normalization", () => {
+    expect(parseAssetRef("script:./deploy.sh").name).toBe("deploy.sh");
+  });
+
+  test("an interior `.` segment collapses (`a/./b` → `a/b`)", () => {
+    expect(parseAssetRef("script:a/./b").name).toBe("a/b");
+  });
+
+  test("an interior `..` that stays within bounds collapses (`a/../b` → `b`)", () => {
+    // This is allowed because after normalization it does not escape the root
+    // and contains no leading `..` segment — a subtle branch the happy-path
+    // tests never cover.
+    expect(parseAssetRef("script:a/../b").name).toBe("b");
+  });
+
+  test("a leading colon (empty type) is an invalid ref", () => {
+    expect(() => parseAssetRef(":name")).toThrow(/Invalid ref/);
+  });
+});
+
+describe("parseAssetRef — `//` boundary is greedy to the first occurrence", () => {
+  test("a name containing `//` is misparsed as an origin boundary and rejected", () => {
+    // `//` ALWAYS delimits origin from body (indexOf, first occurrence). So a
+    // name that itself contains `//` splits into origin=`script:a`, body=`b`,
+    // and `b` has no colon → invalid ref. This documents why names must never
+    // embed `//` (the same origin-vs-body ambiguity that hid the relink bug).
+    expect(() => parseAssetRef("script:a//b")).toThrow(/Invalid ref/);
+  });
+
+  test("a scoped-npm origin keeps its own single-colon intact after the boundary", () => {
+    // The first `//` is the scope/pkg boundary; the type colon lives in the
+    // body. Confirms the boundary split does not swallow the type's colon.
+    const ref = parseAssetRef("npm:@scope/pkg//env:prod");
+    expect(ref.origin).toBe("npm:@scope/pkg");
+    expect(ref.type).toBe("env");
+    expect(ref.name).toBe("prod");
+  });
+});
+
+describe("makeAssetRef — origin is not re-validated but name always is", () => {
+  test("makeAssetRef does not apply the environment→env alias (aliases are parse-only)", () => {
+    // makeAssetRef takes an already-canonical AkmAssetType, so it emits exactly
+    // what it is given. Feeding it "env" yields "env:x"; there is no reverse
+    // alias. This pins the asymmetry between construction and parsing.
+    expect(makeAssetRef("env", "x")).toBe("env:x");
+  });
+});

--- a/tests/coverage-hardening/core-config-walker.test.ts
+++ b/tests/coverage-hardening/core-config-walker.test.ts
@@ -1,0 +1,149 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//
+// Coverage-hardening: config-walker (configGet/configSet/configUnset).
+//
+// NO test file imports config-walker directly — it is only exercised
+// indirectly through the config-cli wrappers, and only for a handful of
+// happy-path keys (output.*, embedding.*, llm.*). Several branchy coercion
+// and schema-descent paths in the walker have zero behavioural coverage:
+//   - catchall descent (index.<passName>.<field>)
+//   - z.record descent (profiles.llm.<name>.<field>)
+//   - boolean case-sensitivity ("True"/"1" must be REJECTED, only "true"/"false")
+//   - number range validation via safeParse (min/max, not just finite)
+//   - empty-segment path rejection ("a..b")
+//   - unset pruning an emptied parent object
+//   - configGet returning null (not throwing) when a parent is null
+// These are exactly the "code runs but only the easy input is tested" gaps.
+//
+
+import { describe, expect, test } from "bun:test";
+import { configGet, configSet, configUnset } from "../../src/core/config/config-walker";
+
+describe("configSet — catchall descent (index.<passName>)", () => {
+  test("descends through the IndexConfig catchall into a per-pass field", () => {
+    const next = configSet({}, "index.graph.llm", "true");
+    expect(next).toEqual({ index: { graph: { llm: true } } });
+  });
+
+  test("coerces + validates the per-pass leaf (boolean rejects non-boolean)", () => {
+    expect(() => configSet({}, "index.graph.llm", "yes")).toThrow(/expected true or false/);
+  });
+
+  test("an unknown per-pass leaf key is rejected as an unknown config key", () => {
+    // The per-pass object is passthrough at the schema level, but the walker
+    // resolves the leaf schema and finds no matching field / catchall, so the
+    // set is refused rather than silently persisting a typo'd leaf.
+    expect(() => configSet({}, "index.graph.bogusLeaf", "1")).toThrow(/Unknown config key/);
+  });
+});
+
+describe("configSet — z.record descent (profiles.llm.<name>)", () => {
+  test("an arbitrary profile name descends into the record value schema", () => {
+    const next = configSet({}, "profiles.llm.myprofile.model", "gpt-4o");
+    expect(next).toEqual({ profiles: { llm: { myprofile: { model: "gpt-4o" } } } });
+  });
+});
+
+describe("configSet — boolean coercion is strictly 'true' | 'false'", () => {
+  test("'true' and 'false' coerce to real booleans", () => {
+    expect(configSet({}, "improve.exploration.enabled", "true")).toEqual({
+      improve: { exploration: { enabled: true } },
+    });
+    expect(configSet({}, "improve.exploration.enabled", "false")).toEqual({
+      improve: { exploration: { enabled: false } },
+    });
+  });
+
+  test("'True' (wrong case) is rejected — no silent truthiness coercion", () => {
+    expect(() => configSet({}, "improve.exploration.enabled", "True")).toThrow(/expected true or false/);
+  });
+
+  test("'1' is rejected — numbers are not truthy booleans here", () => {
+    expect(() => configSet({}, "improve.exploration.enabled", "1")).toThrow(/expected true or false/);
+  });
+});
+
+describe("configSet — number coercion + range validation", () => {
+  test("a valid in-range number is accepted", () => {
+    expect(configSet({}, "improve.calibration.targetAcceptRate", "0.4")).toEqual({
+      improve: { calibration: { targetAcceptRate: 0.4 } },
+    });
+  });
+
+  test("a non-numeric string is rejected at coercion time", () => {
+    expect(() => configSet({}, "improve.calibration.targetAcceptRate", "abc")).toThrow(/expected a number/);
+  });
+
+  test("an out-of-range number is rejected by safeParse (not just finiteness)", () => {
+    // targetAcceptRate is .min(0).max(1); 5 coerces to a finite number but must
+    // fail the leaf schema validation. This is the branch that catches a value
+    // that is a valid number yet an invalid config value.
+    expect(() => configSet({}, "improve.calibration.targetAcceptRate", "5")).toThrow(/Invalid value/);
+  });
+});
+
+describe("configSet — path parsing + unknown keys", () => {
+  test("an empty segment between dots is rejected", () => {
+    expect(() => configSet({}, "output..format", "text")).toThrow(/empty segment between dots/);
+  });
+
+  test("an entirely unknown top-level path is rejected", () => {
+    expect(() => configSet({}, "totally.unknown.path", "x")).toThrow(/Unknown config key/);
+  });
+
+  test("set is immutable — the input object is not mutated", () => {
+    const base = { output: { format: "yaml" as const } };
+    const next = configSet(base, "output.detail", "full");
+    expect(base).toEqual({ output: { format: "yaml" } });
+    expect(next).toEqual({ output: { format: "yaml", detail: "full" } });
+  });
+});
+
+describe("configSet — defaultWriteTarget cross-field validation", () => {
+  test("rejects a target that names no configured source", () => {
+    expect(() => configSet({ sources: [{ name: "a" }] }, "defaultWriteTarget", "b")).toThrow(/Unknown source name "b"/);
+  });
+
+  test("accepts a target that matches a configured source name", () => {
+    const next = configSet({ sources: [{ name: "a" }] }, "defaultWriteTarget", "a");
+    expect(next.defaultWriteTarget).toBe("a");
+  });
+});
+
+describe("configGet — read behaviour", () => {
+  test("returns the value at a known nested path", () => {
+    const config = { output: { format: "yaml", detail: "normal" } };
+    expect(configGet(config, "output.format")).toBe("yaml");
+  });
+
+  test("returns null (does not throw) when a parent is explicitly null", () => {
+    expect(configGet({ output: null }, "output.format")).toBeNull();
+  });
+
+  test("returns null for an unset-but-valid leaf", () => {
+    expect(configGet({ output: {} }, "output.format")).toBeNull();
+  });
+
+  test("throws for an unknown key path", () => {
+    expect(() => configGet({}, "no.such.key")).toThrow(/Unknown config key/);
+  });
+});
+
+describe("configUnset — removal + pruning", () => {
+  test("removes a leaf and prunes the now-empty parent object", () => {
+    expect(configUnset({ output: { format: "text" } }, "output.format")).toEqual({});
+  });
+
+  test("removes only the targeted leaf, leaving siblings intact", () => {
+    expect(configUnset({ output: { format: "text", detail: "full" } }, "output.format")).toEqual({
+      output: { detail: "full" },
+    });
+  });
+
+  test("throws for an unknown key so typos do not silently no-op", () => {
+    expect(() => configUnset({}, "no.such.key")).toThrow(/Unknown config key/);
+  });
+});

--- a/tests/coverage-hardening/db-ref-resolution.test.ts
+++ b/tests/coverage-hardening/db-ref-resolution.test.ts
@@ -1,0 +1,243 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Coverage-hardening: ref/entry_key resolution + usage_events relinking.
+ *
+ * These are the exact functions where the "relink" bug class lives: they map a
+ * caller-supplied ref (`[origin//]type:name`, `.md`/non-`.md`, cross-stash
+ * collisions) onto a stored `entry_key` of the production shape
+ * `<stashDir>:<type>:<name>` via SQL suffix matching. The pre-existing suite
+ * had NO direct test for `findEntryIdByRef` or `relinkUsageEvents`, so a whole
+ * ref SHAPE could break without a single red test. This closes that gap by
+ * exercising every input shape, not just the happy bare ref.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  closeDatabase,
+  findEntryIdByRef,
+  getEntryByRef,
+  openIndexDatabase,
+  relinkUsageEvents,
+  upsertEntry,
+} from "../../src/indexer/db/db";
+import type { StashEntry } from "../../src/indexer/passes/metadata";
+import { getUsageEvents, insertUsageEvent } from "../../src/indexer/usage/usage-events";
+import type { Database } from "../../src/storage/database";
+import { type Cleanup, sandboxXdgCacheHome, sandboxXdgConfigHome } from "../_helpers/sandbox";
+
+// ── Temp dir + env isolation (mirrors tests/db.test.ts) ─────────────────────
+const createdTmpDirs: string[] = [];
+function tmpDb(): Database {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-covdb-"));
+  createdTmpDirs.push(dir);
+  return openIndexDatabase(path.join(dir, "test.db"));
+}
+afterAll(() => {
+  for (const dir of createdTmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+let envCleanup: Cleanup = () => {};
+beforeEach(() => {
+  const cache = sandboxXdgCacheHome();
+  envCleanup = sandboxXdgConfigHome(cache.cleanup).cleanup;
+});
+afterEach(() => {
+  envCleanup();
+  envCleanup = () => {};
+});
+
+// Production entry_key shape is `${stashDir}:${type}:${name}` (see indexer.ts).
+function seedEntry(db: Database, stashDir: string, type: StashEntry["type"], name: string): number {
+  const key = `${stashDir}:${type}:${name}`;
+  const entry = { name, type, description: `desc ${name}` } as StashEntry;
+  return upsertEntry(db, key, `${stashDir}/d`, `${stashDir}/d/${name}.md`, stashDir, entry, `${name} desc`);
+}
+
+// ── findEntryIdByRef ────────────────────────────────────────────────────────
+describe("findEntryIdByRef — ref shape matrix", () => {
+  test("resolves a bare type:name ref against the stashDir-prefixed entry_key", () => {
+    const db = tmpDb();
+    try {
+      const id = seedEntry(db, "/home/u/.local/share/akm", "skill", "deploy");
+      expect(findEntryIdByRef(db, "skill:deploy")).toBe(id);
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("resolves an ORIGIN-QUALIFIED ref (origin// is stripped before matching)", () => {
+    // This is the exemplar shape that silently failed in the relink bug: a
+    // resolver must not treat `local//` / `npm:@x/y//` as part of the key.
+    const db = tmpDb();
+    try {
+      const id = seedEntry(db, "/s", "skill", "deploy");
+      expect(findEntryIdByRef(db, "local//skill:deploy")).toBe(id);
+      expect(findEntryIdByRef(db, "npm:@scope/pkg//skill:deploy")).toBe(id);
+      expect(findEntryIdByRef(db, "owner/repo//skill:deploy")).toBe(id);
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("resolves across the .md / non-.md name boundary in BOTH directions", () => {
+    const db = tmpDb();
+    try {
+      // entry stored WITHOUT .md → a ".md" query still resolves it.
+      const noMd = seedEntry(db, "/s", "skill", "deploy");
+      expect(findEntryIdByRef(db, "skill:deploy.md")).toBe(noMd);
+      // entry stored WITH .md → a bare query still resolves it.
+      const withMd = seedEntry(db, "/s", "knowledge", "guide.md");
+      expect(findEntryIdByRef(db, "knowledge:guide")).toBe(withMd);
+      expect(findEntryIdByRef(db, "knowledge:guide.md")).toBe(withMd);
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("returns undefined for a missing entry (not a throw, not a false match)", () => {
+    const db = tmpDb();
+    try {
+      seedEntry(db, "/s", "skill", "deploy");
+      expect(findEntryIdByRef(db, "skill:nonexistent")).toBeUndefined();
+      // Same name, WRONG type must not match (entry_type is part of the filter).
+      expect(findEntryIdByRef(db, "command:deploy")).toBeUndefined();
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("a similarly-suffixed name does not false-match (type: boundary protects)", () => {
+    // `re-deploy` must not be resolved by a query for `deploy`: the `type:`
+    // prefix in the suffix comparison prevents bare name-suffix collisions.
+    const db = tmpDb();
+    try {
+      const redeploy = seedEntry(db, "/s", "skill", "redeploy");
+      expect(findEntryIdByRef(db, "skill:redeploy")).toBe(redeploy);
+      expect(findEntryIdByRef(db, "skill:deploy")).toBeUndefined();
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("throws (does not silently resolve) on an empty / malformed ref", () => {
+    const db = tmpDb();
+    try {
+      seedEntry(db, "/s", "skill", "deploy");
+      expect(() => findEntryIdByRef(db, "")).toThrow();
+      expect(() => findEntryIdByRef(db, "   ")).toThrow();
+      expect(() => findEntryIdByRef(db, "no-colon")).toThrow();
+    } finally {
+      closeDatabase(db);
+    }
+  });
+});
+
+// ── getEntryByRef — exact-key resolver (contrast with the suffix matcher) ────
+describe("getEntryByRef — exact bare-key resolver", () => {
+  test("matches only the exact bare `type:name` key, not the stashDir-prefixed key", () => {
+    const db = tmpDb();
+    try {
+      // Production keys carry a stashDir prefix, so getEntryByRef (which builds
+      // `type:name` and compares entry_key exactly) only hits entries indexed
+      // with a bare key. Assert the exact-match contract explicitly.
+      const bareId = upsertEntry(
+        db,
+        "memory:claude-prefs",
+        "/d",
+        "/d/claude-prefs.md",
+        "/d",
+        { name: "claude-prefs", type: "memory", description: "d" } as StashEntry,
+        "claude-prefs",
+      );
+      expect(getEntryByRef(db, "memory", "claude-prefs")?.id).toBe(bareId);
+      // A stashDir-prefixed key of the same asset is NOT an exact bare match.
+      seedEntry(db, "/s", "memory", "other");
+      expect(getEntryByRef(db, "memory", "other")).toBeNull();
+    } finally {
+      closeDatabase(db);
+    }
+  });
+});
+
+// ── relinkUsageEvents ───────────────────────────────────────────────────────
+describe("relinkUsageEvents — re-resolve entry_id after a rebuild", () => {
+  test("step 1: nulls out entry_ids that no longer exist in entries", () => {
+    const db = tmpDb();
+    try {
+      // A usage event pointing at an entry_id that is not in `entries`.
+      insertUsageEvent(db, { event_type: "search", entry_ref: "skill:gone", entry_id: 987654 });
+      relinkUsageEvents(db);
+      const rows = getUsageEvents(db);
+      expect(rows).toHaveLength(1);
+      // Its ref cannot be resolved (no such entry) → stays null, never a stale id.
+      expect(rows[0].entry_id).toBeNull();
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("step 2: re-resolves a BARE ref onto the current entry row after id churn", () => {
+    const db = tmpDb();
+    try {
+      // Simulate post-rebuild state: the event's old entry_id is stale (999),
+      // the real entry now lives under a different id.
+      const id = seedEntry(db, "/stash", "skill", "deploy");
+      expect(id).not.toBe(999);
+      insertUsageEvent(db, { event_type: "search", entry_ref: "skill:deploy", entry_id: 999 });
+      relinkUsageEvents(db);
+      const [row] = getUsageEvents(db);
+      expect(row.entry_id).toBe(id); // stale 999 → nulled → re-resolved to id
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("a still-valid entry_id is preserved (not disturbed)", () => {
+    const db = tmpDb();
+    try {
+      const id = seedEntry(db, "/stash", "skill", "keep");
+      insertUsageEvent(db, { event_type: "show", entry_ref: "skill:keep", entry_id: id });
+      relinkUsageEvents(db);
+      const [row] = getUsageEvents(db);
+      expect(row.entry_id).toBe(id);
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("is a no-op-safe best-effort call on an empty usage_events table", () => {
+    const db = tmpDb();
+    try {
+      expect(() => relinkUsageEvents(db)).not.toThrow();
+      expect(getUsageEvents(db)).toHaveLength(0);
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  // Regression guard for the exemplar bug: origin-qualified refs
+  // (`local//skill:deploy`, written routinely by search/show/curate) must
+  // relink after id churn. The old step-2 query compared the RAW `entry_ref`
+  // against the entry_key suffix without stripping the `origin//` prefix, so
+  // these silently stayed null. Now resolved via the canonical findEntryIdByRef
+  // (parseAssetRef strips the origin) — this asserts the branch a bare-ref-only
+  // test would miss.
+  test("step 2: re-resolves an ORIGIN-QUALIFIED ref after id churn", () => {
+    const db = tmpDb();
+    try {
+      const id = seedEntry(db, "/stash", "skill", "deploy");
+      insertUsageEvent(db, { event_type: "search", entry_ref: "local//skill:deploy", entry_id: 999 });
+      relinkUsageEvents(db);
+      const [row] = getUsageEvents(db);
+      expect(row.entry_id).toBe(id);
+    } finally {
+      closeDatabase(db);
+    }
+  });
+});

--- a/tests/coverage-hardening/db-utility-usage.test.ts
+++ b/tests/coverage-hardening/db-utility-usage.test.ts
@@ -1,0 +1,237 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Coverage-hardening: feedback→utility DB write + usage_events retention/query.
+ *
+ * `applyFeedbackToUtilityScore` (the DB read/apply/write wrapper around the pure
+ * MemRL policy) and `purgeOldUsageEvents` (retention cutoff) had NO tests — the
+ * policy math was tested in isolation, but the wrapper's write/no-write and
+ * threshold-crossing branches, and the retention boundary + guard branches,
+ * were untested. `getUsageEvents({ since })` and the delete cascade into
+ * `utility_scores`/`usage_events` were also unexercised. This fills those gaps.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  applyFeedbackToUtilityScore,
+  closeDatabase,
+  deleteEntriesByIds,
+  getUtilityScore,
+  openIndexDatabase,
+  upsertEntry,
+} from "../../src/indexer/db/db";
+import { FEEDBACK_LR } from "../../src/indexer/feedback/utility-policy";
+import type { StashEntry } from "../../src/indexer/passes/metadata";
+import { getUsageEvents, insertUsageEvent, purgeOldUsageEvents } from "../../src/indexer/usage/usage-events";
+import type { Database } from "../../src/storage/database";
+import { type Cleanup, sandboxXdgCacheHome, sandboxXdgConfigHome } from "../_helpers/sandbox";
+
+const createdTmpDirs: string[] = [];
+function tmpDb(): Database {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-covuu-"));
+  createdTmpDirs.push(dir);
+  return openIndexDatabase(path.join(dir, "test.db"));
+}
+afterAll(() => {
+  for (const dir of createdTmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+let envCleanup: Cleanup = () => {};
+beforeEach(() => {
+  const cache = sandboxXdgCacheHome();
+  envCleanup = sandboxXdgConfigHome(cache.cleanup).cleanup;
+});
+afterEach(() => {
+  envCleanup();
+  envCleanup = () => {};
+});
+
+function seedEntry(db: Database, name: string, type: StashEntry["type"] = "skill"): number {
+  const key = `/s:${type}:${name}`;
+  return upsertEntry(db, key, "/s/d", `/s/d/${name}.md`, "/s", { name, type, description: "d" } as StashEntry, name);
+}
+
+// ── applyFeedbackToUtilityScore ─────────────────────────────────────────────
+describe("applyFeedbackToUtilityScore — read/apply/write wrapper", () => {
+  test("zero feedback writes NO row and leaves utility untouched", () => {
+    const db = tmpDb();
+    try {
+      const id = seedEntry(db, "z");
+      const r = applyFeedbackToUtilityScore(db, id, 0, 0);
+      expect(r.previousUtility).toBe(0.5);
+      expect(r.nextUtility).toBe(0.5);
+      expect(r.crossedReviewThreshold).toBe(false);
+      // Critical: the no-feedback branch must not touch the DB.
+      expect(getUtilityScore(db, id)).toBeUndefined();
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("a new entry starts at the 0.5 midpoint and steps up on positive feedback", () => {
+    const db = tmpDb();
+    try {
+      const id = seedEntry(db, "p");
+      const r = applyFeedbackToUtilityScore(db, id, 1, 0);
+      // next = 0.5 + lr·(1 − 0.5)
+      expect(r.nextUtility).toBeCloseTo(0.5 + FEEDBACK_LR * 0.5, 10);
+      const persisted = getUtilityScore(db, id);
+      expect(persisted?.utility).toBeCloseTo(r.nextUtility, 10);
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("persists across calls: a second negative step reads the stored value, not 0.5", () => {
+    const db = tmpDb();
+    try {
+      const id = seedEntry(db, "seq");
+      const up = applyFeedbackToUtilityScore(db, id, 1, 0); // 0.5 → 0.55
+      const down = applyFeedbackToUtilityScore(db, id, 0, 1); // previous must be 0.55, not 0.5
+      expect(down.previousUtility).toBeCloseTo(up.nextUtility, 10);
+      expect(down.nextUtility).toBeCloseTo(up.nextUtility + FEEDBACK_LR * (0 - up.nextUtility), 10);
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("flags a high-utility asset crossing below the review threshold", () => {
+    const db = tmpDb();
+    try {
+      const id = seedEntry(db, "cross");
+      // Seed utility just above 0.5 so a single negative step lands below it.
+      applyFeedbackToUtilityScore(db, id, 1, 0); // 0.5 → 0.55 (>= HIGH threshold)
+      const r = applyFeedbackToUtilityScore(db, id, 0, 1); // 0.55 → ~0.495 (< REVIEW threshold)
+      expect(r.previousUtility).toBeGreaterThanOrEqual(0.5);
+      expect(r.nextUtility).toBeLessThan(0.5);
+      expect(r.crossedReviewThreshold).toBe(true);
+    } finally {
+      closeDatabase(db);
+    }
+  });
+});
+
+// ── purgeOldUsageEvents — retention cutoff + guard branches ──────────────────
+describe("purgeOldUsageEvents — retention boundary", () => {
+  function seedAt(db: Database, daysAgo: number): void {
+    const ts = new Date(Date.now() - daysAgo * 86_400_000).toISOString();
+    db.prepare("INSERT INTO usage_events (event_type, created_at) VALUES ('search', ?)").run(ts);
+  }
+
+  test("deletes rows strictly older than the cutoff, keeps recent rows", () => {
+    const db = tmpDb();
+    try {
+      seedAt(db, 100); // older than 90d → purged
+      seedAt(db, 200); // older → purged
+      seedAt(db, 1); // recent → kept
+      seedAt(db, 89); // just inside window → kept
+      purgeOldUsageEvents(db, 90);
+      const remaining = getUsageEvents(db);
+      expect(remaining).toHaveLength(2);
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("is a no-op for non-positive / non-finite retention (never wipes the table)", () => {
+    const db = tmpDb();
+    try {
+      seedAt(db, 500); // ancient row that a bad cutoff must NOT delete
+      for (const bad of [0, -5, Number.NaN, Number.POSITIVE_INFINITY]) {
+        purgeOldUsageEvents(db, bad);
+        expect(getUsageEvents(db)).toHaveLength(1);
+      }
+    } finally {
+      closeDatabase(db);
+    }
+  });
+});
+
+// ── getUsageEvents({ since }) — inclusive lower bound ───────────────────────
+describe("getUsageEvents — since filter (inclusive)", () => {
+  test("returns only events at or after the since timestamp", () => {
+    const db = tmpDb();
+    try {
+      db.prepare(
+        "INSERT INTO usage_events (event_type, entry_ref, created_at) VALUES ('search','skill:a','2026-01-01 00:00:00')",
+      ).run();
+      db.prepare(
+        "INSERT INTO usage_events (event_type, entry_ref, created_at) VALUES ('search','skill:b','2026-06-15 12:00:00')",
+      ).run();
+      db.prepare(
+        "INSERT INTO usage_events (event_type, entry_ref, created_at) VALUES ('search','skill:c','2026-06-15 12:00:01')",
+      ).run();
+
+      const since = getUsageEvents(db, { since: "2026-06-15 12:00:00" });
+      const refs = since.map((r) => r.entry_ref).sort();
+      // Boundary row (exactly == since) is INCLUDED; the earlier row is excluded.
+      expect(refs).toEqual(["skill:b", "skill:c"]);
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("combines since with an event_type filter (AND semantics)", () => {
+    const db = tmpDb();
+    try {
+      db.prepare(
+        "INSERT INTO usage_events (event_type, entry_ref, created_at) VALUES ('search','skill:old','2026-01-01 00:00:00')",
+      ).run();
+      db.prepare(
+        "INSERT INTO usage_events (event_type, entry_ref, created_at) VALUES ('search','skill:new','2026-06-15 00:00:00')",
+      ).run();
+      db.prepare(
+        "INSERT INTO usage_events (event_type, entry_ref, created_at) VALUES ('show','skill:new','2026-06-16 00:00:00')",
+      ).run();
+
+      const rows = getUsageEvents(db, { since: "2026-06-01 00:00:00", event_type: "search" });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].entry_ref).toBe("skill:new");
+    } finally {
+      closeDatabase(db);
+    }
+  });
+});
+
+// ── deleteEntriesByIds — cascade into utility_scores + usage_events ──────────
+describe("deleteEntriesByIds — related-row cascade", () => {
+  test("removes the deleted entry's utility + usage rows, leaves siblings intact", () => {
+    const db = tmpDb();
+    try {
+      const doomed = seedEntry(db, "doomed");
+      const survivor = seedEntry(db, "survivor");
+      applyFeedbackToUtilityScore(db, doomed, 1, 0);
+      applyFeedbackToUtilityScore(db, survivor, 1, 0);
+      insertUsageEvent(db, { event_type: "search", entry_ref: "skill:doomed", entry_id: doomed });
+      insertUsageEvent(db, { event_type: "search", entry_ref: "skill:survivor", entry_id: survivor });
+
+      deleteEntriesByIds(db, [doomed]);
+
+      // The deleted entry's related rows are gone…
+      expect(getUtilityScore(db, doomed)).toBeUndefined();
+      expect(getUsageEvents(db, { entry_ref: "skill:doomed" })).toHaveLength(0);
+      // …but the survivor's rows are untouched.
+      expect(getUtilityScore(db, survivor)).toBeDefined();
+      expect(getUsageEvents(db, { entry_ref: "skill:survivor" })).toHaveLength(1);
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("empty id list is a safe no-op", () => {
+    const db = tmpDb();
+    try {
+      const id = seedEntry(db, "keep");
+      applyFeedbackToUtilityScore(db, id, 1, 0);
+      expect(() => deleteEntriesByIds(db, [])).not.toThrow();
+      expect(getUtilityScore(db, id)).toBeDefined();
+    } finally {
+      closeDatabase(db);
+    }
+  });
+});

--- a/tests/coverage-hardening/improve-classify-action.test.ts
+++ b/tests/coverage-hardening/improve-classify-action.test.ts
@@ -1,0 +1,100 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Coverage-hardening: `classifyImproveAction` classification boundaries.
+ *
+ * MEMORY records a real production bug (deep-tuning #1, fixed in beta.50):
+ * gated SKIPS were folded into `rejected`, so `rejectedCount` was dominated by
+ * the ~13k-ref gated pool and the "accept rate" was meaningless. The fix routed
+ * gated skips into a new `skipped` bucket and left `rejected` for genuine
+ * content-policy rejections only.
+ *
+ * The existing suite only exercises 4-5 of the 11 `ImproveActionMode` variants
+ * (via `computeImproveRunMetrics` in tests/state-db/improve-runs.test.ts). This
+ * file pins the bucket for EVERY variant of the canonical union directly, so a
+ * future edit that silently re-collapses skipped→rejected (or any other bucket
+ * drift) fails here. This is the exact "one shape tested, other branches could
+ * be broken" gap the coverage-hardening pass targets.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { classifyImproveAction, type ImproveActionClass, type ImproveActionMode } from "../../src/core/improve-types";
+
+// The full canonical union, kept in sync with `ImproveActionMode`. If a new
+// variant is added to the source union but not here, the `assertNever` arm in
+// classifyImproveAction throws for it — but this table also documents intent.
+const EXPECTED: ReadonlyArray<readonly [ImproveActionMode, ImproveActionClass]> = [
+  ["reflect", "accepted"],
+  ["distill", "accepted"],
+  ["memory-inference", "accepted"],
+  ["graph-extraction", "accepted"],
+  ["reflect-cooldown", "skipped"],
+  ["reflect-skipped", "skipped"],
+  ["distill-skipped", "skipped"],
+  ["reflect-guard-rejected", "rejected"],
+  ["reflect-failed", "error"],
+  ["error", "error"],
+  ["memory-prune", "noop"],
+];
+
+describe("classifyImproveAction — every variant maps to its documented bucket", () => {
+  for (const [mode, cls] of EXPECTED) {
+    test(`${mode} => ${cls}`, () => {
+      expect(classifyImproveAction(mode)).toBe(cls);
+    });
+  }
+});
+
+describe("classifyImproveAction — the skipped-vs-rejected boundary (deep-tuning #1)", () => {
+  test("ALL gated skips classify as 'skipped', NEVER 'rejected'", () => {
+    // This is the regression that polluted rejectedCount: cooldown / eligibility
+    // / pool-delta skips are the run declining to act, not value-rejection.
+    const gatedSkips: ImproveActionMode[] = ["reflect-cooldown", "reflect-skipped", "distill-skipped"];
+    for (const mode of gatedSkips) {
+      expect(classifyImproveAction(mode)).toBe("skipped");
+      expect(classifyImproveAction(mode)).not.toBe("rejected");
+    }
+  });
+
+  test("'reflect-guard-rejected' is the ONLY mode that classifies as 'rejected'", () => {
+    const rejectedModes = EXPECTED.filter(([, cls]) => cls === "rejected").map(([mode]) => mode);
+    expect(rejectedModes).toEqual(["reflect-guard-rejected"]);
+  });
+
+  test("failures classify as 'error', not 'accepted' or 'skipped'", () => {
+    for (const mode of ["reflect-failed", "error"] as ImproveActionMode[]) {
+      expect(classifyImproveAction(mode)).toBe("error");
+    }
+  });
+
+  test("'memory-prune' is bookkeeping noop — counted in NO numeric bucket", () => {
+    // A noop must not inflate accepted/rejected/skipped/error.
+    expect(classifyImproveAction("memory-prune")).toBe("noop");
+  });
+});
+
+describe("classifyImproveAction — bucket partition invariants", () => {
+  test("every mapped class is one of the five canonical buckets", () => {
+    const canonical: ImproveActionClass[] = ["accepted", "rejected", "skipped", "error", "noop"];
+    for (const [mode] of EXPECTED) {
+      expect(canonical).toContain(classifyImproveAction(mode));
+    }
+  });
+
+  test("bucket distribution matches the documented taxonomy counts", () => {
+    const counts: Record<ImproveActionClass, number> = {
+      accepted: 0,
+      rejected: 0,
+      skipped: 0,
+      error: 0,
+      noop: 0,
+    };
+    for (const [mode] of EXPECTED) {
+      counts[classifyImproveAction(mode)] += 1;
+    }
+    // 4 write-actions accepted, 3 gated skips, 1 guard-reject, 2 errors, 1 noop.
+    expect(counts).toEqual({ accepted: 4, rejected: 1, skipped: 3, error: 2, noop: 1 });
+  });
+});

--- a/tests/coverage-hardening/llm-embed-cache.test.ts
+++ b/tests/coverage-hardening/llm-embed-cache.test.ts
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Coverage-hardening: the shared LRU embedding cache (llm/embedders/cache.ts).
+ *
+ * Previously only ever cleared (never asserted) by tests/_helpers/cli.ts. The
+ * two behaviours that matter are branchy and easy to get wrong: (1) the cache
+ * KEY must include endpoint+model so different providers can't collide (and
+ * must fall back local→model→localModel correctly), and (2) LRU semantics —
+ * a get() promotes an entry to most-recently-used, and inserting at capacity
+ * evicts the OLDEST, not the newest. Neither is covered by a line-coverage run
+ * of the happy path.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { EmbeddingConnectionConfig } from "../../src/core/config/config-types";
+import {
+  clearEmbeddingCache,
+  embedCacheKey,
+  getCachedEmbedding,
+  setCachedEmbedding,
+} from "../../src/llm/embedders/cache";
+
+beforeEach(() => clearEmbeddingCache());
+afterEach(() => clearEmbeddingCache());
+
+// ── embedCacheKey ─────────────────────────────────────────────────────────────
+
+describe("embedCacheKey", () => {
+  test("uses a local:: prefix when no config is supplied", () => {
+    expect(embedCacheKey("hello")).toBe("local::hello");
+  });
+
+  test("keys on endpoint + model so different providers cannot collide", () => {
+    const a: EmbeddingConnectionConfig = { endpoint: "https://a.example", model: "m1" };
+    const b: EmbeddingConnectionConfig = { endpoint: "https://b.example", model: "m1" };
+    expect(embedCacheKey("q", a)).not.toBe(embedCacheKey("q", b));
+    expect(embedCacheKey("q", a)).toBe("https://a.example:m1:q");
+  });
+
+  test("falls back to localModel when model is absent", () => {
+    const cfg = { endpoint: "https://a.example", localModel: "bge-small" } as EmbeddingConnectionConfig;
+    expect(embedCacheKey("q", cfg)).toBe("https://a.example:bge-small:q");
+  });
+
+  test("a config with empty endpoint/model differs from the no-config local key", () => {
+    const cfg = {} as EmbeddingConnectionConfig;
+    // config present but blank -> "::q", NOT "local::q"
+    expect(embedCacheKey("q", cfg)).toBe("::q");
+    expect(embedCacheKey("q", cfg)).not.toBe(embedCacheKey("q"));
+  });
+
+  test("query text is part of the key", () => {
+    expect(embedCacheKey("one")).not.toBe(embedCacheKey("two"));
+  });
+});
+
+// ── get / set round-trip ──────────────────────────────────────────────────────
+
+describe("embedding cache get/set", () => {
+  test("returns undefined for an absent key", () => {
+    expect(getCachedEmbedding("missing")).toBeUndefined();
+  });
+
+  test("returns the stored vector for a present key", () => {
+    setCachedEmbedding("k", [1, 2, 3]);
+    expect(getCachedEmbedding("k")).toEqual([1, 2, 3]);
+  });
+
+  test("clearEmbeddingCache drops all entries", () => {
+    setCachedEmbedding("k", [9]);
+    clearEmbeddingCache();
+    expect(getCachedEmbedding("k")).toBeUndefined();
+  });
+});
+
+// ── LRU eviction semantics ────────────────────────────────────────────────────
+
+describe("embedding cache LRU eviction", () => {
+  const MAX = 100;
+
+  test("evicts the oldest entry once capacity is exceeded", () => {
+    for (let i = 0; i < MAX; i++) setCachedEmbedding(`key-${i}`, [i]);
+    // Cache is now full with key-0 as the oldest.
+    setCachedEmbedding("overflow", [999]);
+    expect(getCachedEmbedding("key-0")).toBeUndefined(); // evicted
+    expect(getCachedEmbedding("key-1")).toEqual([1]); // survived
+    expect(getCachedEmbedding("overflow")).toEqual([999]);
+  });
+
+  test("a get() promotes an entry so it survives the next eviction", () => {
+    for (let i = 0; i < MAX; i++) setCachedEmbedding(`key-${i}`, [i]);
+    // Touch key-0 -> moves it to most-recently-used, making key-1 the oldest.
+    expect(getCachedEmbedding("key-0")).toEqual([0]);
+    setCachedEmbedding("overflow", [999]);
+    expect(getCachedEmbedding("key-0")).toEqual([0]); // promoted, survived
+    expect(getCachedEmbedding("key-1")).toBeUndefined(); // now the oldest -> evicted
+  });
+
+  // NOTE: a test that overwriting an EXISTING key at capacity should not evict
+  // an unrelated entry was removed — setCachedEmbedding checks size before it
+  // knows the key already exists, so re-caching a present key while full
+  // needlessly evicts the oldest entry. Reported as a minor bug rather than
+  // asserting the buggy behavior.
+});

--- a/tests/coverage-hardening/read-find-entry-id-by-ref.test.ts
+++ b/tests/coverage-hardening/read-find-entry-id-by-ref.test.ts
@@ -1,0 +1,191 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Behavioral coverage for `findEntryIdByRef` — the resolver used at INSERT
+ * time by `akm show` (show.ts) and `akm feedback` (feedback-cli.ts) to attach
+ * an `entry_id` to a usage_events row.
+ *
+ * This function is the direct SIBLING of the `relinkUsageEvents` bug: it too
+ * runs a `substr(entry_key, …)` suffix match. The difference is that
+ * findEntryIdByRef calls `parseAssetRef(ref)` FIRST, stripping any
+ * `origin//` qualifier before building the `type:name` suffix. The relink bug
+ * proved that a suffix match on the RAW ref silently fails for origin-qualified
+ * refs (`source//type:name`). The only prior test of findEntryIdByRef was a
+ * comment; every branch below (origin-qualified, .md ↔ non-.md variants,
+ * cross-type isolation, near-miss suffix collision, absent→undefined) was
+ * previously unexercised, so a regression to the relink shape would have
+ * shipped green.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { closeDatabase, findEntryIdByRef, openIndexDatabase, upsertEntry } from "../../src/indexer/db/db";
+import type { StashEntry } from "../../src/indexer/passes/metadata";
+import type { Database } from "../../src/storage/database";
+import { type Cleanup, sandboxXdgCacheHome, sandboxXdgConfigHome } from "../_helpers/sandbox";
+
+// ── Temp directory management ───────────────────────────────────────────────
+
+const createdTmpDirs: string[] = [];
+
+function tmpDbPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-find-entry-id-"));
+  createdTmpDirs.push(dir);
+  return path.join(dir, "index.db");
+}
+
+afterAll(() => {
+  for (const dir of createdTmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// ── Environment isolation ───────────────────────────────────────────────────
+
+let envCleanup: Cleanup = () => {};
+
+beforeEach(() => {
+  const cacheResult = sandboxXdgCacheHome();
+  const cfgResult = sandboxXdgConfigHome(cacheResult.cleanup);
+  envCleanup = cfgResult.cleanup;
+});
+
+afterEach(() => {
+  envCleanup();
+  envCleanup = () => {};
+});
+
+// ── Seed helper ──────────────────────────────────────────────────────────────
+//
+// Real indexer entry_key form is `${stashDir}:${type}:${name}` (see
+// indexer.ts / index-written-assets.ts). findEntryIdByRef matches the
+// `type:name` SUFFIX of that key, filtered by entry_type. Seed keys in the
+// production shape so the suffix logic is exercised for real.
+
+const STASH = "/home/user/.local/share/akm";
+
+function seed(db: Database, type: StashEntry["type"], name: string, stashDir = STASH): number {
+  const entryKey = `${stashDir}:${type}:${name}`;
+  const filePath = `${stashDir}/${type}/${name}`;
+  const entry = { description: `desc ${name}`, type, name } as unknown as StashEntry;
+  return upsertEntry(db, entryKey, path.dirname(filePath), filePath, stashDir, entry, `${name} desc`);
+}
+
+function withDb(fn: (db: Database) => void): void {
+  const db = openIndexDatabase(tmpDbPath());
+  try {
+    fn(db);
+  } finally {
+    closeDatabase(db);
+  }
+}
+
+describe("findEntryIdByRef — bug-class coverage", () => {
+  test("bare ref (type:name) resolves the entry id", () => {
+    withDb((db) => {
+      const id = seed(db, "skill", "deploy");
+      expect(findEntryIdByRef(db, "skill:deploy")).toBe(id);
+    });
+  });
+
+  // THE RELINK-CLASS GAP: an origin-qualified ref must resolve to the SAME id
+  // as the bare form. The relink bug's suffix match on the raw ref dropped
+  // exactly these; findEntryIdByRef only survives because it parses first.
+  test("origin-qualified ref (local//type:name) resolves to the same id as the bare ref", () => {
+    withDb((db) => {
+      const id = seed(db, "skill", "deploy");
+      expect(findEntryIdByRef(db, "local//skill:deploy")).toBe(id);
+    });
+  });
+
+  test("registry-origin ref (owner/repo//type:name) resolves to the local entry", () => {
+    withDb((db) => {
+      const id = seed(db, "skill", "deploy");
+      expect(findEntryIdByRef(db, "owner/repo//skill:deploy")).toBe(id);
+      expect(findEntryIdByRef(db, "npm:@scope/pkg//skill:deploy")).toBe(id);
+    });
+  });
+
+  test(".md ↔ non-.md variant: ref without .md resolves an entry stored WITH .md", () => {
+    withDb((db) => {
+      const id = seed(db, "knowledge", "guide.md");
+      // Stored name has the .md suffix; a bare `knowledge:guide` ref must still hit it.
+      expect(findEntryIdByRef(db, "knowledge:guide")).toBe(id);
+      // And the exact spelling resolves too.
+      expect(findEntryIdByRef(db, "knowledge:guide.md")).toBe(id);
+    });
+  });
+
+  test(".md ↔ non-.md variant: ref WITH .md resolves an entry stored WITHOUT .md", () => {
+    withDb((db) => {
+      const id = seed(db, "knowledge", "guide");
+      expect(findEntryIdByRef(db, "knowledge:guide.md")).toBe(id);
+      expect(findEntryIdByRef(db, "knowledge:guide")).toBe(id);
+    });
+  });
+
+  test("origin-qualified + .md variant compose (local//knowledge:guide → stored guide.md)", () => {
+    withDb((db) => {
+      const id = seed(db, "knowledge", "guide.md");
+      expect(findEntryIdByRef(db, "local//knowledge:guide")).toBe(id);
+    });
+  });
+
+  test("name with slash (nested path) resolves via full type:name suffix", () => {
+    withDb((db) => {
+      const id = seed(db, "knowledge", "db/migrate/guide.md");
+      expect(findEntryIdByRef(db, "knowledge:db/migrate/guide.md")).toBe(id);
+      expect(findEntryIdByRef(db, "knowledge:db/migrate/guide")).toBe(id);
+      expect(findEntryIdByRef(db, "local//knowledge:db/migrate/guide.md")).toBe(id);
+    });
+  });
+
+  // MISS CASE: this is what determines whether a usage_events row gets a real
+  // entry_id or NULL. An absent entry MUST return undefined (→ entry_id null),
+  // never a false-positive id.
+  test("absent entry returns undefined (records entry_id = null)", () => {
+    withDb((db) => {
+      seed(db, "skill", "deploy");
+      expect(findEntryIdByRef(db, "skill:nonexistent")).toBeUndefined();
+      expect(findEntryIdByRef(db, "local//skill:nonexistent")).toBeUndefined();
+    });
+  });
+
+  test("cross-type isolation: same name under a different type does NOT match", () => {
+    withDb((db) => {
+      const skillId = seed(db, "skill", "deploy");
+      seed(db, "script", "deploy"); // same name, different type
+      // skill:deploy must resolve the skill row, never the script row.
+      expect(findEntryIdByRef(db, "skill:deploy")).toBe(skillId);
+      // A type with no such name resolves to undefined even though the name
+      // exists under other types.
+      expect(findEntryIdByRef(db, "command:deploy")).toBeUndefined();
+    });
+  });
+
+  // NEAR-MISS SUFFIX COLLISION: the suffix match must be anchored by the
+  // `type:` prefix so `skill:deploy` does not accidentally match
+  // `skill:redeploy`. Without the leading `skill:` in the suffix this would
+  // false-positive.
+  test("near-miss suffix does not collide (skill:deploy ≠ skill:redeploy)", () => {
+    withDb((db) => {
+      const redeployId = seed(db, "skill", "redeploy");
+      // Only `redeploy` exists. Querying the shorter `deploy` must NOT match it.
+      expect(findEntryIdByRef(db, "skill:deploy")).toBeUndefined();
+      // Sanity: the real ref still resolves.
+      expect(findEntryIdByRef(db, "skill:redeploy")).toBe(redeployId);
+    });
+  });
+
+  test("resolves across multiple stashes when the type:name suffix matches (origin-insensitive)", () => {
+    withDb((db) => {
+      // Same asset indexed from a non-primary stash. findEntryIdByRef strips
+      // the origin entirely, so an origin-qualified ref still resolves the row.
+      const id = seed(db, "lesson", "postmortem", "/mnt/team-stash");
+      expect(findEntryIdByRef(db, "lesson:postmortem")).toBe(id);
+      expect(findEntryIdByRef(db, "local//lesson:postmortem")).toBe(id);
+    });
+  });
+});

--- a/tests/coverage-hardening/read-search-flag-parsers.test.ts
+++ b/tests/coverage-hardening/read-search-flag-parsers.test.ts
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Coverage for the `akm search` flag parsers that gate which pool and which
+ * belief slice a search runs against. `parseBeliefFilterMode` had ZERO tests;
+ * `parseSearchSource` had only envelope-level coverage. Both are pure and
+ * branchy, and a silent regression (e.g. the `local`→`stash` alias breaking,
+ * or the belief throw-branch being downgraded to a silent default) would
+ * quietly change what results a user sees with no failing test.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { parseBeliefFilterMode, parseSearchSource } from "../../src/commands/read/search";
+import { UsageError } from "../../src/core/errors";
+
+describe("parseBeliefFilterMode", () => {
+  test("undefined defaults to 'all'", () => {
+    expect(parseBeliefFilterMode(undefined)).toBe("all");
+  });
+
+  test("explicit 'all' stays 'all'", () => {
+    expect(parseBeliefFilterMode("all")).toBe("all");
+  });
+
+  test("'current' and 'historical' pass through", () => {
+    expect(parseBeliefFilterMode("current")).toBe("current");
+    expect(parseBeliefFilterMode("historical")).toBe("historical");
+  });
+
+  test("an unknown value throws UsageError (INVALID_FLAG_VALUE), not a silent default", () => {
+    let err: unknown;
+    try {
+      parseBeliefFilterMode("bogus");
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(UsageError);
+    expect((err as UsageError).message).toContain("all|current|historical");
+  });
+
+  test("case-sensitive: 'All' / 'CURRENT' are rejected (no accidental normalization)", () => {
+    expect(() => parseBeliefFilterMode("All")).toThrow(UsageError);
+    expect(() => parseBeliefFilterMode("CURRENT")).toThrow(UsageError);
+  });
+
+  test("empty string is rejected (not treated as the 'all' default)", () => {
+    expect(() => parseBeliefFilterMode("")).toThrow(UsageError);
+  });
+});
+
+describe("parseSearchSource", () => {
+  test("canonical values pass through unchanged", () => {
+    expect(parseSearchSource("stash")).toBe("stash");
+    expect(parseSearchSource("registry")).toBe("registry");
+    expect(parseSearchSource("both")).toBe("both");
+  });
+
+  test("'local' is an alias for 'stash'", () => {
+    expect(parseSearchSource("local")).toBe("stash");
+  });
+
+  test("undefined defaults to 'stash'", () => {
+    expect(parseSearchSource(undefined)).toBe("stash");
+  });
+
+  test("an unknown string passes through verbatim (a named source resolved later)", () => {
+    // Must NOT be coerced to 'stash' — akmSearch validates named sources against
+    // config and needs the original string to look it up / error helpfully.
+    expect(parseSearchSource("team-stash")).toBe("team-stash");
+  });
+});

--- a/tests/coverage-hardening/read-usage-event-recording.test.ts
+++ b/tests/coverage-hardening/read-usage-event-recording.test.ts
@@ -1,0 +1,201 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Behavioral coverage for the usage_events RECORDING contract on the read
+ * path. The read commands attach an `entry_id` at INSERT time:
+ *
+ *   - show.ts   : insertUsageEvent({ ..., entry_ref: ref, entry_id: findEntryIdByRef(db, ref) })
+ *   - feedback  : insertUsageEvent({ ..., entry_ref: ref, entry_id }) then countFeedbackSignals(db, entryId)
+ *
+ * These are the rows that `relinkUsageEvents` later corrupted. This file pins
+ * the recorder's own guarantees, exercising the shapes the exemplar bug hid:
+ *   (a) an ORIGIN-QUALIFIED ref records a NON-NULL entry_id (resolved via the
+ *       parse-first path), while the raw origin-qualified string is preserved
+ *       in entry_ref;
+ *   (b) a ref for an ABSENT entry records entry_id = NULL (never a false id);
+ *   (c) feedback pos/neg aggregation keys on entry_id, so it is correct even
+ *       when entry_ref carries an origin qualifier;
+ *   (d) source defaults to "user" and machine sources persist verbatim (the
+ *       column that gates utility bumps / retrieval demand downstream).
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { closeDatabase, findEntryIdByRef, openIndexDatabase, upsertEntry } from "../../src/indexer/db/db";
+import type { StashEntry } from "../../src/indexer/passes/metadata";
+import { countFeedbackSignals, getUsageEvents, insertUsageEvent } from "../../src/indexer/usage/usage-events";
+import type { Database } from "../../src/storage/database";
+import { type Cleanup, sandboxXdgCacheHome, sandboxXdgConfigHome } from "../_helpers/sandbox";
+
+// ── Temp directory management ───────────────────────────────────────────────
+
+const createdTmpDirs: string[] = [];
+
+function tmpDbPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-usage-recording-"));
+  createdTmpDirs.push(dir);
+  return path.join(dir, "index.db");
+}
+
+afterAll(() => {
+  for (const dir of createdTmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// ── Environment isolation ───────────────────────────────────────────────────
+
+let envCleanup: Cleanup = () => {};
+
+beforeEach(() => {
+  const cacheResult = sandboxXdgCacheHome();
+  const cfgResult = sandboxXdgConfigHome(cacheResult.cleanup);
+  envCleanup = cfgResult.cleanup;
+});
+
+afterEach(() => {
+  envCleanup();
+  envCleanup = () => {};
+});
+
+// ── Seed helper (production entry_key shape) ─────────────────────────────────
+
+const STASH = "/home/user/.local/share/akm";
+
+function seed(db: Database, type: StashEntry["type"], name: string): number {
+  const entryKey = `${STASH}:${type}:${name}`;
+  const filePath = `${STASH}/${type}/${name}`;
+  const entry = { description: `desc ${name}`, type, name } as unknown as StashEntry;
+  return upsertEntry(db, entryKey, path.dirname(filePath), filePath, STASH, entry, `${name} desc`);
+}
+
+function withDb(fn: (db: Database) => void): void {
+  const db = openIndexDatabase(tmpDbPath());
+  try {
+    fn(db);
+  } finally {
+    closeDatabase(db);
+  }
+}
+
+/**
+ * Mirror show.ts's logShowEvent insert path exactly: resolve the entry_id from
+ * the (possibly origin-qualified) ref, then record the raw ref + resolved id.
+ */
+function recordShow(db: Database, ref: string): void {
+  insertUsageEvent(db, {
+    event_type: "show",
+    entry_ref: ref,
+    entry_id: findEntryIdByRef(db, ref),
+    source: "user",
+  });
+}
+
+describe("read-path usage_events recording contract", () => {
+  test("show with a BARE ref records the resolved entry_id and the ref verbatim", () => {
+    withDb((db) => {
+      const id = seed(db, "skill", "deploy");
+      recordShow(db, "skill:deploy");
+
+      const rows = getUsageEvents(db, { event_type: "show" });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].entry_ref).toBe("skill:deploy");
+      expect(rows[0].entry_id).toBe(id);
+    });
+  });
+
+  // The relink-class shape: origin-qualified ref must still get a NON-NULL
+  // entry_id, and the raw origin-qualified string is preserved in entry_ref.
+  test("show with an ORIGIN-QUALIFIED ref records a non-null entry_id + raw qualified ref", () => {
+    withDb((db) => {
+      const id = seed(db, "skill", "deploy");
+      recordShow(db, "local//skill:deploy");
+
+      const rows = getUsageEvents(db, { event_type: "show" });
+      expect(rows).toHaveLength(1);
+      // entry_id resolved despite the origin qualifier (parse-first path).
+      expect(rows[0].entry_id).toBe(id);
+      // The raw qualified ref is what gets stored (this is exactly the string
+      // the relink suffix-match later had to cope with).
+      expect(rows[0].entry_ref).toBe("local//skill:deploy");
+    });
+  });
+
+  test("show for an ABSENT entry records entry_id = NULL (no false-positive id)", () => {
+    withDb((db) => {
+      seed(db, "skill", "deploy");
+      recordShow(db, "skill:ghost");
+
+      const rows = getUsageEvents(db, { event_type: "show", entry_ref: "skill:ghost" });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].entry_id).toBeNull();
+    });
+  });
+
+  test("feedback pos/neg aggregation keys on entry_id even when entry_ref is origin-qualified", () => {
+    withDb((db) => {
+      const id = seed(db, "lesson", "postmortem");
+
+      // Two positive + one negative, recorded under DIFFERENT ref spellings but
+      // the SAME resolved entry_id — exactly how feedback-cli records them.
+      for (const ref of ["lesson:postmortem", "local//lesson:postmortem"]) {
+        insertUsageEvent(db, {
+          event_type: "feedback",
+          entry_ref: ref,
+          entry_id: findEntryIdByRef(db, ref),
+          signal: "positive",
+        });
+      }
+      insertUsageEvent(db, {
+        event_type: "feedback",
+        entry_ref: "owner/repo//lesson:postmortem",
+        entry_id: findEntryIdByRef(db, "owner/repo//lesson:postmortem"),
+        signal: "negative",
+      });
+
+      const { pos, neg } = countFeedbackSignals(db, id);
+      expect(pos).toBe(2);
+      expect(neg).toBe(1);
+    });
+  });
+
+  test("countFeedbackSignals returns {0,0} for an entry with no feedback", () => {
+    withDb((db) => {
+      const id = seed(db, "skill", "untouched");
+      // A show event on the same entry must NOT count as feedback.
+      recordShow(db, "skill:untouched");
+      expect(countFeedbackSignals(db, id)).toEqual({ pos: 0, neg: 0 });
+    });
+  });
+
+  test("source defaults to 'user' and machine sources persist verbatim", () => {
+    withDb((db) => {
+      seed(db, "skill", "deploy");
+      // No source → default 'user' (drives utility bump / retrieval demand).
+      insertUsageEvent(db, { event_type: "show", entry_ref: "skill:deploy", entry_id: 1 });
+      insertUsageEvent(db, { event_type: "search", query: "x", source: "improve" });
+      insertUsageEvent(db, { event_type: "search", query: "y", source: "task" });
+
+      expect(getUsageEvents(db, { source: "user" })).toHaveLength(1);
+      expect(getUsageEvents(db, { source: "improve" })).toHaveLength(1);
+      expect(getUsageEvents(db, { source: "task" })).toHaveLength(1);
+    });
+  });
+
+  test("curate-style per-item events store entry_ref with NO entry_id (backfilled by relink later)", () => {
+    // curate.ts records per-item rows with only entry_ref (no entry_id) — the
+    // shape most exposed to the relink bug. Pin that the recorder writes a NULL
+    // entry_id here so a regression that starts fabricating ids is caught.
+    withDb((db) => {
+      seed(db, "skill", "deploy");
+      insertUsageEvent(db, { event_type: "curate", query: "ship it", entry_ref: "local//skill:deploy" });
+
+      const rows = getUsageEvents(db, { event_type: "curate" });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].entry_ref).toBe("local//skill:deploy");
+      expect(rows[0].entry_id).toBeNull();
+    });
+  });
+});

--- a/tests/coverage-hardening/registry-ref-parse.test.ts
+++ b/tests/coverage-hardening/registry-ref-parse.test.ts
@@ -1,0 +1,189 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Coverage-hardening: parseRegistryRef and maxSatisfying.
+ *
+ * parseRegistryRef is a heavily-branchy ref parser (npm / github / git+ /
+ * file: / http(s) / bare-shorthand / registry-search-id) that was only ever
+ * exercised INDIRECTLY through akmListSources/akmUpdate. Each transport
+ * produces a differently-shaped ParsedRegistryRef (source + id), and the id is
+ * the join key used downstream — a mis-parsed prefix silently mis-keys the
+ * source (the relink-class gap). maxSatisfying + its semver helpers had NO
+ * direct test at all; the caret / tilde / >= / prerelease branches are all
+ * asserted here on real version lists.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { maxSatisfying, parseRegistryRef } from "../../src/registry/resolve";
+
+// ── parseRegistryRef: transport dispatch ──────────────────────────────────────
+
+describe("parseRegistryRef — npm", () => {
+  test("parses an explicit npm: ref", () => {
+    const p = parseRegistryRef("npm:left-pad");
+    expect(p.source).toBe("npm");
+    expect(p.id).toBe("npm:left-pad");
+    if (p.source === "npm") {
+      expect(p.packageName).toBe("left-pad");
+      expect(p.requestedVersionOrTag).toBeUndefined();
+    }
+  });
+
+  test("splits a version suffix off an npm: ref", () => {
+    const p = parseRegistryRef("npm:left-pad@1.3.0");
+    if (p.source !== "npm") throw new Error("expected npm ref");
+    expect(p.packageName).toBe("left-pad");
+    expect(p.requestedVersionOrTag).toBe("1.3.0");
+  });
+
+  test("parses a scoped package with a version", () => {
+    const p = parseRegistryRef("npm:@scope/pkg@2.0.0");
+    if (p.source !== "npm") throw new Error("expected npm ref");
+    expect(p.packageName).toBe("@scope/pkg");
+    expect(p.id).toBe("npm:@scope/pkg");
+    expect(p.requestedVersionOrTag).toBe("2.0.0");
+  });
+
+  // NOTE: a bare, unprefixed scoped ref like "@scope/pkg" is EXPECTED to parse
+  // as npm (parser.ts:85 special-cases `ref.startsWith("@")`), but currently
+  // throws NotFoundError because isPathLikeRef() treats any "/"-containing ref
+  // as an explicit local path. Removed here and reported as a suspected bug —
+  // committing it would only lock in the buggy behavior.
+
+  test("throws on an empty ref", () => {
+    expect(() => parseRegistryRef("")).toThrow();
+    expect(() => parseRegistryRef("   ")).toThrow();
+  });
+});
+
+describe("parseRegistryRef — github", () => {
+  test("parses an explicit github: shorthand", () => {
+    const p = parseRegistryRef("github:owner/repo");
+    if (p.source !== "github") throw new Error("expected github ref");
+    expect(p.owner).toBe("owner");
+    expect(p.repo).toBe("repo");
+    expect(p.id).toBe("github:owner/repo");
+    expect(p.requestedRef).toBeUndefined();
+  });
+
+  test("captures a #ref suffix on github shorthand", () => {
+    const p = parseRegistryRef("github:owner/repo#v1.2.3");
+    if (p.source !== "github") throw new Error("expected github ref");
+    expect(p.requestedRef).toBe("v1.2.3");
+    expect(p.id).toBe("github:owner/repo");
+  });
+
+  test("strips a trailing .git from the repo name", () => {
+    const p = parseRegistryRef("github:owner/repo.git");
+    if (p.source !== "github") throw new Error("expected github ref");
+    expect(p.repo).toBe("repo");
+  });
+
+  test("rejects github shorthand that is not owner/repo shaped", () => {
+    expect(() => parseRegistryRef("github:only-one-segment")).toThrow();
+    expect(() => parseRegistryRef("github:a/b/c")).toThrow();
+  });
+
+  test("parses a full https://github.com URL, decoding the #ref fragment", () => {
+    const p = parseRegistryRef("https://github.com/owner/repo#feature%2Fx");
+    if (p.source !== "github") throw new Error("expected github ref");
+    expect(p.owner).toBe("owner");
+    expect(p.repo).toBe("repo");
+    expect(p.requestedRef).toBe("feature/x");
+  });
+});
+
+describe("parseRegistryRef — git and remote URLs", () => {
+  test("parses a git+ transport ref and strips the transport prefix from the url", () => {
+    const p = parseRegistryRef("git+https://example.com/team/repo.git#main");
+    if (p.source !== "git") throw new Error("expected git ref");
+    expect(p.url).toBe("https://example.com/team/repo.git");
+    expect(p.requestedRef).toBe("main");
+    // id normalises away the .git suffix
+    expect(p.id).toBe("git:https://example.com/team/repo");
+  });
+
+  test("routes a non-github https URL to the generic git parser", () => {
+    const p = parseRegistryRef("https://gitlab.com/group/repo.git");
+    expect(p.source).toBe("git");
+    if (p.source === "git") expect(p.url).toBe("https://gitlab.com/group/repo.git");
+  });
+});
+
+describe("parseRegistryRef — registry search result IDs", () => {
+  test("rejects a skills-sh: search ID with a helpful message (not an installable ref)", () => {
+    let msg = "";
+    try {
+      parseRegistryRef("skills-sh:org/repo/skill-name");
+    } catch (err) {
+      msg = err instanceof Error ? err.message : String(err);
+    }
+    expect(msg).toContain("registry search result ID");
+    // suggests the underlying github repo derived from the first two segments
+    expect(msg).toContain("github:org/repo");
+  });
+
+  test("does NOT mistake a known npm: prefix for a registry search ID", () => {
+    const p = parseRegistryRef("npm:some-pkg");
+    expect(p.source).toBe("npm");
+  });
+});
+
+// ── maxSatisfying: semver range resolution ────────────────────────────────────
+
+describe("maxSatisfying — caret ranges", () => {
+  test("^1.2.3 picks the highest same-major version at or above the floor", () => {
+    expect(maxSatisfying(["1.2.3", "1.5.0", "1.9.9", "2.0.0"], "^1.2.3")).toBe("1.9.9");
+  });
+
+  test("^1.2.3 excludes versions below the floor and different majors", () => {
+    expect(maxSatisfying(["1.0.0", "1.2.0", "2.0.0"], "^1.2.3")).toBeUndefined();
+  });
+
+  test("^0.2.3 pins the minor (0.x special-case): 0.3.0 is excluded", () => {
+    expect(maxSatisfying(["0.2.3", "0.2.9", "0.3.0"], "^0.2.3")).toBe("0.2.9");
+  });
+
+  test("^0.2.3 excludes a lower patch in the same minor", () => {
+    expect(maxSatisfying(["0.2.0", "0.2.2"], "^0.2.3")).toBeUndefined();
+  });
+});
+
+describe("maxSatisfying — tilde and >= ranges", () => {
+  test("~1.2.3 stays within the same major.minor", () => {
+    expect(maxSatisfying(["1.2.3", "1.2.9", "1.3.0"], "~1.2.3")).toBe("1.2.9");
+  });
+
+  test(">=1.2.3 spans across majors and picks the newest", () => {
+    expect(maxSatisfying(["1.2.3", "2.0.0", "3.1.4"], ">=1.2.3")).toBe("3.1.4");
+  });
+
+  test(">=1.2.3 excludes anything strictly below the floor", () => {
+    expect(maxSatisfying(["1.0.0", "1.2.2"], ">=1.2.3")).toBeUndefined();
+  });
+});
+
+describe("maxSatisfying — wildcard and prerelease handling", () => {
+  test("* matches the highest stable version", () => {
+    expect(maxSatisfying(["1.0.0", "2.3.4", "0.9.0"], "*")).toBe("2.3.4");
+  });
+
+  test("prerelease versions are skipped when the range has no prerelease tag", () => {
+    expect(maxSatisfying(["1.2.3-beta.1", "1.2.3-rc.2"], "^1.2.0")).toBeUndefined();
+  });
+
+  test("a stable release is preferred over a prerelease of the same numbers under *", () => {
+    // compareSemver ranks prerelease below its release, so the stable wins.
+    expect(maxSatisfying(["1.2.3-beta.1", "1.2.3"], "*")).toBe("1.2.3");
+  });
+
+  test("ignores entries that are not valid semver", () => {
+    expect(maxSatisfying(["not-a-version", "1.4.0", "latest"], "^1.0.0")).toBe("1.4.0");
+  });
+
+  test("returns undefined for an empty candidate list", () => {
+    expect(maxSatisfying([], "^1.0.0")).toBeUndefined();
+  });
+});

--- a/tests/coverage-hardening/search-ranking.test.ts
+++ b/tests/coverage-hardening/search-ranking.test.ts
@@ -1,0 +1,121 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Coverage-hardening: score-BLENDING math in the hybrid ranking pipeline.
+ *
+ * `normalizeFtsScores` had NO test at all, and `combineSearchScores` was
+ * tested only for its type-exclusion branch (search-exclude-sessions-vector)
+ * — never for the actual numeric blend it exists to compute. These assert the
+ * exact weights/normalization so a regression in the FTS/vector blend (or the
+ * min-max normalization edge cases) is caught, not just "returns results".
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { DbSearchResult } from "../../src/indexer/db/db";
+import type { StashEntry } from "../../src/indexer/passes/metadata";
+import { combineSearchScores, normalizeFtsScores } from "../../src/indexer/search/ranking";
+
+function entry(name: string, type: string): StashEntry {
+  return { name, type, description: `${type} ${name}` };
+}
+
+function ftsResult(id: number, bm25: number, name = `e${id}`, type = "skill"): DbSearchResult {
+  return { id, filePath: `/stash/${type}/${name}.md`, entry: entry(name, type), searchText: name, bm25Score: bm25 };
+}
+
+describe("normalizeFtsScores", () => {
+  test("empty input returns an empty map", () => {
+    expect(normalizeFtsScores([]).size).toBe(0);
+  });
+
+  test("single result normalizes to the top of the band (range === 0)", () => {
+    // range === 0 hits the guard branch → normalized 1.0 → ftsScore 0.3 + 0.7.
+    const map = normalizeFtsScores([ftsResult(1, -2.5)]);
+    expect(map.get(1)?.score).toBeCloseTo(1.0, 10);
+  });
+
+  test("all-equal bm25 scores all normalize to 1.0 (range === 0 guard)", () => {
+    const map = normalizeFtsScores([ftsResult(1, -4), ftsResult(2, -4), ftsResult(3, -4)]);
+    expect(map.get(1)?.score).toBeCloseTo(1.0, 10);
+    expect(map.get(2)?.score).toBeCloseTo(1.0, 10);
+    expect(map.get(3)?.score).toBeCloseTo(1.0, 10);
+  });
+
+  test("best row maps to 1.0, worst to 0.3, middle interpolates within [0.3,1.0]", () => {
+    // Results arrive sorted best-first. FTS bm25 is negative; more-negative =
+    // better, so results[0] is the most-negative. The formula must still put
+    // the best at 1.0 and the worst at 0.3 regardless of sign.
+    const results = [ftsResult(1, -10), ftsResult(2, -6), ftsResult(3, -2)];
+    const map = normalizeFtsScores(results);
+    expect(map.get(1)?.score).toBeCloseTo(1.0, 10); // best
+    expect(map.get(3)?.score).toBeCloseTo(0.3, 10); // worst
+    const mid = map.get(2)?.score ?? 0;
+    expect(mid).toBeGreaterThan(0.3);
+    expect(mid).toBeLessThan(1.0);
+    // -6 is exactly midway between -10 and -2 → normalized 0.5 → 0.3 + 0.35.
+    expect(mid).toBeCloseTo(0.65, 10);
+  });
+
+  test("carries the originating result object through unchanged", () => {
+    const r = ftsResult(7, -3, "carry", "command");
+    const map = normalizeFtsScores([r]);
+    expect(map.get(7)?.result).toBe(r);
+  });
+});
+
+describe("combineSearchScores blend math", () => {
+  const getEntryById = (id: number) =>
+    id === 99 ? { entry: entry("vec-only", "knowledge"), filePath: "/stash/knowledge/vec-only.md" } : undefined;
+
+  test("FTS+vector hit blends 0.7*fts + 0.3*vec and marks rankingMode hybrid", () => {
+    const ftsScoreMap = new Map([[1, { score: 0.8, result: ftsResult(1, -5) }]]);
+    const embedScoreMap = new Map([[1, 0.6]]);
+    const scored = combineSearchScores({ ftsScoreMap, embedScoreMap, getEntryById });
+    const item = scored.find((s) => s.id === 1);
+    expect(item?.rankingMode).toBe("hybrid");
+    // 0.8 * 0.7 + 0.6 * 0.3 = 0.74
+    expect(item?.score).toBeCloseTo(0.74, 10);
+  });
+
+  test("FTS hit with NO vector neighbor keeps the raw fts score and mode fts", () => {
+    const ftsScoreMap = new Map([[1, { score: 0.8, result: ftsResult(1, -5) }]]);
+    const embedScoreMap = new Map<number, number>();
+    const scored = combineSearchScores({ ftsScoreMap, embedScoreMap, getEntryById });
+    const item = scored.find((s) => s.id === 1);
+    expect(item?.rankingMode).toBe("fts");
+    expect(item?.score).toBeCloseTo(0.8, 10); // NOT down-weighted by 0.7
+  });
+
+  test("vector-only neighbor (no FTS hit) scores cosine*0.3 and mode semantic", () => {
+    const ftsScoreMap = new Map<number, { score: number; result: DbSearchResult }>();
+    const embedScoreMap = new Map([[99, 0.9]]);
+    const scored = combineSearchScores({ ftsScoreMap, embedScoreMap, getEntryById });
+    const item = scored.find((s) => s.id === 99);
+    expect(item?.rankingMode).toBe("semantic");
+    expect(item?.score).toBeCloseTo(0.27, 10); // 0.9 * 0.3
+  });
+
+  test("vector-only neighbor with no registry entry is dropped (getEntryById undefined)", () => {
+    const ftsScoreMap = new Map<number, { score: number; result: DbSearchResult }>();
+    const embedScoreMap = new Map([[12345, 0.9]]); // getEntryById returns undefined
+    const scored = combineSearchScores({ ftsScoreMap, embedScoreMap, getEntryById });
+    expect(scored.length).toBe(0);
+  });
+
+  test("typeFilter drops a vector-only neighbor of a different type", () => {
+    // 99 is type 'knowledge'; a typeFilter of 'skill' must exclude it.
+    const ftsScoreMap = new Map<number, { score: number; result: DbSearchResult }>();
+    const embedScoreMap = new Map([[99, 0.9]]);
+    const scored = combineSearchScores({ ftsScoreMap, embedScoreMap, getEntryById, typeFilter: "skill" });
+    expect(scored.some((s) => s.id === 99)).toBe(false);
+  });
+
+  test("an FTS-matched id is never re-added by the vector loop (dedup by seenIds)", () => {
+    const ftsScoreMap = new Map([[1, { score: 0.8, result: ftsResult(1, -5) }]]);
+    const embedScoreMap = new Map([[1, 0.6]]); // same id present in both
+    const scored = combineSearchScores({ ftsScoreMap, embedScoreMap, getEntryById });
+    expect(scored.filter((s) => s.id === 1).length).toBe(1);
+  });
+});

--- a/tests/coverage-hardening/sources-resolution.test.ts
+++ b/tests/coverage-hardening/sources-resolution.test.ts
@@ -1,0 +1,237 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Coverage-hardening: source resolution + transient-stash detection + include
+ * config discovery. These are branchy ref/path classifiers where the existing
+ * suite exercises only the happy shape (a valid config, a symlink escape), so a
+ * whole boundary could be broken and every committed test would still pass.
+ *
+ *   - isTransientStashPath: prefix vs exact-match asymmetry across /tmp,
+ *     /var/tmp, /private/tmp, /var/folders. A regression here would either leak
+ *     the host config (false negative) or misroute a real stash (false positive)
+ *     — the exact incident that motivated the function.
+ *   - findNearestIncludeConfig: NO existing test. Walk-up-to-boundary logic
+ *     with multiple package.json SHAPES (nearest wins, malformed JSON, wrong
+ *     type, empty list, boundary inclusive/exclusive).
+ *   - copyIncludedPaths: only the symlink branch is covered elsewhere; the
+ *     path-escape and missing-path throw branches are not.
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { isTransientStashPath } from "../../src/core/paths";
+import { copyIncludedPaths, findNearestIncludeConfig } from "../../src/sources/include";
+
+const createdTmpDirs: string[] = [];
+
+function makeTmpDir(prefix = "src-hard-"): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  createdTmpDirs.push(dir);
+  return fs.realpathSync(dir);
+}
+
+function writeFile(filePath: string, content = ""): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+afterAll(() => {
+  for (const dir of createdTmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── isTransientStashPath ──────────────────────────────────────────────────────
+
+describe("isTransientStashPath — prefix vs exact-match boundaries", () => {
+  test("matches nested paths under each transient root", () => {
+    for (const p of [
+      "/tmp/foo",
+      "/tmp/foo/bar",
+      "/var/tmp/x",
+      "/private/tmp/x",
+      "/private/var/folders/ab/cd/T/x",
+      "/var/folders/ab/cd/T/x",
+    ]) {
+      expect(isTransientStashPath(p)).toBe(true);
+    }
+  });
+
+  test("matches the bare /tmp and /var/tmp roots (exact, no trailing slash)", () => {
+    expect(isTransientStashPath("/tmp")).toBe(true);
+    expect(isTransientStashPath("/var/tmp")).toBe(true);
+  });
+
+  test("does NOT match a sibling whose name merely starts with 'tmp' — the classic prefix trap", () => {
+    // `/tmpfoo` must not be swept up by the `/tmp/` prefix rule; this is the
+    // false-positive direction that would misroute a real persistent stash.
+    expect(isTransientStashPath("/tmpfoo")).toBe(false);
+    expect(isTransientStashPath("/tmproot/stash")).toBe(false);
+    expect(isTransientStashPath("/var/tmpfoo")).toBe(false);
+  });
+
+  test("does NOT match persistent user/home paths (false-positive guard)", () => {
+    for (const p of ["/home/user/.local/share/akm", "/Users/me/stash", "/opt/akm", "relative/tmp", ""]) {
+      expect(isTransientStashPath(p)).toBe(false);
+    }
+  });
+
+  test("documents the exact-match asymmetry: /private/tmp and /var/folders WITHOUT a trailing slash are NOT transient", () => {
+    // Only `/private/tmp/` (with slash) and `/var/folders/` (with slash) are
+    // matched — the bare directory itself is not. This is intentional current
+    // behavior; pinning it means a future refactor that "normalizes" the rules
+    // has to make a conscious choice rather than silently flipping it.
+    expect(isTransientStashPath("/private/tmp")).toBe(false);
+    expect(isTransientStashPath("/var/folders")).toBe(false);
+    // ...whereas the bare /tmp and /var/tmp ARE matched (asymmetry documented).
+    expect(isTransientStashPath("/tmp")).toBe(true);
+  });
+});
+
+// ── findNearestIncludeConfig ──────────────────────────────────────────────────
+
+function writePkg(dir: string, obj: unknown): void {
+  writeFile(path.join(dir, "package.json"), JSON.stringify(obj));
+}
+
+describe("findNearestIncludeConfig — walk-up + package.json shape handling", () => {
+  test("returns the include list from a package.json at startDir", () => {
+    const root = makeTmpDir();
+    writePkg(root, { akm: { include: ["a.md", "dir/b.md"] } });
+    const cfg = findNearestIncludeConfig(root, root);
+    expect(cfg).toBeDefined();
+    expect(cfg?.baseDir).toBe(root);
+    expect(cfg?.include).toEqual(["a.md", "dir/b.md"]);
+  });
+
+  test("NEAREST config wins — a child package.json shadows the parent", () => {
+    const parent = makeTmpDir();
+    const child = path.join(parent, "pkg");
+    fs.mkdirSync(child, { recursive: true });
+    writePkg(parent, { akm: { include: ["parent.md"] } });
+    writePkg(child, { akm: { include: ["child.md"] } });
+    const cfg = findNearestIncludeConfig(child, parent);
+    expect(cfg?.baseDir).toBe(child);
+    expect(cfg?.include).toEqual(["child.md"]);
+  });
+
+  test("walks UP to find a parent config when startDir has none", () => {
+    const parent = makeTmpDir();
+    const child = path.join(parent, "nested", "deep");
+    fs.mkdirSync(child, { recursive: true });
+    writePkg(parent, { akm: { include: ["root.md"] } });
+    const cfg = findNearestIncludeConfig(child, parent);
+    expect(cfg?.baseDir).toBe(parent);
+    expect(cfg?.include).toEqual(["root.md"]);
+  });
+
+  test("boundary is INCLUSIVE — a config AT the boundary dir is found", () => {
+    const boundary = makeTmpDir();
+    const start = path.join(boundary, "sub");
+    fs.mkdirSync(start, { recursive: true });
+    writePkg(boundary, { akm: { include: ["b.md"] } });
+    const cfg = findNearestIncludeConfig(start, boundary);
+    expect(cfg?.baseDir).toBe(boundary);
+  });
+
+  test("does NOT escape above the boundary — a config in the boundary's PARENT is ignored", () => {
+    const grandparent = makeTmpDir();
+    const boundary = path.join(grandparent, "boundary");
+    const start = path.join(boundary, "sub");
+    fs.mkdirSync(start, { recursive: true });
+    // Config lives ABOVE the boundary — must not be discovered.
+    writePkg(grandparent, { akm: { include: ["escaped.md"] } });
+    const cfg = findNearestIncludeConfig(start, boundary);
+    expect(cfg).toBeUndefined();
+  });
+
+  test("returns undefined when no package.json exists anywhere in range", () => {
+    const root = makeTmpDir();
+    const start = path.join(root, "a", "b");
+    fs.mkdirSync(start, { recursive: true });
+    expect(findNearestIncludeConfig(start, root)).toBeUndefined();
+  });
+
+  test("malformed JSON is skipped (walk continues to a valid parent)", () => {
+    const parent = makeTmpDir();
+    const child = path.join(parent, "child");
+    fs.mkdirSync(child, { recursive: true });
+    writeFile(path.join(child, "package.json"), "{ this is not valid json ");
+    writePkg(parent, { akm: { include: ["valid.md"] } });
+    const cfg = findNearestIncludeConfig(child, parent);
+    expect(cfg?.baseDir).toBe(parent);
+    expect(cfg?.include).toEqual(["valid.md"]);
+  });
+
+  test("a package.json WITHOUT akm.include is skipped (empty/absent akm key)", () => {
+    const parent = makeTmpDir();
+    const child = path.join(parent, "child");
+    fs.mkdirSync(child, { recursive: true });
+    writePkg(child, { name: "no-akm-key", version: "1.0.0" });
+    writePkg(parent, { akm: { include: ["valid.md"] } });
+    const cfg = findNearestIncludeConfig(child, parent);
+    expect(cfg?.baseDir).toBe(parent);
+  });
+
+  test("akm.include of the wrong type (string, not array) is ignored", () => {
+    const root = makeTmpDir();
+    writePkg(root, { akm: { include: "not-an-array" } });
+    expect(findNearestIncludeConfig(root, root)).toBeUndefined();
+  });
+
+  test("an EMPTY include array does not count as a config (keeps walking)", () => {
+    const parent = makeTmpDir();
+    const child = path.join(parent, "child");
+    fs.mkdirSync(child, { recursive: true });
+    writePkg(child, { akm: { include: [] } });
+    writePkg(parent, { akm: { include: ["p.md"] } });
+    const cfg = findNearestIncludeConfig(child, parent);
+    expect(cfg?.baseDir).toBe(parent);
+  });
+
+  test("whitespace-only include entries are trimmed away, leaving no config", () => {
+    const root = makeTmpDir();
+    writePkg(root, { akm: { include: ["   ", "", "\t"] } });
+    expect(findNearestIncludeConfig(root, root)).toBeUndefined();
+  });
+});
+
+// ── copyIncludedPaths — error branches ────────────────────────────────────────
+
+describe("copyIncludedPaths — path-safety error branches", () => {
+  test("throws when an include entry escapes the source root via ..", () => {
+    const source = makeTmpDir();
+    const dest = makeTmpDir();
+    // A sibling file that `../outside.md` would resolve to.
+    writeFile(path.join(path.dirname(source), "outside.md"), "x");
+    expect(() => copyIncludedPaths(["../outside.md"], source, dest)).toThrow(/escapes the package root/);
+  });
+
+  test("throws when an include entry does not exist on disk", () => {
+    const source = makeTmpDir();
+    const dest = makeTmpDir();
+    expect(() => copyIncludedPaths(["ghost.md"], source, dest)).toThrow(/does not exist/);
+  });
+
+  test("copies a real file into dest under its relative path", () => {
+    const source = makeTmpDir();
+    const dest = makeTmpDir();
+    writeFile(path.join(source, "sub", "real.md"), "hello");
+    copyIncludedPaths(["sub/real.md"], source, dest);
+    expect(fs.readFileSync(path.join(dest, "sub", "real.md"), "utf8")).toBe("hello");
+  });
+
+  test("'.' include copies the whole directory contents (whole-dir branch)", () => {
+    const source = makeTmpDir();
+    const dest = makeTmpDir();
+    writeFile(path.join(source, "a.md"), "A");
+    writeFile(path.join(source, "nested", "b.md"), "B");
+    copyIncludedPaths(["."], source, dest);
+    expect(fs.readFileSync(path.join(dest, "a.md"), "utf8")).toBe("A");
+    expect(fs.readFileSync(path.join(dest, "nested", "b.md"), "utf8")).toBe("B");
+  });
+});

--- a/tests/coverage-hardening/tasks-parser-classification.test.ts
+++ b/tests/coverage-hardening/tasks-parser-classification.test.ts
@@ -1,0 +1,202 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Coverage-hardening: `parseTaskDocument` classification + coercion boundaries.
+ *
+ * `resolvePromptSource` is a prompt-shape classifier (file vs asset-ref vs
+ * inline vs Windows-abs) — the same "many shapes, one tested" pattern as the
+ * exemplar relink bug. The existing suite tests `./file`, `agent:name`, plain
+ * inline and one Windows path, but leaves the ambiguous boundaries (word:word
+ * inline vs ref, `../` relative, ref-with-no-name) and the entire `timeoutMs`,
+ * `readParams`, `readStringArray`, and `command`-array coercion logic untested.
+ * A sign/off-by-one or misclassification in any of these silently mis-targets a
+ * scheduled task.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { UsageError } from "../../src/core/errors";
+import { parseTaskDocument } from "../../src/tasks/parser";
+
+function parse(yaml: string, id = "t") {
+  return parseTaskDocument({ yaml, filePath: `/stash/tasks/${id}.yml`, id });
+}
+
+function promptSource(yaml: string) {
+  const task = parse(yaml);
+  if (task.target.kind !== "prompt") throw new Error(`expected prompt target, got ${task.target.kind}`);
+  return task.target.source;
+}
+
+// ── resolvePromptSource classification boundaries ─────────────────────────────
+
+describe("parseTaskDocument — prompt source classification", () => {
+  test("'../' relative path is a file (parent-relative, not just './')", () => {
+    const src = promptSource('schedule: "@daily"\nprompt: ../shared/p.md');
+    expect(src.kind).toBe("file");
+    if (src.kind === "file") expect(src.path).toBe("../shared/p.md");
+  });
+
+  test("absolute path is a file", () => {
+    const src = promptSource('schedule: "@daily"\nprompt: /abs/prompts/p.md');
+    expect(src.kind).toBe("file");
+  });
+
+  test("asset ref with uppercase type still classifies as asset (case-insensitive regex)", () => {
+    const src = promptSource('schedule: "@daily"\nprompt: Agent:StandupBot');
+    expect(src.kind).toBe("asset");
+    if (src.kind === "asset") expect(src.ref).toBe("Agent:StandupBot");
+  });
+
+  test("plain sentence with a colon after a SPACE stays inline (space breaks the ref token)", () => {
+    // "Summarise this: and that" — the token before ':' contains a space, so the
+    // asset-ref regex must NOT match; this is the boundary that keeps ordinary
+    // English prompts from being mis-read as `type:name` refs.
+    const src = promptSource('schedule: "@daily"\nprompt: "Summarise this: and that"');
+    expect(src.kind).toBe("inline");
+    if (src.kind === "inline") expect(src.text).toBe("Summarise this: and that");
+  });
+
+  test("a colon with NOTHING after it is inline, not an asset ref (ref needs a name char)", () => {
+    // Trailing colon: `^[a-z][a-z0-9_-]*:[^\\s]` requires a non-space AFTER ':'.
+    const src = promptSource('schedule: "@daily"\nprompt: "todo:"');
+    expect(src.kind).toBe("inline");
+  });
+
+  test("a bare word (no colon) is inline", () => {
+    const src = promptSource('schedule: "@daily"\nprompt: standup');
+    expect(src.kind).toBe("inline");
+  });
+});
+
+// ── timeoutMs coercion branches ───────────────────────────────────────────────
+
+describe("parseTaskDocument — timeoutMs coercion", () => {
+  const base = 'schedule: "@daily"\nprompt: agent:x';
+
+  test("omitted timeoutMs => undefined (inherit config default)", () => {
+    expect(parse(base).timeoutMs).toBeUndefined();
+  });
+
+  test("positive number => that value (override)", () => {
+    expect(parse(`${base}\ntimeoutMs: 60000`).timeoutMs).toBe(60000);
+  });
+
+  test("explicit null => null (disabled, no timeout)", () => {
+    expect(parse(`${base}\ntimeoutMs: null`).timeoutMs).toBeNull();
+  });
+
+  test("the string 'null' => null (disabled)", () => {
+    expect(parse(`${base}\ntimeoutMs: "null"`).timeoutMs).toBeNull();
+  });
+
+  test("zero => null (disabled) — boundary at 0", () => {
+    expect(parse(`${base}\ntimeoutMs: 0`).timeoutMs).toBeNull();
+  });
+
+  test("negative number => null (disabled)", () => {
+    expect(parse(`${base}\ntimeoutMs: -5`).timeoutMs).toBeNull();
+  });
+
+  test("a non-numeric STRING number (e.g. '60000') is NOT honored => undefined (inherit)", () => {
+    // Only real YAML numbers override; a quoted string number falls through to
+    // 'inherit'. Pinning this documents the shape contract so a future 'be
+    // helpful and parseInt it' change is a conscious decision.
+    expect(parse(`${base}\ntimeoutMs: "60000"`).timeoutMs).toBeUndefined();
+  });
+});
+
+// ── command coercion (array form) ─────────────────────────────────────────────
+
+describe("parseTaskDocument — command target", () => {
+  test("command as a YAML array preserves argv boundaries (no whitespace re-split)", () => {
+    const yaml = ['schedule: "@daily"', "command:", "  - akm", "  - improve", '  - "--limit 25"', ""].join("\n");
+    const task = parse(yaml);
+    expect(task.target.kind).toBe("command");
+    if (task.target.kind === "command") {
+      // The array element "--limit 25" must stay a single argv entry — a string
+      // command would split it on whitespace, an array must not.
+      expect(task.target.cmd).toEqual(["akm", "improve", "--limit 25"]);
+    }
+  });
+
+  test("command as a string splits on whitespace", () => {
+    const task = parse('schedule: "@daily"\ncommand: akm improve --limit 25');
+    if (task.target.kind === "command") {
+      expect(task.target.cmd).toEqual(["akm", "improve", "--limit", "25"]);
+    } else {
+      throw new Error("expected command target");
+    }
+  });
+
+  test("empty command array throws", () => {
+    const yaml = ['schedule: "@daily"', "command: []", ""].join("\n");
+    // An empty array is falsy-count 0 targets => 'must set one of' error path,
+    // OR the empty-array guard — either way it must throw, never silently pass.
+    expect(() => parse(yaml)).toThrow(UsageError);
+  });
+});
+
+// ── params coercion ───────────────────────────────────────────────────────────
+
+describe("parseTaskDocument — workflow params coercion", () => {
+  test("params given as a JSON string are parsed into an object", () => {
+    const yaml = ['schedule: "@daily"', "workflow: workflow:wf", 'params: \'{"region":"us-east-1"}\'', ""].join("\n");
+    const task = parse(yaml);
+    if (task.target.kind === "workflow") {
+      expect(task.target.params).toEqual({ region: "us-east-1" });
+    } else {
+      throw new Error("expected workflow target");
+    }
+  });
+
+  test("omitted params default to an empty object", () => {
+    const task = parse('schedule: "@daily"\nworkflow: workflow:wf');
+    if (task.target.kind === "workflow") {
+      expect(task.target.params).toEqual({});
+    } else {
+      throw new Error("expected workflow target");
+    }
+  });
+
+  test("params as a JSON ARRAY (not a mapping) throws", () => {
+    const yaml = ['schedule: "@daily"', "workflow: workflow:wf", "params: '[1,2,3]'", ""].join("\n");
+    expect(() => parse(yaml)).toThrow(/must be a mapping or a JSON object/);
+  });
+});
+
+// ── tags coercion (string form) ───────────────────────────────────────────────
+
+describe("parseTaskDocument — tags coercion", () => {
+  test("a comma/space-separated STRING of tags is split into an array", () => {
+    const task = parse('schedule: "@daily"\nprompt: agent:x\ntags: "alpha, beta gamma"');
+    expect(task.tags).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  test("a YAML array of tags is preserved", () => {
+    const yaml = ['schedule: "@daily"', "prompt: agent:x", "tags: [one, two]", ""].join("\n");
+    expect(parse(yaml).tags).toEqual(["one", "two"]);
+  });
+
+  test("empty tags => undefined (omitted from the document)", () => {
+    const task = parse('schedule: "@daily"\nprompt: agent:x\ntags: ""');
+    expect(task.tags).toBeUndefined();
+  });
+});
+
+// ── target-count guardrails (exactly-one) ─────────────────────────────────────
+
+describe("parseTaskDocument — exactly-one-target enforcement", () => {
+  test("workflow + command together throws (more than one target)", () => {
+    const yaml = ['schedule: "@daily"', "workflow: workflow:wf", "command: akm improve", ""].join("\n");
+    expect(() => parse(yaml)).toThrow(/more than one/);
+  });
+
+  test("an empty-string target does NOT count as a set target", () => {
+    // `prompt: ""` is treated as unset; with no other target this must hit the
+    // 'must set one of' error, not silently produce an empty prompt target.
+    const yaml = ['schedule: "@daily"', 'prompt: ""', ""].join("\n");
+    expect(() => parse(yaml)).toThrow(/must set one of/);
+  });
+});

--- a/tests/coverage-hardening/walk-dir-staleness.test.ts
+++ b/tests/coverage-hardening/walk-dir-staleness.test.ts
@@ -1,0 +1,399 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Coverage-hardening: the incremental dir-staleness engine
+ * (src/indexer/passes/dir-staleness.ts) had ZERO direct tests. It decides
+ * whether an incremental `akm index` may SKIP a directory — a wrong "fresh"
+ * verdict silently serves stale rows after a rename/delete/edit.
+ *
+ * The briefing calls out this exact class: every DirStaleReason branch must be
+ * proven, and a rename/delete must be DETECTED (not skipped). These tests
+ * drive real files with controlled mtimes + a real (temp-file) index DB, and
+ * assert the concrete `reason.kind` for each branch — happy AND structural.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { closeDatabase, openIndexDatabase, upsertEntry, upsertIndexDirState } from "../../src/indexer/db/db";
+import {
+  canUseIncrementalSkip,
+  computeDirFingerprint,
+  getCachedZeroRowDirState,
+  getDirIndexState,
+  inferZeroRowReason,
+} from "../../src/indexer/passes/dir-staleness";
+import type { StashEntry, StashFile } from "../../src/indexer/passes/metadata";
+import type { Database } from "../../src/storage/database";
+import { type Cleanup, sandboxXdgCacheHome, sandboxXdgConfigHome } from "../_helpers/sandbox";
+
+// ── Generic (non-AKM) temp dir management ───────────────────────────────────
+
+const createdTmpDirs: string[] = [];
+function tmpDir(label = "dir-staleness"): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `akm-${label}-`));
+  createdTmpDirs.push(dir);
+  return dir;
+}
+afterAll(() => {
+  for (const dir of createdTmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// ── Env isolation (mirrors db-scoring.test.ts) ──────────────────────────────
+
+let envCleanup: Cleanup = () => {};
+beforeEach(() => {
+  const cache = sandboxXdgCacheHome();
+  const cfg = sandboxXdgConfigHome(cache.cleanup);
+  envCleanup = cfg.cleanup;
+});
+afterEach(() => {
+  envCleanup();
+  envCleanup = () => {};
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Write a file and force its mtime to a fixed epoch-ms value. */
+function writeFileAtMtime(filePath: string, contents: string, mtimeMs: number): void {
+  fs.writeFileSync(filePath, contents);
+  const seconds = mtimeMs / 1000;
+  fs.utimesSync(filePath, seconds, seconds);
+}
+
+function seedEntry(db: Database, dirPath: string, filePath: string): void {
+  const name = path.basename(filePath).replace(/\.md$/, "");
+  const entry: StashEntry = { name, type: "knowledge", description: `desc ${name}` };
+  upsertEntry(db, `knowledge:${name}`, dirPath, filePath, dirPath, entry, name);
+}
+
+function openDb(): Database {
+  return openIndexDatabase(path.join(tmpDir("stale-db"), "index.db"));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// computeDirFingerprint — dedup + sort + max-mtime + missing-file → Infinity
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("computeDirFingerprint", () => {
+  test("dedups by basename and sorts, joining with NUL", () => {
+    const dir = tmpDir();
+    const a = path.join(dir, "a.md");
+    const b = path.join(dir, "b.md");
+    writeFileAtMtime(a, "a", 1000);
+    writeFileAtMtime(b, "b", 2000);
+    // Duplicate basename (different absolute path) must collapse to one entry.
+    const fp = computeDirFingerprint(dir, [b, a, a]);
+    expect(fp.fileSetHash).toBe(["a.md", "b.md"].join("\0"));
+  });
+
+  test("fileMtimeMaxMs is the max mtime across the files", () => {
+    const dir = tmpDir();
+    const a = path.join(dir, "a.md");
+    const b = path.join(dir, "b.md");
+    writeFileAtMtime(a, "a", 5000);
+    writeFileAtMtime(b, "b", 9000);
+    const fp = computeDirFingerprint(dir, [a, b]);
+    expect(fp.fileMtimeMaxMs).toBe(9000);
+  });
+
+  test("a missing file poisons the mtime to +Infinity (forces rescan)", () => {
+    const dir = tmpDir();
+    const present = path.join(dir, "present.md");
+    writeFileAtMtime(present, "x", 3000);
+    const fp = computeDirFingerprint(dir, [present, path.join(dir, "gone.md")]);
+    expect(fp.fileMtimeMaxMs).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  test("empty file list yields empty hash and zero mtime", () => {
+    const fp = computeDirFingerprint(tmpDir(), []);
+    expect(fp.fileSetHash).toBe("");
+    expect(fp.fileMtimeMaxMs).toBe(0);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// getDirIndexState — every DirStaleReason branch, prev-rows path
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("getDirIndexState — with previously-indexed rows", () => {
+  test("unchanged file set + mtimes <= builtAt → NOT stale (kind unchanged)", () => {
+    const db = openDb();
+    try {
+      const dir = tmpDir();
+      const f1 = path.join(dir, "one.md");
+      const f2 = path.join(dir, "two.md");
+      writeFileAtMtime(f1, "1", 1000);
+      writeFileAtMtime(f2, "2", 1000);
+      seedEntry(db, dir, f1);
+      seedEntry(db, dir, f2);
+      const state = getDirIndexState(db, dir, [f1, f2], 5000 /* builtAt after mtimes */);
+      expect(state.stale).toBe(false);
+      expect(state.reason.kind).toBe("unchanged");
+      expect(state.persistedRowCount).toBe(2);
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("an edited file (mtime > builtAt) → stale, kind mtime-changed", () => {
+    const db = openDb();
+    try {
+      const dir = tmpDir();
+      const f1 = path.join(dir, "one.md");
+      writeFileAtMtime(f1, "1", 9000); // newer than builtAt
+      seedEntry(db, dir, f1);
+      const state = getDirIndexState(db, dir, [f1], 5000);
+      expect(state.stale).toBe(true);
+      expect(state.reason.kind).toBe("mtime-changed");
+      expect(state.reason.detail).toBe("one.md");
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("a DELETED file (fewer files than indexed) → stale, kind file-set-changed", () => {
+    const db = openDb();
+    try {
+      const dir = tmpDir();
+      const f1 = path.join(dir, "one.md");
+      const f2 = path.join(dir, "two.md");
+      writeFileAtMtime(f1, "1", 1000);
+      writeFileAtMtime(f2, "2", 1000);
+      seedEntry(db, dir, f1);
+      seedEntry(db, dir, f2);
+      // two.md deleted on disk → current file list has only one.md
+      const state = getDirIndexState(db, dir, [f1], 5000);
+      expect(state.stale).toBe(true);
+      expect(state.reason.kind).toBe("file-set-changed");
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("a RENAME (same count, different name) → stale, kind file-set-changed", () => {
+    // Regression guard: a rename keeps the file COUNT the same, so a naive
+    // size-only check would wrongly report 'unchanged'. The engine must detect
+    // the new basename that was never indexed.
+    const db = openDb();
+    try {
+      const dir = tmpDir();
+      const original = path.join(dir, "old-name.md");
+      writeFileAtMtime(original, "x", 1000);
+      seedEntry(db, dir, original);
+      const renamed = path.join(dir, "new-name.md");
+      writeFileAtMtime(renamed, "x", 1000);
+      const state = getDirIndexState(db, dir, [renamed], 5000);
+      expect(state.stale).toBe(true);
+      expect(state.reason.kind).toBe("file-set-changed");
+      expect(state.reason.detail).toBe("new-name.md");
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("a file listed but missing on disk → stale, kind missing-file", () => {
+    const db = openDb();
+    try {
+      const dir = tmpDir();
+      const f1 = path.join(dir, "one.md");
+      writeFileAtMtime(f1, "1", 1000);
+      seedEntry(db, dir, f1);
+      // Same basename indexed, but the path passed in does not exist on disk.
+      const ghost = path.join(dir, "one.md");
+      fs.rmSync(f1);
+      const state = getDirIndexState(db, dir, [ghost], 5000);
+      expect(state.stale).toBe(true);
+      expect(state.reason.kind).toBe("missing-file");
+    } finally {
+      closeDatabase(db);
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// getDirIndexState — zero-prev-rows path (cached vs no-previous-rows)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("getDirIndexState — with NO previously-indexed rows", () => {
+  test("cached zero-row fingerprint that still matches → NOT stale, cached-zero-row-state", () => {
+    const db = openDb();
+    try {
+      const dir = tmpDir();
+      const f1 = path.join(dir, "note.md");
+      writeFileAtMtime(f1, "n", 4000);
+      const fp = computeDirFingerprint(dir, [f1]);
+      upsertIndexDirState(db, {
+        dirPath: dir,
+        fileSetHash: fp.fileSetHash,
+        fileMtimeMaxMs: fp.fileMtimeMaxMs,
+        reason: "empty-generated-set",
+      });
+      const state = getDirIndexState(db, dir, [f1], 5000);
+      expect(state.stale).toBe(false);
+      expect(state.reason.kind).toBe("cached-zero-row-state");
+      expect(state.reason.detail).toBe("empty-generated-set");
+      expect(state.persistedRowCount).toBe(0);
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("cached fingerprint that no longer matches (mtime moved) → stale, no-previous-rows", () => {
+    const db = openDb();
+    try {
+      const dir = tmpDir();
+      const f1 = path.join(dir, "note.md");
+      writeFileAtMtime(f1, "n", 4000);
+      const fp = computeDirFingerprint(dir, [f1]);
+      upsertIndexDirState(db, {
+        dirPath: dir,
+        fileSetHash: fp.fileSetHash,
+        fileMtimeMaxMs: fp.fileMtimeMaxMs,
+        reason: "empty-generated-set",
+      });
+      // File edited since the cache was written → fingerprint mismatch.
+      writeFileAtMtime(f1, "n2", 8000);
+      const state = getDirIndexState(db, dir, [f1], 9000);
+      expect(state.stale).toBe(true);
+      expect(state.reason.kind).toBe("no-previous-rows");
+      expect(state.reason.detail).toBe("cached=empty-generated-set");
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("no rows and no cache → stale, no-previous-rows with no cached detail", () => {
+    const db = openDb();
+    try {
+      const dir = tmpDir();
+      const f1 = path.join(dir, "note.md");
+      writeFileAtMtime(f1, "n", 4000);
+      const state = getDirIndexState(db, dir, [f1], 5000);
+      expect(state.stale).toBe(true);
+      expect(state.reason.kind).toBe("no-previous-rows");
+      expect(state.reason.detail).toBeUndefined();
+    } finally {
+      closeDatabase(db);
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// canUseIncrementalSkip + getCachedZeroRowDirState
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("canUseIncrementalSkip", () => {
+  const cachedState = (detail: string) =>
+    ({
+      stale: false,
+      reason: { kind: "cached-zero-row-state" as const, detail },
+      persistedRowCount: 0,
+    }) as const;
+
+  test("deduped-zero-row + priorDirsChanged CANNOT skip (dedup may have moved a row)", () => {
+    expect(canUseIncrementalSkip(cachedState("deduped-zero-row"), true)).toBe(false);
+  });
+
+  test("deduped-zero-row but priorDirsChanged=false CAN skip", () => {
+    expect(canUseIncrementalSkip(cachedState("deduped-zero-row"), false)).toBe(true);
+  });
+
+  test("a non-dedup zero-row reason CAN skip even when prior dirs changed", () => {
+    expect(canUseIncrementalSkip(cachedState("empty-generated-set"), true)).toBe(true);
+  });
+
+  test("a non-cached reason kind is unaffected by the dedup guard", () => {
+    const s = { stale: false, reason: { kind: "unchanged" as const }, persistedRowCount: 2 };
+    expect(canUseIncrementalSkip(s, true)).toBe(true);
+  });
+});
+
+describe("getCachedZeroRowDirState", () => {
+  function setupCached(detail: string): { db: Database; dir: string; file: string } {
+    const db = openDb();
+    const dir = tmpDir();
+    const file = path.join(dir, "note.md");
+    writeFileAtMtime(file, "n", 4000);
+    const fp = computeDirFingerprint(dir, [file]);
+    upsertIndexDirState(db, {
+      dirPath: dir,
+      fileSetHash: fp.fileSetHash,
+      fileMtimeMaxMs: fp.fileMtimeMaxMs,
+      reason: detail,
+    });
+    return { db, dir, file };
+  }
+
+  test("returns the fresh cached state when skip is allowed", () => {
+    const { db, dir, file } = setupCached("empty-generated-set");
+    try {
+      const state = getCachedZeroRowDirState(db, dir, [file], 5000, true);
+      expect(state).toBeDefined();
+      expect(state?.reason.kind).toBe("cached-zero-row-state");
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("returns undefined when the dedup guard forbids the skip", () => {
+    const { db, dir, file } = setupCached("deduped-zero-row");
+    try {
+      // priorDirsChanged=true + deduped-zero-row → skip forbidden.
+      expect(getCachedZeroRowDirState(db, dir, [file], 5000, true)).toBeUndefined();
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("returns undefined when the dir is stale (fingerprint moved)", () => {
+    const { db, dir, file } = setupCached("empty-generated-set");
+    try {
+      writeFileAtMtime(file, "changed", 9000); // fingerprint no longer matches
+      expect(getCachedZeroRowDirState(db, dir, [file], 9500, false)).toBeUndefined();
+    } finally {
+      closeDatabase(db);
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// inferZeroRowReason — priority ordering of the four reason buckets
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("inferZeroRowReason", () => {
+  const emptyStash: StashFile = { entries: [] } as unknown as StashFile;
+  const nonEmptyStash: StashFile = { entries: [{ name: "x", type: "knowledge" }] } as unknown as StashFile;
+
+  test("dedupedRows > 0 wins over everything else", () => {
+    expect(inferZeroRowReason(nonEmptyStash, { kind: "mtime-changed" }, [], "/d", 3)).toBe("deduped-zero-row");
+  });
+
+  test("workflow-noise when a warning skipped a workflow in this dir", () => {
+    const warnings = ["Skipped workflow foo in /d/sub"];
+    expect(inferZeroRowReason(nonEmptyStash, undefined, warnings, "/d", 0)).toBe("workflow-noise");
+  });
+
+  test("empty-generated-set when the stash produced no entries", () => {
+    expect(inferZeroRowReason(emptyStash, undefined, [], "/d", 0)).toBe("empty-generated-set");
+    expect(inferZeroRowReason(null, undefined, [], "/d", 0)).toBe("empty-generated-set");
+  });
+
+  test("falls back to zero-row:<priorReason.kind> when a stash exists but 0 rows survived", () => {
+    expect(inferZeroRowReason(nonEmptyStash, { kind: "file-set-changed" }, [], "/d", 0)).toBe(
+      "zero-row:file-set-changed",
+    );
+  });
+
+  test("falls back to zero-row:unknown when there is no prior reason", () => {
+    expect(inferZeroRowReason(nonEmptyStash, undefined, [], "/d", 0)).toBe("zero-row:unknown");
+  });
+
+  test("a workflow warning for a DIFFERENT dir does not trigger workflow-noise", () => {
+    const warnings = ["Skipped workflow foo in /other"];
+    expect(inferZeroRowReason(nonEmptyStash, undefined, warnings, "/d", 0)).toBe("zero-row:unknown");
+  });
+});

--- a/tests/coverage-hardening/workflows-parser-edge.test.ts
+++ b/tests/coverage-hardening/workflows-parser-edge.test.ts
@@ -1,0 +1,391 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Coverage-hardening: exercises the ERROR branches of the workflow parser that
+ * the happy-path suite (tests/workflow-markdown.test.ts) never touches.
+ *
+ * Baseline coverage (workflow-markdown.test.ts only) left parser.ts at ~90%
+ * funcs / ~72% lines, with every uncovered line being a validation/error
+ * branch: looksLikeWorkflow + stripFencedCodeBlocks (fully uncovered), stray
+ * headings, duplicate/empty subsections, frontmatter type errors, and the
+ * parameter-shape checks. Each test asserts the specific error message so a
+ * regression that drops or mis-routes a branch fails loudly (the relink-class
+ * gap: code executed but only on well-formed input).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { looksLikeWorkflow, parseWorkflow } from "../../src/workflows/parser";
+import type { WorkflowParseResult } from "../../src/workflows/schema";
+
+function parse(markdown: string, path = "workflows/edge.md"): WorkflowParseResult {
+  return parseWorkflow(markdown, { path });
+}
+
+function errors(result: WorkflowParseResult): { line: number; message: string }[] {
+  if (result.ok) throw new Error("expected parse to fail, but it succeeded");
+  return result.errors;
+}
+
+function hasMessage(result: WorkflowParseResult, needle: string): boolean {
+  return errors(result).some((e) => e.message.includes(needle));
+}
+
+// ── looksLikeWorkflow (structural probe, fenced-code stripping) ───────────────
+
+describe("looksLikeWorkflow", () => {
+  const REAL = `# Workflow: Demo
+
+## Step: One
+Step ID: one
+
+### Instructions
+Do it.
+`;
+
+  test("returns true for a body with all four structural markers", () => {
+    expect(looksLikeWorkflow(REAL)).toBe(true);
+  });
+
+  test("returns false when the Step ID line is missing", () => {
+    const body = REAL.replace("Step ID: one\n", "");
+    expect(looksLikeWorkflow(body)).toBe(false);
+  });
+
+  test("returns false when the Instructions heading is missing", () => {
+    const body = REAL.replace("### Instructions\n", "");
+    expect(looksLikeWorkflow(body)).toBe(false);
+  });
+
+  test("ignores markers that live only inside a fenced code block", () => {
+    // A doc that merely SHOWS workflow syntax in a ``` fence must not be
+    // mistaken for a real workflow — stripFencedCodeBlocks blanks the fence.
+    const doc = `# Some Doc
+
+Here is an example workflow:
+
+\`\`\`
+# Workflow: Not Real
+
+## Step: Fake
+Step ID: fake
+
+### Instructions
+Nope.
+\`\`\`
+`;
+    expect(looksLikeWorkflow(doc)).toBe(false);
+  });
+
+  test("still detects a real workflow that also contains an unrelated fenced block", () => {
+    const doc = `${REAL}
+\`\`\`
+console.log("hi");
+\`\`\`
+`;
+    expect(looksLikeWorkflow(doc)).toBe(true);
+  });
+
+  test("treats a tilde-fenced block the same as a backtick fence", () => {
+    const doc = `# Some Doc
+
+~~~
+# Workflow: Not Real
+## Step: Fake
+Step ID: fake
+### Instructions
+Nope.
+~~~
+`;
+    expect(looksLikeWorkflow(doc)).toBe(false);
+  });
+});
+
+// ── Title-level errors ────────────────────────────────────────────────────────
+
+describe("parseWorkflow — title errors", () => {
+  test("rejects an empty title (# Workflow: with no text)", () => {
+    const md = `# Workflow:
+
+## Step: One
+Step ID: one
+
+### Instructions
+Do it.
+`;
+    const result = parse(md);
+    expect(hasMessage(result, "missing a title")).toBe(true);
+  });
+
+  test("rejects a second # Workflow: heading", () => {
+    const md = `# Workflow: First
+
+## Step: One
+Step ID: one
+
+### Instructions
+Do it.
+
+# Workflow: Second
+`;
+    const result = parse(md);
+    expect(hasMessage(result, 'second "# Workflow:" heading')).toBe(true);
+  });
+
+  test("rejects a stray non-Workflow level-1 heading", () => {
+    const md = `# Workflow: Demo
+
+# Random Top Heading
+
+## Step: One
+Step ID: one
+
+### Instructions
+Do it.
+`;
+    const result = parse(md);
+    expect(hasMessage(result, "Unexpected top-level heading")).toBe(true);
+  });
+
+  test("rejects a non-Step level-2 heading", () => {
+    const md = `# Workflow: Demo
+
+## Notes
+
+## Step: One
+Step ID: one
+
+### Instructions
+Do it.
+`;
+    const result = parse(md);
+    expect(hasMessage(result, "Unexpected level-2 heading")).toBe(true);
+  });
+});
+
+// ── Step-level errors ─────────────────────────────────────────────────────────
+
+describe("parseWorkflow — step errors", () => {
+  test("rejects an empty step title (## Step: with no text)", () => {
+    const md = `# Workflow: Demo
+
+## Step:
+Step ID: one
+
+### Instructions
+Do it.
+`;
+    const result = parse(md);
+    expect(hasMessage(result, '"## Step:" heading')).toBe(true);
+  });
+
+  test("rejects a step missing its Step ID line", () => {
+    const md = `# Workflow: Demo
+
+## Step: One
+
+### Instructions
+Do it.
+`;
+    const result = parse(md);
+    expect(hasMessage(result, 'missing a "Step ID:')).toBe(true);
+  });
+
+  test("rejects duplicate Step ID lines within one step", () => {
+    const md = `# Workflow: Demo
+
+## Step: One
+Step ID: one
+Step ID: two
+
+### Instructions
+Do it.
+`;
+    const result = parse(md);
+    expect(hasMessage(result, 'more than one "Step ID:"')).toBe(true);
+  });
+
+  test("rejects a step missing its Instructions section", () => {
+    const md = `# Workflow: Demo
+
+## Step: One
+Step ID: one
+
+### Completion Criteria
+- something
+`;
+    const result = parse(md);
+    expect(hasMessage(result, 'required "### Instructions"')).toBe(true);
+  });
+
+  test("rejects duplicate Instructions sections", () => {
+    const md = `# Workflow: Demo
+
+## Step: One
+Step ID: one
+
+### Instructions
+First.
+
+### Instructions
+Second.
+`;
+    const result = parse(md);
+    expect(hasMessage(result, 'more than one "### Instructions"')).toBe(true);
+  });
+
+  test("rejects an empty Instructions section", () => {
+    const md = `# Workflow: Demo
+
+## Step: One
+Step ID: one
+
+### Instructions
+
+### Completion Criteria
+- ok
+`;
+    const result = parse(md);
+    expect(hasMessage(result, 'empty "### Instructions"')).toBe(true);
+  });
+
+  test("rejects duplicate Completion Criteria sections", () => {
+    const md = `# Workflow: Demo
+
+## Step: One
+Step ID: one
+
+### Instructions
+Do it.
+
+### Completion Criteria
+- a
+
+### Completion Criteria
+- b
+`;
+    const result = parse(md);
+    expect(hasMessage(result, 'more than one "### Completion Criteria"')).toBe(true);
+  });
+
+  test("rejects an empty Completion Criteria section (no bullets)", () => {
+    const md = `# Workflow: Demo
+
+## Step: One
+Step ID: one
+
+### Instructions
+Do it.
+
+### Completion Criteria
+Just prose, no bullets.
+`;
+    const result = parse(md);
+    expect(hasMessage(result, 'empty "### Completion Criteria"')).toBe(true);
+  });
+});
+
+// ── Frontmatter type errors ───────────────────────────────────────────────────
+
+describe("parseWorkflow — frontmatter errors", () => {
+  const BODY = `
+
+# Workflow: Demo
+
+## Step: One
+Step ID: one
+
+### Instructions
+Do it.
+`;
+
+  test("rejects invalid YAML frontmatter", () => {
+    const md = `---\nfoo: [unclosed\n---${BODY}`;
+    const result = parse(md);
+    expect(hasMessage(result, "not valid YAML")).toBe(true);
+  });
+
+  test("rejects frontmatter that is a YAML list, not a mapping", () => {
+    const md = `---\n- one\n- two\n---${BODY}`;
+    const result = parse(md);
+    expect(hasMessage(result, "must be a YAML mapping")).toBe(true);
+  });
+
+  test("rejects a scalar frontmatter value", () => {
+    const md = `---\njust a bare string\n---${BODY}`;
+    const result = parse(md);
+    expect(hasMessage(result, "must be a YAML mapping")).toBe(true);
+  });
+
+  test("accepts tags given as a single string (normalised to a one-element list)", () => {
+    const md = `---\ntags: release\n---${BODY}`;
+    const result = parse(md);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.document.tags).toEqual(["release"]);
+  });
+
+  test("rejects tags containing a non-string / empty entry", () => {
+    const md = `---\ntags:\n  - ok\n  - ""\n---${BODY}`;
+    const result = parse(md);
+    expect(hasMessage(result, '"tags" must be a string or a list')).toBe(true);
+  });
+
+  test("rejects params that is a list rather than a mapping", () => {
+    const md = `---\nparams:\n  - a\n  - b\n---${BODY}`;
+    const result = parse(md);
+    expect(hasMessage(result, '"params" must be a mapping')).toBe(true);
+  });
+
+  test("rejects a param whose description is not a non-empty string", () => {
+    const md = `---\nparams:\n  version: 123\n---${BODY}`;
+    const result = parse(md);
+    expect(hasMessage(result, "must have a non-empty string description")).toBe(true);
+  });
+
+  test("rejects an empty parameter name", () => {
+    const md = `---\nparams:\n  "": some description\n---${BODY}`;
+    const result = parse(md);
+    expect(hasMessage(result, "parameter names must be non-empty")).toBe(true);
+  });
+});
+
+// ── Cross-cutting: error ordering + CRLF handling ─────────────────────────────
+
+describe("parseWorkflow — ordering and line endings", () => {
+  test("returns errors sorted ascending by line number", () => {
+    const md = `# Workflow: Demo
+
+## Notes
+
+## Step: One
+Step ID: bad id
+`;
+    const errs = errors(parse(md));
+    const lines = errs.map((e) => e.line);
+    const sorted = [...lines].sort((a, b) => a - b);
+    expect(lines).toEqual(sorted);
+    expect(errs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("parses identically whether the source uses LF or CRLF line endings", () => {
+    const lf = `# Workflow: Demo
+
+## Step: One
+Step ID: one
+
+### Instructions
+Do it.
+`;
+    const crlf = lf.replace(/\n/g, "\r\n");
+    const lfResult = parse(lf);
+    const crlfResult = parse(crlf);
+    expect(lfResult.ok).toBe(true);
+    expect(crlfResult.ok).toBe(true);
+    if (lfResult.ok && crlfResult.ok) {
+      expect(crlfResult.document.title).toBe(lfResult.document.title);
+      expect(crlfResult.document.steps.map((s) => s.id)).toEqual(lfResult.document.steps.map((s) => s.id));
+      expect(crlfResult.document.steps[0].instructions.text).toBe(lfResult.document.steps[0].instructions.text);
+    }
+  });
+});


### PR DESCRIPTION
## Why

The `relinkUsageEvents` bug (PR #698) hid for months behind a **green** suite: the one existing test executed the function (line coverage looked fine) but only with a bare `type:name` ref, so the broken origin-qualified branch was never exercised. Line coverage can't catch this — only behavioral reasoning can.

This PR is the output of a 6-agent audit that hunted that class across the codebase: *tests that run the code but only on the easy input shape, so a whole branch/format/error-path could break with every test still passing.*

**Stacked on #698** (base = the fix branch; retargets to `main` on merge). 15 new files under `tests/coverage-hardening/`, **245 tests, all green**; biome + isolation-lint + tsc clean.

## Highest-value gaps closed

| Area | What was shallow / missing | Now locked |
|---|---|---|
| **db/storage** | `findEntryIdByRef` & `relinkUsageEvents` had no direct test | all ref shapes (bare, origin-qualified ×3, `.md`↔non-`.md`, miss→null, near-miss non-collision); relink origin-qualified regression; `purgeOldUsageEvents` cutoff boundary; feedback/utility persistence; delete cascade |
| **core** | `parseAssetRef` alias/`vault`/normalization branches; `config-walker` had no direct test | `environment:`→`env` alias, `vault:` migration fork, `../`/`//` name edges; walker descent, coercion, path parsing |
| **search/walk** | incremental-skip engine `dir-staleness.ts` had **0 tests** | every `DirStaleReason` branch incl. **rename + delete detection**; ranking normalize/blend math with numeric assertions |
| **commands/read** | recorder `findEntryIdByRef` path + usage recording untested for qualified refs | origin-qualified record→non-null; absent→null; feedback aggregation across ref spellings; flag parsers (were 0%) |
| **improve** | `classifyImproveAction` tested on 4/11 modes | all 11 modes + skip-vs-reject partition (the beta.50 regression class); `isTransientStashPath` (config-clobber fn); include-config + task parser |
| **workflows/registry/llm** | `parser.ts` ~3%, `validator.ts` low | **both to 100%**; registry ref parsing per-transport + semver ranges; embed-cache LRU eviction |

## Bugs surfaced by the audit (reported, NOT committed as red/weakened tests — for separate triage)

1. **`parseRegistryRef("@scope/pkg")` throws `NotFoundError` instead of parsing as npm** — `isPathLikeRef` treats any `/`-containing ref as an explicit local path, so the scoped-`@` npm branch is dead for on-disk-absent refs. Low impact (users normally type `npm:@scope/pkg`).
2. **`setCachedEmbedding` evicts an unrelated oldest entry when overwriting an existing key at capacity** (`cache.ts:41-48`) — size checked before accounting for the key already existing. Minor (spurious recompute). Fix: `!has(key) && size >= MAX`.
3. **OBS-1 (dead code, not a bug):** `MAX_NEG_DELTA_PER_CALL` (0.15) in `computeNextUtility` can never bind (`|delta| ≤ 0.1`), and negative-count magnitude doesn't scale the step — 1 vs 100 negatives yield the same result, contradicting the docstring. Cleanup candidate.

Design notes (intentional, not bugs): config `.passthrough()` is deliberate; `isTransientStashPath` bare-root asymmetry; `resolvePromptSource` classifies `word:nonspace` (incl. URLs) as an asset ref.

## Guardrails followed
Unit-level only (no spawn/serve/network, in-memory DBs + sandbox helpers), pass `lint-tests-isolation`, real functions over mocks (no `mock.module`). Any test that revealed a bug was pulled and reported rather than weakened to match buggy behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YjU1mGiShdDP4qFW7p4mv