### PR TITLE
fix(telemetry): propagate AKM_EVENT_SOURCE through nested agent spawns so GRR excludes self-reads

### DIFF
--- a/scripts/akm-eval/src/proactive-verdict.ts
+++ b/scripts/akm-eval/src/proactive-verdict.ts
@@ -296,12 +296,16 @@ function classifyProposals(
     let cohort: "proactive" | "reactive" | null = null;
     if (elig === "proactive") cohort = "proactive";
     else if (elig && REACTIVE_SOURCES.has(elig)) cohort = "reactive";
-    else {
-      // Fallback: match the proposal ref against the pilot treatment file.
+    else if (p.source === "reflect") {
+      // A reflect proposal missing its eligibilitySource sub-label is the genuine
+      // gap the pilot-file fallback exists for. Only these should trip usedFallback.
+      // Non-reflect proposals (consolidate/extract/…) are not part of the
+      // proactive-vs-reactive split at all — they must NOT flag the fallback, or the
+      // verdict spuriously reports "pilot-file-fallback" even when every reflect
+      // proposal is cleanly classified by its eligibilitySource.
       usedFallback = true;
       const norm = normalizeRef(p.ref);
-      if (norm && treatmentRefs.has(norm)) cohort = "proactive";
-      else if (p.source === "reflect") cohort = "reactive";
+      cohort = norm && treatmentRefs.has(norm) ? "proactive" : "reactive";
     }
     if (cohort === "proactive") bump(proactive, p.status);
     else if (cohort === "reactive") bump(reactive, p.status);

--- a/src/integrations/agent/profiles.ts
+++ b/src/integrations/agent/profiles.ts
@@ -64,7 +64,13 @@ export interface AgentProfile {
   readonly modelAliases?: Readonly<Record<string, string>>;
 }
 
-const COMMON_PASSTHROUGH = ["HOME", "PATH", "USER", "LANG", "LC_ALL", "TERM", "TMPDIR"] as const;
+// AKM_EVENT_SOURCE carries usage-event provenance (improve/task) so that akm
+// invocations a spawned agent makes are recorded as machine traffic, not user
+// demand (DRIFT-6). Without it in the passthrough whitelist, buildChildEnv drops
+// the stamp at the agent boundary — e.g. `akm wiki ingest` spawns an agent whose
+// `akm curate/show/search` tool-calls then log source='user', silently inflating
+// every lane's read-back (GRR). It is a provenance tag, never a secret.
+const COMMON_PASSTHROUGH = ["HOME", "PATH", "USER", "LANG", "LC_ALL", "TERM", "TMPDIR", "AKM_EVENT_SOURCE"] as const;
 
 /**
  * Built-in profiles for the five agent CLIs the v1 spec calls out

--- a/tests/agent/agent-spawn.test.ts
+++ b/tests/agent/agent-spawn.test.ts
@@ -17,6 +17,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { AgentProfile } from "../../src/integrations/agent/profiles";
+import { getBuiltinAgentProfile } from "../../src/integrations/agent/profiles";
 import type { SpawnedSubprocess, SpawnFn } from "../../src/integrations/agent/spawn";
 import { runAgent } from "../../src/integrations/agent/spawn";
 
@@ -275,5 +276,35 @@ describe("runAgent — argument and env construction", () => {
       envSource: { KEEP_ME: "yes", DROP_ME: "no" } as NodeJS.ProcessEnv,
     });
     expect(capturedEnv).toEqual({ KEEP_ME: "yes", PROFILE_VAR: "1", CALL_VAR: "2" });
+  });
+
+  // Regression: usage-event provenance (AKM_EVENT_SOURCE) must survive the
+  // agent boundary. When a parent akm command already stamped it (e.g. the task
+  // runner sets AKM_EVENT_SOURCE=task), a nested agent — such as the one
+  // `akm wiki ingest` spawns — must inherit it so the agent's own akm reads log
+  // as machine traffic, not user demand. Missing it from the built-in
+  // envPassthrough whitelist silently inflated every lane's read-back (GRR).
+  test("built-in profiles pass AKM_EVENT_SOURCE through to the spawned agent", async () => {
+    const opencode = getBuiltinAgentProfile("opencode");
+    if (!opencode) throw new Error("opencode built-in profile missing");
+    expect(opencode.envPassthrough).toContain("AKM_EVENT_SOURCE");
+
+    let capturedEnv: Record<string, string> | undefined;
+    const spawn: SpawnFn = (_cmd, opts) => {
+      capturedEnv = opts.env;
+      return {
+        exitCode: 0,
+        exited: Promise.resolve(0),
+        stdout: asReadableStream(""),
+        stderr: asReadableStream(""),
+        stdin: null,
+        kill() {},
+      };
+    };
+    await runAgent(opencode, undefined, {
+      spawn,
+      envSource: { PATH: "/usr/bin", AKM_EVENT_SOURCE: "task" } as NodeJS.ProcessEnv,
+    });
+    expect(capturedEnv?.AKM_EVENT_SOURCE).toBe("task");
   });
 });


### PR DESCRIPTION
## Problem

The improve-lane read-back rate (**GRR**) — the meta-review series' governing number for whether the improve pipeline is net-positive — is inflated by cron **self-reads** that log as `source='user'` instead of `'task'`, so they can't be excluded from the numerator.

Verified live (read-only): the `:00`/`:30` `usage_events` `'user'` read spikes trace to the `discord-wiki-articles-ingest` cron (`*/30`) → `akm wiki ingest articles` → an opencode agent whose own `akm curate/show/search` tool-calls are recorded as user demand.

## Root cause

The task runner stamps `AKM_EVENT_SOURCE=task`, but `buildChildEnv` (`spawn.ts`) filters `process.env` through the `profile.envPassthrough` **whitelist**, and `AKM_EVENT_SOURCE` was **not** in `COMMON_PASSTHROUGH` (`profiles.ts`). So the stamp is dropped at every *nested* agent boundary. The runner's own `options.env` stamp (`runner.ts:454`) only covers agents it spawns **directly** — not an agent spawned deeper by a command it runs (`akm wiki ingest`).

## Fix

1. **Add `AKM_EVENT_SOURCE` to `COMMON_PASSTHROUGH`** (one entry). It is a provenance tag, never a secret. The SessionStart plugin `curate` is genuine demand (spread across minutes) and correctly stays `'user'` — this only affects `task`/`improve` traffic that already carries the stamp. + regression test in `tests/agent/agent-spawn.test.ts`.
2. **Scope `proactive-verdict.ts`'s `usedFallback`** to reflect-source proposals. It previously tripped on any proposal lacking `eligibilitySource`, so `consolidate`/`extract` rows (never part of the proactive-vs-reactive split) forced the monthly verdict into `pilot-file-fallback` mode even when every reflect proposal was cleanly classified. (`akm-eval` is a local-only instrument with no test harness; change typechecks under its own tsconfig.)

This fixes the root (a whitelist omission defeating the runner's provenance intent) rather than adding redundant per-lane `eligibilitySource` write-site plumbing — per-lane GRR is already computable via `COALESCE(eligibilitySource, source)`.

## Verification

- lint OK · `tsc --noEmit` clean · unit **5332 / 0** · agent+env integration **9 / 0** · `akm-eval` typechecks under its own tsconfig
- Follow-up (post-merge, after the cron re-runs): the minting-lane GRR numbers will drop **lower** as self-reads are removed, confirming they were upper bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)