### PR TITLE
refactor(improve): remove now-dead isSessionCaptureMemoryName filter (04-R-1)

### DIFF
--- a/src/commands/improve/consolidate.ts
+++ b/src/commands/improve/consolidate.ts
@@ -113,14 +113,9 @@ import {
   consolidateGuardStatus,
   isConsolidationEligibleMemoryName,
   isHotCapturedMemory,
-  isSessionCaptureMemoryName,
 } from "./consolidate/eligibility";
 
-export {
-  isConsolidationEligibleMemoryName,
-  isHotCapturedMemory,
-  isSessionCaptureMemoryName,
-} from "./consolidate/eligibility";
+export { isConsolidationEligibleMemoryName, isHotCapturedMemory } from "./consolidate/eligibility";
 
 // Plan parsing / merging (pure op-reconciliation algebra) lives in
 // ./consolidate/merge. Imported for internal use; mergePlans re-exported.
@@ -2828,10 +2823,6 @@ function loadMemoriesForSource(source: string | undefined, stashDir: string, war
         return path.resolve(e.stashDir) === path.resolve(source);
       })
       .filter((e) => isConsolidationEligibleMemoryName(e.entry.name))
-      // #632 — exclude session-capture telemetry (checkpoints) from the
-      // consolidation pool, mirroring recombine. Their bodies are pipeline
-      // bookkeeping, so consolidating them burns LLM calls on pure noise.
-      .filter((e) => !isSessionCaptureMemoryName(e.entry.name))
       // Skip stale DB entries whose file was deleted by a prior run but not yet
       // re-indexed. Without this guard the deleted file's ref appears in chunks
       // sent to the LLM, which then proposes a second delete → delete_failed
@@ -2861,7 +2852,6 @@ function loadMemoriesForSource(source: string | undefined, stashDir: string, war
         const filePath = path.join(memoriesDir, fname);
         const name = fname.replace(/\.md$/, "");
         if (!isConsolidationEligibleMemoryName(name)) continue;
-        if (isSessionCaptureMemoryName(name)) continue; // #632 — skip telemetry checkpoints
         memories.push({ name, filePath, description: "", tags: [], stashDir: fsStashDir });
       }
     }

--- a/src/commands/improve/consolidate/eligibility.ts
+++ b/src/commands/improve/consolidate/eligibility.ts
@@ -14,24 +14,6 @@ export function isConsolidationEligibleMemoryName(name: string): boolean {
 }
 
 /**
- * #632 — AKM session-capture telemetry memories: auto-generated session-end
- * checkpoints named `<harness>-session-<YYYYMMDD>-<id>` or
- * `<harness>-checkpoint-<YYYYMMDD…>-<id>`, carrying an embedded
- * `akm_memory_kind: session_checkpoint` metadata block. Their bodies are
- * pipeline bookkeeping, not durable knowledge, so the improve passes exclude
- * them from their pools (recombine, consolidate). The `\d{8}` datestamp anchor
- * is what distinguishes a capture name from a durable memory that merely
- * MENTIONS session/checkpoint (e.g. `akm-plugins-session-end-extract-hook`,
- * `session-checkpoint-lint-skips`), which stay in the pool.
- *
- * Lives here (the eligibility module) rather than in recombine so both
- * recombine and consolidate can reuse it without a circular import.
- */
-export function isSessionCaptureMemoryName(name: string): boolean {
-  return /-(session|checkpoint)-\d{8}/.test(name);
-}
-
-/**
  * Returns true when the memory file has `captureMode: hot` in its frontmatter.
  *
  * Hot memories are USER-EXPLICIT (written via `akm remember` on the hot path).

--- a/src/commands/improve/preparation.ts
+++ b/src/commands/improve/preparation.ts
@@ -29,7 +29,7 @@ import {
   gateDecisionsToSamples,
   summarizeCalibration,
 } from "./calibration";
-import { akmConsolidate, type ConsolidateResult, isSessionCaptureMemoryName } from "./consolidate";
+import { akmConsolidate, type ConsolidateResult } from "./consolidate";
 // Eligibility / candidate-selection predicates live in ./eligibility.
 import {
   buildLatestFeedbackTsMap,
@@ -1354,12 +1354,7 @@ export async function runImprovePreparationStage(args: {
         // collapse the lane to exactly 1 ref via the bare `?? 10` fallback.
         const effectiveLimit = options.limit ?? improveProfile?.processes?.reflect?.limit ?? improveProfile.limit ?? 10;
         const highSalienceCap = Math.max(1, Math.floor(effectiveLimit * 0.1));
-        // #632/#4 — session-capture telemetry (checkpoints) must never consume
-        // the scarce high-salience budget. Even with a content-scored row, these
-        // are pipeline bookkeeping, not assets worth reflecting/rewriting.
-        const candidates = noFeedbackCandidates.filter(
-          (r) => !proactiveAndRetrievalSet.has(r.ref) && !isSessionCaptureMemoryName(parseAssetRef(r.ref).name),
-        );
+        const candidates = noFeedbackCandidates.filter((r) => !proactiveAndRetrievalSet.has(r.ref));
         // Collect ALL qualifying candidates, then take the top-N BY SCORE — the
         // previous first-N-in-scan-order break meant a higher-salience candidate
         // found later in the scan lost its slot to an earlier lower-scoring one.

--- a/src/commands/improve/recombine.ts
+++ b/src/commands/improve/recombine.ts
@@ -72,7 +72,7 @@ import {
   isValidWhenToUse,
   validateProposalFrontmatter,
 } from "../proposal/validators/proposal-quality-validators";
-import { isConsolidationEligibleMemoryName, isSessionCaptureMemoryName } from "./consolidate";
+import { isConsolidationEligibleMemoryName } from "./consolidate";
 import { resolveImproveLlmFn } from "./shared";
 
 export type { RecombineResult } from "../../core/improve-types";
@@ -251,11 +251,6 @@ const JUNK_ENTITY_NORMS = new Set([
   "status",
 ]);
 
-// #632 — `isSessionCaptureMemoryName` now lives in ./consolidate/eligibility so
-// both recombine and consolidate can reuse it without a circular import. It is
-// re-exported here for back-compat (existing importers + tests).
-export { isSessionCaptureMemoryName };
-
 /**
  * #632 — an entity carries no clustering signal (and must be skipped) when it is
  * a generic extraction artefact (session / structured-log bookkeeping), a raw
@@ -325,15 +320,7 @@ export function buildRelatednessClusters(
   },
 ): MemoryCluster[] {
   // Only consolidation-eligible memories participate (exclude `.derived`).
-  // #632 — durable memories only: exclude `.derived` (via
-  // `isConsolidationEligibleMemoryName`) AND session-capture telemetry dumps
-  // whose embedded metadata pollutes both tag and entity clustering.
-  const memories = entries.filter(
-    (e) =>
-      e.entry.type === "memory" &&
-      isConsolidationEligibleMemoryName(e.entry.name) &&
-      !isSessionCaptureMemoryName(e.entry.name),
-  );
+  const memories = entries.filter((e) => e.entry.type === "memory" && isConsolidationEligibleMemoryName(e.entry.name));
 
   // signal -> member entries
   const groups = new Map<string, DbIndexedEntry[]>();

--- a/src/indexer/graph/graph-extraction.ts
+++ b/src/indexer/graph/graph-extraction.ts
@@ -1123,15 +1123,10 @@ interface EligibleFile {
  *
  * Inferred-child memories (frontmatter `inferred: true`) are skipped — they
  * are already derived summaries, with no additional internal graph structure worth
- * extracting. Session-capture telemetry checkpoints are skipped too (see below).
+ * extracting.
  *
  * Exported for direct unit testing.
  */
-// #632 — canonical session-capture name shape, mirrored from
-// isSessionCaptureMemoryName (src/commands/improve/consolidate/eligibility.ts).
-// Inlined to avoid an improve-layer import from the indexer layer.
-const SESSION_CAPTURE_NAME_RE = /-(session|checkpoint)-\d{8}/;
-
 export function collectEligibleFiles(
   stashRoot: string,
   includeTypes: string[] = [...DEFAULT_GRAPH_EXTRACTION_INCLUDE_TYPES],
@@ -1155,13 +1150,6 @@ export function collectEligibleFiles(
       // Skip inferred memory children — they are atomic and there's no
       // graph to extract from a single-fact body.
       if (type === "memory" && parsed.data.inferred === true) continue;
-      // #632 — skip session-capture telemetry checkpoints (named
-      // `<harness>-(session|checkpoint)-<YYYYMMDD>-<id>`). Their bodies are
-      // pipeline bookkeeping; graph-extracting them lifts metadata fields as
-      // entities that then dominate clustering as bland stash-wide buckets.
-      // Mirrors isSessionCaptureMemoryName (consolidate/eligibility.ts); inlined
-      // here to keep the indexer layer free of an improve-layer import.
-      if (type === "memory" && SESSION_CAPTURE_NAME_RE.test(path.basename(filePath, ".md"))) continue;
       const body = parsed.content.trim();
       if (!body) continue;
       out.push({ absPath: filePath, type, body });

--- a/tests/commands/improve-recombine.test.ts
+++ b/tests/commands/improve-recombine.test.ts
@@ -672,43 +672,6 @@ describe("recombine #632 — entity clustering end-to-end", () => {
   );
 
   test(
-    "session-capture telemetry memories are excluded from the real akmRecombine pool",
-    async () => {
-      const stash = isolatedStash();
-      // A durable trio sharing tag:print — must cluster.
-      writeMemory(stash, "print-a", ["print"], "The print provider resolves per repo.");
-      writeMemory(stash, "print-b", ["print"], "Pagination is handled by paged.js.");
-      writeMemory(stash, "print-c", ["print"], "Chromium renders the final PDF.");
-      // A session-capture telemetry dump sharing the SAME tag — must be EXCLUDED
-      // from the pool (datestamped capture name), so the cluster stays at 3.
-      writeMemory(stash, "claude-session-20260601-aaaabbbb", ["print"], "Session checkpoint bookkeeping.");
-      await buildIndex(stash);
-
-      const seenMembers: string[][] = [];
-      const res = await akmRecombine({
-        stashDir: stash,
-        config: recombineEnabledConfig(),
-        sourceRun: "run-session-exclude",
-        relatednessSource: "tags",
-        minClusterSize: 3,
-        recombineLlmFn: async (prompt) => {
-          seenMembers.push(
-            ["print-a", "print-b", "print-c", "claude-session-20260601-aaaabbbb"].filter((n) => prompt.includes(n)),
-          );
-          return generalization("Print artifacts are repo-scoped.", "Generalization body.");
-        },
-      });
-
-      expect(res.clustersFormed).toBe(1);
-      // Exactly the durable trio; the session-capture memory is filtered out of
-      // the pool even though it carries the same tag.
-      expect(seenMembers[0]?.sort()).toEqual(["print-a", "print-b", "print-c"]);
-      expect(seenMembers[0]).not.toContain("claude-session-20260601-aaaabbbb");
-    },
-    TIMEOUT_MS,
-  );
-
-  test(
     "the default relatednessSource ('both', #632) clusters by entity with NO explicit source",
     async () => {
       const stash = isolatedStash();

--- a/tests/recombine-tuning.test.ts
+++ b/tests/recombine-tuning.test.ts
@@ -44,7 +44,6 @@ import {
   capClusters,
   isJunkEntity,
   isJunkTag,
-  isSessionCaptureMemoryName,
   selectClustersForRun,
 } from "../src/commands/improve/recombine";
 import { listProposals } from "../src/commands/proposal/repository";
@@ -558,18 +557,6 @@ describe("recombine #632 — entity-based clustering", () => {
   });
 });
 
-// ── #632 — exclude session-capture telemetry memories from the pool ────────────
-//
-// The dominant real-world noise source: AKM session-end checkpoint memories
-// (`<harness>-session-<YYYYMMDD>-<id>` / `<harness>-checkpoint-<YYYYMMDD…>-<id>`)
-// carry an embedded `akm_memory_kind: session_checkpoint` metadata block whose
-// fields the graph extracts as ENTITIES (`session_checkpoint`, `harness`,
-// `buffered observations`, `tool_*_observed`, …). With ~20% of the pool being
-// these telemetry dumps, those bookkeeping entities form the largest clusters
-// and dominate the largest-first selection — reproducing #632 under entity
-// signatures. They are telemetry, not durable knowledge, so they are excluded
-// from the recombine pool.
-
 describe("recombine #632 — selectClustersForRun (entity/tag blend)", () => {
   // Build a cluster of `size` members with the given signature.
   const cl = (signature: string, size: number) => ({
@@ -650,64 +637,5 @@ describe("recombine #632 — selectClustersForRun (entity/tag blend)", () => {
     expect(selectClustersForRun(ranked, 1).map((c) => c.signature)).toEqual(["entity:x"]);
     // cap 2 → 1 entity + 1 tag (entity not crowded out by the 3-slot reserve).
     expect(selectClustersForRun(ranked, 2).map((c) => c.signature)).toEqual(["entity:x", "tag:a"]);
-  });
-});
-
-describe("recombine #632 — session-capture telemetry detection", () => {
-  test("recognises AKM session/checkpoint capture names (datestamped)", () => {
-    for (const name of [
-      "claude-session-20260623-00db9c0b",
-      "opencode-session-20260529-ses_18ae",
-      "opencode-checkpoint-20260529T195618-ses_18db",
-    ]) {
-      expect(isSessionCaptureMemoryName(name)).toBe(true);
-    }
-  });
-
-  test("keeps durable memories that merely mention session/checkpoint", () => {
-    for (const name of [
-      "akm-plugins-session-end-extract-hook",
-      "session-checkpoint-lint-skips",
-      "print-md-source-provider",
-      "guardian-auth-boundary",
-    ]) {
-      expect(isSessionCaptureMemoryName(name)).toBe(false);
-    }
-  });
-});
-
-describe("recombine #632 — pool excludes session-capture memories", () => {
-  test("session-capture memories never cluster, even when they share a signal", () => {
-    // Three session-capture memories sharing a tag AND an entity — must NOT cluster.
-    const entries = [
-      memoryEntry(1, "claude-session-20260601-aaaa", ["akm"]),
-      memoryEntry(2, "claude-session-20260602-bbbb", ["akm"]),
-      memoryEntry(3, "opencode-checkpoint-20260603T010101-ses_1", ["akm"]),
-    ];
-    const entityByEntryId = new Map<number, string[]>([
-      [1, ["session_checkpoint"]],
-      [2, ["session_checkpoint"]],
-      [3, ["session_checkpoint"]],
-    ]);
-    const clusters = buildRelatednessClusters(entries, {
-      minClusterSize: 3,
-      relatednessSource: "both",
-      entityByEntryId,
-    });
-    expect(clusters).toEqual([]);
-  });
-
-  test("durable memories still cluster when session-capture siblings are filtered out", () => {
-    const entries = [
-      memoryEntry(1, "print-md-a", ["print"]),
-      memoryEntry(2, "print-md-b", ["print"]),
-      memoryEntry(3, "print-md-c", ["print"]),
-      // Telemetry sibling sharing the same tag — excluded, so it must not inflate the cluster.
-      memoryEntry(4, "claude-session-20260601-aaaa", ["print"]),
-    ];
-    const clusters = buildRelatednessClusters(entries, { minClusterSize: 3, relatednessSource: "tags" });
-    expect(clusterShape(clusters)).toEqual([
-      { signature: "tag:print", members: ["memory:print-md-a", "memory:print-md-b", "memory:print-md-c"] },
-    ]);
   });
 });


### PR DESCRIPTION
## Summary

Removes the `isSessionCaptureMemoryName` session-capture exclusion filter, which now matches an **empty set** and is dead code (meta-review **04-R-1**).

The predicate `/-(session|checkpoint)-\d{8}/` excluded auto-minted session-checkpoint telemetry from the improve pools. Those memories are gone:
- `-session-` auto-mints deleted in stash commit `a2421b04` (814 files, B2)
- remaining `-checkpoint-` telemetry deleted in `f5073c3c` (90 files: 45 base + 45 derived), index rebuilt
- Plugin minting shut down in both harnesses (03-R1/06-M1; akm-plugins #80/#81)

Verified read-only: **0** files on disk and **0** index entries match the predicate, and **0** carry `akm_memory_kind: session_checkpoint`. Nothing to filter, and nothing new can be created.

## Removed
- `isSessionCaptureMemoryName` predicate (`consolidate/eligibility.ts`)
- 4 call sites: `recombine.buildRelatednessClusters`, `consolidate` DB + FS memory pools, `preparation` high-salience reflect lane
- inlined `SESSION_CAPTURE_NAME_RE` skip in `graph-extraction.collectEligibleFiles`
- now-dead imports / re-exports
- the tests asserting the filter (2 in `recombine-tuning.test.ts`, 1 in `improve-recombine.test.ts`)

**Net −167 LOC** (6 insertions / 173 deletions).

## Deliberately kept (proved general-purpose, NOT session-capture-only)
- **`JUNK_ENTITY_NORMS` / `isJunkEntity`** — its `session` / `session_checkpoint` entries are emitted by *live durable memories* (e.g. `zero-tolerance-*`, `akm-recombine-entity-clustering-beta44-marker`, `admin-route-gating-via-feature-flags`), so it still protects entity clustering from bland buckets.
- **`excludeTags`** (#632 config-driven project tag exclusion)
- **`isConsolidationEligibleMemoryName`** (`.derived` guard)

## Verification
- `bun run check`: **green** — lint (biome + custom lints + schema) OK, `tsc --noEmit` 0 errors, unit **5385 pass / 0 fail**, integration **743 pass / 34 skip / 0 fail**
- curate-golden eval (`AKM_EMBED_DETERMINISTIC=1`): **ndcg=0.854 mrr=0.900**, identical to baseline (**Δ=0** on every metric) — the filter lived only in the improve pools, not the curate/search ranking path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YjU1mGiShdDP4qFW7p4mv