### PR TITLE
Follow-ups: unify duration units, honor active --profile, add getDbPath env seam

### DIFF
--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -8,7 +8,7 @@ import { readEvents } from "../core/events";
 import { openLogsDatabase } from "../core/logs-db";
 import { getStateDbPathInDataDir } from "../core/paths";
 import { listExistingTableNames, openStateDatabase } from "../core/state-db";
-import { parseDuration, parseSinceToIso } from "../core/time";
+import { DURATION_UNITS, parseDuration, parseSinceToIso } from "../core/time";
 import { readSemanticStatus } from "../indexer/search/semantic-status";
 import type { SessionLogEntry } from "../integrations/session-logs";
 import { getExecutionLogCandidates } from "../integrations/session-logs";
@@ -83,17 +83,11 @@ export function parseHealthSince(since?: string): string {
     return new Date(Date.now() - DEFAULT_SINCE_MS).toISOString();
   }
   const trimmed = since.trim();
-  // TODO(product): `m` here means MONTHS (approximated as 30 days), but the
-  // since-parsers in consolidate.ts and `--window-compare` (windows.ts) read
-  // `m` as MINUTES. This month-vs-minute discrepancy for the same shorthand is
-  // a genuine inconsistency that needs a human product decision — do NOT
-  // silently unify it here; both semantics are preserved via explicit unit maps
-  // passed to core/time.ts `parseDuration`.
-  const durationMs = parseDuration(trimmed.toLowerCase(), {
-    h: 60 * 60 * 1000,
-    m: 30 * 24 * 60 * 60 * 1000,
-    d: 24 * 60 * 60 * 1000,
-  });
+  // Unit grammar is the CLI-wide canonical map: `m` = minutes, `M` = months.
+  // (Historically `--since 5m` meant 5 months here; it now means 5 minutes,
+  // with `5M` for months — unified with consolidate / `--window-compare`.)
+  // Not lower-cased: case distinguishes `m` (minutes) from `M` (months).
+  const durationMs = parseDuration(trimmed, DURATION_UNITS);
   if (durationMs !== null) {
     return new Date(Date.now() - durationMs).toISOString();
   }

--- a/src/commands/health/windows.ts
+++ b/src/commands/health/windows.ts
@@ -11,7 +11,7 @@ import fs from "node:fs";
 import { UsageError } from "../../core/errors";
 import { readEvents } from "../../core/events";
 import { buildTaskRunId, getLoggedRunIds } from "../../core/logs-db";
-import { parseDuration } from "../../core/time";
+import { DURATION_UNITS, parseDuration } from "../../core/time";
 import type { Database } from "../../storage/database";
 import { queryTaskHistory, type TaskHistoryRow } from "../../storage/repositories/task-history-repository";
 import {
@@ -41,13 +41,9 @@ import {
  */
 export function resolveWindowCompare(duration: string, now: () => number = () => Date.now()): WindowSpec[] {
   const trimmed = duration.trim();
-  // NOTE: `m` = MINUTES here (unlike `akm health --since` / `--expires` where
-  // `m` = months). Preserved via the explicit unit map; see core/time.ts.
-  const ms = parseDuration(trimmed.toLowerCase(), {
-    h: 60 * 60 * 1000,
-    m: 60 * 1000,
-    d: 24 * 60 * 60 * 1000,
-  });
+  // Canonical CLI unit grammar: `m` = minutes, `M` = months. Not lower-cased,
+  // so case distinguishes the two. See core/time.ts DURATION_UNITS.
+  const ms = parseDuration(trimmed, DURATION_UNITS);
   if (ms === null) {
     throw new UsageError("--window-compare must be a duration like '24h', '7d', or '30m'.", "INVALID_FLAG_VALUE");
   }

--- a/src/commands/improve/collapse-detector.ts
+++ b/src/commands/improve/collapse-detector.ts
@@ -29,7 +29,7 @@
 import { randomBytes } from "node:crypto";
 import { makeAssetRef } from "../../core/asset/asset-ref";
 import type { AkmAssetType } from "../../core/common";
-import type { AkmConfig } from "../../core/config/config";
+import type { AkmConfig, ImproveProfileConfig } from "../../core/config/config";
 import { getImproveProcessConfig } from "../../core/config/config";
 import { appendEvent, type EventsContext } from "../../core/events";
 import { withStateDb } from "../../core/state-db";
@@ -465,6 +465,8 @@ export function runCollapseDetector(args: {
   acceptedActions: number;
   mergeFloorViolations: number;
   config: AkmConfig;
+  /** Active improve profile, so the threshold read honors `--profile`. */
+  improveProfile?: ImproveProfileConfig;
   eventsCtx?: EventsContext;
   indexDbPath?: string;
 }): CycleMetricsRow | undefined {
@@ -478,7 +480,7 @@ export function runCollapseDetector(args: {
       const db = indexDb;
       // Over-generation threshold mirrors the guard actually in effect —
       // reading the same config key keeps the two aligned when tuned.
-      const antiCollapse = getImproveProcessConfig(args.config, "consolidate")?.antiCollapse as
+      const antiCollapse = getImproveProcessConfig(args.config, "consolidate", args.improveProfile)?.antiCollapse as
         | { maxGeneration?: number }
         | undefined;
       const maxGeneration = antiCollapse?.maxGeneration ?? DEFAULT_MAX_GENERATION;

--- a/src/commands/improve/consolidate.ts
+++ b/src/commands/improve/consolidate.ts
@@ -18,7 +18,7 @@ import { ConfigError } from "../../core/errors";
 import { parseEmbeddedJsonResponse } from "../../core/parse";
 import { resolveStashStandards } from "../../core/standards/resolve-stash-standards";
 import { detectTruncatedDescription } from "../../core/text-truncation";
-import { parseDuration } from "../../core/time";
+import { DURATION_UNITS, parseDuration } from "../../core/time";
 import { createProposal, isProposalSkipped, listProposals } from "../proposal/repository";
 import {
   hasSupersededStatus,
@@ -2726,11 +2726,10 @@ async function checkPreEmitDedup(opts: {
  * doesn't match the pattern (assumed to already be an ISO timestamp).
  */
 function parseSinceToIso(since: string): string {
-  // Case-sensitive units, matching the original local regex `/^(\d+)(m|h|d)$/`.
-  // NOTE: here `m` = MINUTES (see core/time.ts parseDuration for the cross-call
-  // `m` month-vs-minute discrepancy). Non-matching input is returned unchanged
-  // (assumed to already be an ISO timestamp).
-  const ms = parseDuration(since, { m: 60_000, h: 3_600_000, d: 86_400_000 });
+  // Canonical CLI unit grammar: `m` = minutes, `M` = months (see core/time.ts
+  // DURATION_UNITS). Non-matching input is returned unchanged (assumed to
+  // already be an ISO timestamp).
+  const ms = parseDuration(since, DURATION_UNITS);
   if (ms === null) return since;
   return new Date(Date.now() - ms).toISOString();
 }

--- a/src/commands/improve/consolidate.ts
+++ b/src/commands/improve/consolidate.ts
@@ -11,7 +11,7 @@ import { parseAssetRef } from "../../core/asset/asset-ref";
 import { assembleAssetFromString, serializeFrontmatter } from "../../core/asset/asset-serialize";
 import { parseFrontmatter } from "../../core/asset/frontmatter";
 import { resolveStashDir, timestampForFilename } from "../../core/common";
-import type { AkmConfig } from "../../core/config/config";
+import type { AkmConfig, ImproveProfileConfig } from "../../core/config/config";
 import { getDefaultLlmConfig, getImproveProcessConfig, loadConfig } from "../../core/config/config";
 import { ConfigError } from "../../core/errors";
 // Note: appendEvent import removed (WS-3a: archive TTL machinery retired)
@@ -268,6 +268,13 @@ export interface ConsolidatePerfTelemetry {
 type ConsolidateOpKind = "merge" | "delete" | "promote" | "contradict";
 
 export interface AkmConsolidateOptions {
+  /**
+   * The improve profile resolved for the current `akm improve --profile <name>`
+   * run. When set, its per-process overrides win over the `default` profile at
+   * the secondary process-config reads inside this pass; absent (standalone
+   * `akm consolidate`) falls back to the `default` profile.
+   */
+  improveProfile?: ImproveProfileConfig;
   target?: string; // which source to target; defaults to primary writable stash
   dryRun?: boolean; // generate AI plan but skip all writes
   /**
@@ -879,8 +886,8 @@ function archiveMemory(
  * silent 400s from LM Studio). The investigation lives at
  * `/tmp/akm-health-investigations/consolidation-no-op.md`.
  */
-function resolveConsolidateLlmConfig(config: AkmConfig) {
-  const consolidateProcess = getImproveProcessConfig(config, "consolidate");
+function resolveConsolidateLlmConfig(config: AkmConfig, activeProfile?: ImproveProfileConfig) {
+  const consolidateProcess = getImproveProcessConfig(config, "consolidate", activeProfile);
   const runnerSpec = resolveImproveProcessRunnerFromProfile(consolidateProcess, config);
   if (runnerSpec && runnerIsLlm(runnerSpec)) {
     return runnerSpec.connection;
@@ -1115,7 +1122,8 @@ async function narrowConsolidationPool(
   // Without that flag no assets will ever carry the hot-probation marker, so
   // running the filter loop would be pure unnecessary I/O over the full corpus.
   const hotProbationEnabled =
-    (getImproveProcessConfig(config, "extract")?.hotProbation as { enabled?: boolean } | undefined)?.enabled === true;
+    (getImproveProcessConfig(config, "extract", opts.improveProfile)?.hotProbation as { enabled?: boolean } | undefined)
+      ?.enabled === true;
   let hotProbationCount = 0;
   if (hotProbationEnabled) {
     const hotProbationMemories: typeof memories = [];
@@ -1363,7 +1371,7 @@ async function planConsolidation(
   //
   // Honor `profiles.improve.default.processes.consolidate.profile` first; fall
   // back to the default LLM. See {@link resolveConsolidateLlmConfig}.
-  const llmConfig = resolveConsolidateLlmConfig(config);
+  const llmConfig = resolveConsolidateLlmConfig(config, opts.improveProfile);
   const isHttpPath = !!llmConfig;
 
   // Chunk sizing: derive a safe chunk size from the configured model context
@@ -1406,7 +1414,9 @@ async function planConsolidation(
   let finalClusteredMemories = clusteredMemories;
   {
     const antiCollapseForCluster: AntiCollapseConfig =
-      (getImproveProcessConfig(config, "consolidate")?.antiCollapse as AntiCollapseConfig | undefined) ?? {};
+      (getImproveProcessConfig(config, "consolidate", opts.improveProfile)?.antiCollapse as
+        | AntiCollapseConfig
+        | undefined) ?? {};
     if (antiCollapseForCluster.enabled !== false && clusteredMemories.length > 2) {
       const fraction = antiCollapseForCluster.randomClusterFraction ?? 0.05;
       const randomCount = Math.max(1, Math.floor(clusteredMemories.length * fraction));
@@ -1776,6 +1786,7 @@ async function applyConsolidationPlan(
   allOps: ConsolidateOperation[],
   accounting: ConsolidateAccounting,
   dedupCollapsed: number,
+  activeProfile?: ImproveProfileConfig,
 ): Promise<{
   merged: number;
   deleted: number;
@@ -1815,6 +1826,7 @@ async function applyConsolidationPlan(
 
   const opCtx: ConsolidateOpContext = {
     config,
+    improveProfile: activeProfile,
     stashDir,
     sourceRun,
     target,
@@ -1971,7 +1983,17 @@ async function akmConsolidateInner(
 
   // -- Pass 3: execute the plan against the filesystem ------------------------
   const { merged, deleted, contradicted, mergeFloorViolations, mergedSecondaries, promoted } =
-    await applyConsolidationPlan(config, stashDir, sourceRun, memories, warnings, allOps, accounting, dedupCollapsed);
+    await applyConsolidationPlan(
+      config,
+      stashDir,
+      sourceRun,
+      memories,
+      warnings,
+      allOps,
+      accounting,
+      dedupCollapsed,
+      opts.improveProfile,
+    );
 
   const runDurationMs = Date.now() - startMs;
   const budgetFraction =
@@ -2022,6 +2044,8 @@ async function akmConsolidateInner(
  */
 export interface ConsolidateOpContext {
   config: AkmConfig;
+  /** Active improve profile for this run, if any (see AkmConsolidateOptions). */
+  improveProfile?: ImproveProfileConfig;
   stashDir: string;
   sourceRun: string;
   target: ReturnType<typeof resolveWriteTarget>;
@@ -2129,7 +2153,14 @@ export async function handleMergeOp(op: ConsolidateMergeOp, opIndex: number, ctx
     return;
   }
 
-  const mergeResult = await generateMergedContent(config, op.primary, primaryBody, op.secondaries, memoryByRef);
+  const mergeResult = await generateMergedContent(
+    config,
+    op.primary,
+    primaryBody,
+    op.secondaries,
+    memoryByRef,
+    ctx.improveProfile,
+  );
 
   if ("error" in mergeResult) {
     warnings.push(`Merge: ${mergeResult.error} for ${mergeResult.detail}.`);
@@ -2198,7 +2229,9 @@ export async function handleMergeOp(op: ConsolidateMergeOp, opIndex: number, ctx
   // pipeline from building ever-deeper LLM-merged trees that lose the
   // source fidelity of the original episodes.
   const antiCollapseConfig: AntiCollapseConfig =
-    (getImproveProcessConfig(config, "consolidate")?.antiCollapse as AntiCollapseConfig | undefined) ?? {};
+    (getImproveProcessConfig(config, "consolidate", ctx.improveProfile)?.antiCollapse as
+      | AntiCollapseConfig
+      | undefined) ?? {};
   if (antiCollapseConfig.enabled !== false) {
     const allParticipants = [op.primary, ...op.secondaries];
     // One read per participant: generation counter, stripped body (for the
@@ -2855,6 +2888,7 @@ async function generateMergedContent(
   primaryBody: string,
   secondaryRefs: string[],
   memoryByRef: Map<string, MemoryEntry>,
+  activeProfile?: ImproveProfileConfig,
 ): Promise<MergeResult> {
   // Only handle single-secondary merges per design (one call per merge op)
   const secRef = secondaryRefs[0];
@@ -2901,7 +2935,7 @@ async function generateMergedContent(
 
   // Use the same per-process profile resolution as the chunk-plan call above
   // so the merge generation step doesn't silently revert to the default LLM.
-  const llmConfig = resolveConsolidateLlmConfig(config);
+  const llmConfig = resolveConsolidateLlmConfig(config, activeProfile);
   const result = await tryLlmFeature(
     "memory_consolidation",
     config,

--- a/src/commands/improve/distill.ts
+++ b/src/commands/improve/distill.ts
@@ -61,7 +61,7 @@ import { parseFrontmatter, writeSalienceToFrontmatter } from "../../core/asset/f
 import { stripMarkdownFences } from "../../core/asset/markdown";
 import { authoringRulesForType } from "../../core/authoring-rules";
 import { resolveStashDir } from "../../core/common";
-import type { AkmConfig, LlmConnectionConfig } from "../../core/config/config";
+import type { AkmConfig, ImproveProfileConfig, LlmConnectionConfig } from "../../core/config/config";
 import { getDefaultLlmConfig, getImproveProcessConfig, loadConfig } from "../../core/config/config";
 import { ConfigError, UsageError } from "../../core/errors";
 import { appendEvent, readEvents } from "../../core/events";
@@ -167,6 +167,11 @@ export function isDistillRefusedInputType(type: string): boolean {
 export interface AkmDistillOptions {
   /** Asset ref to distil from (`[origin//]type:name`). */
   ref: string;
+  /**
+   * Active improve profile for this run. When set, its per-process `distill`
+   * overrides win over the `default` profile; absent falls back to `default`.
+   */
+  improveProfile?: ImproveProfileConfig;
   /**
    * Proposal target mode. `lesson` preserves the legacy behaviour.
    * `auto` lets memory refs graduate into knowledge proposals when a
@@ -871,8 +876,9 @@ export async function akmDistill(options: AkmDistillOptions): Promise<AkmDistill
   // into the distill prompt so the LLM avoids overwriting prior generalizations
   // (catastrophic interference). DEFAULT OFF.
   const clsConfig =
-    (getImproveProcessConfig(config, "distill")?.cls as { enabled?: boolean; adjacentCount?: number } | undefined) ??
-    {};
+    (getImproveProcessConfig(config, "distill", options.improveProfile)?.cls as
+      | { enabled?: boolean; adjacentCount?: number }
+      | undefined) ?? {};
   let clsContext = "";
   if (clsConfig.enabled) {
     try {
@@ -1132,7 +1138,9 @@ export async function akmDistill(options: AkmDistillOptions): Promise<AkmDistill
   // source memories. A contradiction flag routes to human review (not auto-accept).
   // DEFAULT OFF. Fail-open: any error is treated as no-contradiction.
   const fidelityConfig =
-    (getImproveProcessConfig(config, "distill")?.fidelityCheck as { enabled?: boolean } | undefined) ?? {};
+    (getImproveProcessConfig(config, "distill", options.improveProfile)?.fidelityCheck as
+      | { enabled?: boolean }
+      | undefined) ?? {};
   if (fidelityConfig.enabled && assetContent) {
     try {
       const proposalBody = stripBodyForFidelity(content);

--- a/src/commands/improve/extract.ts
+++ b/src/commands/improve/extract.ts
@@ -676,6 +676,11 @@ async function processSession(
   // When enabled, system-generated extractions enter captureMode: hot-probation
   // so they spend ONE consolidation cycle in probation before the deterministic
   // dedup+quality pass promotes them. Default OFF.
+  // Reads the `default` profile deliberately: this per-session hot-probation
+  // flag lives inside the 18-arg `processSession`, which has no handle to the
+  // active profile, and threading a 19th positional arg for a DEFAULT-OFF flag
+  // isn't worth the param bloat. The extract STAGE toggle (in `akmExtract`,
+  // below) already honors `--profile`.
   const hotProbationEnabled =
     (getImproveProcessConfig(config, "extract")?.hotProbation as { enabled?: boolean } | undefined)?.enabled === true;
 
@@ -1267,6 +1272,8 @@ export interface CountNewExtractCandidatesOptions {
    * gate never re-reads `XDG_DATA_HOME` live mid-run.
    */
   stateDbPath?: string;
+  /** Active improve profile, so the discovery window honors `--profile`. */
+  improveProfile?: ImproveProfileConfig;
 }
 
 /**
@@ -1286,7 +1293,7 @@ export interface CountNewExtractCandidatesOptions {
  * changed session is actually re-processed.
  */
 export function countNewExtractCandidates(config: AkmConfig, options: CountNewExtractCandidatesOptions = {}): number {
-  const extractProcess = getImproveProcessConfig(config, "extract");
+  const extractProcess = getImproveProcessConfig(config, "extract", options.improveProfile);
   const effectiveSince = options.since ?? extractProcess?.defaultSince;
   // Mirror akmExtract: when no explicit window is set, default per-harness to
   // "since the last run" (floored at 48h) instead of a fixed 24h. Keeps this

--- a/src/commands/improve/loop-stages.ts
+++ b/src/commands/improve/loop-stages.ts
@@ -285,6 +285,8 @@ export async function runImproveLoopStage(args: ImproveRunContext): Promise<Impr
           const reflectCallArgs = {
             ref: planned.ref,
             task: options.task,
+            // Active profile so reflect's per-process reads honor `--profile`.
+            ...(improveProfile ? { improveProfile } : {}),
             ...(options.stashDir ? { stashDir: options.stashDir } : {}),
             ...(reflectErrors.length > 0 ? { avoidPatterns: [...reflectErrors] } : {}),
             agentProcess: options.agentProcess ?? "reflect",
@@ -565,6 +567,8 @@ export async function runImproveLoopStage(args: ImproveRunContext): Promise<Impr
             ref: planned.ref,
             ...(parsedPlannedRef.type === "memory" ? { proposalKind: "auto" as const } : {}),
             ...(options.stashDir ? { stashDir: options.stashDir } : {}),
+            // Active profile so distill's per-process reads honor `--profile`.
+            ...(improveProfile ? { improveProfile } : {}),
             // Attribution: carry the eligibility lane so distill stamps it on the
             // distill_invoked event and the persisted proposal.
             ...(planned.eligibilitySource ? { eligibilitySource: planned.eligibilitySource } : {}),
@@ -785,6 +789,7 @@ export async function runImprovePostLoopStage(args: {
       recombination = await recombineFn({
         stashDir: primaryStashDir,
         config: options.config ?? loadConfig(),
+        improveProfile,
         ...(options.runId ? { sourceRun: options.runId } : {}),
         ...(budgetSignal ? { signal: budgetSignal } : {}),
         ...(options.autoAccept !== undefined ? { autoAccept: options.autoAccept } : {}),
@@ -821,6 +826,7 @@ export async function runImprovePostLoopStage(args: {
       proceduralCompilation = await proceduralFn({
         stashDir: primaryStashDir,
         config: options.config ?? loadConfig(),
+        ...(improveProfile ? { improveProfile } : {}),
         ...(options.runId ? { sourceRun: options.runId } : {}),
         ...(budgetSignal ? { signal: budgetSignal } : {}),
         ...(options.autoAccept !== undefined ? { autoAccept: options.autoAccept } : {}),
@@ -845,6 +851,7 @@ export async function runImprovePostLoopStage(args: {
   if (!options.dryRun && (consolidationRan || recombineWorked)) {
     cycleMetrics = runCollapseDetector({
       runId: options.runId ?? "improve-adhoc",
+      ...(improveProfile ? { improveProfile } : {}),
       pass: consolidationRan && recombineWorked ? "both" : consolidationRan ? "consolidate" : "recombine",
       // prep+loop gate accepts, PLUS recombine's confirmed-lesson promotions —
       // recombine churn is the historically observed failure mode and its

--- a/src/commands/improve/preparation.ts
+++ b/src/commands/improve/preparation.ts
@@ -390,6 +390,9 @@ export async function runConsolidationPass(args: {
         ...options.consolidateOptions,
         config: consolidationConfig,
         stashDir: options.stashDir,
+        // Active profile for this improve run — lets consolidate's secondary
+        // process-config reads honor `--profile <name>` instead of `default`.
+        improveProfile,
         autoTriggered: volumeTriggered,
         // Tie consolidate proposals back to this improve invocation so
         // accept-rate-per-run aggregation works. Mirrors reflect/propose/extract.
@@ -588,6 +591,7 @@ async function runSessionExtractPass(args: {
       const countFn = options.extractCandidateCountFn ?? countNewExtractCandidates;
       const newCandidateCount = countFn(extractConfig, {
         ...(options.extractHarnesses ? { harnesses: options.extractHarnesses } : {}),
+        improveProfile,
         // Use the ACTIVE profile's discovery window so the gate counts over the
         // same window akmExtract will scan (not always `default`).
         ...(improveProfile.processes?.extract?.defaultSince

--- a/src/commands/improve/procedural.ts
+++ b/src/commands/improve/procedural.ts
@@ -26,7 +26,7 @@ import fs from "node:fs";
 import proceduralSystemPrompt from "../../assets/prompts/procedural-system.md" with { type: "text" };
 import { parseFrontmatter } from "../../core/asset/frontmatter";
 import { resolveStashDir } from "../../core/common";
-import type { AkmConfig } from "../../core/config/config";
+import type { AkmConfig, ImproveProfileConfig } from "../../core/config/config";
 import { loadConfig } from "../../core/config/config";
 import { appendEvent, type EventsContext } from "../../core/events";
 import type { EligibilitySource, ProceduralCompilationResult } from "../../core/improve-types";
@@ -59,6 +59,8 @@ export type ProceduralLlmFn = (prompt: string) => Promise<string | null>;
 export interface AkmProceduralOptions {
   stashDir?: string;
   config: AkmConfig;
+  /** Active improve profile, so the LLM runner selection honors `--profile`. */
+  improveProfile?: ImproveProfileConfig;
   /** PROV-DM run token stamped on every emitted proposal. */
   sourceRun?: string;
   /** Caller budget signal; an aborted signal short-circuits before any LLM call. */
@@ -359,6 +361,7 @@ export async function akmProcedural(opts: AkmProceduralOptions): Promise<Procedu
       systemPrompt: PROCEDURAL_SYSTEM_PROMPT,
       tag: "[procedural]",
       signal: opts.signal,
+      activeProfile: opts.improveProfile,
     });
   if (!llmFn) {
     warnings.push("procedural: no LLM configured — skipping");

--- a/src/commands/improve/recombine.ts
+++ b/src/commands/improve/recombine.ts
@@ -45,7 +45,7 @@ import recombineSystemPrompt from "../../assets/prompts/recombine-system.md" wit
 import { assembleAssetFromString } from "../../core/asset/asset-serialize";
 import { parseFrontmatter } from "../../core/asset/frontmatter";
 import { resolveStashDir } from "../../core/common";
-import type { AkmConfig } from "../../core/config/config";
+import type { AkmConfig, ImproveProfileConfig } from "../../core/config/config";
 import { loadConfig } from "../../core/config/config";
 import { appendEvent, type EventsContext } from "../../core/events";
 import type { EligibilitySource, RecombineResult } from "../../core/improve-types";
@@ -122,6 +122,8 @@ export type RecombineLlmFn = (clusterPrompt: string) => Promise<string | null>;
 export interface AkmRecombineOptions {
   stashDir?: string;
   config: AkmConfig;
+  /** Active improve profile, so the LLM runner selection honors `--profile`. */
+  improveProfile?: ImproveProfileConfig;
   /** PROV-DM run token stamped on every emitted proposal. */
   sourceRun?: string;
   /** Caller budget signal; an aborted signal short-circuits before any LLM call. */
@@ -673,6 +675,7 @@ export async function akmRecombine(opts: AkmRecombineOptions): Promise<Recombine
       systemPrompt: RECOMBINE_SYSTEM_PROMPT,
       tag: "[recombine]",
       signal: opts.signal,
+      activeProfile: opts.improveProfile,
     });
   if (!llmFn) {
     warnings.push("recombine: no LLM configured — skipping");

--- a/src/commands/improve/reflect.ts
+++ b/src/commands/improve/reflect.ts
@@ -32,7 +32,7 @@ import { parseFrontmatter } from "../../core/asset/frontmatter";
 import { stripMarkdownFences } from "../../core/asset/markdown";
 import { DESCRIPTION_MAX_CHARS, requiresDescription } from "../../core/authoring-rules";
 import { resolveStashDir } from "../../core/common";
-import type { AkmConfig, LlmConnectionConfig, LlmProfileConfig } from "../../core/config/config";
+import type { AkmConfig, ImproveProfileConfig, LlmConnectionConfig, LlmProfileConfig } from "../../core/config/config";
 import { getImproveProcessConfig, loadConfig } from "../../core/config/config";
 import { ConfigError, UsageError } from "../../core/errors";
 import { appendEvent, readEvents } from "../../core/events";
@@ -84,6 +84,12 @@ import { deriveLessonRef, runLessonQualityJudge } from "./distill";
 import { classifyReflectChange } from "./reflect-noise";
 
 export interface AkmReflectOptions {
+  /**
+   * Active improve profile for this run. When set, its per-process `reflect`
+   * override wins over the `default` profile (e.g. runner resolution); absent
+   * falls back to `default`.
+   */
+  improveProfile?: ImproveProfileConfig;
   /** Optional asset ref (`type:name`) to focus on. */
   ref?: string;
   /** Optional task hint passed through to the reflection prompt. */
@@ -1057,7 +1063,7 @@ export async function akmReflect(options: AkmReflectOptions = {}): Promise<AkmRe
       runnerSpec = options.runner;
     } else {
       const cfg = options.config ?? loadConfig();
-      const reflectProcess = getImproveProcessConfig(cfg, "reflect");
+      const reflectProcess = getImproveProcessConfig(cfg, "reflect", options.improveProfile);
       // Resolve the runner from the improve profile's reflect entry when present.
       runnerSpec = resolveImproveProcessRunnerFromProfile(reflectProcess, cfg) ?? undefined;
       if (runnerSpec) {

--- a/src/commands/improve/shared.ts
+++ b/src/commands/improve/shared.ts
@@ -9,7 +9,7 @@
  * of any improve-specific state — these are leaf utilities.
  */
 
-import type { AkmConfig } from "../../core/config/config";
+import type { AkmConfig, ImproveProfileConfig } from "../../core/config/config";
 import { getDefaultLlmConfig, getImproveProcessConfig } from "../../core/config/config";
 import { warn } from "../../core/warn";
 import { resolveImproveProcessRunnerFromProfile, runnerIsLlm } from "../../integrations/agent/runner";
@@ -33,10 +33,13 @@ export function refSlug(ref: string): string {
 
 /**
  * Resolve the production LLM seam for an improve process (`recombine` /
- * `procedural`) from the active default improve profile. Returns a function
- * that issues one bounded chatCompletion per call, or `undefined` when no LLM
- * is configured (the pass then makes no calls). Previously copied verbatim in
- * recombine.ts and procedural.ts.
+ * `procedural`). Returns a function that issues one bounded chatCompletion per
+ * call, or `undefined` when no LLM is configured (the pass then makes no
+ * calls). Previously copied verbatim in recombine.ts and procedural.ts.
+ *
+ * When `opts.activeProfile` is supplied, its per-process runner override wins
+ * over the `default` profile so `akm improve --profile <name>` selects the
+ * profile's model; absent falls back to `default`.
  */
 export function resolveImproveLlmFn(
   config: AkmConfig,
@@ -45,9 +48,10 @@ export function resolveImproveLlmFn(
     systemPrompt: string;
     tag: string;
     signal?: AbortSignal;
+    activeProfile?: ImproveProfileConfig;
   },
 ): ((prompt: string) => Promise<string | null>) | undefined {
-  const processConfig = getImproveProcessConfig(config, opts.processKey);
+  const processConfig = getImproveProcessConfig(config, opts.processKey, opts.activeProfile);
   const runnerSpec = resolveImproveProcessRunnerFromProfile(processConfig, config);
   const llmConfig = runnerSpec && runnerIsLlm(runnerSpec) ? runnerSpec.connection : getDefaultLlmConfig(config);
   if (!llmConfig) return undefined;

--- a/src/commands/read/remember-cli.ts
+++ b/src/commands/read/remember-cli.ts
@@ -76,7 +76,7 @@ export const rememberCommand = defineJsonCommand({
     },
     expires: {
       type: "string",
-      description: "Expiry duration shorthand (e.g. 30d, 12h, 6m). Resolved to an ISO date.",
+      description: "Expiry duration shorthand (e.g. 30d, 12h, 5m minutes, 3M months). Resolved to an ISO date.",
     },
     source: {
       type: "string",

--- a/src/commands/read/remember-cli.ts
+++ b/src/commands/read/remember-cli.ts
@@ -76,7 +76,7 @@ export const rememberCommand = defineJsonCommand({
     },
     expires: {
       type: "string",
-      description: "Expiry duration shorthand (e.g. 30d, 12h, 5m minutes, 3M months). Resolved to an ISO date.",
+      description: "Expiry duration shorthand — e.g. 30d, 12h, 5m (minutes), 3M (months). Resolved to an ISO date.",
     },
     source: {
       type: "string",

--- a/src/commands/remember.ts
+++ b/src/commands/remember.ts
@@ -14,7 +14,7 @@ import { serializeFrontmatter } from "../core/asset/asset-serialize";
 import { toErrorMessage, tryReadStdinText } from "../core/common";
 import { getDefaultLlmConfig, loadConfig } from "../core/config/config";
 import { UsageError } from "../core/errors";
-import { parseDuration as parseDurationSpec } from "../core/time";
+import { DURATION_UNITS, parseDuration as parseDurationSpec } from "../core/time";
 import { warn } from "../core/warn";
 import type { StashEntryScope } from "../indexer/passes/metadata";
 import { SCOPE_KEYS } from "../indexer/passes/metadata";
@@ -56,19 +56,19 @@ export interface MemoryFrontmatterFields {
 
 /**
  * Parse a shorthand duration string to a number of milliseconds.
- * Supports: `30d` (days), `12h` (hours), `6m` (months, approximated as 30d).
+ * Supports the CLI-wide canonical grammar: `30d` (days), `12h` (hours),
+ * `5m` (minutes), `3M` (months, approximated as 30d).
  */
 export function parseDuration(s: string): number {
-  // NOTE: `m` = MONTHS here (approximated as 30 days), unlike consolidate /
-  // --window-compare where `m` = minutes. Lower-case first so mixed-case units
-  // (e.g. "7D") match the lower-case unit map. See core/time.ts parseDuration.
-  const ms = parseDurationSpec(s.trim().toLowerCase(), {
-    d: 24 * 60 * 60 * 1000,
-    h: 60 * 60 * 1000,
-    m: 30 * 24 * 60 * 60 * 1000,
-  });
+  // Canonical CLI unit grammar: `m` = minutes, `M` = months. Not lower-cased,
+  // so case distinguishes the two (`5m` = 5 minutes, `5M` = 5 months). See
+  // core/time.ts DURATION_UNITS.
+  const ms = parseDurationSpec(s.trim(), DURATION_UNITS);
   if (ms === null) {
-    throw new UsageError(`Invalid --expires format "${s}". Use shorthand like 30d, 12h, or 6m.`, "INVALID_FLAG_VALUE");
+    throw new UsageError(
+      `Invalid --expires format "${s}". Use shorthand like 30d, 12h, 5m, or 3M.`,
+      "INVALID_FLAG_VALUE",
+    );
   }
   return ms;
 }

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -267,22 +267,25 @@ type NamedKeys<T> = keyof {
 export type ImproveProcessName = NamedKeys<NonNullable<ImproveProfileConfig["processes"]>>;
 
 /**
- * Resolve the per-process config section for an improve process from the
- * on-disk config, centralizing the deeply-nested lookup
- * `config.profiles?.improve?.default?.processes?.<name>` that was previously
- * copy-pasted across the improve command family (20+ call sites).
+ * Resolve the per-process config section for an improve process,
+ * centralizing the deeply-nested lookup
+ * `profile?.processes?.<name>` that was previously copy-pasted across the
+ * improve command family (20+ call sites).
  *
- * KNOWN LATENT BUG (human follow-up): this hardcodes the `"default"` improve
- * profile rather than resolving the *active* profile. Behavior is preserved
- * intentionally — every caller already depended on `"default"` — but a config
- * that selects a non-default active improve profile would have its per-process
- * overrides silently ignored. Do NOT switch to active-profile resolution here
- * without auditing every call site for the behavior change.
+ * When an `activeProfile` is supplied (the profile resolved for the current
+ * `akm improve --profile <name>` run), its per-process override wins; otherwise
+ * — and as a fallback when the active profile does not define the section — the
+ * lookup falls back to the `"default"` improve profile from the on-disk config.
+ * Callers that have not yet threaded the active profile pass only `config` and
+ * get the historical default-profile behavior unchanged.
  */
 export function getImproveProcessConfig(
   config: AkmConfig,
   processName: ImproveProcessName,
+  activeProfile?: ImproveProfileConfig,
 ): ImproveProcessConfig | undefined {
+  const fromActiveProfile = activeProfile?.processes?.[processName];
+  if (fromActiveProfile !== undefined) return fromActiveProfile;
   return config.profiles?.improve?.default?.processes?.[processName];
 }
 

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -130,8 +130,8 @@ export function getConfigDir(env: NodeJS.ProcessEnv = process.env, platform = pr
   return path.join(home, ".config", "akm");
 }
 
-export function getConfigPath(): string {
-  return path.join(getConfigDir(), "config.json");
+export function getConfigPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(getConfigDir(env), "config.json");
 }
 
 // ── Cache directory ──────────────────────────────────────────────────────────
@@ -245,8 +245,8 @@ export function getDataDir(env: NodeJS.ProcessEnv = process.env, platform = proc
   return path.join(home, ".local", "share", "akm");
 }
 
-export function getDbPath(): string {
-  return path.join(getDataDir(), "index.db");
+export function getDbPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(getDataDir(env), "index.db");
 }
 
 export function getIndexWriterLockPath(): string {

--- a/src/core/time.ts
+++ b/src/core/time.ts
@@ -56,7 +56,7 @@ export const DURATION_UNITS: Readonly<Record<string, number>> = {
  * two collapse. Amount is parsed with base-10 `parseInt`; `null` is returned
  * rather than throwing so each caller keeps its own error/fallback policy.
  */
-export function parseDuration(spec: string, units: Record<string, number> = DURATION_UNITS): number | null {
+export function parseDuration(spec: string, units: Readonly<Record<string, number>> = DURATION_UNITS): number | null {
   const match = spec.trim().match(/^(\d+)([a-zA-Z])$/);
   if (!match) return null;
   const amount = Number.parseInt(match[1] ?? "", 10);

--- a/src/core/time.ts
+++ b/src/core/time.ts
@@ -14,25 +14,49 @@ import { UsageError } from "./errors";
 
 // ── Duration-shorthand parsing ───────────────────────────────────────────────
 
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+/** A month is approximated as 30 days — this shorthand is not calendar-exact. */
+const MONTH_MS = 30 * DAY_MS;
+
 /**
- * Parse a compact duration shorthand (e.g. `"30d"`, `"12h"`, `"6m"`) into a
- * number of milliseconds using an explicit `units` map, or return `null` when
- * the input does not match `<digits><letter>` or the unit is not in the map.
+ * Canonical duration-shorthand unit map shared by every `--since` / `--expires`
+ * / `--window-compare` consumer.
  *
- * The unit map is passed by the caller ON PURPOSE: the codebase historically
- * disagreed on what `"m"` means — some call sites read it as MINUTES
- * (`consolidate`, `--window-compare`) and others as MONTHS (`akm health`,
- * `--expires`). This helper deliberately does NOT pick a winner; each caller
- * supplies the multipliers matching its own long-standing semantics so this
- * consolidation is pure DRY and changes no observable behaviour. See the TODO
- * at `parseHealthSince` for the unresolved product decision.
+ * The grammar is intentionally uniform across the whole CLI:
+ *   - `m` = MINUTES, `M` = MONTHS (30-day approximation)
+ *   - `h`/`H` = hours, `d`/`D` = days
  *
- * Matching is case-sensitive against the map keys; callers that accept
- * mixed-case units (e.g. `"7D"`) should lower-case the spec before calling.
- * Amount is parsed with base-10 `parseInt`; `null` is returned rather than
- * throwing so each caller keeps its own error/fallback policy.
+ * Matching is CASE-SENSITIVE (see {@link parseDuration}), which is what lets
+ * `m` and `M` mean different things. Historically `akm health --since` and
+ * `remember --expires` read a case-insensitive `m` as MONTHS while
+ * `consolidate` / `--window-compare` read it as MINUTES; that split is now
+ * resolved in favour of the conventional `m`=minutes, with `M` reserved for
+ * months. Upper-case `H`/`D` aliases are retained so specs that previously
+ * relied on the old case-insensitive parsers (e.g. `"7D"`) keep working.
  */
-export function parseDuration(spec: string, units: Record<string, number>): number | null {
+export const DURATION_UNITS: Readonly<Record<string, number>> = {
+  m: MINUTE_MS,
+  M: MONTH_MS,
+  h: HOUR_MS,
+  H: HOUR_MS,
+  d: DAY_MS,
+  D: DAY_MS,
+};
+
+/**
+ * Parse a compact duration shorthand (e.g. `"30d"`, `"12h"`, `"5m"`, `"3M"`)
+ * into a number of milliseconds using an explicit `units` map (default
+ * {@link DURATION_UNITS}), or return `null` when the input does not match
+ * `<digits><letter>` or the unit is not in the map.
+ *
+ * Matching is CASE-SENSITIVE against the map keys, so `m` (minutes) and `M`
+ * (months) are distinct — do NOT lower-case the spec before calling, or the
+ * two collapse. Amount is parsed with base-10 `parseInt`; `null` is returned
+ * rather than throwing so each caller keeps its own error/fallback policy.
+ */
+export function parseDuration(spec: string, units: Record<string, number> = DURATION_UNITS): number | null {
   const match = spec.trim().match(/^(\d+)([a-zA-Z])$/);
   if (!match) return null;
   const amount = Number.parseInt(match[1] ?? "", 10);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_CONFIG,
   getDefaultLlmConfig,
   getImproveProcessConfig,
+  type ImproveProfileConfig,
   loadConfig,
   loadUserConfig,
   requireLlmConfig,
@@ -694,10 +695,11 @@ describe("llm config", () => {
 
 // ── getImproveProcessConfig accessor ─────────────────────────────────────────
 
-// Characterization tests pinning the CURRENT behavior of the centralized
-// deep-chain accessor: it resolves the hardcoded "default" improve profile.
-// These lock in behavior for the refactor that migrated the 20+ inline
-// `config.profiles?.improve?.default?.processes?.X` call sites onto it.
+// The centralized deep-chain accessor. Without an active profile it resolves
+// the "default" improve profile (the historical 2-arg behavior); with an
+// active profile (an `akm improve --profile <name>` run) that profile's
+// per-process override wins, falling back to "default" when it doesn't define
+// the section.
 describe("getImproveProcessConfig", () => {
   test("returns the named process section from the default improve profile", () => {
     const cfg = {
@@ -722,7 +724,7 @@ describe("getImproveProcessConfig", () => {
     expect(getImproveProcessConfig({ ...DEFAULT_CONFIG, profiles: {} } as AkmConfig, "reflect")).toBeUndefined();
   });
 
-  test("hardcodes the 'default' profile — a non-default improve profile is ignored (latent bug)", () => {
+  test("without an active profile, only the 'default' profile is consulted", () => {
     const cfg = {
       ...DEFAULT_CONFIG,
       profiles: {
@@ -733,6 +735,31 @@ describe("getImproveProcessConfig", () => {
       },
     } as unknown as AkmConfig;
     expect(getImproveProcessConfig(cfg, "distill")).toBeUndefined();
+  });
+
+  test("an active profile's per-process override wins over the default", () => {
+    const cfg = {
+      ...DEFAULT_CONFIG,
+      profiles: {
+        improve: { default: { processes: { distill: { enabled: false } } } },
+      },
+    } as unknown as AkmConfig;
+    const activeProfile = { processes: { distill: { enabled: true } } } as unknown as ImproveProfileConfig;
+    // `--profile` honored: the active profile's section is returned, not default's.
+    expect(getImproveProcessConfig(cfg, "distill", activeProfile)).toEqual({ enabled: true });
+  });
+
+  test("falls back to the default profile when the active profile omits the section", () => {
+    const cfg = {
+      ...DEFAULT_CONFIG,
+      profiles: {
+        improve: { default: { processes: { consolidate: { enabled: true, minPoolSize: 7 } } } },
+      },
+    } as unknown as AkmConfig;
+    // Active profile defines `distill` but not `consolidate` → consolidate falls
+    // back to default; a profile that doesn't override a process keeps default.
+    const activeProfile = { processes: { distill: { enabled: true } } } as unknown as ImproveProfileConfig;
+    expect(getImproveProcessConfig(cfg, "consolidate", activeProfile)).toEqual({ enabled: true, minPoolSize: 7 });
   });
 });
 

--- a/tests/core/time.test.ts
+++ b/tests/core/time.test.ts
@@ -3,13 +3,13 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import { describe, expect, test } from "bun:test";
-import { parseDuration } from "../../src/core/time";
+import { DURATION_UNITS, parseDuration } from "../../src/core/time";
 
 // Characterization tests pinning the shared duration-shorthand parser that the
 // four former copies (consolidate, health, --window-compare, --expires) now
-// route through. The key contract is that `m` is caller-defined via the unit
-// map — MINUTES for some callers, MONTHS for others — and the helper never
-// picks a winner.
+// route through. The unit map is still caller-overridable, but every CLI
+// consumer now shares the canonical DURATION_UNITS grammar: `m` = minutes,
+// `M` = months (case-sensitive, so the two never collapse).
 
 const MINUTE = 60_000;
 const HOUR = 60 * 60 * 1000;
@@ -60,5 +60,24 @@ describe("parseDuration", () => {
 
   test("amount 0 yields 0 (callers enforce their own positivity policy)", () => {
     expect(parseDuration("0h", { h: HOUR })).toBe(0);
+  });
+
+  test("defaults to the canonical DURATION_UNITS grammar: m=minutes, M=months", () => {
+    // The whole-CLI unification: `m` is minutes and `M` is months everywhere.
+    expect(parseDuration("5m")).toBe(5 * MINUTE);
+    expect(parseDuration("5M")).toBe(5 * MONTH_30D);
+    expect(parseDuration("12h")).toBe(12 * HOUR);
+    expect(parseDuration("7d")).toBe(7 * DAY);
+    // Upper-case H/D aliases retained for specs that relied on the old
+    // case-insensitive health/expires parsers.
+    expect(parseDuration("12H")).toBe(12 * HOUR);
+    expect(parseDuration("7D")).toBe(7 * DAY);
+  });
+
+  test("DURATION_UNITS encodes the canonical multipliers", () => {
+    expect(DURATION_UNITS.m).toBe(MINUTE);
+    expect(DURATION_UNITS.M).toBe(MONTH_30D);
+    expect(DURATION_UNITS.h).toBe(HOUR);
+    expect(DURATION_UNITS.d).toBe(DAY);
   });
 });

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -188,9 +188,7 @@ describe("getConfigPath", () => {
 
   test("honors an injected env object (DI seam) over process.env", () => {
     process.env.XDG_CONFIG_HOME = "/ambient-cfg";
-    expect(getConfigPath({ XDG_CONFIG_HOME: "/injected-cfg" })).toBe(
-      path.join("/injected-cfg", "akm", "config.json"),
-    );
+    expect(getConfigPath({ XDG_CONFIG_HOME: "/injected-cfg" })).toBe(path.join("/injected-cfg", "akm", "config.json"));
   });
 });
 

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -185,6 +185,13 @@ describe("getConfigPath", () => {
     process.env.XDG_CONFIG_HOME = "/test-cfg";
     expect(getConfigPath()).toBe(path.join("/test-cfg", "akm", "config.json"));
   });
+
+  test("honors an injected env object (DI seam) over process.env", () => {
+    process.env.XDG_CONFIG_HOME = "/ambient-cfg";
+    expect(getConfigPath({ XDG_CONFIG_HOME: "/injected-cfg" })).toBe(
+      path.join("/injected-cfg", "akm", "config.json"),
+    );
+  });
 });
 
 // ── getCacheDir ─────────────────────────────────────────────────────────────
@@ -387,6 +394,12 @@ describe("getDbPath", () => {
     process.env.XDG_DATA_HOME = "/data";
     delete process.env.AKM_DATA_DIR;
     expect(getDbPath()).toBe(path.join("/data", "akm", "index.db"));
+  });
+
+  test("honors an injected env object (DI seam) over process.env", () => {
+    process.env.XDG_DATA_HOME = "/ambient-data";
+    delete process.env.AKM_DATA_DIR;
+    expect(getDbPath({ XDG_DATA_HOME: "/injected-data" })).toBe(path.join("/injected-data", "akm", "index.db"));
   });
 });
 

--- a/tests/remember-frontmatter.test.ts
+++ b/tests/remember-frontmatter.test.ts
@@ -193,8 +193,10 @@ describe("remember --expires", () => {
     expect(parsed.data.expires as string).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 
-  test("--expires 6m resolves to a future ISO date ~6 months from now", async () => {
-    const { result } = await runCli(["remember", "Long-term access", "--tag", "access", "--expires", "6m"]);
+  test("--expires 6M resolves to a future ISO date ~6 months from now", async () => {
+    // Canonical grammar: `M` = months (30-day approximation). `m` now means
+    // minutes, so months must be requested with the upper-case unit.
+    const { result } = await runCli(["remember", "Long-term access", "--tag", "access", "--expires", "6M"]);
     expect(result.status).toBe(0);
 
     const json = JSON.parse(result.stdout) as { path: string };

--- a/tests/remember-unit.test.ts
+++ b/tests/remember-unit.test.ts
@@ -12,8 +12,14 @@ describe("parseDuration", () => {
     expect(parseDuration("12h")).toBe(12 * 60 * 60 * 1000);
   });
 
-  test("parses months as 30-day approximation", () => {
-    expect(parseDuration("6m")).toBe(6 * 30 * 24 * 60 * 60 * 1000);
+  test("parses minutes with lowercase `m`", () => {
+    expect(parseDuration("5m")).toBe(5 * 60 * 1000);
+  });
+
+  test("parses months as a 30-day approximation with uppercase `M`", () => {
+    // `m` = minutes, `M` = months — the CLI-wide canonical grammar. (`m` here
+    // formerly meant months; it is now minutes, with `M` reserved for months.)
+    expect(parseDuration("3M")).toBe(3 * 30 * 24 * 60 * 60 * 1000);
   });
 
   test("rejects invalid format", () => {


### PR DESCRIPTION
## Summary

Follow-up work to the code-quality PR (#702), completing the three items that were deliberately deferred there. Each change is test-first and passes the same strict gate (tsc clean, full `bun run lint` clean, no new unit-test failures).

### 1. `fix(cli)`: unify duration shorthand — `m`=minutes, `M`=months (behavior change)
Resolves the flagged month-vs-minute discrepancy (product decision): `m` meant **months** in `akm health --since` / `remember --expires` but **minutes** in consolidate / `--window-compare`. Introduces a canonical `DURATION_UNITS` map in `core/time.ts` (`m`=minutes, `M`=months, `h`/`H`=hours, `d`/`D`=days, case-sensitive) and routes all four consumers through it.

- **User-visible change:** `akm health --since 5m` and `remember --expires 5m` now mean **5 minutes**; use **`5M`** for 5 months. Consolidate / `--window-compare` are unchanged (they already read `m` as minutes) and now additionally accept `M` for months.
- Updated the two tests that pinned the old `m`=months behavior and the `--expires` help text.

### 2. `fix(improve)`: honor the active `--profile` in per-process config reads (behavior change)
`getImproveProcessConfig` now takes the active improve profile and prefers its per-process override, falling back to the `default` profile (and to `default` entirely when no profile is threaded). The resolved `improveProfile` is threaded through the improve stage entry points — consolidate (+ its narrow/plan/apply passes and op context), distill, reflect, the extract candidate-count gate, recombine/procedural (LLM-runner selection via `resolveImproveLlmFn`), and the collapse detector.

- **User-visible change:** `akm improve --profile <name>` now applies that profile's per-process settings instead of silently reading `default`. Standalone / default-profile runs are unchanged — the fallback preserves prior behavior, so a profile that doesn't override a process still gets the default.
- One per-session hot-probation read inside the 18-arg `processSession` intentionally stays on the default profile, to avoid growing that already-bloated signature for a DEFAULT-OFF flag (the extract stage toggle still honors `--profile`).

### 3. `refactor(core)`: `getDbPath` / `getConfigPath` env seam (no behavior change)
Gives both the same `env: NodeJS.ProcessEnv = process.env` parameter `getCacheDir` already exposes, so callers/tests can inject a resolved env instead of relying on ambient `process.env`. Seeds the RunContext dependency-injection direction from the review.

## Test plan

- Full gate green on the final tree: `bunx tsc --noEmit` (0), `bun run lint` (0), `bun run test:unit` → **21,424 pass**; the only failures are the same 4 pre-existing tests that fail solely in a root-uid / native-lib sandbox and pass in normal CI (unchanged, not touched).
- New / updated tests: canonical-grammar coverage in `tests/core/time.test.ts` (m=minutes, M=months, H/D aliases); `--expires` month cases moved to `M` in `tests/remember-unit.test.ts` and `tests/remember-frontmatter.test.ts`; active-profile override + fallback cases in `tests/config.test.ts`; injected-env seam cases in `tests/paths.test.ts`.

## Checklist

- [x] Tests pass (`bun test`) — unit suite green (see test plan re: 4 environment-only failures)
- [x] Lint passes (`bun run lint`)
- [x] Docs updated (if applicable) — CLI help text for `--expires` updated; behavior changes documented in this description


---
_Generated by [Claude Code](https://claude.ai/code/session_01LkDrjEVxVc7dqUgyTGny6J)_