### PR TITLE
fix: scoped-npm ref parsing + embed-cache eviction; drop dead utility cap

### DIFF
--- a/src/indexer/feedback/utility-policy.ts
+++ b/src/indexer/feedback/utility-policy.ts
@@ -35,17 +35,6 @@ const FEEDBACK_REWARD_POSITIVE = 1.0;
 const FEEDBACK_REWARD_NEGATIVE = 0.0;
 
 /**
- * Maximum total negative utility delta allowed in a single
- * `applyFeedbackToUtilityScore` call regardless of negativeCount.
- *
- * This caps the per-day negative impact (the function is called once per
- * feedback event — spamming 10 negatives in one session can move utility
- * at most `MAX_NEG_DELTA_PER_CALL`). The cap prevents a noisy negative-
- * feedback stream from silently destroying a high-utility asset's ranking.
- */
-export const MAX_NEG_DELTA_PER_CALL = 0.15;
-
-/**
  * Utility threshold below which a review-needed escalation is triggered.
  * When a previously high-utility asset (≥ HIGH_UTILITY_THRESHOLD) drops
  * below this value, the caller should create an escalation proposal.
@@ -82,8 +71,10 @@ export interface FeedbackUtilityResult {
  *   reward   = weighted average of positive and negative signals
  *   nextUtil = clamp(currentUtil + lr × (reward − currentUtil), 0, 1)
  *
- * The negative impact is additionally capped at {@link MAX_NEG_DELTA_PER_CALL}
- * to prevent a noisy feedback stream from silently erasing a high-utility asset.
+ * The step is inherently bounded: reward ∈ [0, 1] and currentUtil ∈ [0, 1], so
+ * a single call moves utility by at most {@link FEEDBACK_LR}. Because `reward`
+ * is a proportion, the magnitude of `negativeCount` does not enlarge the step —
+ * a burst of negatives cannot over-erase a high-utility asset in one call.
  *
  * Pure: no DB access. When both counts are zero, utility is unchanged.
  */
@@ -105,13 +96,8 @@ export function computeNextUtility(
         ? FEEDBACK_REWARD_NEGATIVE
         : (positiveCount * FEEDBACK_REWARD_POSITIVE + negativeCount * FEEDBACK_REWARD_NEGATIVE) / total;
 
-  // MemRL bounded-step EMA: lr × (reward − current)
-  let delta = FEEDBACK_LR * (reward - previousUtility);
-
-  // Per-call negative cap: if delta is negative (net negative feedback), cap it.
-  if (delta < 0) {
-    delta = Math.max(delta, -MAX_NEG_DELTA_PER_CALL);
-  }
+  // MemRL bounded-step EMA: lr × (reward − current). |delta| ≤ FEEDBACK_LR.
+  const delta = FEEDBACK_LR * (reward - previousUtility);
 
   const nextUtility = Math.max(0, Math.min(1, previousUtility + delta));
 

--- a/src/indexer/feedback/utility-policy.ts
+++ b/src/indexer/feedback/utility-policy.ts
@@ -72,9 +72,11 @@ export interface FeedbackUtilityResult {
  *   nextUtil = clamp(currentUtil + lr × (reward − currentUtil), 0, 1)
  *
  * The step is inherently bounded: reward ∈ [0, 1] and currentUtil ∈ [0, 1], so
- * a single call moves utility by at most {@link FEEDBACK_LR}. Because `reward`
- * is a proportion, the magnitude of `negativeCount` does not enlarge the step —
- * a burst of negatives cannot over-erase a high-utility asset in one call.
+ * a single call moves utility by at most {@link FEEDBACK_LR} in either
+ * direction. `reward` is a proportion of the counts, not their magnitude, so
+ * with no positive signals the number of negatives is irrelevant (reward is 0
+ * whether there is 1 negative or 100). Mixing in positives shifts reward and so
+ * the step, but never past the learning-rate bound.
  *
  * Pure: no DB access. When both counts are zero, utility is unchanged.
  */

--- a/src/llm/embedders/cache.ts
+++ b/src/llm/embedders/cache.ts
@@ -38,7 +38,9 @@ export function getCachedEmbedding(key: string): EmbeddingVector | undefined {
 }
 
 export function setCachedEmbedding(key: string, value: EmbeddingVector): void {
-  // Evict oldest entry if at capacity
+  // Delete first so an overwrite refreshes LRU recency AND is not counted as a
+  // new insert: only a genuinely new key at capacity should evict the oldest.
+  embedCache.delete(key);
   if (embedCache.size >= EMBED_CACHE_MAX) {
     const oldest = embedCache.keys().next().value;
     if (oldest !== undefined) {

--- a/src/registry/resolve.ts
+++ b/src/registry/resolve.ts
@@ -285,6 +285,10 @@ function tryParseLocalRef(rawRef: string, explicitPath: boolean): ParsedLocalRef
 }
 
 function isPathLikeRef(ref: string): boolean {
+  // A leading `@` marks an npm scope (`@scope/pkg`), never a filesystem path —
+  // treat it as non-path so it falls through to the npm branch instead of
+  // being resolved (and rejected) as an explicit local path.
+  if (ref.startsWith("@")) return false;
   if (ref === "." || ref === "..") return true;
   if (path.isAbsolute(ref)) return true;
   if (ref.startsWith("./") || ref.startsWith("../") || ref.startsWith(".\\") || ref.startsWith("..\\")) {

--- a/tests/embed-cache.test.ts
+++ b/tests/embed-cache.test.ts
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { clearEmbeddingCache, getCachedEmbedding, setCachedEmbedding } from "../src/llm/embedders/cache";
+
+/**
+ * The embedding cache is a module-level LRU (capacity 100). These tests pin
+ * the eviction contract, including the regression where overwriting an
+ * already-present key at capacity evicted an unrelated oldest entry.
+ */
+describe("embedding cache LRU eviction", () => {
+  const CAP = 100;
+
+  afterEach(() => clearEmbeddingCache());
+
+  function fill(n: number): void {
+    for (let i = 0; i < n; i++) setCachedEmbedding(`k${i}`, [i]);
+  }
+
+  test("evicts the oldest entry when a NEW key is inserted at capacity", () => {
+    fill(CAP); // k0..k99
+    setCachedEmbedding("k100", [100]); // new key → oldest (k0) evicted
+    expect(getCachedEmbedding("k0")).toBeUndefined();
+    expect(getCachedEmbedding("k100")).toEqual([100]);
+    expect(getCachedEmbedding("k99")).toEqual([99]);
+  });
+
+  test("overwriting an EXISTING key at capacity does NOT evict another entry", () => {
+    fill(CAP); // k0..k99, k0 is the oldest
+    // Overwrite an existing key. A Map.set on an existing key does not grow the
+    // map, so nothing should be evicted — k0 must survive.
+    setCachedEmbedding("k50", [500]);
+    expect(getCachedEmbedding("k0")).toEqual([0]);
+    expect(getCachedEmbedding("k50")).toEqual([500]);
+  });
+
+  test("re-inserting an existing key refreshes its LRU recency", () => {
+    fill(CAP); // k0 oldest
+    setCachedEmbedding("k0", [0]); // touch k0 → now most-recently-used
+    setCachedEmbedding("k100", [100]); // new key evicts the now-oldest (k1)
+    expect(getCachedEmbedding("k0")).toEqual([0]); // survived
+    expect(getCachedEmbedding("k1")).toBeUndefined(); // evicted instead
+  });
+
+  test("getCachedEmbedding promotes an entry so it survives the next eviction", () => {
+    fill(CAP); // k0 oldest
+    getCachedEmbedding("k0"); // promote k0 to MRU
+    setCachedEmbedding("k100", [100]); // evicts k1 (new oldest), not k0
+    expect(getCachedEmbedding("k0")).toEqual([0]);
+    expect(getCachedEmbedding("k1")).toBeUndefined();
+  });
+});

--- a/tests/registry-resolve.test.ts
+++ b/tests/registry-resolve.test.ts
@@ -189,12 +189,16 @@ describe("parseRegistryRef — bare scoped npm package", () => {
 
   test("parses `@scope/pkg@1.2.3` as npm with the requested version", () => {
     const parsed = parseRegistryRef("@scope/pkg@1.2.3");
-    expect(parsed.source).toBe("npm");
-    expect(parsed).toMatchObject({ source: "npm", packageName: "@scope/pkg" });
+    expect(parsed).toMatchObject({
+      source: "npm",
+      packageName: "@scope/pkg",
+      requestedVersionOrTag: "1.2.3",
+    });
   });
 
   test("still routes an explicit `./@scope` path through the local branch", () => {
-    // Leading ./ marks an explicit path; a missing one must still throw.
-    expect(() => parseRegistryRef("./@scope/does-not-exist")).toThrow();
+    // Leading ./ marks an explicit path; a missing one must throw the local
+    // NotFoundError, proving it did NOT fall through to npm parsing.
+    expect(() => parseRegistryRef("./@scope/does-not-exist")).toThrow(/Local path not found/);
   });
 });

--- a/tests/registry-resolve.test.ts
+++ b/tests/registry-resolve.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { UsageError } from "../src/core/errors";
 import {
+  parseRegistryRef,
   trustedNpmTarballHosts,
   UntrustedNpmTarballError,
   validateGitRef,
@@ -170,5 +171,30 @@ describe("validateNpmTarballUrl", () => {
     const hosts = trustedNpmTarballHosts();
     expect(hosts.has("registry.npmjs.org")).toBe(true);
     expect(hosts.size).toBe(1);
+  });
+});
+
+// ── parseRegistryRef: scoped-npm vs path disambiguation ──────────────────────
+
+describe("parseRegistryRef — bare scoped npm package", () => {
+  // Regression: a ref starting with `@` is an npm scope, never a filesystem
+  // path. `isPathLikeRef` used to return true for any ref containing `/`, so
+  // `@scope/pkg` was routed to tryParseLocalRef(explicitPath=true) and threw
+  // NotFoundError before the `@`-npm branch could run.
+  test("parses `@scope/pkg` (not on disk) as an npm ref instead of throwing", () => {
+    const parsed = parseRegistryRef("@scope/pkg");
+    expect(parsed.source).toBe("npm");
+    expect(parsed).toMatchObject({ source: "npm", packageName: "@scope/pkg" });
+  });
+
+  test("parses `@scope/pkg@1.2.3` as npm with the requested version", () => {
+    const parsed = parseRegistryRef("@scope/pkg@1.2.3");
+    expect(parsed.source).toBe("npm");
+    expect(parsed).toMatchObject({ source: "npm", packageName: "@scope/pkg" });
+  });
+
+  test("still routes an explicit `./@scope` path through the local branch", () => {
+    // Leading ./ marks an explicit path; a missing one must still throw.
+    expect(() => parseRegistryRef("./@scope/does-not-exist")).toThrow();
   });
 });

--- a/tests/utility-policy.test.ts
+++ b/tests/utility-policy.test.ts
@@ -7,7 +7,6 @@ import {
   computeNextUtility,
   FEEDBACK_LR,
   HIGH_UTILITY_THRESHOLD,
-  MAX_NEG_DELTA_PER_CALL,
   UTILITY_REVIEW_THRESHOLD,
 } from "../src/indexer/feedback/utility-policy";
 
@@ -50,7 +49,7 @@ describe("computeNextUtility", () => {
     expect(r.nextUtility).toBeCloseTo(0.5, 10);
   });
 
-  test("clamps the result into [0, 1] and never over-steps the negative cap", () => {
+  test("clamps into [0, 1] and a single call steps by at most FEEDBACK_LR", () => {
     for (const prev of [0, 0.25, 0.5, 0.75, 1]) {
       for (const [pos, neg] of [
         [0, 0],
@@ -61,9 +60,19 @@ describe("computeNextUtility", () => {
         const r = computeNextUtility(prev, pos, neg);
         expect(r.nextUtility).toBeGreaterThanOrEqual(0);
         expect(r.nextUtility).toBeLessThanOrEqual(1);
-        // A single call can only move utility down by at most the per-call cap.
-        expect(prev - r.nextUtility).toBeLessThanOrEqual(MAX_NEG_DELTA_PER_CALL + 1e-9);
+        // The EMA step is bounded by the learning rate in BOTH directions —
+        // reward ∈ [0,1] and prev ∈ [0,1] ⇒ |delta| ≤ FEEDBACK_LR. This is the
+        // real bound (the former 0.15 cap could never bind at lr=0.1).
+        expect(Math.abs(prev - r.nextUtility)).toBeLessThanOrEqual(FEEDBACK_LR + 1e-9);
       }
     }
+  });
+
+  test("negativeCount magnitude does not enlarge the downward step", () => {
+    // reward is a proportion, so 1 vs 100 negatives (0 positives) produce the
+    // same step — the guarantee the removed per-call cap falsely claimed to add.
+    const one = computeNextUtility(0.8, 0, 1).nextUtility;
+    const many = computeNextUtility(0.8, 0, 100).nextUtility;
+    expect(many).toBeCloseTo(one, 10);
   });
 });


### PR DESCRIPTION
Follow-up to the coverage-hardening audit (#699), which surfaced these three items. Each is verified test-first (items 1 & 2 fail on pre-fix code).

## 1. `parseRegistryRef("@scope/pkg")` threw instead of npm-parsing
`isPathLikeRef` returned `true` for any ref containing `/`, so a bare scoped package `@scope/pkg` was routed to `tryParseLocalRef(explicitPath=true)` and threw `NotFoundError: Local path not found: …/@scope/pkg` — the `@`→npm branch (`resolve.ts:85`) was dead for scoped refs not on disk.

**Fix:** a leading `@` marks an npm scope, never a filesystem path → `isPathLikeRef` returns `false` for it, so it falls through to npm. Explicit `./@scope/…` paths still resolve as local (leading `./` is path-like).

## 2. `setCachedEmbedding` evicted an unrelated entry on at-capacity overwrite
The size check (`size >= MAX`) ran before accounting for the key already existing. Since `Map.set` on an existing key doesn't grow the map, overwriting a present key at capacity evicted the oldest unrelated entry (spurious recompute).

**Fix:** delete the key first, then evict only if still at capacity, then set. This also makes an overwrite refresh LRU recency (matching `getCachedEmbedding`).

## 3. Removed `MAX_NEG_DELTA_PER_CALL` (dead code)
With `FEEDBACK_LR = 0.1` and `reward, prev ∈ [0,1]`, `|delta| ≤ 0.1`, so the `0.15` negative clamp could **never bind**. Its docstring claimed it prevents a "burst of 10 negatives" from over-dropping utility — but `reward` is a proportion, so 1 vs 100 negatives already produce the same step. The existing test asserted `prev - next ≤ 0.15`, vacuously true.

**Fix (subtraction):** deleted the constant and the dead clamp; corrected the docstring to state the real bound (the EMA is inherently bounded by the learning rate); updated the test to assert `|delta| ≤ FEEDBACK_LR` **and** that `negativeCount` magnitude doesn't enlarge the step.

## Verification
- New/updated regression tests; items 1 & 2 fail on pre-fix code, pass after.
- `tests/registry-resolve.test.ts`, `tests/embed-cache.test.ts` (new), `tests/utility-policy.test.ts`.
- Full unit suite: 5081 pass / 0 fail. tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YjU1mGiShdDP4qFW7p4mv