### PR TITLE
chore(tasks): retire the nightly update-stashes cron template (06-M2)

### DIFF
--- a/src/assets/tasks/core/update-stashes.yml
+++ b/src/assets/tasks/core/update-stashes.yml
@@ -1,4 +1,0 @@
-schedule: "0 1 * * *"
-command: akm update
-enabled: true
-description: Pull latest changes for all managed stash sources

--- a/src/commands/tasks/default-tasks.ts
+++ b/src/commands/tasks/default-tasks.ts
@@ -44,8 +44,9 @@ export interface DefaultTaskSpec {
 }
 
 /**
- * The canonical default improve task set. `update-stashes` is deliberately NOT
- * listed here — it ships as an embedded core template and is left unchanged.
+ * The canonical default improve task set. The `update-stashes` embedded core
+ * template (nightly `akm update --all`) was retired in meta-review 06-M2:
+ * third-party stash pulls are on-demand only now, not a scheduled cron.
  */
 export const DEFAULT_IMPROVE_TASKS: readonly DefaultTaskSpec[] = [
   {

--- a/tests/setup-scheduled-tasks.test.ts
+++ b/tests/setup-scheduled-tasks.test.ts
@@ -90,11 +90,11 @@ function makeDeps(installed: Array<{ id: string; enabled: boolean }>) {
 describe("stepScheduledTasks", () => {
   beforeEach(resetClack);
 
-  test("lists all 7 embedded tasks with id, description, and schedule in the multiselect", async () => {
+  test("lists all 6 embedded tasks with id, description, and schedule in the multiselect", async () => {
     const { deps } = makeDeps([]);
     await stepScheduledTasks(deps);
     const opts = state.multiselectConfig?.options ?? [];
-    expect(opts.length).toBe(7);
+    expect(opts.length).toBe(6);
     const improve = opts.find((o) => o.value === "improve");
     expect(improve?.label).toBe("core/improve");
     expect(improve?.hint).toContain("Run improve pipeline nightly");

--- a/tests/tasks-embedded.test.ts
+++ b/tests/tasks-embedded.test.ts
@@ -3,16 +3,18 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 /**
- * Embedded core task registry — asserts the 7 bundled templates are present
+ * Embedded core task registry — asserts the 6 bundled templates are present
  * with the exact ids, commands, and default schedules from issue #512, and
  * that they are read from the bundled assets dir (not any user stash).
+ *
+ * `update-stashes` (nightly `akm update --all`) was retired in meta-review
+ * 06-M2 — third-party stash pulls are on-demand only now.
  */
 import { describe, expect, test } from "bun:test";
 import { listEmbeddedTasks } from "../src/tasks/embedded";
 
 const EXPECTED = [
   { id: "improve", command: "akm improve --auto-accept safe", schedule: "0 2 * * *" },
-  { id: "update-stashes", command: "akm update", schedule: "0 1 * * *" },
   { id: "backup", command: "akm db backups", schedule: "0 3 * * 0" },
   { id: "version-check", command: "akm info --check-version", schedule: "0 9 * * 1" },
   { id: "index-refresh", command: "akm index", schedule: "0 4 * * *" },
@@ -21,9 +23,9 @@ const EXPECTED = [
 ] as const;
 
 describe("embedded core task registry", () => {
-  test("enumerates all 7 templates", () => {
+  test("enumerates all 6 templates", () => {
     const tasks = listEmbeddedTasks();
-    expect(tasks.length).toBe(7);
+    expect(tasks.length).toBe(6);
   });
 
   test("each template has the exact id, command, and default schedule", () => {


### PR DESCRIPTION
Meta-review minting-shutdown, part 1 of 2 (akm side). Retires the embedded core task template that scheduled a nightly 14-third-party-source supply-chain pull (`akm update`, 01:00) — it runs below every improve gate. Third-party stash pulls are on-demand only now.

- Deletes `src/assets/tasks/core/update-stashes.yml`. The `akm update` command itself is unchanged (on-demand pulls still work).
- Migrates the two embedded-task count assertions (7→6 templates); `listEmbeddedTasks()` scans the dir at runtime, so no registry edit was needed.
- `bun run check` green (unit 5390/0, integration 743/0).

**Owner steps after merge:** remove the live `update-stashes` crontab entry on the host (`akm tasks remove update-stashes`), and `bun run build` + reinstall (~beta.59) to reach cron. The paired akm-plugin change (delete the `captureMemory --force` session_checkpoint write, 03-R1/06-M1) is a separate PR. The recombine `isSessionCaptureMemoryName` filter deletion is DEFERRED — it's load-bearing (excludes all session-capture memories from clustering, not just checkpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YjU1mGiShdDP4qFW7p4mv