### PR TITLE
P0.5 seam alignment: model-alias tiers, registry-derived builders, runner abort/usage seams, runStructured core

### DIFF
--- a/docs/configuration-agent-profiles.md
+++ b/docs/configuration-agent-profiles.md
@@ -141,12 +141,20 @@ binary is on `PATH`):
 | --- | --- | --- | --- | --- |
 | `opencode` | `opencode` | `["run"]` | `interactive` | `opencode` |
 | `claude` | `claude` | `[]` | `interactive` | `claude` |
-| `codex` | `codex` | `[]` | `interactive` | `default` |
-| `gemini` | `gemini` | `[]` | `interactive` | `default` |
-| `aider` | `aider` | `["--no-auto-commits"]` | `interactive` | `default` |
+| `codex` | `codex` | `[]` | `interactive` | *(none — dispatch errors)* |
+| `gemini` | `gemini` | `[]` | `interactive` | *(none — dispatch errors)* |
+| `aider` | `aider` | `["--no-auto-commits"]` | `interactive` | *(none — dispatch errors)* |
 
 Each has a `-headless` variant (e.g. `opencode-headless`) that sets
 `stdio: "captured"` and `parseOutput: "json"` for automation contexts.
+
+The `codex`, `gemini`, and `aider` profiles have no dedicated command builder
+yet: dispatching them with a prompt/model/system-prompt raises a `ConfigError`
+instead of silently building a command with the wrong flag shapes (aider, for
+example, treats positional args as file names). Interactive launch (no
+dispatch flags) still works. If your CLI is flag-compatible with opencode or
+claude, set `commandBuilder` on a custom profile; dedicated builders for these
+CLIs arrive with the workflow-orchestration harness adapters.
 
 In v2 config the built-in profile names still resolve — but to use them from
 `profiles.agent`, declare them explicitly so the profile pool is self-contained.

--- a/docs/configuration-agent-profiles.md
+++ b/docs/configuration-agent-profiles.md
@@ -189,6 +189,40 @@ Three convenience aliases resolve to platform-appropriate model strings:
 
 Aliases are case-insensitive. An unrecognised alias is passed verbatim.
 
+### Global alias tiers
+
+The config-root `modelAliases` key defines semantic tiers once and resolves
+them per-platform at dispatch time. Each alias maps platform names to the
+exact model string that platform expects; the reserved `"*"` key is a
+fallback for platforms without their own column. Values are always literal
+model strings — never other aliases.
+
+```jsonc
+// ~/.config/akm/config.json
+{
+  "modelAliases": {
+    "fast":     { "claude": "claude-haiku-4-5-20251001", "opencode": "opencode/claude-haiku-4-5" },
+    "balanced": { "claude": "claude-sonnet-4-6",         "opencode": "opencode/claude-sonnet-4-6" },
+    "deep":     { "claude": "claude-opus-4-7",           "*": "opencode/claude-opus-4-7" }
+  }
+}
+```
+
+```sh
+akm agent claude-cli --model deep --prompt "architecture review"
+akm agent opencode-default --model deep --prompt "architecture review"
+# Same alias, per-platform model strings.
+```
+
+Platform keys match the platform string the profile's command builder
+resolves against: `claude`, `opencode`, `opencode-sdk`, or — for custom
+profiles handled by the default builder — the profile's own name. Unknown
+platform keys are inert.
+
+Resolution precedence (highest first): per-profile `modelAliases` → global
+`modelAliases` (platform column, then `"*"`) → built-in aliases → verbatim
+pass-through.
+
 ### Custom aliases
 
 Add per-profile aliases under the profile's `modelAliases` key:

--- a/docs/technical/akm-workflows-orchestration-plan.md
+++ b/docs/technical/akm-workflows-orchestration-plan.md
@@ -787,9 +787,10 @@ a run to another harness or vendor is a profile change, not a workflow edit.
 
 1. New root config key `modelAliases`: `alias → { <platformId>: modelString,
    "*"?: modelString }`. One resolution level — values are literal model
-   strings, never other aliases (no recursion). Platform keys are validated
-   against `HARNESS_REGISTRY` ids (the registry-derivation item in
-   *Reconciliation*), so a typo'd platform is a config error.
+   strings, never other aliases (no recursion). Platform keys are free-form:
+   custom profiles resolve under their own name via the default builder, so a
+   closed enum would reject legitimate columns. Unknown keys are inert; the
+   `"*"` fallback covers new platforms without config churn.
 2. Resolution order in `resolveModel`: profile `modelAliases` → global
    `modelAliases[alias][platform]` → global `modelAliases[alias]["*"]` →
    `BUILTIN_ALIASES` → verbatim. Case-insensitive as today.

--- a/schemas/akm-config.json
+++ b/schemas/akm-config.json
@@ -127,6 +127,16 @@
                     "type": "null"
                   }
                 ]
+              },
+              "modelAliases": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "propertyNames": {
+                  "minLength": 1
+                }
               }
             },
             "required": [
@@ -4221,6 +4231,22 @@
       },
       "additionalProperties": true
     },
+    "modelAliases": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string",
+          "minLength": 1
+        },
+        "propertyNames": {
+          "minLength": 1
+        }
+      },
+      "propertyNames": {
+        "minLength": 1
+      }
+    },
     "stashDir": {
       "type": "string",
       "minLength": 1
@@ -4885,6 +4911,16 @@
                         "type": "null"
                       }
                     ]
+                  },
+                  "modelAliases": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "propertyNames": {
+                      "minLength": 1
+                    }
                   }
                 },
                 "required": [
@@ -8978,6 +9014,22 @@
             }
           },
           "additionalProperties": true
+        },
+        "modelAliases": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "minLength": 1
+            },
+            "propertyNames": {
+              "minLength": 1
+            }
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
         },
         "stashDir": {
           "type": "string",

--- a/src/commands/agent/agent-dispatch.ts
+++ b/src/commands/agent/agent-dispatch.ts
@@ -35,6 +35,12 @@ export interface AkmAgentDispatchOptions {
   llmConfig?: LlmConnectionConfig;
   timeoutMs?: number;
   /**
+   * Working directory for the spawned agent CLI. Not honoured by the
+   * opencode-sdk path (the SDK server is process-wide; see the plan's open
+   * seam decision on per-call cwd).
+   */
+  cwd?: string;
+  /**
    * When present, the platform-specific AgentCommandBuilder uses these fields
    * to construct the argv (system prompt, model alias, tool policy). When
    * absent, falls back to the legacy positional-prompt behaviour.
@@ -136,6 +142,7 @@ export async function akmAgentDispatch(options: AkmAgentDispatchOptions): Promis
     parseOutput: "text" as const,
     ...(options.args?.length && !options.commandRef && !options.workflowRef ? { args: options.args } : {}),
     ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+    ...(options.cwd ? { cwd: options.cwd } : {}),
     ...(dispatchRequest !== undefined ? { dispatch: dispatchRequest } : {}),
   };
   const result: AgentRunResult = profile.sdkMode

--- a/src/commands/agent/contribute-cli.ts
+++ b/src/commands/agent/contribute-cli.ts
@@ -63,6 +63,10 @@ export const agentCommand = defineCommand({
         "Model override — accepts aliases (opus, sonnet, haiku) or exact platform model IDs. Overrides the model specified in the agent asset.",
     },
     "timeout-ms": { type: "string", description: "Override the agent CLI timeout in milliseconds" },
+    cwd: {
+      type: "string",
+      description: "Working directory for the spawned agent (defaults to the current directory)",
+    },
   },
   async run({ args }) {
     await runWithJsonErrors(async () => {
@@ -102,6 +106,7 @@ export const agentCommand = defineCommand({
       const promptText = getStringArg(args, "prompt");
       const commandRef = getStringArg(args, "command");
       const workflowRef = getStringArg(args, "workflow");
+      const cwd = getStringArg(args, "cwd");
 
       // Only build a dispatch request when there is something to dispatch — a
       // prompt, an agent asset, or a model override. When none of these are
@@ -123,9 +128,11 @@ export const agentCommand = defineCommand({
                 systemPrompt,
                 model,
                 tools: assetTools,
+                ...(cwd ? { cwd } : {}),
               },
             }
           : {}),
+        ...(cwd ? { cwd } : {}),
         ...(timeoutMs !== undefined && Number.isFinite(timeoutMs) ? { timeoutMs } : {}),
       });
 

--- a/src/core/concurrent.ts
+++ b/src/core/concurrent.ts
@@ -5,17 +5,26 @@
 /**
  * Maps over items concurrently with a pool size limit.
  * Uses Promise.allSettled semantics — one failure does not cancel others.
+ *
+ * Cooperative cancellation (P0.5 seam for the workflow scheduler): when
+ * `opts.signal` aborts, workers stop CLAIMING new items — in-flight `fn`
+ * calls run to completion (pass the same signal into `fn`'s own work to
+ * preempt those too). Unclaimed items stay `undefined` in the result,
+ * indistinguishable from individual failures by design: callers already
+ * treat `undefined` as "no result".
  */
 export async function concurrentMap<T, R>(
   items: T[],
   fn: (item: T, index: number) => Promise<R>,
   concurrency = 1,
+  opts?: { signal?: AbortSignal },
 ): Promise<Array<R | undefined>> {
   const results: Array<R | undefined> = new Array(items.length).fill(undefined);
   let nextIndex = 0;
 
   async function worker(): Promise<void> {
     while (nextIndex < items.length) {
+      if (opts?.signal?.aborted) return;
       const i = nextIndex++;
       try {
         results[i] = await fn(items[i], i);

--- a/src/core/config/config-schema.ts
+++ b/src/core/config/config-schema.ts
@@ -163,6 +163,11 @@ export const AgentProfileConfigSchema = z
     // timeout (e.g. `akm wiki ingest` without `--timeout-ms`). null = no
     // timeout. Honored by resolveAgentProfile (integrations/agent/config.ts).
     timeoutMs: z.union([positiveInt, z.null()]).optional(),
+    // Per-profile model aliases: lowercase alias → exact model string for
+    // this profile's CLI. Highest-precedence tier in resolveModel
+    // (integrations/agent/model-aliases.ts) — beats the config-root
+    // `modelAliases` table and the built-in opus/sonnet/haiku entries.
+    modelAliases: z.record(z.string().min(1), z.string().min(1)).optional(),
   })
   .passthrough();
 
@@ -930,6 +935,15 @@ export const AkmConfigShape = {
   configVersion: z.union([z.string().min(1), z.number()]).optional(),
   profiles: ProfilesSchema.optional(),
   defaults: DefaultsSchema.optional(),
+  // Global model-alias tiers: alias → platform → exact model string, with a
+  // reserved `"*"` platform key as fallback. Lets workflows/callers name a
+  // semantic tier ("fast", "deep") that resolves per-harness at dispatch
+  // time. Values are literal model strings, never other aliases (one
+  // resolution level). Platform keys match the platform string a command
+  // builder resolves against ("claude", "opencode", "opencode-sdk", or a
+  // custom profile's name for the default builder) — unknown keys are inert.
+  // Precedence: profile modelAliases > this table > built-in aliases.
+  modelAliases: z.record(z.string().min(1), z.record(z.string().min(1), z.string().min(1))).optional(),
   stashDir: nonEmptyString.optional(),
   semanticSearchMode: z.enum(["off", "auto"]).default("auto"),
   embedding: EmbeddingConnectionConfigSchema.optional(),

--- a/src/core/structured.ts
+++ b/src/core/structured.ts
@@ -1,0 +1,116 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `runStructured<T>()` — transport-free structured-output core (P0.5 seam).
+ *
+ * akm has two structured-output paths that share no code: the LLM HTTP path
+ * (`llm/structured-call.ts` + `responseSchema`) and the agent JSON path
+ * (`agent/spawn.ts` `parseOutput: "json"` — embedded-JSON scan, no schema,
+ * no retry). This module is the ONE validation-driven retry loop both are
+ * meant to converge on: the workflow engine's schema units compose it with a
+ * dispatch adapter per runner (llm = `chatCompletion` + `responseSchema`;
+ * agent/sdk = `runAgent`/`runOpencodeSdk` + prompt-injected schema;
+ * native-schema CLIs pass the schema through and still validate).
+ *
+ * Layering: this file lives in `core/` — NOT `llm/` — because the agent path
+ * must be able to reach it and `agent/ ⇏ llm/` is an enforced invariant
+ * (`tests/architecture/agent-no-llm-sdk-guard.test.ts`). The transport is
+ * always injected; this module never performs IO of its own.
+ *
+ * Retry semantics: only parse/validation misses are retried (with corrective
+ * feedback appended to the re-dispatch). Transport errors PROPAGATE — the
+ * transports own their own retry discipline (`chatCompletion` has a bounded
+ * jittered retry; `runAgent` has timeout/abort semantics).
+ */
+
+import { parseEmbeddedJsonResponse } from "./parse";
+
+/** Outcome of one validation attempt. */
+export type StructuredValidation<T> = { ok: true; value: T } | { ok: false; errors: string[] };
+
+export interface RunStructuredOptions<T> {
+  /**
+   * Injected transport: perform one round-trip and return the raw text
+   * response. On retries, `feedback` carries the corrective message built
+   * from the previous attempt's parse/validation failure — the adapter
+   * decides how to weave it into its prompt/messages.
+   */
+  dispatch: (feedback?: string) => Promise<string>;
+  /**
+   * Extract the candidate structure from the raw response. Returns
+   * `undefined` when no structure was found. Defaults to
+   * {@link parseEmbeddedJsonResponse} (strips think-blocks/code fences,
+   * scans for embedded JSON).
+   */
+  parse?: (raw: string) => unknown;
+  /** Validate the parsed candidate against the caller's schema/rules. */
+  validate: (candidate: unknown) => StructuredValidation<T>;
+  /** Total attempts including the first (default 2 — one corrective retry). */
+  maxAttempts?: number;
+  /** Override the default corrective-feedback message builder. */
+  buildFeedback?: (failure: { reason: "parse_error" | "validation_error"; errors: string[]; raw: string }) => string;
+}
+
+export type RunStructuredResult<T> =
+  | { ok: true; value: T; attempts: number }
+  | {
+      ok: false;
+      reason: "parse_error" | "validation_error";
+      /** Failure detail from the FINAL attempt. */
+      errors: string[];
+      attempts: number;
+      /** Raw response of the final attempt, for diagnostics/unit rows. */
+      raw: string;
+    };
+
+function defaultFeedback(failure: { reason: "parse_error" | "validation_error"; errors: string[] }): string {
+  if (failure.reason === "parse_error") {
+    return "Your previous response contained no parseable JSON. Respond with ONLY a JSON value that matches the requested schema — no prose, no code fences.";
+  }
+  return `Your previous JSON response failed validation:\n- ${failure.errors.join("\n- ")}\nRespond again with ONLY a corrected JSON value.`;
+}
+
+/**
+ * Run the dispatch→parse→validate loop, re-dispatching with corrective
+ * feedback on parse/validation misses, up to `maxAttempts` total attempts.
+ * Never throws for structure problems (returns a typed failure); transport
+ * throws propagate untouched.
+ */
+export async function runStructured<T>(options: RunStructuredOptions<T>): Promise<RunStructuredResult<T>> {
+  const parse = options.parse ?? ((raw: string) => parseEmbeddedJsonResponse(raw));
+  const buildFeedback = options.buildFeedback ?? defaultFeedback;
+  const maxAttempts = Math.max(1, options.maxAttempts ?? 2);
+
+  let feedback: string | undefined;
+  let lastFailure: Extract<RunStructuredResult<T>, { ok: false }> | undefined;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const raw = await options.dispatch(feedback);
+
+    const candidate = parse(raw);
+    if (candidate === undefined) {
+      lastFailure = {
+        ok: false,
+        reason: "parse_error",
+        errors: ["no JSON structure found in response"],
+        attempts: attempt,
+        raw,
+      };
+      feedback = buildFeedback({ reason: "parse_error", errors: lastFailure.errors, raw });
+      continue;
+    }
+
+    const verdict = options.validate(candidate);
+    if (verdict.ok) {
+      return { ok: true, value: verdict.value, attempts: attempt };
+    }
+    lastFailure = { ok: false, reason: "validation_error", errors: verdict.errors, attempts: attempt, raw };
+    feedback = buildFeedback({ reason: "validation_error", errors: verdict.errors, raw });
+  }
+
+  // maxAttempts >= 1 guarantees at least one loop iteration set lastFailure
+  // (a success would have returned), so the non-null assertion is safe.
+  return lastFailure as Extract<RunStructuredResult<T>, { ok: false }>;
+}

--- a/src/integrations/agent/builder-shared.ts
+++ b/src/integrations/agent/builder-shared.ts
@@ -38,8 +38,24 @@ export interface AgentDispatchRequest {
   model?: string;
   /** Tool policy — from agent asset frontmatter `tools:`. */
   tools?: ShowResponse["toolPolicy"];
-  /** Working directory for the subprocess. */
+  /**
+   * Working directory for the subprocess. Consumed by `runAgent` (as the
+   * fallback when `RunAgentOptions.cwd` is absent), not by builders — argv
+   * never encodes a working directory.
+   */
   cwd?: string;
+  /**
+   * Reasoning-effort hint for harnesses that accept one (reserved for the
+   * workflow engine's IR `effort` field; no builder consumes it yet).
+   */
+  effort?: string;
+  /**
+   * JSON Schema the unit's output must validate against. Reserved for the
+   * workflow engine's structured-output normalization: harnesses with native
+   * schema flags (e.g. Codex `--output-schema`) will pass it through; others
+   * get it injected into the prompt. No builder consumes it yet.
+   */
+  schema?: Record<string, unknown>;
 }
 
 /** Concrete command ready to hand to the spawn wrapper. */

--- a/src/integrations/agent/builders.ts
+++ b/src/integrations/agent/builders.ts
@@ -14,8 +14,8 @@
  * `BUILTIN_BUILDERS`. Nothing else changes.
  */
 
-import { claudeBuilder } from "../harnesses/claude/agent-builder";
-import { opencodeBuilder } from "../harnesses/opencode/agent-builder";
+import { ConfigError } from "../../core/errors";
+import { HARNESS_REGISTRY } from "../harnesses";
 // Types + shared validation helpers live in the leaf module `builder-shared.ts`
 // so per-harness builders (harnesses/claude/agent-builder.ts) can depend on them
 // without importing this file back — avoiding an init-order cycle through
@@ -23,6 +23,7 @@ import { opencodeBuilder } from "../harnesses/opencode/agent-builder";
 // sites keep working.
 import { type AgentCommandBuilder, assertNotFlag } from "./builder-shared";
 import { resolveModel } from "./model-aliases";
+import { getBuiltinAgentProfile } from "./profiles";
 
 export type { AgentCommandBuilder, AgentDispatchRequest, BuiltCommand } from "./builder-shared";
 export { assertNotFlag, normalizeTools } from "./builder-shared";
@@ -61,21 +62,47 @@ const defaultBuilder: AgentCommandBuilder = {
 
 // ── Registry ──────────────────────────────────────────────────────────────────
 
-const BUILTIN_BUILDERS: Readonly<Record<string, AgentCommandBuilder>> = {
-  opencode: opencodeBuilder,
-  "opencode-headless": opencodeBuilder,
-  claude: claudeBuilder,
-  "claude-headless": claudeBuilder,
-};
+/**
+ * DERIVED from `HARNESS_REGISTRY` (P0.5 registry-drift fix): each harness that
+ * owns an `agentBuilder` is registered under its canonical id, its
+ * `<id>-headless` profile variant, and every alias. Previously this was a
+ * hand-maintained map that could (and did) drift from the harness registry.
+ */
+const BUILTIN_BUILDERS: Readonly<Record<string, AgentCommandBuilder>> = (() => {
+  const registry: Record<string, AgentCommandBuilder> = {};
+  for (const harness of HARNESS_REGISTRY as readonly (typeof HARNESS_REGISTRY)[number][]) {
+    if (!harness.agentBuilder) continue;
+    registry[harness.id] = harness.agentBuilder;
+    registry[`${harness.id}-headless`] = harness.agentBuilder;
+    for (const alias of harness.aliases) registry[alias] = harness.agentBuilder;
+  }
+  return Object.freeze(registry);
+})();
 
 /**
- * Return the builder for the given platform name, falling back to the default
- * builder for unknown platforms. Custom builders injected via tests can be
- * passed as `registry`.
+ * Return the builder for the given platform name.
+ *
+ * A *custom* profile (unknown platform) falls back to the default builder —
+ * that generic `--system-prompt`/`--model`/`--` shape is the documented
+ * contract for user-defined wrappers. A *known built-in agent CLI* with no
+ * dedicated builder (codex, gemini, aider + their `-headless` variants) is a
+ * loud `ConfigError` instead: the default flag shape is wrong for those CLIs
+ * (aider, for one, treats positionals as file names), so the old silent
+ * fallback produced a broken command that "ran" and failed downstream.
+ * Custom builders injected via tests can be passed as `registry`.
  */
 export function getCommandBuilder(
   platform: string,
   registry: Record<string, AgentCommandBuilder> = BUILTIN_BUILDERS,
 ): AgentCommandBuilder {
-  return registry[platform] ?? defaultBuilder;
+  const found = registry[platform];
+  if (found) return found;
+  if (getBuiltinAgentProfile(platform)) {
+    throw new ConfigError(
+      `agent dispatch for "${platform}" is not supported yet: no command builder exists for this CLI, and the generic flag shape would produce a broken command.`,
+      "INVALID_CONFIG_FILE",
+      'Use an "opencode" or "claude" profile, or — if your CLI is flag-compatible with one of those — set `profiles.agent.<name>.commandBuilder` to "opencode" or "claude".',
+    );
+  }
+  return defaultBuilder;
 }

--- a/src/integrations/agent/builders.ts
+++ b/src/integrations/agent/builders.ts
@@ -50,7 +50,7 @@ const defaultBuilder: AgentCommandBuilder = {
       args.push("--system-prompt", req.systemPrompt);
     }
     if (req.model) {
-      const resolved = resolveModel(req.model, profile.name, profile.modelAliases);
+      const resolved = resolveModel(req.model, profile.name, profile.modelAliases, profile.globalModelAliases);
       args.push("--model", resolved);
     }
     args.push("--");

--- a/src/integrations/agent/config.ts
+++ b/src/integrations/agent/config.ts
@@ -15,6 +15,7 @@
  */
 import type { AgentProfileConfig, AkmConfig } from "../../core/config/config";
 import { ConfigError } from "../../core/errors";
+import type { GlobalModelAliasTable } from "./model-aliases";
 import {
   type AgentProfile,
   BUILTIN_AGENT_PROFILE_NAMES,
@@ -33,7 +34,11 @@ export const DEFAULT_AGENT_TIMEOUT_MS = 60_000;
  * user override (`profiles.agent[name]`) on top of the built-in profile (if
  * any). Returns `undefined` when neither yields a usable profile.
  */
-export function resolveAgentProfile(name: string, overrides?: AgentProfileConfig): AgentProfile | undefined {
+export function resolveAgentProfile(
+  name: string,
+  overrides?: AgentProfileConfig,
+  globalModelAliases?: GlobalModelAliasTable,
+): AgentProfile | undefined {
   const builtin = getBuiltinAgentProfile(name);
   const platform = overrides?.platform;
   // For opencode-sdk profiles, allow synthesizing without a built-in.
@@ -52,7 +57,16 @@ export function resolveAgentProfile(name: string, overrides?: AgentProfileConfig
       ...(sdkMode ? { sdkMode: true } : {}),
     } as AgentProfile);
 
-  if (!overrides) return base;
+  if (!overrides) {
+    return globalModelAliases ? { ...base, globalModelAliases } : base;
+  }
+
+  // Per-profile aliases from config extend (and shadow) the built-in
+  // profile's own entries. (Previously always used base.modelAliases, so the
+  // documented `profiles.agent.<name>.modelAliases` config was silently
+  // dropped — same bug class as the timeoutMs override below.)
+  const modelAliases =
+    overrides.modelAliases || base.modelAliases ? { ...base.modelAliases, ...overrides.modelAliases } : undefined;
 
   return {
     name,
@@ -73,16 +87,18 @@ export function resolveAgentProfile(name: string, overrides?: AgentProfileConfig
     endpoint: base.endpoint,
     apiKey: base.apiKey,
     commandBuilder: base.commandBuilder,
-    modelAliases: base.modelAliases,
+    modelAliases,
+    ...(globalModelAliases ? { globalModelAliases } : {}),
   };
 }
 
 /**
  * Resolve the runnable profile for `name`, or `undefined` if none is
- * available (no built-in and no user override).
+ * available (no built-in and no user override). Threads the config-root
+ * `modelAliases` tier table onto the resolved profile.
  */
 export function resolveProfileFromConfig(name: string, config?: AkmConfig): AgentProfile | undefined {
-  return resolveAgentProfile(name, config?.profiles?.agent?.[name]);
+  return resolveAgentProfile(name, config?.profiles?.agent?.[name], config?.modelAliases);
 }
 
 /**

--- a/src/integrations/agent/model-aliases.ts
+++ b/src/integrations/agent/model-aliases.ts
@@ -10,12 +10,22 @@
  *
  * Resolution order (highest → lowest precedence):
  *   1. Profile-level modelAliases from config.json (user-defined)
- *   2. Built-in alias table
- *   3. Verbatim pass-through (caller already supplied an exact model ID)
+ *   2. Global modelAliases from config.json — platform column, then "*" fallback
+ *   3. Built-in alias table
+ *   4. Verbatim pass-through (caller already supplied an exact model ID)
  */
 
 /** Per-platform model string map. Keys are platform names; values are exact CLI model strings. */
 export type PlatformModelMap = Record<string, string>;
+
+/**
+ * Global alias table from the config root `modelAliases` key: alias →
+ * platform → exact model string. The reserved platform key `"*"` is a
+ * fallback used when no platform-specific column matches. Values are always
+ * literal model strings — never other aliases (one resolution level, no
+ * recursion).
+ */
+export type GlobalModelAliasTable = Record<string, PlatformModelMap>;
 
 interface ModelAliasEntry {
   readonly alias: string;
@@ -61,12 +71,21 @@ const BUILTIN_ALIASES: readonly ModelAliasEntry[] = [
  *
  * @param model   Raw alias ("opus") or exact model ID ("claude-opus-4-7").
  * @param platform Builder platform name ("claude", "opencode", ...).
- * @param custom  Profile-level aliases from config.json — take priority over builtins.
+ * @param custom  Profile-level aliases from config.json — take priority over globals and builtins.
+ * @param global  Config-root `modelAliases` tier table (alias → platform → model, `"*"` fallback).
  * @returns Resolved model string, or `model` verbatim when no alias matches.
  */
-export function resolveModel(model: string, platform: string, custom?: PlatformModelMap): string {
+export function resolveModel(
+  model: string,
+  platform: string,
+  custom?: PlatformModelMap,
+  global?: GlobalModelAliasTable,
+): string {
   const key = model.toLowerCase();
   if (custom?.[key]) return custom[key];
+  const tier = global?.[key];
+  const fromGlobal = tier?.[platform] ?? tier?.["*"];
+  if (fromGlobal) return fromGlobal;
   const entry = BUILTIN_ALIASES.find((a) => a.alias === key);
   return entry?.platforms[platform] ?? model;
 }

--- a/src/integrations/agent/profiles.ts
+++ b/src/integrations/agent/profiles.ts
@@ -59,9 +59,16 @@ export interface AgentProfile {
   /**
    * Per-profile model aliases merged on top of the built-in alias table.
    * Keys are lowercase alias strings; values are the exact model string this
-   * platform's CLI expects. Configured under agent.profiles.<name>.modelAliases.
+   * platform's CLI expects. Configured under profiles.agent.<name>.modelAliases.
    */
   readonly modelAliases?: Readonly<Record<string, string>>;
+  /**
+   * Config-root `modelAliases` tier table (alias → platform → model string,
+   * `"*"` fallback), stamped onto the resolved profile so command builders can
+   * pass it to resolveModel without a config dependency. Precedence sits
+   * between the per-profile `modelAliases` and the built-in alias table.
+   */
+  readonly globalModelAliases?: Readonly<Record<string, Readonly<Record<string, string>>>>;
 }
 
 // AKM_EVENT_SOURCE carries usage-event provenance (improve/task) so that akm

--- a/src/integrations/agent/spawn.ts
+++ b/src/integrations/agent/spawn.ts
@@ -388,7 +388,9 @@ export async function runAgent(
       stdout: stdioMode === "captured" ? "pipe" : "inherit",
       stderr: stdioMode === "captured" ? "pipe" : "inherit",
       env,
-      ...(options.cwd ? { cwd: options.cwd } : {}),
+      // options.cwd wins; dispatch.cwd is the request-level fallback (it was
+      // declared on AgentDispatchRequest but consumed by nothing — P0.5 fix).
+      ...((options.cwd ?? options.dispatch?.cwd) ? { cwd: options.cwd ?? options.dispatch?.cwd } : {}),
       // Spawn in its own process group so killGroup(-pid, signal) reaches all
       // descendants (e.g. the .opencode binary that opencode's node wrapper forks).
       // Only applied in captured mode — interactive mode inherits the parent

--- a/src/integrations/agent/spawn.ts
+++ b/src/integrations/agent/spawn.ts
@@ -444,11 +444,11 @@ export async function runAgent(
     if (!proc || proc.exitCode !== null) return;
     aborted = true;
     killGroup(proc, "SIGTERM");
-    setTimeoutImpl(() => {
+    const sigkillTimer = setTimeoutImpl(() => {
       if (!proc || proc.exitCode !== null) return;
       killGroup(proc, "SIGKILL");
     }, 5000);
-  };
+    (sigkillTimer as any)?.unref?.();
   if (abortSignal) {
     // A signal that aborted between the pre-spawn check and here is handled
     // by calling the listener directly.

--- a/src/integrations/agent/spawn.ts
+++ b/src/integrations/agent/spawn.ts
@@ -60,7 +60,11 @@ export type AgentFailureReason =
   | "llm_invalid_json"
   | "content_policy_reject"
   | "unsupported_type"
-  | "no_change";
+  | "no_change"
+  // Cooperative cancellation via RunAgentOptions.signal (P0.5 seam for the
+  // workflow scheduler's budget preemption). Distinct from "timeout" so
+  // callers can tell a budget/user abort from a wall-clock expiry.
+  | "aborted";
 
 /** Minimum subprocess surface we need. The runtime spawn returns this shape. */
 export interface SpawnedSubprocess {
@@ -135,6 +139,13 @@ export interface RunAgentOptions {
   args?: readonly string[];
   /** Optional stdin payload (only honoured in `captured` mode). */
   stdin?: string;
+  /**
+   * Cooperative cancellation. When the signal aborts, the child process
+   * group gets SIGTERM (then SIGKILL after 5 s) and the run resolves with
+   * `reason: "aborted"`. Lets a scheduler preempt a running agent at a
+   * budget ceiling instead of waiting out the timeout.
+   */
+  signal?: AbortSignal;
   /** Process env source. Defaults to `process.env`. Tests inject a fake. */
   envSource?: NodeJS.ProcessEnv;
   /** Spawn function. Defaults to the runtime spawn. Tests inject a fake. */
@@ -160,6 +171,18 @@ export interface RunAgentOptions {
   builderRegistry?: Record<string, import("./builders").AgentCommandBuilder>;
 }
 
+/**
+ * Best-effort token accounting for one agent run. Harness-neutral shape;
+ * fields are only set when the harness actually reported them (0 is a real
+ * value, absent means unknown). The CLI spawn path has no usage contract
+ * yet, so today this is populated only by the OpenCode SDK runner.
+ */
+export interface AgentTokenUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  reasoningTokens?: number;
+}
+
 /** Result envelope. `ok=false` always carries a `reason`. */
 export interface AgentRunResult {
   ok: boolean;
@@ -172,6 +195,10 @@ export interface AgentRunResult {
   reason?: AgentFailureReason;
   /** Human-readable error message paired with `reason`. */
   error?: string;
+  /** Token accounting, when the harness reported it (SDK path today). */
+  usage?: AgentTokenUsage;
+  /** The harness's own session id, when it exposes one (SDK path today). */
+  sessionId?: string;
 }
 
 const DEFAULT_TIMEOUT_MS = DEFAULT_AGENT_TIMEOUT_MS;
@@ -339,6 +366,20 @@ export async function runAgent(
   const env = { ...buildChildEnv(profile, options), ...(builtEnv ?? {}) };
   const start = Date.now();
 
+  // Cooperative cancel: refuse to spawn at all when the caller's signal is
+  // already aborted (e.g. the run's budget was exhausted before this unit).
+  if (options.signal?.aborted) {
+    return {
+      ok: false,
+      exitCode: null,
+      stdout: "",
+      stderr: "",
+      durationMs: 0,
+      reason: "aborted",
+      error: `agent CLI "${profile.name}" not started: caller signal already aborted`,
+    };
+  }
+
   let proc: SpawnedSubprocess;
   try {
     const spawnFn = resolveSpawnFn(options);
@@ -393,6 +434,26 @@ export async function runAgent(
     }, timeoutMs);
   }
 
+  // Cooperative cancel: same SIGTERM→SIGKILL discipline as the timeout, but
+  // flagged separately so the result carries `reason: "aborted"`.
+  let aborted = false;
+  const abortSignal = options.signal;
+  const onAbort = () => {
+    if (!proc || proc.exitCode !== null) return;
+    aborted = true;
+    killGroup(proc, "SIGTERM");
+    setTimeoutImpl(() => {
+      if (!proc || proc.exitCode !== null) return;
+      killGroup(proc, "SIGKILL");
+    }, 5000);
+  };
+  if (abortSignal) {
+    // A signal that aborted between the pre-spawn check and here is handled
+    // by calling the listener directly.
+    if (abortSignal.aborted) onAbort();
+    else abortSignal.addEventListener("abort", onAbort, { once: true });
+  }
+
   // Stream-drain timeout: the overall wall-clock budget plus a 2 s grace
   // period. When a process is killed via SIGTERM/SIGKILL (from our timeout
   // handler or from outside) some runtimes keep the pipe write-end open in
@@ -440,6 +501,7 @@ export async function runAgent(
     exitCode = await proc.exited;
   } catch (err) {
     if (timer !== undefined) clearTimeoutImpl(timer);
+    abortSignal?.removeEventListener("abort", onAbort);
     // BUG-H2: drain stream readers before the early return so they don't
     // surface as unhandled rejections after the function resolves.
     // The streams already carry a built-in drain timeout so this allSettled
@@ -457,9 +519,22 @@ export async function runAgent(
     };
   }
   clearTimeoutImpl(timer);
+  abortSignal?.removeEventListener("abort", onAbort);
 
   const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
   const durationMs = Date.now() - start;
+
+  if (aborted) {
+    return {
+      ok: false,
+      exitCode,
+      stdout,
+      stderr,
+      durationMs,
+      reason: "aborted",
+      error: `agent CLI "${profile.name}" aborted by caller signal`,
+    };
+  }
 
   if (timedOut) {
     return {

--- a/src/integrations/agent/spawn.ts
+++ b/src/integrations/agent/spawn.ts
@@ -448,7 +448,8 @@ export async function runAgent(
       if (!proc || proc.exitCode !== null) return;
       killGroup(proc, "SIGKILL");
     }, 5000);
-    (sigkillTimer as any)?.unref?.();
+    if (typeof sigkillTimer !== "number") sigkillTimer.unref?.();
+  };
   if (abortSignal) {
     // A signal that aborted between the pre-spawn check and here is handled
     // by calling the listener directly.

--- a/src/integrations/harnesses/claude/agent-builder.ts
+++ b/src/integrations/harnesses/claude/agent-builder.ts
@@ -36,7 +36,7 @@ export const claudeBuilder: AgentCommandBuilder = {
       args.push("--system-prompt", req.systemPrompt);
     }
     if (req.model) {
-      const resolved = resolveModel(req.model, "claude", profile.modelAliases);
+      const resolved = resolveModel(req.model, "claude", profile.modelAliases, profile.globalModelAliases);
       args.push("--model", resolved);
     }
     if (req.tools) {

--- a/src/integrations/harnesses/claude/index.ts
+++ b/src/integrations/harnesses/claude/index.ts
@@ -27,6 +27,7 @@
  */
 
 import { BaseHarness, type HarnessCapabilities } from "../types";
+import { claudeBuilder } from "./agent-builder";
 
 export { claudeBuilder } from "./agent-builder";
 export { claudeCodeImporter } from "./config-import";
@@ -58,6 +59,7 @@ export class ClaudeHarness extends BaseHarness {
   // Home-relative config dir scanned by `akm setup` (#567). Claude Code has a
   // session-log provider, so offering it as a stash source is functional.
   readonly setupDetectionDir = ".claude";
+  readonly agentBuilder = claudeBuilder;
   readonly capabilities = caps({
     sessionLogs: true,
     agentDispatch: true,

--- a/src/integrations/harnesses/opencode-sdk/sdk-runner.ts
+++ b/src/integrations/harnesses/opencode-sdk/sdk-runner.ts
@@ -17,6 +17,7 @@
 import { type LlmConnectionConfig, resolveSecret } from "../../../core/config/config";
 import type { ShowResponse } from "../../../sources/types";
 import { DEFAULT_AGENT_TIMEOUT_MS } from "../../agent/config";
+import { resolveModel } from "../../agent/model-aliases";
 import type { AgentProfile } from "../../agent/profiles";
 import type { AgentFailureReason, AgentRunResult, RunAgentOptions } from "../../agent/spawn";
 
@@ -114,17 +115,23 @@ function toolsToSdkAllowlist(tools: ShowResponse["toolPolicy"]): Record<string, 
   return out;
 }
 
-async function getOrStartServer(profile: AgentProfile, llmConfig?: LlmConnectionConfig): Promise<SdkServer> {
-  if (_server) return _server;
-
-  const { createOpencode } = await import("@opencode-ai/sdk").catch(() => {
-    throw new Error("OpenCode SDK not available. Install @opencode-ai/sdk or configure a CLI agent instead.");
-  });
-
+/**
+ * Assemble the OpenCode SDK server config from the profile + LLM fallback.
+ * Pure and exported for tests. `profile.model` is resolved through the model
+ * alias tables (platform key `"opencode-sdk"`) so config aliases like
+ * `"model": "fast"` work on the SDK path the same way they do for CLI
+ * builders. Note there is no built-in alias column for `opencode-sdk` —
+ * built-in opus/sonnet/haiku strings are CLI-provider-qualified and would
+ * collide with the `akm-custom/` provider prefixing below, so only profile
+ * and config-root alias tables apply here.
+ */
+export function buildSdkConfig(profile: AgentProfile, llmConfig?: LlmConnectionConfig): Record<string, unknown> {
   // Resolve endpoint and model: profile fields take precedence over config.llm
   const endpoint = profile.endpoint ?? llmConfig?.endpoint;
   const apiKey = resolveSecret(profile.apiKey ?? llmConfig?.apiKey);
-  const model = profile.model;
+  const model = profile.model
+    ? resolveModel(profile.model, "opencode-sdk", profile.modelAliases, profile.globalModelAliases)
+    : undefined;
 
   const sdkConfig: Record<string, unknown> = {};
   if (model) sdkConfig.model = model;
@@ -144,6 +151,17 @@ async function getOrStartServer(profile: AgentProfile, llmConfig?: LlmConnection
       sdkConfig.model = `akm-custom/${model}`;
     }
   }
+  return sdkConfig;
+}
+
+async function getOrStartServer(profile: AgentProfile, llmConfig?: LlmConnectionConfig): Promise<SdkServer> {
+  if (_server) return _server;
+
+  const { createOpencode } = await import("@opencode-ai/sdk").catch(() => {
+    throw new Error("OpenCode SDK not available. Install @opencode-ai/sdk or configure a CLI agent instead.");
+  });
+
+  const sdkConfig = buildSdkConfig(profile, llmConfig);
 
   _server = (await createOpencode(Object.keys(sdkConfig).length > 0 ? { config: sdkConfig } : {})) as SdkServer;
 

--- a/src/integrations/harnesses/opencode-sdk/sdk-runner.ts
+++ b/src/integrations/harnesses/opencode-sdk/sdk-runner.ts
@@ -19,7 +19,7 @@ import type { ShowResponse } from "../../../sources/types";
 import { DEFAULT_AGENT_TIMEOUT_MS } from "../../agent/config";
 import { resolveModel } from "../../agent/model-aliases";
 import type { AgentProfile } from "../../agent/profiles";
-import type { AgentFailureReason, AgentRunResult, RunAgentOptions } from "../../agent/spawn";
+import type { AgentFailureReason, AgentRunResult, AgentTokenUsage, RunAgentOptions } from "../../agent/spawn";
 
 /** Minimal surface of the OpenCode SDK client used by this runner. */
 interface SdkClient {
@@ -35,7 +35,15 @@ interface SdkClient {
         system?: string;
         tools?: Record<string, boolean>;
       };
-    }): Promise<{ data?: { parts?: { type: string; text?: string }[] } }>;
+    }): Promise<{
+      data?: {
+        // AssistantMessage projection (SDK 1.2.20 types.gen.d.ts): token
+        // accounting lives on info.tokens. Fields optional here so a fake or
+        // an older server that omits them cannot crash extraction.
+        info?: { tokens?: { input?: number; output?: number; reasoning?: number } };
+        parts?: { type: string; text?: string }[];
+      };
+    }>;
     delete(args: { path: { id: string } }): Promise<unknown>;
   };
 }
@@ -173,6 +181,25 @@ async function getOrStartServer(profile: AgentProfile, llmConfig?: LlmConnection
   return _server;
 }
 
+/**
+ * Extract best-effort token usage from a prompt response. Only numeric
+ * fields the server actually reported are copied; returns undefined when
+ * nothing usable is present (older servers, test fakes).
+ */
+function extractUsage(info?: {
+  tokens?: { input?: number; output?: number; reasoning?: number };
+}): AgentTokenUsage | undefined {
+  const tokens = info?.tokens;
+  if (!tokens) return undefined;
+  const usage: AgentTokenUsage = {};
+  if (typeof tokens.input === "number" && Number.isFinite(tokens.input)) usage.inputTokens = tokens.input;
+  if (typeof tokens.output === "number" && Number.isFinite(tokens.output)) usage.outputTokens = tokens.output;
+  if (typeof tokens.reasoning === "number" && Number.isFinite(tokens.reasoning)) {
+    usage.reasoningTokens = tokens.reasoning;
+  }
+  return Object.keys(usage).length > 0 ? usage : undefined;
+}
+
 export async function runOpencodeSdk(
   profile: AgentProfile,
   prompt: string,
@@ -180,6 +207,18 @@ export async function runOpencodeSdk(
   llmConfig?: LlmConnectionConfig,
 ): Promise<AgentRunResult> {
   const start = Date.now();
+
+  if (opts.signal?.aborted) {
+    return {
+      ok: false,
+      stdout: "",
+      stderr: "",
+      durationMs: 0,
+      exitCode: null,
+      reason: "aborted" as AgentFailureReason,
+      error: `opencode-sdk agent "${profile.name}" not started: caller signal already aborted`,
+    };
+  }
 
   let client: SdkClient;
   try {
@@ -243,19 +282,50 @@ export async function runOpencodeSdk(
 
   let timer: ReturnType<typeof setTimeoutImpl> | undefined;
   const TIMED_OUT = Symbol("opencode-sdk-timeout");
+  const ABORTED = Symbol("opencode-sdk-aborted");
+
+  // Cooperative cancel: there is no OS process to signal, so an abort simply
+  // wins the race below; the finally block reaps the in-flight session, same
+  // as the timeout path.
+  let onAbort: (() => void) | undefined;
+  const abortSignal = opts.signal;
 
   try {
     const promptPromise = client.session.prompt({ path: { id: sessionId }, body });
+    type PromptResult = Awaited<typeof promptPromise>;
 
-    const result =
-      timeoutMs === null
-        ? await promptPromise
-        : await Promise.race<{ data?: { parts?: { type: string; text?: string }[] } } | typeof TIMED_OUT>([
-            promptPromise,
-            new Promise<typeof TIMED_OUT>((resolve) => {
-              timer = setTimeoutImpl(() => resolve(TIMED_OUT), timeoutMs);
-            }),
-          ]);
+    const racers: Promise<PromptResult | typeof TIMED_OUT | typeof ABORTED>[] = [promptPromise];
+    if (timeoutMs !== null) {
+      racers.push(
+        new Promise<typeof TIMED_OUT>((resolve) => {
+          timer = setTimeoutImpl(() => resolve(TIMED_OUT), timeoutMs);
+        }),
+      );
+    }
+    if (abortSignal) {
+      racers.push(
+        new Promise<typeof ABORTED>((resolve) => {
+          onAbort = () => resolve(ABORTED);
+          if (abortSignal.aborted) onAbort();
+          else abortSignal.addEventListener("abort", onAbort, { once: true });
+        }),
+      );
+    }
+
+    const result = racers.length === 1 ? await promptPromise : await Promise.race(racers);
+
+    if (result === ABORTED) {
+      return {
+        ok: false,
+        stdout: "",
+        stderr: "",
+        durationMs: Date.now() - start,
+        exitCode: null,
+        reason: "aborted" as AgentFailureReason,
+        error: `opencode-sdk agent "${profile.name}" aborted by caller signal`,
+        sessionId,
+      };
+    }
 
     if (result === TIMED_OUT) {
       return {
@@ -266,12 +336,17 @@ export async function runOpencodeSdk(
         exitCode: null,
         reason: "timeout" as AgentFailureReason,
         error: `opencode-sdk agent "${profile.name}" timed out after ${timeoutMs}ms`,
+        sessionId,
       };
     }
 
     const parts = result.data?.parts ?? [];
     const textPart = parts.find((p) => p.type === "text");
     const stdout = textPart?.text ?? "";
+    // Token accounting from the AssistantMessage (previously discarded) —
+    // the seam that makes workflow budget.maxTokens meterable on the
+    // default sdk runner.
+    const usage = extractUsage(result.data?.info);
 
     return {
       ok: true,
@@ -279,6 +354,8 @@ export async function runOpencodeSdk(
       stderr: "",
       durationMs: Date.now() - start,
       exitCode: 0,
+      sessionId,
+      ...(usage ? { usage } : {}),
     };
   } catch (e) {
     return {
@@ -289,9 +366,11 @@ export async function runOpencodeSdk(
       exitCode: 1,
       reason: "non_zero_exit" as AgentFailureReason,
       error: String(e),
+      sessionId,
     };
   } finally {
     if (timer !== undefined) clearTimeoutImpl(timer);
+    if (abortSignal && onAbort) abortSignal.removeEventListener("abort", onAbort);
     // Clean up session to prevent disk accumulation in ~/.local/share/opencode/
     await client.session.delete({ path: { id: sessionId } }).catch(() => {});
   }

--- a/src/integrations/harnesses/opencode/agent-builder.ts
+++ b/src/integrations/harnesses/opencode/agent-builder.ts
@@ -36,7 +36,7 @@ export const opencodeBuilder: AgentCommandBuilder = {
       args.push("--system-prompt", req.systemPrompt);
     }
     if (req.model) {
-      const resolved = resolveModel(req.model, "opencode", profile.modelAliases);
+      const resolved = resolveModel(req.model, "opencode", profile.modelAliases, profile.globalModelAliases);
       args.push("--model", resolved);
     }
     args.push("--");

--- a/src/integrations/harnesses/opencode/index.ts
+++ b/src/integrations/harnesses/opencode/index.ts
@@ -20,6 +20,7 @@
  */
 
 import { BaseHarness, type HarnessCapabilities } from "../types";
+import { opencodeBuilder } from "./agent-builder";
 
 export { opencodeBuilder } from "./agent-builder";
 export { openCodeImporter } from "./config-import";
@@ -53,6 +54,7 @@ export class OpencodeHarness extends BaseHarness {
   // `v1ProfilePlatform()` resolves most-specific-id-first, so "opencode-sdk-*"
   // is claimed by OpencodeSdkHarness before this prefix can over-match it.
   protected readonly v1ProfilePrefixes = ["opencode"] as const;
+  readonly agentBuilder = opencodeBuilder;
   readonly capabilities = caps({
     sessionLogs: true,
     agentDispatch: true,

--- a/src/integrations/harnesses/types.ts
+++ b/src/integrations/harnesses/types.ts
@@ -23,6 +23,8 @@
  * implementations are migrated under each harness in #563/#564.
  */
 
+import type { AgentCommandBuilder } from "../agent/builder-shared";
+
 /**
  * Capability flags describing which of akm's six integration surfaces a
  * harness participates in. A subsystem filters `HARNESS_REGISTRY` by the
@@ -95,6 +97,18 @@ export interface AkmHarness {
   readonly capabilities: HarnessCapabilities;
 
   /**
+   * The harness-owned agent command builder, when dispatch goes through the
+   * CLI spawn path. `BUILTIN_BUILDERS` in `agent/builders.ts` is DERIVED from
+   * this field (id, `<id>-headless`, and aliases all map to it) so the
+   * builder registry cannot drift from the harness registry. Absent for
+   * harnesses that dispatch without argv construction (opencode-sdk) — and
+   * for dispatch-capable CLIs that do not have a dedicated builder yet, in
+   * which case dispatch fails loudly rather than falling back to a
+   * wrong-flag-shape default (see `getCommandBuilder`).
+   */
+  readonly agentBuilder?: AgentCommandBuilder;
+
+  /**
    * Does a legacy v1 agent-profile name belong to this harness? (#566)
    *
    * v1 agent profiles never carried an explicit `platform`; the platform was
@@ -126,6 +140,7 @@ export abstract class BaseHarness implements AkmHarness {
   abstract readonly capabilities: HarnessCapabilities;
   readonly runtimeId?: string;
   readonly setupDetectionDir?: string;
+  readonly agentBuilder?: AgentCommandBuilder;
 
   /**
    * Lowercase prefixes that a decorated v1 profile name may start with and

--- a/src/llm/call-ai.ts
+++ b/src/llm/call-ai.ts
@@ -14,7 +14,7 @@
 import type { AkmConfig } from "../core/config/config";
 import { getDefaultLlmConfig } from "../core/config/config";
 import { warn } from "../core/warn";
-import { resolveAgentProfile, runAgent } from "../integrations/agent";
+import { resolveProfileFromConfig, runAgent } from "../integrations/agent";
 import { chatCompletion } from "./client";
 
 export interface CallAiOptions {
@@ -38,7 +38,7 @@ export async function callAi(config: AkmConfig, prompt: string, opts: CallAiOpti
   const defaultAgentName = config.defaults?.agent;
   if (defaultAgentName) {
     try {
-      const profile = resolveAgentProfile(defaultAgentName, config.profiles?.agent?.[defaultAgentName]);
+      const profile = resolveProfileFromConfig(defaultAgentName, config);
       if (!profile) {
         return {
           ok: false,

--- a/tests/agent/agent-builders.test.ts
+++ b/tests/agent/agent-builders.test.ts
@@ -537,3 +537,41 @@ describe("builder + globalModelAliases integration", () => {
     expect(argv[argv.indexOf("--model") + 1]).toBe("opencode/profile-wins");
   });
 });
+
+// ── Registry-derived builders + missing-builder error (P0.5 drift fix) ────────
+
+describe("getCommandBuilder — derived from HARNESS_REGISTRY", () => {
+  test("canonical ids, -headless variants, and aliases resolve to the harness builder", async () => {
+    const { getCommandBuilder } = await import("../../src/integrations/agent/builders");
+    expect(getCommandBuilder("opencode").platform).toBe("opencode");
+    expect(getCommandBuilder("opencode-headless").platform).toBe("opencode");
+    expect(getCommandBuilder("claude").platform).toBe("claude");
+    expect(getCommandBuilder("claude-headless").platform).toBe("claude");
+    // 'claude-code' is the registered alias of the claude harness.
+    expect(getCommandBuilder("claude-code").platform).toBe("claude");
+  });
+
+  test("known built-in CLIs without a dedicated builder throw a ConfigError", async () => {
+    const { getCommandBuilder } = await import("../../src/integrations/agent/builders");
+    const { ConfigError } = await import("../../src/core/errors");
+    for (const platform of ["codex", "gemini", "aider", "codex-headless", "gemini-headless", "aider-headless"]) {
+      expect(() => getCommandBuilder(platform)).toThrow(ConfigError);
+    }
+  });
+
+  test("unknown custom platforms still fall back to the default builder", async () => {
+    const { getCommandBuilder } = await import("../../src/integrations/agent/builders");
+    expect(getCommandBuilder("my-custom-wrapper").platform).toBe("default");
+  });
+
+  test("dispatching a codex profile through runAgent surfaces the ConfigError", async () => {
+    const { runAgent } = await import("../../src/integrations/agent/spawn");
+    const profile = makeFakeProfile({ name: "codex", bin: "codex" });
+    await expect(
+      runAgent(profile, undefined, {
+        stdio: "captured",
+        dispatch: { prompt: "do a thing", model: "opus" },
+      }),
+    ).rejects.toThrow(/no command builder exists/);
+  });
+});

--- a/tests/agent/agent-builders.test.ts
+++ b/tests/agent/agent-builders.test.ts
@@ -436,3 +436,104 @@ describe("builders — argument injection guards", () => {
     ).not.toThrow();
   });
 });
+
+// ── Global model-alias tiers (config-root `modelAliases`) ─────────────────────
+
+describe("resolveModel — global alias tiers", () => {
+  const global = {
+    fast: { claude: "claude-haiku-4-5-20251001", opencode: "opencode/claude-haiku-4-5", "*": "haiku-generic" },
+    deep: { "*": "deep-generic" },
+    opus: { claude: "my-pinned-opus" },
+  };
+
+  test("platform column wins over '*' fallback", async () => {
+    const { resolveModel } = await import("../../src/integrations/agent/model-aliases");
+    expect(resolveModel("fast", "claude", undefined, global)).toBe("claude-haiku-4-5-20251001");
+    expect(resolveModel("fast", "opencode", undefined, global)).toBe("opencode/claude-haiku-4-5");
+  });
+
+  test("'*' fallback used when no platform column matches", async () => {
+    const { resolveModel } = await import("../../src/integrations/agent/model-aliases");
+    expect(resolveModel("fast", "codex", undefined, global)).toBe("haiku-generic");
+    expect(resolveModel("deep", "claude", undefined, global)).toBe("deep-generic");
+  });
+
+  test("profile-level custom alias beats the global table", async () => {
+    const { resolveModel } = await import("../../src/integrations/agent/model-aliases");
+    expect(resolveModel("fast", "claude", { fast: "profile-wins" }, global)).toBe("profile-wins");
+  });
+
+  test("global table shadows the built-in alias table", async () => {
+    const { resolveModel } = await import("../../src/integrations/agent/model-aliases");
+    expect(resolveModel("opus", "claude", undefined, global)).toBe("my-pinned-opus");
+    // …but only for platforms the global entry names: no column + no '*' falls
+    // through to the built-in table.
+    expect(resolveModel("opus", "opencode", undefined, global)).toBe("opencode/claude-opus-4-7");
+  });
+
+  test("alias lookup is case-insensitive; unknown alias passes through verbatim", async () => {
+    const { resolveModel } = await import("../../src/integrations/agent/model-aliases");
+    expect(resolveModel("FAST", "claude", undefined, global)).toBe("claude-haiku-4-5-20251001");
+    expect(resolveModel("exact-model-id", "claude", undefined, global)).toBe("exact-model-id");
+  });
+});
+
+// ── resolveAgentProfile: modelAliases config wiring (previously dropped) ──────
+
+describe("resolveAgentProfile — modelAliases from config", () => {
+  test("overrides.modelAliases reaches the resolved profile (bug fix)", async () => {
+    const { resolveAgentProfile } = await import("../../src/integrations/agent/config");
+    const profile = resolveAgentProfile("claude", {
+      platform: "claude",
+      modelAliases: { quick: "claude-haiku-4-5-20251001" },
+    });
+    expect(profile?.modelAliases).toEqual({ quick: "claude-haiku-4-5-20251001" });
+  });
+
+  test("globalModelAliases is stamped onto the profile with and without overrides", async () => {
+    const { resolveAgentProfile } = await import("../../src/integrations/agent/config");
+    const global = { fast: { "*": "generic-fast" } };
+    const withOverrides = resolveAgentProfile("claude", { platform: "claude" }, global);
+    expect(withOverrides?.globalModelAliases).toEqual(global);
+    const withoutOverrides = resolveAgentProfile("claude", undefined, global);
+    expect(withoutOverrides?.globalModelAliases).toEqual(global);
+  });
+
+  test("resolveProfileFromConfig threads the config-root modelAliases table", async () => {
+    const { resolveProfileFromConfig } = await import("../../src/integrations/agent/config");
+    const config = {
+      modelAliases: { fast: { claude: "claude-haiku-4-5-20251001" } },
+      profiles: { agent: { claude: { platform: "claude" as const } } },
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: partial config shape for the seam under test
+    const profile = resolveProfileFromConfig("claude", config as any);
+    expect(profile?.globalModelAliases).toEqual(config.modelAliases);
+  });
+});
+
+// ── Integration: builder resolves through the global tier table ──────────────
+
+describe("builder + globalModelAliases integration", () => {
+  test("claudeBuilder resolves a global tier alias", async () => {
+    const { getCommandBuilder } = await import("../../src/integrations/agent/builders");
+    const builder = getCommandBuilder("claude");
+    const profile = makeClaudeProfile({
+      globalModelAliases: { fast: { claude: "claude-haiku-4-5-20251001" } },
+    });
+    const cmd = builder.build(profile, { prompt: "go", model: "fast" });
+    const argv = cmd.argv as string[];
+    expect(argv[argv.indexOf("--model") + 1]).toBe("claude-haiku-4-5-20251001");
+  });
+
+  test("profile.modelAliases beats globalModelAliases in the builder", async () => {
+    const { getCommandBuilder } = await import("../../src/integrations/agent/builders");
+    const builder = getCommandBuilder("opencode");
+    const profile = makeOpencodeProfile({
+      modelAliases: { fast: "opencode/profile-wins" },
+      globalModelAliases: { fast: { opencode: "opencode/global-loses" } },
+    });
+    const cmd = builder.build(profile, { prompt: "go", model: "fast" });
+    const argv = cmd.argv as string[];
+    expect(argv[argv.indexOf("--model") + 1]).toBe("opencode/profile-wins");
+  });
+});

--- a/tests/agent/agent-spawn.test.ts
+++ b/tests/agent/agent-spawn.test.ts
@@ -308,3 +308,54 @@ describe("runAgent — argument and env construction", () => {
     expect(capturedEnv?.AKM_EVENT_SOURCE).toBe("task");
   });
 });
+
+describe("runAgent — cooperative abort (RunAgentOptions.signal, P0.5)", () => {
+  test("pre-aborted signal returns reason 'aborted' without spawning", async () => {
+    let spawnCalled = false;
+    const spawn: SpawnFn = () => {
+      spawnCalled = true;
+      throw new Error("must not spawn");
+    };
+    const controller = new AbortController();
+    controller.abort();
+    const result = await runAgent(makeProfile(), "task", { spawn, signal: controller.signal });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("aborted");
+    expect(spawnCalled).toBe(false);
+  });
+
+  test("aborting mid-run kills the child and maps to reason 'aborted'", async () => {
+    // Fake timers so the 5s SIGKILL follow-up never leaves a live timer.
+    const fakeSet = ((cb: () => void) => {
+      void cb;
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    }) as unknown as typeof setTimeout;
+    const fakeClear = (() => {}) as unknown as typeof clearTimeout;
+
+    const { spawn } = fakeSpawnFn({ exitCode: 0, hangsUntilKilled: true });
+    const controller = new AbortController();
+    const promise = runAgent(makeProfile(), "go", {
+      spawn,
+      setTimeoutFn: fakeSet,
+      clearTimeoutFn: fakeClear,
+      timeoutMs: null,
+      signal: controller.signal,
+    });
+    // Let runAgent register the abort listener, then abort.
+    await new Promise((r) => setTimeout(r, 5));
+    controller.abort();
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("aborted");
+    expect(result.error).toContain("aborted by caller signal");
+  });
+
+  test("a clean fast exit is not misreported when the signal aborts afterwards", async () => {
+    const { spawn } = fakeSpawnFn({ exitCode: 0, stdout: "done" });
+    const controller = new AbortController();
+    const result = await runAgent(makeProfile(), "go", { spawn, signal: controller.signal });
+    controller.abort(); // after completion — listener already removed
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+});

--- a/tests/agent/agent-spawn.test.ts
+++ b/tests/agent/agent-spawn.test.ts
@@ -359,3 +359,40 @@ describe("runAgent — cooperative abort (RunAgentOptions.signal, P0.5)", () => 
     expect(result.reason).toBeUndefined();
   });
 });
+
+describe("runAgent — dispatch.cwd is consumed (P0.5)", () => {
+  function captureSpawnOpts() {
+    const captured: { cwd?: string }[] = [];
+    const spawn: SpawnFn = (_argv, opts) => {
+      captured.push({ cwd: (opts as { cwd?: string } | undefined)?.cwd });
+      return {
+        exitCode: null,
+        exited: Promise.resolve(0),
+        stdout: asReadableStream(""),
+        stderr: asReadableStream(""),
+        pid: 1234,
+        kill() {},
+      } as unknown as SpawnedSubprocess;
+    };
+    return { spawn, captured };
+  }
+
+  test("dispatch.cwd reaches the spawn options when options.cwd is absent", async () => {
+    const { spawn, captured } = captureSpawnOpts();
+    await runAgent(makeProfile({ name: "claude", bin: "claude" }), undefined, {
+      spawn,
+      dispatch: { prompt: "go", cwd: "/tmp/unit-workdir" },
+    });
+    expect(captured[0]?.cwd).toBe("/tmp/unit-workdir");
+  });
+
+  test("options.cwd wins over dispatch.cwd", async () => {
+    const { spawn, captured } = captureSpawnOpts();
+    await runAgent(makeProfile({ name: "claude", bin: "claude" }), undefined, {
+      spawn,
+      cwd: "/tmp/options-wins",
+      dispatch: { prompt: "go", cwd: "/tmp/dispatch-loses" },
+    });
+    expect(captured[0]?.cwd).toBe("/tmp/options-wins");
+  });
+});

--- a/tests/config-schema-single-source.test.ts
+++ b/tests/config-schema-single-source.test.ts
@@ -83,3 +83,38 @@ describe("AkmConfig derives from the Zod schema (single source of truth)", () =>
     expect(parsed.profiles?.improve?.default?.processes?.graphExtraction?.fullScan).toBe(false);
   });
 });
+
+// ── Config-root modelAliases (global model tiers) ─────────────────────────────
+
+describe("modelAliases config validation", () => {
+  test("root modelAliases table and per-profile modelAliases parse", () => {
+    const result = AkmConfigSchema.safeParse({
+      modelAliases: {
+        fast: { claude: "claude-haiku-4-5-20251001", "*": "haiku" },
+        deep: { "*": "claude-opus-4-7" },
+      },
+      profiles: {
+        agent: {
+          claude: { platform: "claude", modelAliases: { quick: "claude-haiku-4-5-20251001" } },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.modelAliases?.fast?.["*"]).toBe("haiku");
+      expect(result.data.profiles?.agent?.claude?.modelAliases?.quick).toBe("claude-haiku-4-5-20251001");
+    }
+  });
+
+  test("non-string leaf values are rejected loudly", () => {
+    const result = AkmConfigSchema.safeParse({
+      modelAliases: { fast: { claude: 42 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("empty alias or platform keys are rejected", () => {
+    expect(AkmConfigSchema.safeParse({ modelAliases: { "": { claude: "x" } } }).success).toBe(false);
+    expect(AkmConfigSchema.safeParse({ modelAliases: { fast: { "": "x" } } }).success).toBe(false);
+  });
+});

--- a/tests/core/concurrent.test.ts
+++ b/tests/core/concurrent.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for `concurrentMap` — the bounded worker pool the workflow
+ * scheduler generalizes (P0.5). Previously untested despite indexer use.
+ *
+ * Covered:
+ *   • Order-preserving results at bounded concurrency.
+ *   • Individual failures leave `undefined` without cancelling siblings.
+ *   • The concurrency cap is actually enforced.
+ *   • Abort: no NEW items are claimed after the signal fires; in-flight
+ *     calls complete.
+ */
+import { describe, expect, test } from "bun:test";
+import { concurrentMap } from "../../src/core/concurrent";
+
+describe("concurrentMap", () => {
+  test("maps all items, preserving index order", async () => {
+    const results = await concurrentMap([1, 2, 3, 4], async (n) => n * 10, 2);
+    expect(results).toEqual([10, 20, 30, 40]);
+  });
+
+  test("an individual failure leaves undefined and does not cancel others", async () => {
+    const results = await concurrentMap(
+      [1, 2, 3],
+      async (n) => {
+        if (n === 2) throw new Error("boom");
+        return n;
+      },
+      3,
+    );
+    expect(results).toEqual([1, undefined, 3]);
+  });
+
+  test("enforces the concurrency cap", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await concurrentMap(
+      Array.from({ length: 8 }, (_, i) => i),
+      async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await new Promise((r) => setTimeout(r, 5));
+        inFlight--;
+      },
+      3,
+    );
+    expect(peak).toBeLessThanOrEqual(3);
+    expect(peak).toBeGreaterThan(1);
+  });
+
+  test("abort stops claiming new items; in-flight items complete", async () => {
+    const controller = new AbortController();
+    const started: number[] = [];
+    const results = await concurrentMap(
+      Array.from({ length: 10 }, (_, i) => i),
+      async (i) => {
+        started.push(i);
+        if (i === 1) controller.abort();
+        await new Promise((r) => setTimeout(r, 5));
+        return i;
+      },
+      2,
+      { signal: controller.signal },
+    );
+    // Workers claimed at most one more item after the abort (the claim that
+    // was already past the check); the tail was never started.
+    expect(started.length).toBeLessThanOrEqual(4);
+    expect(results.filter((r) => r !== undefined).length).toBe(started.length);
+    expect(results[9]).toBeUndefined();
+  });
+
+  test("pre-aborted signal maps nothing", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let calls = 0;
+    const results = await concurrentMap(
+      [1, 2, 3],
+      async (n) => {
+        calls++;
+        return n;
+      },
+      2,
+      { signal: controller.signal },
+    );
+    expect(calls).toBe(0);
+    expect(results).toEqual([undefined, undefined, undefined]);
+  });
+});

--- a/tests/core/structured.test.ts
+++ b/tests/core/structured.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for `runStructured` — the transport-free structured-output core
+ * (P0.5 seam for the workflow engine's schema units).
+ *
+ * Covered:
+ *   • First-attempt success (no retry, no feedback).
+ *   • Parse miss → corrective feedback → success on retry.
+ *   • Validation miss → validator errors surface in the feedback.
+ *   • Exhausted attempts return a typed failure (never throws).
+ *   • Transport errors propagate untouched (transports own their retries).
+ *   • Default parser tolerates fenced/prose-wrapped JSON.
+ */
+import { describe, expect, test } from "bun:test";
+import { runStructured, type StructuredValidation } from "../../src/core/structured";
+
+interface Finding {
+  file: string;
+  summary: string;
+}
+
+function validateFinding(candidate: unknown): StructuredValidation<Finding> {
+  if (typeof candidate !== "object" || candidate === null) {
+    return { ok: false, errors: ["expected an object"] };
+  }
+  const record = candidate as Record<string, unknown>;
+  const errors: string[] = [];
+  if (typeof record.file !== "string") errors.push("file: expected string");
+  if (typeof record.summary !== "string") errors.push("summary: expected string");
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, value: { file: record.file as string, summary: record.summary as string } };
+}
+
+describe("runStructured", () => {
+  test("first-attempt success passes no feedback and reports attempts: 1", async () => {
+    const feedbacks: (string | undefined)[] = [];
+    const result = await runStructured({
+      dispatch: async (feedback) => {
+        feedbacks.push(feedback);
+        return '{"file":"a.ts","summary":"ok"}';
+      },
+      validate: validateFinding,
+    });
+    expect(result).toEqual({ ok: true, value: { file: "a.ts", summary: "ok" }, attempts: 1 });
+    expect(feedbacks).toEqual([undefined]);
+  });
+
+  test("parse miss retries with corrective feedback and succeeds", async () => {
+    const feedbacks: (string | undefined)[] = [];
+    const responses = ["total prose, no json here", '{"file":"b.ts","summary":"fixed"}'];
+    const result = await runStructured({
+      dispatch: async (feedback) => {
+        feedbacks.push(feedback);
+        return responses.shift() ?? "";
+      },
+      validate: validateFinding,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.attempts).toBe(2);
+    expect(feedbacks[1]).toContain("no parseable JSON");
+  });
+
+  test("validation miss feeds the validator's errors back to the transport", async () => {
+    const feedbacks: (string | undefined)[] = [];
+    const responses = ['{"file":123}', '{"file":"c.ts","summary":"now valid"}'];
+    const result = await runStructured({
+      dispatch: async (feedback) => {
+        feedbacks.push(feedback);
+        return responses.shift() ?? "";
+      },
+      validate: validateFinding,
+    });
+    expect(result.ok).toBe(true);
+    expect(feedbacks[1]).toContain("file: expected string");
+    expect(feedbacks[1]).toContain("summary: expected string");
+  });
+
+  test("exhausted attempts return the FINAL attempt's typed failure", async () => {
+    let calls = 0;
+    const result = await runStructured({
+      dispatch: async () => {
+        calls++;
+        return '{"file": 42}';
+      },
+      validate: validateFinding,
+      maxAttempts: 3,
+    });
+    expect(calls).toBe(3);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("validation_error");
+      expect(result.attempts).toBe(3);
+      expect(result.raw).toBe('{"file": 42}');
+    }
+  });
+
+  test("maxAttempts: 1 disables retry entirely", async () => {
+    let calls = 0;
+    const result = await runStructured({
+      dispatch: async () => {
+        calls++;
+        return "nope";
+      },
+      validate: validateFinding,
+      maxAttempts: 1,
+    });
+    expect(calls).toBe(1);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("parse_error");
+  });
+
+  test("transport errors propagate — runStructured owns only structure retries", async () => {
+    await expect(
+      runStructured({
+        dispatch: async () => {
+          throw new Error("connection refused");
+        },
+        validate: validateFinding,
+      }),
+    ).rejects.toThrow("connection refused");
+  });
+
+  test("default parser handles fenced and prose-wrapped JSON", async () => {
+    const result = await runStructured({
+      dispatch: async () => 'Here you go:\n```json\n{"file":"d.ts","summary":"fenced"}\n```\nHope that helps!',
+      validate: validateFinding,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.file).toBe("d.ts");
+  });
+
+  test("custom buildFeedback overrides the default corrective message", async () => {
+    const feedbacks: (string | undefined)[] = [];
+    const responses = ["prose", '{"file":"e.ts","summary":"ok"}'];
+    await runStructured({
+      dispatch: async (feedback) => {
+        feedbacks.push(feedback);
+        return responses.shift() ?? "";
+      },
+      validate: validateFinding,
+      buildFeedback: ({ reason }) => `CUSTOM:${reason}`,
+    });
+    expect(feedbacks[1]).toBe("CUSTOM:parse_error");
+  });
+});

--- a/tests/opencode-sdk-runner.test.ts
+++ b/tests/opencode-sdk-runner.test.ts
@@ -245,3 +245,68 @@ describe("buildSdkConfig — model alias resolution", () => {
     expect(cfg.model).toBe("akm-custom/qwen3-30b-a3b");
   });
 });
+
+// ── P0.5 seams: usage + sessionId + cooperative abort ─────────────────────────
+
+describe("runOpencodeSdk — usage/sessionId seams (P0.5)", () => {
+  const profile: AgentProfile = {
+    name: "opencode-sdk",
+    bin: "",
+    args: [],
+    stdio: "captured",
+    envPassthrough: [],
+    parseOutput: "text",
+    sdkMode: true,
+  };
+
+  test("token usage from the AssistantMessage is surfaced (previously discarded)", async () => {
+    const capture: PromptCapture = {};
+    const fake = makeFakeServer(capture, async () => ({
+      data: {
+        info: { tokens: { input: 120, output: 45, reasoning: 7 } },
+        parts: [{ type: "text", text: "answer" }],
+      },
+    }));
+    __setTestServer(fake.server as never);
+    const result = await runOpencodeSdk(profile, "hi", {});
+    expect(result.ok).toBe(true);
+    expect(result.usage).toEqual({ inputTokens: 120, outputTokens: 45, reasoningTokens: 7 });
+    expect(result.sessionId).toBe("sess-1");
+  });
+
+  test("missing token info yields no usage field, not a crash", async () => {
+    const capture: PromptCapture = {};
+    const fake = makeFakeServer(capture);
+    __setTestServer(fake.server as never);
+    const result = await runOpencodeSdk(profile, "hi", {});
+    expect(result.ok).toBe(true);
+    expect(result.usage).toBeUndefined();
+    expect(result.sessionId).toBe("sess-1");
+  });
+
+  test("abort mid-prompt returns reason 'aborted' and reaps the session", async () => {
+    const capture: PromptCapture = {};
+    const fake = makeFakeServer(capture, () => new Promise(() => {})); // never resolves
+    __setTestServer(fake.server as never);
+    const controller = new AbortController();
+    const promise = runOpencodeSdk(profile, "hi", { timeoutMs: null, signal: controller.signal });
+    await new Promise((r) => setTimeout(r, 5));
+    controller.abort();
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("aborted");
+    expect(fake.deletedRef()).toBe(true);
+  });
+
+  test("pre-aborted signal short-circuits before any session is created", async () => {
+    const capture: PromptCapture = {};
+    const fake = makeFakeServer(capture);
+    __setTestServer(fake.server as never);
+    const controller = new AbortController();
+    controller.abort();
+    const result = await runOpencodeSdk(profile, "hi", { signal: controller.signal });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("aborted");
+    expect(capture.body).toBeUndefined();
+  });
+});

--- a/tests/opencode-sdk-runner.test.ts
+++ b/tests/opencode-sdk-runner.test.ts
@@ -186,3 +186,62 @@ describe("runOpencodeSdk — #564 bug fix (3): timeout enforcement", () => {
     expect(res.reason).toBeUndefined();
   });
 });
+
+// ── buildSdkConfig — model alias resolution on the SDK path ──────────────────
+
+describe("buildSdkConfig — model alias resolution", () => {
+  const baseProfile: AgentProfile = {
+    name: "opencode-sdk",
+    bin: "",
+    args: [],
+    stdio: "captured",
+    envPassthrough: [],
+    parseOutput: "text",
+    sdkMode: true,
+  };
+
+  test("profile.modelAliases resolves before the SDK config is built", async () => {
+    const { buildSdkConfig } = await import("../src/integrations/harnesses/opencode-sdk/sdk-runner");
+    const cfg = buildSdkConfig({
+      ...baseProfile,
+      model: "fast",
+      modelAliases: { fast: "anthropic/claude-haiku-4-5" },
+    });
+    expect(cfg.model).toBe("anthropic/claude-haiku-4-5");
+  });
+
+  test("global tier table resolves via the opencode-sdk platform column, then '*'", async () => {
+    const { buildSdkConfig } = await import("../src/integrations/harnesses/opencode-sdk/sdk-runner");
+    const viaColumn = buildSdkConfig({
+      ...baseProfile,
+      model: "deep",
+      globalModelAliases: { deep: { "opencode-sdk": "anthropic/claude-opus-4-7", "*": "wrong" } },
+    });
+    expect(viaColumn.model).toBe("anthropic/claude-opus-4-7");
+    const viaStar = buildSdkConfig({
+      ...baseProfile,
+      model: "deep",
+      globalModelAliases: { deep: { "*": "anthropic/claude-opus-4-7" } },
+    });
+    expect(viaStar.model).toBe("anthropic/claude-opus-4-7");
+  });
+
+  test("unaliased model passes through verbatim; unqualified model gets akm-custom prefix with endpoint", async () => {
+    const { buildSdkConfig } = await import("../src/integrations/harnesses/opencode-sdk/sdk-runner");
+    const plain = buildSdkConfig({ ...baseProfile, model: "anthropic/claude-sonnet-4-6" });
+    expect(plain.model).toBe("anthropic/claude-sonnet-4-6");
+    const prefixed = buildSdkConfig({ ...baseProfile, model: "my-local-model", endpoint: "http://localhost:1234/v1" });
+    expect(prefixed.model).toBe("akm-custom/my-local-model");
+  });
+
+  test("alias resolving to an unqualified string still gets akm-custom prefix with endpoint", async () => {
+    const { buildSdkConfig } = await import("../src/integrations/harnesses/opencode-sdk/sdk-runner");
+    const cfg = buildSdkConfig({
+      ...baseProfile,
+      model: "fast",
+      modelAliases: { fast: "qwen3-30b-a3b" },
+      endpoint: "http://localhost:1234/v1",
+    });
+    expect(cfg.model).toBe("akm-custom/qwen3-30b-a3b");
+  });
+});


### PR DESCRIPTION
## Summary

Implements the **P0.5 — seam alignment** phase of [`docs/technical/akm-workflows-orchestration-plan.md`](https://github.com/itlackey/akm/blob/main/docs/technical/akm-workflows-orchestration-plan.md) (formalized 2026-07-05). Every item is a bugfix or additive seam — no new features, no behavior change for correctly-configured setups — fitting the 0.9 hardening scope. These are the prerequisites the P1 `akm workflow run` engine builds on.

### Commits (each independently gated)

1. **Global model-alias tiers + dropped-config fixes** (`ec78ac89`)
   - New config-root `modelAliases` key: `alias → { platform: model, "*": fallback }`, resolved between per-profile aliases and built-ins. Workflows/callers can say `--model deep` and get the right model string per harness.
   - Fixes `resolveAgentProfile` silently dropping user-configured per-profile `modelAliases` (same bug class as the earlier `timeoutMs` fix) and adds the missing field to `AgentProfileConfigSchema`.
   - The OpenCode SDK runner now resolves `profile.model` through `resolveModel` (aliases were dead on the default native harness); SDK config assembly extracted to a pure, tested `buildSdkConfig`.

2. **Registry-derived builders; missing builder = loud error** (`00727a96`)
   - `AkmHarness` gains `agentBuilder`; `BUILTIN_BUILDERS` is derived from `HARNESS_REGISTRY` (id, `<id>-headless`, aliases) instead of hand-maintained.
   - Dispatching codex/gemini/aider now raises `ConfigError` with a `commandBuilder` hint instead of silently building a wrong-flag-shape command. Custom profiles keep the documented default-builder fallback. Interactive launch is unaffected.

3. **Runner seams: usage/sessionId + AbortSignal** (`a482c4e3`)
   - `AgentRunResult` gains `usage`/`sessionId`; `RunAgentOptions` gains `signal` with SIGTERM→SIGKILL discipline and a new `aborted` failure reason (distinct from `timeout` so budget preemption is tellable from wall-clock expiry).
   - `runOpencodeSdk` stops discarding AssistantMessage token accounting (verified against pinned `@opencode-ai/sdk` 1.2.20 types) — the seam that makes workflow `budget.maxTokens` meterable.

4. **cwd wiring + reserved dispatch fields** (`d83b2747`)
   - `AgentDispatchRequest.cwd` was declared but consumed by nothing — now flows into the spawn cwd; `akm agent --cwd` added. Reserved `effort`/`schema` fields documented as not-yet-consumed.

5. **Core primitives** (`4e3333d3`)
   - `runStructured<T>` — transport-free validation-retry loop in `core/` (respects the enforced `agent ⇏ llm` layering), the convergence point for llm/agent/sdk structured output in P1.
   - `concurrentMap` gains additive `{signal}` — workers stop claiming items on abort; in-flight items complete.

### Deliberate deferral

The SDK server-per-cwd refactor (plan open seam decision 1) is deferred — it only matters for P4 `isolation: worktree`, and the plan records the cheaper interim (route isolated units to the CLI runner).

### Verification

`bun run check` fully green: biome + tsc clean, **5459 unit / 0 fail** (8 process shards), **743 integration / 0 fail** (34 gated skips). JSON config schema regenerated. New coverage: alias-tier resolution, registry derivation + error path, abort semantics (CLI + SDK), usage extraction, `runStructured`, `concurrentMap` (both previously untested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVWNxS3btKHgpMzz5QJEHT