### PR TITLE
test(health): fix #499 release-blocking flake — non-atomic Date.now() in wallTime tests

### DIFF
--- a/scripts/lint-tests-isolation.ts
+++ b/scripts/lint-tests-isolation.ts
@@ -53,6 +53,16 @@
  * poisoning. Use the swap-and-restore seams instead (tests/_helpers/seams.ts;
  * pattern: docs/design/di-seams-plan.md). No allowlist — zero is the invariant.
  *
+ * Rule 7 (non-atomic Date.now()): flag ≥2 `new Date(Date.now() …)` timestamp
+ * constructions in ONE scope (test/it/describe/hook/function). Reading the wall
+ * clock more than once for a set of related timestamps means the reads can
+ * straddle a millisecond boundary under load, so any exact assertion on the
+ * delta between the derived timestamps flakes. This is the verified root cause
+ * of the #499 release-blocking health flake (a `22s`/22000ms task interval
+ * intermittently measured 22001+). Capture the clock ONCE — `const now =
+ * Date.now()` — and derive every timestamp from `now`. A single
+ * `new Date(Date.now() …)` per scope is fine. No allowlist — zero is the invariant.
+ *
  * Exit codes:
  *   0 — no violations
  *   1 — violations found (or internal error)
@@ -311,7 +321,14 @@ export function collectTestFiles(dir: string): string[] {
   return results;
 }
 
-type Rule = "mkdtemp-env" | "unguarded-env" | "elapsed-assertion" | "raw-akm-mkdtemp" | "unit-real-spawn" | "mock-module";
+type Rule =
+  | "mkdtemp-env"
+  | "unguarded-env"
+  | "elapsed-assertion"
+  | "raw-akm-mkdtemp"
+  | "unit-real-spawn"
+  | "mock-module"
+  | "nonatomic-now";
 
 interface Violation {
   file: string;
@@ -490,6 +507,43 @@ function lintFile(filePath: string): Violation[] {
     }
   }
 
+  // ── Rule 7: non-atomic Date.now() timestamp construction ───────────────────
+  // Building ≥2 `new Date(Date.now() …)` timestamps in ONE scope reads the wall
+  // clock more than once; if the reads straddle a millisecond boundary (a loaded
+  // CI shard scheduler), any exact assertion on the delta between the derived
+  // timestamps flakes. This is the verified root cause of the #499 release-
+  // blocking health flake — its `22s` (22000ms) task interval intermittently
+  // measured 22001+ because `taskStart`/`taskEnd` came from two `Date.now()`
+  // calls. Fix: capture the clock ONCE (`const now = Date.now()`) and derive
+  // every timestamp from `now` (skew-immune by construction). A single
+  // `new Date(Date.now() …)` per scope is fine. No allowlist — zero is the
+  // invariant. Scopes are delimited by test/it/describe/hook/function starts.
+  {
+    const lines = src.split("\n");
+    const SCOPE_START = /\b(?:test|it|describe|beforeEach|afterEach|beforeAll|afterAll)\s*\(|\bfunction\b/;
+    const NOW_TS = /new Date\(\s*Date\.now\(\)/g;
+    let hits: number[] = [];
+    const flush = () => {
+      if (hits.length >= 2) {
+        violations.push({
+          file: rel,
+          rule: "nonatomic-now",
+          detail: `${hits.length} \`new Date(Date.now() …)\` reads in one scope (lines ${hits.join(", ")}) — capture the clock once (\`const now = Date.now()\`) and derive every timestamp from \`now\`, else an exact delta assertion flakes under CI load (#499 class)`,
+          line: hits[0],
+        });
+      }
+      hits = [];
+    };
+    for (let i = 0; i < lines.length; i++) {
+      const l = lines[i];
+      if (/^\s*(\/\/|\*)/.test(l)) continue; // skip comment lines
+      if (SCOPE_START.test(l)) flush();
+      const matches = l.match(NOW_TS);
+      if (matches) for (let k = 0; k < matches.length; k++) hits.push(i + 1);
+    }
+    flush();
+  }
+
   return violations;
 }
 
@@ -525,6 +579,7 @@ if (import.meta.main) {
     "raw-akm-mkdtemp": "raw mkdtempSync(…akm-test…) outside tests/_helpers/",
     "unit-real-spawn": "real process spawn in unit-scope test",
     "mock-module": "mock.module call (banned — suite runs without --isolate)",
+    "nonatomic-now": "non-atomic Date.now() timestamp construction (#499 flake class)",
   };
 
   console.error(`lint-tests-isolation: ${violations.length} violation(s) found\n`);

--- a/tests/akm-eval-proposal-quality.test.ts
+++ b/tests/akm-eval-proposal-quality.test.ts
@@ -202,8 +202,9 @@ describe("runProposalQualityCase — windowed validationPassRate", () => {
 
   test("WITH since: 24h, a recent successful proposal + zero recent rejections = 100%", async () => {
     const f = freshFixture();
-    const oneHourAgo = new Date(Date.now() - 3_600_000).toISOString();
-    const thirtyDaysAgo = new Date(Date.now() - 30 * 86_400_000).toISOString();
+    const now = Date.now();
+    const oneHourAgo = new Date(now - 3_600_000).toISOString();
+    const thirtyDaysAgo = new Date(now - 30 * 86_400_000).toISOString();
     buildStateDb({
       dbPath: f.dbPath,
       proposals: [

--- a/tests/health-command.test.ts
+++ b/tests/health-command.test.ts
@@ -591,8 +591,9 @@ describe("akmHealth", () => {
   });
 
   test("reflect content-policy guard hits are counted separately from failed (Pattern A)", () => {
-    const start = new Date(Date.now() - 60_000).toISOString();
-    const end = new Date(Date.now() - 30_000).toISOString();
+    const now = Date.now();
+    const start = new Date(now - 60_000).toISOString();
+    const end = new Date(now - 30_000).toISOString();
     const db = openStateDatabase();
     try {
       recordImproveRun(db, {
@@ -654,8 +655,9 @@ describe("akmHealth", () => {
   });
 
   test("distill outcome:skipped surfaces as actions.distill.deferred with skipReason breakdown", () => {
-    const start = new Date(Date.now() - 60_000).toISOString();
-    const end = new Date(Date.now() - 30_000).toISOString();
+    const now = Date.now();
+    const start = new Date(now - 60_000).toISOString();
+    const end = new Date(now - 30_000).toISOString();
     const db = openStateDatabase();
     try {
       recordImproveRun(db, {
@@ -722,8 +724,9 @@ describe("akmHealth", () => {
     // result.reason for reflect-skipped, so 18/18 type-filter+raw-wiki skips
     // were a single opaque scalar in `akm health`. Mirror the
     // `distill.deferredByReason` shape (commit d1273d0).
-    const start = new Date(Date.now() - 60_000).toISOString();
-    const end = new Date(Date.now() - 30_000).toISOString();
+    const now = Date.now();
+    const start = new Date(now - 60_000).toISOString();
+    const end = new Date(now - 30_000).toISOString();
     const db = openStateDatabase();
     try {
       recordImproveRun(db, {
@@ -779,8 +782,9 @@ describe("akmHealth", () => {
     // The split lets dashboards distinguish prompt-tuning levers from
     // validator-config levers. Legacy `qualityRejected` is preserved as the
     // sum for back-compat.
-    const start = new Date(Date.now() - 60_000).toISOString();
-    const end = new Date(Date.now() - 30_000).toISOString();
+    const now = Date.now();
+    const start = new Date(now - 60_000).toISOString();
+    const end = new Date(now - 30_000).toISOString();
     const db = openStateDatabase();
     try {
       recordImproveRun(db, {
@@ -828,8 +832,9 @@ describe("akmHealth", () => {
     // had no LLM verdict and were a pure silent drop. The new
     // `judgedNoAction` counter surfaces them; `skipReasons` turns the
     // free-text warnings bag into a typed histogram.
-    const start = new Date(Date.now() - 60_000).toISOString();
-    const end = new Date(Date.now() - 30_000).toISOString();
+    const now = Date.now();
+    const start = new Date(now - 60_000).toISOString();
+    const end = new Date(now - 30_000).toISOString();
     const db = openStateDatabase();
     try {
       recordImproveRun(db, {
@@ -1114,8 +1119,9 @@ describe("akmHealth", () => {
   // rate reflects the rate model output succeeded for the calls that
   // actually hit the LLM, independent of cache state.
   test("memoryInference.yieldRate uses freshAttempts (considered - cacheHits), not considered", () => {
-    const start = new Date(Date.now() - 60_000).toISOString();
-    const end = new Date(Date.now() - 30_000).toISOString();
+    const now = Date.now();
+    const start = new Date(now - 60_000).toISOString();
+    const end = new Date(now - 30_000).toISOString();
     const db = openStateDatabase();
     try {
       recordImproveRun(db, {
@@ -1164,10 +1170,11 @@ describe("health — window comparison", () => {
   // ── Phase 2: --group-by run ────────────────────────────────────────────────
   describe("akm health --group-by run", () => {
     function seedTwoRuns(): { startA: string; endA: string; startB: string; endB: string } {
-      const startA = new Date(Date.now() - 60_000).toISOString();
-      const endA = new Date(Date.now() - 30_000).toISOString();
-      const startB = new Date(Date.now() - 25_000).toISOString();
-      const endB = new Date(Date.now() - 10_000).toISOString();
+      const now = Date.now();
+      const startA = new Date(now - 60_000).toISOString();
+      const endA = new Date(now - 30_000).toISOString();
+      const startB = new Date(now - 25_000).toISOString();
+      const endB = new Date(now - 10_000).toISOString();
       const db = openStateDatabase();
       try {
         upsertTaskHistory(db, {
@@ -1268,8 +1275,9 @@ describe("health — window comparison", () => {
 
     test("per-run summary fields parity with window aggregator (one row)", () => {
       // Seed a single run, then compare aggregator output vs runs[0].
-      const startA = new Date(Date.now() - 60_000).toISOString();
-      const endA = new Date(Date.now() - 30_000).toISOString();
+      const now = Date.now();
+      const startA = new Date(now - 60_000).toISOString();
+      const endA = new Date(now - 30_000).toISOString();
       const db = openStateDatabase();
       try {
         upsertTaskHistory(db, {
@@ -1598,11 +1606,12 @@ describe("health — window comparison", () => {
     });
 
     test("duplicate window names throw UsageError", () => {
+      const now = Date.now();
       expect(() =>
         akmHealth({
           windows: [
-            { name: "dup", since: new Date(Date.now() - 7200_000).toISOString() },
-            { name: "dup", since: new Date(Date.now() - 3600_000).toISOString() },
+            { name: "dup", since: new Date(now - 7200_000).toISOString() },
+            { name: "dup", since: new Date(now - 3600_000).toISOString() },
           ],
         }),
       ).toThrow(/duplicate name/);
@@ -1798,8 +1807,9 @@ describe("akm health --group-by run", () => {
     pinHealthEnv("gbrun");
     const db = openStateDatabase();
     try {
-      const startA = new Date(Date.now() - 60_000).toISOString();
-      const endA = new Date(Date.now() - 30_000).toISOString();
+      const now = Date.now();
+      const startA = new Date(now - 60_000).toISOString();
+      const endA = new Date(now - 30_000).toISOString();
       upsertTaskHistory(db, {
         task_id: "akm-improve",
         status: "completed",

--- a/tests/health-command.test.ts
+++ b/tests/health-command.test.ts
@@ -150,12 +150,15 @@ describe("akmHealth", () => {
   });
 
   test("reports rich improve metrics from improve_runs (Phase 1)", () => {
-    const startA = new Date(Date.now() - 60_000).toISOString();
-    const endA = new Date(Date.now() - 30_000).toISOString();
-    const startB = new Date(Date.now() - 25_000).toISOString();
-    const endB = new Date(Date.now() - 10_000).toISOString();
-    const startDry = new Date(Date.now() - 9_000).toISOString();
-    const endDry = new Date(Date.now() - 5_000).toISOString();
+    // Single clock read so every derived interval is exact regardless of CI
+    // scheduling (see the #499 note on the legacy-row test below).
+    const now = Date.now();
+    const startA = new Date(now - 60_000).toISOString();
+    const endA = new Date(now - 30_000).toISOString();
+    const startB = new Date(now - 25_000).toISOString();
+    const endB = new Date(now - 10_000).toISOString();
+    const startDry = new Date(now - 9_000).toISOString();
+    const endDry = new Date(now - 5_000).toISOString();
 
     // Wall-time rows in task_history for task_id='akm-improve'.
     const db = openStateDatabase();
@@ -386,8 +389,11 @@ describe("akmHealth", () => {
   });
 
   test("manual run row with distinct started_at<completed_at and no task_history yields wallTime from the row delta (#499)", () => {
-    const start = new Date(Date.now() - 60_000).toISOString();
-    const end = new Date(Date.now() - 45_000).toISOString(); // 15s row delta
+    // Single clock read so the 15s delta is exact regardless of CI scheduling
+    // (see the #499 note on the legacy-row test below).
+    const now = Date.now();
+    const start = new Date(now - 60_000).toISOString();
+    const end = new Date(now - 45_000).toISOString(); // 15s row delta
     const db = openStateDatabase();
     try {
       // No task_history interval — this is a manually-invoked `akm improve`.
@@ -426,10 +432,11 @@ describe("akmHealth", () => {
   });
 
   test("window memorySummary is the latest run's whole-stash snapshot, not the sum across runs", () => {
-    const olderStart = new Date(Date.now() - 120_000).toISOString();
-    const olderEnd = new Date(Date.now() - 110_000).toISOString();
-    const newerStart = new Date(Date.now() - 60_000).toISOString();
-    const newerEnd = new Date(Date.now() - 50_000).toISOString();
+    const now = Date.now();
+    const olderStart = new Date(now - 120_000).toISOString();
+    const olderEnd = new Date(now - 110_000).toISOString();
+    const newerStart = new Date(now - 60_000).toISOString();
+    const newerEnd = new Date(now - 50_000).toISOString();
     const db = openStateDatabase();
     try {
       for (const [id, start, end, eligible, derived] of [
@@ -478,10 +485,11 @@ describe("akmHealth", () => {
   });
 
   test("improve run is attributed to its scheduled akm-improve task via the ±5min task_history join", () => {
-    const taskStart = new Date(Date.now() - 60_000).toISOString();
-    const runStart = new Date(Date.now() - 59_000).toISOString(); // 1s after the task fired
-    const runEnd = new Date(Date.now() - 40_000).toISOString();
-    const taskEnd = new Date(Date.now() - 39_000).toISOString();
+    const now = Date.now();
+    const taskStart = new Date(now - 60_000).toISOString();
+    const runStart = new Date(now - 59_000).toISOString(); // 1s after the task fired
+    const runEnd = new Date(now - 40_000).toISOString();
+    const taskEnd = new Date(now - 39_000).toISOString();
     const db = openStateDatabase();
     try {
       upsertTaskHistory(db, {
@@ -527,10 +535,15 @@ describe("akmHealth", () => {
   });
 
   test("legacy row with started_at==completed_at falls back to containing task_history interval duration (#499)", () => {
-    const taskStart = new Date(Date.now() - 60_000).toISOString();
-    const taskEnd = new Date(Date.now() - 38_000).toISOString(); // 22s interval
+    // Capture the clock ONCE — deriving taskStart/taskEnd from two separate
+    // Date.now() calls made the 22s interval flaky: if ≥1ms elapsed between the
+    // calls (a loaded CI shard scheduler), the duration became 22001+ and the
+    // exact `toBe(22_000)` assertion below failed. (#499 residual root cause.)
+    const now = Date.now();
+    const taskStart = new Date(now - 60_000).toISOString();
+    const taskEnd = new Date(now - 38_000).toISOString(); // 22s interval
     // Legacy/backfill row: started_at == completed_at, falling inside the task interval.
-    const stamp = new Date(Date.now() - 50_000).toISOString();
+    const stamp = new Date(now - 50_000).toISOString();
     const db = openStateDatabase();
     try {
       upsertTaskHistory(db, {

--- a/tests/health-html-report.test.ts
+++ b/tests/health-html-report.test.ts
@@ -30,8 +30,9 @@ afterEach(() => {
 
 /** Seed one realistic improve run into the isolated state.db. */
 function seedImproveRun(id = "run-html-1", ok = true): void {
-  const startedAt = new Date(Date.now() - 10 * 60_000).toISOString();
-  const completedAt = new Date(Date.now() - 5 * 60_000).toISOString();
+  const now = Date.now();
+  const startedAt = new Date(now - 10 * 60_000).toISOString();
+  const completedAt = new Date(now - 5 * 60_000).toISOString();
   const db = openStateDatabase();
   try {
     recordImproveRun(db, {

--- a/tests/remember-frontmatter.test.ts
+++ b/tests/remember-frontmatter.test.ts
@@ -206,8 +206,9 @@ describe("remember --expires", () => {
     expect(expires).toMatch(/^\d{4}-\d{2}-\d{2}$/);
 
     const expiresDate = new Date(expires);
-    const expectedMin = new Date(Date.now() + 170 * 24 * 60 * 60 * 1000); // ~5.7 months
-    const expectedMax = new Date(Date.now() + 185 * 24 * 60 * 60 * 1000); // ~6.2 months
+    const now = Date.now();
+    const expectedMin = new Date(now + 170 * 24 * 60 * 60 * 1000); // ~5.7 months
+    const expectedMax = new Date(now + 185 * 24 * 60 * 60 * 1000); // ~6.2 months
     expect(expiresDate >= expectedMin).toBe(true);
     expect(expiresDate <= expectedMax).toBe(true);
   });


### PR DESCRIPTION
## Root cause (proven, not guessed)

The `akmHealth … legacy row … task_history interval duration (#499)` test blocked the beta.58 release — CI shard 2 failed with `wallTime.minMs` expected `22000`, got `22001+`. It passes **3/3 locally** and was long filed under the "XDG_DATA_HOME env race" flake class. That diagnosis was wrong for the residual flake:

- The env-race half **is already fixed** — every test in `health-command.test.ts` runs under `withIsolatedAkmStorage()` (per-test isolated state DB), so cross-test pollution is gone.
- The **actual** root cause is in the test's timestamp construction: it built `taskStart` and `taskEnd` from **two separate `Date.now()` calls** and asserted their difference is *exactly* 22000. `health/task-runs.ts` computes `durationMs = completed_at − started_at`, so:

```
gap between the two Date.now() calls → asserted duration
  0ms  → 22000  (PASS — always, locally)
  1ms  → 22001  (FAIL)
  5ms  → 22005  (FAIL)
```

On a fast local box both `Date.now()` land in the same millisecond; on a loaded CI shard ≥1ms elapses between the two calls and the exact `toBe(22000)` fails. Proven with a `Bun.sleepSync(gap)` repro.

## Fix

Capture `Date.now()` **once** per test into `const now` and derive every timestamp from it — skew-immune by construction (repro confirms the delta stays 22000 at 0/1/5/50ms gaps). Applied to the two flaky exact-duration tests (`toBe(15_000)` / `toBe(22_000)`) plus three same-pattern sibling tests (latent landmines of the same class).

**Test-only, no production change** — real stored rows have atomic per-row timestamps; the flake was purely in test setup. Full `bun run check` green (777 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YjU1mGiShdDP4qFW7p4mv

---

## Guard against recurrence (Rule 7)

This flake was a *class*, not a one-off. Added **Rule 7** to `lint-tests-isolation.ts` (runs in `bun run check`): flag ≥2 `new Date(Date.now() …)` constructions within a single scope (test / it / describe / hook / function). A single read per scope is fine; the fix is always to capture `const now = Date.now()` once. No allowlist — zero is the invariant.

The rule surfaced every remaining instance of the pattern across the suite; all were fixed (mechanical single-`now` refactors — none other than the two already fixed asserted an exact delta): the rest of `health-command.test.ts`, `health-html-report.test.ts`'s `seedImproveRun` helper, `akm-eval-proposal-quality.test.ts`, and `remember-frontmatter.test.ts`. Suite stays at **zero** lint violations; full `bun run check` green.

Also corrected the project memory that had misattributed the #499 root cause to an env race, with the greppable anti-pattern for next time.
