### PR TITLE
Implement stash organization conventions (SPEC-1..8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`fable` built-in model alias** — resolves to `claude-fable-5`
   (`opencode/claude-fable-5` on opencode); recommended resolution target for
   the `deep` workflow model tier.
+- **`akm lint` now checks the frontmatter xref channels for broken refs.**
+  The existing `missing-ref` check additionally scans the `xrefs:`,
+  `supersededBy:`, and `contradictedBy:` frontmatter keys of non-wiki markdown
+  assets (memories, knowledge, lessons, facts, agents, commands, skills,
+  workflows) — the channels the stash back-linking conventions route
+  provenance and correction links through, and previously the only ref channel
+  with zero checking. Dangling refs are flagged with a detail naming the key
+  (`missing ref: <ref> (frontmatter <key>; resolved to <relPath>)`). The
+  `refs: []` body-scan carve-out does not suppress the new pass; `lint_skip:
+  [missing-ref]` suppresses both; non-ref values (URLs, `raw/<slug>`,
+  `<placeholder>` templates, shell vars) are ignored; refs resolving in a
+  configured extra stash root stay clean. **Note for `--fail-on-flagged` CI
+  users:** stashes with already-dangling xrefs (e.g. from past renames) will
+  gain new `missing-ref` findings on upgrade — fix the refs or add
+  `lint_skip: [missing-ref]` per file. `sources:`, `source_refs:`, and
+  `evidenceSources:` are deliberately not checked (wiki `sources:` is covered
+  by `akm wiki lint`; the latter two legitimately point at merged-away
+  assets).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   with. The conventions' `description:`/`when_to_use:` orientation routing
   remains primary — this flag makes body openings additionally pay retrieval
   rent, it does not replace structured metadata. See `docs/configuration.md`.
+- **`akm mv <ref> <new-name>` — rename with inbound-xref rewrite and
+  utility-history preservation (Experimental).** The stash conventions'
+  forced-rename procedure ("grep and fix inbound xrefs in the same pass") was
+  agent-executable except for the part only the CLI can do: a rename used to
+  mint a new index row, orphaning the `utility_scores` /
+  `utility_scores_scoped` / embeddings / salience rows keyed by entry id —
+  the "rename resets learned ranking" cost the conventions warn about. The
+  new verb does the whole pass: it moves the file (a memory's `.derived.md`
+  twin moves together, keeping the `entry_key + ".derived"` belief-inheritance
+  coupling), rewrites inbound refs across the writable stash's markdown files
+  — body prose, frontmatter ref-list keys (`xrefs:`/`refs:`/`supersededBy:`/
+  …), and fenced code blocks — with complete-ref boundary matching (a longer
+  ref sharing the old ref as a prefix is untouched), and re-keys the index
+  row **in place** so the row id and every id-keyed ranking table survive;
+  the moved row and rewritten citers are FTS-refreshed so search reflects the
+  new name immediately. Scope v1: flat-markdown asset types (`memory`,
+  `knowledge`, `command`, `agent`, `workflow`, `lesson`, `session`, `fact`)
+  in the primary writable stash only, and the source ref must be the
+  canonical spelling — a ref that resolves only through one of lint's
+  fallback resolutions (knowledge-subdir alias, direct-path) is rejected
+  naming the canonical ref, since a fallback-keyed move would strand the
+  index row and dangle canonical citers. Wiki refs, cross-type targets,
+  existing targets, unresolvable refs, type-root escapes, `.derived` twin
+  refs as the source (rename the base — the twin follows), and target names
+  ending in `.derived` (reserved twin suffix) are rejected with the
+  standard envelope (exit 2, nothing moved). Read-only sources are scanned
+  but never written — their citing files are reported in `readOnlyCiters` as
+  manual follow-ups. Output:
+  `{ok, from, to, rewrote: [{file, count}], readOnlyCiters, utilityPreserved}`;
+  a successful move appends an `mv` event. The operation spans FS + DB and is
+  not transactional, but its ordering (plan rewrites → apply citer edits →
+  rename last → re-key index last) makes an interrupted run safely
+  re-runnable; with no local index built, the rename still succeeds and the
+  next `akm index` picks it up, and `utilityPreserved: false` discloses when
+  an existing index could not be re-keyed (the ranking history then resets
+  on the next full index). Added to the v1 §9.4 command surface as an
+  Experimental-tier additive entry (see `STABILITY.md`).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   returns an additive `hint` output key pointing at the stash's placement
   conventions (`fact:conventions/organization` when that fact exists), so CLI
   writers see the conventions that LLM flows already receive by injection.
+- **`--supersedes <ref>` on `akm remember` and `akm import` — atomic
+  correction + demotion of the superseded asset.** The stash conventions'
+  corrections pattern needs TWO writes (the new correction asset with an xref
+  to what it corrects, plus a metadata edit demoting the old asset), which
+  previously meant hand-editing the old file's frontmatter and remembering to
+  reindex it. The new repeatable flag does both: the correction is written
+  with the old ref folded into its `xrefs:` (correction provenance), and the
+  old asset gains `beliefState: superseded` +
+  `supersededBy: [<new ref>]` via the shared `writeSupersededEdge` primitive
+  (sibling of `writeContradictEdge`) — a metadata-only frontmatter edit that
+  preserves every other key and the body byte-for-byte, sorted-set-appended
+  and idempotent across re-runs. The mutated old file is reindexed by the
+  write path, so `--belief current` hides it and ranking demotes it
+  immediately. An unresolvable ref is input validation: exit 2 with the
+  standard `{ok:false,error,code}` envelope and NOTHING written or demoted
+  (no partial correction); a ref resolving to the asset being written itself
+  (self-supersede via `--force` overwrite) is rejected the same way instead
+  of letting a correction demote itself. An old asset that resolves only
+  outside the write target and the working stash (in a read-only source, or
+  in a writable source that is not this write's target) is not mutated: the
+  correction still writes, stderr warns, and the JSON output reports the
+  additive `superseded: [{ref, applied: false, reason}]` key (`applied: true`
+  on success) — the reason names the `--target` remedy when one exists. An
+  old asset whose existing frontmatter is not parseable YAML is likewise
+  skipped (`applied: false`) rather than rewritten through the lossy lenient
+  parser. On a git write target the demotion is ordered before the
+  batch-at-boundary commit, so the correction and the demoted old asset land
+  in one commit.
 
 ### Changed
 
@@ -177,6 +205,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   --refresh`. Embeddings are not regenerated when indexed text changes; the
   drift here is small (the merged tokens already appear in the name field),
   but a purge/re-embed picks up the new text exactly.
+- **Demoting belief states now cap an entry's final search score**
+  (superseded ≤ 0.25, contradicted ≤ 0.2, archived ≤ 0.15, deprecated ≤
+  0.28). The existing additive belief penalties are applied inside the
+  multiplicative boost sum on a min-max-normalized FTS base (rank-1 vs rank-2
+  base can differ by up to 0.7), so a superseded incumbent that was the best
+  keyword match stayed clamp-pinned at 1.0 above its own correction — the
+  demotion was invisible exactly when the corrections pattern needs it. The
+  ceiling is applied once at the end of the single scoring pipeline (sort
+  order and displayed scores stay consistent); demoted entries remain listed
+  under the default `--belief all`, keep their relative ordering, and the
+  `--belief` filter axis is unchanged. Semantic-only hits are judged against
+  the `search.minScore` floor by their pre-ceiling score, so a ceiling below
+  the floor (archived 0.15 < default 0.2) ranks the hit last instead of
+  silently dropping it. Ordering changes only for stashes containing
+  belief-flagged assets.
+- **`mutateFrontmatter` (belief-edge writers: supersede/contradict edges,
+  belief refresh) now preserves the body bytes verbatim** when the file
+  already has a frontmatter block, instead of re-normalizing the
+  fence-to-body separator through `assembleAsset`. A metadata edit is no
+  longer a (whitespace-level) content edit; files gaining their first
+  frontmatter block still use the canonical shape.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   parser. On a git write target the demotion is ordered before the
   batch-at-boundary commit, so the correction and the demoted old asset land
   in one commit.
+- **Ref-prefix search queries — `akm search "<type>:<prefix>/"` now enumerates
+  that subtree.** A query shaped like a ref prefix (trailing slash required:
+  `memory:projectA/`; a bare `memory:` lists the whole type) translates to a
+  typed index enumeration narrowed to entry names under the prefix, instead of
+  degenerating into the AND-token FTS query its sanitized form used to produce
+  (`"memory projectA"` — noise, since `entry_type` is not an FTS column). The
+  listing is recursive and `/`-boundary exact (`projectA/` cannot leak a
+  sibling `projectAlpha/…` scope), matches names case-insensitively (the CLI
+  lowercases queries; on-disk scope directories may carry mixed case), and
+  composes with `--limit`, `--belief`, `--filter`, and named `--source`
+  narrowing exactly like the existing empty-query enumeration — hits carry the
+  fixed browse score `1` in deterministic listing order, not a relevance
+  ranking. The parsed type is explicit intent: a bare `session:` enumerates
+  sessions just like `--type session` (the default session exclusion is an
+  untyped-path policy), while an explicit `--type` flag always wins over the
+  type parsed from the query (the branch fires only on untyped searches). A
+  full ref without the trailing slash (`memory:projectA/auth-tip`) stays an
+  ordinary keyword search — resolving a single ref is `akm show`'s job.
+  **Stable-surface note:** `akm search` is Stable; this changes results for a
+  query shape that previously returned noise or nothing. A user literally
+  keyword-searching for the string `memory:x/` loses the old fuzzy token
+  behavior — accepted as negligible.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   and a real domain asset always outranks the facts. That invariant is pinned
   by `tests/search-convention-fact-demotion.test.ts`, which becomes the
   regression guard if a demotion contributor is ever revisited.
+- **Config-gated indexing of the self-situating body opening —
+  `index.indexBodyOpening` (default `false`).** Body prose is not indexed
+  (the FTS `content` column carries only TOC headings and parameters), which
+  is why the stash conventions route orientation into
+  `description:`/`when_to_use:`. With the new flag enabled, the metadata pass
+  captures the first prose paragraph of each markdown asset body — skipping
+  headings (ATX and setext), fenced code blocks, thematic breaks, and a
+  leading nested frontmatter block (only when its content is actually
+  frontmatter-shaped: prose wrapped in decorative `---` lines is captured,
+  not discarded); capped at 280 chars with word-boundary truncation and a
+  trailing ellipsis — into `entry.bodyOpening`, which folds into the
+  lowest-weight `content` FTS column (bm25 weight 1.0, so a name match always
+  outranks a body-opening-only match) and into the search/embedding text.
+  Secret and env files are never read for it, and session-kind memories
+  (`akm_memory_kind` in outer or nested inner frontmatter) are excluded —
+  their bodies are raw transcripts. Both indexing walks and write-path
+  indexing honor the flag (the metadata pass reads the user config directly).
+  With the flag absent or `false`, entries and search fields stay
+  byte-identical to before. **Costs of toggling (either direction):** indexed
+  text changes, so collapse-detector canary recall baselines shift — re-mint
+  via `akm improve canary --refresh` — and embeddings are NOT regenerated for
+  entries that already have one, while incremental runs re-extract only
+  changed files. Run `akm index --full` after toggling: it re-extracts every
+  entry and wipes embeddings so they rebuild from the new text; until then
+  `akm index` warns that the flag differs from the state the index was built
+  with. The conventions' `description:`/`when_to_use:` orientation routing
+  remains primary — this flag makes body openings additionally pay retrieval
+  rent, it does not replace structured metadata. See `docs/configuration.md`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   query shape that previously returned noise or nothing. A user literally
   keyword-searching for the string `memory:x/` loses the old fuzzy token
   behavior — accepted as negligible.
+- **The `category:` frontmatter key is now captured into the index** as
+  `entry.category` (entry_json only — no schema migration). The key already
+  drives convention-fact prompt injection (`resolveStashStandards`) and the
+  fact linter, but the indexer never captured it, so no category-keyed search
+  or ranking policy was implementable. Captured for all markdown asset types
+  alongside `beliefState` (trimmed; blank/non-string values ignored; no
+  default invented), and whitelisted through the `.stash.json` entry
+  round-trip. Search results and ranking are unchanged — this is capture
+  only (a unit test pins that `category` never enters the FTS search
+  fields). **Requires a reindex to take effect** for existing entries. The
+  companion rank-time demotion of `category: convention` facts on untyped
+  queries was NOT shipped: the prescribed measurement (full skeleton
+  convention facts plus a real `knowledge/auth` asset, untyped `auth` query,
+  semantic off) shows no crowding — FTS is exact-first, so prefix expansion
+  onto the facts' tokens only happens when nothing matches the query exactly,
+  and a real domain asset always outranks the facts. That invariant is pinned
+  by `tests/search-convention-fact-demotion.test.ts`, which becomes the
+  regression guard if a demotion contributor is ever revisited.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   by `akm wiki lint`; the latter two legitimately point at merged-away
   assets).
 
+### Changed
+
+- **Directory (scope/domain) tokens now always merge into `tags` at index
+  time**, even when an asset sets explicit `tags:` frontmatter. Previously
+  explicit tags suppressed all path-derived tags, so a nested asset like
+  `memory:projectA/auth-tip` with `tags: [auth]` silently lost the exact
+  tag-match ranking boost for its scope token unless the author restated it.
+  The merged tokens come from the canonical ref subpath
+  (`extractDirTagsFromName`), which also fixes the flat-walk indexing path
+  losing directory segments in the empty-tags fallback. Filename tokens are
+  still auto-derived only when `tags` is empty (they already live in the FTS
+  name column and aliases), and the empty-tags fallback itself is unchanged.
+  **Operator notes:** the change takes effect on the next reindex and alters
+  indexed tag text for nested assets with explicit tags, so collapse-detector
+  canary recall baselines may shift — re-mint them with `akm improve canary
+  --refresh`. Embeddings are not regenerated when indexed text changes; the
+  drift here is small (the merged tokens already appear in the name field),
+  but a purge/re-embed picks up the new text exactly.
+
 ### Fixed
 
 - **Check-in directives now survive plain-text output and `workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `evidenceSources:` are deliberately not checked (wiki `sources:` is covered
   by `akm wiki lint`; the latter two legitimately point at merged-away
   assets).
+- **`--xref <ref>` on `akm remember` and `akm import` — write-time
+  cross-references with validation.** The stash back-linking conventions route
+  provenance and associative links through `xrefs:` frontmatter, but neither
+  CLI write flow could express them (remember always generated its own
+  frontmatter block; import wrote content verbatim). The new repeatable flag
+  records refs in the written asset's `xrefs:` frontmatter list, which the
+  indexer folds into search hints — the new asset becomes findable from
+  searches for its source. `remember` merges the refs into its generated
+  frontmatter (composes with `--tag`/scope flags; does not trigger the
+  tags-required check); `import` dedupe-appends into the document's existing
+  frontmatter, or adds a block when the document has none — never a nested
+  second block. A document whose existing frontmatter is not a parseable YAML
+  mapping aborts the import (exit 2, nothing written) rather than being
+  rewritten lossily; importing it without `--xref` still preserves it
+  verbatim. Every ref is validated before anything is written, against the
+  write target plus all configured sources (read-only cross-stash sources
+  count): an unresolvable ref fails with the standard usage envelope (exit 2)
+  and leaves the stash untouched. The conventions' ~5-xref cap stays soft —
+  exceeding it warns on stderr but still writes. Additionally, a type-root
+  write (no `--path`, flat name) into a stash carrying convention facts now
+  returns an additive `hint` output key pointing at the stash's placement
+  conventions (`fact:conventions/organization` when that fact exists), so CLI
+  writers see the conventions that LLM flows already receive by injection.
 
 ### Changed
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -95,6 +95,14 @@ for scripted use.
 - **Memory belief-state transitions** — `captureMode`, `beliefState`,
   contradiction edges, and the consolidate journal are observable but
   the algorithm that writes them is tuning across patch releases.
+- **`akm mv`** — rename an asset within its type directory in the primary
+  writable stash, with inbound-ref rewrite across the stash's markdown files
+  and an in-place index re-key that preserves the asset's accumulated
+  usage-ranking history. New verb (an Experimental-tier additive entry on the
+  v1 §9.4 command surface): the JSON output shape
+  (`from`/`to`/`rewrote`/`readOnlyCiters`/`utilityPreserved`), the supported
+  asset-type set, and the validation rules may change while the rename flow
+  matures.
 - **`akm workflow run` + YAML workflow programs** — orchestrated workflows
   are written as YAML programs (`workflows/*.yaml`, `version: 1`, validated
   against `schemas/akm-workflow.json`) with `${{ … }}` expressions, per-step

--- a/docs/agents/AGENTS.full.md
+++ b/docs/agents/AGENTS.full.md
@@ -11,6 +11,8 @@ akm search "<query>" --source both            # Also search registries for insta
 akm search "<query>" --source registry        # Search registries only
 akm search "<query>" --limit 10               # Limit results
 akm search "<query>" --detail full            # Include scores, paths, timing
+akm search "memory:projectA/"                 # Enumerate a typed subtree (ref-prefix; trailing slash required)
+akm search "knowledge:"                       # List every asset of a type
 akm curate "<task>"                          # Curate the best matches for a task
 ```
 
@@ -22,6 +24,12 @@ akm curate "<task>"                          # Curate the best matches for a tas
 | `--format` | `json`, `jsonl`, `text`, `yaml` | `json` |
 | `--detail` | `brief`, `normal`, `full` | `brief` |
 | `--shape` | `human`, `agent`, `summary` (`summary` only on `show`) | `human` |
+
+Ref-prefix queries (`"<type>:<prefix>/"` or a bare `"<type>:"`) return a
+deterministic listing, not a relevance ranking. A full ref without the
+trailing slash (`memory:projectA/auth-tip`) stays an ordinary keyword search —
+resolving a single ref is `akm show`'s job — and an explicit `--type` flag
+wins over the type parsed from the query.
 
 ## Show
 
@@ -183,6 +191,28 @@ akm clone "npm:@scope/pkg//script:deploy.sh"  # Clone from remote package
 ```
 
 When `--dest` is provided, `akm setup` is not required first.
+
+## Move / Rename (Experimental)
+
+Rename an asset within its type directory in the primary writable stash. Prefer
+NOT renaming (a ref is chosen once); when a rename is forced, `akm mv` does the
+whole convention pass: it moves the file (a memory's `.derived.md` twin moves
+together), rewrites inbound refs across the writable stash — body prose,
+frontmatter ref lists (`xrefs:`/`refs:`/`supersededBy:`), and fenced examples —
+and re-keys the index row in place so the asset's learned ranking history
+survives.
+
+```sh
+akm mv memory:projectA/old-note projectA/new-note  # Rename; subdirectories allowed in the new name
+akm mv memory:solo memory:renamed-solo             # Same-type ref-shaped target also accepted
+```
+
+Wiki refs, cross-type targets, existing targets, `../` escapes, non-canonical
+source spellings (the error names the canonical ref), `.derived` twin sources
+(rename the base — the twin follows), and `.derived`-suffixed target names are
+rejected (exit 2, nothing moved). Read-only sources are scanned but never
+written — their citing files come back in `readOnlyCiters` as manual
+follow-ups. Verify with `akm lint` (missing-ref) afterwards.
 
 ## Sync
 

--- a/docs/agents/AGENTS.md
+++ b/docs/agents/AGENTS.md
@@ -8,6 +8,7 @@ You have access to a searchable library of scripts, skills, commands, agents, kn
 akm search "<query>"                          # Search for assets
 akm curate "<task>"                          # Curate the best matches for a task
 akm search "<query>" --type workflow          # Filter to workflow assets
+akm search "memory:projectA/"                 # List a typed subtree (ref-prefix query; trailing slash required)
 akm search "<query>" --source both            # Also search registries
 akm show <ref>                                # View asset details
 akm show knowledge:my-doc                    # Show a knowledge asset
@@ -24,6 +25,7 @@ akm wiki ingest <name>                        # Dispatch defaults.agent (or --pr
 akm feedback <ref> --positive|--negative      # Record whether an asset helped
 akm add <ref>                                 # Add a source (npm, GitHub, git, local dir)
 akm clone <ref>                               # Copy an asset to the working stash (optional --dest arg to clone to specific location)
+akm mv memory:old-note new-note               # Rename an asset: inbound refs rewritten, ranking history preserved
 akm sync                                      # Commit (and push if writable) the primary git stash
 akm sync my-skills -m "Update"               # Sync a named writable git stash
 akm registry search "<query>"                 # Search all registries

--- a/docs/archive/v1-architecture-spec.md
+++ b/docs/archive/v1-architecture-spec.md
@@ -731,6 +731,20 @@ hints | config *`.
 - `propose <type> <name> [--task ...]` — produce generation proposals into
   the proposal queue (§11, §12).
 
+**Shipped post-0.9 as Experimental-tier additions** (additive to this frozen
+surface — a new top-level command in v1.x only registers an output shape;
+renaming or removing it later is still major; see STABILITY.md):
+- `mv <ref> <new-name>` — rename an asset within its type directory in the
+  primary writable stash. Moves the file (a memory's `.derived.md` twin moves
+  together), rewrites inbound refs across the writable stash's markdown files
+  in the same pass, and re-keys the index row in place so the asset's
+  accumulated usage-ranking history (utility scores, embeddings, salience)
+  survives the rename. The source must be the asset's canonical ref spelling
+  (lint-resolver fallback spellings are rejected naming the canonical ref),
+  and a `.derived` twin can never move alone. Read-only sources are scanned
+  but never written; their citing files are reported as manual follow-ups.
+  Wiki refs are rejected (wikis carry their own xref + lint system).
+
 **`Planned for v1`** (declared by this spec, implemented across milestones
 0.9 – 1.0):
 - `agent <profile> [--prompt <text>] [--command <ref>] [--workflow <ref>] [args...]`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -883,22 +883,34 @@ What it does, in order (designed to be safely re-runnable if interrupted):
    e.g. a knowledge-subdir alias — the error names the canonical ref to
    use), a `.derived` twin ref as the source (rename the base; the twin
    moves with it), and target names ending in `.derived` (reserved
-   distilled-twin suffix). Supported types: `memory`, `knowledge`,
-   `command`, `agent`, `lesson`, `session`, `fact` (flat-markdown layouts;
-   multi-file `skill` directories are out of scope for now).
+   distilled-twin suffix). The deterministic `.md`-suffixed alias spelling
+   IS accepted — for the source ref and the target name alike — and is
+   canonicalized before anything is keyed off it (`akm mv memory:foo.md
+   bar.md` behaves exactly like `akm mv memory:foo bar`). Supported types:
+   `memory`, `knowledge`, `command`, `agent`, `lesson`, `session`, `fact`
+   (flat-markdown layouts; multi-file `skill` directories are out of scope
+   for now).
 2. **Plans the inbound-ref rewrite** across every markdown file in the
-   writable stash plus task `.yml`/`.yaml` files under `tasks/` (task YAML
-   carries refs in `workflow:`/`prompt:` keys) — body prose, frontmatter
+   writable stash plus `.yml`/`.yaml` files under `tasks/` (task YAML
+   carries refs in `workflow:`/`prompt:` keys) and under `workflows/`
+   (workflow YAML programs carry refs in their step/instructions text;
+   workflows are rewritten as *citers* even though `workflow:` refs cannot
+   themselves be moved) — body prose, frontmatter
    ref-list keys (`xrefs:`, `refs:`, `supersededBy:`, …, including
    flow-style lists like `xrefs: [memory:x]`), and fenced code blocks (a
    rename must not leave stale examples). Alias spellings the resolver
    treats as the same asset — the `.md`-suffixed form, the
    `local//`-prefixed form, and resolver-fallback forms like the
    knowledge-subdir basename alias — are rewritten to the new **canonical**
-   ref. Matching is complete-ref boundary matching: a longer ref that
-   shares the old ref as a prefix is untouched.
-3. **Applies the citer edits, then renames the file last.** A memory's
-   `.derived.md` twin moves together with its base.
+   ref, and a ref followed by sentence punctuation (`See memory:old.`) is
+   rewritten with the punctuation preserved. Matching is complete-ref
+   boundary matching: a longer ref that shares the old ref as a prefix is
+   untouched.
+3. **Creates the target's parent directory, applies the citer edits, then
+   renames the file last.** The parent-dir step comes first so a blocked
+   target (e.g. a path segment that exists as a file) aborts before any
+   citer has been edited. A memory's `.derived.md` twin moves together with
+   its base.
 4. **Re-keys the index row in place and refreshes search** — the new name and
    the rewritten citers are immediately findable, the row's `usage_events`
    history is re-pointed at the new ref (so it survives a later

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -849,6 +849,63 @@ When `--dest` is provided, the working stash (`AKM_STASH_DIR`) is not
 required. This makes clone usable in CI or fresh environments without
 running `akm setup` first.
 
+### mv (Experimental)
+
+Rename an asset **within its type directory** in the primary writable stash.
+`akm mv` is the CLI half of the stash conventions' forced-rename procedure
+("grep and fix inbound xrefs in the same pass"): it moves the file, rewrites
+inbound refs across the writable stash, and re-keys the search-index row **in
+place** — the row id survives, so the asset's accumulated usage-ranking
+history (utility scores, embeddings, salience) is preserved instead of
+resetting the way a delete-and-recreate rename would.
+
+```sh
+akm mv memory:projectA/old-note projectA/new-note   # Rename (target is a name; subdirectories allowed)
+akm mv memory:solo memory:renamed-solo              # Same-type ref-shaped target also accepted
+akm mv knowledge:guides/old guides/new              # Body refs, xrefs:/refs: lists, and fenced examples all rewritten
+```
+
+What it does, in order (designed to be safely re-runnable if interrupted):
+
+1. **Validates everything first** — a failure exits `2` with the standard
+   error envelope and moves nothing. Rejected: wiki refs (wikis have their
+   own xref + lint system — use `akm wiki lint`), cross-type targets
+   (`memory:` → `knowledge:`), an already-existing target, an unresolvable
+   source ref, targets escaping the type root (`../`), non-canonical source
+   spellings (a ref that resolves only through one of lint's fallback
+   resolutions, e.g. a knowledge-subdir alias — the error names the
+   canonical ref to use), a `.derived` twin ref as the source (rename the
+   base; the twin moves with it), and target names ending in `.derived`
+   (reserved distilled-twin suffix). Supported types: `memory`, `knowledge`,
+   `command`, `agent`, `workflow`, `lesson`, `session`, `fact`
+   (flat-markdown layouts; multi-file `skill` directories are out of scope
+   for now).
+2. **Plans the inbound-ref rewrite** across every markdown file in the
+   writable stash — body prose, frontmatter ref-list keys (`xrefs:`, `refs:`,
+   `supersededBy:`, …), and fenced code blocks (a rename must not leave stale
+   examples). Matching is complete-ref boundary matching: a longer ref that
+   shares the old ref as a prefix is untouched.
+3. **Applies the citer edits, then renames the file last.** A memory's
+   `.derived.md` twin moves together with its base.
+4. **Re-keys the index row in place and refreshes search** — the new name and
+   the rewritten citers are immediately findable. With no local index built
+   yet, the rename still succeeds (the index picks the file up on the next
+   `akm index`).
+
+Read-only sources are scanned but **never written**: their citing files are
+reported in `readOnlyCiters` as manual follow-ups.
+
+Output shape:
+`{ok, from, to, rewrote: [{file, count}], readOnlyCiters: [{file, count}], utilityPreserved}`.
+`utilityPreserved` is `false` when an existing index could not be re-keyed
+(unreadable/locked, or the moved file's row sat under an unexpected key) —
+the move still succeeds, but the asset's ranking history resets on the next
+`akm index`.
+A successful move appends an `mv` event to the events stream; a failed one
+appends nothing. Verify a rename dangled nothing with `akm lint` (its
+`missing-ref` check covers body text and the frontmatter xref channels).
+Listed as **Experimental** in `STABILITY.md`.
+
 ### sync
 
 Stage and commit local changes in a git-backed stash. If the stash has a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -336,7 +336,25 @@ akm search "deploy" --filter user=alice --filter agent=claude
 
 # Include proposal-queue entries (v1 spec §4.2):
 akm search "deploy" --include-proposed
+
+# Ref-prefix enumeration — list a typed subtree instead of keyword-matching:
+akm search "memory:projectA/"
+akm search "knowledge:"
 ```
+
+A query shaped like a **ref prefix** — `<type>:<prefix>/` with a trailing
+slash, or a bare `<type>:` — is not keyword-matched. It enumerates the type's
+entries whose names start with the prefix: `akm search "memory:projectA/"`
+lists exactly the `projectA/` subtree of memories (recursive, `/`-boundary
+exact — a sibling `projectAlpha/` scope does not leak), and `akm search
+"session:"` lists every session (the parsed type is explicit intent, so the
+default `session` exclusion — an untyped-path policy — does not apply). Hits
+carry the fixed browse score `1` in deterministic listing order, matching the
+empty-query enumeration contract, and compose with `--limit`, `--belief`,
+`--filter`, and named `--source` narrowing. A full ref without the trailing
+slash (`memory:projectA/auth-tip`) stays an ordinary keyword search — use
+`akm show` to resolve a single ref. An explicit `--type` flag wins over the
+type parsed from the query.
 
 | Flag | Values | Default | Description |
 | --- | --- | --- | --- |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -929,6 +929,11 @@ akm remember "Long meeting notes..." --enrich
 akm remember "Use staging cluster for blue-green" \
   --user alice --agent claude --run run-42 --channel "#ops"
 
+# Cite provenance / related assets in frontmatter `xrefs:` (validated at write time):
+akm remember "The token rotation quirk applies to staging too" \
+  --xref knowledge:auth/vendor-x-token-api \
+  --xref memory:projectA/token-quirk
+
 # Route the write to a specific writable stash (0.8.0+):
 akm remember "Deployment needs VPN access" --target team-stash
 
@@ -944,6 +949,7 @@ akm remember "Deployment needs VPN access" --wiki architecture
 | `--tag <v>` | Tag to attach to the memory. Repeatable: `--tag foo --tag bar` |
 | `--expires <dur>` | Expiry shorthand (`30d`, `12h`, `6m`). Resolved to an ISO date |
 | `--source <s>` | Free-form source reference — URL, asset ref, file path, or any string |
+| `--xref <ref>` | Cross-reference ref recorded in the memory's `xrefs:` frontmatter list. Repeatable: `--xref knowledge:auth-flow --xref memory:vpn-note`. Each ref must resolve in the write target or a configured source (read-only sources count); an unresolvable ref fails with exit 2 before anything is written. More than 5 refs warns (soft cap) but still writes. Does not trigger the tags-required check. |
 | `--auto` | Apply heuristic tagging from the body (opt-in, zero-latency, pure TS) |
 | `--enrich` | Call the configured LLM for tag/description proposals (opt-in, 10s timeout, fails soft) |
 | `--user <id>` | Scope this memory to a user id. Persisted as the canonical `scope_user` frontmatter key. |
@@ -972,6 +978,16 @@ multi-tenant / multi-agent contract; the same shape is read back by
 [Configuration → Memory scope](configuration.md#memory-scope) for the
 frontmatter schema and round-trip rules.
 
+**Cross-references** (`--xref`) implement the stash back-linking conventions'
+provenance channel: the refs land in the memory's `xrefs:` frontmatter list,
+which the indexer folds into the asset's search hints, so the new memory is
+findable from searches for its source. Refs are validated before anything is
+written — against the write target plus every configured source, including
+read-only cross-stash sources — so a typo'd ref fails fast (exit 2) instead
+of becoming permanent silent noise. When a write lands at the type root (no
+`--path`, flat name) in a stash that carries convention facts, the JSON output
+includes an additive `hint` key pointing at the stash's placement conventions.
+
 ### import
 
 Import a knowledge document. This writes a markdown file into `knowledge/` in
@@ -990,6 +1006,9 @@ akm import ./notes/release.txt --name release-checklist
 akm import - --name scratch-notes < notes.md
 akm import https://example.com/docs/auth
 
+# Cite provenance in the document's frontmatter `xrefs:` (validated at write time):
+akm import ./notes/oauth-quirks.md --xref knowledge:auth/vendor-x-token-api
+
 # Route the write to a specific writable stash (0.8.0+):
 akm import ./docs/auth-flow.md --target team-stash
 
@@ -1003,6 +1022,7 @@ akm import https://example.com/docs/auth --wiki research
 | `--name` | Optional knowledge name. Defaults to the source filename, URL path, or a slug from stdin content |
 | `--force` | Overwrite an existing knowledge document with the same name |
 | `--target <name>` | Override the write destination. Accepts a source name from your config; falls back to `defaultWriteTarget` then the working stash. |
+| `--xref <ref>` | Cross-reference ref merged into the document's `xrefs:` frontmatter list. Repeatable. A document without frontmatter gains a block; a document with valid frontmatter keeps every existing key and value and gets the refs dedupe-appended (never a nested second block). Each ref must resolve in the write target or a configured source; an unresolvable ref fails with exit 2 before anything is written. If the document's existing frontmatter is not a parseable YAML mapping, the import fails (exit 2) rather than rewriting the block lossily — fix the frontmatter or import without `--xref`, which preserves the file verbatim. |
 | `--wiki <name>` | Save the content into the named wiki directory (`wikis/<name>/raw/`) instead of `knowledge/`. The wiki must already exist (created with `akm wiki create`). |
 
 URL imports fetch only the exact page you pass, convert it to markdown, and do
@@ -1011,6 +1031,16 @@ the URL path (for example, `/docs/auth` -> `knowledge/docs/auth.md`).
 
 The source must be a readable file path, a reachable HTTP/HTTPS URL, or `-` to
 read the document from stdin.
+
+`--xref` behaves as on `remember` (validated refs, soft ~5 cap, additive
+`hint` output key on type-root writes), with one import-specific rule: because
+imported documents may already carry frontmatter, the refs are **merged** —
+existing keys are preserved and the `xrefs:` list is dedupe-appended, so the
+result always has exactly one frontmatter block. The merge requires the
+existing block to parse as a YAML mapping; a malformed block aborts the import
+(exit 2, nothing written) instead of silently flattening the values the parser
+could not read. Importing the same document *without* `--xref` always
+preserves it byte-for-byte.
 
 ### feedback
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -934,6 +934,11 @@ akm remember "The token rotation quirk applies to staging too" \
   --xref knowledge:auth/vendor-x-token-api \
   --xref memory:projectA/token-quirk
 
+# Correct an existing memory: write the fix AND demote the stale incumbent
+# (beliefState: superseded + supersededBy on the old asset, in one step):
+akm remember "Staging now uses the new gateway endpoint" \
+  --name new-endpoint --supersedes memory:projectA/old-endpoint
+
 # Route the write to a specific writable stash (0.8.0+):
 akm remember "Deployment needs VPN access" --target team-stash
 
@@ -950,6 +955,7 @@ akm remember "Deployment needs VPN access" --wiki architecture
 | `--expires <dur>` | Expiry shorthand (`30d`, `12h`, `6m`). Resolved to an ISO date |
 | `--source <s>` | Free-form source reference — URL, asset ref, file path, or any string |
 | `--xref <ref>` | Cross-reference ref recorded in the memory's `xrefs:` frontmatter list. Repeatable: `--xref knowledge:auth-flow --xref memory:vpn-note`. Each ref must resolve in the write target or a configured source (read-only sources count); an unresolvable ref fails with exit 2 before anything is written. More than 5 refs warns (soft cap) but still writes. Does not trigger the tags-required check. |
+| `--supersedes <ref>` | Ref of an existing asset this memory corrects. Repeatable. Writes the correction with the old ref folded into its `xrefs:` (correction provenance) AND demotes the old asset — `beliefState: superseded` + `supersededBy: [<new ref>]`, a metadata-only frontmatter edit that preserves every other key and the body — then reindexes it so ranking prefers the correction and `--belief current` hides the stale version immediately. An unresolvable ref fails with exit 2 before anything is written or demoted; so does a ref naming the asset being written itself (a correction cannot supersede itself, e.g. `--force` overwriting the same name). A ref that resolves only outside the write target and the working stash still writes the correction but skips the demotion: stderr warns and the JSON output reports `superseded: [{ref, applied: false, reason}]` — the reason names the `--target` remedy when the old asset lives in a configured writable source. An old asset whose existing frontmatter is not parseable YAML is skipped the same way (`applied: false`) instead of being rewritten lossily. Re-running the same correction is idempotent. On a git write target the correction and the demoted old asset land in the same single boundary commit. |
 | `--auto` | Apply heuristic tagging from the body (opt-in, zero-latency, pure TS) |
 | `--enrich` | Call the configured LLM for tag/description proposals (opt-in, 10s timeout, fails soft) |
 | `--user <id>` | Scope this memory to a user id. Persisted as the canonical `scope_user` frontmatter key. |
@@ -988,6 +994,19 @@ of becoming permanent silent noise. When a write lands at the type root (no
 `--path`, flat name) in a stash that carries convention facts, the JSON output
 includes an additive `hint` key pointing at the stash's placement conventions.
 
+**Corrections** (`--supersedes`) implement the conventions' two-write
+corrections pattern in one command: the new asset is written with an xref to
+what it corrects, and the old asset gets a metadata-only demotion
+(`beliefState: superseded` + `supersededBy: [<new ref>]`) that the write path
+reindexes immediately. The old asset is demoted only when it lives in the
+write target or the working stash — a match in any other configured source
+(read-only, or writable but not this write's target) is reported as
+`applied: false` (with a stderr warning) while the correction still writes;
+so is an old asset whose existing frontmatter is not parseable YAML, which a
+demotion rewrite would corrupt. Validation happens before any write, so a
+typo'd ref, or a ref naming the asset being written itself (exit 2), leaves
+both assets untouched — no partial correction.
+
 ### import
 
 Import a knowledge document. This writes a markdown file into `knowledge/` in
@@ -1009,6 +1028,9 @@ akm import https://example.com/docs/auth
 # Cite provenance in the document's frontmatter `xrefs:` (validated at write time):
 akm import ./notes/oauth-quirks.md --xref knowledge:auth/vendor-x-token-api
 
+# Import a corrected doc AND demote the one it replaces (in one step):
+akm import ./notes/modern-guide.md --supersedes knowledge:legacy-guide
+
 # Route the write to a specific writable stash (0.8.0+):
 akm import ./docs/auth-flow.md --target team-stash
 
@@ -1023,6 +1045,7 @@ akm import https://example.com/docs/auth --wiki research
 | `--force` | Overwrite an existing knowledge document with the same name |
 | `--target <name>` | Override the write destination. Accepts a source name from your config; falls back to `defaultWriteTarget` then the working stash. |
 | `--xref <ref>` | Cross-reference ref merged into the document's `xrefs:` frontmatter list. Repeatable. A document without frontmatter gains a block; a document with valid frontmatter keeps every existing key and value and gets the refs dedupe-appended (never a nested second block). Each ref must resolve in the write target or a configured source; an unresolvable ref fails with exit 2 before anything is written. If the document's existing frontmatter is not a parseable YAML mapping, the import fails (exit 2) rather than rewriting the block lossily — fix the frontmatter or import without `--xref`, which preserves the file verbatim. |
+| `--supersedes <ref>` | Ref of an existing asset this document corrects. Repeatable. Imports the correction with the old ref merged into its `xrefs:` AND demotes the old asset (`beliefState: superseded` + `supersededBy: [<new ref>]`, a metadata-only frontmatter edit), then reindexes it. Same validation (including the self-supersede rejection), skipped-demotion (`applied: false`), idempotence, and git-boundary-commit behaviour as on `remember` (see above). |
 | `--wiki <name>` | Save the content into the named wiki directory (`wikis/<name>/raw/`) instead of `knowledge/`. The wiki must already exist (created with `akm wiki create`). |
 
 URL imports fetch only the exact page you pass, convert it to markdown, and do

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -854,8 +854,10 @@ running `akm setup` first.
 Rename an asset **within its type directory** in the primary writable stash.
 `akm mv` is the CLI half of the stash conventions' forced-rename procedure
 ("grep and fix inbound xrefs in the same pass"): it moves the file, rewrites
-inbound refs across the writable stash, and re-keys the search-index row **in
-place** — the row id survives, so the asset's accumulated usage-ranking
+inbound refs across the writable stash, re-keys the search-index row **in
+place** (the row id survives, and the row's usage-event history is re-pointed
+at the new ref so it survives even a later `akm index --full`), and re-keys
+the `state.db` salience/outcome rows — the asset's accumulated usage-ranking
 history (utility scores, embeddings, salience) is preserved instead of
 resetting the way a delete-and-recreate rename would.
 
@@ -869,38 +871,53 @@ What it does, in order (designed to be safely re-runnable if interrupted):
 
 1. **Validates everything first** — a failure exits `2` with the standard
    error envelope and moves nothing. Rejected: wiki refs (wikis have their
-   own xref + lint system — use `akm wiki lint`), cross-type targets
-   (`memory:` → `knowledge:`), an already-existing target, an unresolvable
-   source ref, targets escaping the type root (`../`), non-canonical source
-   spellings (a ref that resolves only through one of lint's fallback
-   resolutions, e.g. a knowledge-subdir alias — the error names the
-   canonical ref to use), a `.derived` twin ref as the source (rename the
-   base; the twin moves with it), and target names ending in `.derived`
-   (reserved distilled-twin suffix). Supported types: `memory`, `knowledge`,
-   `command`, `agent`, `workflow`, `lesson`, `session`, `fact`
-   (flat-markdown layouts; multi-file `skill` directories are out of scope
-   for now).
+   own xref + lint system — use `akm wiki lint`), workflow refs (workflows
+   may be `.yaml`/`.yml` programs — rename the file manually under
+   `workflows/`, keeping its extension, fix inbound refs in the same pass,
+   and verify with `akm lint`), cross-type targets (`memory:` →
+   `knowledge:`), an already-existing target (including a memory target
+   whose orphaned `<name>.derived.md` twin still exists — a rename must not
+   silently adopt a stranger's distillation), an unresolvable source ref,
+   targets escaping the type root (`../`), non-canonical source spellings
+   (a ref that resolves only through one of lint's fallback resolutions,
+   e.g. a knowledge-subdir alias — the error names the canonical ref to
+   use), a `.derived` twin ref as the source (rename the base; the twin
+   moves with it), and target names ending in `.derived` (reserved
+   distilled-twin suffix). Supported types: `memory`, `knowledge`,
+   `command`, `agent`, `lesson`, `session`, `fact` (flat-markdown layouts;
+   multi-file `skill` directories are out of scope for now).
 2. **Plans the inbound-ref rewrite** across every markdown file in the
-   writable stash — body prose, frontmatter ref-list keys (`xrefs:`, `refs:`,
-   `supersededBy:`, …), and fenced code blocks (a rename must not leave stale
-   examples). Matching is complete-ref boundary matching: a longer ref that
+   writable stash plus task `.yml`/`.yaml` files under `tasks/` (task YAML
+   carries refs in `workflow:`/`prompt:` keys) — body prose, frontmatter
+   ref-list keys (`xrefs:`, `refs:`, `supersededBy:`, …, including
+   flow-style lists like `xrefs: [memory:x]`), and fenced code blocks (a
+   rename must not leave stale examples). Alias spellings the resolver
+   treats as the same asset — the `.md`-suffixed form, the
+   `local//`-prefixed form, and resolver-fallback forms like the
+   knowledge-subdir basename alias — are rewritten to the new **canonical**
+   ref. Matching is complete-ref boundary matching: a longer ref that
    shares the old ref as a prefix is untouched.
 3. **Applies the citer edits, then renames the file last.** A memory's
    `.derived.md` twin moves together with its base.
 4. **Re-keys the index row in place and refreshes search** — the new name and
-   the rewritten citers are immediately findable. With no local index built
-   yet, the rename still succeeds (the index picks the file up on the next
-   `akm index`).
+   the rewritten citers are immediately findable, the row's `usage_events`
+   history is re-pointed at the new ref (so it survives a later
+   `akm index --full`), and the `state.db` `asset_salience` /
+   `asset_outcome` rows (keyed by asset ref) move to the new ref too. With
+   no local index built yet, the rename still succeeds (the index picks the
+   file up on the next `akm index`).
 
 Read-only sources are scanned but **never written**: their citing files are
 reported in `readOnlyCiters` as manual follow-ups.
 
 Output shape:
-`{ok, from, to, rewrote: [{file, count}], readOnlyCiters: [{file, count}], utilityPreserved}`.
+`{ok, from, to, rewrote: [{file, count}], readOnlyCiters: [{file, count}], utilityPreserved, warnings?}`.
 `utilityPreserved` is `false` when an existing index could not be re-keyed
 (unreadable/locked, or the moved file's row sat under an unexpected key) —
 the move still succeeds, but the asset's ranking history resets on the next
-`akm index`.
+`akm index`. When any re-key could not be completed, the additive `warnings`
+array says why (index re-key failure, stranded row, or a `state.db`
+salience re-key failure).
 A successful move appends an `mv` event to the events stream; a failed one
 appends nothing. Verify a rename dangled nothing with `akm lint` (its
 `missing-ref` check covers body text and the frontmatter xref channels).

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -229,6 +229,16 @@ that subtree.
 or multi-team stashes. They survive renames, sort cleanly on disk, and
 require no configuration.
 
+**Which subdirectory?** Choose the partition axis by asset **type**:
+scope-born types (`memory`, `lesson`, `task`, `env`, `secret`) take the current
+**project/client** slug; reuse-born types (`knowledge`, `skill`, `wiki`, `fact`)
+take a stable **domain**. The full rules — depth limits, no-volatile-facets,
+off-axis facets as tags, and how to cross-link for retrieval — ship as the
+`fact:conventions/organization`, `fact:conventions/backlinks`, and
+`fact:conventions/domains` convention facts in the stash skeleton, and are
+surfaced to agents automatically at authoring time. See
+[design/stash-organization-conventions.md](design/stash-organization-conventions.md).
+
 Future iterations (no committed dates):
 
 - A `--namespace <ns>` flag will provide a thin name-prefix normalizer on

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -237,8 +237,11 @@ search — resolving a single ref is `akm show`'s job — and an explicit
 
 **Recommendation:** use physical subdirectories now to organize multi-project
 or multi-team stashes. They sort cleanly on disk and require no configuration.
-Treat the resulting ref as permanent — a rename breaks inbound refs and resets
-the asset's usage-ranking history.
+Treat the resulting ref as permanent — a raw file rename breaks inbound refs
+and resets the asset's usage-ranking history. When a rename is unavoidable,
+use `akm mv <ref> <new-name>` (Experimental): it rewrites inbound refs across
+the writable stash and re-keys the index row in place so the learned ranking
+history survives. See [cli.md](cli.md#mv-experimental).
 
 **Which subdirectory?** Choose the partition axis by asset **type**:
 scope-born types (`memory`, `lesson`, `task`, `env`, `secret`) take the current

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -226,8 +226,14 @@ knowledge/clientX/api-guide.md   →  knowledge:clientX/api-guide
 This works for **any** asset type. The subpath segments become part of the
 indexed name, so `akm search "projectA" --type memory` narrows results to
 that subtree, and `akm show memory:projectA/auth-tip` resolves the full ref.
-(There is no ref-prefix query syntax — `akm search "memory:projectA/"` does
-not filter.)
+There is also a **ref-prefix query syntax**: `akm search "memory:projectA/"`
+enumerates exactly that subtree (typed, recursive, `/`-boundary exact — a
+sibling `projectAlpha/` scope does not leak), and a bare `akm search
+"memory:"` lists the whole type. Ref-prefix hits are a deterministic listing
+with the fixed browse score `1`, not a relevance ranking. A full ref without
+the trailing slash (`memory:projectA/auth-tip`) stays an ordinary keyword
+search — resolving a single ref is `akm show`'s job — and an explicit
+`--type` flag always wins over the type parsed from the query.
 
 **Recommendation:** use physical subdirectories now to organize multi-project
 or multi-team stashes. They sort cleanly on disk and require no configuration.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -86,7 +86,7 @@ my-stash/
 
 ## Asset Types
 
-There are eleven asset types:
+There are fourteen asset types:
 
 | Type | Purpose | What the agent gets |
 | --- | --- | --- |
@@ -102,6 +102,8 @@ There are eleven asset types:
 | **lesson** | A distilled feedback lesson | `when_to_use` guidance plus the lesson body (see [`akm improve`](cli.md#improve)) |
 | **memory** | Context from external systems | Background information the agent should consider |
 | **fact** | A durable stash-level fact | Mostly-static semantic knowledge — personal/team/project details, coding conventions / "constitution", and stash-meta (naming conventions, active projects). `category` scopes it; `pinned: true` marks always-injected core context (see [design note](design/fact-asset-type.md)) |
+| **task** | A scheduled or on-demand automation task | Stored under `tasks/` |
+| **session** | An indexed session summary | Machine-placed under `sessions/<harness>/<id>.md`; excluded from untyped search by default |
 
 ### Classification Taxonomy
 
@@ -221,22 +223,27 @@ skills/projectB/lint-fix.md      →  skill:projectB/lint-fix
 knowledge/clientX/api-guide.md   →  knowledge:clientX/api-guide
 ```
 
-This works for **any** asset type. Search and show treat the prefixed name
-like any other ref, so `akm search "memory:projectA/"` narrows results to
-that subtree.
+This works for **any** asset type. The subpath segments become part of the
+indexed name, so `akm search "projectA" --type memory` narrows results to
+that subtree, and `akm show memory:projectA/auth-tip` resolves the full ref.
+(There is no ref-prefix query syntax — `akm search "memory:projectA/"` does
+not filter.)
 
 **Recommendation:** use physical subdirectories now to organize multi-project
-or multi-team stashes. They survive renames, sort cleanly on disk, and
-require no configuration.
+or multi-team stashes. They sort cleanly on disk and require no configuration.
+Treat the resulting ref as permanent — a rename breaks inbound refs and resets
+the asset's usage-ranking history.
 
 **Which subdirectory?** Choose the partition axis by asset **type**:
 scope-born types (`memory`, `lesson`, `task`, `env`, `secret`) take the current
-**project/client** slug; reuse-born types (`knowledge`, `skill`, `wiki`, `fact`)
-take a stable **domain**. The full rules — depth limits, no-volatile-facets,
-off-axis facets as tags, and how to cross-link for retrieval — ship as the
-`fact:conventions/organization`, `fact:conventions/backlinks`, and
-`fact:conventions/domains` convention facts in the stash skeleton, and are
-surfaced to agents automatically at authoring time. See
+**project/client** slug; reuse-born types (`knowledge`, `skill`, `wiki`,
+`fact`, `script`) take a stable **domain**; global types (`command`, `agent`,
+`workflow`) stay at the type root or a tool slug. The full rules — depth
+limits, no-volatile-facets, off-axis facets as tags, and how to cross-link for
+retrieval — ship as the `fact:conventions/organization`,
+`fact:conventions/backlinks`, and `fact:conventions/domains` convention facts
+in the stash skeleton, and are surfaced to agents automatically at authoring
+time. See
 [design/stash-organization-conventions.md](design/stash-organization-conventions.md).
 
 Future iterations (no committed dates):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,7 @@ in-place rewrite. Set `AKM_NO_AUTO_MIGRATE=1` to suppress the rewrite.
 | `index.metadataEnhance.enabled` | boolean | `false` | Toggles the `akm index` metadata-enhancement pass. Replaces the legacy `features.index.metadata_enhance` entry. |
 | `index.stalenessDetection.enabled` | boolean | `false` | Toggles the `akm index` staleness-detection pass. |
 | `index.stalenessDetection.thresholdDays` | integer | `90` | Days before a memory is re-evaluated for staleness. |
+| `index.indexBodyOpening` | boolean | `false` | Index the first prose paragraph of each markdown asset body (capped at 280 chars) into the lowest-weight `content` search column and the embedding text. Secret/env files and session-kind memories are never captured. Toggling changes indexed text — see [`index.*`](#index) for the costs. |
 | `semanticSearchMode` | `"off"` \| `"auto"` | `"auto"` | Semantic vector search mode. |
 | `embedding` | object | null (local) | Embedding connection settings. Unchanged from v1. |
 | `output.format` | string | `json` | Default output format (`json`, `text`, `yaml`). |
@@ -390,6 +391,23 @@ measuring with `scripts/akm-eval` + the health report.
 | `index.metadataEnhance.enabled` | `false` | LLM-driven description/tag enrichment during `akm index`. |
 | `index.stalenessDetection.enabled` | `false` | Run the staleness-detection validator pass during `akm index`. |
 | `index.stalenessDetection.thresholdDays` | `90` | Days before a memory is re-evaluated for staleness. |
+| `index.indexBodyOpening` | `false` | Capture the first prose paragraph of each markdown asset body into search. |
+
+`index.indexBodyOpening` (default `false`) captures the first prose paragraph
+of each markdown asset body — the stash conventions' "self-situating opening"
+— onto the indexed entry (capped at 280 chars, word-boundary truncated) and
+folds it into the lowest-weight `content` FTS column and the embedding text,
+so orientation prose becomes retrievable without ever outranking
+name/description/tag matches. Secret and env files are never read for it, and
+session-kind memories (the `akm_memory_kind` marker in outer or nested inner
+frontmatter) are excluded — their bodies are raw transcripts. **Costs of
+toggling (either direction):** indexed text changes, so (1) collapse-detector
+canary recall baselines shift — re-mint them with `akm improve canary
+--refresh`; and (2) embeddings are **not** regenerated for entries that
+already have one, and incremental runs only re-extract changed files — run
+`akm index --full` after toggling to re-extract every entry and rebuild
+embeddings from the new text. Until that full run happens, `akm index` warns
+that the flag differs from the state the index was built with.
 
 Any **other** key under `index` is treated as a per-pass entry (keyed by pass
 name, e.g. `index.graph`). Per-pass entries accept: `llm` (boolean — set

--- a/docs/design/stash-conventions-code-spec.md
+++ b/docs/design/stash-conventions-code-spec.md
@@ -1,6 +1,6 @@
 # Spec: code changes for the stash organization & back-linking conventions
 
-Status: proposed (specs only — no implementation in this change)
+Status: implemented (SPEC-1..8 landed 2026-07-11/12; SPEC-6 shipped capture-only — the rank-time demotion was dropped after the spec's own prescribed curate-golden measurement showed no crowding, with tests/search-convention-fact-demotion.test.ts pinning that invariant; see CHANGELOG.md for per-spec outcomes)
 Author: akm
 Date: 2026-07-11
 Companion: [stash-organization-conventions.md](stash-organization-conventions.md)

--- a/docs/design/stash-conventions-code-spec.md
+++ b/docs/design/stash-conventions-code-spec.md
@@ -1,0 +1,231 @@
+# Spec: code changes for the stash organization & back-linking conventions
+
+Status: proposed (specs only — no implementation in this change)
+Author: akm
+Date: 2026-07-11
+Companion: [stash-organization-conventions.md](stash-organization-conventions.md)
+
+## Overview
+
+Implementation specs for the code changes the finalized stash-organization/back-linking conventions imply. All file paths, functions, and line anchors below were verified against the working tree at /home/user/akm (branch claude/akm-stash-conventions-69633n). Key grounding corrections discovered during the survey: (1) `akm lint` ALREADY runs a deterministic broken-ref check (`missing-ref`, src/commands/lint/base-linter.ts:593-620) over BODY text and `refs:` frontmatter arrays for memories/knowledge/lessons/facts/agents/commands/skills/workflows — the conventions' "non-wiki xrefs have no broken-link lint" claim is precisely true only for the `xrefs:`/`supersededBy:`/`contradictedBy:` FRONTMATTER channel, which is exactly the channel the conventions mandate; so candidate #1 shrinks to a small, surgical extension of the existing check rather than a new lint system. (2) `akm remember` cannot express xrefs at all today — it always wraps content in its own generated frontmatter (buildMemoryFrontmatter, src/commands/remember.ts:87-117), so an agent following the mandatory-provenance rule through the CLI would produce nested frontmatter blocks; candidate #3 is therefore load-bearing, not sugar. (3) The path-tag suppression guard (metadata.ts:1113-1115) behaves differently on the two indexing paths: the flat walk passes `path.dirname(file)` as the tag root (metadata.ts:1194,1202), so even the empty-tags fallback sees NO directory segments there — the fix should derive scope/domain tokens from `canonicalName` (the ref subpath), which is uniform across both paths. (4) Embeddings are only generated for entries lacking one (db.ts:1561-1568); changing indexed text does NOT re-embed, which constrains specs 2 and 8. Argued down (with reasons in the relevant specs): non-wiki orphan lint (orphanhood is the legitimate normal state under the finalized conventions — associative xrefs discretionary, hubs optional, bidirectionality best-effort; a per-asset orphan flag would mark most of a healthy stash); non-wiki uncited-source lint (provenance is conditional per the finalized backlinks rule "an original observation with no source carries none — never invent provenance"; a deterministic checker cannot distinguish original from derived and would incentivize fabricated provenance, the exact failure mode the review killed); xrefs feeding the entity graph (the finalized text now teaches xrefs NEVER feed the graph and body prose is the channel; deterministic ref-token edges would pollute canonical entity names and re-open the rejected typed-provenance debate); typed `sources:` channel for all types (explicitly rejected by the judge as convention-ahead-of-mechanics — stays a design-doc open question); new consolidation/promotion code (none needed — resolveStashStandards already injects the amended convention facts into consolidate.ts:1510, extract.ts:1060, distill.ts:910, recombine.ts:676, procedural.ts:371, reflect via resolveStandardsContext, propose.ts:180, schema-repair.ts:181; correction demotion is covered by SPEC-5); and surfacing lint findings in `akm health` (health checks are runtime/state-db probes — lint already has its CI gate via --fail-on-flagged).
+
+## Specs
+
+| ID | Priority | Title | Sizing |
+|---|---|---|---|
+| SPEC-1 | P0 | Extend akm lint missing-ref to frontmatter xref channels (xrefs, supersededBy, contradictedBy) | S |
+| SPEC-2 | P0 | Merge path-derived scope/domain tokens into tags even when explicit tags exist | S |
+| SPEC-3 | P1 | --xref on akm remember and akm import with write-time ref resolution (+ type-root placement hint) | M |
+| SPEC-4 | P1 | Real ref-prefix filter: akm search "<type>:<prefix>/" translates to typed enumeration with name-prefix narrowing | M |
+| SPEC-5 | P1 | --supersedes on remember/import: atomic correction + demotion of the superseded asset | S |
+| SPEC-6 | P2 | Capture fact category into the index and demote category:convention facts at rank time | S |
+| SPEC-7 | P2 | akm mv: rename with inbound-xref rewrite and utility-history preservation | L |
+| SPEC-8 | P2 | Config-gated indexing of the self-situating body opening | M |
+
+### SPEC-1 — Extend akm lint missing-ref to frontmatter xref channels (xrefs, supersededBy, contradictedBy)
+
+**Priority:** P0 · **Sizing:** S — ~40 lines in one function plus tests; all helpers exist.
+
+**Problem.** The conventions route provenance and correction links through `xrefs:`/`supersededBy:` frontmatter, and warn that renames dangle non-wiki xrefs silently. Verified gap: BaseLinter.runBaseChecks scans only ctx.body (or the `refs:` frontmatter array when present) via checkMissingRefs (base-linter.ts:243-308, invoked at :608-620); the `xrefs:`, `supersededBy:`, and `contradictedBy:` keys are never validated for ANY asset type. Wikis get broken-xref lint (src/wiki/wiki.ts lintWiki, :919-1000) but only for intra-wiki refs. So the single channel the conventions mandate is the single channel with zero checking. Orphan and uncited-source checks for non-wiki assets are ARGUED DOWN: orphanhood is the sanctioned normal state (discretionary associative links, best-effort bidirectionality), and uncited-source is undecidable without knowing whether an asset is derived — flagging it would push agents toward fabricated provenance.
+
+**Convention rule served.** backlinks.md 'One xref is mandatory when the asset derives from another' + corrections/beliefState rules; organization.md 'Non-wiki inbound xrefs have no broken-link lint, so a rename dangles them silently'. Surface decision per mandate: akm lint (already the deterministic offline checker with missing-ref, CI-gated via --fail-on-flagged; health is runtime probes; the indexer must stay fail-open and non-judgmental).
+
+**Design.** In BaseLinter.runBaseChecks (src/commands/lint/base-linter.ts), inside the existing `shouldRun("missing-ref")` block (:608): add a frontmatter-key pass that runs REGARDLESS of the `refs:` body-scan carve-out (that carve-out governs only the body scan). For each key of ["xrefs", "supersededBy", "contradictedBy"]: read `ctx.data[key]` through the existing `readRefsArray` helper (:348-355); if non-null, run `checkMissingRefs(values.join("\n"), ctx.stashRoot, ctx.extraStashRoots)` and emit issue type `missing-ref` with detail `missing ref: <ref> (frontmatter <key>; resolved to <relPath>)`, fixed: false. No changes to REF_RE (:158), refToRelPath (:175), or refExistsInAnyStash (:195) — those are contract-locked with akm-plugins (header block :5-39). Non-ref-shaped values (URLs, `raw/<slug>`, `<placeholder>` templates, shell vars) fall out naturally via checkMissingRefs' existing guards (:259-297). All four md linters (KnowledgeLinter, MemoryLinter, DefaultLinter/lessons, FactLinter) inherit automatically since they route through runBaseChecks; wikis stay untouched ("wikis" absent from STASH_SUBDIRS, src/commands/lint/index.ts:37-47). `lint_skip: [missing-ref]` suppresses the new pass too (it lives inside the same shouldRun gate). Cross-stash refs resolve via extraStashRoots already plumbed from resolveSourceEntries (index.ts:106-109).
+
+**Files.**
+- `src/commands/lint/base-linter.ts`
+- `tests/lint.test.ts`
+
+**Contracts & stability.** ref-resolver contract (tests/contracts/ref-resolver-contract.test.ts + akm-plugins sister copy) untouched — no resolver behavior change. LintIssueType union unchanged (reuse missing-ref; consumers keyed on issue type see no new variant). AkmLintResult shape unchanged; `ok:true` semantics preserved (findings are flagged, never errors). akm lint is not in STABILITY.md's Stable list — additive detail-string change is safe.
+
+**Test plan.** tests/lint.test.ts, extending the existing 'missing-ref check' describe block (:476): (1) memory with `xrefs: [knowledge:auth/nonexistent]` → flagged, detail contains 'frontmatter xrefs'; (2) resolvable xref → clean; (3) `refs: []` (authoritative-empty) does NOT suppress the xrefs scan; (4) dangling `supersededBy:` → flagged; (5) URL and `<placeholder>` values in xrefs skipped; (6) `lint_skip: [missing-ref]` suppresses both body and frontmatter passes; (7) xref resolvable only in an extraStashRoot → clean. Run `bun test tests/lint.test.ts` + `bun test tests/contracts/ref-resolver-contract.test.ts`.
+
+**Risks.** Existing stashes with already-dangling xrefs get newly flagged — intended, but note in CHANGELOG so --fail-on-flagged CI users aren't surprised. `sources:` deliberately excluded (non-wiki sources: was rejected by the judge; wiki sources: are checked by lintWiki's broken-source). `source_refs:`/`evidenceSources:` excluded — they legitimately point at merged-away/pruned assets (historical provenance) and would be noise.
+
+### SPEC-2 — Merge path-derived scope/domain tokens into tags even when explicit tags exist
+
+**Priority:** P0 · **Sizing:** S — one helper + one merge line + tests; the cost is coordination (canaries, doc follow-up), not code.
+
+**Problem.** Verified footgun: extractTagsFromPath fires only when tags are empty (metadata.ts:1113-1115), so setting explicit tags silently drops the path scope/domain token from the tags FTS column (bm25 weight 3.0, db.ts:850) and from tagRankingContributor's exact-match boost (+0.15/token cap 0.3, ranking-contributors.ts:171-183) and from projectContextRankingContributor's tag field (:394-413). The finalized conventions work around this in prose ('restate the scope/domain token'), and the finalized unresolved-items list explicitly names 'always-merge path tags' as task-#6 intake. Additional verified defect: on the flat-walk path, buildEntryFromFile receives dirPath = path.dirname(file) (metadata.ts:1194→1202), so even the empty-tags fallback derives tags from the FILENAME only — directory segments are lost there today.
+
+**Convention rule served.** organization.md footgun bullet ('path and filename tokens are auto-added to tags only when tags is empty... you lose the tag-match ranking boost') + off-axis-facets-as-tags rule; design-doc unresolved intake item 'always-merge path tags'.
+
+**Design.** In buildEntryFromFile (src/indexer/passes/metadata.ts, around :1113-1117): (a) keep the empty-tags fallback `entry.tags = extractTagsFromPath(file, dirPath)` byte-identical (back-compat for aliases + collapse-detector canaries); (b) add an unconditional merge of DIRECTORY-segment tokens derived from `canonicalName` (the ref subpath — uniform across generateMetadata and generateMetadataFlat): new exported pure helper `extractDirTagsFromName(name: string): string[]` = name.split("/").slice(0, -1), each segment split on /[-_.]+/, lowercased, length > 1 (same tokenization as extractTagsFromPath :1337-1351). Insert `entry.tags = [...(entry.tags ?? []), ...extractDirTagsFromName(canonicalName)]` immediately before the existing `entry.tags = normalizeTerms(entry.tags ?? [])` at :1117, which dedupes. Filename tokens are deliberately NOT merged when explicit tags exist — they already live in the FTS name column at weight 10.0 and in aliases (buildAliases :1258), and merging them would inflate exact-tag matches for every filename word. Ranking impact assessed: entries with explicit tags in subdirectories gain the tag-match boost for their scope/domain token (the intended convention outcome); FTS tags column gains tokens already present in name (small bm25 delta); project-context boost unchanged in score (per-token hit counted once across fields). buildSearchText changes for affected entries → search_text/entry_json churn on next reindex.
+
+**Files.**
+- `src/indexer/passes/metadata.ts`
+- `tests/metadata.test.ts`
+- `tests/ranking-regression.test.ts (assert/adjust)`
+- `src/assets/stash-skeleton/facts/conventions/organization.md (follow-up: soften footgun bullet AFTER task #5 lands)`
+- `docs/design/stash-organization-conventions.md (strike the intake item)`
+
+**Contracts & stability.** No DB schema change (tags live in entry_json + FTS). R5 canary coordination REQUIRED: search-fields.ts:27-32 NOTE — changing tag content shifts collapse-detector recall baselines for existing canary sets; CHANGELOG must tell operators to re-mint via `akm improve canary --refresh`. Embeddings do NOT auto-regenerate on search_text change (db.ts:1561-1568 embeds only entries lacking a row) — drift is small here (duplicated name tokens) but note it.
+
+**Test plan.** tests/metadata.test.ts: (1) nested asset memories/projectA/auth-tip.md with explicit `tags: [auth]` → tags contain both 'auth' and 'projecta'; (2) root-level asset with explicit tags unchanged (pins the existing package.json-keywords assertion at :262-270, ['git','diff'] stays exact); (3) empty-tags nested asset unchanged vs today on the generateMetadata path; (4) flat-walk (generateMetadataFlat) nested asset now carries dir tokens; (5) author restating the token → deduped once. Ranking: extend tests/ranking-regression.test.ts or tests/ranking-contributor-ablation.test.ts with a scoped-memory-with-explicit-tags case asserting the tag boost fires for the path token.
+
+**Risks.** One-time index churn for every nested asset with explicit tags; canary re-mint burden on existing installs; the just-finalized convention text documents the OLD behavior ('you lose the tag-match ranking boost') — the follow-up doc edit must land in the same release or the injected fact teaches a stale model; multi-word dir segments (client-x) become two tags ('client','x'→'client' only, x dropped) — acceptable, matches existing tokenization.
+
+### SPEC-3 — --xref on akm remember and akm import with write-time ref resolution (+ type-root placement hint)
+
+**Priority:** P1 · **Sizing:** M — three command files, frontmatter merge logic on import, validation plumbing, and a wide test surface.
+
+**Problem.** The conventions make one xref mandatory for derived assets, but neither CLI write flow can express xrefs: `akm remember` always generates its own frontmatter block (buildMemoryFrontmatter, remember.ts:87-117) and prepends it to the body (remember-cli.ts:149-165, 241-253) — agent-supplied frontmatter would nest and be ignored by parseFrontmatter; `akm import` (stash-cli.ts:169-223) writes content verbatim with no xref channel. There is also no write-time check that a cited ref resolves — a typo'd provenance ref becomes permanent silent noise in FTS hints.
+
+**Convention rule served.** backlinks.md provenance rule ('cite the source ref... it also makes this asset findable from searches for its source') and the ~5 cap heuristic; mechanics: xrefs frontmatter folds into FTS hints for all md types via applyWikiFrontmatter (metadata.ts:609-626, called for all non-secret .md at :1064) — verified, so no indexer change is needed.
+
+**Design.** remember: add repeatable `--xref <ref>` collected via parseAllFlagValues("--xref") (existing pattern at remember-cli.ts:130). Extend MemoryFrontmatterFields and buildMemoryFrontmatter (src/commands/remember.ts:34-117) with `xrefs?: string[]` serialized as a YAML list (serializeFrontmatter already handles arrays). Validation before any write: for each xref, split type:name, resolve via refToRelPath + refExistsInAnyStash imported from ../lint/base-linter (cross-command import precedent: improve/preparation.ts:23, contribute-cli.ts:33) against [writeTarget.source.path, ...resolveSourceEntries(stashRoot, cfg) roots] (mirror lint/index.ts:106-109); any unresolvable ref → UsageError (exit 2, {ok:false,error,code} envelope) listing the bad refs with hint 'akm search "<slug>" --type <type>'. More than 5 xrefs → stderr warn only (SOFT cap stays soft). --xref counts as structured metadata (hasStructuredArgs) but does NOT trigger the tags-required check. import: same flag on importKnowledgeCommand (src/commands/sources/stash-cli.ts:169); since imported docs may carry their own frontmatter, merge BEFORE writeMarkdownAsset: parseFrontmatter(content) → dedupe-append xrefs → assembleAsset(data, body) (src/core/asset/asset-serialize.ts:62), so write-path indexing (knowledge.ts:192 indexWrittenAssets) sees final content. Placement hint (surfaces the conventions to CLI writers, who never receive resolveStashStandards injection): when the asset lands at the type root (no --path and the final name has no '/') and resolveStashStandards(source.path) returns non-empty, add additive JSON output key `hint: "Wrote to the <type> root. This stash has placement conventions — see akm show fact:conventions/organization"` (parallel to search's existing `tip` key). No write-target branching added anywhere — frontmatter assembly happens before writeAssetToSource, honoring the src/core/write-source.ts boundary.
+
+**Files.**
+- `src/commands/read/remember-cli.ts`
+- `src/commands/remember.ts`
+- `src/commands/sources/stash-cli.ts`
+- `src/commands/read/knowledge.ts (only if the hint is computed inside writeMarkdownAsset; otherwise untouched)`
+- `tests/remember-frontmatter.test.ts`
+- `tests/remember-unit.test.ts`
+- `tests/commands/remember.test.ts`
+- `tests/commands/import.test.ts`
+- `docs/cli.md`
+
+**Contracts & stability.** remember/import are Stable write commands (STABILITY.md) — new flags and a new top-level output key are additive; failure path uses the standard UsageError → exit 2 envelope. CLI-surface contract test (tests/contracts/v1-spec-section-9-4-cli-surface.test.ts) pins command NAMES only — unaffected. docs/cli.md needs the flag rows.
+
+**Test plan.** (1) remember --xref with resolvable ref → frontmatter contains xrefs list; subsequent `akm search <source-slug>` returns the new memory (hints fold verified end-to-end); (2) unresolvable --xref → exit 2, {ok:false,error,code}, nothing written; (3) six xrefs → warn on stderr, still writes; (4) import --xref onto a doc WITH existing frontmatter → merged, no duplicate keys, body intact; (5) import --xref onto frontmatter-less doc → block added; (6) type-root write with convention facts present → hint key emitted; with --path → no hint; on a skeleton-less stash → no hint; (7) envelope tests via tests/commands/*-envelope patterns.
+
+**Risks.** Hard-fail validation on a SOFT-convention channel: justified as input validation of an explicitly passed flag (precedent: --target rejects unknown source names), not convention enforcement — an agent that wants an unchecked ref can put it in the body. The commands/read → commands/lint import is established but slightly smelly; do NOT relocate refToRelPath/refExistsInAnyStash now (the contract test and akm-plugins sister pin the base-linter path); a later core/ extraction must move both contract tests in lockstep. Hint key adds minor output noise for scripted consumers — additive key, documented.
+
+### SPEC-4 — Real ref-prefix filter: akm search "<type>:<prefix>/" translates to typed enumeration with name-prefix narrowing
+
+**Priority:** P1 · **Sizing:** M — parser is trivial; the enumerate-path refactor plus doc/consistency coordination is the bulk.
+
+**Problem.** The idiom the conventions were originally written around does not exist: sanitizeFtsQuery (src/indexer/search/fts-query.ts:21-35) strips ':' and '/', and entry_type is not an FTS column, so `akm search "memory:projectA/"` degenerates to the AND-query 'memory projectA' (noise). Task #5 ships docs stating the negative; the finalized open-questions intake item 1 asks to make the natural idiom real: 'Detect type:prefix/-shaped queries in search and translate to entry_type + entry_key LIKE'.
+
+**Convention rule served.** Design-doc open-questions intake: 'Ref-prefix filter in code... making the natural idiom real (today it returns nothing)'; also restores deterministic subtree reconstruction for scope-born types (organization.md's 'akm search "projectA" --type memory' matches stray projectA tokens anywhere in name/tags/hints — prefix filtering is exact).
+
+**Design.** New pure helper in src/indexer/search/fts-query.ts: `parseRefPrefixQuery(query: string, knownTypes: readonly string[]): { type: string; namePrefix: string } | null`. Match rules (conservative): trimmed query must be exactly `<known-type>:` (namePrefix '') or `<known-type>:<prefix>/` — trailing slash REQUIRED for a non-empty prefix so bare refs like `memory:a/b` stay ordinary searches (that's `akm show` territory); type validated against getAssetTypes() (src/core/asset/asset-spec.ts) passed in by the caller to keep fts-query dependency-free. In searchDatabase (src/indexer/search/db-search.ts:280), before the hasSearchableTokens branch (:302) and only when `searchType === "any"` (an explicit --type flag wins): if parsed, take the existing empty-query enumerate path (:314-366) with typeFilter = parsed.type plus a new predicate `ie.entry.name.startsWith(parsed.namePrefix)` — refactor that block into a shared `enumerateEntries(opts)` helper with an optional namePrefix. getAllEntries (db.ts:904) already supports typed enumeration; in-memory prefix filtering is fine at stash scale (an entry_key LIKE SQL push-down is a later optimization — entry_key is `${stashDir}:${type}:${name}` per index-written-assets.ts:88, so LIKE needs care with stashDir colons). Downstream source/scope/quality/belief filters, dedupe, and limit reuse unchanged; hits carry score 1, mode 'keyword'. Registry search path untouched.
+
+**Files.**
+- `src/indexer/search/fts-query.ts`
+- `src/indexer/search/db-search.ts`
+- `tests/fts-query.test.ts`
+- `tests/db-scoring.test.ts or new tests/search-ref-prefix.test.ts`
+- `docs/concepts.md (amend the just-applied negative parenthetical)`
+- `docs/design/stash-organization-conventions.md (Review-round note + strike intake item)`
+- `CHANGELOG.md`
+
+**Contracts & stability.** akm search is Stable: this changes results for a query shape that today returns noise — additive in spirit but MUST get a CHANGELOG callout. The v1 §6 orchestration contract ('search consults the local FTS index; one query path') is respected — the enumerate path already exists and is index-backed. CRITICAL coordination with task #5: concepts.md will say 'There is no ref-prefix query syntax' and the docConsistency sweep greps for the dead idiom family — after this ships those exact sentences must flip to positive statements in the SAME PR, and the sweep's whitelist updated; convention facts may then re-adopt the idiom in a later doc pass (do not churn them immediately).
+
+**Test plan.** fts-query unit: known type + trailing slash parses; no trailing slash → null; unknown type → null; bare `wiki:` → {type:'wiki', namePrefix:''}; whitespace tolerance. Integration (sandboxed stash + index): `memory:projectA/` returns exactly the projectA subtree and nothing else; `memory:` equals `--type memory` enumeration; explicit `--type knowledge` + query `memory:a/` does NOT trigger the branch; session exclusion irrelevant (typed path); scope/belief/source filters compose; empty subtree → hits [] with the standard tip.
+
+**Risks.** curate's LLM-generated queries can now hit the branch — acceptable (deterministic subtree listing is strictly better than token noise). A user literally searching for the string 'memory:x/' loses fuzzy behavior — accepted, negligible. Enumeration ranking is insertion-ordered with score 1 (no utility ranking) — matches the existing empty-query contract; document it.
+
+### SPEC-5 — --supersedes on remember/import: atomic correction + demotion of the superseded asset
+
+**Priority:** P1 · **Sizing:** S — one ~15-line helper mirroring writeContradictEdge, flag plumbing shared with SPEC-3, plus tests.
+
+**Problem.** The finalized corrections pattern requires TWO writes: the new correction asset (with an xref to what it corrects) AND a metadata edit on the old asset (beliefState: superseded, supersededBy: [<new ref>]) so the ranker demotes the stale incumbent (beliefStateBoost -0.25, ranking-contributors.ts:107-123, fires for ANY flagged type). Today only improve's LLM flows write belief edges (writeContradictEdge, memory-belief.ts:59-73); an agent following the convention must hand-edit the old file's frontmatter and remember to reindex it. The finalized open-questions intake names 'Automate correction demotion' explicitly.
+
+**Convention rule served.** backlinks.md corrections bullet ('also set the old asset's beliefState: superseded and supersededBy: [<new ref>] — a metadata edit, not a content edit — so the ranker demotes the stale version') + fact.md mirror clause + intake item 'Automate correction demotion. curate/improve could set beliefState: superseded on the old asset when a correction cites it' (an explicit CLI flag is the deterministic version of that automation).
+
+**Design.** Add `--supersedes <ref>` (repeatable) to rememberCommand and importKnowledgeCommand. Flow: (1) validate each ref resolves (SPEC-3's resolver plumbing) and locate the target file; (2) require the file to live under the resolved WRITE TARGET's source.path (or the primary stash) — honoring the 'improve/lint only operate on writable sources' constraint; a match in a read-only extra root → stderr warn, new asset still written, JSON reports `superseded: [{ref, applied: false, reason}]`; (3) fold the superseded refs into the new asset's xrefs list automatically (correction provenance per the convention); (4) after writing the new asset, call new helper `writeSupersededEdge(filePath, supersededByRef)` — sibling of writeContradictEdge in src/commands/improve/memory/memory-belief.ts, built on mutateFrontmatter (src/core/asset/frontmatter.ts:143), idempotent, sets beliefState: 'superseded' and sorted-set-appends supersededBy; (5) reindex the mutated old file via indexWrittenAssets(source.path, [oldPath]) so demotion is immediately live (write-path indexing is the writer's job, knowledge.ts:190-192); (6) order the mutation BEFORE commitWriteTargetBoundary so git targets batch both files in one commit (knowledge.ts:189). Indexer support verified pre-existing: applyCuratedFrontmatter parses beliefState/supersededBy for all md types (metadata.ts:488-492); `--belief current` filtering already excludes superseded.
+
+**Files.**
+- `src/commands/read/remember-cli.ts`
+- `src/commands/sources/stash-cli.ts`
+- `src/commands/improve/memory/memory-belief.ts`
+- `src/commands/read/knowledge.ts (only for commit-boundary ordering if the mutation is done inside the write path)`
+- `tests/commands/remember.test.ts`
+- `tests/commands/import.test.ts`
+- `tests/belief-state-phase1a.test.ts (assert no regression)`
+
+**Contracts & stability.** Stable write commands — additive flags; new optional `superseded` JSON output key is additive. Does not touch the Experimental 'memory belief-state transitions' algorithm surface (it reuses the existing states verbatim). No write-target branching added — mutateFrontmatter edits a file in place under an already-resolved writable source.
+
+**Test plan.** (1) remember --supersedes memory:projectA/old → old file frontmatter gains beliefState: superseded + supersededBy: [memory:...new]; subsequent search ranks new above old; --belief current hides old; (2) idempotent re-run (same supersededBy entry not duplicated); (3) unresolvable ref → exit 2, nothing written; (4) old asset in read-only source → new asset written, applied:false reported; (5) new asset's xrefs include the superseded ref; (6) git write target: single batch commit contains both files.
+
+**Risks.** A write command mutating a SECOND file is new for remember/import — scoped strictly to metadata via the established mutateFrontmatter primitive; must not clobber unrelated frontmatter (mutateFrontmatter preserves other keys). Superseding a knowledge doc that is itself heavily cited leaves citers pointing at a demoted asset — correct per the convention (history preserved, demoted not deleted). Crash between write and mutation leaves the correction un-demoted — lint (SPEC-1) plus re-run idempotence make this recoverable.
+
+### SPEC-6 — Capture fact category into the index and demote category:convention facts at rank time
+
+**Priority:** P2 · **Sizing:** S — capture + one contributor + tests; the real cost is deciding the constant with eval data.
+
+**Problem.** Convention facts are delivered by prompt injection (resolveStashStandards selects by category, :24,71-107), yet they also compete in untyped search: their name/description/when_to_use tokens match domain-term queries via prefix expansion (buildPrefixQuery, fts-query.ts:44-58) and carry the fact TYPE_BOOST 0.22 (ranking-contributors.ts:11-22). Verified blocker: `category` is NOT captured onto StashEntry at all today (no mention in metadata.ts) — only FactLinter reads it from raw frontmatter — so neither demotion nor exclusion is currently implementable without a capture change.
+
+**Convention rule served.** Design-doc open-questions intake: 'Convention facts crowd domain-term queries... consider excluding category: convention facts from default untyped search (their delivery channel is prompt injection, parallel to the session default exclusion) or demoting the category at rank time.'
+
+**Design.** Two steps. (1) Capture: add `category?: string` to StashEntry (src/indexer/passes/metadata.ts, interface near :113), read it in applyCuratedFrontmatter (`asNonEmptyString(fmData.category)`, alongside beliefState at :488) and whitelist it in the coerceEntry function (:280-398 region, mirroring beliefState at :342-344). entry_json-only — no DB migration. (2) Rank: new `conventionFactRankingContributor` in src/indexer/search/ranking-contributors.ts — appliesTo: entry.type === 'fact' && entry.category === 'convention'; adjust: -0.25 (nets the fact TYPE_BOOST 0.22 to ~-0.03, i.e. convention facts rank like an unboosted asset instead of knowledge-tier). `category: meta` facts NOT demoted (active-projects canon must surface — SPEC-alignment with domains.md's 'category: meta fact' home for slug canon). Demotion chosen over default-exclusion: exclusion on a Stable read surface silently hides results and the existing opt-back-in (`--include-sessions`, db-search.ts:308-309) is TYPE-keyed, not category-keyed — a parallel category mechanism would grow flag surface for a hypothesized problem. Exact-name boost (+2.0) and `--type fact` keep the facts fully reachable when wanted.
+
+**Files.**
+- `src/indexer/passes/metadata.ts`
+- `src/indexer/search/ranking-contributors.ts`
+- `tests/ranking-contributor-ablation.test.ts`
+- `tests/fact-asset.test.ts`
+- `tests/metadata.test.ts`
+
+**Contracts & stability.** Search Stable surface: ordering shift only for convention facts on untyped queries — CHANGELOG note. Requires a reindex to take effect (entry_json) — note in CHANGELOG. No output-shape change. Collapse-detector canaries unaffected (FTS text unchanged — this is rank-time only).
+
+**Test plan.** (1) metadata: fact with category: convention → entry.category captured; roundtrip through coerceEntry; (2) ablation test: untyped 'auth' query over a fixture with knowledge:auth/x and fact:conventions/backlinks → knowledge ranks first; contributor absent → previous order (pins the delta); (3) exact-name query 'backlinks' still surfaces the fact top-3; (4) --type fact ordering among facts unchanged relative to each other except convention-vs-meta.
+
+**Risks.** Demotes user-authored convention facts they might genuinely search for — mitigated by exact-name and typed search; magnitude (-0.25) is a guess pending measurement — land AFTER a curate-golden measurement run (curate-golden-eval.test.ts) confirms crowding is real; if it isn't, drop this spec entirely (it is the most speculative of the intake items).
+
+### SPEC-7 — akm mv: rename with inbound-xref rewrite and utility-history preservation
+
+**Priority:** P2 · **Sizing:** L — new verb, FS+DB coordination, contract/spec/doc updates, wide test matrix.
+
+**Problem.** The conventions' forced-rename procedure ('grep and fix inbound xrefs in the same pass') is agent-executable EXCEPT for the part only the CLI can do: a rename mints a new entries row (entry_key UNIQUE, schema.ts:96; entry_key = `${stashDir}:${type}:${name}`, index-written-assets.ts:88) which orphans utility_scores / utility_scores_scoped rows keyed by entry_id (schema.ts:175-199) plus embeddings and salience — the verified 'rename resets learned ranking' cost the review added to the no-rename rule. Rename assistance is a mandatory-candidate #4 example.
+
+**Convention rule served.** organization.md 'A ref is chosen once. Default to not renaming... a renamed file is a new index entry, so the asset's accumulated usage-ranking history resets' + headline rule 'if forced, grep and fix inbound xrefs in the same pass'.
+
+**Design.** New top-level verb `akm mv <ref> <new-name>` (new src/commands/mv-cli.ts registered in src/cli.ts subCommands :540-579). Scope v1 to md asset types resolvable by refToRelPath, primary writable stash only (improve/lint constraint); wiki refs rejected (wiki has its own xref+lint system); memory refs move the `.derived.md` twin together (twin coupling pinned at db.ts:384-409 — entry_key suffix relation must survive). Steps: (1) resolve old ref → absolute path (refToRelPath + existence, base-linter helpers); (2) compute new path via resolveAssetPathFromName, guard isWithin(typeRoot) + target-not-exists; (3) fs.rename (and twin); (4) inbound rewrite across the writable stash's md files (reuse collectMarkdownFiles pattern from lint/index.ts:65): replace old-ref occurrences in body AND frontmatter ref-list keys (xrefs/refs/supersededBy/contradictedBy/source_refs/currentBeliefRefs) using REF_RE-style boundary matching; rewrite inside fenced blocks too (a rename must not leave stale examples); read-only sources are scanned but NOT written — their citing files are reported as manual follow-ups; (5) index re-key in place: UPDATE entries SET entry_key/file_path/dir_path/entry_json(name)/search_text WHERE id = <old id> — preserving id keeps utility_scores, utility_scores_scoped, embeddings, and asset_salience attached; mark FTS-dirty for the row; then indexWrittenAssets for every rewritten citer; (6) JSON report {ok, from, to, rewrote:[{file,count}], readOnlyCiters:[], utilityPreserved:true}; standard error envelope + exit codes on failure; appendEvent eventType 'mv'.
+
+**Files.**
+- `src/commands/mv-cli.ts (new)`
+- `src/cli.ts`
+- `src/indexer/db/db.ts (re-key helper)`
+- `src/commands/lint/base-linter.ts (import-only reuse)`
+- `tests/commands/mv.test.ts (new)`
+- `docs/technical/v1-architecture-spec.md (§9.4)`
+- `tests/contracts/v1-spec-section-9-4-cli-surface.test.ts (additive command entry)`
+- `docs/cli.md`
+- `STABILITY.md (list as Experimental)`
+
+**Contracts & stability.** HEAVIEST contract footprint of the set: §9.4 declares the command surface exhaustive, so adding `mv` requires the spec doc §9.4 edit + the contract test's command list (additive — the test only asserts presence, but the doc freeze is the governance step). Ship as Experimental in STABILITY.md. ref-resolver contract untouched (read-only reuse).
+
+**Test plan.** (1) e2e: move memory:projectA/old-name → memory:projectA/new-name with two citers (one body ref, one xrefs entry) → both rewritten; `akm lint` reports zero missing-ref afterward (SPEC-1 synergy); (2) utility preservation: record usage events pre-move (bumpUtilityScoresBatch path), assert post-move search still applies the utility boost to the moved asset (patterns in tests/coverage-hardening/db-utility-usage.test.ts); (3) .derived twin moves and stays belief-linked; (4) target-exists → exit 2, nothing moved; (5) read-only citer reported, not mutated; (6) fenced-block occurrence rewritten.
+
+**Risks.** Partial-failure atomicity (rename applied, rewrite interrupted) — mitigate by ordering: compute full rewrite plan first, apply file edits, rename last, re-key index last; still not transactional across FS+DB — document and make re-runnable. Graph tables key extractions by file path (graph_files) — stale until next graph pass; acceptable (graph is a derived cache). Highest-effort, lowest-frequency operation of the set — hence P2 despite high per-use value; sequence last.
+
+### SPEC-8 — Config-gated indexing of the self-situating body opening
+
+**Priority:** P2 · **Sizing:** M — extraction + fold are small; config/schema/contract/canary coordination dominates.
+
+**Problem.** Body prose is not FTS/embedding-indexed (content column = TOC headings + parameters only, search-fields.ts:63-73; embeddings built from the same field string via buildSearchText :83-88), so the conventions route orientation into description:/when_to_use:. The intake keeps the complementary code change open: 'Surface the first body paragraph into an indexed field (or embed body openings) so orientation prose pays retrieval rent.'
+
+**Convention rule served.** Design-doc open-questions intake item 'Index self-situating body text'; backlinks.md self-situating section (body header currently serves only the entity graph and human readers).
+
+**Design.** Minimal, gated: (1) metadata pass — in buildEntryFromFile's md branch (metadata.ts:1056-1072), extract the first non-heading, non-fence, non-empty paragraph of parsed.content, capped at 280 chars, into new StashEntry field `bodyOpening?: string` (skip secrets/env by existing guards; skip session-kind memories via the akm_memory_kind marker already recognized in base-linter patterns); (2) search fold — append bodyOpening to the `content` field (lowest bm25 weight 1.0) in buildSearchFields (search-fields.ts:63-73), NOT hints (hints carries xrefs/when_to_use and feeds no per-entry cap logic; content is the designated catch-all); (3) gate behind config `index.indexBodyOpening` (default false initially) because two verified costs trigger on ANY buildSearchFields change: the R5 collapse-detector canary baselines shift (search-fields.ts:27-32 — operators must `akm improve canary --refresh`), and embeddings do NOT regenerate for existing entries (db.ts:1561-1568 embeds only rows lacking an embedding) so semantic installs need an explicit purge/re-embed (purge helper exists at db.ts:176-189). Flip the default in a later minor once re-mint tooling and CHANGELOG guidance exist. Guardrail: this makes body headers ALSO pay rent — the shipped convention's description:/when_to_use: routing remains primary; do not re-teach body-only orientation.
+
+**Files.**
+- `src/indexer/passes/metadata.ts`
+- `src/indexer/search/search-fields.ts`
+- `src/core/config/config.ts (config key + schema)`
+- `schemas/ (config schema, via tests/contracts/config-schema-drift.test.ts expectations)`
+- `tests/metadata.test.ts`
+- `tests/fts-field-weighting.test.ts`
+
+**Contracts & stability.** config-schema-drift contract test must be updated with the new key (it pins the schema). Search Stable surface: results change only when the flag is on. Canary + embedding coordination as described — the CHANGELOG entry is part of the deliverable.
+
+**Test plan.** (1) extraction unit tests: heading-first bodies, fenced-first bodies, frontmatter-only files, 280-char cap, session memories skipped; (2) flag off → buildSearchFields byte-identical to today (pins the default); (3) flag on → FTS query matching an orientation-only phrase returns the asset via the content column; (4) fts-field-weighting test asserts name-match still outranks body-opening-match.
+
+**Risks.** Index size growth (bounded by cap); stale-embedding drift when the flag is toggled without purge — emit a warning from `akm index` when the flag state differs from the indexed state (store a meta key, pattern: setMeta 'hasEmbeddings' indexer.ts:375); most speculative retrieval win of the set — keep default-off until eval evidence (curate goldens) shows lift.
+
+## Sequencing
+
+Recommended order: SPEC-1 → SPEC-2 → SPEC-3 → SPEC-5 → SPEC-4 → SPEC-6 → SPEC-8 → SPEC-7. Rationale: SPEC-1 first — it is the P0 with zero behavioral risk (lint-only, additive findings), it makes the conventions' central warning actionable immediately, and it establishes the resolver-reuse pattern SPEC-3/5 build on; it also becomes the verification tool for everything later (SPEC-7's rewrites are checked by it). SPEC-2 second — tiny code change, but schedule its convention-text follow-up (softening the footgun bullet) AFTER task #5's apply pass lands so the same file isn't churned twice, and bundle the canary re-mint CHANGELOG note. SPEC-3 then SPEC-5 as one arc — SPEC-5 reuses SPEC-3's flag plumbing and validation helper, and together they ship the complete convention loop (provenance at write time + corrections with demotion) that agents currently cannot execute through the CLI at all. SPEC-4 after task #5 is fully verified — it must amend the exact negative sentences task #5 just wrote into concepts.md and the design doc, so sequencing it earlier guarantees doc churn and docConsistency-sweep conflicts; it is independent of all other specs code-wise. SPEC-6 only after a measurement pass (curate goldens) confirms convention-fact crowding is real — it is the most speculative item and its demotion constant should be eval-derived, not guessed. SPEC-8 after SPEC-6's capture groundwork and once canary re-mint guidance exists (it shares the R5/embedding coordination burden and is default-off anyway). SPEC-7 last — largest effort, heaviest contract/governance footprint (§9.4 surface freeze), lowest frequency of use, and it benefits from SPEC-1 (verification) and SPEC-4 (subtree enumeration for pre/post-move checks) already being in place.
+
+## Open questions
+
+- SPEC-4 syntax scope: should `type:prefix` WITHOUT a trailing slash also enumerate (chosen: no — it collides with exact refs, which belong to `akm show`), and should the branch fire when --type is also passed and agrees (chosen: explicit flag wins, branch fires only on searchType 'any')? Maintainer confirmation wanted before pinning tests.
+- SPEC-3 failure mode: hard-fail (exit 2) on an unresolvable --xref was chosen as input validation; if maintainers prefer fail-open for SOFT-convention consistency, the alternative is stderr warn + write anyway — decide before the flag ships since flipping later is a behavior change on a Stable command.
+- Embedding staleness policy: upsertEntry does not invalidate an existing embedding when search_text changes (db.ts:1561-1568 only embeds rows lacking one), which SPEC-2 mildly and SPEC-8 seriously depend on — is a general 'search_text hash → re-embed' invalidation (delete embedding row on changed hash) worth a standalone fix ahead of SPEC-8?
+- SPEC-7 governance: is adding a verb to the §9.4 'exhaustive' surface acceptable pre-1.0 as an Experimental-tier addition, or should rename assistance ship as a subcommand of an existing noun group to dodge the freeze? The contract test itself is additive-safe; the freeze is a documentation/governance question.
+- SPEC-2 scope: the merge is spec'd for file-derived entries via buildEntryFromFile only; entries declared in .stash.json (loadStashFile path) keep their literal tags — confirm that is intended (they are hand-curated manifests).
+- Post-SPEC-4 convention-text re-adoption: once the ref-prefix idiom is real, should the skeleton convention facts switch back from `akm search "<slug>" --type <type>` to the prefix idiom (a second doc churn of the files task #5 just rewrote), or should both idioms be documented? Recommend deferring one full release to avoid teaching an idiom older CLI versions don't support.
+- SPEC-6 predicate breadth: demote only category: convention, or also category: meta? Spec'd as convention-only (meta facts like active-projects canon should surface in search); flag for review since domains.md now tells agents to keep slug canon in a meta fact partly BECAUSE it is retrievable.

--- a/docs/design/stash-organization-conventions.md
+++ b/docs/design/stash-organization-conventions.md
@@ -27,10 +27,14 @@ load-bearing facts, each verified in code:
 
 1. **Path becomes the ref.** A file's subpath under its type dir is part of its
    ref name — `memories/projectA/auth-tip.md` → `memory:projectA/auth-tip`. Works
-   for every type. There is NO ref-prefix query syntax: `sanitizeFtsQuery` strips
-   `:` and `/` and `entry_type` is not an FTS column, so
-   `akm search "memory:projectA/"` returns nothing useful (empirically tested).
-   The working idiom is `akm search "projectA" --type memory`. The path is
+   for every type. A ref-prefix query syntax exists since SPEC-4 landed
+   (amended 2026-07-11): `akm search "memory:projectA/"` enumerates exactly
+   that subtree (typed, recursive, `/`-boundary exact) and a bare `memory:`
+   enumerates the whole type. At review time the idiom was false —
+   `sanitizeFtsQuery` strips `:` and `/` and `entry_type` is not an FTS
+   column, so the query degenerated to token noise (empirically tested; see
+   the Review round). `akm search "projectA" --type memory` remains the
+   token-match alternative. The path is
    therefore the one facet you cannot express twice and cannot change without
    breaking the ref (and every inbound reference to it).
 2. **Retrieval is search, not browse — and folders are highly visible to the
@@ -213,7 +217,12 @@ corrections, each code-verified or empirically tested:
 - **The ref-prefix search idiom was false.** `akm search "<type>:<prefix>/"`
   never worked (`sanitizeFtsQuery` strips `:` and `/`; `entry_type` is not an
   FTS column) — live-tested at zero hits. All convention text now uses
-  `akm search "<slug>" --type <type>`.
+  `akm search "<slug>" --type <type>`. *Amendment (2026-07-11): SPEC-4 has
+  since made the idiom real — `<type>:<prefix>/` (and bare `<type>:`) queries
+  now translate to a typed subtree enumeration (`parseRefPrefixQuery`). The
+  finding was correct at review time; the shipped convention facts keep the
+  `--type` idiom for now (re-adoption deferred one release — see open
+  questions).*
 - **"Folders are invisible to the ranker" was backwards.** Subpath tokens are
   indexed in the FTS `name` column at the highest weight and earn the cwd
   project-context boost; the claimed "indexing-confidence bump" does not exist.
@@ -238,10 +247,12 @@ corrections, each code-verified or empirically tested:
 ## Open questions / future work
 
 Items with an implementation path are specced in
-[stash-conventions-code-spec.md](stash-conventions-code-spec.md): ref-prefix
-filter → SPEC-4, convention-fact query crowding → SPEC-6, body-orientation
-indexing → SPEC-8 (the tag footgun's SPEC-2 and correction demotion's SPEC-5
-have landed — see fact 6 and the demotion bullet below). Scheduled
+[stash-conventions-code-spec.md](stash-conventions-code-spec.md):
+convention-fact query crowding → SPEC-6, body-orientation
+indexing → SPEC-8 (the tag footgun's SPEC-2, correction demotion's SPEC-5,
+and the ref-prefix filter's SPEC-4
+have landed — see facts 1 and 6 and the demotion and ref-prefix bullets
+below). Scheduled
 consolidation is argued down there
 (the improve pipeline already injects the amended conventions); vocabulary
 governance and the typed provenance channel remain genuinely open.
@@ -272,9 +283,16 @@ governance and the typed provenance channel remain genuinely open.
   `entry.scope` (user/agent/run/channel) / `scopeKey` concepts in code — the
   convention facts deliberately say "project/client slug" and "partition axis" to
   avoid cross-wiring; keep it that way.
-- **Ref-prefix filter in code.** Detect `type:prefix/`-shaped queries in search
-  and translate to `entry_type` + `entry_key LIKE`, making the natural idiom
-  real (today it returns nothing).
+- **Ref-prefix filter in code.** Closed by SPEC-4 in
+  [stash-conventions-code-spec.md](stash-conventions-code-spec.md)
+  (implemented: `parseRefPrefixQuery` detects `<type>:<prefix>/` — and bare
+  `<type>:` — queries on the untyped search path and translates them to a
+  typed index enumeration with name-prefix narrowing; hits carry the fixed
+  browse score 1, an explicit `--type` wins over the parsed type, and the
+  in-memory prefix filter leaves an `entry_key LIKE` SQL push-down as a later
+  optimization). Whether the skeleton convention facts should re-adopt the
+  idiom over `akm search "<slug>" --type <type>` stays deferred one release so
+  older CLI versions aren't taught a query shape they don't support.
 - **Index self-situating body text.** Surface the first body paragraph into an
   indexed field (or embed body openings) so orientation prose pays retrieval
   rent.

--- a/docs/design/stash-organization-conventions.md
+++ b/docs/design/stash-organization-conventions.md
@@ -1,0 +1,192 @@
+# Design: stash organization & back-linking conventions
+
+Status: accepted (conventions shipped in the stash skeleton)
+Author: akm
+Date: 2026-07-11
+
+## Problem
+
+The stash skeleton already ships per-type authoring conventions
+(`facts/conventions/assets/<type>.md`) that tell an agent **how to write** each
+asset type. Nothing told an agent **where to place** an asset (which
+subdirectory) or **how to cross-link** it. Yet placement and linking are exactly
+what determine whether the same knowledge is *retrievable* two sessions later, or
+re-derived from scratch — and whether cross-project reuse happens or duplicates
+accumulate.
+
+The request that drove this: define conventions that instruct agents how to
+organize assets under their type directories (subdirectories for projects,
+domains, etc.) and how to back-link them to improve retrieval during agentic
+tasks. This document records the analysis, a structured debate, and the resulting
+conventions.
+
+## What AKM's mechanics dictate (the ground truth)
+
+Any organization scheme has to fit how AKM actually stores and retrieves. The
+load-bearing facts, each verified in code:
+
+1. **Path becomes the ref.** A file's subpath under its type dir is part of its
+   ref name — `memories/projectA/auth-tip.md` → `memory:projectA/auth-tip`. Works
+   for every type. `akm search "memory:projectA/"` narrows by prefix. The path is
+   therefore the one facet you cannot express twice and cannot change without
+   breaking the ref (and every inbound reference to it).
+2. **Retrieval is search, not browse.** There is no folder walk at query time —
+   agents `akm search`/`akm curate`, then `akm show <ref>`. A subdirectory buys
+   only a small indexing-confidence bump and a ref-prefix filter. Folders are
+   invisible to the ranker.
+3. **The FTS surface is `name`, `description`, `tags`, `hints`, `content`**
+   (`entries_fts`, `src/indexer/db/schema.ts`). There is **no `project` field** —
+   a bare `project:` frontmatter value is invisible to search. Off-axis facets
+   must be `tags` to be retrievable.
+4. **`xrefs:` fold into the FTS `hints` field for all types**
+   (`src/indexer/search/search-fields.ts:58`). Back-links are a *retrieval*
+   signal, not decoration — which means both too few and too many degrade
+   ranking.
+5. **Project relevance is recovered at query time, rename-proof.** Ranking blends
+   a per-project usage signal — `scopedUtility * 0.7 + globalUtility * 0.3`
+   (`SCOPED_UTILITY_BLEND_SCOPED`, `src/indexer/search/ranking-contributors.ts`),
+   keyed by a cwd-anchor independent of the path. So a reusable asset does not
+   need the *project* baked into its path to rank well inside a project.
+6. **Path tags are auto-derived only when `tags` is empty**
+   (`src/indexer/passes/metadata.ts:1114`). Setting `tags` explicitly *suppresses*
+   the path-derived tag — a real footgun.
+7. **The entity/relation graph boost extracts from body content, not the path**
+   (`graph-extraction.ts`). Canonical entity naming must live in the prose.
+8. **`category: convention|meta` facts are surfaced to every non-wiki authoring
+   flow** (`resolveStashStandards`); `facts/conventions/assets/<type>.md` is
+   surfaced type-scoped (`resolveTypeConventions`). This is the only channel that
+   reaches a browse-blind agent mid-task — so conventions must ship as facts.
+9. **Non-wiki xrefs have no broken-link lint.** Only wikis get
+   orphan/broken-xref/stale-index/uncited-raw checks. A rename silently dangles
+   non-wiki inbound links.
+
+## Research inputs
+
+Three parallel research briefs (Karpathy's LLM wiki; agent memory / RAG /
+GraphRAG; PKM taxonomies — Zettelkasten, PARA, Johnny.Decimal) converged on a few
+transferable principles:
+
+- **Separate raw from synthesized, and keep raw immutable.** Karpathy's core
+  invariant: interpret and correct in a synthesized layer that *cites* the raw
+  source; never edit the source. Gives every claim an auditable provenance chain.
+- **The index is the catalog — don't hand-maintain one.** Karpathy's `index.md`
+  exists because a filesystem has no ranker. AKM already has one (plus a utility
+  signal), so effort should go into per-asset *retrievability* (strong title,
+  accurate first paragraph, tags, xrefs), not a hand-kept catalog.
+- **Metadata/facets beat folder depth for retrieval.** The literature repeatedly
+  measures metadata-enriched and "contextual"/self-situating retrieval as
+  materially better (e.g. contextual headers cutting failed retrievals by a large
+  margin) — because the reader is a ranker, not a browser.
+- **Atomicity + sparse, real links (Zettelkasten), not dense mandatory links.**
+  Backlinks help multi-hop recall, but forced density produces junk edges.
+- **Controlled vocabulary prevents bucket drift**, but deep hierarchies and
+  opaque codes (Johnny.Decimal) fail when nobody browses.
+
+## The debate
+
+Four positions were argued and adversarially critiqued:
+
+| Position | Thesis | Verdict |
+|---|---|---|
+| **Domain-first taxonomy** | Path = stable subject domain; lowest rename rate, highest lexical signal. | reject-keep-ideas |
+| **Scope-first namespacing** | Path = project/client/team; scope is the dominant retrieval filter. | reject-keep-ideas |
+| **Flat + faceted + dense backlinks** | Minimal folders; organizing signal lives in frontmatter + a dense link graph the index can read. | adopt-with-changes |
+| **Hybrid "narrowest stable scope" ladder** | One folder = the narrowest stable boundary (client > project > domain > root), rest in facets. | adopt-with-changes |
+
+The critiques were decisive:
+
+- **A single global axis fails both ways.** Domain-first makes project scope
+  invisible (no `project` FTS field; agents that write `project:` frontmatter get
+  zero retrieval benefit) and splits "everything about project A's auth" across
+  three query idioms. Scope-first strands reusable assets behind an arbitrary
+  project home and creates a `shared/` dumping ground.
+- **The per-asset "narrowest scope" ladder is non-deterministic.** Two agents run
+  the delete/archive test on equivalent insights and pick different rungs,
+  fragmenting a topic across `memory:projectA/` and `knowledge/auth/` with no
+  reconciliation pass — and the wrong guess is baked into an immutable ref.
+- **Mandatory dense xrefs actively hurt.** Because ref strings fold into the FTS
+  `hints` field, a link quota smears a popular source's ref token across dozens of
+  citers (destroying its ranking signal) and fills the entity graph with
+  plausible-but-wrong edges.
+- **Per-namespace hub wikis rot.** As an obligation they contend on concurrent
+  writes, generate stale-index lint noise, and flatten the multi-hop graph into a
+  namespace-wide star.
+
+## Decision
+
+**Resolve the project-vs-domain tension by asset TYPE, not per-asset judgment.**
+This is the one rule that is both deterministic mid-task and mechanically
+justified:
+
+- **Scope-born types** (`memory`, `lesson`, `task`, `env`, `secret`) → the
+  current **project/client** slug. They are born bound to the work in front of
+  the agent, so the working context *is* the answer — zero counterfactual
+  reasoning, and the `memory:projectA/` prefix filter reconstructs the project.
+- **Reuse-born types** (`knowledge`, `skill`, `wiki`, `fact`) → a stable
+  **domain** from a short closed vocabulary. Project relevance is already
+  recovered by scoped-utility ranking (fact 5), so spending the path on the
+  project axis is redundant; the domain prefix is the only handle that
+  co-locates cross-project reuse.
+- **Global-by-nature types** (`command`, `agent`, `workflow`, stash-wide `env`) →
+  type root or a tool slug.
+
+Supporting rules, all shipped as convention facts:
+
+- One path axis; depth 1 (2 max for strict containment); lowercase-hyphen
+  semantic segments; **no volatile facets in the path** (status/date/version/…);
+  flat type-root fallback instead of inventing a one-off domain.
+- Off-axis facets go in `tags` (never a bare `project:` field), and you must
+  restate the path token when you set `tags` explicitly (fact 6).
+- **Exactly one mandatory xref — provenance.** Associative xrefs are discretionary
+  and capped (~5). Corrections are new assets that xref the source; the source is
+  never edited (Karpathy immutability inside AKM's flat model).
+- **Self-situating header on every asset** — title + one-line orientation naming
+  what it is, its scope/domain, and key entities in canonical spelling. Highest
+  leverage, lowest cost, feeds FTS + embeddings + the entity graph + humans at
+  once.
+- Hubs are optional wiki assets for a few high-traffic domains, never a per-write
+  obligation. The FTS index is the catalog.
+- A ref is an address chosen once: **default to not renaming**; if unavoidable,
+  grep the stash for the old ref and fix inbound xrefs in the same pass.
+
+Rejected over-builds: mandatory dense/bidirectional xrefs, per-namespace hub
+wikis, the per-asset scope ladder, and any hand-maintained catalog.
+
+## What shipped
+
+Convention facts in the stash skeleton (`src/assets/stash-skeleton/facts/conventions/`):
+
+- `organization.md` (`category: convention`) — the partition-by-type placement
+  rules. Surfaced to every non-wiki author.
+- `backlinks.md` (`category: convention`) — the cross-linking / provenance /
+  canonical-naming rules. Surfaced to every non-wiki author.
+- `domains.md` (`category: convention`) — the editable domain vocabulary and
+  canonical entity spellings for reuse-born assets.
+- A short **Placement & linking** section added to each
+  `facts/conventions/assets/<type>.md`, stating that type's default axis
+  (surfaced type-scoped).
+
+Because these are `category: convention` facts, `resolveStashStandards` injects
+them into the authoring context automatically — no code change was required to
+enforce the surfacing. They are soft guidance; a stash owner edits them to match
+how their stash is queried.
+
+## Open questions / future work
+
+- **A thin HARD floor.** Extend orphan/broken-xref/uncited-raw lint beyond wikis
+  to `knowledge`/`memory`/`lesson` so provenance-xref and canonical-slug rules are
+  enforced, not only advised. Soft conventions degrade under token pressure;
+  non-wiki lint is code that does not yet exist.
+- **Kill the tag footgun in code.** Always merge path segments into `tags` rather
+  than only when `tags` is empty, removing the explicit-tags trap.
+- **Vocabulary governance.** How an agent proposes a `fact:conventions/domains`
+  addition mid-task without blocking on human review (interim: flat type-root
+  fallback + a proposal note).
+- **Scheduled consolidation.** A curate/consolidate trigger to dedup near-duplicate
+  atoms, promote recurring memories into domain knowledge, and fix danglers —
+  since no reorg pass happens organically and utility ranking is cold-start-biased
+  toward incumbents.
+- **Naming collision.** The convention's "scope" wording vs the existing
+  `entry.scope` (user/agent/run/channel) / `scopeKey` concepts in code — the
+  convention facts deliberately say "project/client slug" and "partition axis" to
+  avoid cross-wiring; keep it that way.

--- a/docs/design/stash-organization-conventions.md
+++ b/docs/design/stash-organization-conventions.md
@@ -293,9 +293,18 @@ governance and the typed provenance channel remain genuinely open.
   optimization). Whether the skeleton convention facts should re-adopt the
   idiom over `akm search "<slug>" --type <type>` stays deferred one release so
   older CLI versions aren't taught a query shape they don't support.
-- **Index self-situating body text.** Surface the first body paragraph into an
-  indexed field (or embed body openings) so orientation prose pays retrieval
-  rent.
+- **Index self-situating body text.** Closed by SPEC-8 in
+  [stash-conventions-code-spec.md](stash-conventions-code-spec.md)
+  (implemented, default-off: the `index.indexBodyOpening` config flag makes
+  the metadata pass capture the first prose paragraph of a markdown body —
+  capped at 280 chars; secrets/env and session-kind memories excluded — into
+  `entry.bodyOpening`, folded into the lowest-weight `content` FTS column and
+  the embedding text). Stays default-off until eval evidence (curate goldens)
+  shows lift; toggling requires `akm index --full` (embeddings do not
+  regenerate for already-embedded entries) plus a canary re-mint, and `akm
+  index` warns while the flag diverges from the built state. The
+  `description:`/`when_to_use:` orientation routing the conventions teach
+  remains primary.
 - **Typed provenance channel.** Evaluate `sources:` for all types, indexed
   outside `hints` — it would separate provenance from associative links and
   resolve the xref-cap tension mechanically. Rejected for the shipped

--- a/docs/design/stash-organization-conventions.md
+++ b/docs/design/stash-organization-conventions.md
@@ -36,10 +36,10 @@ load-bearing facts, each verified in code:
 2. **Retrieval is search, not browse — and folders are highly visible to the
    ranker.** There is no folder walk at query time — agents `akm search`/
    `akm curate`, then `akm show <ref>`. A subdirectory's real payoff: its tokens
-   join the FTS `name` column at the highest bm25 weight (10.0), auto-derive
-   into `tags` when `tags` is empty, and match the cwd project-context boost
-   (`projectContextRankingContributor`, +0.2/token, cap 0.5). No
-   "indexing-confidence bump" for subdirectories exists in code.
+   join the FTS `name` column at the highest bm25 weight (10.0), always merge
+   into `tags` (since SPEC-2 landed; see fact 6), and match the cwd
+   project-context boost (`projectContextRankingContributor`, +0.2/token,
+   cap 0.5). No "indexing-confidence bump" for subdirectories exists in code.
 3. **The FTS surface is `name`, `description`, `tags`, `hints`, `content`**
    (`entries_fts`, `src/indexer/db/schema.ts`). There is **no `project` field** —
    a bare `project:` frontmatter value is invisible to search. Off-axis facets
@@ -57,9 +57,14 @@ load-bearing facts, each verified in code:
    global + scoped utility history. A reusable asset does not need the *project*
    baked into its path to rank well inside a project — and a rename costs
    learned ranking.
-6. **Path tags are auto-derived only when `tags` is empty**
-   (`src/indexer/passes/metadata.ts:1114`). Setting `tags` explicitly *suppresses*
-   the path-derived tag — a real footgun.
+6. **Directory (scope/domain) tokens always merge into `tags`** — since SPEC-2
+   landed (`extractDirTagsFromName`, `src/indexer/passes/metadata.ts`) they are
+   derived from the canonical ref subpath, so explicit `tags` no longer
+   suppress the scope token, both indexing walks agree, and the exact-tag
+   ranking boost fires for the path token without restating it. Filename
+   tokens are still auto-derived only when `tags` is empty (they already live
+   in the FTS `name` column and in aliases). The old explicit-tags footgun is
+   gone; existing installs pick the merged tags up on the next reindex.
 7. **The entity/relation graph boost extracts from body content, not the path**
    (`graph-extraction.ts`). Canonical entity naming must live in the prose.
 8. **`category: convention|meta` facts are surfaced to every non-wiki authoring
@@ -150,8 +155,9 @@ Supporting rules, all shipped as convention facts:
 - One path axis; depth 1 (2 max for strict containment); lowercase-hyphen
   semantic segments; **no volatile facets in the path** (status/date/version/…);
   flat type-root fallback instead of inventing a one-off domain.
-- Off-axis facets go in `tags` (never a bare `project:` field), and you must
-  restate the path token when you set `tags` explicitly (fact 6).
+- Off-axis facets go in `tags` (never a bare `project:` field); the path
+  scope/domain token merges into `tags` automatically, so it never needs
+  restating (fact 6).
 - **A provenance xref is mandatory when the asset derives from another** (never
   invented for original observations). Associative xrefs are discretionary and
   capped (~5, a heuristic). Corrections are new assets that xref what they
@@ -232,12 +238,12 @@ corrections, each code-verified or empirically tested:
 ## Open questions / future work
 
 Items with an implementation path are specced in
-[stash-conventions-code-spec.md](stash-conventions-code-spec.md): the tag
-footgun → SPEC-2, ref-prefix filter → SPEC-4, correction demotion → SPEC-5,
-convention-fact query crowding → SPEC-6, body-orientation indexing → SPEC-8.
-Scheduled consolidation is argued down there (the improve pipeline already
-injects the amended conventions); vocabulary governance and the typed
-provenance channel remain genuinely open.
+[stash-conventions-code-spec.md](stash-conventions-code-spec.md): ref-prefix
+filter → SPEC-4, correction demotion → SPEC-5, convention-fact query
+crowding → SPEC-6, body-orientation indexing → SPEC-8 (the tag footgun's
+SPEC-2 has landed — see fact 6). Scheduled consolidation is argued down there
+(the improve pipeline already injects the amended conventions); vocabulary
+governance and the typed provenance channel remain genuinely open.
 
 - **A thin HARD floor.** `akm lint` runs a deterministic `missing-ref` check
   over body text and `refs:` frontmatter for non-wiki markdown assets; the gap
@@ -248,8 +254,12 @@ provenance channel remain genuinely open.
   non-wiki assets are argued down (orphanhood is the sanctioned normal state
   under discretionary linking; uncited-source is undecidable without knowing
   whether an asset is derived).
-- **Kill the tag footgun in code.** Always merge path segments into `tags` rather
-  than only when `tags` is empty, removing the explicit-tags trap.
+- **Kill the tag footgun in code.** Closed by SPEC-2 in
+  [stash-conventions-code-spec.md](stash-conventions-code-spec.md)
+  (implemented: directory tokens from the canonical ref subpath now always
+  merge into `tags`; filename tokens still derive only when `tags` is empty).
+  Takes effect on reindex; operators with collapse-detector canary sets should
+  re-mint baselines via `akm improve canary --refresh`.
 - **Vocabulary governance.** How an agent proposes a `fact:conventions/domains`
   addition mid-task without blocking on human review (interim: flat type-root
   fallback + a proposal note).

--- a/docs/design/stash-organization-conventions.md
+++ b/docs/design/stash-organization-conventions.md
@@ -58,9 +58,11 @@ load-bearing facts, each verified in code:
    keyed by a cwd-anchor (a hash of the querying project root), not the asset's
    path. It is NOT rename-proof for the asset: `entry_key` includes the full
    name, so renaming a file mints a new entry row and orphans its accumulated
-   global + scoped utility history. A reusable asset does not need the *project*
-   baked into its path to rank well inside a project — and a rename costs
-   learned ranking.
+   global + scoped utility history — unless the rename goes through `akm mv`
+   (SPEC-7, Experimental; amended 2026-07-12), which re-keys the index row in
+   place so the id-keyed utility/embedding/salience history survives. A
+   reusable asset does not need the *project* baked into its path to rank well
+   inside a project — and a manual rename costs learned ranking.
 6. **Directory (scope/domain) tokens always merge into `tags`** — since SPEC-2
    landed (`extractDirTagsFromName`, `src/indexer/passes/metadata.ts`) they are
    derived from the canonical ref subpath, so explicit `tags` no longer
@@ -78,9 +80,11 @@ load-bearing facts, each verified in code:
 9. **Non-wiki xref breakage is caught by `akm lint`, not at write time.** The
    deterministic `missing-ref` check covers body refs, the `refs:` frontmatter
    array, and (since SPEC-1 landed) the `xrefs:`/`supersededBy:`/
-   `contradictedBy:` frontmatter channels. A rename still dangles non-wiki
-   inbound links silently — nothing catches them until the next `akm lint`
-   run flags them. Wikis are excluded from `akm lint` and instead get their own
+   `contradictedBy:` frontmatter channels. A *manual* rename still dangles
+   non-wiki inbound links silently — nothing catches them until the next
+   `akm lint` run flags them; since SPEC-7 landed (amended 2026-07-12),
+   `akm mv` rewrites inbound refs across the writable stash in the same pass
+   as the move. Wikis are excluded from `akm lint` and instead get their own
    orphan/broken-xref/broken-source/stale-index/uncited-raw checks via
    `akm wiki lint`.
 
@@ -180,7 +184,9 @@ Supporting rules, all shipped as convention facts:
 - Hubs are optional wiki assets for a few high-traffic domains, never a per-write
   obligation. The FTS index is the catalog.
 - A ref is an address chosen once: **default to not renaming**; if unavoidable,
-  grep the stash for the old ref and fix inbound xrefs in the same pass.
+  grep the stash for the old ref and fix inbound xrefs in the same pass (since
+  SPEC-7 landed, `akm mv` performs that whole pass mechanically — amended
+  2026-07-12).
 
 Rejected over-builds: mandatory dense/bidirectional xrefs, per-namespace hub
 wikis, the per-asset scope ladder, and any hand-maintained catalog.
@@ -234,6 +240,11 @@ corrections, each code-verified or empirically tested:
   and human readers.
 - **"Rename-proof" was misleading** — a rename orphans the asset's utility
   history (new `entry_key` row), strengthening the no-rename rule.
+  *Amendment (2026-07-12): true for manual renames only since SPEC-7 landed —
+  `akm mv` rewrites inbound refs and re-keys the index row in place, so a
+  tooled rename preserves the learned ranking history. The no-rename default
+  stands: mv cannot fix citers in read-only sources (it reports them as
+  `readOnlyCiters` manual follow-ups).*
 - **Corrections now pair with `beliefState: superseded`/`supersededBy`**
   (parsed for all markdown types, demoted at rank time), and immutability was
   rescoped to ingested material only, resolving a contradiction with the
@@ -246,16 +257,17 @@ corrections, each code-verified or empirically tested:
 
 ## Open questions / future work
 
-Items with an implementation path are specced in
-[stash-conventions-code-spec.md](stash-conventions-code-spec.md):
-convention-fact query crowding → SPEC-6, body-orientation
-indexing → SPEC-8 (the tag footgun's SPEC-2, correction demotion's SPEC-5,
-and the ref-prefix filter's SPEC-4
-have landed — see facts 1 and 6 and the demotion and ref-prefix bullets
-below). Scheduled
-consolidation is argued down there
-(the improve pipeline already injects the amended conventions); vocabulary
-governance and the typed provenance channel remain genuinely open.
+Items with an implementation path were specced in
+[stash-conventions-code-spec.md](stash-conventions-code-spec.md), and all
+eight specs have since landed (amended 2026-07-12): the lint frontmatter
+channels (SPEC-1), the tag merge (SPEC-2), `--xref` (SPEC-3), the ref-prefix
+filter (SPEC-4), `--supersedes` demotion (SPEC-5), category capture (SPEC-6 —
+shipped capture-only; the rank-time demotion was dropped after measurement
+showed no crowding), `akm mv` (SPEC-7), and default-off body-opening indexing
+(SPEC-8) — see the closed bullets below. What remains genuinely open:
+vocabulary governance, scheduled consolidation (argued down in the spec — the
+improve pipeline already injects the amended conventions), and the typed
+provenance channel.
 
 - **A thin HARD floor.** `akm lint` runs a deterministic `missing-ref` check
   over body text and `refs:` frontmatter for non-wiki markdown assets; the gap
@@ -293,6 +305,17 @@ governance and the typed provenance channel remain genuinely open.
   optimization). Whether the skeleton convention facts should re-adopt the
   idiom over `akm search "<slug>" --type <type>` stays deferred one release so
   older CLI versions aren't taught a query shape they don't support.
+- **A tooled rename.** Closed by SPEC-7 in
+  [stash-conventions-code-spec.md](stash-conventions-code-spec.md)
+  (implemented, Experimental: `akm mv <ref> <new-name>` moves the file — a
+  memory's `.derived.md` twin moves with it — rewrites inbound refs across
+  the writable stash in the same pass, covering body prose, frontmatter ref
+  lists, and fenced examples, and re-keys the index row in place so the
+  asset's accumulated utility/embedding/salience history survives). The
+  no-rename default stands: read-only sources are scanned but never written —
+  their citing files surface as `readOnlyCiters` manual follow-ups — and the
+  skeleton organization fact now names `akm mv` as the forced-rename tool
+  (with the manual grep-and-fix procedure kept as the older-CLI fallback).
 - **Index self-situating body text.** Closed by SPEC-8 in
   [stash-conventions-code-spec.md](stash-conventions-code-spec.md)
   (implemented, default-off: the `index.indexBodyOpening` config flag makes
@@ -315,7 +338,18 @@ governance and the typed provenance channel remain genuinely open.
   the fact type boost (0.22); consider excluding `category: convention` facts
   from default untyped search (their delivery channel is prompt injection,
   parallel to the `session` default exclusion) or demoting the category at rank
-  time.
+  time. *Amendment (2026-07-12): closed by SPEC-6 in
+  [stash-conventions-code-spec.md](stash-conventions-code-spec.md), shipped
+  capture-only. The `category:` key is now captured into the index as
+  `entry.category` (takes effect on reindex), making a category-keyed policy
+  implementable — but the spec's prescribed measurement (full skeleton
+  convention facts plus a real `knowledge/auth` asset, untyped `auth` query,
+  semantic off) showed NO crowding: FTS is exact-first, so prefix expansion
+  onto the facts' tokens fires only when nothing matches the query exactly,
+  and a real domain asset always outranks the facts. The rank-time demotion
+  contributor was therefore dropped;
+  `tests/search-convention-fact-demotion.test.ts` pins the no-crowding
+  invariant and is the regression guard if demotion is ever revisited.*
 - **Automate correction demotion.** Closed by SPEC-5 in
   [stash-conventions-code-spec.md](stash-conventions-code-spec.md)
   (implemented as the deterministic CLI form: `--supersedes <old ref>` on

--- a/docs/design/stash-organization-conventions.md
+++ b/docs/design/stash-organization-conventions.md
@@ -239,9 +239,10 @@ corrections, each code-verified or empirically tested:
 
 Items with an implementation path are specced in
 [stash-conventions-code-spec.md](stash-conventions-code-spec.md): ref-prefix
-filter → SPEC-4, correction demotion → SPEC-5, convention-fact query
-crowding → SPEC-6, body-orientation indexing → SPEC-8 (the tag footgun's
-SPEC-2 has landed — see fact 6). Scheduled consolidation is argued down there
+filter → SPEC-4, convention-fact query crowding → SPEC-6, body-orientation
+indexing → SPEC-8 (the tag footgun's SPEC-2 and correction demotion's SPEC-5
+have landed — see fact 6 and the demotion bullet below). Scheduled
+consolidation is argued down there
 (the improve pipeline already injects the amended conventions); vocabulary
 governance and the typed provenance channel remain genuinely open.
 
@@ -288,5 +289,12 @@ governance and the typed provenance channel remain genuinely open.
   from default untyped search (their delivery channel is prompt injection,
   parallel to the `session` default exclusion) or demoting the category at rank
   time.
-- **Automate correction demotion.** `curate`/`improve` could set
-  `beliefState: superseded` on the old asset when a correction cites it.
+- **Automate correction demotion.** Closed by SPEC-5 in
+  [stash-conventions-code-spec.md](stash-conventions-code-spec.md)
+  (implemented as the deterministic CLI form: `--supersedes <old ref>` on
+  `akm remember`/`akm import` writes the correction with the xref, sets
+  `beliefState: superseded` + `supersededBy: [<new ref>]` on the old asset,
+  and reindexes it; demoting belief states now also cap the final search
+  score so the stale incumbent cannot outrank its correction). An LLM-side
+  `curate`/`improve` pass that detects citing corrections automatically
+  remains open.

--- a/docs/design/stash-organization-conventions.md
+++ b/docs/design/stash-organization-conventions.md
@@ -27,13 +27,19 @@ load-bearing facts, each verified in code:
 
 1. **Path becomes the ref.** A file's subpath under its type dir is part of its
    ref name — `memories/projectA/auth-tip.md` → `memory:projectA/auth-tip`. Works
-   for every type. `akm search "memory:projectA/"` narrows by prefix. The path is
+   for every type. There is NO ref-prefix query syntax: `sanitizeFtsQuery` strips
+   `:` and `/` and `entry_type` is not an FTS column, so
+   `akm search "memory:projectA/"` returns nothing useful (empirically tested).
+   The working idiom is `akm search "projectA" --type memory`. The path is
    therefore the one facet you cannot express twice and cannot change without
    breaking the ref (and every inbound reference to it).
-2. **Retrieval is search, not browse.** There is no folder walk at query time —
-   agents `akm search`/`akm curate`, then `akm show <ref>`. A subdirectory buys
-   only a small indexing-confidence bump and a ref-prefix filter. Folders are
-   invisible to the ranker.
+2. **Retrieval is search, not browse — and folders are highly visible to the
+   ranker.** There is no folder walk at query time — agents `akm search`/
+   `akm curate`, then `akm show <ref>`. A subdirectory's real payoff: its tokens
+   join the FTS `name` column at the highest bm25 weight (10.0), auto-derive
+   into `tags` when `tags` is empty, and match the cwd project-context boost
+   (`projectContextRankingContributor`, +0.2/token, cap 0.5). No
+   "indexing-confidence bump" for subdirectories exists in code.
 3. **The FTS surface is `name`, `description`, `tags`, `hints`, `content`**
    (`entries_fts`, `src/indexer/db/schema.ts`). There is **no `project` field** —
    a bare `project:` frontmatter value is invisible to search. Off-axis facets
@@ -42,11 +48,15 @@ load-bearing facts, each verified in code:
    (`src/indexer/search/search-fields.ts:58`). Back-links are a *retrieval*
    signal, not decoration — which means both too few and too many degrade
    ranking.
-5. **Project relevance is recovered at query time, rename-proof.** Ranking blends
+5. **Project relevance is recovered at query time.** Ranking blends
    a per-project usage signal — `scopedUtility * 0.7 + globalUtility * 0.3`
    (`SCOPED_UTILITY_BLEND_SCOPED`, `src/indexer/search/ranking-contributors.ts`),
-   keyed by a cwd-anchor independent of the path. So a reusable asset does not
-   need the *project* baked into its path to rank well inside a project.
+   keyed by a cwd-anchor (a hash of the querying project root), not the asset's
+   path. It is NOT rename-proof for the asset: `entry_key` includes the full
+   name, so renaming a file mints a new entry row and orphans its accumulated
+   global + scoped utility history. A reusable asset does not need the *project*
+   baked into its path to rank well inside a project — and a rename costs
+   learned ranking.
 6. **Path tags are auto-derived only when `tags` is empty**
    (`src/indexer/passes/metadata.ts:1114`). Setting `tags` explicitly *suppresses*
    the path-derived tag — a real footgun.
@@ -121,12 +131,12 @@ justified:
 - **Scope-born types** (`memory`, `lesson`, `task`, `env`, `secret`) → the
   current **project/client** slug. They are born bound to the work in front of
   the agent, so the working context *is* the answer — zero counterfactual
-  reasoning, and the `memory:projectA/` prefix filter reconstructs the project.
-- **Reuse-born types** (`knowledge`, `skill`, `wiki`, `fact`) → a stable
-  **domain** from a short closed vocabulary. Project relevance is already
+  reasoning, and `akm search "projectA" --type memory` reconstructs the project.
+- **Reuse-born types** (`knowledge`, `skill`, `wiki`, `fact`, `script`) → a
+  stable **domain** from a short closed vocabulary. Project relevance is already
   recovered by scoped-utility ranking (fact 5), so spending the path on the
   project axis is redundant; the domain prefix is the only handle that
-  co-locates cross-project reuse.
+  co-locates cross-project reuse. For a wiki, the domain names the wiki itself.
 - **Global-by-nature types** (`command`, `agent`, `workflow`, stash-wide `env`) →
   type root or a tool slug.
 
@@ -137,13 +147,21 @@ Supporting rules, all shipped as convention facts:
   flat type-root fallback instead of inventing a one-off domain.
 - Off-axis facets go in `tags` (never a bare `project:` field), and you must
   restate the path token when you set `tags` explicitly (fact 6).
-- **Exactly one mandatory xref — provenance.** Associative xrefs are discretionary
-  and capped (~5). Corrections are new assets that xref the source; the source is
-  never edited (Karpathy immutability inside AKM's flat model).
-- **Self-situating header on every asset** — title + one-line orientation naming
-  what it is, its scope/domain, and key entities in canonical spelling. Highest
-  leverage, lowest cost, feeds FTS + embeddings + the entity graph + humans at
-  once.
+- **A provenance xref is mandatory when the asset derives from another** (never
+  invented for original observations). Associative xrefs are discretionary and
+  capped (~5, a heuristic). Corrections are new assets that xref what they
+  correct, paired with `beliefState: superseded`/`supersededBy` on the stale
+  asset; immutability applies to ingested material (wiki `raw/`, vendored docs,
+  transcripts) — synthesized knowledge pages are the rewritable layer (Karpathy
+  immutability inside AKM's flat model).
+- **Self-situating text on every asset** — the orientation line goes in
+  `description:`/`when_to_use:` (the indexed fields; body prose is NOT indexed —
+  FTS `content` is TOC headings + parameters only, and embeddings are built from
+  the same field string, never the body). The body header still feeds the
+  entity graph (extracted from body prose) and human readers at `akm show`.
+  Anthropic's Contextual Retrieval figures (35%/49%/67% top-20 failure-rate
+  reduction) were measured on chunk-prepended context in a chunked RAG pipeline —
+  an analogy motivating the description-field placement, not a measurement of it.
 - Hubs are optional wiki assets for a few high-traffic domains, never a per-write
   obligation. The FTS index is the catalog.
 - A ref is an address chosen once: **default to not renaming**; if unavoidable,
@@ -171,12 +189,59 @@ them into the authoring context automatically — no code change was required to
 enforce the surfacing. They are soft guidance; a stash owner edits them to match
 how their stash is queried.
 
+The code changes the finalized conventions imply are specced separately in
+[stash-conventions-code-spec.md](stash-conventions-code-spec.md) (8 specs,
+prioritized and sequenced; nothing implemented in this change).
+
+## Review round
+
+A two-reviewer adversarial review (retrieval mechanics / IR + KM methodology /
+agent usability), with cross-rebuttals, tuned the shipped conventions. Decisive
+corrections, each code-verified or empirically tested:
+
+- **The ref-prefix search idiom was false.** `akm search "<type>:<prefix>/"`
+  never worked (`sanitizeFtsQuery` strips `:` and `/`; `entry_type` is not an
+  FTS column) — live-tested at zero hits. All convention text now uses
+  `akm search "<slug>" --type <type>`.
+- **"Folders are invisible to the ranker" was backwards.** Subpath tokens are
+  indexed in the FTS `name` column at the highest weight and earn the cwd
+  project-context boost; the claimed "indexing-confidence bump" does not exist.
+- **xrefs never feed the entity graph** — extraction reads body prose
+  (memory + knowledge) with frontmatter stripped, so graph-relevant
+  relationships must be stated in the body.
+- **Body prose is not FTS/embedding-indexed** — self-situating orientation
+  belongs in `description:`/`when_to_use:`; the body header serves the graph
+  and human readers.
+- **"Rename-proof" was misleading** — a rename orphans the asset's utility
+  history (new `entry_key` row), strengthening the no-rename rule.
+- **Corrections now pair with `beliefState: superseded`/`supersededBy`**
+  (parsed for all markdown types, demoted at rank time), and immutability was
+  rescoped to ingested material only, resolving a contradiction with the
+  knowledge type conventions.
+- Completeness: `script` joined the reuse-born bucket; wikis take the domain as
+  the wiki NAME; `env` got a decision test; a `conventions` domain entered the
+  vocabulary (the shipped facts had violated their own list); a two-domain
+  tie-break was added; and duplicated pointer text was trimmed from the nine
+  co-injected per-type files.
+
 ## Open questions / future work
 
-- **A thin HARD floor.** Extend orphan/broken-xref/uncited-raw lint beyond wikis
-  to `knowledge`/`memory`/`lesson` so provenance-xref and canonical-slug rules are
-  enforced, not only advised. Soft conventions degrade under token pressure;
-  non-wiki lint is code that does not yet exist.
+Items with an implementation path are specced in
+[stash-conventions-code-spec.md](stash-conventions-code-spec.md): the tag
+footgun → SPEC-2, ref-prefix filter → SPEC-4, correction demotion → SPEC-5,
+convention-fact query crowding → SPEC-6, body-orientation indexing → SPEC-8.
+Scheduled consolidation is argued down there (the improve pipeline already
+injects the amended conventions); vocabulary governance and the typed
+provenance channel remain genuinely open.
+
+- **A thin HARD floor.** `akm lint` already runs a deterministic `missing-ref`
+  check over body text and `refs:` frontmatter for non-wiki markdown assets; the
+  gap is precisely the `xrefs:`/`supersededBy:`/`contradictedBy:` frontmatter
+  channels the conventions mandate. Orphan and uncited-source checks for non-wiki
+  assets are argued down (orphanhood is the sanctioned normal state under
+  discretionary linking; uncited-source is undecidable without knowing whether an
+  asset is derived). Specced as SPEC-1 in
+  [stash-conventions-code-spec.md](stash-conventions-code-spec.md).
 - **Kill the tag footgun in code.** Always merge path segments into `tags` rather
   than only when `tags` is empty, removing the explicit-tags trap.
 - **Vocabulary governance.** How an agent proposes a `fact:conventions/domains`
@@ -190,3 +255,22 @@ how their stash is queried.
   `entry.scope` (user/agent/run/channel) / `scopeKey` concepts in code — the
   convention facts deliberately say "project/client slug" and "partition axis" to
   avoid cross-wiring; keep it that way.
+- **Ref-prefix filter in code.** Detect `type:prefix/`-shaped queries in search
+  and translate to `entry_type` + `entry_key LIKE`, making the natural idiom
+  real (today it returns nothing).
+- **Index self-situating body text.** Surface the first body paragraph into an
+  indexed field (or embed body openings) so orientation prose pays retrieval
+  rent.
+- **Typed provenance channel.** Evaluate `sources:` for all types, indexed
+  outside `hints` — it would separate provenance from associative links and
+  resolve the xref-cap tension mechanically. Rejected for the shipped
+  convention because non-wiki `sources:` earns no retrieval benefit today and
+  provenance-in-xrefs powers the "what did we build on this?" query.
+- **Convention facts crowd domain-term queries.** Their name/description/
+  when_to_use tokens (bodies are unindexed) match via prefix expansion and carry
+  the fact type boost (0.22); consider excluding `category: convention` facts
+  from default untyped search (their delivery channel is prompt injection,
+  parallel to the `session` default exclusion) or demoting the category at rank
+  time.
+- **Automate correction demotion.** `curate`/`improve` could set
+  `beliefState: superseded` on the old asset when a correction cites it.

--- a/docs/design/stash-organization-conventions.md
+++ b/docs/design/stash-organization-conventions.md
@@ -66,9 +66,14 @@ load-bearing facts, each verified in code:
    flow** (`resolveStashStandards`); `facts/conventions/assets/<type>.md` is
    surfaced type-scoped (`resolveTypeConventions`). This is the only channel that
    reaches a browse-blind agent mid-task — so conventions must ship as facts.
-9. **Non-wiki xrefs have no broken-link lint.** Only wikis get
-   orphan/broken-xref/stale-index/uncited-raw checks. A rename silently dangles
-   non-wiki inbound links.
+9. **Non-wiki xref breakage is caught by `akm lint`, not at write time.** The
+   deterministic `missing-ref` check covers body refs, the `refs:` frontmatter
+   array, and (since SPEC-1 landed) the `xrefs:`/`supersededBy:`/
+   `contradictedBy:` frontmatter channels. A rename still dangles non-wiki
+   inbound links silently — nothing catches them until the next `akm lint`
+   run flags them. Wikis are excluded from `akm lint` and instead get their own
+   orphan/broken-xref/broken-source/stale-index/uncited-raw checks via
+   `akm wiki lint`.
 
 ## Research inputs
 
@@ -234,14 +239,15 @@ Scheduled consolidation is argued down there (the improve pipeline already
 injects the amended conventions); vocabulary governance and the typed
 provenance channel remain genuinely open.
 
-- **A thin HARD floor.** `akm lint` already runs a deterministic `missing-ref`
-  check over body text and `refs:` frontmatter for non-wiki markdown assets; the
-  gap is precisely the `xrefs:`/`supersededBy:`/`contradictedBy:` frontmatter
-  channels the conventions mandate. Orphan and uncited-source checks for non-wiki
-  assets are argued down (orphanhood is the sanctioned normal state under
-  discretionary linking; uncited-source is undecidable without knowing whether an
-  asset is derived). Specced as SPEC-1 in
-  [stash-conventions-code-spec.md](stash-conventions-code-spec.md).
+- **A thin HARD floor.** `akm lint` runs a deterministic `missing-ref` check
+  over body text and `refs:` frontmatter for non-wiki markdown assets; the gap
+  was precisely the `xrefs:`/`supersededBy:`/`contradictedBy:` frontmatter
+  channels the conventions mandate — closed by SPEC-1 in
+  [stash-conventions-code-spec.md](stash-conventions-code-spec.md) (implemented:
+  the same check now scans those keys too). Orphan and uncited-source checks for
+  non-wiki assets are argued down (orphanhood is the sanctioned normal state
+  under discretionary linking; uncited-source is undecidable without knowing
+  whether an asset is derived).
 - **Kill the tag footgun in code.** Always merge path segments into `tags` rather
   than only when `tags` is empty, removing the explicit-tags trap.
 - **Vocabulary governance.** How an agent proposes a `fact:conventions/domains`

--- a/schemas/akm-config.json
+++ b/schemas/akm-config.json
@@ -4342,6 +4342,10 @@
             }
           },
           "additionalProperties": true
+        },
+        "indexBodyOpening": {
+          "type": "boolean",
+          "description": "Index the first prose paragraph of each markdown asset body (capped at 280 chars) into the lowest-weight `content` search column and the embedding text (default false). Secret/env files and session-kind memories are never captured. Toggling the flag changes indexed text: run `akm index --full` afterwards to re-extract every entry and regenerate embeddings, and re-mint collapse-detector canary baselines via `akm improve canary --refresh`."
         }
       },
       "additionalProperties": {
@@ -9143,6 +9147,10 @@
                 }
               },
               "additionalProperties": true
+            },
+            "indexBodyOpening": {
+              "type": "boolean",
+              "description": "Index the first prose paragraph of each markdown asset body (capped at 280 chars) into the lowest-weight `content` search column and the embedding text (default false). Secret/env files and session-kind memories are never captured. Toggling the flag changes indexed text: run `akm index --full` afterwards to re-extract every entry and regenerate embeddings, and re-mint collapse-detector canary baselines via `akm improve canary --refresh`."
             }
           },
           "additionalProperties": {

--- a/src/assets/hints/cli-hints-full.md
+++ b/src/assets/hints/cli-hints-full.md
@@ -12,6 +12,8 @@ akm search "<query>" --source both            # Also search registries
 akm search "<query>" --source registry        # Search registries only
 akm search "<query>" --limit 10               # Limit results
 akm search "<query>" --detail full            # Include scores, paths, timing
+akm search "memory:projectA/"                 # Enumerate a typed subtree (ref-prefix; trailing slash required)
+akm search "knowledge:"                       # List every asset of a type
 ```
 
 | Flag | Values | Default |
@@ -22,6 +24,12 @@ akm search "<query>" --detail full            # Include scores, paths, timing
 | `--format` | `json`, `jsonl`, `text`, `yaml` | `json` |
 | `--detail` | `brief`, `normal`, `full` | `brief` |
 | `--shape` | `human`, `agent`, `summary` (`summary` only on `show`) | `human` |
+
+Ref-prefix queries (`"<type>:<prefix>/"` or a bare `"<type>:"`) return a
+deterministic listing, not a relevance ranking. A full ref without the
+trailing slash (`memory:projectA/auth-tip`) stays an ordinary keyword search —
+resolving a single ref is `akm show`'s job — and an explicit `--type` flag
+wins over the type parsed from the query.
 
 ## Curate
 

--- a/src/assets/hints/cli-hints-full.md
+++ b/src/assets/hints/cli-hints-full.md
@@ -69,8 +69,10 @@ akm remember "Deployment needs VPN access"     # Record a memory in your stash
 akm remember --name release-retro < notes.md   # Save multiline memory from stdin
 akm remember "note" --target my-other-stash    # Route write to a named writable stash source
 akm remember "note" --xref knowledge:auth-flow # Cite provenance in frontmatter xrefs (repeatable; ref must resolve)
+akm remember "fix" --supersedes memory:old-note # Write a correction AND demote the old asset (beliefState: superseded)
 akm import ./docs/auth-flow.md                 # Import a file as knowledge
 akm import ./doc.md --xref knowledge:auth-flow # Merge provenance xrefs into the imported doc's frontmatter
+akm import ./new.md --supersedes knowledge:old # Import a correction AND demote the doc it replaces
 akm import - --name scratch-notes < notes.md   # Import stdin as a knowledge doc
 akm import https://example.com/docs/auth       # Fetch one URL and import it as knowledge
 akm import ./doc.md --target my-other-stash    # Route import to a named writable stash source

--- a/src/assets/hints/cli-hints-full.md
+++ b/src/assets/hints/cli-hints-full.md
@@ -190,6 +190,28 @@ akm clone "npm:@scope/pkg//script:deploy.sh"  # Clone from remote package
 
 When `--dest` is provided, `akm init` is not required first.
 
+## Move / Rename (Experimental)
+
+Rename an asset within its type directory in the primary writable stash. Prefer
+NOT renaming (a ref is chosen once); when a rename is forced, `akm mv` does the
+whole convention pass: it moves the file (a memory's `.derived.md` twin moves
+together), rewrites inbound refs across the writable stash — body prose,
+frontmatter ref lists (`xrefs:`/`refs:`/`supersededBy:`), and fenced examples —
+and re-keys the index row in place so the asset's learned ranking history
+survives.
+
+```sh
+akm mv memory:projectA/old-note projectA/new-note  # Rename; subdirectories allowed in the new name
+akm mv memory:solo memory:renamed-solo             # Same-type ref-shaped target also accepted
+```
+
+Wiki refs, cross-type targets, existing targets, `../` escapes, non-canonical
+source spellings (the error names the canonical ref), `.derived` twin sources
+(rename the base — the twin follows), and `.derived`-suffixed target names are
+rejected (exit 2, nothing moved). Read-only sources are scanned but never
+written — their citing files come back in `readOnlyCiters` as manual
+follow-ups. Verify with `akm lint` (missing-ref) afterwards.
+
 ## Sync
 
 Commit local changes in a git-backed stash. Behaviour adapts automatically.

--- a/src/assets/hints/cli-hints-full.md
+++ b/src/assets/hints/cli-hints-full.md
@@ -68,7 +68,9 @@ akm show knowledge:my-doc                    # Show content (local or remote)
 akm remember "Deployment needs VPN access"     # Record a memory in your stash
 akm remember --name release-retro < notes.md   # Save multiline memory from stdin
 akm remember "note" --target my-other-stash    # Route write to a named writable stash source
+akm remember "note" --xref knowledge:auth-flow # Cite provenance in frontmatter xrefs (repeatable; ref must resolve)
 akm import ./docs/auth-flow.md                 # Import a file as knowledge
+akm import ./doc.md --xref knowledge:auth-flow # Merge provenance xrefs into the imported doc's frontmatter
 akm import - --name scratch-notes < notes.md   # Import stdin as a knowledge doc
 akm import https://example.com/docs/auth       # Fetch one URL and import it as knowledge
 akm import ./doc.md --target my-other-stash    # Route import to a named writable stash source

--- a/src/assets/hints/cli-hints-short.md
+++ b/src/assets/hints/cli-hints-short.md
@@ -25,6 +25,7 @@ and `workflow list` operate within the current scope only.
 akm search "<query>"                          # Search all sources
 akm curate "<task>"                          # Curate the best matches for a task
 akm search "<query>" --type workflow          # Filter to workflow assets
+akm search "memory:projectA/"                 # List a typed subtree (ref-prefix query; trailing slash required)
 akm search "<query>" --source both            # Also search registries
 akm show <ref>                                # View asset details
 akm workflow next <ref>                       # Start or resume a workflow

--- a/src/assets/hints/cli-hints-short.md
+++ b/src/assets/hints/cli-hints-short.md
@@ -43,6 +43,7 @@ akm proposal reject skill:my-skill --reason "..."  # Reject by ref
 akm feedback <ref> --positive|--negative      # Record whether an asset helped
 akm add <ref>                                 # Add a source (npm, GitHub, git, local dir)
 akm clone <ref>                               # Copy an asset to the working stash (optional --dest arg to clone to specific location)
+akm mv memory:old-note new-note               # Rename an asset: inbound refs rewritten, ranking history preserved
 akm sync                                      # Commit (and push if writable remote) changes in the primary stash (--no-push to commit only)
 akm improve --no-sync                         # Run improve without the end-of-run auto-commit
 akm improve --no-push                         # Auto-commit but skip push for this run

--- a/src/assets/hints/cli-hints-short.md
+++ b/src/assets/hints/cli-hints-short.md
@@ -31,6 +31,7 @@ akm workflow next <ref>                       # Start or resume a workflow
 akm remember "Deployment needs VPN access"    # Record a memory in your stash
 akm remember "note" --target my-stash         # Route write to a named writable stash source
 akm remember "note" --xref knowledge:auth-flow # Cite provenance in frontmatter xrefs (repeatable)
+akm remember "fix" --supersedes memory:old-note # Write a correction AND demote the superseded asset
 akm import ./notes/release-checklist.md       # Import a knowledge doc into your stash
 akm import ./doc.md --target my-stash         # Route import to a named writable stash source
 akm wiki list                                 # List available wikis

--- a/src/assets/hints/cli-hints-short.md
+++ b/src/assets/hints/cli-hints-short.md
@@ -30,6 +30,7 @@ akm show <ref>                                # View asset details
 akm workflow next <ref>                       # Start or resume a workflow
 akm remember "Deployment needs VPN access"    # Record a memory in your stash
 akm remember "note" --target my-stash         # Route write to a named writable stash source
+akm remember "note" --xref knowledge:auth-flow # Cite provenance in frontmatter xrefs (repeatable)
 akm import ./notes/release-checklist.md       # Import a knowledge doc into your stash
 akm import ./doc.md --target my-stash         # Route import to a named writable stash source
 akm wiki list                                 # List available wikis

--- a/src/assets/stash-skeleton/README.md
+++ b/src/assets/stash-skeleton/README.md
@@ -17,6 +17,10 @@ consistency and reducing repeated context-setting.
 | `workflows/` | Workflows | Multi-step orchestration sequences |
 | `tasks/` | Tasks | Scheduled or on-demand automation tasks |
 | `lessons/` | Lessons | Durable lessons extracted from past sessions |
+| `facts/` | Facts | Durable stash-level context; the house conventions in `facts/conventions/` are auto-surfaced to authoring agents |
+| `wikis/` | Wikis | Agent-maintained knowledge bases (see `akm wiki`) |
+| `scripts/` | Scripts | Executable helpers agents and humans can run |
+| `env/`, `secrets/` | Env & Secrets | Configuration groups and single credentials; values are never content-indexed |
 
 Add your own assets to any of these directories. AKM will index them automatically
 on the next `akm index` run (or when the background improve pipeline picks them up).
@@ -25,19 +29,20 @@ on the next `akm index` run (or when the background improve pipeline picks them 
 
 A file's path under its type directory becomes part of its ref
 (`knowledge/auth/oauth-refresh-races.md` → `knowledge:auth/oauth-refresh-races`),
-and `akm search "knowledge:auth/"` narrows to that subtree. Retrieval is search,
-not folder-browse, so pick subdirectories deliberately. The house rules live in
-three convention facts under `facts/conventions/` and are surfaced to agents
-automatically when they author assets:
+and its segments are search terms: `akm search "auth" --type knowledge` narrows
+to that subtree. Retrieval is search, not folder-browse, so pick subdirectories
+deliberately. The house rules live in three convention facts under
+`facts/conventions/` and are surfaced to agents automatically when they author
+assets:
 
 - **`fact:conventions/organization`** — the single path axis, chosen by asset
   type. **Scope-born** types (`memory`, `lesson`, `task`, `env`, `secret`) go
   under the current **project/client** slug; **reuse-born** types (`knowledge`,
-  `skill`, `wiki`, `fact`) go under a stable **domain**; global types stay at the
-  type root.
-- **`fact:conventions/backlinks`** — how to cross-link: one mandatory provenance
-  xref, sparse real associative links, corrections as new assets, canonical
-  entity naming.
+  `skill`, `wiki`, `fact`, `script`) go under a stable **domain**; global types
+  stay at the type root.
+- **`fact:conventions/backlinks`** — how to cross-link: a provenance xref
+  whenever an asset derives from another, sparse real associative links,
+  corrections as new assets, canonical entity naming.
 - **`fact:conventions/domains`** — the (editable) domain vocabulary for
   reuse-born assets, plus canonical entity spellings.
 

--- a/src/assets/stash-skeleton/README.md
+++ b/src/assets/stash-skeleton/README.md
@@ -21,6 +21,29 @@ consistency and reducing repeated context-setting.
 Add your own assets to any of these directories. AKM will index them automatically
 on the next `akm index` run (or when the background improve pipeline picks them up).
 
+## How to organize assets
+
+A file's path under its type directory becomes part of its ref
+(`knowledge/auth/oauth-refresh-races.md` → `knowledge:auth/oauth-refresh-races`),
+and `akm search "knowledge:auth/"` narrows to that subtree. Retrieval is search,
+not folder-browse, so pick subdirectories deliberately. The house rules live in
+three convention facts under `facts/conventions/` and are surfaced to agents
+automatically when they author assets:
+
+- **`fact:conventions/organization`** — the single path axis, chosen by asset
+  type. **Scope-born** types (`memory`, `lesson`, `task`, `env`, `secret`) go
+  under the current **project/client** slug; **reuse-born** types (`knowledge`,
+  `skill`, `wiki`, `fact`) go under a stable **domain**; global types stay at the
+  type root.
+- **`fact:conventions/backlinks`** — how to cross-link: one mandatory provenance
+  xref, sparse real associative links, corrections as new assets, canonical
+  entity naming.
+- **`fact:conventions/domains`** — the (editable) domain vocabulary for
+  reuse-born assets, plus canonical entity spellings.
+
+Per-type nuances live in `facts/conventions/assets/<type>.md`. All of these are
+soft guidance — edit them to match how your stash is queried.
+
 ## For agents: how to access this stash
 
 All assets in this stash are searchable via the `akm` CLI. Use these commands to

--- a/src/assets/stash-skeleton/facts/conventions/assets/agent.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/agent.md
@@ -42,5 +42,3 @@ Use an agent when a recurring task benefits from a specialized role, bounded res
 - Agent definitions are usually **global**: keep them at the type root or under a
   role/domain slug (`agent:reviewer`). Point the agent at the standards and type
   conventions it must read first via xrefs.
-- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
-  full placement and cross-linking rules.

--- a/src/assets/stash-skeleton/facts/conventions/assets/agent.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/agent.md
@@ -36,3 +36,11 @@ Use an agent when a recurring task benefits from a specialized role, bounded res
 - Add explicit negative guidance when the agent overreaches.
 - Keep role instructions stable and concise; move large background material into knowledge assets.
 - Use lessons to capture operational improvements, then promote stable ones into the agent when they become part of the role.
+
+## Placement & linking
+
+- Agent definitions are usually **global**: keep them at the type root or under a
+  role/domain slug (`agent:reviewer`). Point the agent at the standards and type
+  conventions it must read first via xrefs.
+- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
+  full placement and cross-linking rules.

--- a/src/assets/stash-skeleton/facts/conventions/assets/command.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/command.md
@@ -36,3 +36,11 @@ Use a command when the user or agent needs to perform the same prompt-shaped tas
 - If command output regularly becomes useful durable knowledge, instruct the agent to file the result into the right asset type.
 - If the command starts handling multiple unrelated tasks, split it into smaller commands.
 - Preserve a clear invocation contract so future agents can call the command safely.
+
+## Placement & linking
+
+- Commands are usually **global**: keep them at the type root or under a
+  tool/domain slug. Scope to a project only when the command is genuinely
+  project-specific.
+- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
+  full placement and cross-linking rules.

--- a/src/assets/stash-skeleton/facts/conventions/assets/command.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/command.md
@@ -42,5 +42,3 @@ Use a command when the user or agent needs to perform the same prompt-shaped tas
 - Commands are usually **global**: keep them at the type root or under a
   tool/domain slug. Scope to a project only when the command is genuinely
   project-specific.
-- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
-  full placement and cross-linking rules.

--- a/src/assets/stash-skeleton/facts/conventions/assets/fact.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/fact.md
@@ -34,7 +34,8 @@ Use a fact for stable information that future agents should treat as true or nor
 ## Maintenance strategy
 
 - Revise or supersede facts when the durable truth changes.
-- Do not allow contradictory facts to remain equally active.
+- Do not allow contradictory facts to remain equally active: mark the loser
+  `beliefState: superseded` / `supersededBy: [<new ref>]` so ranking demotes it.
 - Promote repeated memories or lessons into facts only when they become stable context.
 - Keep convention and meta facts especially clear, because they steer future asset creation.
 
@@ -47,5 +48,3 @@ Use a fact for stable information that future agents should treat as true or nor
   author, so this is where naming, placement, and linking house-rules live. Keep
   each one short — they inject into authoring prompts. Reserve `pinned: true` for
   the small always-injected core.
-- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
-  full placement and cross-linking rules.

--- a/src/assets/stash-skeleton/facts/conventions/assets/fact.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/fact.md
@@ -37,3 +37,15 @@ Use a fact for stable information that future agents should treat as true or nor
 - Do not allow contradictory facts to remain equally active.
 - Promote repeated memories or lessons into facts only when they become stable context.
 - Keep convention and meta facts especially clear, because they steer future asset creation.
+
+## Placement & linking
+
+- Facts are **reuse-born**: give a policy/standard fact a domain-like prefix
+  (`fact:policies/pii-handling`) or the type root for personal/meta facts.
+- Facts are also the **delivery layer** for stash-wide conventions:
+  `category: convention` or `category: meta` facts are surfaced to every non-wiki
+  author, so this is where naming, placement, and linking house-rules live. Keep
+  each one short — they inject into authoring prompts. Reserve `pinned: true` for
+  the small always-injected core.
+- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
+  full placement and cross-linking rules.

--- a/src/assets/stash-skeleton/facts/conventions/assets/knowledge.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/knowledge.md
@@ -36,15 +36,15 @@ Use a knowledge asset for durable reference material, synthesized explanations, 
 
 - Update the existing page when new information changes the same topic; append a dated note rather than silently rewriting when provenance matters.
 - Create a new page when the concept deserves its own durable entry.
-- Add links both ways when a new relationship matters.
+- Add a return link when you are already editing the related page in the same pass.
 - Periodically scan for orphaned, stale, or overlapping knowledge docs and consolidate them.
 
 ## Placement & linking
 
 - Knowledge is **reuse-born**: file it under a stable **domain** prefix from
   `fact:conventions/domains` (`knowledge:auth/oauth-refresh-races`), not under a
-  project — that prefix is what lets any project prefix-search and reuse it.
-- Treat ingested source docs as immutable; record corrections as new assets that
-  xref the source. Carry a provenance xref and a self-situating header.
-- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
-  full placement and cross-linking rules.
+  project — that domain slug is what any project searches to reuse it.
+- Knowledge pages are the rewritable synthesized layer — update them in place.
+  Ingested source material stays immutable; corrections to it are new assets
+  that xref the source. Carry a provenance xref when derived, and a
+  self-situating header.

--- a/src/assets/stash-skeleton/facts/conventions/assets/knowledge.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/knowledge.md
@@ -38,3 +38,13 @@ Use a knowledge asset for durable reference material, synthesized explanations, 
 - Create a new page when the concept deserves its own durable entry.
 - Add links both ways when a new relationship matters.
 - Periodically scan for orphaned, stale, or overlapping knowledge docs and consolidate them.
+
+## Placement & linking
+
+- Knowledge is **reuse-born**: file it under a stable **domain** prefix from
+  `fact:conventions/domains` (`knowledge:auth/oauth-refresh-races`), not under a
+  project — that prefix is what lets any project prefix-search and reuse it.
+- Treat ingested source docs as immutable; record corrections as new assets that
+  xref the source. Carry a provenance xref and a self-situating header.
+- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
+  full placement and cross-linking rules.

--- a/src/assets/stash-skeleton/facts/conventions/assets/lesson.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/lesson.md
@@ -47,5 +47,3 @@ Use a lesson to record:
 - Lessons are **scope-born**: file them under the **project/client** they were
   learned in (`lesson:projectA/token-refresh-gotcha`) and xref the asset the
   lesson corrects or refines.
-- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
-  full placement and cross-linking rules.

--- a/src/assets/stash-skeleton/facts/conventions/assets/lesson.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/lesson.md
@@ -41,3 +41,11 @@ Use a lesson to record:
 - Create a new lesson only when the trigger or failure mode is meaningfully different.
 - Deprecate or revise stale lessons instead of allowing contradictory guidance to accumulate.
 - When a lesson becomes broadly normative, consider promoting the stable rule into a `fact:conventions/...` asset.
+
+## Placement & linking
+
+- Lessons are **scope-born**: file them under the **project/client** they were
+  learned in (`lesson:projectA/token-refresh-gotcha`) and xref the asset the
+  lesson corrects or refines.
+- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
+  full placement and cross-linking rules.

--- a/src/assets/stash-skeleton/facts/conventions/assets/memory.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/memory.md
@@ -36,3 +36,14 @@ Use a memory when a future agent would make a better decision by knowing a speci
 - Consolidate repeated memories into a clearer fact or knowledge asset.
 - Convert broad, stable conventions into `fact` assets.
 - Archive memories that are no longer current rather than letting stale context keep influencing agents.
+
+## Placement & linking
+
+- Memories are **scope-born**: file them under the **current project/client**
+  slug (`memory:projectA/auth-token-refresh`) — the working context is the
+  answer, so no per-asset judgment is needed. Add the subject as a tag
+  (`tags: [auth, projectA]`) for cross-cutting recall.
+- When a memory turns out to be domain-general, **append** a new
+  `knowledge:<domain>/…` asset that xrefs it — never rename the memory up a rung.
+- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
+  full placement and cross-linking rules.

--- a/src/assets/stash-skeleton/facts/conventions/assets/memory.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/memory.md
@@ -45,5 +45,3 @@ Use a memory when a future agent would make a better decision by knowing a speci
   (`tags: [auth, projectA]`) for cross-cutting recall.
 - When a memory turns out to be domain-general, **append** a new
   `knowledge:<domain>/…` asset that xrefs it — never rename the memory up a rung.
-- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
-  full placement and cross-linking rules.

--- a/src/assets/stash-skeleton/facts/conventions/assets/script.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/script.md
@@ -41,3 +41,11 @@ Use a script when a task is mechanical, repeatable, and better handled by a dete
 - Keep dangerous actions behind explicit flags.
 - When a script becomes a core operation, add or update a workflow that explains when to run it.
 - If the script encodes a convention, also document that convention in a fact or knowledge asset.
+
+## Placement & linking
+
+- Scripts are usually **reuse-born**: file a general helper under a
+  tool/domain slug (`script:build/release`); keep a project-specific script under
+  the project slug only when it truly won't generalize.
+- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
+  full placement and cross-linking rules.

--- a/src/assets/stash-skeleton/facts/conventions/assets/script.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/script.md
@@ -44,8 +44,7 @@ Use a script when a task is mechanical, repeatable, and better handled by a dete
 
 ## Placement & linking
 
-- Scripts are usually **reuse-born**: file a general helper under a
-  tool/domain slug (`script:build/release`); keep a project-specific script under
-  the project slug only when it truly won't generalize.
-- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
-  full placement and cross-linking rules.
+- Scripts are **reuse-born**: file a general helper under a tool/domain slug
+  from `fact:conventions/domains` (`script:build/release`). Use the project slug
+  only when the script hard-codes project-specific paths, endpoints, or
+  credentials.

--- a/src/assets/stash-skeleton/facts/conventions/assets/skill.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/skill.md
@@ -38,3 +38,12 @@ Use a skill when the stash needs reusable procedural guidance for a recurring cl
 - Add companion knowledge docs when the skill needs background material that would bloat the main procedure.
 - Promote durable recurring corrections into the skill; leave one-off observations in memories or lessons.
 - Prefer small edits that preserve the skill’s operational shape over broad rewrites that erase tested guidance.
+
+## Placement & linking
+
+- Skills are **reuse-born**: place `skills/<domain>/<name>/SKILL.md` under a
+  stable **domain** prefix from `fact:conventions/domains`
+  (`skill:testing/flaky-test-triage`) so any project finds and reuses it instead
+  of duplicating the procedure.
+- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
+  full placement and cross-linking rules.

--- a/src/assets/stash-skeleton/facts/conventions/assets/skill.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/skill.md
@@ -45,5 +45,3 @@ Use a skill when the stash needs reusable procedural guidance for a recurring cl
   stable **domain** prefix from `fact:conventions/domains`
   (`skill:testing/flaky-test-triage`) so any project finds and reuses it instead
   of duplicating the procedure.
-- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
-  full placement and cross-linking rules.

--- a/src/assets/stash-skeleton/facts/conventions/assets/workflow.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/workflow.md
@@ -41,3 +41,11 @@ Use a workflow when the task requires multiple steps, branching decisions, repea
 - Add logging expectations when the workflow creates durable state.
 - Extract reusable sub-procedures into skills or scripts when the workflow grows too broad.
 - Record recurring mistakes as lessons, then fold stable corrections back into the workflow.
+
+## Placement & linking
+
+- Workflows are usually **global**: keep them at the type root or under a
+  tool/domain slug (`workflow:release-train`). Scoping a workflow to one project
+  rarely improves retrieval and adds rename risk.
+- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
+  full placement and cross-linking rules.

--- a/src/assets/stash-skeleton/facts/conventions/assets/workflow.md
+++ b/src/assets/stash-skeleton/facts/conventions/assets/workflow.md
@@ -47,5 +47,3 @@ Use a workflow when the task requires multiple steps, branching decisions, repea
 - Workflows are usually **global**: keep them at the type root or under a
   tool/domain slug (`workflow:release-train`). Scoping a workflow to one project
   rarely improves retrieval and adds rename risk.
-- See `fact:conventions/organization` and `fact:conventions/backlinks` for the
-  full placement and cross-linking rules.

--- a/src/assets/stash-skeleton/facts/conventions/backlinks.md
+++ b/src/assets/stash-skeleton/facts/conventions/backlinks.md
@@ -37,8 +37,10 @@ xrefs:
   ref** (`memory:projectA/token-quirk` xrefs `knowledge:auth/vendor-x-token-api`
   — it also makes this asset findable from searches for its source). An
   original observation with no source carries none — never invent provenance.
-  Wikis enforce the analogous rule mechanically (`sources:` + `uncited-raw`
-  lint); non-wiki provenance is discipline only.
+  `akm remember`/`akm import` write this channel via `--xref <ref>`
+  (repeatable; refs are checked at write time). Wikis enforce the analogous
+  rule mechanically (`sources:` + `uncited-raw` lint); non-wiki provenance is
+  discipline only.
 - **Associative xrefs are discretionary — real relationships only.** Add one when
   you already know a genuine load-bearing connection. Do **not** hit a link
   quota by pointing at the topically-nearest sibling — a plausible-but-wrong

--- a/src/assets/stash-skeleton/facts/conventions/backlinks.md
+++ b/src/assets/stash-skeleton/facts/conventions/backlinks.md
@@ -70,8 +70,11 @@ xrefs:
 ## Self-situating headers and canonical naming
 
 Put the one-line orientation in `description:` and the trigger conditions in
-`when_to_use:` — those are indexed fields; body prose is not (only headings
-reach the index). Then open the body with a plain title plus a one-line
+`when_to_use:` — those are indexed fields; body prose is not indexed by
+default (only headings reach the index; the opt-in `index.indexBodyOpening`
+flag adds just the first body paragraph, at the lowest weight —
+`description:`/`when_to_use:` remain the primary orientation channel). Then
+open the body with a plain title plus a one-line
 orientation naming what it is, its scope/domain, and its key entities in
 canonical spelling (`Postgres`, `OAuth`, `TLS`, `Acme`) — the entity/relation
 graph is extracted from body prose, and readers land here from `akm show`.

--- a/src/assets/stash-skeleton/facts/conventions/backlinks.md
+++ b/src/assets/stash-skeleton/facts/conventions/backlinks.md
@@ -1,15 +1,16 @@
 ---
 category: convention
-description: How to cross-link assets so retrieval compounds — one mandatory provenance xref, sparse real associative xrefs, corrections as new assets, and canonical entity naming.
+description: How to cross-link assets so retrieval compounds — a provenance xref when derived, sparse real associative xrefs, corrections as new assets, and canonical entity naming.
 when_to_use: Surfaced to authoring agents when they create or revise any non-wiki asset that derives from, corrects, or relates to another asset.
 ---
 
 <!--
   SOFT guidance only — advice, not a contract. Back-linking here is a RETRIEVAL
-  mechanism, not decoration: `xrefs:` frontmatter folds into the search index and
-  feeds the entity/relation graph boost. Over-linking degrades ranking, so these
-  rules are deliberately conservative. Wikis have their own xref + lint system —
-  this convention is for non-wiki assets.
+  mechanism, not decoration: `xrefs:` frontmatter folds into the search index;
+  the entity/relation graph is extracted from BODY prose (memory + knowledge),
+  never from frontmatter. Over-linking degrades ranking, so these rules are
+  deliberately conservative. Wikis have their own xref + lint system — this
+  convention is for non-wiki assets.
 -->
 
 # Back-linking conventions
@@ -25,46 +26,52 @@ lever — which means both too few and too many hurt.
 description: OAuth refresh-token race on token rotation
 tags: [auth, projectA]
 xrefs:
-  - knowledge:vendor-x/token-api        # provenance: what this was synthesized from
+  - knowledge:auth/vendor-x-token-api   # provenance: what this was synthesized from
   - lesson:projectA/token-refresh-gotcha # one real associative link
 ---
 ```
 
 ## Link rules
 
-- **Exactly one mandatory xref: provenance.** Every synthesized or derived asset
-  cites the ref of the source it came from
-  (`memory:projectA/token-quirk` xrefs `knowledge:vendor-x/token-api`). It is
-  single-target, self-limiting, and the one link backed by real lint
-  (`uncited-raw`, for wikis).
+- **One xref is mandatory when the asset derives from another: cite the source
+  ref** (`memory:projectA/token-quirk` xrefs `knowledge:auth/vendor-x-token-api`
+  — it also makes this asset findable from searches for its source). An
+  original observation with no source carries none — never invent provenance.
+  Wikis enforce the analogous rule mechanically (`sources:` + `uncited-raw`
+  lint); non-wiki provenance is discipline only.
 - **Associative xrefs are discretionary — real relationships only.** Add one when
   you already know a genuine load-bearing connection. Do **not** hit a link
-  quota by pointing at the topically-nearest sibling you can name — a
-  plausible-but-wrong edge poisons the graph boost and surfaces unrelated assets.
-- **Cap total xrefs at ~5.** Because ref strings fold into the FTS hint field, a
-  high-degree asset smears its ref token across every citer, wrecking the ranking
-  signal of popular sources and hubs.
-- **Corrections are new assets, never edits to a source.** Treat ingested
-  `knowledge/` as immutable-by-discipline. A hard-won fix is a new `lesson:` or
-  `knowledge:` asset that xrefs the thing it corrects
-  (`lesson:projectA/oauth-race-fix` xrefs `knowledge:auth/oauth-refresh-races`) —
-  this preserves provenance and lets the synthesized layer be rewritten without
-  losing ground truth.
+  quota by pointing at the topically-nearest sibling — a plausible-but-wrong
+  xref makes this asset a false search match for the other topic, and a wrong
+  relationship asserted in prose poisons the entity graph. A relationship you
+  want the graph to learn must be named in the body (e.g. open with "Corrects
+  knowledge:auth/oauth-refresh-races").
+- **Cap total xrefs at ~5 (a heuristic, not a measured threshold).** Each xref
+  folds its ref tokens into THIS asset's search hints — past a handful, the
+  asset matches queries about several other topics and its own ranking signal
+  blurs.
+- **Corrections are new assets; ingested material is immutable.** Treat wiki
+  `raw/`, vendored docs, and transcripts as immutable-by-discipline: a hard-won
+  fix is a new `lesson:` or `knowledge:` asset that xrefs what it corrects.
+  Synthesized `knowledge:` pages are the rewritable layer — update them in
+  place. When a correction supersedes a standalone asset (memory OR knowledge),
+  also set the old asset's `beliefState: superseded` and
+  `supersededBy: [<new ref>]` — a metadata edit, not a content edit — so the
+  ranker demotes the stale version instead of letting it outrank your fix.
 - **Bidirectional back-links are best-effort.** Add a return xref only when you
   are already editing the target in the same pass. Never require editing a
   separate hot file just to add a back-xref — concurrent writes drop it under
   last-writer-wins and no lint will notice.
 
-## Canonical naming feeds the graph
+## Self-situating headers and canonical naming
 
-The entity/relation graph is extracted from **body text, not the path**. So the
-retrieval boost only fires when names are spelled consistently. Open every asset
-with a **self-situating header** — a plain title plus a one-line orientation
-naming what it is, its scope/domain, and its key entities in canonical spelling
-(`Postgres`, `OAuth`, `TLS`, `Acme`). This single move helps FTS, embeddings, the
-entity graph, and humans at once, and the literature ties it to a large drop in
-failed retrievals. Keep a short canonical-spelling list in
-`fact:conventions/domains` (or a `fact:canonical-names`) so agents don't
+Put the one-line orientation in `description:` and the trigger conditions in
+`when_to_use:` — those are indexed fields; body prose is not (only headings
+reach the index). Then open the body with a plain title plus a one-line
+orientation naming what it is, its scope/domain, and its key entities in
+canonical spelling (`Postgres`, `OAuth`, `TLS`, `Acme`) — the entity/relation
+graph is extracted from body prose, and readers land here from `akm show`.
+Keep the canonical-spelling list in `fact:conventions/domains` so agents don't
 fragment `postgres` / `postgresql` / `pg`.
 
 ## Hubs are optional, not per-namespace obligations

--- a/src/assets/stash-skeleton/facts/conventions/backlinks.md
+++ b/src/assets/stash-skeleton/facts/conventions/backlinks.md
@@ -1,0 +1,84 @@
+---
+category: convention
+description: How to cross-link assets so retrieval compounds — one mandatory provenance xref, sparse real associative xrefs, corrections as new assets, and canonical entity naming.
+when_to_use: Surfaced to authoring agents when they create or revise any non-wiki asset that derives from, corrects, or relates to another asset.
+---
+
+<!--
+  SOFT guidance only — advice, not a contract. Back-linking here is a RETRIEVAL
+  mechanism, not decoration: `xrefs:` frontmatter folds into the search index and
+  feeds the entity/relation graph boost. Over-linking degrades ranking, so these
+  rules are deliberately conservative. Wikis have their own xref + lint system —
+  this convention is for non-wiki assets.
+-->
+
+# Back-linking conventions
+
+Cross-references are how knowledge compounds instead of being re-derived every
+session. In AKM they are also **indexed**: the strings in an asset's `xrefs:`
+frontmatter fold into its search-hint text, and knowledge/memory bodies feed an
+LLM-extracted entity/relation graph that boosts ranking. So links are a retrieval
+lever — which means both too few and too many hurt.
+
+```yaml
+---
+description: OAuth refresh-token race on token rotation
+tags: [auth, projectA]
+xrefs:
+  - knowledge:vendor-x/token-api        # provenance: what this was synthesized from
+  - lesson:projectA/token-refresh-gotcha # one real associative link
+---
+```
+
+## Link rules
+
+- **Exactly one mandatory xref: provenance.** Every synthesized or derived asset
+  cites the ref of the source it came from
+  (`memory:projectA/token-quirk` xrefs `knowledge:vendor-x/token-api`). It is
+  single-target, self-limiting, and the one link backed by real lint
+  (`uncited-raw`, for wikis).
+- **Associative xrefs are discretionary — real relationships only.** Add one when
+  you already know a genuine load-bearing connection. Do **not** hit a link
+  quota by pointing at the topically-nearest sibling you can name — a
+  plausible-but-wrong edge poisons the graph boost and surfaces unrelated assets.
+- **Cap total xrefs at ~5.** Because ref strings fold into the FTS hint field, a
+  high-degree asset smears its ref token across every citer, wrecking the ranking
+  signal of popular sources and hubs.
+- **Corrections are new assets, never edits to a source.** Treat ingested
+  `knowledge/` as immutable-by-discipline. A hard-won fix is a new `lesson:` or
+  `knowledge:` asset that xrefs the thing it corrects
+  (`lesson:projectA/oauth-race-fix` xrefs `knowledge:auth/oauth-refresh-races`) —
+  this preserves provenance and lets the synthesized layer be rewritten without
+  losing ground truth.
+- **Bidirectional back-links are best-effort.** Add a return xref only when you
+  are already editing the target in the same pass. Never require editing a
+  separate hot file just to add a back-xref — concurrent writes drop it under
+  last-writer-wins and no lint will notice.
+
+## Canonical naming feeds the graph
+
+The entity/relation graph is extracted from **body text, not the path**. So the
+retrieval boost only fires when names are spelled consistently. Open every asset
+with a **self-situating header** — a plain title plus a one-line orientation
+naming what it is, its scope/domain, and its key entities in canonical spelling
+(`Postgres`, `OAuth`, `TLS`, `Acme`). This single move helps FTS, embeddings, the
+entity graph, and humans at once, and the literature ties it to a large drop in
+failed retrievals. Keep a short canonical-spelling list in
+`fact:conventions/domains` (or a `fact:canonical-names`) so agents don't
+fragment `postgres` / `postgresql` / `pg`.
+
+## Hubs are optional, not per-namespace obligations
+
+A hub (a `wiki:` overview page that xrefs the key assets in a domain) is worth
+authoring for a **few genuinely high-traffic domains** — wikis are the one type
+with real orphan/broken-xref/stale-index lint to keep a hub honest. Do **not**
+mandate a hub per namespace and do not edit a hub on every write: that is O(n)
+maintenance, a concurrent-write contention point, and it flattens the multi-hop
+graph into a namespace-wide star. Let the FTS index be the catalog; spend the
+effort on per-asset self-situating headers instead.
+
+## Keep assets atomic
+
+One concept per asset. If a note covers two concepts, write two assets and xref
+them — atomic assets give the ranker clean, single-topic targets and give you a
+real relationship to link rather than a blurred one to bury.

--- a/src/assets/stash-skeleton/facts/conventions/backlinks.md
+++ b/src/assets/stash-skeleton/facts/conventions/backlinks.md
@@ -60,6 +60,8 @@ xrefs:
   also set the old asset's `beliefState: superseded` and
   `supersededBy: [<new ref>]` — a metadata edit, not a content edit — so the
   ranker demotes the stale version instead of letting it outrank your fix.
+  `akm remember`/`akm import` do both writes in one step via
+  `--supersedes <old ref>` (adds the xref and demotes the old asset).
 - **Bidirectional back-links are best-effort.** Add a return xref only when you
   are already editing the target in the same pass. Never require editing a
   separate hot file just to add a back-xref — concurrent writes drop it under

--- a/src/assets/stash-skeleton/facts/conventions/domains.md
+++ b/src/assets/stash-skeleton/facts/conventions/domains.md
@@ -1,29 +1,34 @@
 ---
 category: convention
-description: The closed vocabulary of domain prefixes for reuse-born assets (knowledge/skill/wiki/fact), plus canonical entity spellings. Edit this to match your stash.
-when_to_use: Surfaced to authoring agents when they must pick a domain prefix for a knowledge, skill, wiki, or fact asset.
+description: The closed vocabulary of domain prefixes for reuse-born assets (knowledge/skill/wiki/fact/script), plus canonical entity spellings. Edit this to match your stash.
+when_to_use: Surfaced to authoring agents alongside the other convention facts; consult it when picking a domain prefix for a knowledge, skill, fact, or script asset (for wikis, the domain names the wiki).
 ---
 
 <!--
   SOFT guidance only. This is the domain vocabulary that `organization.md` refers
   to. It is intentionally SHORT and STARTER — replace these with the domains your
   stash actually accumulates. A closed list keeps agents from coining a new
-  folder per session (which fragments prefix search); the flat type-root fallback
-  in organization.md handles anything that doesn't fit yet.
+  folder per session (which fragments the tree and splits slug search); the flat
+  type-root fallback in organization.md handles anything that doesn't fit yet.
 -->
 
 # Domain vocabulary
 
-Reuse-born assets (`knowledge`, `skill`, `wiki`, `fact`) take a **domain prefix**
-from this list, e.g. `knowledge:auth/oauth-refresh-races`,
-`skill:testing/flaky-test-triage`. Pick the closest match. If nothing fits, write
+Reuse-born assets (`knowledge`, `skill`, `wiki`, `fact`, `script`) take a
+**domain prefix** from this list, e.g. `knowledge:auth/oauth-refresh-races`,
+`skill:testing/flaky-test-triage` (for a wiki, the domain names the wiki:
+`wikis/auth/`). Pick the closest match. If two fit, take the one naming the
+SUBJECT of the doc (what it teaches, not where it was met) and put the other in
+tags; if still tied, the earlier entry in this list wins. If nothing fits, write
 the asset at the type root and propose an addition here — do **not** invent a
 one-off domain mid-task.
 
 ## Starter domains
 
-Add, remove, and rename to fit your stash. Keep the list short (roughly a dozen);
-add a subdomain only where volume justifies it.
+Add, remove, and rename to fit your stash. Keep the list short (roughly a dozen)
+— the whole list rides along in every authoring prompt, and a short closed list
+is what keeps two agents picking the same slug. Add a subdomain only where
+volume justifies it.
 
 - `auth` — authentication, authorization, tokens, sessions
 - `networking` — protocols, TLS, DNS, proxies, connectivity
@@ -36,20 +41,23 @@ add a subdomain only where volume justifies it.
 - `frontend` — UI, rendering, client state
 - `data-pipelines` — ETL, streaming, batch processing
 - `tooling` — dev tooling, editor/agent integration, scripts
-- `policies` — durable house rules and standards (`fact:policies/…`)
+- `policies` — organizational/business rules the work must obey (PII handling, licensing) (`fact:policies/…`)
+- `conventions` — stash authoring house-rules (`fact:conventions/…`; auto-surfaced to authoring agents — keep them in this directory)
 
 ## Canonical entity spellings
 
-Spell these consistently in asset **bodies** so the entity/relation graph boost
-does not fragment. Extend as your stash grows.
+Pick ONE name per entity and use it everywhere in asset **bodies** — retrieval
+is case-insensitive but treats aliases as different entities, so alias variants
+fragment the entity graph. Extend as your stash grows.
 
 - Postgres (not postgresql / pg)
-- OAuth (not oauth / Oauth)
-- TLS (not tls / ssl when you mean TLS)
-- Kubernetes (not k8s in prose titles)
+- Kubernetes (not k8s)
+- TLS (not ssl when you mean TLS)
+- OAuth
 
 Project and client slugs are **not** listed here — those are scope slugs for
 scope-born types (`memory`, `lesson`, `task`, `env`, `secret`). Keep their
-canonical spellings wherever your stash tracks active projects (e.g. a
-`fact:canonical-names` or your `.meta/` orientation doc) and `akm search` for an
-existing spelling before minting a new one.
+canonical spellings in a `category: meta` fact (e.g. `fact:active-projects`) so
+they auto-inject at authoring time — not in `.meta/`, which is unindexed and
+invisible mid-task — and `akm search` for an existing spelling before minting a
+new one.

--- a/src/assets/stash-skeleton/facts/conventions/domains.md
+++ b/src/assets/stash-skeleton/facts/conventions/domains.md
@@ -1,0 +1,55 @@
+---
+category: convention
+description: The closed vocabulary of domain prefixes for reuse-born assets (knowledge/skill/wiki/fact), plus canonical entity spellings. Edit this to match your stash.
+when_to_use: Surfaced to authoring agents when they must pick a domain prefix for a knowledge, skill, wiki, or fact asset.
+---
+
+<!--
+  SOFT guidance only. This is the domain vocabulary that `organization.md` refers
+  to. It is intentionally SHORT and STARTER — replace these with the domains your
+  stash actually accumulates. A closed list keeps agents from coining a new
+  folder per session (which fragments prefix search); the flat type-root fallback
+  in organization.md handles anything that doesn't fit yet.
+-->
+
+# Domain vocabulary
+
+Reuse-born assets (`knowledge`, `skill`, `wiki`, `fact`) take a **domain prefix**
+from this list, e.g. `knowledge:auth/oauth-refresh-races`,
+`skill:testing/flaky-test-triage`. Pick the closest match. If nothing fits, write
+the asset at the type root and propose an addition here — do **not** invent a
+one-off domain mid-task.
+
+## Starter domains
+
+Add, remove, and rename to fit your stash. Keep the list short (roughly a dozen);
+add a subdomain only where volume justifies it.
+
+- `auth` — authentication, authorization, tokens, sessions
+- `networking` — protocols, TLS, DNS, proxies, connectivity
+- `databases` — storage engines, queries, migrations (subdomain e.g. `databases/postgres`)
+- `testing` — test strategy, fixtures, flaky-test triage, coverage
+- `build` — build systems, packaging, CI pipelines
+- `cloud` — infra, deploy targets, IaC (subdomain e.g. `cloud/aws`)
+- `observability` — logging, metrics, tracing, alerting
+- `security` — threat modeling, secrets handling, hardening
+- `frontend` — UI, rendering, client state
+- `data-pipelines` — ETL, streaming, batch processing
+- `tooling` — dev tooling, editor/agent integration, scripts
+- `policies` — durable house rules and standards (`fact:policies/…`)
+
+## Canonical entity spellings
+
+Spell these consistently in asset **bodies** so the entity/relation graph boost
+does not fragment. Extend as your stash grows.
+
+- Postgres (not postgresql / pg)
+- OAuth (not oauth / Oauth)
+- TLS (not tls / ssl when you mean TLS)
+- Kubernetes (not k8s in prose titles)
+
+Project and client slugs are **not** listed here — those are scope slugs for
+scope-born types (`memory`, `lesson`, `task`, `env`, `secret`). Keep their
+canonical spellings wherever your stash tracks active projects (e.g. a
+`fact:canonical-names` or your `.meta/` orientation doc) and `akm search` for an
+existing spelling before minting a new one.

--- a/src/assets/stash-skeleton/facts/conventions/organization.md
+++ b/src/assets/stash-skeleton/facts/conventions/organization.md
@@ -1,28 +1,31 @@
 ---
 category: convention
-description: Where to place an asset in the stash — the one path partition axis, chosen by asset type, so refs stay stable and prefix-scoped retrieval works.
+description: Where to place an asset in the stash — the one path partition axis, chosen by asset type, so refs stay stable and slug search (akm search "<slug>" --type <type>) co-locates related assets.
 when_to_use: Surfaced to authoring agents when they create or move any non-wiki asset and must decide its subdirectory/name.
 ---
 
 <!--
   SOFT guidance only — advice, not a contract. Nothing here is enforced by the
   proposal gate. It steers WHERE assets go so that path-derived refs stay stable
-  and `akm search "<type>:<prefix>/"` keeps working. Tune the axis choices and
-  the domain vocabulary to match how your stash is actually queried.
+  and scoped search (`akm search "<slug>" --type <type>`) keeps working. Tune
+  the axis choices and the domain vocabulary to match how your stash is queried.
 -->
 
 # Stash organization conventions
 
 A file's path under its type directory **becomes part of its ref**
 (`knowledge/auth/oauth-refresh-races.md` → `knowledge:auth/oauth-refresh-races`).
-That ref is an address other assets cite and `akm search` filters by prefix. The
+That ref is an address other assets cite, and its segments are search terms —
+`akm search "projectA" --type memory` reconstructs a project's memories. The
 path is therefore the one facet you **cannot express twice and cannot change
 without breaking the ref** — so spend it deliberately, on exactly one axis.
 
 Retrieval is search, not browse: no one walks these folders at query time. A
-subdirectory buys you only two things — a small indexing-confidence bump and a
-ref-prefix filter (`akm search "memory:projectA/"`). Every other facet belongs
-in frontmatter, where the index can actually read it.
+subdirectory buys you three things: its tokens are indexed as part of the
+asset's **name** (the highest-weighted search field), they auto-derive into
+`tags` when `tags` is empty, and for scope-born types a slug matching the
+current repo's name earns an automatic in-project ranking boost. Every other
+facet belongs in frontmatter, where the index can actually read it.
 
 ## Choose the partition axis by asset TYPE, not per-asset judgment
 
@@ -32,25 +35,34 @@ differently and bake the wrong guess into an immutable ref. Decide by type:
 - **Scope-born types → current project / client / team slug.**
   `memory`, `lesson`, `task`, `env`, `secret`. These are born bound to the work
   in front of you, so the working context *is* the answer — no judgment needed.
+  When the scope is a single repo, use its repo/package name as the slug (as
+  `git remote`/package.json spell it) — ranking auto-boosts assets whose name
+  or tags match the current repo. Client/team slugs get no such boost; just
+  reuse the existing spelling.
   - `memory:projectA/auth-token-refresh`
   - `lesson:clientX/migration-rollback-gotcha`
   - `secret:clientX/api-key`
 - **Reuse-born types → stable domain from a short vocabulary.**
-  `knowledge`, `skill`, `wiki`, `fact`. These are meant to be reused across
-  projects, so co-locate them by subject and let any project prefix-search them.
+  `knowledge`, `skill`, `wiki`, `fact`, `script`. These are meant to be reused
+  across projects, so co-locate them by subject — any project retrieves them
+  with `akm search "<domain>" --type <type>`. For a wiki the domain names the
+  wiki itself (`wikis/auth/`); inside it, its `schema.md` and wiki lint govern
+  layout, not these rules.
   - `knowledge:auth/oauth-refresh-races`
   - `skill:testing/flaky-test-triage`
   - `fact:policies/pii-handling`
 - **Global-by-nature types → type root or a tool slug.**
   `command`, `agent`, `workflow`, and stash-wide `env`. Scoping these to a
-  project rarely improves precision and only adds rename risk.
+  project rarely improves precision and only adds rename risk. `env` defaults
+  to the project/client slug; only an env consumed by every project sits at
+  the type root — if any single project would break when it changes, it is
+  scope-born.
 
 **Why reuse types don't take the project axis:** project relevance is already
 recovered at query time — AKM blends a per-project usage signal into ranking
-(scoped utility, keyed independently of the path, so it is rename-proof).
-Spending the scarce path segment on the project axis for a reusable asset is
-therefore redundant; free it for the domain, which is the *only* handle that
-co-locates cross-project reuse.
+(scoped utility, keyed off the current repo, not the asset's path). Free the
+scarce path segment for the domain — the *only* handle that co-locates
+cross-project reuse.
 
 ## Placement rules
 
@@ -74,20 +86,22 @@ co-locates cross-project reuse.
   (`acme` vs `acme-corp`) so the prefix does not fragment. Keep the domain
   vocabulary in `fact:conventions/domains`.
 - **Off-axis facets go in `tags:`, not a bare field.** The indexed FTS fields are
-  name, description, tags, hints, and content — there is **no `project` field**,
-  so `project: projectA` in frontmatter is invisible to search. Put the off-axis
-  facet in `tags` instead (a project-scoped memory adds `tags: [auth]`; a
-  domain-scoped asset genuinely tied to a project adds `tags: [projectA]`
-  sparingly).
-- **Footgun:** path segments are auto-added to `tags` **only when `tags` is
-  empty**. The moment you set `tags` explicitly you must also include the path
-  scope/domain token, or you silently drop the auto-derived one.
+  name, description, tags, hints, and content (headings only — body prose is
+  not indexed) — there is **no `project` field**, so `project: projectA` in
+  frontmatter is invisible to search. Put the off-axis facet in `tags` instead
+  (a project-scoped memory adds `tags: [auth]`; a domain-scoped asset genuinely
+  tied to a project adds `tags: [projectA]` sparingly).
+- **Footgun:** path and filename tokens are auto-added to `tags` **only when
+  `tags` is empty**. When you set `tags` explicitly, restate the scope/domain
+  token — the name field still carries it, but you lose the tag-match ranking
+  boost.
 
 ## Renames and evolution
 
 - **A ref is chosen once. Default to not renaming.** Non-wiki inbound xrefs have
   no broken-link lint, so a rename dangles them silently while the dead ref
-  string keeps scoring in FTS.
+  string keeps scoring in FTS — and a renamed file is a new index entry, so the
+  asset's accumulated usage-ranking history resets.
 - If a rename is truly unavoidable, treat it as an xref-fixing operation: grep
   the stash for the old ref string and fix every inbound reference in the same
   pass.

--- a/src/assets/stash-skeleton/facts/conventions/organization.md
+++ b/src/assets/stash-skeleton/facts/conventions/organization.md
@@ -1,0 +1,104 @@
+---
+category: convention
+description: Where to place an asset in the stash — the one path partition axis, chosen by asset type, so refs stay stable and prefix-scoped retrieval works.
+when_to_use: Surfaced to authoring agents when they create or move any non-wiki asset and must decide its subdirectory/name.
+---
+
+<!--
+  SOFT guidance only — advice, not a contract. Nothing here is enforced by the
+  proposal gate. It steers WHERE assets go so that path-derived refs stay stable
+  and `akm search "<type>:<prefix>/"` keeps working. Tune the axis choices and
+  the domain vocabulary to match how your stash is actually queried.
+-->
+
+# Stash organization conventions
+
+A file's path under its type directory **becomes part of its ref**
+(`knowledge/auth/oauth-refresh-races.md` → `knowledge:auth/oauth-refresh-races`).
+That ref is an address other assets cite and `akm search` filters by prefix. The
+path is therefore the one facet you **cannot express twice and cannot change
+without breaking the ref** — so spend it deliberately, on exactly one axis.
+
+Retrieval is search, not browse: no one walks these folders at query time. A
+subdirectory buys you only two things — a small indexing-confidence bump and a
+ref-prefix filter (`akm search "memory:projectA/"`). Every other facet belongs
+in frontmatter, where the index can actually read it.
+
+## Choose the partition axis by asset TYPE, not per-asset judgment
+
+Deciding "project or domain?" per asset is non-deterministic — two agents guess
+differently and bake the wrong guess into an immutable ref. Decide by type:
+
+- **Scope-born types → current project / client / team slug.**
+  `memory`, `lesson`, `task`, `env`, `secret`. These are born bound to the work
+  in front of you, so the working context *is* the answer — no judgment needed.
+  - `memory:projectA/auth-token-refresh`
+  - `lesson:clientX/migration-rollback-gotcha`
+  - `secret:clientX/api-key`
+- **Reuse-born types → stable domain from a short vocabulary.**
+  `knowledge`, `skill`, `wiki`, `fact`. These are meant to be reused across
+  projects, so co-locate them by subject and let any project prefix-search them.
+  - `knowledge:auth/oauth-refresh-races`
+  - `skill:testing/flaky-test-triage`
+  - `fact:policies/pii-handling`
+- **Global-by-nature types → type root or a tool slug.**
+  `command`, `agent`, `workflow`, and stash-wide `env`. Scoping these to a
+  project rarely improves precision and only adds rename risk.
+
+**Why reuse types don't take the project axis:** project relevance is already
+recovered at query time — AKM blends a per-project usage signal into ranking
+(scoped utility, keyed independently of the path, so it is rename-proof).
+Spending the scarce path segment on the project axis for a reusable asset is
+therefore redundant; free it for the domain, which is the *only* handle that
+co-locates cross-project reuse.
+
+## Placement rules
+
+- **One axis only.** Never encode two dimensions in the path
+  (`client/project/subsystem`, or `domain+status`). Second dimensions go in tags.
+- **Depth 1 by default, 2 max**, and only for strict stable containment
+  (`knowledge/databases/postgres/…`, `secret/clientX/projectA/…`). Never a third
+  semantic level — deeper axes go in frontmatter.
+- **Segments are lowercase-hyphen semantic tokens** that read as query terms
+  (`connection-pooling`, `tls-handshake-debugging`) — never opaque IDs, numbers,
+  or Johnny.Decimal-style codes, which carry no search signal.
+- **Never put a volatile facet in the path** — status, date, version, priority,
+  author, `wip`/`done`. Each one changes and forces a ref-breaking rename. They
+  belong in frontmatter tags.
+- **Flat fallback beats an invented folder.** If no domain fits a reuse-type
+  asset, write it at the type root (`knowledge:http-retry-basics`) rather than
+  coining a one-off domain. An unneeded folder is pure rename liability; propose
+  a vocabulary addition instead of fragmenting the tree.
+- **Reuse an existing slug before minting a new one.** Before coining a new
+  project/client/domain slug, `akm search` for the existing spelling
+  (`acme` vs `acme-corp`) so the prefix does not fragment. Keep the domain
+  vocabulary in `fact:conventions/domains`.
+- **Off-axis facets go in `tags:`, not a bare field.** The indexed FTS fields are
+  name, description, tags, hints, and content — there is **no `project` field**,
+  so `project: projectA` in frontmatter is invisible to search. Put the off-axis
+  facet in `tags` instead (a project-scoped memory adds `tags: [auth]`; a
+  domain-scoped asset genuinely tied to a project adds `tags: [projectA]`
+  sparingly).
+- **Footgun:** path segments are auto-added to `tags` **only when `tags` is
+  empty**. The moment you set `tags` explicitly you must also include the path
+  scope/domain token, or you silently drop the auto-derived one.
+
+## Renames and evolution
+
+- **A ref is chosen once. Default to not renaming.** Non-wiki inbound xrefs have
+  no broken-link lint, so a rename dangles them silently while the dead ref
+  string keeps scoring in FTS.
+- If a rename is truly unavoidable, treat it as an xref-fixing operation: grep
+  the stash for the old ref string and fix every inbound reference in the same
+  pass.
+- When a project-scoped note turns out to be domain-general, **append, don't
+  promote**: write a new `knowledge:<domain>/…` asset that xrefs the originating
+  memory. Never rename the memory up a rung — that breaks its ref. The atomic
+  note still serves factoid recall; the new synthesis serves reuse; the xref
+  bridges them.
+
+## Real isolation is a separate stash, not a folder
+
+A path prefix is a ranking scope, not a security boundary. When you need enforced
+isolation (client confidentiality, secret-leak containment), mount a **separate
+stash** and let source resolution keep it apart — don't rely on a subdirectory.

--- a/src/assets/stash-skeleton/facts/conventions/organization.md
+++ b/src/assets/stash-skeleton/facts/conventions/organization.md
@@ -98,10 +98,11 @@ cross-project reuse.
 
 ## Renames and evolution
 
-- **A ref is chosen once. Default to not renaming.** Non-wiki inbound xrefs have
-  no broken-link lint, so a rename dangles them silently while the dead ref
-  string keeps scoring in FTS — and a renamed file is a new index entry, so the
-  asset's accumulated usage-ranking history resets.
+- **A ref is chosen once. Default to not renaming.** A rename dangles inbound
+  xrefs silently at write time — nothing catches the breakage until the next
+  `akm lint` run flags the dead frontmatter refs (`missing-ref`) — while the
+  dead ref string keeps scoring in FTS, and a renamed file is a new index
+  entry, so the asset's accumulated usage-ranking history resets.
 - If a rename is truly unavoidable, treat it as an xref-fixing operation: grep
   the stash for the old ref string and fix every inbound reference in the same
   pass.

--- a/src/assets/stash-skeleton/facts/conventions/organization.md
+++ b/src/assets/stash-skeleton/facts/conventions/organization.md
@@ -87,7 +87,9 @@ cross-project reuse.
   vocabulary in `fact:conventions/domains`.
 - **Off-axis facets go in `tags:`, not a bare field.** The indexed FTS fields are
   name, description, tags, hints, and content (headings only — body prose is
-  not indexed) — there is **no `project` field**, so `project: projectA` in
+  not indexed by default; the opt-in `index.indexBodyOpening` flag adds just
+  the first body paragraph, at the lowest weight) — there is **no `project`
+  field**, so `project: projectA` in
   frontmatter is invisible to search. Put the off-axis facet in `tags` instead
   (a project-scoped memory adds `tags: [auth]`; a domain-scoped asset genuinely
   tied to a project adds `tags: [projectA]` sparingly).
@@ -99,14 +101,19 @@ cross-project reuse.
 
 ## Renames and evolution
 
-- **A ref is chosen once. Default to not renaming.** A rename dangles inbound
-  xrefs silently at write time — nothing catches the breakage until the next
-  `akm lint` run flags the dead frontmatter refs (`missing-ref`) — while the
-  dead ref string keeps scoring in FTS, and a renamed file is a new index
-  entry, so the asset's accumulated usage-ranking history resets.
-- If a rename is truly unavoidable, treat it as an xref-fixing operation: grep
-  the stash for the old ref string and fix every inbound reference in the same
-  pass.
+- **A ref is chosen once. Default to not renaming.** A manual rename dangles
+  inbound xrefs silently at write time — nothing catches the breakage until
+  the next `akm lint` run flags the dead frontmatter refs (`missing-ref`) —
+  while the dead ref string keeps scoring in FTS, and a manually renamed file
+  is a new index entry, so the asset's accumulated usage-ranking history
+  resets.
+- If a rename is truly unavoidable, prefer `akm mv <ref> <new-name>`
+  (Experimental): it moves the file, rewrites inbound references across the
+  writable stash in the same pass, and keeps the asset's usage-ranking
+  history. Citing files in read-only sources are reported for manual
+  follow-up. On an older CLI without `akm mv`, treat the rename as an
+  xref-fixing operation: grep the stash for the old ref string and fix every
+  inbound reference in the same pass.
 - When a project-scoped note turns out to be domain-general, **append, don't
   promote**: write a new `knowledge:<domain>/…` asset that xrefs the originating
   memory. Never rename the memory up a rung — that breaks its ref. The atomic

--- a/src/assets/stash-skeleton/facts/conventions/organization.md
+++ b/src/assets/stash-skeleton/facts/conventions/organization.md
@@ -22,10 +22,10 @@ without breaking the ref** — so spend it deliberately, on exactly one axis.
 
 Retrieval is search, not browse: no one walks these folders at query time. A
 subdirectory buys you three things: its tokens are indexed as part of the
-asset's **name** (the highest-weighted search field), they auto-derive into
-`tags` when `tags` is empty, and for scope-born types a slug matching the
-current repo's name earns an automatic in-project ranking boost. Every other
-facet belongs in frontmatter, where the index can actually read it.
+asset's **name** (the highest-weighted search field), they are auto-added to
+`tags` (even when you set `tags` explicitly), and for scope-born types a slug
+matching the current repo's name earns an automatic in-project ranking boost.
+Every other facet belongs in frontmatter, where the index can actually read it.
 
 ## Choose the partition axis by asset TYPE, not per-asset judgment
 
@@ -91,10 +91,11 @@ cross-project reuse.
   frontmatter is invisible to search. Put the off-axis facet in `tags` instead
   (a project-scoped memory adds `tags: [auth]`; a domain-scoped asset genuinely
   tied to a project adds `tags: [projectA]` sparingly).
-- **Footgun:** path and filename tokens are auto-added to `tags` **only when
-  `tags` is empty**. When you set `tags` explicitly, restate the scope/domain
-  token — the name field still carries it, but you lose the tag-match ranking
-  boost.
+- **Directory tokens join `tags` on their own.** The scope/domain segments of
+  the path are always auto-added to `tags` — even when you set `tags`
+  explicitly — so there is no need to restate them; the tag-match ranking
+  boost fires for the scope token either way. Filename tokens are auto-added
+  only when `tags` is empty.
 
 ## Renames and evolution
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -90,6 +90,7 @@ import type { WindowSpec } from "./commands/health/types";
 import { parseWindowSpec } from "./commands/health/windows";
 import { extractCommand } from "./commands/improve/extract-cli";
 import { improveCommand } from "./commands/improve/improve-cli";
+import { mvCommand } from "./commands/mv-cli";
 import { hintsCommand, lessonsCommand, logCommand } from "./commands/observability-cli";
 import { proposalCommand } from "./commands/proposal/proposal-cli";
 import { rememberCommand } from "./commands/read/remember-cli";
@@ -557,6 +558,7 @@ export const main = defineCommand({
     import: importKnowledgeCommand,
     sync: syncCommand,
     clone: cloneCommand,
+    mv: mvCommand,
     registry: registryCommand,
     config: configCommand,
     feedback: feedbackCommand,

--- a/src/commands/agent/contribute-cli.ts
+++ b/src/commands/agent/contribute-cli.ts
@@ -149,7 +149,7 @@ export const lintCommand = defineCommand({
   meta: {
     name: "lint",
     description:
-      "Scan stash .md files for structural issues (unquoted colons, missing updated field, orphaned stubs, placeholder stubs, missing name/type, stale paths). Use --fix to auto-fix Tier 1 issues. Exits 0 on success regardless of findings; use --fail-on-flagged for CI fail-on-finding behavior.",
+      "Scan stash .md files for structural issues (unquoted colons, missing updated field, orphaned stubs, placeholder stubs, missing name/type, stale paths, broken refs in body text and in refs/xrefs/supersededBy/contradictedBy frontmatter). Use --fix to auto-fix Tier 1 issues. Exits 0 on success regardless of findings; use --fail-on-flagged for CI fail-on-finding behavior.",
   },
   args: {
     fix: {

--- a/src/commands/improve/memory/memory-belief.ts
+++ b/src/commands/improve/memory/memory-belief.ts
@@ -39,6 +39,26 @@ export type {
   MemoryBeliefTransitionLogRecord,
 } from "./memory-improve";
 
+// ── Shared edge-list reader ───────────────────────────────────────────────────
+
+/**
+ * Read a frontmatter edge value (`supersededBy` / `contradictedBy`) as a
+ * string list, promoting a scalar string to a one-element list.
+ *
+ * Scalar edges are LIVE data: the indexer's `normalizeNonEmptyStringList`
+ * accepts them and lint deliberately never flags them. An Array.isArray-only
+ * read treats a scalar as "no existing edges" and silently destroys the edge
+ * on the next merge — mirror `mergeXrefsIntoContent`'s scalar promotion
+ * instead.
+ */
+function readEdgeList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === "string" && v.trim().length > 0);
+  }
+  if (typeof value === "string" && value.trim()) return [value.trim()];
+  return [];
+}
+
 // ── Contradiction edge writer ─────────────────────────────────────────────────
 
 /**
@@ -58,9 +78,7 @@ export type {
  */
 export function writeContradictEdge(filePath: string, contradictedByRef: string): void {
   mutateFrontmatter(filePath, (parsed) => {
-    const existing: string[] = Array.isArray(parsed.data.contradictedBy)
-      ? (parsed.data.contradictedBy as string[])
-      : [];
+    const existing = readEdgeList(parsed.data.contradictedBy);
     if (existing.includes(contradictedByRef)) return null; // Already written — idempotent.
 
     const nextContradictedBy = [...new Set([...existing, contradictedByRef])].sort();
@@ -89,13 +107,22 @@ export function writeContradictEdge(filePath: string, contradictedByRef: string)
  * is already demoted, the file is not rewritten. Multiple corrections
  * sorted-set-append their refs.
  *
+ * Never WEAKENS an existing demotion: `contradicted` and `archived` rank
+ * BELOW `superseded` (severity order deprecated > superseded > contradicted >
+ * archived — see `BELIEF_STATE_SCORE_CEILINGS` in
+ * src/indexer/search/ranking-contributors.ts), so superseding an already
+ * contradicted/archived asset keeps the stronger state and only appends the
+ * `supersededBy` edge.
+ *
  * @param filePath        - Absolute path to the asset markdown file.
  * @param supersededByRef - The ref of the correction that supersedes this asset.
  */
 export function writeSupersededEdge(filePath: string, supersededByRef: string): void {
   mutateFrontmatter(filePath, (parsed) => {
-    const existing: string[] = Array.isArray(parsed.data.supersededBy) ? (parsed.data.supersededBy as string[]) : [];
-    if (existing.includes(supersededByRef) && parsed.data.beliefState === "superseded") {
+    const existing = readEdgeList(parsed.data.supersededBy);
+    const currentState = parsed.data.beliefState;
+    const nextState = currentState === "contradicted" || currentState === "archived" ? currentState : "superseded";
+    if (existing.includes(supersededByRef) && currentState === nextState) {
       return null; // Already written — idempotent.
     }
 
@@ -103,7 +130,7 @@ export function writeSupersededEdge(filePath: string, supersededByRef: string): 
     return {
       ...parsed.data,
       supersededBy: nextSupersededBy,
-      beliefState: "superseded",
+      beliefState: nextState,
     };
   });
 }

--- a/src/commands/improve/memory/memory-belief.ts
+++ b/src/commands/improve/memory/memory-belief.ts
@@ -71,3 +71,39 @@ export function writeContradictEdge(filePath: string, contradictedByRef: string)
     };
   });
 }
+
+// ── Supersession edge writer ─────────────────────────────────────────────────
+
+/**
+ * Write `supersededBy` and `beliefState: superseded` edges to an asset file's
+ * frontmatter (SPEC-5, stash-conventions-code-spec.md).
+ *
+ * Sibling of {@link writeContradictEdge}: the shared primitive for the
+ * conventions' corrections pattern — when a new asset supersedes an old one,
+ * the old asset gets a METADATA-ONLY demotion edit (every other frontmatter
+ * key and the body are preserved) so the ranker's beliefStateBoost demotes the
+ * stale incumbent and `--belief current` hides it. Used by
+ * `akm remember --supersedes` / `akm import --supersedes`.
+ *
+ * Idempotent: if `supersededByRef` is already in `supersededBy` and the file
+ * is already demoted, the file is not rewritten. Multiple corrections
+ * sorted-set-append their refs.
+ *
+ * @param filePath        - Absolute path to the asset markdown file.
+ * @param supersededByRef - The ref of the correction that supersedes this asset.
+ */
+export function writeSupersededEdge(filePath: string, supersededByRef: string): void {
+  mutateFrontmatter(filePath, (parsed) => {
+    const existing: string[] = Array.isArray(parsed.data.supersededBy) ? (parsed.data.supersededBy as string[]) : [];
+    if (existing.includes(supersededByRef) && parsed.data.beliefState === "superseded") {
+      return null; // Already written — idempotent.
+    }
+
+    const nextSupersededBy = [...new Set([...existing, supersededByRef])].sort();
+    return {
+      ...parsed.data,
+      supersededBy: nextSupersededBy,
+      beliefState: "superseded",
+    };
+  });
+}

--- a/src/commands/improve/memory/memory-belief.ts
+++ b/src/commands/improve/memory/memory-belief.ts
@@ -70,8 +70,18 @@ function readEdgeList(value: unknown): string[] {
  *   - `memory-contradiction-detect.ts` for the M-1 automated contradiction pass
  *   - `resolveFamilyContradictions` in `memory-improve.ts` for SCC resolution
  *
- * Idempotent: if the `contradictedByRef` is already in `contradictedBy`,
- * the file is not rewritten.
+ * Idempotent: if the `contradictedByRef` is already in `contradictedBy` AND
+ * the file already carries the demotion state, the file is not rewritten. The
+ * guard is state-aware like its sibling {@link writeSupersededEdge}: an edge
+ * present WITHOUT the demotion (e.g. a hand-written `contradictedBy:` line,
+ * or a beliefState lost to a partial edit) is repaired, not skipped — an
+ * edge-only guard would make such a file a permanent no-op while
+ * consolidate's handleContradictOp reports the contradiction as applied.
+ *
+ * Never weakens a stronger demotion: `archived` ranks BELOW `contradicted`
+ * (see `BELIEF_STATE_SCORE_CEILINGS` in
+ * src/indexer/search/ranking-contributors.ts), so contradicting an archived
+ * memory keeps `archived` and only appends the edge.
  *
  * @param filePath          - Absolute path to the memory markdown file.
  * @param contradictedByRef - The ref that contradicts this memory.
@@ -79,13 +89,17 @@ function readEdgeList(value: unknown): string[] {
 export function writeContradictEdge(filePath: string, contradictedByRef: string): void {
   mutateFrontmatter(filePath, (parsed) => {
     const existing = readEdgeList(parsed.data.contradictedBy);
-    if (existing.includes(contradictedByRef)) return null; // Already written — idempotent.
+    const currentState = parsed.data.beliefState;
+    const nextState = currentState === "archived" ? currentState : "contradicted";
+    if (existing.includes(contradictedByRef) && currentState === nextState) {
+      return null; // Already written — idempotent.
+    }
 
     const nextContradictedBy = [...new Set([...existing, contradictedByRef])].sort();
     return {
       ...parsed.data,
       contradictedBy: nextContradictedBy,
-      beliefState: "contradicted",
+      beliefState: nextState,
     };
   });
 }

--- a/src/commands/lint/base-linter.ts
+++ b/src/commands/lint/base-linter.ts
@@ -150,12 +150,33 @@ function buildRefTypeAlternation(): string {
   return types.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
 }
 
+/**
+ * Body-ref boundary grammar, shared with `akm mv`'s ref-rewrite pattern —
+ * `src/commands/mv-cli.ts` imports these constants so the two grammars cannot
+ * drift. Any character-class change here retargets both the lint missing-ref
+ * scan and mv's inbound-xref rewriting.
+ *
+ * `REF_BOUNDARY_PREFIX_CLASS_SRC` is the character class a ref may start
+ * after (a ref also matches at line start): whitespace, backtick, quote,
+ * `(`, or `[` — the `[` admits markdown-link-style refs like
+ * `see [memory:foo]`, which the legacy class silently skipped.
+ *
+ * `REF_SLUG_CHAR_CLASS_SRC` is the character class a ref's `<type>:<slug>`
+ * token is made of; the first excluded character ends the ref.
+ */
+export const REF_BOUNDARY_PREFIX_CLASS_SRC = "[\\s`\"'(\\[]";
+export const REF_SLUG_CHAR_CLASS_SRC = "[^\\s\"'`)\\]>,\\n]";
+
 // Only the TYPE alternation is registry-derived; the surrounding grammar
 // (boundary prefix, capture group, slug charset) is byte-identical to the
-// legacy hand-written pattern. Deriving the types from `getAssetTypes()` means
-// `env`/`secret` (added in 0.9) are now matched, and the removed `vault` type
-// is not — both follow the registry automatically.
-const REF_RE = new RegExp(`(?:^|[\\s\`"'(])((${buildRefTypeAlternation()}):[^\\s"'\`)\\]>,\\n]+)`, "gm");
+// legacy hand-written pattern, except that the boundary prefix now also
+// admits `[`. Deriving the types from `getAssetTypes()` means `env`/`secret`
+// (added in 0.9) are now matched, and the removed `vault` type is not — both
+// follow the registry automatically.
+const REF_RE = new RegExp(
+  `(?:^|${REF_BOUNDARY_PREFIX_CLASS_SRC})((${buildRefTypeAlternation()}):${REF_SLUG_CHAR_CLASS_SRC}+)`,
+  "gm",
+);
 
 /**
  * Map from ref type to relative path pattern within stashRoot. Returns null to
@@ -390,6 +411,23 @@ function readRefsArray(value: unknown): string[] | null {
     if (typeof entry === "string" && entry.trim()) out.push(entry.trim());
   }
   return out;
+}
+
+/**
+ * Like {@link readRefsArray} but also accepts a single scalar string,
+ * normalizing it to a one-element list. The indexer's
+ * `normalizeNonEmptyStringList` treats `supersededBy: memory:x` and
+ * `supersededBy: [memory:x]` identically — both are live data — so the
+ * frontmatter xref-channel check must validate both shapes; the array-only
+ * reader silently skipped dangling scalar refs. Returns `null` for any other
+ * type (missing key, number, object) and for a blank scalar.
+ */
+function readRefStringOrArray(value: unknown): string[] | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? [trimmed] : null;
+  }
+  return readRefsArray(value);
 }
 
 /**
@@ -663,15 +701,22 @@ export abstract class BaseLinter implements AssetLinter {
       // Non-ref-shaped values (URLs, `raw/<slug>`, `<placeholder>`
       // templates, shell vars) fall out via checkMissingRefs' guards.
       //
-      // Skipped when ctx.frontmatter is null: on the task/YAML path
-      // (lint/index.ts) the whole file IS the body (`body === raw`), so
-      // ref values under these keys are already caught by the body scan
-      // above — running the pass again would double-report each dangling
-      // ref. Md files without a frontmatter block also land here, with
-      // empty ctx.data, so nothing is lost for them either.
-      if (ctx.frontmatter !== null) {
+      // Gate: runs when the file has a frontmatter block OR when an
+      // authoritative `refs:` list was extracted. On the task/YAML path
+      // (lint/index.ts) ctx.frontmatter is always null and the whole file
+      // IS the body (`body === raw`); the top-level YAML keys land in
+      // ctx.data. Without `refs:` the body scan above already catches ref
+      // values under these keys, so running the pass would double-report —
+      // skip it. With `refs:` present the body scan is suppressed
+      // (refSource is the refs list), so this pass is the ONLY thing that
+      // validates the xref keys — it must run or dangling task xrefs go
+      // unreported. The two cases are mutually exclusive, so no ref is
+      // ever double-reported. Md files without a frontmatter block and
+      // without `refs:` land in the skip branch with empty ctx.data, so
+      // nothing is lost for them either.
+      if (ctx.frontmatter !== null || explicitRefs !== null) {
         for (const key of XREF_FRONTMATTER_KEYS) {
-          const values = readRefsArray(ctx.data?.[key]);
+          const values = readRefStringOrArray(ctx.data?.[key]);
           if (values === null) continue;
           const missingXrefs = checkMissingRefs(values.join("\n"), ctx.stashRoot, ctx.extraStashRoots);
           for (const { ref, resolvedRelPath } of missingXrefs) {

--- a/src/commands/lint/base-linter.ts
+++ b/src/commands/lint/base-linter.ts
@@ -310,6 +310,21 @@ function checkMissingRefs(
 // ── frontmatter refs ─────────────────────────────────────────────────────────
 
 /**
+ * Frontmatter keys that carry cross-reference lists per the stash
+ * organization conventions: `xrefs:` (provenance / associative links),
+ * `supersededBy:` and `contradictedBy:` (belief-state correction links).
+ * The missing-ref check validates each of these in ADDITION to the body /
+ * `refs:` scan — they are the channel the conventions mandate, and a rename
+ * would otherwise dangle them silently.
+ *
+ * `sources:` is deliberately excluded (non-wiki `sources:` was rejected as a
+ * typed channel; wiki `sources:` is checked by lintWiki). `source_refs:` /
+ * `evidenceSources:` are excluded too — they legitimately point at
+ * merged-away or pruned assets (historical provenance).
+ */
+const XREF_FRONTMATTER_KEYS = ["xrefs", "supersededBy", "contradictedBy"] as const;
+
+/**
  * Return the `refs:` array from frontmatter when it is present and is an
  * array of strings; otherwise return `null` to signal the caller should
  * fall back to scanning the body. An empty array (`refs: []`) is also
@@ -616,6 +631,35 @@ export abstract class BaseLinter implements AssetLinter {
           detail: `missing ref: ${ref} (resolved to ${resolvedRelPath})`,
           fixed: false,
         });
+      }
+
+      // Frontmatter xref channels (xrefs / supersededBy / contradictedBy).
+      // Runs regardless of the `refs:` body-scan carve-out above — that
+      // carve-out governs only the BODY scan (`refs: []` declares "no
+      // outbound refs in the body", not "skip my correction links").
+      // Non-ref-shaped values (URLs, `raw/<slug>`, `<placeholder>`
+      // templates, shell vars) fall out via checkMissingRefs' guards.
+      //
+      // Skipped when ctx.frontmatter is null: on the task/YAML path
+      // (lint/index.ts) the whole file IS the body (`body === raw`), so
+      // ref values under these keys are already caught by the body scan
+      // above — running the pass again would double-report each dangling
+      // ref. Md files without a frontmatter block also land here, with
+      // empty ctx.data, so nothing is lost for them either.
+      if (ctx.frontmatter !== null) {
+        for (const key of XREF_FRONTMATTER_KEYS) {
+          const values = readRefsArray(ctx.data?.[key]);
+          if (values === null) continue;
+          const missingXrefs = checkMissingRefs(values.join("\n"), ctx.stashRoot, ctx.extraStashRoots);
+          for (const { ref, resolvedRelPath } of missingXrefs) {
+            issues.push({
+              file: ctx.relPath,
+              issue: "missing-ref",
+              detail: `missing ref: ${ref} (frontmatter ${key}; resolved to ${resolvedRelPath})`,
+              fixed: false,
+            });
+          }
+        }
       }
     }
 

--- a/src/commands/lint/base-linter.ts
+++ b/src/commands/lint/base-linter.ts
@@ -158,13 +158,19 @@ function buildRefTypeAlternation(): string {
  *
  * `REF_BOUNDARY_PREFIX_CLASS_SRC` is the character class a ref may start
  * after (a ref also matches at line start): whitespace, backtick, quote,
- * `(`, or `[` — the `[` admits markdown-link-style refs like
- * `see [memory:foo]`, which the legacy class silently skipped.
+ * `(`, `[`, or `,` — the `[` admits markdown-link-style refs like
+ * `see [memory:foo]`, which the legacy class silently skipped, and the `,`
+ * admits the ref AFTER a bare comma in a no-space flow list like
+ * `xrefs: [memory:a,memory:b]` (valid YAML). `,` is already a slug
+ * TERMINATOR (excluded from `REF_SLUG_CHAR_CLASS_SRC`), so `a,b` splits
+ * cleanly and adding it here cannot extend any existing match; false
+ * positives are fenced by the type alternation — a comma only starts a match
+ * when a literal `<type>:` follows it.
  *
  * `REF_SLUG_CHAR_CLASS_SRC` is the character class a ref's `<type>:<slug>`
  * token is made of; the first excluded character ends the ref.
  */
-export const REF_BOUNDARY_PREFIX_CLASS_SRC = "[\\s`\"'(\\[]";
+export const REF_BOUNDARY_PREFIX_CLASS_SRC = "[\\s`\"'(,\\[]";
 export const REF_SLUG_CHAR_CLASS_SRC = "[^\\s\"'`)\\]>,\\n]";
 
 // Only the TYPE alternation is registry-derived; the surrounding grammar

--- a/src/commands/lint/base-linter.ts
+++ b/src/commands/lint/base-linter.ts
@@ -194,41 +194,64 @@ export function refToRelPath(refType: string, refName: string): string | null {
  */
 export function refExistsInAnyStash(relPath: string, refType: string, refName: string, stashRoots: string[]): boolean {
   for (const root of stashRoots) {
-    const absPath = path.join(root, relPath);
-    if (fs.existsSync(absPath)) return true;
-    // Multi-file skill layout: directory containing SKILL.md
-    const bareDir = absPath.replace(/\.md$/, "");
-    if (fs.existsSync(bareDir) && fs.existsSync(path.join(bareDir, "SKILL.md"))) return true;
-    // .derived.md variant for memory refs
-    if (refType === "memory") {
-      const derivedPath = path.join(root, "memories", `${refName}.derived.md`);
-      if (fs.existsSync(derivedPath)) return true;
-    }
-    // Knowledge-specific: search subdirectories like knowledge/projects/, knowledge/tools/, etc.
-    if (refType === "knowledge") {
-      try {
-        const knowledgeDir = path.join(root, "knowledge");
-        if (fs.existsSync(knowledgeDir) && fs.statSync(knowledgeDir).isDirectory()) {
-          const entries = fs.readdirSync(knowledgeDir, { withFileTypes: true });
-          for (const entry of entries) {
-            if (!entry.isDirectory()) continue;
-            const subPath = path.join(knowledgeDir, entry.name, `${refName}.md`);
-            if (fs.existsSync(subPath)) return true;
-          }
-        }
-      } catch {
-        // Ignore errors reading directory
-      }
-    }
-    // Fallback: the refName may already encode the full stash-relative path
-    // (e.g. knowledge:skills/foo/references/bar where the file lives at
-    // <stash>/skills/foo/references/bar.md, not <stash>/knowledge/skills/...).
-    const directPath = path.join(root, `${refName}.md`);
-    if (fs.existsSync(directPath)) return true;
-    const directDir = path.join(root, refName);
-    if (fs.existsSync(directDir) && fs.existsSync(path.join(directDir, "SKILL.md"))) return true;
+    if (resolveRefPathInStash(relPath, refType, refName, root) !== null) return true;
   }
   return false;
+}
+
+/**
+ * Resolve the on-disk primary file for a ref within a SINGLE stash root, using
+ * the same reachability rules (in the same order) as
+ * {@link refExistsInAnyStash}, which delegates here. Returns the absolute path
+ * of the file that makes the ref "exist" — for a multi-file skill directory
+ * that is its `SKILL.md` primary — or `null` when the ref does not resolve in
+ * this root.
+ *
+ * Extracted for SPEC-5 (`--supersedes` demotion): write commands need the
+ * superseded asset's actual file to mutate, and forking a second resolver
+ * would drift from lint's. NOT part of the akm-plugins ref-resolver contract
+ * (the contract pins `refToRelPath` + `refExistsInAnyStash`; this is the
+ * shared internal both build on).
+ */
+export function resolveRefPathInStash(relPath: string, refType: string, refName: string, root: string): string | null {
+  const absPath = path.join(root, relPath);
+  if (fs.existsSync(absPath)) return absPath;
+  // Multi-file skill layout: directory containing SKILL.md
+  const bareDir = absPath.replace(/\.md$/, "");
+  if (fs.existsSync(bareDir) && fs.existsSync(path.join(bareDir, "SKILL.md"))) {
+    return path.join(bareDir, "SKILL.md");
+  }
+  // .derived.md variant for memory refs
+  if (refType === "memory") {
+    const derivedPath = path.join(root, "memories", `${refName}.derived.md`);
+    if (fs.existsSync(derivedPath)) return derivedPath;
+  }
+  // Knowledge-specific: search subdirectories like knowledge/projects/, knowledge/tools/, etc.
+  if (refType === "knowledge") {
+    try {
+      const knowledgeDir = path.join(root, "knowledge");
+      if (fs.existsSync(knowledgeDir) && fs.statSync(knowledgeDir).isDirectory()) {
+        const entries = fs.readdirSync(knowledgeDir, { withFileTypes: true });
+        for (const entry of entries) {
+          if (!entry.isDirectory()) continue;
+          const subPath = path.join(knowledgeDir, entry.name, `${refName}.md`);
+          if (fs.existsSync(subPath)) return subPath;
+        }
+      }
+    } catch {
+      // Ignore errors reading directory
+    }
+  }
+  // Fallback: the refName may already encode the full stash-relative path
+  // (e.g. knowledge:skills/foo/references/bar where the file lives at
+  // <stash>/skills/foo/references/bar.md, not <stash>/knowledge/skills/...).
+  const directPath = path.join(root, `${refName}.md`);
+  if (fs.existsSync(directPath)) return directPath;
+  const directDir = path.join(root, refName);
+  if (fs.existsSync(directDir) && fs.existsSync(path.join(directDir, "SKILL.md"))) {
+    return path.join(directDir, "SKILL.md");
+  }
+  return null;
 }
 
 /**

--- a/src/commands/mv-cli.ts
+++ b/src/commands/mv-cli.ts
@@ -1,0 +1,557 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `akm mv <ref> <new-name>` — rename an asset within its type directory
+ * (SPEC-7, stash-conventions-code-spec.md).
+ *
+ * The stash organization conventions' forced-rename procedure ("grep and fix
+ * inbound xrefs in the same pass") is agent-executable EXCEPT for the part
+ * only the CLI can do: a rename mints a new `entries` row (entry_key is
+ * UNIQUE), which orphans the utility_scores / utility_scores_scoped /
+ * embeddings / asset_salience rows keyed by entry_id — the "rename resets
+ * learned ranking" cost the conventions warn about. This verb does the whole
+ * pass: move the file, rewrite inbound refs, and re-key the index row IN
+ * PLACE so the accumulated history survives.
+ *
+ * Scope (v1, Experimental — see STABILITY.md):
+ *   - flat-markdown asset types only ({@link MV_SUPPORTED_TYPES});
+ *   - the primary writable stash only (no `--target`);
+ *   - the source ref must be the CANONICAL spelling — lint-resolver fallback
+ *     spellings are rejected with the canonical ref named (see
+ *     {@link resolveMoveSourcePath});
+ *   - wiki refs are rejected (wikis have their own xref + lint system);
+ *   - a memory's `.derived.md` twin moves together and keeps its
+ *     `entry_key === <base entry_key> + ".derived"` coupling; a twin ref
+ *     cannot be moved alone, and target names ending `.derived` are rejected
+ *     (reserved suffix).
+ *
+ * Ordering (partial-failure mitigation — the operation spans FS + DB and is
+ * NOT transactional): validate everything first, compute the full rewrite
+ * plan, apply the citer edits, rename the file(s) LAST among the FS steps,
+ * then re-key the index. The command is RE-RUNNABLE after an interruption:
+ * a crash before the rename leaves the source resolvable under its old ref
+ * (already-edited citers simply yield zero further rewrites on the retry);
+ * a crash after the rename but before the index re-key is healed by the next
+ * full `akm index` (at the cost of the utility history the re-key preserves).
+ * Graph tables (graph_files) key extractions by file path and stay stale
+ * until the next graph pass — acceptable, the graph is a derived cache.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { defineJsonCommand, output } from "../cli/shared";
+import { parseAssetRef, refToString } from "../core/asset/asset-ref";
+import { deriveCanonicalAssetNameFromStashRoot, TYPE_DIRS } from "../core/asset/asset-spec";
+import { type AkmAssetType, isWithin, resolveStashDir, toPosix } from "../core/common";
+import { UsageError } from "../core/errors";
+import { appendEvent } from "../core/events";
+import { getDbPath } from "../core/paths";
+import { warnVerbose } from "../core/warn";
+import { closeDatabase, openExistingDatabase, rebuildFts, rekeyEntryInPlace } from "../indexer/db/db";
+import { indexWrittenAssets, WRITE_PATH_INDEX_BUSY_TIMEOUT_MS } from "../indexer/index-written-assets";
+import { resolveSourceEntries } from "../indexer/search/search-source";
+import { refToRelPath, resolveRefPathInStash } from "./lint/base-linter";
+
+// ── Scope ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Asset types `akm mv` can rename in v1: exactly the types whose canonical
+ * layout is one flat `.md` file per name (the `markdownSpec` family), so a
+ * rename is a single-file move and inbound refs are rewritable by complete-ref
+ * matching. Deliberately excluded:
+ *   - `wiki` — wikis carry their own xref + lint system (`akm wiki lint`);
+ *   - `skill` — the canonical layout is a multi-file `skills/<name>/SKILL.md`
+ *     directory (a directory rename, out of v1 scope);
+ *   - `script` — unresolvable by the slug resolver (contract-pinned);
+ *   - `task` / `env` / `secret` — not markdown assets.
+ */
+const MV_SUPPORTED_TYPES: readonly string[] = [
+  "memory",
+  "knowledge",
+  "command",
+  "agent",
+  "workflow",
+  "lesson",
+  "session",
+  "fact",
+];
+
+// ── Ref rewriting ─────────────────────────────────────────────────────────────
+
+/**
+ * Boundary grammar shared with lint's `REF_RE` (base-linter.ts): a ref starts
+ * at line start or after whitespace / backtick / quote / `(`, and its slug
+ * runs until whitespace, `"`, `'`, backtick, `)`, `]`, `>`, or `,`. Complete-
+ * ref matching is what keeps a longer ref sharing the old ref as a prefix
+ * (e.g. `memory:a/base-note-extra` when moving `memory:a/base-note`)
+ * untouched.
+ */
+const REF_PREFIX_SRC = "(^|[\\s`\"'(])";
+const REF_SUFFIX_SRC = "(?![^\\s\"'`)\\]>,\\n])";
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Build the rewrite pattern for one old ref. When the source is a base
+ * memory, the optional `.derived` tail also rewrites explicit twin refs
+ * (`memory:a/note.derived` → `memory:a/new.derived`) — the twin file moves
+ * together, so its ref must too. The tail group is empty-capturing otherwise
+ * so the replacer's group indices stay stable.
+ */
+function buildRefPattern(fromRef: string, includeDerivedTail: boolean): RegExp {
+  const tail = includeDerivedTail ? "(\\.derived)?" : "()";
+  return new RegExp(`${REF_PREFIX_SRC}${escapeRegExp(fromRef)}${tail}${REF_SUFFIX_SRC}`, "gm");
+}
+
+/** Replace every boundary-matched occurrence, returning the count replaced. */
+function rewriteRefs(content: string, pattern: RegExp, toRef: string): { content: string; count: number } {
+  let count = 0;
+  const next = content.replace(pattern, (_match, prefix: string, derivedTail: string | undefined) => {
+    count += 1;
+    return `${prefix}${toRef}${derivedTail ?? ""}`;
+  });
+  return { content: next, count };
+}
+
+// ── File walking ──────────────────────────────────────────────────────────────
+
+/**
+ * Every `.md` file under `root`, recursively. Skips dot-directories (index
+ * state, `.cache/` mirrors) and `registry/` caches — the same read-only
+ * carve-outs `akm lint --fix` honours (lint/index.ts).
+ */
+function collectMarkdownFiles(root: string): string[] {
+  const results: string[] = [];
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "registry") continue;
+        walk(full);
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        results.push(full);
+      }
+    }
+  };
+  walk(root);
+  return results;
+}
+
+// ── Source resolution ─────────────────────────────────────────────────────────
+
+/**
+ * Resolve the on-disk file for the ref being moved, within the primary
+ * writable stash ONLY. Reuses lint's shared resolver (`resolveRefPathInStash`,
+ * base-linter.ts — do not fork a second resolver), then requires the hit to
+ * be CANONICAL: the resolved file must be exactly `<stashDir>/<relPath>`, the
+ * path the ref's spelling maps to.
+ *
+ * Lint's resolver accepts fallback spellings on purpose (a knowledge-subdir
+ * alias like `knowledge:g` for `knowledge/guides/g.md`, a refName encoding a
+ * full stash-relative path, a base memory ref satisfied by its `.derived.md`
+ * twin, a `SKILL.md` directory primary) — fine for existence checks, fatal
+ * for a move: the citer rewrite targets the typed spelling (canonical citers
+ * would dangle), the index re-key derives its old entry_key from the typed
+ * spelling (the real row would be stranded as a ghost and a duplicate row
+ * minted — the exact utility-history reset `mv` exists to prevent), and the
+ * direct-path fallback would even RELOCATE the file out of its real home into
+ * the type root. So:
+ *   - `null` — the ref does not resolve at all (also for a base memory ref
+ *     whose only on-disk presence is the `.derived.md` twin: the base file is
+ *     what `mv` renames — the twin is carried along, never moved alone —
+ *     and for a `SKILL.md` directory primary, out of v1 scope);
+ *   - throws `UsageError` (exit 2) — the ref resolves ONLY via a fallback
+ *     spelling; the message names the canonical ref when one is derivable.
+ */
+function resolveMoveSourcePath(
+  stashDir: string,
+  relPath: string,
+  refType: AkmAssetType,
+  refName: string,
+): string | null {
+  const resolved = resolveRefPathInStash(relPath, refType, refName, stashDir);
+  if (!resolved) return null;
+  if (resolved.endsWith(".derived.md") && !refName.endsWith(".derived")) return null;
+  if (path.basename(resolved) === "SKILL.md" && !relPath.endsWith(`${path.sep}SKILL.md`)) return null;
+  if (path.resolve(resolved) === path.resolve(stashDir, relPath)) return resolved;
+
+  // Fallback hit — reject, steering to the canonical spelling when it exists.
+  const typedRef = refToString({ type: refType, name: refName });
+  const canonicalName = deriveCanonicalAssetNameFromStashRoot(refType, stashDir, resolved);
+  const canonicalRelPath = canonicalName ? refToRelPath(refType, canonicalName) : null;
+  if (
+    canonicalName &&
+    canonicalName !== refName &&
+    canonicalRelPath &&
+    path.resolve(stashDir, canonicalRelPath) === path.resolve(resolved)
+  ) {
+    const canonicalRef = refToString({ type: refType, name: canonicalName });
+    throw new UsageError(
+      `"${typedRef}" resolves only through a fallback spelling — the asset's canonical ref is ${canonicalRef}. ` +
+        "akm mv needs the canonical spelling so the citer rewrite and the index re-key target the same ref — nothing moved.",
+      "INVALID_FLAG_VALUE",
+      `Re-run with the canonical ref: akm mv ${canonicalRef} <new-name>.`,
+    );
+  }
+  throw new UsageError(
+    `"${typedRef}" resolves to ${toPosix(path.relative(stashDir, resolved))}, outside the ${TYPE_DIRS[refType]}/ ` +
+      "type root — akm mv renames within a type directory only; nothing moved.",
+    "INVALID_FLAG_VALUE",
+  );
+}
+
+// ── Index re-key ──────────────────────────────────────────────────────────────
+
+/**
+ * Re-key the moved row(s) in the local index, preserving row ids (and with
+ * them the utility/embedding/salience history). FAIL-OPEN like every
+ * write-path index touch: an absent index.db is skipped silently (the next
+ * full `akm index` picks the renamed file up fresh), and any error reduces
+ * to a verbose warning — the rename itself has already succeeded.
+ *
+ * The returned flag is the `utilityPreserved` claim in the command's output,
+ * so it must be honest:
+ *   - true — no index exists, the file was never indexed (nothing to
+ *     preserve; the next `akm index` picks it up fresh), or the row(s) were
+ *     re-keyed in place;
+ *   - false — an existing index could not be re-keyed (open/SQL error), or a
+ *     row for the moved file exists under some OTHER entry_key than the one
+ *     the canonical spelling derives (e.g. a differently-normalized stash
+ *     path at index time): that history is now stranded on a ghost row and
+ *     will NOT survive the next index run.
+ */
+function rekeyIndexForMove(opts: {
+  stashDir: string;
+  type: string;
+  oldName: string;
+  newName: string;
+  oldPath: string;
+  newPath: string;
+  toRef: string;
+  twinOldPath: string | null;
+  twinNewPath: string | null;
+}): boolean {
+  const dbPath = getDbPath();
+  try {
+    if (!fs.existsSync(dbPath)) return true;
+    let preserved = true;
+    const db = openExistingDatabase(dbPath);
+    try {
+      db.exec(`PRAGMA busy_timeout = ${WRITE_PATH_INDEX_BUSY_TIMEOUT_MS}`);
+      // A null re-key means "no row under the expected old key". That is fine
+      // when the file was simply never indexed, but a lie if a row for the
+      // file DOES exist under another key — then history is stranded.
+      const strandedRow = (movedFrom: string): boolean =>
+        db.prepare("SELECT id FROM entries WHERE file_path = ? LIMIT 1").get(movedFrom) != null;
+      const oldKey = `${opts.stashDir}:${opts.type}:${opts.oldName}`;
+      const newKey = `${opts.stashDir}:${opts.type}:${opts.newName}`;
+      const rekeyed = rekeyEntryInPlace(db, {
+        oldEntryKey: oldKey,
+        newEntryKey: newKey,
+        newName: opts.newName,
+        newFilePath: opts.newPath,
+      });
+      if (rekeyed === null && strandedRow(opts.oldPath)) preserved = false;
+      let twinRekeyed: number | null = null;
+      if (opts.twinNewPath) {
+        // The twin coupling (db.ts getBaseBeliefStatesForDerivedTwins) is
+        // `twin entry_key === base entry_key + ".derived"` — preserved here.
+        twinRekeyed = rekeyEntryInPlace(db, {
+          oldEntryKey: `${oldKey}.derived`,
+          newEntryKey: `${newKey}.derived`,
+          newName: `${opts.newName}.derived`,
+          newFilePath: opts.twinNewPath,
+          newDerivedFrom: opts.toRef,
+        });
+        if (twinRekeyed === null && opts.twinOldPath && strandedRow(opts.twinOldPath)) preserved = false;
+      }
+      if (rekeyed !== null || twinRekeyed !== null) {
+        rebuildFts(db, { incremental: true });
+      }
+    } finally {
+      closeDatabase(db);
+    }
+    if (!preserved) {
+      warnVerbose(
+        "akm mv: the index holds a row for the moved file under an unexpected key — its utility history was not " +
+          "re-keyed and resets on the next `akm index`.",
+      );
+    }
+    return preserved;
+  } catch (error) {
+    warnVerbose(
+      "akm mv: index re-key skipped (the index heals on the next `akm index`; utility history for the moved asset may reset):",
+      error instanceof Error ? error.message : String(error),
+    );
+    return false;
+  }
+}
+
+// ── Command ───────────────────────────────────────────────────────────────────
+
+export const mvCommand = defineJsonCommand({
+  meta: {
+    name: "mv",
+    description:
+      "Rename an asset within its type directory (Experimental). Moves the file (a memory's .derived.md twin " +
+      "moves together), rewrites inbound refs across the writable stash in the same pass — body prose, " +
+      "frontmatter ref lists (xrefs/refs/supersededBy/...), and fenced code examples — and re-keys the search " +
+      "index row in place so the asset's accumulated usage-ranking history (utility scores, embeddings, " +
+      "salience) survives the rename. Read-only sources are scanned but never written; their citing files are " +
+      "reported in `readOnlyCiters` as manual follow-ups. Operates on the primary writable stash only, and the " +
+      "source ref must be the asset's canonical spelling (alias/fallback spellings are rejected, naming the " +
+      "canonical ref). Wiki refs are not supported (use `akm wiki lint` after a manual wiki rename).",
+  },
+  args: {
+    ref: {
+      type: "positional",
+      description: "Current asset ref, e.g. memory:projectA/old-note",
+      // Optional in citty so run() is invoked even when omitted; re-validated
+      // below to surface a structured UsageError (exit 2) instead of citty's
+      // unstructured missing-argument failure.
+      required: false,
+    },
+    newName: {
+      type: "positional",
+      description: "New name (subdirectories allowed, e.g. projectA/new-note), or a same-type ref like memory:new-note",
+      required: false,
+    },
+  },
+  async run({ args }) {
+    const refArg = typeof args.ref === "string" ? args.ref.trim() : "";
+    const targetArg = typeof args.newName === "string" ? args.newName.trim() : "";
+    if (!refArg || !targetArg) {
+      throw new UsageError(
+        "Usage: akm mv <ref> <new-name>.",
+        "MISSING_REQUIRED_ARGUMENT",
+        "Pass the asset's current ref and its new name, e.g. `akm mv memory:projectA/old-note projectA/new-note`.",
+      );
+    }
+
+    // ── Validation (everything before any write; a failure moves nothing) ──
+    const source = parseAssetRef(refArg);
+    if (source.origin && source.origin !== "local") {
+      throw new UsageError(
+        `akm mv operates on the primary writable stash only — the origin prefix "${source.origin}//" is not supported.`,
+        "INVALID_FLAG_VALUE",
+      );
+    }
+    if (source.type === "wiki") {
+      throw new UsageError(
+        "akm mv does not support wiki refs — wiki pages have their own xref + lint system. " +
+          "Rename the page manually, fix citations in the same pass, and verify with `akm wiki lint <name>`.",
+        "INVALID_FLAG_VALUE",
+      );
+    }
+    if (!MV_SUPPORTED_TYPES.includes(source.type)) {
+      throw new UsageError(
+        `akm mv supports flat-markdown asset types (${MV_SUPPORTED_TYPES.join(", ")}); "${source.type}:" refs cannot be moved.`,
+        "INVALID_FLAG_VALUE",
+      );
+    }
+    // The `.derived` suffix is the distilled-twin marker: a twin's entry_key
+    // must stay exactly `<base entry_key>.derived` (db.ts
+    // getBaseBeliefStatesForDerivedTwins), so a twin can never move alone and
+    // no independent asset may squat on the suffix.
+    if (source.type === "memory" && source.name.endsWith(".derived")) {
+      const baseRef = refToString({ type: "memory", name: source.name.slice(0, -".derived".length) });
+      throw new UsageError(
+        `"${refToString({ type: source.type, name: source.name })}" names a .derived.md distilled twin — a twin ` +
+          "cannot be moved on its own without breaking its belief-inheritance coupling to the base memory. " +
+          `Rename the base ref instead (akm mv ${baseRef} <new-name>); the twin moves with it.`,
+        "INVALID_FLAG_VALUE",
+      );
+    }
+
+    // The target may be a bare name ("projectA/new-note") or a ref-shaped
+    // spelling. Parsing the bare form through the same ref grammar gives it
+    // identical name validation (traversal, null bytes, absolute paths).
+    const target = parseAssetRef(targetArg.includes(":") ? targetArg : `${source.type}:${targetArg}`);
+    if (target.origin) {
+      throw new UsageError(
+        `The target must be a name within the ${source.type} type — origin prefixes are not supported.`,
+        "INVALID_FLAG_VALUE",
+      );
+    }
+    if (target.type !== source.type) {
+      throw new UsageError(
+        `Cross-type move is not supported: "${refToString({ type: source.type, name: source.name })}" is a ` +
+          `${source.type}: asset but the target names the ${target.type}: type. akm mv renames within one asset type.`,
+        "INVALID_FLAG_VALUE",
+      );
+    }
+    const newName = target.name;
+    if (source.type === "memory" && newName.endsWith(".derived")) {
+      throw new UsageError(
+        `The target name "${newName}" ends with the reserved .derived suffix (the distilled-twin marker) — a base ` +
+          "memory renamed onto it would masquerade as a twin of a memory that does not exist. Pick a name without " +
+          "the suffix; a real twin always moves together with its base.",
+        "INVALID_FLAG_VALUE",
+      );
+    }
+    const fromRef = refToString({ type: source.type, name: source.name });
+    const toRef = refToString({ type: source.type, name: newName });
+
+    const stashDir = resolveStashDir();
+    const typeDir = TYPE_DIRS[source.type];
+    const typeRoot = path.join(stashDir, typeDir);
+
+    const oldRelPath = refToRelPath(source.type, source.name);
+    const newRelPath = refToRelPath(source.type, newName);
+    if (!oldRelPath || !newRelPath) {
+      // Unreachable for MV_SUPPORTED_TYPES; guards a future registry change.
+      throw new UsageError(`"${source.type}:" refs are not path-resolvable and cannot be moved.`, "INVALID_FLAG_VALUE");
+    }
+
+    const oldPath = resolveMoveSourcePath(stashDir, oldRelPath, source.type, source.name);
+    if (!oldPath) {
+      throw new UsageError(
+        `Cannot resolve ${fromRef} in the writable stash at ${stashDir} — nothing moved.`,
+        "MISSING_REQUIRED_ARGUMENT",
+        "akm mv renames assets in the primary writable stash only. Check the ref with `akm show <ref>` or `akm search`.",
+      );
+    }
+
+    const newPath = path.join(stashDir, newRelPath);
+    // Defense-in-depth: parseAssetRef already rejects `../` traversal, but the
+    // computed target must land inside the type root regardless.
+    if (!isWithin(newPath, typeRoot)) {
+      throw new UsageError(
+        `Target "${targetArg}" escapes the ${typeDir}/ type root — nothing moved.`,
+        "PATH_ESCAPE_VIOLATION",
+      );
+    }
+    if (path.resolve(newPath) === path.resolve(oldPath)) {
+      throw new UsageError(`Source and target resolve to the same file (${fromRef}) — nothing to move.`);
+    }
+    if (fs.existsSync(newPath)) {
+      throw new UsageError(
+        `Target ${toRef} already exists at ${toPosix(path.relative(stashDir, newPath))} — nothing moved.`,
+        "RESOURCE_ALREADY_EXISTS",
+        "Pick an unused name, or move the existing asset out of the way first.",
+      );
+    }
+
+    // Memory `.derived.md` twin: moves together with its base (the entry_key
+    // suffix coupling the belief-state inheritance relies on).
+    const isBaseMemory = source.type === "memory" && !source.name.endsWith(".derived");
+    const twinOldPath = isBaseMemory ? oldPath.replace(/\.md$/, ".derived.md") : null;
+    const hasTwin = twinOldPath !== null && fs.existsSync(twinOldPath);
+    const twinNewPath = hasTwin ? newPath.replace(/\.md$/, ".derived.md") : null;
+    if (twinNewPath && fs.existsSync(twinNewPath)) {
+      throw new UsageError(
+        `Target twin ${toRef}.derived already exists at ${toPosix(path.relative(stashDir, twinNewPath))} — nothing moved.`,
+        "RESOURCE_ALREADY_EXISTS",
+      );
+    }
+
+    // ── Plan the inbound-ref rewrite (no writes yet) ───────────────────────
+    const pattern = buildRefPattern(fromRef, isBaseMemory);
+    const plans: Array<{ absPath: string; relPath: string; count: number; content: string }> = [];
+    for (const absPath of collectMarkdownFiles(stashDir)) {
+      let raw: string;
+      try {
+        raw = fs.readFileSync(absPath, "utf8");
+      } catch {
+        continue;
+      }
+      const { content, count } = rewriteRefs(raw, pattern, toRef);
+      if (count > 0) {
+        plans.push({ absPath, relPath: toPosix(path.relative(stashDir, absPath)), count, content });
+      }
+    }
+
+    // Read-only sources: scanned, never written — manual follow-ups.
+    const readOnlyCiters: Array<{ file: string; count: number }> = [];
+    let sources: ReturnType<typeof resolveSourceEntries> = [];
+    try {
+      sources = resolveSourceEntries(stashDir);
+    } catch (error) {
+      warnVerbose(
+        "akm mv: could not enumerate configured sources for the read-only citer scan:",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+    for (const src of sources) {
+      if (path.resolve(src.path) === path.resolve(stashDir)) continue;
+      for (const absPath of collectMarkdownFiles(src.path)) {
+        let raw: string;
+        try {
+          raw = fs.readFileSync(absPath, "utf8");
+        } catch {
+          continue;
+        }
+        const { count } = rewriteRefs(raw, pattern, toRef);
+        if (count > 0) readOnlyCiters.push({ file: absPath, count });
+      }
+    }
+
+    // ── Apply citer edits, then rename last (see module docstring) ────────
+    for (const plan of plans) {
+      fs.writeFileSync(plan.absPath, plan.content, "utf8");
+    }
+    fs.mkdirSync(path.dirname(newPath), { recursive: true });
+    fs.renameSync(oldPath, newPath);
+    if (twinOldPath && twinNewPath) {
+      fs.renameSync(twinOldPath, twinNewPath);
+    }
+
+    // ── Index: re-key in place, then reindex the touched files ────────────
+    const utilityPreserved = rekeyIndexForMove({
+      stashDir,
+      type: source.type,
+      oldName: source.name,
+      newName,
+      oldPath,
+      newPath,
+      toRef,
+      twinOldPath: hasTwin ? twinOldPath : null,
+      twinNewPath,
+    });
+    // Rewritten citers (and the moved file itself) go through the standard
+    // write-path reindex so their FTS hints reflect the new ref immediately.
+    // Fail-open; an absent/empty index is skipped inside the helper.
+    const touched = new Set<string>([newPath]);
+    if (twinNewPath) touched.add(twinNewPath);
+    for (const plan of plans) {
+      // A self-citing moved file was edited at its OLD path but now lives at
+      // the new one; report the file that exists.
+      if (plan.absPath === oldPath) continue;
+      if (twinOldPath && plan.absPath === twinOldPath) continue;
+      touched.add(plan.absPath);
+    }
+    await indexWrittenAssets(stashDir, [...touched]);
+
+    appendEvent({
+      eventType: "mv",
+      ref: toRef,
+      metadata: {
+        from: fromRef,
+        to: toRef,
+        rewroteFiles: plans.length,
+        readOnlyCiters: readOnlyCiters.length,
+        twinMoved: hasTwin,
+      },
+    });
+
+    output("mv", {
+      ok: true,
+      from: fromRef,
+      to: toRef,
+      rewrote: plans.map((plan) => ({ file: plan.relPath, count: plan.count })),
+      readOnlyCiters,
+      utilityPreserved,
+    });
+  },
+});

--- a/src/commands/mv-cli.ts
+++ b/src/commands/mv-cli.ts
@@ -21,8 +21,10 @@
  * Scope (v1, Experimental — see STABILITY.md):
  *   - flat-markdown asset types only ({@link MV_SUPPORTED_TYPES});
  *   - the primary writable stash only (no `--target`);
- *   - the source ref must be the CANONICAL spelling — lint-resolver fallback
- *     spellings are rejected with the canonical ref named (see
+ *   - the source ref may be the canonical spelling or its deterministic
+ *     `.md`-suffixed / `local//`-prefixed alias (both are canonicalized
+ *     before anything is keyed off them) — lint-resolver FALLBACK spellings
+ *     are rejected with the canonical ref named (see
  *     {@link resolveMoveSourcePath});
  *   - wiki refs are rejected (wikis have their own xref + lint system);
  *   - a memory's `.derived.md` twin moves together and keeps its
@@ -32,8 +34,9 @@
  *
  * Ordering (partial-failure mitigation — the operation spans FS + DB and is
  * NOT transactional): validate everything first, compute the full rewrite
- * plan, apply the citer edits, rename the file(s) LAST among the FS steps,
- * then re-key the index. The command is RE-RUNNABLE after an interruption:
+ * plan, create the target's parent directory (so a blocked target aborts
+ * before any citer is edited), apply the citer edits, rename the file(s)
+ * LAST among the FS steps, then re-key the index. The command is RE-RUNNABLE after an interruption:
  * a crash before the rename leaves the source resolvable under its old ref
  * (already-edited citers simply yield zero further rewrites on the retry);
  * a crash after the rename but before the index re-key is healed by the next
@@ -192,27 +195,53 @@ function rewriteRefs(content: string, ctx: RewriteContext): { content: string; c
       return `${prefix}${ctx.toRef}${derivedTail ?? ""}`;
     });
   }
-  next = next.replace(ctx.aliasScan, (match, prefix: string, token: string) => {
+  /**
+   * Probe one ref-shaped token through lint's shared resolver:
+   *   - `{ rewriteTo }` — it resolves to the moved file (or its twin) and
+   *     must be rewritten to the new canonical ref;
+   *   - `"other"` — it names a different asset (or IS the new canonical ref,
+   *     just written by pass 1, which may itself resolve to the old path
+   *     through a fallback — e.g. moving knowledge:guides/x to the knowledge
+   *     root while guides/x.md still exists at planning time; never rewrite
+   *     it to itself) and must be left alone;
+   *   - `"unresolved"` — it resolves to nothing (the punctuation-retry case).
+   */
+  const probe = (token: string): { rewriteTo: string } | "other" | "unresolved" => {
     const bare = token.startsWith("local//") ? token.slice("local//".length) : token;
-    // The new canonical ref (just written by pass 1) may itself resolve to
-    // the old path through a fallback (e.g. moving knowledge:guides/x to the
-    // knowledge root while guides/x.md still exists at planning time) — never
-    // rewrite it to itself.
-    if (bare === ctx.toRef || bare === `${ctx.toRef}.derived`) return match;
+    if (bare === ctx.toRef || bare === `${ctx.toRef}.derived`) return "other";
     const name = bare.slice(ctx.type.length + 1);
-    if (!name) return match;
+    if (!name) return "unresolved";
     const relPath = refToRelPath(ctx.type, name);
-    if (!relPath) return match;
+    if (!relPath) return "unresolved";
     const resolved = resolveRefPathInStash(relPath, ctx.type, name, ctx.scanRoot);
-    if (!resolved) return match;
+    if (!resolved) return "unresolved";
     const resolvedAbs = path.resolve(resolved);
-    if (resolvedAbs === ctx.oldPathResolved) {
-      count += 1;
-      return `${prefix}${ctx.toRef}`;
-    }
+    if (resolvedAbs === ctx.oldPathResolved) return { rewriteTo: ctx.toRef };
     if (ctx.twinOldPathResolved && resolvedAbs === ctx.twinOldPathResolved) {
+      return { rewriteTo: `${ctx.toRef}.derived` };
+    }
+    return "other";
+  };
+  next = next.replace(ctx.aliasScan, (match, prefix: string, token: string) => {
+    const full = probe(token);
+    if (full !== "other" && full !== "unresolved") {
       count += 1;
-      return `${prefix}${ctx.toRef}.derived`;
+      return `${prefix}${full.rewriteTo}`;
+    }
+    if (full === "other") return match;
+    // The slug charset admits sentence punctuation ('.', ';', ':', '!', '?'),
+    // so a prose citation like "See memory:old." parses as the token "old." —
+    // which resolves to nothing. Retry with the trailing punctuation run
+    // stripped, but ONLY after the full token failed to resolve: a genuinely
+    // dotted name (memory:v1.2-notes) or a `.md`-suffixed alias that resolves
+    // won the probe above and is never mangled. The punctuation is preserved
+    // outside the rewritten ref.
+    const punctuation = /[.,;:!?)]+$/.exec(token)?.[0] ?? "";
+    if (!punctuation || punctuation.length === token.length) return match;
+    const trimmed = probe(token.slice(0, token.length - punctuation.length));
+    if (trimmed !== "other" && trimmed !== "unresolved") {
+      count += 1;
+      return `${prefix}${trimmed.rewriteTo}${punctuation}`;
     }
     return match;
   });
@@ -223,16 +252,20 @@ function rewriteRefs(content: string, ctx: RewriteContext): { content: string; c
 
 /**
  * Every ref-carrying file under `root`, recursively: all `.md` files, plus
- * `.yml`/`.yaml` files under the `tasks/` type dir — task YAML legitimately
- * carries refs (`workflow: workflow:…`, `prompt: agent:/memory:…`, see
- * src/tasks/parser.ts) and lint's missing-ref body scan covers them, so a
- * rename must rewrite them like any other citer or the scheduled task
- * dangles. Skips dot-directories (index state, `.cache/` mirrors) and
- * `registry/` caches — the same read-only carve-outs `akm lint --fix`
- * honours (lint/index.ts).
+ * `.yml`/`.yaml` files under the `tasks/` and `workflows/` type dirs — task
+ * YAML legitimately carries refs (`workflow: workflow:…`, `prompt:
+ * agent:/memory:…`, see src/tasks/parser.ts) and workflow YAML *programs*
+ * carry refs in their step/instructions text, and lint's missing-ref body
+ * scan covers both, so a rename must rewrite them like any other citer or
+ * the scheduled task / workflow step dangles. (Workflows are CITERS only:
+ * `workflow:` refs still cannot be MOVED — see {@link MV_SUPPORTED_TYPES}.)
+ * Skips dot-directories (index state, `.cache/` mirrors) and `registry/`
+ * caches — the same read-only carve-outs `akm lint --fix` honours
+ * (lint/index.ts).
  */
 function collectCiterFiles(root: string): string[] {
   const tasksRoot = path.join(root, TYPE_DIRS.task ?? "tasks");
+  const workflowsRoot = path.join(root, TYPE_DIRS.workflow ?? "workflows");
   const results: string[] = [];
   const walk = (dir: string): void => {
     let entries: fs.Dirent[];
@@ -250,7 +283,10 @@ function collectCiterFiles(root: string): string[] {
       } else if (entry.isFile()) {
         if (entry.name.endsWith(".md")) {
           results.push(full);
-        } else if ((entry.name.endsWith(".yml") || entry.name.endsWith(".yaml")) && isWithin(full, tasksRoot)) {
+        } else if (
+          (entry.name.endsWith(".yml") || entry.name.endsWith(".yaml")) &&
+          (isWithin(full, tasksRoot) || isWithin(full, workflowsRoot))
+        ) {
           results.push(full);
         }
       }
@@ -448,6 +484,7 @@ function rekeyStateDbForMove(fromRef: string, toRef: string, includeTwin: boolea
     const pairs: Array<[string, string]> = [[fromRef, toRef]];
     if (includeTwin) pairs.push([`${fromRef}.derived`, `${toRef}.derived`]);
     const db = openDatabase(statePath);
+    const tableFailures: string[] = [];
     try {
       db.exec(`PRAGMA busy_timeout = ${WRITE_PATH_INDEX_BUSY_TIMEOUT_MS}`);
       for (const table of ["asset_salience", "asset_outcome"] as const) {
@@ -460,12 +497,25 @@ function rekeyStateDbForMove(fromRef: string, toRef: string, includeTwin: boolea
               db.prepare(`UPDATE ${table} SET asset_ref = ? WHERE asset_ref = ?`).run(newRef, oldRef);
             }
           })();
-        } catch {
-          // Table missing on an older state.db — nothing of this kind to re-key.
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          // The ONLY swallowable failure: the table is missing on an older
+          // state.db (migrations run in the improve loop, never here) —
+          // nothing of this kind to re-key. Anything else (lock timeout,
+          // incompatible schema) strands history and must reach the report.
+          if (/no such table/i.test(message)) continue;
+          tableFailures.push(`${table}: ${message}`);
         }
       }
     } finally {
       db.close();
+    }
+    if (tableFailures.length > 0) {
+      const warning =
+        `state.db salience re-key failed (${tableFailures.join("; ")}) — the rename itself succeeded, but the ` +
+        "asset's salience/outcome history stays keyed to the old ref until the next improve run re-mints it.";
+      warnVerbose(`akm mv: ${warning}`);
+      return warning;
     }
     return null;
   } catch (error) {
@@ -487,15 +537,16 @@ export const mvCommand = defineJsonCommand({
       "Rename an asset within its type directory (Experimental). Moves the file (a memory's .derived.md twin " +
       "moves together), rewrites inbound refs across the writable stash in the same pass — body prose, " +
       "frontmatter ref lists (xrefs/refs/supersededBy/...), fenced code examples, task .yml files under tasks/, " +
-      "and alias spellings of the same asset (.md-suffixed, local//-prefixed, and resolver-fallback forms are " +
-      "rewritten to the new canonical ref) — and re-keys the search-index row in place (including its " +
-      "usage-event history) plus the state.db salience/outcome rows, so the asset's accumulated usage-ranking " +
-      "history survives the rename. Read-only sources are scanned but never written; their citing files are " +
-      "reported in `readOnlyCiters` as manual follow-ups. Operates on the primary writable stash only, and the " +
-      "source ref must be the asset's canonical spelling (alias/fallback spellings are rejected, naming the " +
-      "canonical ref). Wiki refs are not supported (use `akm wiki lint` after a manual wiki rename); workflow " +
-      "refs are not supported in v1 (workflows may be .yaml programs — rename the file manually and verify with " +
-      "`akm lint`).",
+      "workflow .yaml/.yml programs under workflows/, and alias spellings of the same asset (.md-suffixed, " +
+      "local//-prefixed, and resolver-fallback forms are rewritten to the new canonical ref) — and re-keys the " +
+      "search-index row in place (including its usage-event history) plus the state.db salience/outcome rows, " +
+      "so the asset's accumulated usage-ranking history survives the rename. Read-only sources are scanned but " +
+      "never written; their citing files are reported in `readOnlyCiters` as manual follow-ups. Operates on the " +
+      "primary writable stash only. The source ref (and the target name) may carry the .md-suffixed alias " +
+      "spelling — both are canonicalized — but resolver-fallback source spellings are rejected, naming the " +
+      "canonical ref. Wiki refs are not supported (use `akm wiki lint` after a manual wiki rename); workflow " +
+      "refs cannot be MOVED in v1 (workflows may be .yaml programs — rename the file manually and verify with " +
+      "`akm lint`), though workflow files ARE rewritten as citers.",
   },
   args: {
     ref: {
@@ -557,9 +608,10 @@ export const mvCommand = defineJsonCommand({
     // The `.derived` suffix is the distilled-twin marker: a twin's entry_key
     // must stay exactly `<base entry_key>.derived` (db.ts
     // getBaseBeliefStatesForDerivedTwins), so a twin can never move alone and
-    // no independent asset may squat on the suffix.
-    if (source.type === "memory" && source.name.endsWith(".derived")) {
-      const baseRef = refToString({ type: "memory", name: source.name.slice(0, -".derived".length) });
+    // no independent asset may squat on the suffix. The `.md`-suffixed alias
+    // spelling of a twin ref names the same file, so it is caught here too.
+    if (source.type === "memory" && /\.derived(\.md)?$/.test(source.name)) {
+      const baseRef = refToString({ type: "memory", name: source.name.replace(/\.derived(\.md)?$/, "") });
       throw new UsageError(
         `"${refToString({ type: source.type, name: source.name })}" names a .derived.md distilled twin — a twin ` +
           "cannot be moved on its own without breaking its belief-inheritance coupling to the base memory. " +
@@ -585,7 +637,20 @@ export const mvCommand = defineJsonCommand({
         "INVALID_FLAG_VALUE",
       );
     }
-    const newName = target.name;
+    // Accept the `.md`-suffixed alias spelling of the TARGET, but operate on
+    // the canonical extensionless name: every MV_SUPPORTED_TYPES layout is
+    // the markdownSpec family, whose `toAssetPath` writes `<name>.md` either
+    // way — so `bar.md` names the same file as `bar`, while a `bar.md`-keyed
+    // toRef/entry_key would rewrite citers to a non-canonical ref and strand
+    // the re-keyed history behind a row the write-path index pass (which
+    // derives the canonical name `bar` from the file) immediately duplicates.
+    const newName = target.name.endsWith(".md") ? target.name.slice(0, -".md".length) : target.name;
+    if (!newName) {
+      throw new UsageError(
+        `Target "${targetArg}" names no asset once the .md extension is stripped — nothing moved.`,
+        "INVALID_FLAG_VALUE",
+      );
+    }
     if (source.type === "memory" && newName.endsWith(".derived")) {
       throw new UsageError(
         `The target name "${newName}" ends with the reserved .derived suffix (the distilled-twin marker) — a base ` +
@@ -594,7 +659,6 @@ export const mvCommand = defineJsonCommand({
         "INVALID_FLAG_VALUE",
       );
     }
-    const fromRef = refToString({ type: source.type, name: source.name });
     const toRef = refToString({ type: source.type, name: newName });
 
     const stashDir = resolveStashDir();
@@ -611,11 +675,20 @@ export const mvCommand = defineJsonCommand({
     const oldPath = resolveMoveSourcePath(stashDir, oldRelPath, source.type, source.name);
     if (!oldPath) {
       throw new UsageError(
-        `Cannot resolve ${fromRef} in the writable stash at ${stashDir} — nothing moved.`,
+        `Cannot resolve ${refToString({ type: source.type, name: source.name })} in the writable stash at ` +
+          `${stashDir} — nothing moved.`,
         "MISSING_REQUIRED_ARGUMENT",
         "akm mv renames assets in the primary writable stash only. Check the ref with `akm show <ref>` or `akm search`.",
       );
     }
+    // The accepted spelling may be the `.md`-suffixed alias of the same file
+    // (markdownSpec.toAssetPath maps `foo` and `foo.md` to memories/foo.md).
+    // Everything keyed off the source — the citer rewrite patterns, the index
+    // entry_key re-key, the state.db asset_ref re-key, the report — must use
+    // the CANONICAL extensionless name derived from the resolved path, or the
+    // real rows (keyed by the canonical spelling) are silently missed.
+    const sourceName = deriveCanonicalAssetNameFromStashRoot(source.type, stashDir, oldPath) ?? source.name;
+    const fromRef = refToString({ type: source.type, name: sourceName });
 
     const newPath = path.join(stashDir, newRelPath);
     // Defense-in-depth: parseAssetRef already rejects `../` traversal, but the
@@ -644,7 +717,7 @@ export const mvCommand = defineJsonCommand({
     // name whose orphaned `<name>.derived.md` lingers (consolidate/dedup
     // delete the base file without twin cleanup) would silently adopt the
     // stranger file as the renamed memory's distillation.
-    const isBaseMemory = source.type === "memory" && !source.name.endsWith(".derived");
+    const isBaseMemory = source.type === "memory" && !sourceName.endsWith(".derived");
     const twinOldPath = isBaseMemory ? oldPath.replace(/\.md$/, ".derived.md") : null;
     const hasTwin = twinOldPath !== null && fs.existsSync(twinOldPath);
     const targetTwinPath = isBaseMemory ? newPath.replace(/\.md$/, ".derived.md") : null;
@@ -711,10 +784,15 @@ export const mvCommand = defineJsonCommand({
     }
 
     // ── Apply citer edits, then rename last (see module docstring) ────────
+    // The target's parent directory is created FIRST: if it cannot be (a
+    // segment of the target's subdirectory path exists as a FILE, or the
+    // parent is unwritable), the command must abort before any citer has
+    // been edited — otherwise citers would already point at a ref whose
+    // file never arrives.
+    fs.mkdirSync(path.dirname(newPath), { recursive: true });
     for (const plan of plans) {
       fs.writeFileSync(plan.absPath, plan.content, "utf8");
     }
-    fs.mkdirSync(path.dirname(newPath), { recursive: true });
     fs.renameSync(oldPath, newPath);
     if (twinOldPath && twinNewPath) {
       fs.renameSync(twinOldPath, twinNewPath);
@@ -724,7 +802,7 @@ export const mvCommand = defineJsonCommand({
     const { preserved: utilityPreserved, warning: indexWarning } = rekeyIndexForMove({
       stashDir,
       type: source.type,
-      oldName: source.name,
+      oldName: sourceName,
       newName,
       oldPath,
       newPath,

--- a/src/commands/mv-cli.ts
+++ b/src/commands/mv-cli.ts
@@ -10,10 +10,13 @@
  * inbound xrefs in the same pass") is agent-executable EXCEPT for the part
  * only the CLI can do: a rename mints a new `entries` row (entry_key is
  * UNIQUE), which orphans the utility_scores / utility_scores_scoped /
- * embeddings / asset_salience rows keyed by entry_id — the "rename resets
- * learned ranking" cost the conventions warn about. This verb does the whole
- * pass: move the file, rewrite inbound refs, and re-key the index row IN
- * PLACE so the accumulated history survives.
+ * embeddings rows keyed by entry_id, detaches usage_events keyed by the old
+ * entry_ref, and strands the state.db asset_salience / asset_outcome rows
+ * keyed by `asset_ref` TEXT — the "rename resets learned ranking" cost the
+ * conventions warn about. This verb does the whole pass: move the file,
+ * rewrite inbound refs, re-key the index row IN PLACE (including the
+ * usage_events entry_ref history), and re-key the state.db salience/outcome
+ * rows so the accumulated history survives.
  *
  * Scope (v1, Experimental — see STABILITY.md):
  *   - flat-markdown asset types only ({@link MV_SUPPORTED_TYPES});
@@ -48,11 +51,18 @@ import { type AkmAssetType, isWithin, resolveStashDir, toPosix } from "../core/c
 import { UsageError } from "../core/errors";
 import { appendEvent } from "../core/events";
 import { getDbPath } from "../core/paths";
+import { getStateDbPath } from "../core/state-db";
 import { warnVerbose } from "../core/warn";
 import { closeDatabase, openExistingDatabase, rebuildFts, rekeyEntryInPlace } from "../indexer/db/db";
 import { indexWrittenAssets, WRITE_PATH_INDEX_BUSY_TIMEOUT_MS } from "../indexer/index-written-assets";
 import { resolveSourceEntries } from "../indexer/search/search-source";
-import { refToRelPath, resolveRefPathInStash } from "./lint/base-linter";
+import { openDatabase } from "../storage/database";
+import {
+  REF_BOUNDARY_PREFIX_CLASS_SRC,
+  REF_SLUG_CHAR_CLASS_SRC,
+  refToRelPath,
+  resolveRefPathInStash,
+} from "./lint/base-linter";
 
 // ── Scope ─────────────────────────────────────────────────────────────────────
 
@@ -65,54 +75,146 @@ import { refToRelPath, resolveRefPathInStash } from "./lint/base-linter";
  *   - `skill` — the canonical layout is a multi-file `skills/<name>/SKILL.md`
  *     directory (a directory rename, out of v1 scope);
  *   - `script` — unresolvable by the slug resolver (contract-pinned);
+ *   - `workflow` — workflows may live as `.yaml`/`.yml` programs
+ *     (`WORKFLOW_EXTENSIONS`), and `workflowSpec.toAssetPath` resolves them
+ *     by a cwd-relative existence probe with a `<name>.md` fallback — a mv
+ *     would either rename a YAML program to `.md` (misclassifying it) or
+ *     fail to resolve it from any cwd but the stash root. Out of v1 scope;
+ *     rejected with a dedicated error naming the manual procedure;
  *   - `task` / `env` / `secret` — not markdown assets.
  */
-const MV_SUPPORTED_TYPES: readonly string[] = [
-  "memory",
-  "knowledge",
-  "command",
-  "agent",
-  "workflow",
-  "lesson",
-  "session",
-  "fact",
-];
+const MV_SUPPORTED_TYPES: readonly string[] = ["memory", "knowledge", "command", "agent", "lesson", "session", "fact"];
 
 // ── Ref rewriting ─────────────────────────────────────────────────────────────
 
 /**
- * Boundary grammar shared with lint's `REF_RE` (base-linter.ts): a ref starts
- * at line start or after whitespace / backtick / quote / `(`, and its slug
- * runs until whitespace, `"`, `'`, backtick, `)`, `]`, `>`, or `,`. Complete-
- * ref matching is what keeps a longer ref sharing the old ref as a prefix
- * (e.g. `memory:a/base-note-extra` when moving `memory:a/base-note`)
- * untouched.
+ * Boundary grammar IMPORTED from lint's `REF_RE` fragments (base-linter.ts
+ * `REF_BOUNDARY_PREFIX_CLASS_SRC` / `REF_SLUG_CHAR_CLASS_SRC`) so the two
+ * grammars cannot drift: a ref starts at line start or after whitespace /
+ * backtick / quote / `(` / `[` (the `[` admits flow-style YAML lists like
+ * `xrefs: [memory:foo]` and bracketed body refs), and its slug runs until
+ * the first non-slug character. Complete-ref matching is what keeps a longer
+ * ref sharing the old ref as a prefix (e.g. `memory:a/base-note-extra` when
+ * moving `memory:a/base-note`) untouched.
  */
-const REF_PREFIX_SRC = "(^|[\\s`\"'(])";
-const REF_SUFFIX_SRC = "(?![^\\s\"'`)\\]>,\\n])";
+const REF_PREFIX_SRC = `(^|${REF_BOUNDARY_PREFIX_CLASS_SRC})`;
+const REF_SUFFIX_SRC = `(?!${REF_SLUG_CHAR_CLASS_SRC})`;
 
 function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /**
- * Build the rewrite pattern for one old ref. When the source is a base
- * memory, the optional `.derived` tail also rewrites explicit twin refs
- * (`memory:a/note.derived` → `memory:a/new.derived`) — the twin file moves
- * together, so its ref must too. The tail group is empty-capturing otherwise
- * so the replacer's group indices stay stable.
+ * Build the rewrite patterns for one old ref: the canonical spelling plus
+ * the DETERMINISTIC alias spellings the resolver stack accepts for the same
+ * asset — the `.md`-suffixed form (`markdownSpec.toAssetPath` accepts both)
+ * and the `local//`-prefixed form (`makeAssetRef`/`parseAssetRef` round-trip
+ * it). All alias spellings rewrite to the NEW CANONICAL ref. When the source
+ * is a base memory, the optional `.derived` tail also rewrites explicit twin
+ * refs (`memory:a/note.derived` → `memory:a/new.derived`) — the twin file
+ * moves together, so its ref must too. The tail group is empty-capturing
+ * otherwise so the replacer's group indices stay stable.
  */
-function buildRefPattern(fromRef: string, includeDerivedTail: boolean): RegExp {
+function buildRewritePatterns(fromRef: string, includeDerivedTail: boolean): RegExp[] {
   const tail = includeDerivedTail ? "(\\.derived)?" : "()";
-  return new RegExp(`${REF_PREFIX_SRC}${escapeRegExp(fromRef)}${tail}${REF_SUFFIX_SRC}`, "gm");
+  const core = escapeRegExp(fromRef);
+  return [
+    new RegExp(`${REF_PREFIX_SRC}${core}${tail}${REF_SUFFIX_SRC}`, "gm"),
+    new RegExp(`${REF_PREFIX_SRC}${core}${tail}\\.md${REF_SUFFIX_SRC}`, "gm"),
+    new RegExp(`${REF_PREFIX_SRC}local//${core}${tail}(?:\\.md)?${REF_SUFFIX_SRC}`, "gm"),
+  ];
 }
 
-/** Replace every boundary-matched occurrence, returning the count replaced. */
-function rewriteRefs(content: string, pattern: RegExp, toRef: string): { content: string; count: number } {
+/**
+ * Everything {@link rewriteRefs} needs to rewrite one file's content:
+ * the deterministic patterns (pass 1) and the resolver-backed alias scan
+ * (pass 2) that catches remaining spellings — e.g. the knowledge-subdir
+ * basename alias (`knowledge:guide` for `knowledge/guides/guide.md`) — by
+ * resolving every ref-shaped token of the moved type through lint's shared
+ * resolver and rewriting the ones that point at the moved file's old path.
+ */
+interface RewriteContext {
+  patterns: RegExp[];
+  /** Matches `<type>:<slug>` tokens, optionally `local//`-prefixed. */
+  aliasScan: RegExp;
+  type: AkmAssetType;
+  toRef: string;
+  /** Root the moved file lives in (alias tokens are resolved against it). */
+  scanRoot: string;
+  oldPathResolved: string;
+  twinOldPathResolved: string | null;
+}
+
+function buildRewriteContext(opts: {
+  type: AkmAssetType;
+  fromRef: string;
+  toRef: string;
+  isBaseMemory: boolean;
+  stashDir: string;
+  oldPath: string;
+  twinOldPath: string | null;
+}): RewriteContext {
+  return {
+    patterns: buildRewritePatterns(opts.fromRef, opts.isBaseMemory),
+    aliasScan: new RegExp(
+      `(^|${REF_BOUNDARY_PREFIX_CLASS_SRC})((?:local//)?${escapeRegExp(opts.type)}:${REF_SLUG_CHAR_CLASS_SRC}+)`,
+      "gm",
+    ),
+    type: opts.type,
+    toRef: opts.toRef,
+    scanRoot: opts.stashDir,
+    oldPathResolved: path.resolve(opts.oldPath),
+    twinOldPathResolved: opts.twinOldPath ? path.resolve(opts.twinOldPath) : null,
+  };
+}
+
+/**
+ * Replace every occurrence of the moved ref, returning the count replaced.
+ *
+ * Two passes:
+ *   1. the deterministic patterns (canonical / `.md`-suffixed / `local//`);
+ *   2. the resolver scan — any remaining ref-shaped token of the moved type
+ *      that resolves (via `resolveRefPathInStash`, lint's shared resolver)
+ *      to the moved file's old path is an alias spelling of the same asset
+ *      and is rewritten to the new canonical ref too. Because this pass
+ *      rewrites EVERY token that resolves to the old path, nothing
+ *      ref-shaped can still point at the moved file afterwards.
+ *
+ * Runs at PLANNING time, before the rename — the old file must still be on
+ * disk for the resolver probes.
+ */
+function rewriteRefs(content: string, ctx: RewriteContext): { content: string; count: number } {
   let count = 0;
-  const next = content.replace(pattern, (_match, prefix: string, derivedTail: string | undefined) => {
-    count += 1;
-    return `${prefix}${toRef}${derivedTail ?? ""}`;
+  let next = content;
+  for (const pattern of ctx.patterns) {
+    next = next.replace(pattern, (_match, prefix: string, derivedTail: string | undefined) => {
+      count += 1;
+      return `${prefix}${ctx.toRef}${derivedTail ?? ""}`;
+    });
+  }
+  next = next.replace(ctx.aliasScan, (match, prefix: string, token: string) => {
+    const bare = token.startsWith("local//") ? token.slice("local//".length) : token;
+    // The new canonical ref (just written by pass 1) may itself resolve to
+    // the old path through a fallback (e.g. moving knowledge:guides/x to the
+    // knowledge root while guides/x.md still exists at planning time) — never
+    // rewrite it to itself.
+    if (bare === ctx.toRef || bare === `${ctx.toRef}.derived`) return match;
+    const name = bare.slice(ctx.type.length + 1);
+    if (!name) return match;
+    const relPath = refToRelPath(ctx.type, name);
+    if (!relPath) return match;
+    const resolved = resolveRefPathInStash(relPath, ctx.type, name, ctx.scanRoot);
+    if (!resolved) return match;
+    const resolvedAbs = path.resolve(resolved);
+    if (resolvedAbs === ctx.oldPathResolved) {
+      count += 1;
+      return `${prefix}${ctx.toRef}`;
+    }
+    if (ctx.twinOldPathResolved && resolvedAbs === ctx.twinOldPathResolved) {
+      count += 1;
+      return `${prefix}${ctx.toRef}.derived`;
+    }
+    return match;
   });
   return { content: next, count };
 }
@@ -120,11 +222,17 @@ function rewriteRefs(content: string, pattern: RegExp, toRef: string): { content
 // ── File walking ──────────────────────────────────────────────────────────────
 
 /**
- * Every `.md` file under `root`, recursively. Skips dot-directories (index
- * state, `.cache/` mirrors) and `registry/` caches — the same read-only
- * carve-outs `akm lint --fix` honours (lint/index.ts).
+ * Every ref-carrying file under `root`, recursively: all `.md` files, plus
+ * `.yml`/`.yaml` files under the `tasks/` type dir — task YAML legitimately
+ * carries refs (`workflow: workflow:…`, `prompt: agent:/memory:…`, see
+ * src/tasks/parser.ts) and lint's missing-ref body scan covers them, so a
+ * rename must rewrite them like any other citer or the scheduled task
+ * dangles. Skips dot-directories (index state, `.cache/` mirrors) and
+ * `registry/` caches — the same read-only carve-outs `akm lint --fix`
+ * honours (lint/index.ts).
  */
-function collectMarkdownFiles(root: string): string[] {
+function collectCiterFiles(root: string): string[] {
+  const tasksRoot = path.join(root, TYPE_DIRS.task ?? "tasks");
   const results: string[] = [];
   const walk = (dir: string): void => {
     let entries: fs.Dirent[];
@@ -139,8 +247,12 @@ function collectMarkdownFiles(root: string): string[] {
       if (entry.isDirectory()) {
         if (entry.name === "registry") continue;
         walk(full);
-      } else if (entry.isFile() && entry.name.endsWith(".md")) {
-        results.push(full);
+      } else if (entry.isFile()) {
+        if (entry.name.endsWith(".md")) {
+          results.push(full);
+        } else if ((entry.name.endsWith(".yml") || entry.name.endsWith(".yaml")) && isWithin(full, tasksRoot)) {
+          results.push(full);
+        }
       }
     }
   };
@@ -230,6 +342,9 @@ function resolveMoveSourcePath(
  *     the canonical spelling derives (e.g. a differently-normalized stash
  *     path at index time): that history is now stranded on a ghost row and
  *     will NOT survive the next index run.
+ *
+ * When `preserved` is false, `warning` carries the reason for the command's
+ * JSON report — a re-key failure must be user-visible, not verbose-only.
  */
 function rekeyIndexForMove(opts: {
   stashDir: string;
@@ -238,13 +353,14 @@ function rekeyIndexForMove(opts: {
   newName: string;
   oldPath: string;
   newPath: string;
+  fromRef: string;
   toRef: string;
   twinOldPath: string | null;
   twinNewPath: string | null;
-}): boolean {
+}): { preserved: boolean; warning: string | null } {
   const dbPath = getDbPath();
   try {
-    if (!fs.existsSync(dbPath)) return true;
+    if (!fs.existsSync(dbPath)) return { preserved: true, warning: null };
     let preserved = true;
     const db = openExistingDatabase(dbPath);
     try {
@@ -261,6 +377,8 @@ function rekeyIndexForMove(opts: {
         newEntryKey: newKey,
         newName: opts.newName,
         newFilePath: opts.newPath,
+        oldRef: opts.fromRef,
+        newRef: opts.toRef,
       });
       if (rekeyed === null && strandedRow(opts.oldPath)) preserved = false;
       let twinRekeyed: number | null = null;
@@ -272,6 +390,8 @@ function rekeyIndexForMove(opts: {
           newEntryKey: `${newKey}.derived`,
           newName: `${opts.newName}.derived`,
           newFilePath: opts.twinNewPath,
+          oldRef: `${opts.fromRef}.derived`,
+          newRef: `${opts.toRef}.derived`,
           newDerivedFrom: opts.toRef,
         });
         if (twinRekeyed === null && opts.twinOldPath && strandedRow(opts.twinOldPath)) preserved = false;
@@ -283,18 +403,78 @@ function rekeyIndexForMove(opts: {
       closeDatabase(db);
     }
     if (!preserved) {
-      warnVerbose(
-        "akm mv: the index holds a row for the moved file under an unexpected key — its utility history was not " +
-          "re-keyed and resets on the next `akm index`.",
-      );
+      const warning =
+        "index re-key skipped: the index holds a row for the moved file under an unexpected key — its utility " +
+        "history was not re-keyed and resets on the next `akm index`.";
+      warnVerbose(`akm mv: ${warning}`);
+      return { preserved: false, warning };
     }
-    return preserved;
+    return { preserved: true, warning: null };
   } catch (error) {
-    warnVerbose(
-      "akm mv: index re-key skipped (the index heals on the next `akm index`; utility history for the moved asset may reset):",
-      error instanceof Error ? error.message : String(error),
-    );
-    return false;
+    const message = error instanceof Error ? error.message : String(error);
+    const warning =
+      `index re-key failed (${message}) — the rename itself succeeded and the index heals on the next ` +
+      "`akm index`, but the asset's utility history was NOT re-keyed and resets on that run.";
+    warnVerbose(`akm mv: ${warning}`);
+    return { preserved: false, warning };
+  }
+}
+
+/**
+ * Re-key the state.db `asset_salience` / `asset_outcome` rows after a rename.
+ *
+ * Both tables are keyed by `asset_ref` TEXT (the bare `makeAssetRef`
+ * `type:name` form — NOT entry_id; see core/state/migrations.ts 009/010), so
+ * the salience boost `loadSalienceRankScores` applies at search time and the
+ * outcome-loop history would otherwise strand on the old ref until the next
+ * improve run re-mints a type-weight stub row — losing a distill-written
+ * content-derived `encoding_salience` for good.
+ *
+ * Collision policy (conservative): a row already sitting at the NEW ref can
+ * only be an orphan of a previously deleted asset — the caller has verified
+ * no file exists at the target — so the LIVE asset's history wins: the
+ * orphan row is deleted and the moved asset's row re-keyed onto the ref.
+ *
+ * FAIL-OPEN like the index re-key: no state.db means the improve loop never
+ * ran (nothing to re-key); the file is never created here, migrations are
+ * never run (a missing table on an old state.db is simply skipped), and any
+ * error reduces to a warning in the report — the rename has already
+ * succeeded. Returns the warning for the JSON report, or null.
+ */
+function rekeyStateDbForMove(fromRef: string, toRef: string, includeTwin: boolean): string | null {
+  const statePath = getStateDbPath();
+  try {
+    if (!fs.existsSync(statePath)) return null;
+    const pairs: Array<[string, string]> = [[fromRef, toRef]];
+    if (includeTwin) pairs.push([`${fromRef}.derived`, `${toRef}.derived`]);
+    const db = openDatabase(statePath);
+    try {
+      db.exec(`PRAGMA busy_timeout = ${WRITE_PATH_INDEX_BUSY_TIMEOUT_MS}`);
+      for (const table of ["asset_salience", "asset_outcome"] as const) {
+        try {
+          db.transaction(() => {
+            for (const [oldRef, newRef] of pairs) {
+              const moved = db.prepare(`SELECT asset_ref FROM ${table} WHERE asset_ref = ?`).get(oldRef);
+              if (!moved) continue;
+              db.prepare(`DELETE FROM ${table} WHERE asset_ref = ?`).run(newRef);
+              db.prepare(`UPDATE ${table} SET asset_ref = ? WHERE asset_ref = ?`).run(newRef, oldRef);
+            }
+          })();
+        } catch {
+          // Table missing on an older state.db — nothing of this kind to re-key.
+        }
+      }
+    } finally {
+      db.close();
+    }
+    return null;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const warning =
+      `state.db salience re-key failed (${message}) — the rename itself succeeded, but the asset's salience/` +
+      "outcome history stays keyed to the old ref until the next improve run re-mints it.";
+    warnVerbose(`akm mv: ${warning}`);
+    return warning;
   }
 }
 
@@ -306,12 +486,16 @@ export const mvCommand = defineJsonCommand({
     description:
       "Rename an asset within its type directory (Experimental). Moves the file (a memory's .derived.md twin " +
       "moves together), rewrites inbound refs across the writable stash in the same pass — body prose, " +
-      "frontmatter ref lists (xrefs/refs/supersededBy/...), and fenced code examples — and re-keys the search " +
-      "index row in place so the asset's accumulated usage-ranking history (utility scores, embeddings, " +
-      "salience) survives the rename. Read-only sources are scanned but never written; their citing files are " +
+      "frontmatter ref lists (xrefs/refs/supersededBy/...), fenced code examples, task .yml files under tasks/, " +
+      "and alias spellings of the same asset (.md-suffixed, local//-prefixed, and resolver-fallback forms are " +
+      "rewritten to the new canonical ref) — and re-keys the search-index row in place (including its " +
+      "usage-event history) plus the state.db salience/outcome rows, so the asset's accumulated usage-ranking " +
+      "history survives the rename. Read-only sources are scanned but never written; their citing files are " +
       "reported in `readOnlyCiters` as manual follow-ups. Operates on the primary writable stash only, and the " +
       "source ref must be the asset's canonical spelling (alias/fallback spellings are rejected, naming the " +
-      "canonical ref). Wiki refs are not supported (use `akm wiki lint` after a manual wiki rename).",
+      "canonical ref). Wiki refs are not supported (use `akm wiki lint` after a manual wiki rename); workflow " +
+      "refs are not supported in v1 (workflows may be .yaml programs — rename the file manually and verify with " +
+      "`akm lint`).",
   },
   args: {
     ref: {
@@ -353,6 +537,14 @@ export const mvCommand = defineJsonCommand({
       throw new UsageError(
         "akm mv does not support wiki refs — wiki pages have their own xref + lint system. " +
           "Rename the page manually, fix citations in the same pass, and verify with `akm wiki lint <name>`.",
+        "INVALID_FLAG_VALUE",
+      );
+    }
+    if (source.type === "workflow") {
+      throw new UsageError(
+        "akm mv does not support workflow refs in v1 — workflows may live as .yaml/.yml programs, which the " +
+          "flat-markdown rename path would misresolve or rename to .md. Rename the file manually under " +
+          "workflows/ (keeping its extension), fix inbound refs in the same pass, and verify with `akm lint`.",
         "INVALID_FLAG_VALUE",
       );
     }
@@ -446,29 +638,45 @@ export const mvCommand = defineJsonCommand({
     }
 
     // Memory `.derived.md` twin: moves together with its base (the entry_key
-    // suffix coupling the belief-state inheritance relies on).
+    // suffix coupling the belief-state inheritance relies on). The TARGET
+    // twin-collision check runs whenever the target could carry a twin —
+    // NOT only when the source has one: renaming a twin-less memory onto a
+    // name whose orphaned `<name>.derived.md` lingers (consolidate/dedup
+    // delete the base file without twin cleanup) would silently adopt the
+    // stranger file as the renamed memory's distillation.
     const isBaseMemory = source.type === "memory" && !source.name.endsWith(".derived");
     const twinOldPath = isBaseMemory ? oldPath.replace(/\.md$/, ".derived.md") : null;
     const hasTwin = twinOldPath !== null && fs.existsSync(twinOldPath);
-    const twinNewPath = hasTwin ? newPath.replace(/\.md$/, ".derived.md") : null;
-    if (twinNewPath && fs.existsSync(twinNewPath)) {
+    const targetTwinPath = isBaseMemory ? newPath.replace(/\.md$/, ".derived.md") : null;
+    if (targetTwinPath && fs.existsSync(targetTwinPath)) {
       throw new UsageError(
-        `Target twin ${toRef}.derived already exists at ${toPosix(path.relative(stashDir, twinNewPath))} — nothing moved.`,
+        `Target twin ${toRef}.derived already exists at ${toPosix(path.relative(stashDir, targetTwinPath))} — ` +
+          "renaming onto it would adopt that orphaned distilled twin as this memory's own. Nothing moved.",
         "RESOURCE_ALREADY_EXISTS",
+        "Pick an unused name, or delete the orphaned .derived.md file first if it belongs to a removed memory.",
       );
     }
+    const twinNewPath = hasTwin ? targetTwinPath : null;
 
     // ── Plan the inbound-ref rewrite (no writes yet) ───────────────────────
-    const pattern = buildRefPattern(fromRef, isBaseMemory);
+    const rewriteCtx = buildRewriteContext({
+      type: source.type,
+      fromRef,
+      toRef,
+      isBaseMemory,
+      stashDir,
+      oldPath,
+      twinOldPath: hasTwin ? twinOldPath : null,
+    });
     const plans: Array<{ absPath: string; relPath: string; count: number; content: string }> = [];
-    for (const absPath of collectMarkdownFiles(stashDir)) {
+    for (const absPath of collectCiterFiles(stashDir)) {
       let raw: string;
       try {
         raw = fs.readFileSync(absPath, "utf8");
       } catch {
         continue;
       }
-      const { content, count } = rewriteRefs(raw, pattern, toRef);
+      const { content, count } = rewriteRefs(raw, rewriteCtx);
       if (count > 0) {
         plans.push({ absPath, relPath: toPosix(path.relative(stashDir, absPath)), count, content });
       }
@@ -487,14 +695,17 @@ export const mvCommand = defineJsonCommand({
     }
     for (const src of sources) {
       if (path.resolve(src.path) === path.resolve(stashDir)) continue;
-      for (const absPath of collectMarkdownFiles(src.path)) {
+      for (const absPath of collectCiterFiles(src.path)) {
         let raw: string;
         try {
           raw = fs.readFileSync(absPath, "utf8");
         } catch {
           continue;
         }
-        const { count } = rewriteRefs(raw, pattern, toRef);
+        // Same detection as the writable pass (canonical + alias spellings,
+        // alias tokens resolved against the WRITABLE stash where the moved
+        // file lives) — count-only, never written.
+        const { count } = rewriteRefs(raw, rewriteCtx);
         if (count > 0) readOnlyCiters.push({ file: absPath, count });
       }
     }
@@ -509,18 +720,23 @@ export const mvCommand = defineJsonCommand({
       fs.renameSync(twinOldPath, twinNewPath);
     }
 
-    // ── Index: re-key in place, then reindex the touched files ────────────
-    const utilityPreserved = rekeyIndexForMove({
+    // ── Index + state.db: re-key in place, then reindex touched files ─────
+    const { preserved: utilityPreserved, warning: indexWarning } = rekeyIndexForMove({
       stashDir,
       type: source.type,
       oldName: source.name,
       newName,
       oldPath,
       newPath,
+      fromRef,
       toRef,
       twinOldPath: hasTwin ? twinOldPath : null,
       twinNewPath,
     });
+    // Salience/outcome history lives in state.db keyed by asset_ref TEXT —
+    // re-keyed here so the salience boost genuinely "survives the rename".
+    const stateWarning = rekeyStateDbForMove(fromRef, toRef, hasTwin);
+    const warnings = [indexWarning, stateWarning].filter((w): w is string => w !== null);
     // Rewritten citers (and the moved file itself) go through the standard
     // write-path reindex so their FTS hints reflect the new ref immediately.
     // Fail-open; an absent/empty index is skipped inside the helper.
@@ -554,6 +770,9 @@ export const mvCommand = defineJsonCommand({
       rewrote: plans.map((plan) => ({ file: plan.relPath, count: plan.count })),
       readOnlyCiters,
       utilityPreserved,
+      // Additive: present only when a re-key could not be completed, so the
+      // report (not just --verbose stderr) says WHY history may reset.
+      ...(warnings.length > 0 ? { warnings } : {}),
     });
   },
 });

--- a/src/commands/mv-cli.ts
+++ b/src/commands/mv-cli.ts
@@ -94,8 +94,10 @@ const MV_SUPPORTED_TYPES: readonly string[] = ["memory", "knowledge", "command",
  * Boundary grammar IMPORTED from lint's `REF_RE` fragments (base-linter.ts
  * `REF_BOUNDARY_PREFIX_CLASS_SRC` / `REF_SLUG_CHAR_CLASS_SRC`) so the two
  * grammars cannot drift: a ref starts at line start or after whitespace /
- * backtick / quote / `(` / `[` (the `[` admits flow-style YAML lists like
- * `xrefs: [memory:foo]` and bracketed body refs), and its slug runs until
+ * backtick / quote / `(` / `[` / `,` (the `[` admits flow-style YAML lists
+ * like `xrefs: [memory:foo]` and bracketed body refs; the `,` admits the
+ * refs after the first in a NO-SPACE flow list `[memory:a,memory:b]`), and
+ * its slug runs until
  * the first non-slug character. Complete-ref matching is what keeps a longer
  * ref sharing the old ref as a prefix (e.g. `memory:a/base-note-extra` when
  * moving `memory:a/base-note`) untouched.
@@ -299,6 +301,45 @@ function collectCiterFiles(root: string): string[] {
 // ── Source resolution ─────────────────────────────────────────────────────────
 
 /**
+ * Return the ON-DISK casing of `relPath` under `root` as a posix-separated
+ * relative path, or `null` when a segment cannot be found (file deleted
+ * mid-flight, unreadable directory — callers treat null as "unverifiable"
+ * and keep the `existsSync` verdict).
+ *
+ * The casing guard for {@link resolveMoveSourcePath}: on a case-INSENSITIVE
+ * filesystem (macOS/Windows defaults) `existsSync` matches a wrong-case
+ * spelling and `resolveRefPathInStash` returns the user-cased join verbatim,
+ * so a byte-comparison of the resolved path against the ref-derived path
+ * compares the string against itself. This helper reads each path segment's
+ * true name from its parent's directory listing instead — deliberately NOT
+ * `fs.realpathSync.native`, which also resolves symlinks and would
+ * false-mismatch a stash root reached through one (e.g. /tmp on macOS).
+ * Matching is byte-first, then Unicode-lowercase — an approximation of the
+ * filesystem's own case folding that can only miss toward `null`
+ * (unverifiable), never toward a wrong entry.
+ */
+export function deriveOnDiskCasedRelPath(root: string, relPath: string): string | null {
+  const segments = toPosix(relPath).split("/").filter(Boolean);
+  const cased: string[] = [];
+  let dir = root;
+  for (const segment of segments) {
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(dir);
+    } catch {
+      return null;
+    }
+    const onDisk = entries.includes(segment)
+      ? segment
+      : entries.find((entry) => entry.toLowerCase() === segment.toLowerCase());
+    if (onDisk === undefined) return null;
+    cased.push(onDisk);
+    dir = path.join(dir, onDisk);
+  }
+  return cased.join("/");
+}
+
+/**
  * Resolve the on-disk file for the ref being moved, within the primary
  * writable stash ONLY. Reuses lint's shared resolver (`resolveRefPathInStash`,
  * base-linter.ts — do not fork a second resolver), then requires the hit to
@@ -332,17 +373,32 @@ function resolveMoveSourcePath(
   if (!resolved) return null;
   if (resolved.endsWith(".derived.md") && !refName.endsWith(".derived")) return null;
   if (path.basename(resolved) === "SKILL.md" && !relPath.endsWith(`${path.sep}SKILL.md`)) return null;
-  if (path.resolve(resolved) === path.resolve(stashDir, relPath)) return resolved;
+  // The byte-equal comparison below cannot catch a CASE alias: on a
+  // case-insensitive filesystem the resolver's `existsSync` matches
+  // `memory:Foo` against memories/foo.md and returns the USER-cased join, so
+  // the comparison checks the string against itself. Every downstream key is
+  // case-sensitive regardless of the filesystem (the citer rewrite matches
+  // bytes, the index entry_key is BINARY-collated, state.db asset_ref
+  // likewise), so a wrong-case source must be rejected like any other
+  // fallback spelling: verify the ON-DISK casing and, on mismatch, fall
+  // through to the rejection below with the true-cased path so the error
+  // names the canonical ref.
+  let onDiskResolved = resolved;
+  if (path.resolve(resolved) === path.resolve(stashDir, relPath)) {
+    const onDiskRelPath = deriveOnDiskCasedRelPath(stashDir, relPath);
+    if (onDiskRelPath === null || onDiskRelPath === toPosix(relPath)) return resolved;
+    onDiskResolved = path.join(stashDir, onDiskRelPath);
+  }
 
   // Fallback hit — reject, steering to the canonical spelling when it exists.
   const typedRef = refToString({ type: refType, name: refName });
-  const canonicalName = deriveCanonicalAssetNameFromStashRoot(refType, stashDir, resolved);
+  const canonicalName = deriveCanonicalAssetNameFromStashRoot(refType, stashDir, onDiskResolved);
   const canonicalRelPath = canonicalName ? refToRelPath(refType, canonicalName) : null;
   if (
     canonicalName &&
     canonicalName !== refName &&
     canonicalRelPath &&
-    path.resolve(stashDir, canonicalRelPath) === path.resolve(resolved)
+    path.resolve(stashDir, canonicalRelPath) === path.resolve(onDiskResolved)
   ) {
     const canonicalRef = refToString({ type: refType, name: canonicalName });
     throw new UsageError(
@@ -353,7 +409,7 @@ function resolveMoveSourcePath(
     );
   }
   throw new UsageError(
-    `"${typedRef}" resolves to ${toPosix(path.relative(stashDir, resolved))}, outside the ${TYPE_DIRS[refType]}/ ` +
+    `"${typedRef}" resolves to ${toPosix(path.relative(stashDir, onDiskResolved))}, outside the ${TYPE_DIRS[refType]}/ ` +
       "type root — akm mv renames within a type directory only; nothing moved.",
     "INVALID_FLAG_VALUE",
   );
@@ -648,6 +704,21 @@ export const mvCommand = defineJsonCommand({
     if (!newName) {
       throw new UsageError(
         `Target "${targetArg}" names no asset once the .md extension is stripped — nothing moved.`,
+        "INVALID_FLAG_VALUE",
+      );
+    }
+    // Reject empty path segments: `path.posix.normalize` (parseAssetRef's
+    // name normalization) PRESERVES a trailing slash — "bar/" (and "bar\",
+    // normalized to it) sails through the traversal checks, and the file
+    // would land at e.g. memories/bar/.md: a dot-prefixed file the index
+    // walker skips, unreachable by `akm show`, with every citer rewritten to
+    // the phantom ref "memory:bar/". Interior doubles ("a//b") are collapsed
+    // by the normalization, so a trailing empty segment is the only shape
+    // that reaches this check — but reject ANY empty segment regardless.
+    if (newName.split("/").some((segment) => segment.length === 0)) {
+      throw new UsageError(
+        `Target "${targetArg}" contains an empty path segment (trailing "/" or "\\") — the file would be written ` +
+          "as a hidden dotfile the index cannot see. Pass a name, e.g. `akm mv <ref> projectA/new-note` — nothing moved.",
         "INVALID_FLAG_VALUE",
       );
     }

--- a/src/commands/mv-cli.ts
+++ b/src/commands/mv-cli.ts
@@ -316,15 +316,17 @@ export const mvCommand = defineJsonCommand({
   args: {
     ref: {
       type: "positional",
-      description: "Current asset ref, e.g. memory:projectA/old-note",
+      description: "Current asset ref (required), e.g. memory:projectA/old-note",
       // Optional in citty so run() is invoked even when omitted; re-validated
       // below to surface a structured UsageError (exit 2) instead of citty's
-      // unstructured missing-argument failure.
+      // unstructured missing-argument failure. The "(required)" note in the
+      // description keeps the rendered help honest about that contract.
       required: false,
     },
     newName: {
       type: "positional",
-      description: "New name (subdirectories allowed, e.g. projectA/new-note), or a same-type ref like memory:new-note",
+      description:
+        "New name (required; subdirectories allowed, e.g. projectA/new-note), or a same-type ref like memory:new-note",
       required: false,
     },
   },

--- a/src/commands/read/knowledge.ts
+++ b/src/commands/read/knowledge.ts
@@ -14,8 +14,9 @@ import fs from "node:fs";
 import path from "node:path";
 import { parse as yamlParse } from "yaml";
 import { assertFlatAssetName, combineCreatePath, normalizeCreateSubPath } from "../../core/asset/asset-create";
+import { type AssetRef, parseAssetRef } from "../../core/asset/asset-ref";
 import { assembleAsset } from "../../core/asset/asset-serialize";
-import { resolveAssetPathFromName } from "../../core/asset/asset-spec";
+import { resolveAssetPathFromName, TYPE_DIRS } from "../../core/asset/asset-spec";
 import { parseFrontmatter } from "../../core/asset/frontmatter";
 import { isHttpUrl, isWithin, resolveStashDir, tryReadStdinText } from "../../core/common";
 import { loadConfig } from "../../core/config/config";
@@ -32,7 +33,7 @@ import { indexWrittenAssets } from "../../indexer/index-written-assets";
 import { resolveSourceEntries, type SearchSource } from "../../indexer/search/search-source";
 import { fetchWebsiteMarkdownSnapshot, shouldAllowPrivateWebsiteUrlForTests } from "../../sources/website-ingest";
 import { writeSupersededEdge } from "../improve/memory/memory-belief";
-import { refExistsInAnyStash, refToRelPath, resolveRefPathInStash } from "../lint/base-linter";
+import { refToRelPath, resolveRefPathInStash } from "../lint/base-linter";
 
 const MAX_CAPTURED_ASSET_SLUG_LENGTH = 64;
 
@@ -137,6 +138,125 @@ export async function readKnowledgeInput(
   return { content: snapshot.content, preferredName: snapshot.preferredName };
 }
 
+// ── Shared write-ref validation (--xref / --supersedes) ─────────────────────
+
+/** A `--xref` / `--supersedes` flag value parsed to its components. */
+interface ParsedWriteRef {
+  /** The raw flag value as passed (trimmed) — what lands in frontmatter. */
+  ref: string;
+  /** Canonical asset type (aliases resolved by `parseAssetRef`). */
+  type: string;
+  /** Normalized asset name. */
+  name: string;
+}
+
+/**
+ * Parse a `--xref` / `--supersedes` value through the canonical ref parser
+ * (`parseAssetRef`) so malformed and origin-prefixed spellings get a
+ * structured error instead of a misleading "did not resolve". A `local//`
+ * origin is accepted (it names the same local resolution this validator
+ * performs, mirroring lint's `local//` strip); any other origin is rejected —
+ * write-time validation only resolves local stash roots.
+ */
+function parseWriteRef(raw: string, flag: "--xref" | "--supersedes"): ParsedWriteRef {
+  let parsed: AssetRef;
+  try {
+    parsed = parseAssetRef(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new UsageError(
+      `${flag} "${raw}" is not a valid asset ref: ${message}`,
+      "INVALID_FLAG_VALUE",
+      `Refs use the form type:name, e.g. ${flag} knowledge:auth-flow.`,
+    );
+  }
+  if (parsed.origin && parsed.origin !== "local") {
+    throw new UsageError(
+      `${flag} "${raw}" carries the origin prefix "${parsed.origin}//" — ${flag} only resolves refs in the write target, the working stash, and configured sources.`,
+      "INVALID_FLAG_VALUE",
+      `Pass the plain type:name form, e.g. ${flag} ${parsed.type}:${parsed.name}.`,
+    );
+  }
+  return { ref: raw, type: parsed.type, name: parsed.name };
+}
+
+/**
+ * The ONE root set write-time ref validation resolves against, shared by
+ * `resolveXrefsForWrite` and `resolveSupersedesForWrite` so the two flags can
+ * never disagree on what a ref resolves to:
+ *
+ *   1. the resolved write target (mutable),
+ *   2. the primary working stash when it is a different directory (mutable) —
+ *      a `--target`/`defaultWriteTarget` write must still see working-stash
+ *      assets, which `resolveSourceEntries(writeTarget)` alone omits,
+ *   3. every other configured source (read-only for demotion purposes).
+ *
+ * NOTE: this is deliberately a superset of lint's root set (lint roots at the
+ * working stash; this roots at the write target AND the working stash).
+ */
+function resolveWriteRefRoots(target?: string): {
+  /** Demotion-eligible roots, write target first (existing dirs only). */
+  mutableRoots: string[];
+  /** Every other configured source (existing dirs only), with metadata. */
+  otherSources: SearchSource[];
+} {
+  const cfg = loadConfig();
+  const stashRoot = resolveWriteTarget(cfg, target).source.path;
+  let workingStash: string | undefined;
+  try {
+    workingStash = resolveStashDir({ readOnly: true });
+  } catch {
+    // No working stash configured — the write target alone.
+  }
+  const mutableRoots: string[] = [stashRoot];
+  if (workingStash && path.resolve(workingStash) !== path.resolve(stashRoot)) mutableRoots.push(workingStash);
+  const otherSources = resolveSourceEntries(stashRoot, cfg).filter(
+    (s) => !mutableRoots.some((m) => path.resolve(m) === path.resolve(s.path)) && fs.existsSync(s.path),
+  );
+  return { mutableRoots: mutableRoots.filter((p) => fs.existsSync(p)), otherSources };
+}
+
+/**
+ * True when write-time validation must FAIL OPEN for this ref type — exactly
+ * lint's `checkMissingRefs` policy (`if (relPath === null) continue`,
+ * base-linter.ts): a type the slug resolver cannot map to a path (`script:` is
+ * contract-pinned to return null) is accepted without an existence check
+ * rather than being unwinnable. `workflow:` never fails open — it resolves
+ * stash-rooted via {@link locateWriteRefInRoot}.
+ */
+function isFailOpenRefType(type: string, name: string): boolean {
+  return type !== "workflow" && refToRelPath(type, name) === null;
+}
+
+/**
+ * Resolve a write-time ref to its primary on-disk file within a single stash
+ * root. Wraps lint's `resolveRefPathInStash` with one addition: `workflow:`
+ * refs are probed against the ROOT's workflows/ dir first (every recognized
+ * workflow extension), because `workflowSpec.toAssetPath` inside
+ * `refToRelPath` probes the CWD — and write validation must not depend on the
+ * caller's cwd.
+ */
+function locateWriteRefInRoot(type: string, name: string, root: string): string | null {
+  if (type === "workflow") {
+    const typeRoot = path.join(root, TYPE_DIRS.workflow ?? "workflows");
+    const candidate = resolveAssetPathFromName("workflow", typeRoot, name);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  const relPath = refToRelPath(type, name);
+  if (relPath === null) return null;
+  return resolveRefPathInStash(relPath, type, name, root);
+}
+
+/** Build the shared exit-2 error for refs that resolved in no root. */
+function unresolvedRefsError(flag: "--xref" | "--supersedes", unresolved: ParsedWriteRef[]): UsageError {
+  const first = unresolved[0];
+  return new UsageError(
+    `${flag} ref${unresolved.length > 1 ? "s" : ""} did not resolve in the write target or any configured source: ${unresolved.map((u) => u.ref).join(", ")}`,
+    "INVALID_FLAG_VALUE",
+    `Find the intended asset with \`akm search "${first.name}" --type ${first.type}\`. Refs use the form type:name.`,
+  );
+}
+
 // ── Cross-references (--xref) ────────────────────────────────────────────────
 
 /**
@@ -149,14 +269,17 @@ export const XREF_SOFT_CAP = 5;
 /**
  * Validate `--xref` flag values before ANY write happens.
  *
- * Each ref (`type:name`) must resolve to a real asset in the resolved write
- * target or any configured stash source (mirrors lint's missing-ref root set,
- * so cross-stash provenance refs into read-only sources are accepted). An
- * unresolvable ref is input validation of an explicitly passed flag — it
- * throws {@link UsageError} (exit 2) naming every bad ref, and the caller must
- * invoke this before writing so a failed validation leaves the stash
- * untouched. Resolution reuses the lint ref-resolver helpers
- * (`refToRelPath` / `refExistsInAnyStash`) — do not fork a second resolver.
+ * Each ref (`type:name`) must resolve to a real asset in the write-ref root
+ * set (write target + working stash + configured sources — see
+ * {@link resolveWriteRefRoots}; cross-stash provenance refs into read-only
+ * sources are accepted). An unresolvable ref is input validation of an
+ * explicitly passed flag — it throws {@link UsageError} (exit 2) naming every
+ * bad ref, and the caller must invoke this before writing so a failed
+ * validation leaves the stash untouched. Resolution reuses the lint
+ * ref-resolver helpers (`refToRelPath` / `resolveRefPathInStash`) — do not
+ * fork a second resolver — and mirrors lint's fail-open policy: a type the
+ * resolver cannot map to a path (`script:`) is accepted without an existence
+ * check.
  *
  * Returns the trimmed, deduplicated refs in argv order. More than
  * {@link XREF_SOFT_CAP} refs emits a stderr warning (soft cap) but still
@@ -170,35 +293,19 @@ export function resolveXrefsForWrite(rawXrefs: string[], target?: string): strin
   }
   if (xrefs.length === 0) return xrefs;
 
-  const cfg = loadConfig();
-  const stashRoot = resolveWriteTarget(cfg, target).source.path;
-  const extraStashRoots = resolveSourceEntries(stashRoot, cfg)
-    .map((s) => s.path)
-    .filter((p) => p !== stashRoot && fs.existsSync(p));
-  const allRoots = [stashRoot, ...extraStashRoots];
+  const { mutableRoots, otherSources } = resolveWriteRefRoots(target);
+  const allRoots = [...mutableRoots, ...otherSources.map((s) => s.path)];
 
-  const unresolved: string[] = [];
+  const unresolved: ParsedWriteRef[] = [];
   for (const ref of xrefs) {
-    const colonIdx = ref.indexOf(":");
-    const refType = colonIdx > 0 ? ref.slice(0, colonIdx) : "";
-    const refName = colonIdx > 0 ? ref.slice(colonIdx + 1) : "";
-    const relPath = refType && refName ? refToRelPath(refType, refName) : null;
-    if (relPath === null || !refExistsInAnyStash(relPath, refType, refName, allRoots)) {
-      unresolved.push(ref);
+    const parsed = parseWriteRef(ref, "--xref");
+    if (isFailOpenRefType(parsed.type, parsed.name)) continue;
+    if (!allRoots.some((root) => locateWriteRefInRoot(parsed.type, parsed.name, root) !== null)) {
+      unresolved.push(parsed);
     }
   }
   if (unresolved.length > 0) {
-    const first = unresolved[0];
-    const colonIdx = first.indexOf(":");
-    const hint =
-      colonIdx > 0
-        ? `Find the intended asset with \`akm search "${first.slice(colonIdx + 1)}" --type ${first.slice(0, colonIdx)}\`. Refs use the form type:name.`
-        : "Refs use the form type:name, e.g. --xref knowledge:auth-flow.";
-    throw new UsageError(
-      `--xref ref${unresolved.length > 1 ? "s" : ""} did not resolve in the write target or any configured source: ${unresolved.join(", ")}`,
-      "INVALID_FLAG_VALUE",
-      hint,
-    );
+    throw unresolvedRefsError("--xref", unresolved);
   }
 
   if (xrefs.length > XREF_SOFT_CAP) {
@@ -296,6 +403,16 @@ export interface SupersededTarget {
 }
 
 /**
+ * Asset types `--supersedes` must refuse to demote: the demotion writes a YAML
+ * frontmatter block onto the target file, and these types are RAW files whose
+ * bytes are the value (a secret's entire content is the credential; a task is
+ * pure YAML that a prepended second document breaks; scripts have arbitrary
+ * syntax). Prepending frontmatter corrupts them. `akm mv` excludes the same
+ * types as "not markdown assets" (plus `script`, unresolvable by design).
+ */
+const SUPERSEDE_REJECTED_TYPES: ReadonlySet<string> = new Set(["secret", "env", "task", "script"]);
+
+/**
  * Validate `--supersedes` flag values before ANY write happens.
  *
  * The conventions' corrections pattern needs TWO writes: the new correction
@@ -305,6 +422,12 @@ export interface SupersededTarget {
  * (same resolver + root set as {@link resolveXrefsForWrite}); an unresolvable
  * ref throws {@link UsageError} (exit 2) naming every bad ref, so a failed
  * validation leaves the stash untouched — no partial correction.
+ *
+ * Because the demotion PREPENDS a YAML frontmatter block when the target file
+ * has none, only markdown assets may be demoted: refs of a raw asset type
+ * ({@link SUPERSEDE_REJECTED_TYPES}) and refs resolving to any non-`.md` file
+ * (e.g. a YAML workflow program) are rejected with {@link UsageError} BEFORE
+ * any write — never silently corrupted.
  *
  * Demotion targets must live under the resolved write target's source path or
  * the working stash — honoring the "only operate on writable sources"
@@ -325,49 +448,53 @@ export function resolveSupersedesForWrite(rawRefs: string[], target?: string): S
   }
   if (refs.length === 0) return [];
 
-  const cfg = loadConfig();
-  const stashRoot = resolveWriteTarget(cfg, target).source.path;
-  let workingStash: string | undefined;
-  try {
-    workingStash = resolveStashDir({ readOnly: true });
-  } catch {
-    // No working stash configured — the write target alone accepts demotions.
-  }
-  const mutableRoots: string[] = [stashRoot];
-  if (workingStash && path.resolve(workingStash) !== path.resolve(stashRoot)) mutableRoots.push(workingStash);
-  const otherSources = resolveSourceEntries(stashRoot, cfg).filter(
-    (s) => !mutableRoots.some((m) => path.resolve(m) === path.resolve(s.path)) && fs.existsSync(s.path),
-  );
+  const { mutableRoots, otherSources } = resolveWriteRefRoots(target);
   // Mutable roots first: when a ref resolves in several roots, demote the copy
   // this command is allowed to mutate. Non-mutable roots keep their SearchSource
   // so the skip reason can distinguish "re-run with --target" (a configured
   // writable source that simply is not this write's target) from genuinely
   // read-only sources.
   const orderedRoots: Array<{ path: string; source?: SearchSource }> = [
-    ...mutableRoots.filter((p) => fs.existsSync(p)).map((p) => ({ path: p })),
+    ...mutableRoots.map((p) => ({ path: p })),
     ...otherSources.map((s) => ({ path: s.path, source: s })),
   ];
 
   const plan: SupersededTarget[] = [];
-  const unresolved: string[] = [];
+  const unresolved: ParsedWriteRef[] = [];
   for (const ref of refs) {
-    const colonIdx = ref.indexOf(":");
-    const refType = colonIdx > 0 ? ref.slice(0, colonIdx) : "";
-    const refName = colonIdx > 0 ? ref.slice(colonIdx + 1) : "";
-    const relPath = refType && refName ? refToRelPath(refType, refName) : null;
+    const parsed = parseWriteRef(ref, "--supersedes");
+    // Data-corruption gate (SPEC-5): demotion is a frontmatter write; a raw
+    // asset type must be rejected up front — resolving it and mutating the
+    // file would prepend a YAML block over its raw bytes.
+    if (SUPERSEDE_REJECTED_TYPES.has(parsed.type)) {
+      throw new UsageError(
+        `--supersedes cannot demote ${ref}: "${parsed.type}:" assets are raw files, and the demotion writes YAML frontmatter that would corrupt them.`,
+        "INVALID_FLAG_VALUE",
+        "Only markdown assets (e.g. memory:, knowledge:, fact:) can carry the beliefState/supersededBy demotion. Replace or delete the raw asset instead.",
+      );
+    }
     let located: { root: string; source?: SearchSource; filePath: string } | null = null;
-    if (relPath !== null) {
-      for (const root of orderedRoots) {
-        const filePath = resolveRefPathInStash(relPath, refType, refName, root.path);
-        if (filePath !== null) {
-          located = { root: root.path, source: root.source, filePath };
-          break;
-        }
+    for (const root of orderedRoots) {
+      const filePath = locateWriteRefInRoot(parsed.type, parsed.name, root.path);
+      if (filePath !== null) {
+        located = { root: root.path, source: root.source, filePath };
+        break;
       }
     }
     if (located === null) {
-      unresolved.push(ref);
+      unresolved.push(parsed);
       continue;
+    }
+    // Belt-and-suspenders for the same corruption class: whatever the type,
+    // the demotion may only touch a markdown file. Rejects e.g. a YAML
+    // workflow program (`workflow:deploy` resolving to workflows/deploy.yaml,
+    // or the explicit `workflow:deploy.yaml` spelling).
+    if (!located.filePath.toLowerCase().endsWith(".md")) {
+      throw new UsageError(
+        `--supersedes ${ref} resolves to a non-markdown file (${located.filePath}) — the demotion writes YAML frontmatter and would corrupt it.`,
+        "INVALID_FLAG_VALUE",
+        "Only markdown assets can carry the beliefState/supersededBy demotion. Replace or delete the file instead.",
+      );
     }
     const { root, source, filePath } = located;
     const writable = source === undefined;
@@ -393,17 +520,7 @@ export function resolveSupersedesForWrite(rawRefs: string[], target?: string): S
   }
 
   if (unresolved.length > 0) {
-    const first = unresolved[0];
-    const colonIdx = first.indexOf(":");
-    const hint =
-      colonIdx > 0
-        ? `Find the intended asset with \`akm search "${first.slice(colonIdx + 1)}" --type ${first.slice(0, colonIdx)}\`. Refs use the form type:name.`
-        : "Refs use the form type:name, e.g. --supersedes memory:projectA/old-note.";
-    throw new UsageError(
-      `--supersedes ref${unresolved.length > 1 ? "s" : ""} did not resolve in the write target or any configured source: ${unresolved.join(", ")}`,
-      "INVALID_FLAG_VALUE",
-      hint,
-    );
+    throw unresolvedRefsError("--supersedes", unresolved);
   }
   return plan;
 }
@@ -532,7 +649,23 @@ export async function writeMarkdownAsset(options: {
       superseded.push({ ref: item.ref, applied: false, reason });
       continue;
     }
-    writeSupersededEdge(item.filePath, result.ref);
+    // A demotion failure (fs error, concurrent delete, malformed YAML the
+    // pre-check missed) must NOT abort the correction: the new asset is
+    // already on disk, and bailing out here would skip the boundary commit and
+    // the write-path indexing below — leaving the correction unindexed and,
+    // on a git target, uncommitted (and a re-run hits RESOURCE_ALREADY_EXISTS).
+    // Degrade to the same applied:false report the non-writable path uses.
+    try {
+      writeSupersededEdge(item.filePath, result.ref);
+    } catch (error) {
+      const reason = `demotion failed: ${error instanceof Error ? error.message : String(error)}`;
+      warn(
+        `Warning: superseded asset ${item.ref} was NOT demoted (${reason}). ` +
+          "The correction was written and cites it in xrefs; demote the old asset manually or re-run the correction with --force.",
+      );
+      superseded.push({ ref: item.ref, applied: false, reason });
+      continue;
+    }
     superseded.push({ ref: item.ref, applied: true });
     const files = demotedByRoot.get(item.stashRoot) ?? [];
     files.push(item.filePath);

--- a/src/commands/read/knowledge.ts
+++ b/src/commands/read/knowledge.ts
@@ -17,7 +17,7 @@ import { assertFlatAssetName, combineCreatePath, normalizeCreateSubPath } from "
 import { assembleAsset } from "../../core/asset/asset-serialize";
 import { resolveAssetPathFromName } from "../../core/asset/asset-spec";
 import { parseFrontmatter } from "../../core/asset/frontmatter";
-import { isHttpUrl, isWithin, tryReadStdinText } from "../../core/common";
+import { isHttpUrl, isWithin, resolveStashDir, tryReadStdinText } from "../../core/common";
 import { loadConfig } from "../../core/config/config";
 import { UsageError } from "../../core/errors";
 import { resolveStashStandards } from "../../core/standards/resolve-stash-standards";
@@ -29,9 +29,10 @@ import {
   writeAssetToSource,
 } from "../../core/write-source";
 import { indexWrittenAssets } from "../../indexer/index-written-assets";
-import { resolveSourceEntries } from "../../indexer/search/search-source";
+import { resolveSourceEntries, type SearchSource } from "../../indexer/search/search-source";
 import { fetchWebsiteMarkdownSnapshot, shouldAllowPrivateWebsiteUrlForTests } from "../../sources/website-ingest";
-import { refExistsInAnyStash, refToRelPath } from "../lint/base-linter";
+import { writeSupersededEdge } from "../improve/memory/memory-belief";
+import { refExistsInAnyStash, refToRelPath, resolveRefPathInStash } from "../lint/base-linter";
 
 const MAX_CAPTURED_ASSET_SLUG_LENGTH = 64;
 
@@ -233,14 +234,7 @@ export function mergeXrefsIntoContent(content: string, xrefs: string[]): string 
   if (xrefs.length === 0) return content;
   const parsed = parseFrontmatter(content);
   if (parsed.frontmatter?.trim()) {
-    let mergeable = false;
-    try {
-      const fmValue = yamlParse(parsed.frontmatter) as unknown;
-      mergeable = fmValue !== null && typeof fmValue === "object" && !Array.isArray(fmValue);
-    } catch {
-      mergeable = false; // yaml.parse threw → parseFrontmatter used the lossy lenient fallback
-    }
-    if (!mergeable) {
+    if (!isParseableYamlMapping(parsed.frontmatter)) {
       throw new UsageError(
         "--xref cannot merge into this document: its frontmatter is not a parseable YAML mapping, and rewriting it would drop the values the parser could not read.",
         "INVALID_FLAG_VALUE",
@@ -259,6 +253,159 @@ export function mergeXrefsIntoContent(content: string, xrefs: string[]): string 
     if (!merged.includes(ref)) merged.push(ref);
   }
   return assembleAsset({ ...parsed.data, xrefs: merged }, parsed.content);
+}
+
+/**
+ * True when a raw frontmatter block (the text between the `---` fences)
+ * parses as a YAML mapping — the precondition for any round-trip rewrite.
+ * Malformed YAML falls back to `parseFrontmatter`'s lossy lenient scanner
+ * (scalars only), and re-serializing that result destroys list/nested values
+ * (`tags: [a, b]` → `tags: ""`), so writers must refuse instead of rewriting.
+ */
+function isParseableYamlMapping(frontmatter: string): boolean {
+  try {
+    const fmValue = yamlParse(frontmatter) as unknown;
+    return fmValue !== null && typeof fmValue === "object" && !Array.isArray(fmValue);
+  } catch {
+    return false;
+  }
+}
+
+// ── Corrections (--supersedes) ───────────────────────────────────────────────
+
+/**
+ * A validated `--supersedes` target: the old asset a correction demotes.
+ * Produced by {@link resolveSupersedesForWrite}, consumed by
+ * {@link writeMarkdownAsset} AFTER the new asset is written.
+ */
+export interface SupersededTarget {
+  /** The old asset's ref (`type:name`) as passed on the CLI (trimmed). */
+  ref: string;
+  /** Absolute path of the old asset's primary on-disk file. */
+  filePath: string;
+  /** Stash/source root containing the file (the reindex scope after mutation). */
+  stashRoot: string;
+  /**
+   * Whether the demotion may be applied: true only when the file lives under
+   * the resolved write target or the working stash. Refs resolving in any
+   * other configured source are reported (`applied: false`) but never mutated.
+   */
+  writable: boolean;
+  /** Human-readable reason when `writable` is false. */
+  reason?: string;
+}
+
+/**
+ * Validate `--supersedes` flag values before ANY write happens.
+ *
+ * The conventions' corrections pattern needs TWO writes: the new correction
+ * asset (with an xref to what it corrects) and a metadata edit demoting the
+ * old asset (`beliefState: superseded` + `supersededBy: [<new ref>]`). This
+ * helper performs the validation half: each ref must resolve to a real asset
+ * (same resolver + root set as {@link resolveXrefsForWrite}); an unresolvable
+ * ref throws {@link UsageError} (exit 2) naming every bad ref, so a failed
+ * validation leaves the stash untouched — no partial correction.
+ *
+ * Demotion targets must live under the resolved write target's source path or
+ * the working stash — honoring the "only operate on writable sources"
+ * constraint (and never dirtying a non-target source outside its boundary
+ * commit). A ref that resolves only in another configured source — read-only
+ * OR writable-but-not-the-target — is returned with `writable: false` and a
+ * reason (naming the `--target` remedy when the source is writable); the
+ * caller writes the correction anyway and reports the demotion as not
+ * applied.
+ *
+ * Returns the deduplicated plan in argv order; empty input returns [].
+ */
+export function resolveSupersedesForWrite(rawRefs: string[], target?: string): SupersededTarget[] {
+  const refs: string[] = [];
+  for (const raw of rawRefs) {
+    const trimmed = raw.trim();
+    if (trimmed && !refs.includes(trimmed)) refs.push(trimmed);
+  }
+  if (refs.length === 0) return [];
+
+  const cfg = loadConfig();
+  const stashRoot = resolveWriteTarget(cfg, target).source.path;
+  let workingStash: string | undefined;
+  try {
+    workingStash = resolveStashDir({ readOnly: true });
+  } catch {
+    // No working stash configured — the write target alone accepts demotions.
+  }
+  const mutableRoots: string[] = [stashRoot];
+  if (workingStash && path.resolve(workingStash) !== path.resolve(stashRoot)) mutableRoots.push(workingStash);
+  const otherSources = resolveSourceEntries(stashRoot, cfg).filter(
+    (s) => !mutableRoots.some((m) => path.resolve(m) === path.resolve(s.path)) && fs.existsSync(s.path),
+  );
+  // Mutable roots first: when a ref resolves in several roots, demote the copy
+  // this command is allowed to mutate. Non-mutable roots keep their SearchSource
+  // so the skip reason can distinguish "re-run with --target" (a configured
+  // writable source that simply is not this write's target) from genuinely
+  // read-only sources.
+  const orderedRoots: Array<{ path: string; source?: SearchSource }> = [
+    ...mutableRoots.filter((p) => fs.existsSync(p)).map((p) => ({ path: p })),
+    ...otherSources.map((s) => ({ path: s.path, source: s })),
+  ];
+
+  const plan: SupersededTarget[] = [];
+  const unresolved: string[] = [];
+  for (const ref of refs) {
+    const colonIdx = ref.indexOf(":");
+    const refType = colonIdx > 0 ? ref.slice(0, colonIdx) : "";
+    const refName = colonIdx > 0 ? ref.slice(colonIdx + 1) : "";
+    const relPath = refType && refName ? refToRelPath(refType, refName) : null;
+    let located: { root: string; source?: SearchSource; filePath: string } | null = null;
+    if (relPath !== null) {
+      for (const root of orderedRoots) {
+        const filePath = resolveRefPathInStash(relPath, refType, refName, root.path);
+        if (filePath !== null) {
+          located = { root: root.path, source: root.source, filePath };
+          break;
+        }
+      }
+    }
+    if (located === null) {
+      unresolved.push(ref);
+      continue;
+    }
+    const { root, source, filePath } = located;
+    const writable = source === undefined;
+    // The eligibility rule is write-target-or-working-stash, NOT source
+    // writability: mutating a non-target writable source would leave it dirty
+    // outside any boundary commit. Name the remedy when one exists.
+    const namedWritableSource = source?.writable === true ? source.registryId : undefined;
+    plan.push({
+      ref,
+      filePath,
+      stashRoot: root,
+      writable,
+      ...(writable
+        ? {}
+        : {
+            reason: namedWritableSource
+              ? `resolves outside the write target and the working stash, in writable source "${namedWritableSource}" at ${root}; ` +
+                `re-run with --target ${namedWritableSource} to demote it there`
+              : `resolves outside the write target and the working stash, in a read-only source at ${root}; ` +
+                "demotion only applies to assets in the write target or the working stash",
+          }),
+    });
+  }
+
+  if (unresolved.length > 0) {
+    const first = unresolved[0];
+    const colonIdx = first.indexOf(":");
+    const hint =
+      colonIdx > 0
+        ? `Find the intended asset with \`akm search "${first.slice(colonIdx + 1)}" --type ${first.slice(0, colonIdx)}\`. Refs use the form type:name.`
+        : "Refs use the form type:name, e.g. --supersedes memory:projectA/old-note.";
+    throw new UsageError(
+      `--supersedes ref${unresolved.length > 1 ? "s" : ""} did not resolve in the write target or any configured source: ${unresolved.join(", ")}`,
+      "INVALID_FLAG_VALUE",
+      hint,
+    );
+  }
+  return plan;
 }
 
 // ── Asset writing ────────────────────────────────────────────────────────────
@@ -286,7 +433,23 @@ export async function writeMarkdownAsset(options: {
    * slug). e.g. `path: "personal/projects"` → `memories/personal/projects/<name>.md`.
    */
   path?: string;
-}): Promise<{ ref: string; path: string; stashDir: string; hint?: string }> {
+  /**
+   * Validated `--supersedes` targets (from {@link resolveSupersedesForWrite}).
+   * After the new asset is written, each writable target is demoted via
+   * `writeSupersededEdge` (metadata-only frontmatter edit) BEFORE the git
+   * boundary commit — so a git target batches the correction AND the demoted
+   * incumbent into the single boundary commit — and then reindexed so the
+   * demotion is immediately live. Non-writable targets warn on stderr and are
+   * reported as `applied: false` in the returned `superseded` key.
+   */
+  supersedes?: SupersededTarget[];
+}): Promise<{
+  ref: string;
+  path: string;
+  stashDir: string;
+  hint?: string;
+  superseded?: Array<{ ref: string; applied: boolean; reason?: string }>;
+}> {
   const cfg = loadConfig();
   const target = resolveWriteTarget(cfg, options.target);
   const { source, config } = target;
@@ -313,15 +476,83 @@ export async function writeMarkdownAsset(options: {
       "RESOURCE_ALREADY_EXISTS",
     );
   }
+  // A correction cannot supersede ITSELF. Under `--force` the ref resolves to
+  // the very file this command is about to overwrite, and the demotion would
+  // immediately mark the fresh correction superseded (plus a self-xref) —
+  // silently hiding the fix from `--belief current` and capping its rank.
+  // Input validation: exit 2, before any write, nothing demoted.
+  for (const item of options.supersedes ?? []) {
+    if (path.resolve(item.filePath) === path.resolve(assetPath)) {
+      throw new UsageError(
+        `--supersedes ${item.ref} resolves to the asset being written ("${options.type}:${normalizedName}") — a correction cannot supersede itself.`,
+        "INVALID_FLAG_VALUE",
+        "Write the correction under a different --name, or drop --supersedes when overwriting an asset in place with --force.",
+      );
+    }
+  }
 
   const ref = { type: options.type, name: normalizedName };
   const result = await writeAssetToSource(source, config, ref, options.content);
+  // SPEC-5 (--supersedes): demote each superseded asset by mutating its
+  // frontmatter (`beliefState: superseded` + sorted-set-append `supersededBy`;
+  // every other key and the body are preserved). Ordered BEFORE
+  // commitWriteTargetBoundary so a git target batches the correction and the
+  // demoted incumbent into the single boundary commit instead of leaving the
+  // metadata edit as dirty residue after it.
+  const superseded: Array<{ ref: string; applied: boolean; reason?: string }> = [];
+  const demotedByRoot = new Map<string, string[]>();
+  for (const item of options.supersedes ?? []) {
+    if (!item.writable) {
+      const reason = item.reason ?? "target is not writable";
+      warn(
+        `Warning: superseded asset ${item.ref} was NOT demoted (${reason}). ` +
+          "The correction was written and cites it in xrefs; demote the old asset where it is writable.",
+      );
+      superseded.push({ ref: item.ref, applied: false, reason });
+      continue;
+    }
+    // The demotion round-trips the old file's frontmatter through the YAML
+    // parser. A malformed block would silently fall back to the lossy lenient
+    // scanner and re-serializing that result destroys list/nested values —
+    // skip instead of rewriting, mirroring mergeXrefsIntoContent's
+    // abort-on-malformed policy (the correction itself still writes).
+    let oldFrontmatter: string | null = null;
+    try {
+      oldFrontmatter = parseFrontmatter(fs.readFileSync(item.filePath, "utf8")).frontmatter;
+    } catch {
+      // Unreadable file — let writeSupersededEdge surface the real fs error.
+    }
+    if (oldFrontmatter?.trim() && !isParseableYamlMapping(oldFrontmatter)) {
+      const reason =
+        "its existing frontmatter is not a parseable YAML mapping — rewriting it would drop the values the parser could not read";
+      warn(
+        `Warning: superseded asset ${item.ref} was NOT demoted (${reason}). ` +
+          "The correction was written and cites it in xrefs; fix the old asset's frontmatter and re-run the correction with --force.",
+      );
+      superseded.push({ ref: item.ref, applied: false, reason });
+      continue;
+    }
+    writeSupersededEdge(item.filePath, result.ref);
+    superseded.push({ ref: item.ref, applied: true });
+    const files = demotedByRoot.get(item.stashRoot) ?? [];
+    files.push(item.filePath);
+    demotedByRoot.set(item.stashRoot, files);
+  }
   // 0.9.0 (issue #507): single batch commit at the write boundary for git
   // targets. No-op for filesystem/primary-stash targets.
   commitWriteTargetBoundary(target, `Update ${formatRefForMessage(ref)}`);
   // Write-path indexing: the asset is searchable immediately. Fail-open; reads
-  // no longer trigger reindexes, so keeping the index current is the writer's job.
-  await indexWrittenAssets(source.path, [result.path]);
+  // no longer trigger reindexes, so keeping the index current is the writer's
+  // job. Demoted files reindex under their own containing root (usually the
+  // write target itself; the working stash when writing to a --target) so
+  // `--belief current` filtering and the beliefState ranking demotion take
+  // effect without waiting for the next full index.
+  const demotedInTargetRoot = demotedByRoot.get(source.path) ?? [];
+  demotedByRoot.delete(source.path);
+  await indexWrittenAssets(source.path, [result.path, ...demotedInTargetRoot]);
+  for (const [root, files] of demotedByRoot) {
+    await indexWrittenAssets(root, files);
+  }
   // Placement hint (stash-organization conventions): CLI writers never receive
   // the resolveStashStandards prompt injection LLM flows get, so a type-root
   // write into a stash that carries convention/meta facts points the writer at
@@ -348,5 +579,6 @@ export async function writeMarkdownAsset(options: {
     path: result.path,
     stashDir: source.path,
     ...(hint ? { hint } : {}),
+    ...(superseded.length > 0 ? { superseded } : {}),
   };
 }

--- a/src/commands/read/knowledge.ts
+++ b/src/commands/read/knowledge.ts
@@ -14,7 +14,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { parse as yamlParse } from "yaml";
 import { assertFlatAssetName, combineCreatePath, normalizeCreateSubPath } from "../../core/asset/asset-create";
-import { type AssetRef, parseAssetRef } from "../../core/asset/asset-ref";
+import { type AssetRef, makeAssetRef, parseAssetRef } from "../../core/asset/asset-ref";
 import { assembleAsset } from "../../core/asset/asset-serialize";
 import { resolveAssetPathFromName, TYPE_DIRS } from "../../core/asset/asset-spec";
 import { parseFrontmatter } from "../../core/asset/frontmatter";
@@ -142,7 +142,14 @@ export async function readKnowledgeInput(
 
 /** A `--xref` / `--supersedes` flag value parsed to its components. */
 interface ParsedWriteRef {
-  /** The raw flag value as passed (trimmed) — what lands in frontmatter. */
+  /**
+   * The CANONICAL `type:name` spelling rebuilt from the parsed components —
+   * what lands in frontmatter. Persisting the raw flag value instead would
+   * store spellings `parseAssetRef` accepts but later ref scanners (lint's
+   * registry-derived `REF_RE`, mv's rewriter) do not recognize: the
+   * `environment:` alias of `env:`, backslash-separated names, and the
+   * `local//` origin prefix (stripped here the same way lint strips it).
+   */
   ref: string;
   /** Canonical asset type (aliases resolved by `parseAssetRef`). */
   type: string;
@@ -177,7 +184,26 @@ function parseWriteRef(raw: string, flag: "--xref" | "--supersedes"): ParsedWrit
       `Pass the plain type:name form, e.g. ${flag} ${parsed.type}:${parsed.name}.`,
     );
   }
-  return { ref: raw, type: parsed.type, name: parsed.name };
+  // Canonical bare form: type alias resolved, name normalized, `local//`
+  // dropped (it names the same local resolution this validator performs).
+  return { ref: makeAssetRef(parsed.type, parsed.name), type: parsed.type, name: parsed.name };
+}
+
+/**
+ * Trim, parse, and dedupe `--xref` / `--supersedes` flag values, in argv
+ * order. Parsing comes BEFORE deduplication so two alias spellings of the
+ * same asset (`environment:prod` and `env:prod`, `local//knowledge:x` and
+ * `knowledge:x`) collapse into one canonical entry.
+ */
+function parseWriteRefs(rawRefs: string[], flag: "--xref" | "--supersedes"): ParsedWriteRef[] {
+  const parsedRefs: ParsedWriteRef[] = [];
+  for (const raw of rawRefs) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    const parsed = parseWriteRef(trimmed, flag);
+    if (!parsedRefs.some((p) => p.ref === parsed.ref)) parsedRefs.push(parsed);
+  }
+  return parsedRefs;
 }
 
 /**
@@ -281,24 +307,20 @@ export const XREF_SOFT_CAP = 5;
  * resolver cannot map to a path (`script:`) is accepted without an existence
  * check.
  *
- * Returns the trimmed, deduplicated refs in argv order. More than
- * {@link XREF_SOFT_CAP} refs emits a stderr warning (soft cap) but still
- * returns them all.
+ * Returns the CANONICAL `type:name` spellings (alias types resolved, names
+ * normalized, `local//` stripped — see {@link ParsedWriteRef}), deduplicated
+ * in argv order. More than {@link XREF_SOFT_CAP} refs emits a stderr warning
+ * (soft cap) but still returns them all.
  */
 export function resolveXrefsForWrite(rawXrefs: string[], target?: string): string[] {
-  const xrefs: string[] = [];
-  for (const raw of rawXrefs) {
-    const trimmed = raw.trim();
-    if (trimmed && !xrefs.includes(trimmed)) xrefs.push(trimmed);
-  }
-  if (xrefs.length === 0) return xrefs;
+  const parsedRefs = parseWriteRefs(rawXrefs, "--xref");
+  if (parsedRefs.length === 0) return [];
 
   const { mutableRoots, otherSources } = resolveWriteRefRoots(target);
   const allRoots = [...mutableRoots, ...otherSources.map((s) => s.path)];
 
   const unresolved: ParsedWriteRef[] = [];
-  for (const ref of xrefs) {
-    const parsed = parseWriteRef(ref, "--xref");
+  for (const parsed of parsedRefs) {
     if (isFailOpenRefType(parsed.type, parsed.name)) continue;
     if (!allRoots.some((root) => locateWriteRefInRoot(parsed.type, parsed.name, root) !== null)) {
       unresolved.push(parsed);
@@ -307,6 +329,9 @@ export function resolveXrefsForWrite(rawXrefs: string[], target?: string): strin
   if (unresolved.length > 0) {
     throw unresolvedRefsError("--xref", unresolved);
   }
+
+  // The CANONICAL spellings are what land in frontmatter (see ParsedWriteRef).
+  const xrefs = parsedRefs.map((p) => p.ref);
 
   if (xrefs.length > XREF_SOFT_CAP) {
     warn(
@@ -386,7 +411,11 @@ function isParseableYamlMapping(frontmatter: string): boolean {
  * {@link writeMarkdownAsset} AFTER the new asset is written.
  */
 export interface SupersededTarget {
-  /** The old asset's ref (`type:name`) as passed on the CLI (trimmed). */
+  /**
+   * The old asset's CANONICAL ref (`type:name` — alias spellings passed on
+   * the CLI are canonicalized, see {@link ParsedWriteRef}). Folded into the
+   * correction's xrefs by the callers, so it must be scanner-recognizable.
+   */
   ref: string;
   /** Absolute path of the old asset's primary on-disk file. */
   filePath: string;
@@ -441,12 +470,8 @@ const SUPERSEDE_REJECTED_TYPES: ReadonlySet<string> = new Set(["secret", "env", 
  * Returns the deduplicated plan in argv order; empty input returns [].
  */
 export function resolveSupersedesForWrite(rawRefs: string[], target?: string): SupersededTarget[] {
-  const refs: string[] = [];
-  for (const raw of rawRefs) {
-    const trimmed = raw.trim();
-    if (trimmed && !refs.includes(trimmed)) refs.push(trimmed);
-  }
-  if (refs.length === 0) return [];
+  const parsedRefs = parseWriteRefs(rawRefs, "--supersedes");
+  if (parsedRefs.length === 0) return [];
 
   const { mutableRoots, otherSources } = resolveWriteRefRoots(target);
   // Mutable roots first: when a ref resolves in several roots, demote the copy
@@ -461,14 +486,13 @@ export function resolveSupersedesForWrite(rawRefs: string[], target?: string): S
 
   const plan: SupersededTarget[] = [];
   const unresolved: ParsedWriteRef[] = [];
-  for (const ref of refs) {
-    const parsed = parseWriteRef(ref, "--supersedes");
+  for (const parsed of parsedRefs) {
     // Data-corruption gate (SPEC-5): demotion is a frontmatter write; a raw
     // asset type must be rejected up front — resolving it and mutating the
     // file would prepend a YAML block over its raw bytes.
     if (SUPERSEDE_REJECTED_TYPES.has(parsed.type)) {
       throw new UsageError(
-        `--supersedes cannot demote ${ref}: "${parsed.type}:" assets are raw files, and the demotion writes YAML frontmatter that would corrupt them.`,
+        `--supersedes cannot demote ${parsed.ref}: "${parsed.type}:" assets are raw files, and the demotion writes YAML frontmatter that would corrupt them.`,
         "INVALID_FLAG_VALUE",
         "Only markdown assets (e.g. memory:, knowledge:, fact:) can carry the beliefState/supersededBy demotion. Replace or delete the raw asset instead.",
       );
@@ -491,7 +515,7 @@ export function resolveSupersedesForWrite(rawRefs: string[], target?: string): S
     // or the explicit `workflow:deploy.yaml` spelling).
     if (!located.filePath.toLowerCase().endsWith(".md")) {
       throw new UsageError(
-        `--supersedes ${ref} resolves to a non-markdown file (${located.filePath}) — the demotion writes YAML frontmatter and would corrupt it.`,
+        `--supersedes ${parsed.ref} resolves to a non-markdown file (${located.filePath}) — the demotion writes YAML frontmatter and would corrupt it.`,
         "INVALID_FLAG_VALUE",
         "Only markdown assets can carry the beliefState/supersededBy demotion. Replace or delete the file instead.",
       );
@@ -503,7 +527,7 @@ export function resolveSupersedesForWrite(rawRefs: string[], target?: string): S
     // outside any boundary commit. Name the remedy when one exists.
     const namedWritableSource = source?.writable === true ? source.registryId : undefined;
     plan.push({
-      ref,
+      ref: parsed.ref,
       filePath,
       stashRoot: root,
       writable,

--- a/src/commands/read/knowledge.ts
+++ b/src/commands/read/knowledge.ts
@@ -12,11 +12,16 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { parse as yamlParse } from "yaml";
 import { assertFlatAssetName, combineCreatePath, normalizeCreateSubPath } from "../../core/asset/asset-create";
+import { assembleAsset } from "../../core/asset/asset-serialize";
 import { resolveAssetPathFromName } from "../../core/asset/asset-spec";
+import { parseFrontmatter } from "../../core/asset/frontmatter";
 import { isHttpUrl, isWithin, tryReadStdinText } from "../../core/common";
 import { loadConfig } from "../../core/config/config";
 import { UsageError } from "../../core/errors";
+import { resolveStashStandards } from "../../core/standards/resolve-stash-standards";
+import { warn } from "../../core/warn";
 import {
   commitWriteTargetBoundary,
   formatRefForMessage,
@@ -24,7 +29,9 @@ import {
   writeAssetToSource,
 } from "../../core/write-source";
 import { indexWrittenAssets } from "../../indexer/index-written-assets";
+import { resolveSourceEntries } from "../../indexer/search/search-source";
 import { fetchWebsiteMarkdownSnapshot, shouldAllowPrivateWebsiteUrlForTests } from "../../sources/website-ingest";
+import { refExistsInAnyStash, refToRelPath } from "../lint/base-linter";
 
 const MAX_CAPTURED_ASSET_SLUG_LENGTH = 64;
 
@@ -129,6 +136,131 @@ export async function readKnowledgeInput(
   return { content: snapshot.content, preferredName: snapshot.preferredName };
 }
 
+// ── Cross-references (--xref) ────────────────────────────────────────────────
+
+/**
+ * Soft cap on xrefs per asset, from the back-linking conventions' "~5" rule.
+ * Exceeding it warns on stderr but never blocks the write (the cap is a
+ * heuristic, not a validator bound).
+ */
+export const XREF_SOFT_CAP = 5;
+
+/**
+ * Validate `--xref` flag values before ANY write happens.
+ *
+ * Each ref (`type:name`) must resolve to a real asset in the resolved write
+ * target or any configured stash source (mirrors lint's missing-ref root set,
+ * so cross-stash provenance refs into read-only sources are accepted). An
+ * unresolvable ref is input validation of an explicitly passed flag — it
+ * throws {@link UsageError} (exit 2) naming every bad ref, and the caller must
+ * invoke this before writing so a failed validation leaves the stash
+ * untouched. Resolution reuses the lint ref-resolver helpers
+ * (`refToRelPath` / `refExistsInAnyStash`) — do not fork a second resolver.
+ *
+ * Returns the trimmed, deduplicated refs in argv order. More than
+ * {@link XREF_SOFT_CAP} refs emits a stderr warning (soft cap) but still
+ * returns them all.
+ */
+export function resolveXrefsForWrite(rawXrefs: string[], target?: string): string[] {
+  const xrefs: string[] = [];
+  for (const raw of rawXrefs) {
+    const trimmed = raw.trim();
+    if (trimmed && !xrefs.includes(trimmed)) xrefs.push(trimmed);
+  }
+  if (xrefs.length === 0) return xrefs;
+
+  const cfg = loadConfig();
+  const stashRoot = resolveWriteTarget(cfg, target).source.path;
+  const extraStashRoots = resolveSourceEntries(stashRoot, cfg)
+    .map((s) => s.path)
+    .filter((p) => p !== stashRoot && fs.existsSync(p));
+  const allRoots = [stashRoot, ...extraStashRoots];
+
+  const unresolved: string[] = [];
+  for (const ref of xrefs) {
+    const colonIdx = ref.indexOf(":");
+    const refType = colonIdx > 0 ? ref.slice(0, colonIdx) : "";
+    const refName = colonIdx > 0 ? ref.slice(colonIdx + 1) : "";
+    const relPath = refType && refName ? refToRelPath(refType, refName) : null;
+    if (relPath === null || !refExistsInAnyStash(relPath, refType, refName, allRoots)) {
+      unresolved.push(ref);
+    }
+  }
+  if (unresolved.length > 0) {
+    const first = unresolved[0];
+    const colonIdx = first.indexOf(":");
+    const hint =
+      colonIdx > 0
+        ? `Find the intended asset with \`akm search "${first.slice(colonIdx + 1)}" --type ${first.slice(0, colonIdx)}\`. Refs use the form type:name.`
+        : "Refs use the form type:name, e.g. --xref knowledge:auth-flow.";
+    throw new UsageError(
+      `--xref ref${unresolved.length > 1 ? "s" : ""} did not resolve in the write target or any configured source: ${unresolved.join(", ")}`,
+      "INVALID_FLAG_VALUE",
+      hint,
+    );
+  }
+
+  if (xrefs.length > XREF_SOFT_CAP) {
+    warn(
+      `Warning: ${xrefs.length} xrefs exceeds the ~${XREF_SOFT_CAP} soft cap from the back-linking conventions. ` +
+        "Each xref folds into this asset's search hints, so extras blur its ranking signal. Writing anyway.",
+    );
+  }
+  return xrefs;
+}
+
+/**
+ * Merge validated xrefs into a markdown document's frontmatter `xrefs:` list.
+ *
+ * A document without frontmatter gains a single block; a document WITH
+ * frontmatter keeps every existing key and gets the refs dedupe-appended to
+ * its `xrefs:` list — never a nested second block. Runs BEFORE the asset is
+ * written so write-path indexing sees the final content. Returns `content`
+ * unchanged when `xrefs` is empty.
+ *
+ * The merge round-trips the frontmatter through the YAML parser, so it is
+ * only safe when the existing block parses as a YAML mapping. Malformed YAML
+ * would silently fall back to `parseFrontmatter`'s lenient scalar-only
+ * scanner and re-serializing that lossy result would destroy list/nested
+ * values (`tags: [a, b]` → `tags: ""`). Rather than corrupt data the caller
+ * asked to preserve, a block that is not a parseable YAML mapping throws
+ * {@link UsageError} (exit 2, before any write) — fix the frontmatter or run
+ * the command without `--xref`, which keeps the file verbatim. Known
+ * cosmetic limitation: YAML comments and anchors in a VALID block do not
+ * survive the round-trip (values are preserved).
+ */
+export function mergeXrefsIntoContent(content: string, xrefs: string[]): string {
+  if (xrefs.length === 0) return content;
+  const parsed = parseFrontmatter(content);
+  if (parsed.frontmatter?.trim()) {
+    let mergeable = false;
+    try {
+      const fmValue = yamlParse(parsed.frontmatter) as unknown;
+      mergeable = fmValue !== null && typeof fmValue === "object" && !Array.isArray(fmValue);
+    } catch {
+      mergeable = false; // yaml.parse threw → parseFrontmatter used the lossy lenient fallback
+    }
+    if (!mergeable) {
+      throw new UsageError(
+        "--xref cannot merge into this document: its frontmatter is not a parseable YAML mapping, and rewriting it would drop the values the parser could not read.",
+        "INVALID_FLAG_VALUE",
+        "Fix the document's frontmatter (e.g. an unterminated quote) and retry, or run the command without --xref to keep the file verbatim.",
+      );
+    }
+  }
+  const existingValue = parsed.data.xrefs;
+  const existing = Array.isArray(existingValue)
+    ? existingValue.filter((v): v is string => typeof v === "string" && v.trim().length > 0)
+    : typeof existingValue === "string" && existingValue.trim()
+      ? [existingValue.trim()]
+      : [];
+  const merged = [...existing];
+  for (const ref of xrefs) {
+    if (!merged.includes(ref)) merged.push(ref);
+  }
+  return assembleAsset({ ...parsed.data, xrefs: merged }, parsed.content);
+}
+
 // ── Asset writing ────────────────────────────────────────────────────────────
 
 /**
@@ -154,7 +286,7 @@ export async function writeMarkdownAsset(options: {
    * slug). e.g. `path: "personal/projects"` → `memories/personal/projects/<name>.md`.
    */
   path?: string;
-}): Promise<{ ref: string; path: string; stashDir: string }> {
+}): Promise<{ ref: string; path: string; stashDir: string; hint?: string }> {
   const cfg = loadConfig();
   const target = resolveWriteTarget(cfg, options.target);
   const { source, config } = target;
@@ -190,9 +322,31 @@ export async function writeMarkdownAsset(options: {
   // Write-path indexing: the asset is searchable immediately. Fail-open; reads
   // no longer trigger reindexes, so keeping the index current is the writer's job.
   await indexWrittenAssets(source.path, [result.path]);
+  // Placement hint (stash-organization conventions): CLI writers never receive
+  // the resolveStashStandards prompt injection LLM flows get, so a type-root
+  // write into a stash that carries convention/meta facts points the writer at
+  // the placement conventions. Additive output key, advisory only — parallel
+  // to search's `tip`. Fail-open: the hint must never break a completed write.
+  let hint: string | undefined;
+  if (!subPath && !normalizedName.includes("/")) {
+    try {
+      if (resolveStashStandards(source.path).trim().length > 0) {
+        // Only point at the canonical organization fact when it actually
+        // exists — resolveStashStandards fires for ANY convention/meta fact,
+        // and a dead `akm show` pointer is worse than generic wording.
+        const orgFactPath = path.join(source.path, "facts", "conventions", "organization.md");
+        hint = fs.existsSync(orgFactPath)
+          ? `Wrote to the ${options.type} root. This stash has placement conventions — see \`akm show fact:conventions/organization\`.`
+          : `Wrote to the ${options.type} root. This stash has placement conventions — see the convention facts under its facts/ directory.`;
+      }
+    } catch {
+      // Advisory only.
+    }
+  }
   return {
     ref: result.ref,
     path: result.path,
     stashDir: source.path,
+    ...(hint ? { hint } : {}),
   };
 }

--- a/src/commands/read/remember-cli.ts
+++ b/src/commands/read/remember-cli.ts
@@ -292,11 +292,16 @@ export const rememberCommand = defineJsonCommand({
 
     const contentWithFrontmatter = `${frontmatterBlock}\n${body}`;
 
+    // Derive the asset slug from the body, exactly like the hot path above:
+    // `contentWithFrontmatter` starts with the `---` fence, which
+    // inferAssetName would slugify to "" and fall back to a random
+    // memory-<epoch>-<rand> name.
     const result = await writeMarkdownAsset({
       type: "memory",
       content: contentWithFrontmatter,
       name: args.name,
       fallbackPrefix: "memory",
+      preferredName: inferAssetName(body, "memory"),
       force: args.force,
       target: args.target,
       path: args.path,

--- a/src/commands/read/remember-cli.ts
+++ b/src/commands/read/remember-cli.ts
@@ -15,7 +15,7 @@ import {
   runAutoHeuristics,
   runLlmEnrich,
 } from "../remember";
-import { assertFlatAssetName, inferAssetName, writeMarkdownAsset } from "./knowledge";
+import { assertFlatAssetName, inferAssetName, resolveXrefsForWrite, writeMarkdownAsset } from "./knowledge";
 import { akmSearch } from "./search";
 
 // ── Helper: similar memory search ────────────────────────────────────────────
@@ -82,6 +82,11 @@ export const rememberCommand = defineJsonCommand({
       type: "string",
       description: "Source reference (URL, asset ref, file path, or any free-form string)",
     },
+    xref: {
+      type: "string",
+      description:
+        "Cross-reference ref recorded in the memory's `xrefs:` frontmatter (repeatable: --xref knowledge:auth-flow --xref memory:vpn-note). Each ref must resolve in the write target or a configured source; an unresolvable ref aborts the write.",
+    },
     auto: {
       type: "boolean",
       description: "Apply heuristic tagging (code, subjective, source, observed_at) from the body",
@@ -129,6 +134,13 @@ export const rememberCommand = defineJsonCommand({
     // only exposes the last value for repeated string flags.
     const rawTags = parseAllFlagValues("--tag");
 
+    // Collect and validate --xref occurrences (repeatable, same argv pattern
+    // as --tag). Validation happens BEFORE any write: an unresolvable ref is
+    // input validation (UsageError → exit 2) and must leave the stash
+    // untouched. Refs resolvable only in a configured extra stash source are
+    // accepted (cross-stash provenance).
+    const xrefs = resolveXrefsForWrite(parseAllFlagValues("--xref"), args.target);
+
     // Collect scope flags. Scope alone counts as structured metadata so we
     // emit frontmatter, but it does NOT trigger the "tags required" check —
     // memory + scope (no tags) is a valid combination for multi-tenant use.
@@ -140,7 +152,10 @@ export const rememberCommand = defineJsonCommand({
     const hasScope = Object.keys(scopeFields).length > 0;
 
     const hasTagRequiringArgs = rawTags.length > 0 || !!args.expires || !!args.source || !!args.description;
-    const hasStructuredArgs = hasTagRequiringArgs || hasScope || args.auto;
+    // --xref counts as structured metadata (it must land in frontmatter) but,
+    // like scope, does NOT trigger the tags-required check — provenance
+    // without tags is a valid write.
+    const hasStructuredArgs = hasTagRequiringArgs || hasScope || args.auto || xrefs.length > 0;
 
     if (!hasStructuredArgs) {
       // Phase 1B / Rec 7: even the zero-flag hot-path emits
@@ -242,6 +257,7 @@ export const rememberCommand = defineJsonCommand({
       description,
       tags,
       source,
+      xrefs,
       observed_at,
       expires,
       subjective,

--- a/src/commands/read/remember-cli.ts
+++ b/src/commands/read/remember-cli.ts
@@ -15,7 +15,13 @@ import {
   runAutoHeuristics,
   runLlmEnrich,
 } from "../remember";
-import { assertFlatAssetName, inferAssetName, resolveXrefsForWrite, writeMarkdownAsset } from "./knowledge";
+import {
+  assertFlatAssetName,
+  inferAssetName,
+  resolveSupersedesForWrite,
+  resolveXrefsForWrite,
+  writeMarkdownAsset,
+} from "./knowledge";
 import { akmSearch } from "./search";
 
 // ── Helper: similar memory search ────────────────────────────────────────────
@@ -87,6 +93,11 @@ export const rememberCommand = defineJsonCommand({
       description:
         "Cross-reference ref recorded in the memory's `xrefs:` frontmatter (repeatable: --xref knowledge:auth-flow --xref memory:vpn-note). Each ref must resolve in the write target or a configured source; an unresolvable ref aborts the write.",
     },
+    supersedes: {
+      type: "string",
+      description:
+        "Ref of an existing asset this memory corrects (repeatable: --supersedes memory:projectA/old-note). Writes the correction with an xref to the old asset AND demotes the old asset (`beliefState: superseded` + `supersededBy`, a metadata-only edit) so ranking prefers the correction and `--belief current` hides the stale version. An unresolvable or self-referencing ref aborts the write; a ref outside the write target and working stash still writes the correction but skips the demotion (reported as applied: false).",
+    },
     auto: {
       type: "boolean",
       description: "Apply heuristic tagging (code, subjective, source, observed_at) from the body",
@@ -141,6 +152,18 @@ export const rememberCommand = defineJsonCommand({
     // accepted (cross-stash provenance).
     const xrefs = resolveXrefsForWrite(parseAllFlagValues("--xref"), args.target);
 
+    // Collect and validate --supersedes occurrences (repeatable). Same
+    // before-any-write validation contract: an unresolvable ref exits 2 with
+    // nothing written AND nothing demoted (no partial correction). The
+    // superseded refs fold into the new memory's xrefs automatically
+    // (correction provenance per the back-linking conventions); the demotion
+    // itself runs inside writeMarkdownAsset, ordered before the git boundary
+    // commit.
+    const supersedes = resolveSupersedesForWrite(parseAllFlagValues("--supersedes"), args.target);
+    for (const s of supersedes) {
+      if (!xrefs.includes(s.ref)) xrefs.push(s.ref);
+    }
+
     // Collect scope flags. Scope alone counts as structured metadata so we
     // emit frontmatter, but it does NOT trigger the "tags required" check —
     // memory + scope (no tags) is a valid combination for multi-tenant use.
@@ -177,6 +200,7 @@ export const rememberCommand = defineJsonCommand({
         force: args.force,
         target: args.target,
         path: args.path,
+        supersedes,
       });
       appendEvent({
         eventType: "remember",
@@ -276,6 +300,7 @@ export const rememberCommand = defineJsonCommand({
       force: args.force,
       target: args.target,
       path: args.path,
+      supersedes,
     });
     appendEvent({
       eventType: "remember",

--- a/src/commands/read/search-cli.ts
+++ b/src/commands/read/search-cli.ts
@@ -40,7 +40,13 @@ function resolveEventSource(): UsageEventSource | undefined {
 export const searchCommand = defineJsonCommand({
   meta: { name: "search", description: "Search the stash" },
   args: {
-    query: { type: "positional", description: "Search query (omit to list all assets)", required: false, default: "" },
+    query: {
+      type: "positional",
+      description:
+        'Search query (omit to list all assets). A ref-prefix query — "<type>:<prefix>/" or bare "<type>:" — enumerates that subtree/type instead of keyword-matching; an explicit --type wins over the parsed type.',
+      required: false,
+      default: "",
+    },
     type: {
       type: "string",
       description:

--- a/src/commands/remember.ts
+++ b/src/commands/remember.ts
@@ -35,6 +35,14 @@ export interface MemoryFrontmatterFields {
   description?: string;
   tags?: string[];
   source?: string;
+  /**
+   * Cross-reference refs (`type:name`) collected via `--xref` (repeatable).
+   * Persisted as the `xrefs:` frontmatter list — the channel the stash
+   * back-linking conventions mandate for provenance/associative links; the
+   * indexer folds these into the asset's search hints. An empty array is
+   * treated the same as absent.
+   */
+  xrefs?: string[];
   observed_at?: string;
   expires?: string;
   subjective?: boolean;
@@ -89,6 +97,7 @@ export function buildMemoryFrontmatter(fields: MemoryFrontmatterFields): string 
   if (fields.description?.trim()) obj.description = fields.description;
   if (fields.tags && fields.tags.length > 0) obj.tags = fields.tags;
   if (fields.source?.trim()) obj.source = fields.source;
+  if (fields.xrefs && fields.xrefs.length > 0) obj.xrefs = fields.xrefs;
   if (fields.observed_at?.trim()) obj.observed_at = fields.observed_at;
   if (fields.expires?.trim()) obj.expires = fields.expires;
   if (fields.subjective) obj.subjective = true;

--- a/src/commands/sources/stash-cli.ts
+++ b/src/commands/sources/stash-cli.ts
@@ -41,6 +41,7 @@ import { resolveWriteTarget } from "../../core/write-source";
 import { akmIndex } from "../../indexer/indexer";
 import { getHyphenatedBoolean, getOutputMode, parseFlagValue } from "../../output/context";
 import {
+  inferAssetName,
   mergeXrefsIntoContent,
   readKnowledgeInput,
   resolveSupersedesForWrite,
@@ -236,12 +237,17 @@ export const importKnowledgeCommand = defineJsonCommand({
     // Imported docs may carry their own frontmatter: merge (dedupe-append)
     // BEFORE the write so write-path indexing sees the final content and no
     // second frontmatter block is ever nested.
+    // The slug must come from the ORIGINAL content: when xrefs are merged the
+    // document starts with the `---` fence, which inferAssetName would slugify
+    // to "" and fall back to a random knowledge-<epoch>-<rand> name. A stdin
+    // import (no filename-derived preferredName) therefore pre-infers the name
+    // from the pre-merge content so --xref/--supersedes never change the slug.
     const result = await writeMarkdownAsset({
       type: "knowledge",
       content: mergeXrefsIntoContent(content, xrefs),
       name: args.name ?? (isHttpUrl(args.source) ? preferredName : undefined),
       fallbackPrefix: "knowledge",
-      preferredName,
+      preferredName: preferredName ?? (xrefs.length > 0 ? inferAssetName(content, "knowledge") : undefined),
       force: args.force,
       target: args.target,
       path: args.path,

--- a/src/commands/sources/stash-cli.ts
+++ b/src/commands/sources/stash-cli.ts
@@ -29,7 +29,7 @@
 import path from "node:path";
 import { defineCommand } from "citty";
 import * as p from "../../cli/clack";
-import { defineJsonCommand, output, runWithJsonErrors } from "../../cli/shared";
+import { defineJsonCommand, output, parseAllFlagValues, runWithJsonErrors } from "../../cli/shared";
 import { assertFlatAssetName } from "../../core/asset/asset-create";
 import { isHttpUrl } from "../../core/common";
 import { loadConfig } from "../../core/config/config";
@@ -40,7 +40,7 @@ import { clearLogFile, info, isVerbose, setLogFile } from "../../core/warn";
 import { resolveWriteTarget } from "../../core/write-source";
 import { akmIndex } from "../../indexer/indexer";
 import { getHyphenatedBoolean, getOutputMode, parseFlagValue } from "../../output/context";
-import { readKnowledgeInput, writeMarkdownAsset } from "../read/knowledge";
+import { mergeXrefsIntoContent, readKnowledgeInput, resolveXrefsForWrite, writeMarkdownAsset } from "../read/knowledge";
 import { assembleInfo } from "./info";
 import { akmInit } from "./init";
 
@@ -197,15 +197,28 @@ export const importKnowledgeCommand = defineJsonCommand({
       description:
         "Override the write destination. Accepts a source name from your config; falls back to defaultWriteTarget then the working stash.",
     },
+    xref: {
+      type: "string",
+      description:
+        "Cross-reference ref merged into the document's `xrefs:` frontmatter (repeatable: --xref knowledge:auth-flow). Existing frontmatter is preserved (dedupe-append, never a nested block); a document whose frontmatter is not parseable YAML aborts the import rather than being rewritten lossily. Each ref must resolve in the write target or a configured source; an unresolvable ref aborts the import.",
+    },
   },
   async run({ args }) {
     // `--name` is a flat name; subdirectory placement is `--path`'s job.
     assertFlatAssetName(args.name);
+    // Collect and validate --xref occurrences (repeatable; citty only exposes
+    // the last value, so read argv directly). Validation happens BEFORE any
+    // read/write so an unresolvable ref (UsageError → exit 2) leaves the
+    // stash untouched.
+    const xrefs = resolveXrefsForWrite(parseAllFlagValues("--xref"), args.target);
     const stashDir = resolveWriteTarget(loadConfig(), args.target).source.path;
     const { content, preferredName } = await readKnowledgeInput(args.source, { stashDir });
+    // Imported docs may carry their own frontmatter: merge (dedupe-append)
+    // BEFORE the write so write-path indexing sees the final content and no
+    // second frontmatter block is ever nested.
     const result = await writeMarkdownAsset({
       type: "knowledge",
-      content,
+      content: mergeXrefsIntoContent(content, xrefs),
       name: args.name ?? (isHttpUrl(args.source) ? preferredName : undefined),
       fallbackPrefix: "knowledge",
       preferredName,

--- a/src/commands/sources/stash-cli.ts
+++ b/src/commands/sources/stash-cli.ts
@@ -40,7 +40,13 @@ import { clearLogFile, info, isVerbose, setLogFile } from "../../core/warn";
 import { resolveWriteTarget } from "../../core/write-source";
 import { akmIndex } from "../../indexer/indexer";
 import { getHyphenatedBoolean, getOutputMode, parseFlagValue } from "../../output/context";
-import { mergeXrefsIntoContent, readKnowledgeInput, resolveXrefsForWrite, writeMarkdownAsset } from "../read/knowledge";
+import {
+  mergeXrefsIntoContent,
+  readKnowledgeInput,
+  resolveSupersedesForWrite,
+  resolveXrefsForWrite,
+  writeMarkdownAsset,
+} from "../read/knowledge";
 import { assembleInfo } from "./info";
 import { akmInit } from "./init";
 
@@ -202,6 +208,11 @@ export const importKnowledgeCommand = defineJsonCommand({
       description:
         "Cross-reference ref merged into the document's `xrefs:` frontmatter (repeatable: --xref knowledge:auth-flow). Existing frontmatter is preserved (dedupe-append, never a nested block); a document whose frontmatter is not parseable YAML aborts the import rather than being rewritten lossily. Each ref must resolve in the write target or a configured source; an unresolvable ref aborts the import.",
     },
+    supersedes: {
+      type: "string",
+      description:
+        "Ref of an existing asset this document corrects (repeatable: --supersedes knowledge:legacy-guide). Imports the correction with an xref to the old asset AND demotes the old asset (`beliefState: superseded` + `supersededBy`, a metadata-only edit) so ranking prefers the correction and `--belief current` hides the stale version. An unresolvable or self-referencing ref aborts the import; a ref outside the write target and working stash still imports the correction but skips the demotion (reported as applied: false).",
+    },
   },
   async run({ args }) {
     // `--name` is a flat name; subdirectory placement is `--path`'s job.
@@ -211,6 +222,15 @@ export const importKnowledgeCommand = defineJsonCommand({
     // read/write so an unresolvable ref (UsageError → exit 2) leaves the
     // stash untouched.
     const xrefs = resolveXrefsForWrite(parseAllFlagValues("--xref"), args.target);
+    // Collect and validate --supersedes occurrences (repeatable). Same
+    // before-any-read/write contract: an unresolvable ref exits 2 with nothing
+    // imported AND nothing demoted. The superseded refs fold into the imported
+    // doc's xrefs automatically (correction provenance); the demotion runs
+    // inside writeMarkdownAsset, ordered before the git boundary commit.
+    const supersedes = resolveSupersedesForWrite(parseAllFlagValues("--supersedes"), args.target);
+    for (const s of supersedes) {
+      if (!xrefs.includes(s.ref)) xrefs.push(s.ref);
+    }
     const stashDir = resolveWriteTarget(loadConfig(), args.target).source.path;
     const { content, preferredName } = await readKnowledgeInput(args.source, { stashDir });
     // Imported docs may carry their own frontmatter: merge (dedupe-append)
@@ -225,6 +245,7 @@ export const importKnowledgeCommand = defineJsonCommand({
       force: args.force,
       target: args.target,
       path: args.path,
+      supersedes,
     });
     appendEvent({
       eventType: "import",

--- a/src/commands/sources/stash-cli.ts
+++ b/src/commands/sources/stash-cli.ts
@@ -31,6 +31,7 @@ import { defineCommand } from "citty";
 import * as p from "../../cli/clack";
 import { defineJsonCommand, output, parseAllFlagValues, runWithJsonErrors } from "../../cli/shared";
 import { assertFlatAssetName } from "../../core/asset/asset-create";
+import { parseFrontmatter } from "../../core/asset/frontmatter";
 import { isHttpUrl } from "../../core/common";
 import { loadConfig } from "../../core/config/config";
 import { UsageError } from "../../core/errors";
@@ -237,17 +238,21 @@ export const importKnowledgeCommand = defineJsonCommand({
     // Imported docs may carry their own frontmatter: merge (dedupe-append)
     // BEFORE the write so write-path indexing sees the final content and no
     // second frontmatter block is ever nested.
-    // The slug must come from the ORIGINAL content: when xrefs are merged the
-    // document starts with the `---` fence, which inferAssetName would slugify
-    // to "" and fall back to a random knowledge-<epoch>-<rand> name. A stdin
-    // import (no filename-derived preferredName) therefore pre-infers the name
-    // from the pre-merge content so --xref/--supersedes never change the slug.
+    // The slug must come from the document BODY: a merged (or self-carried)
+    // frontmatter block puts the `---` fence on the first line, which
+    // inferAssetName would slugify to "" and fall back to a random
+    // knowledge-<epoch>-<rand> name. A stdin import (no filename-derived
+    // preferredName) therefore pre-infers the name from the pre-merge
+    // content's PARSED body — not the raw text, whose first line is the fence
+    // whenever the piped doc carries its own frontmatter — so --xref/
+    // --supersedes never change the slug and a frontmattered doc gets its
+    // heading-derived slug on every path.
     const result = await writeMarkdownAsset({
       type: "knowledge",
       content: mergeXrefsIntoContent(content, xrefs),
       name: args.name ?? (isHttpUrl(args.source) ? preferredName : undefined),
       fallbackPrefix: "knowledge",
-      preferredName: preferredName ?? (xrefs.length > 0 ? inferAssetName(content, "knowledge") : undefined),
+      preferredName: preferredName ?? inferAssetName(parseFrontmatter(content).content, "knowledge"),
       force: args.force,
       target: args.target,
       path: args.path,

--- a/src/core/asset/frontmatter.ts
+++ b/src/core/asset/frontmatter.ts
@@ -12,7 +12,7 @@
 
 import fs from "node:fs";
 import { parse as yamlParse, stringify as yamlStringify } from "yaml";
-import { assembleAsset } from "./asset-serialize";
+import { assembleAsset, serializeFrontmatter } from "./asset-serialize";
 
 /**
  * Sub-signal breakdown produced by `scoreEncodingSalience` in encoding-salience.ts.
@@ -138,6 +138,13 @@ function parseFrontmatterLenient(frontmatter: string): Record<string, unknown> {
  * or `null` to skip the write entirely (e.g. for idempotent no-ops). The body
  * content is preserved from the parse.
  *
+ * A frontmatter mutation is a METADATA edit, not a content edit: when the file
+ * already has a frontmatter block, only that block is replaced and the body
+ * bytes are kept verbatim (routing through `assembleAsset` would strip the
+ * body's leading blank lines and force a trailing newline, silently reshaping
+ * assets whose writer used a different separator style). A file gaining its
+ * FIRST frontmatter block goes through the canonical `assembleAsset` shape.
+ *
  * @returns `true` if a write occurred, `false` if the mutator returned `null`.
  */
 export function mutateFrontmatter(
@@ -148,7 +155,11 @@ export function mutateFrontmatter(
   const parsed = parseFrontmatter(raw);
   const nextFrontmatter = mutator(parsed);
   if (nextFrontmatter === null) return false;
-  fs.writeFileSync(filePath, assembleAsset(nextFrontmatter, parsed.content), "utf8");
+  const next =
+    parsed.frontmatter !== null
+      ? `---\n${serializeFrontmatter(nextFrontmatter)}\n---\n${parsed.content}`
+      : assembleAsset(nextFrontmatter, parsed.content);
+  fs.writeFileSync(filePath, next, "utf8");
   return true;
 }
 

--- a/src/core/config/config-schema.ts
+++ b/src/core/config/config-schema.ts
@@ -841,6 +841,13 @@ const StalenessDetectionSchema = z
  * Passthrough so per-pass entries (keyed by arbitrary pass names like `graph`,
  * `enrichment`) can live next to the reserved keys.
  *
+ * Reserved scalar key `indexBodyOpening` (stash-conventions SPEC-8, default
+ * false): when true, the metadata pass captures the first prose paragraph of
+ * each markdown asset body into `entry.bodyOpening`, which folds into the
+ * lowest-weight `content` FTS column and the embedding text. It is a boolean,
+ * not a per-pass object — the preprocess below exempts it from the
+ * object-shape check so it never routes into the per-pass catchall.
+ *
  * The outer preprocess emits the legacy parser's actionable error messages
  * for the two most common type-shape mistakes:
  *   - An array at the `index` block.
@@ -861,6 +868,18 @@ export const IndexConfigSchema = z.preprocess(
     }
     if (typeof raw !== "object") return raw;
     for (const [passName, value] of Object.entries(raw as Record<string, unknown>)) {
+      if (passName === "indexBodyOpening") {
+        if (typeof value !== "boolean") {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message:
+              "Invalid `index.indexBodyOpening`: expected a boolean (true to index the first body paragraph " +
+              `of markdown assets into search). Got ${Array.isArray(value) ? "array" : typeof value}.`,
+          });
+          return raw;
+        }
+        continue;
+      }
       if (typeof value !== "object" || value === null || Array.isArray(value)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
@@ -900,6 +919,16 @@ export const IndexConfigSchema = z.preprocess(
     .object({
       metadataEnhance: MetadataEnhanceSchema.optional(),
       stalenessDetection: StalenessDetectionSchema.optional(),
+      indexBodyOpening: z
+        .boolean()
+        .optional()
+        .describe(
+          "Index the first prose paragraph of each markdown asset body (capped at 280 chars) into the " +
+            "lowest-weight `content` search column and the embedding text (default false). Secret/env files " +
+            "and session-kind memories are never captured. Toggling the flag changes indexed text: run " +
+            "`akm index --full` afterwards to re-extract every entry and regenerate embeddings, and re-mint " +
+            "collapse-detector canary baselines via `akm improve canary --refresh`.",
+        ),
     })
     .catchall(IndexPassConfigSchema),
 );

--- a/src/core/config/config-types.ts
+++ b/src/core/config/config-types.ts
@@ -137,8 +137,9 @@ export type IndexPassConfig = z.infer<typeof import("./config-schema").IndexPass
 
 /**
  * Index-time configuration. Combines well-known feature sections
- * (`metadataEnhance`; `stalenessDetection` is retired but tolerated) with
- * per-pass overrides keyed by pass name.
+ * (`metadataEnhance`; `stalenessDetection` is retired but tolerated) and the
+ * `indexBodyOpening` boolean feature flag (stash-conventions SPEC-8, default
+ * false) with per-pass overrides keyed by pass name.
  */
 export type IndexConfig = z.infer<typeof import("./config-schema").IndexConfigSchema>;
 

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -532,9 +532,10 @@ export function resolveSecret(value: string | undefined): string | undefined {
 /**
  * Reserved well-known keys on IndexConfig that are NOT per-pass entries.
  * `stalenessDetection` is retired (10-Q3) but stays reserved so a leftover
- * config section is never misread as a pass entry.
+ * config section is never misread as a pass entry. `indexBodyOpening`
+ * (stash-conventions SPEC-8) is a boolean feature flag, not a pass section.
  */
-const INDEX_RESERVED_KEYS = new Set(["metadataEnhance", "stalenessDetection"]);
+const INDEX_RESERVED_KEYS = new Set(["metadataEnhance", "stalenessDetection", "indexBodyOpening"]);
 
 export function getIndexPassConfig(config: IndexConfig | undefined, passName: string): IndexPassConfig | undefined {
   if (!config) return undefined;

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -49,6 +49,13 @@ export type EventType =
   | "update"
   | "remember"
   | "import"
+  /**
+   * SPEC-7 — emitted once per successful `akm mv` rename. `ref` carries the
+   * NEW ref; metadata carries `{from, to, rewroteFiles, readOnlyCiters,
+   * twinMoved}` (counts only — never file contents). A failed mv emits
+   * nothing.
+   */
+  | "mv"
   | "save"
   | "feedback"
   // Proposal substrate (#225). `promoted` and `rejected` are emitted by the

--- a/src/indexer/db/db.ts
+++ b/src/indexer/db/db.ts
@@ -429,6 +429,17 @@ export interface RekeyEntryOptions {
   /** Absolute path of the renamed file (feeds `file_path` / `dir_path`). */
   newFilePath: string;
   /**
+   * Old canonical bare ref (`type:oldName`, `makeAssetRef` form). Together
+   * with {@link newRef} this drives the `usage_events.entry_ref` rewrite —
+   * `entry_ref` (not `entry_id`) is the STABLE column `relinkUsageEvents`
+   * uses to re-attach events after a full rebuild re-mints every entry id,
+   * so leaving old-ref events behind would reset the asset's usage/utility
+   * history at the first `akm index --full`.
+   */
+  oldRef: string;
+  /** New canonical bare ref (`type:newName`, `makeAssetRef` form). */
+  newRef: string;
+  /**
    * For memory `.derived` twins: the base memory's NEW ref (e.g.
    * `memory:projectA/new-name`), written into the `derived_from` column and
    * `entry_json.derivedFrom`. Omit to leave both untouched.
@@ -440,16 +451,31 @@ export interface RekeyEntryOptions {
  * SPEC-7 (`akm mv`): re-key an entries row IN PLACE after an on-disk rename.
  *
  * The row id is preserved on purpose — `utility_scores`,
- * `utility_scores_scoped`, `embeddings`, and `asset_salience` are all keyed
- * by `entry_id`, so an UPDATE (rather than a delete + insert under the new
- * `entry_key`) is what keeps the asset's accumulated usage-ranking history
- * attached across a rename. `entry_json.name` (and `filename`, when present)
- * is patched and `search_text` rebuilt so search reflects the new name; the
- * row is marked FTS-dirty for the caller's `rebuildFts({incremental: true})`.
+ * `utility_scores_scoped`, and `embeddings` are keyed by `entry_id`, so an
+ * UPDATE (rather than a delete + insert under the new `entry_key`) is what
+ * keeps the asset's accumulated usage-ranking history attached across a
+ * rename. (`asset_salience` / `asset_outcome` live in state.db keyed by
+ * `asset_ref` TEXT and are re-keyed separately by `akm mv` — see
+ * mv-cli.ts `rekeyStateDbForMove`.) `entry_json.name` (and `filename`, when
+ * present) is patched and `search_text` rebuilt so search reflects the new
+ * name; the row is marked FTS-dirty for the caller's
+ * `rebuildFts({incremental: true})`.
+ *
+ * `usage_events.entry_ref` rows for the old ref are rewritten to the new ref
+ * in the same transaction — both the bare `type:name` spelling and the
+ * origin-qualified `origin//type:name` spelling (search/show writers persist
+ * either, see {@link getRetrievalCounts}). Without this, events keep the old
+ * ref, `relinkUsageEvents` finds no matching entry after the next full
+ * rebuild, and the utility history the re-key exists to preserve silently
+ * resets.
  *
  * A stale row already occupying `newEntryKey` (the caller has verified no
  * FILE exists at the target, so such a row can only be a leftover for a
- * deleted file) is removed first — the moved row must keep its id.
+ * deleted file) is evicted first — through {@link deleteRelatedRows}, so its
+ * child rows (embeddings, entries_vec, utility scores, usage events) go with
+ * it. A bare `DELETE FROM entries` would trip the non-CASCADE `embeddings`
+ * FK under `PRAGMA foreign_keys = ON` and roll back the whole re-key.
+ * The moved row keeps its id.
  *
  * Returns the surviving row id, or `null` when no row matches `oldEntryKey`
  * (nothing indexed under the old name — the caller falls open and the next
@@ -483,8 +509,12 @@ export function rekeyEntryInPlace(db: Database, opts: RekeyEntryOptions): number
       | undefined
       | null;
     if (stale && stale.id !== row.id) {
-      db.prepare("DELETE FROM entries_fts WHERE entry_id = ?").run(stale.id);
-      db.prepare("DELETE FROM entries_fts_dirty WHERE entry_id = ?").run(stale.id);
+      // Full child-row cleanup (embeddings, entries_vec, utility scores,
+      // usage events, FTS + dirty marks) BEFORE the entries delete: the
+      // `embeddings` FK is non-CASCADE and `foreign_keys = ON`, so a bare
+      // entries delete would throw and roll back the entire re-key; and
+      // without it the FK-less child rows would orphan permanently.
+      deleteRelatedRows(db, [{ id: stale.id }]);
       db.prepare("DELETE FROM entries WHERE id = ?").run(stale.id);
     }
     db.prepare(
@@ -493,6 +523,20 @@ export function rekeyEntryInPlace(db: Database, opts: RekeyEntryOptions): number
     if (opts.newDerivedFrom !== undefined) {
       db.prepare("UPDATE entries SET derived_from = ? WHERE id = ?").run(opts.newDerivedFrom, row.id);
     }
+    // Re-point usage history at the new ref (see the docstring): the bare
+    // spelling exactly, and the origin-qualified spelling by rewriting only
+    // the part after the last `//` (stored origins never contain `//`, so a
+    // qualified ref has exactly one — same normalization as
+    // getRetrievalCounts). Legacy DBs may predate usage_events.
+    bestEffort(() => {
+      db.prepare("UPDATE usage_events SET entry_ref = ? WHERE entry_ref = ?").run(opts.newRef, opts.oldRef);
+      db.prepare(
+        `UPDATE usage_events
+            SET entry_ref = substr(entry_ref, 1, instr(entry_ref, '//') + 1) || ?
+          WHERE instr(entry_ref, '//') > 0
+            AND substr(entry_ref, instr(entry_ref, '//') + 2) = ?`,
+      ).run(opts.newRef, opts.oldRef);
+    }, "usage_events table may be missing on legacy DBs — no usage history to re-key");
     db.prepare("INSERT OR IGNORE INTO entries_fts_dirty (entry_id) VALUES (?)").run(row.id);
   })();
 

--- a/src/indexer/db/db.ts
+++ b/src/indexer/db/db.ts
@@ -20,7 +20,7 @@ import {
 } from "../feedback/utility-policy";
 import type { StashEntry } from "../passes/metadata";
 import { buildPrefixQuery, sanitizeFtsQuery } from "../search/fts-query";
-import { buildSearchFields } from "../search/search-fields";
+import { buildSearchFields, buildSearchText } from "../search/search-fields";
 import { ENTRY_COLUMNS, type EntryRow, rowToIndexedEntry } from "./entry-mapper";
 import { ensureSchema } from "./schema";
 
@@ -416,6 +416,87 @@ export function getBaseBeliefStatesForDerivedTwins(db: Database, twinIds: number
     }, "legacy DB / entry_json without beliefState — treat as no twin inheritance");
   }
   return out;
+}
+
+/** Parameters for {@link rekeyEntryInPlace}. */
+export interface RekeyEntryOptions {
+  /** Current `entry_key` of the row to re-key (`<stashDir>:<type>:<oldName>`). */
+  oldEntryKey: string;
+  /** New `entry_key` after the rename (`<stashDir>:<type>:<newName>`). */
+  newEntryKey: string;
+  /** New canonical asset name, written into `entry_json.name`. */
+  newName: string;
+  /** Absolute path of the renamed file (feeds `file_path` / `dir_path`). */
+  newFilePath: string;
+  /**
+   * For memory `.derived` twins: the base memory's NEW ref (e.g.
+   * `memory:projectA/new-name`), written into the `derived_from` column and
+   * `entry_json.derivedFrom`. Omit to leave both untouched.
+   */
+  newDerivedFrom?: string;
+}
+
+/**
+ * SPEC-7 (`akm mv`): re-key an entries row IN PLACE after an on-disk rename.
+ *
+ * The row id is preserved on purpose — `utility_scores`,
+ * `utility_scores_scoped`, `embeddings`, and `asset_salience` are all keyed
+ * by `entry_id`, so an UPDATE (rather than a delete + insert under the new
+ * `entry_key`) is what keeps the asset's accumulated usage-ranking history
+ * attached across a rename. `entry_json.name` (and `filename`, when present)
+ * is patched and `search_text` rebuilt so search reflects the new name; the
+ * row is marked FTS-dirty for the caller's `rebuildFts({incremental: true})`.
+ *
+ * A stale row already occupying `newEntryKey` (the caller has verified no
+ * FILE exists at the target, so such a row can only be a leftover for a
+ * deleted file) is removed first — the moved row must keep its id.
+ *
+ * Returns the surviving row id, or `null` when no row matches `oldEntryKey`
+ * (nothing indexed under the old name — the caller falls open and the next
+ * full `akm index` picks the file up as a fresh entry).
+ */
+export function rekeyEntryInPlace(db: Database, opts: RekeyEntryOptions): number | null {
+  const row = db.prepare("SELECT id, entry_json, search_text FROM entries WHERE entry_key = ?").get(opts.oldEntryKey) as
+    | { id: number; entry_json: string; search_text: string }
+    | undefined
+    | null;
+  if (!row) return null;
+
+  // Patch the JSON payload. On corrupt entry_json still re-key key + paths so
+  // the utility history survives; the next full index heals the JSON.
+  let entryJson = row.entry_json;
+  let searchText = row.search_text;
+  try {
+    const entry = JSON.parse(row.entry_json) as StashEntry;
+    entry.name = opts.newName;
+    if (typeof entry.filename === "string") entry.filename = path.basename(opts.newFilePath);
+    if (opts.newDerivedFrom !== undefined) entry.derivedFrom = opts.newDerivedFrom;
+    entryJson = JSON.stringify(entry);
+    searchText = buildSearchText(entry);
+  } catch {
+    /* corrupt entry_json — key/path-only re-key */
+  }
+
+  db.transaction(() => {
+    const stale = db.prepare("SELECT id FROM entries WHERE entry_key = ?").get(opts.newEntryKey) as
+      | { id: number }
+      | undefined
+      | null;
+    if (stale && stale.id !== row.id) {
+      db.prepare("DELETE FROM entries_fts WHERE entry_id = ?").run(stale.id);
+      db.prepare("DELETE FROM entries_fts_dirty WHERE entry_id = ?").run(stale.id);
+      db.prepare("DELETE FROM entries WHERE id = ?").run(stale.id);
+    }
+    db.prepare(
+      "UPDATE entries SET entry_key = ?, dir_path = ?, file_path = ?, entry_json = ?, search_text = ? WHERE id = ?",
+    ).run(opts.newEntryKey, path.dirname(opts.newFilePath), opts.newFilePath, entryJson, searchText, row.id);
+    if (opts.newDerivedFrom !== undefined) {
+      db.prepare("UPDATE entries SET derived_from = ? WHERE id = ?").run(opts.newDerivedFrom, row.id);
+    }
+    db.prepare("INSERT OR IGNORE INTO entries_fts_dirty (entry_id) VALUES (?)").run(row.id);
+  })();
+
+  return row.id;
 }
 
 /**

--- a/src/indexer/db/db.ts
+++ b/src/indexer/db/db.ts
@@ -467,7 +467,10 @@ export interface RekeyEntryOptions {
  * either, see {@link getRetrievalCounts}). Without this, events keep the old
  * ref, `relinkUsageEvents` finds no matching entry after the next full
  * rebuild, and the utility history the re-key exists to preserve silently
- * resets.
+ * resets. DETACHED orphan events already sitting at the new ref (entry_id
+ * NULL — a deleted stranger's history) are deleted first, so the moved asset
+ * never adopts them (live asset's history wins, matching the stale-row
+ * eviction below).
  *
  * A stale row already occupying `newEntryKey` (the caller has verified no
  * FILE exists at the target, so such a row can only be a leftover for a
@@ -529,6 +532,22 @@ export function rekeyEntryInPlace(db: Database, opts: RekeyEntryOptions): number
     // qualified ref has exactly one — same normalization as
     // getRetrievalCounts). Legacy DBs may predate usage_events.
     bestEffort(() => {
+      // Live-asset-wins collision policy, mirroring the stale-entries eviction
+      // above and mv's state.db re-key: DETACHED orphan events (entry_id NULL
+      // — a deleted asset's history retained by a full rebuild) already
+      // sitting AT the new ref are evicted BEFORE the old→new rewrite. No
+      // stale entries row exists for them, so the deleteRelatedRows path
+      // never sees them (it deletes by entry_id only) — left in place, the
+      // moved asset would adopt the stranger's history: getRetrievalCounts
+      // reads by entry_ref immediately, and the next full rebuild's
+      // relinkUsageEvents would attach every stranger event by ref.
+      db.prepare("DELETE FROM usage_events WHERE entry_id IS NULL AND entry_ref = ?").run(opts.newRef);
+      db.prepare(
+        `DELETE FROM usage_events
+          WHERE entry_id IS NULL
+            AND instr(entry_ref, '//') > 0
+            AND substr(entry_ref, instr(entry_ref, '//') + 2) = ?`,
+      ).run(opts.newRef);
       db.prepare("UPDATE usage_events SET entry_ref = ? WHERE entry_ref = ?").run(opts.newRef, opts.oldRef);
       db.prepare(
         `UPDATE usage_events

--- a/src/indexer/index-written-assets.ts
+++ b/src/indexer/index-written-assets.ts
@@ -25,7 +25,15 @@ import fs from "node:fs";
 import path from "node:path";
 import { getDbPath } from "../core/paths";
 import { warnVerbose } from "../core/warn";
-import { closeDatabase, getEntryCount, openExistingDatabase, rebuildFts, upsertEntry } from "./db/db";
+import { takeWorkflowDocument } from "../workflows/runtime/document-cache";
+import {
+  closeDatabase,
+  getEntryCount,
+  openExistingDatabase,
+  rebuildFts,
+  upsertEntry,
+  upsertWorkflowDocument,
+} from "./db/db";
 import { generateMetadataFlat } from "./passes/metadata";
 import { buildSearchText } from "./search/search-fields";
 
@@ -73,10 +81,10 @@ export async function indexWrittenAssets(stashDir: string, filePaths: string[]):
     for (const file of files) {
       const generated = await generateMetadataFlat(stashDir, [file]);
       const entry = generated.entries[0];
-      // Workflows carry a side-table document upsert this fast path doesn't
-      // do; no current caller writes them, but guard so one never lands
-      // half-indexed.
-      if (entry && entry.type !== "workflow") pairs.push({ file, entry });
+      // Workflows also carry a workflow_documents side-table upsert — handled
+      // below, mirroring the full walk — since `akm mv` rewrites citer files
+      // that can be workflows.
+      if (entry) pairs.push({ file, entry });
     }
     if (pairs.length === 0) return;
 
@@ -92,7 +100,14 @@ export async function indexWrittenAssets(stashDir: string, filePaths: string[]):
         } catch {
           // stat raced a delete — index without the size, like the full walk does.
         }
-        upsertEntry(db, entryKey, path.dirname(file), file, stashDir, entryWithSize, buildSearchText(entry));
+        const entryId = upsertEntry(db, entryKey, path.dirname(file), file, stashDir, entryWithSize, buildSearchText(entry));
+        if (entry.type === "workflow") {
+          // Same contract as the full walk (indexer.ts): the renderer cached
+          // the parsed document during metadata generation; persist it so the
+          // workflow runtime never sees an entry without its document.
+          const doc = takeWorkflowDocument(entry);
+          if (doc) upsertWorkflowDocument(db, entryId, doc, fs.readFileSync(file));
+        }
       }
       rebuildFts(db, { incremental: true });
     } finally {

--- a/src/indexer/index-written-assets.ts
+++ b/src/indexer/index-written-assets.ts
@@ -100,7 +100,15 @@ export async function indexWrittenAssets(stashDir: string, filePaths: string[]):
         } catch {
           // stat raced a delete — index without the size, like the full walk does.
         }
-        const entryId = upsertEntry(db, entryKey, path.dirname(file), file, stashDir, entryWithSize, buildSearchText(entry));
+        const entryId = upsertEntry(
+          db,
+          entryKey,
+          path.dirname(file),
+          file,
+          stashDir,
+          entryWithSize,
+          buildSearchText(entry),
+        );
         if (entry.type === "workflow") {
           // Same contract as the full walk (indexer.ts): the renderer cached
           // the parsed document during metadata generation; persist it so the

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -374,6 +374,15 @@ async function runFinalizePhase(ctx: IndexRunContext): Promise<void> {
   setMeta(db, "stashDirs", JSON.stringify(sourceDirs));
   setMeta(db, "hasEmbeddings", embeddingResult.success ? "1" : "0");
 
+  // Stash-organization conventions (SPEC-8): track which `index.indexBodyOpening`
+  // state the index was built with, and warn while the flag diverges from it.
+  const bodyOpeningWarning = reconcileBodyOpeningIndexState(
+    db,
+    config.index?.indexBodyOpening === true,
+    ctx.full || !isIncremental,
+  );
+  if (bodyOpeningWarning) warn(bodyOpeningWarning);
+
   warnIfVecMissing(db);
 
   const totalEntries = getEntryCount(db);
@@ -403,6 +412,47 @@ async function runFinalizePhase(ctx: IndexRunContext): Promise<void> {
 
   // suppress unused warning — sources was previously used inline
   void sources;
+}
+
+/**
+ * Stash-organization conventions (SPEC-8): reconcile the `index.indexBodyOpening`
+ * flag with the state the index was last FULLY built with (index_meta key
+ * `indexBodyOpening`), returning a warning message while they diverge.
+ *
+ * Incremental runs re-extract only changed files (and embeddings are only
+ * generated for rows lacking one), so a flag toggle leaves the index MIXED
+ * until a full rebuild — `akm index --full` re-extracts every entry and wipes
+ * embeddings so they regenerate from the new text. The warning therefore
+ * repeats on every incremental run until a full walk records the flag state
+ * as applied.
+ *
+ * A missing meta key on an incremental run means the index predates this
+ * feature, i.e. it was necessarily built with the flag OFF — so the absent
+ * key reads (and is seeded) as "0", never as the current flag value. This
+ * keeps the most likely real toggle scenario — upgrade, enable the flag, run
+ * a plain `akm index` — warning until `--full` runs (review finding).
+ *
+ * Exported for tests; production's only caller is the finalize phase above.
+ */
+export function reconcileBodyOpeningIndexState(
+  db: Database,
+  flagEnabled: boolean,
+  isFullWalk: boolean,
+): string | undefined {
+  const bodyOpeningFlag = flagEnabled ? "1" : "0";
+  const prevBodyOpeningFlag = getMeta(db, "indexBodyOpening") ?? "0";
+  // Only a full walk (which includes the first build ever) may record the
+  // current flag as the applied state; incremental runs preserve — or, for a
+  // pre-feature index, seed — the state of the last full build.
+  setMeta(db, "indexBodyOpening", isFullWalk ? bodyOpeningFlag : prevBodyOpeningFlag);
+  if (isFullWalk || prevBodyOpeningFlag === bodyOpeningFlag) return undefined;
+  return (
+    `index.indexBodyOpening is ${flagEnabled ? "enabled" : "disabled"} but the index was built with it ` +
+    `${flagEnabled ? "disabled" : "enabled"}. Incremental runs only re-extract changed files, so ` +
+    "indexed text and embeddings are stale for unchanged entries. Run `akm index --full` to apply the new " +
+    "setting everywhere (embeddings regenerate), and re-mint collapse-detector canary baselines via " +
+    "`akm improve canary --refresh` if you use them."
+  );
 }
 
 // ── Clean pass ───────────────────────────────────────────────────────────────

--- a/src/indexer/passes/metadata.ts
+++ b/src/indexer/passes/metadata.ts
@@ -12,6 +12,7 @@ import {
 import { parseFrontmatter } from "../../core/asset/frontmatter";
 import type { TocHeading } from "../../core/asset/markdown";
 import { asNonEmptyString, isAssetType, writeFileAtomic } from "../../core/common";
+import { loadUserConfig } from "../../core/config/config";
 import { isVerbose, warn } from "../../core/warn";
 import { buildFileContext, buildRenderContext, getRenderer, runMatchers } from "../walk/file-context";
 import { applyMetadataContributors } from "./metadata-contributors";
@@ -173,6 +174,18 @@ export interface StashEntry {
    * without a full table scan.
    */
   derivedFrom?: string;
+  /**
+   * First prose paragraph of the asset body — the conventions' self-situating
+   * opening (stash-conventions SPEC-8). Captured by the metadata pass only
+   * when the `index.indexBodyOpening` config flag is enabled (default off),
+   * capped at {@link BODY_OPENING_MAX_CHARS} chars (word-boundary truncation
+   * with a trailing ellipsis). `buildSearchFields` folds it into the
+   * lowest-weight `content` FTS column whenever present on an entry (the fold
+   * is unconditional so FTS rebuilds from stored entry_json stay faithful).
+   * Never captured for secret/env files or session-kind memories
+   * (`akm_memory_kind` marker in outer or inner nested frontmatter).
+   */
+  bodyOpening?: string;
 }
 
 export interface StashFile {
@@ -385,6 +398,12 @@ export function validateStashEntry(entry: unknown): StashEntry | null {
   if (evidenceSources) result.evidenceSources = evidenceSources;
   if (typeof e.derivedFrom === "string" && e.derivedFrom.trim().length > 0) {
     result.derivedFrom = e.derivedFrom.trim();
+  }
+  // SPEC-8: `bodyOpening` must survive the whitelist so entries round-tripped
+  // through `.stash.json` keep their captured opening. Preserved verbatim —
+  // the extractor already trimmed and capped it at capture time.
+  if (typeof e.bodyOpening === "string" && e.bodyOpening.trim().length > 0) {
+    result.bodyOpening = e.bodyOpening;
   }
   if (typeof e.scope === "object" && e.scope !== null && !Array.isArray(e.scope)) {
     const scope = normalizeScopeObject(e.scope as Record<string, unknown>);
@@ -1016,6 +1035,166 @@ export function isEnrichmentComplete(entry: StashEntry): boolean {
   return hasDescription && hasTags && hasSearchHints;
 }
 
+// ── Body-opening extraction (stash-conventions SPEC-8) ──────────────────────
+
+/**
+ * Maximum length of a captured self-situating body opening. Bounds index-size
+ * growth and keeps a single verbose opening from dominating the low-weight
+ * `content` FTS column.
+ */
+export const BODY_OPENING_MAX_CHARS = 280;
+
+/**
+ * Minimum characters retained when the cap truncates at a word boundary. A
+ * boundary cut that would retain less than this falls back to a hard cut, so
+ * one pathological long token cannot gut the capture.
+ */
+const BODY_OPENING_MIN_RETAINED_CHARS = 250;
+
+/**
+ * True when `index.indexBodyOpening` is enabled in the user config.
+ *
+ * The gate is the GLOBAL user config, read directly by the metadata pass so
+ * every indexing entry point (stash walk, flat walk, write-path indexing)
+ * honors the flag without parameter plumbing. Fail-open: an unreadable or
+ * invalid config must never break indexing (CLI entry points surface config
+ * errors loudly on their own), so any load failure reads as "off".
+ */
+function isBodyOpeningIndexingEnabled(): boolean {
+  try {
+    return loadUserConfig().index?.indexBodyOpening === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Locate a leading nested frontmatter block in a body: up to three blank
+ * lines, then a `---` line, closed by a later `---` line. Mirrors the
+ * base-linter's `parseInnerFrontmatterBlock` recognition — when `akm
+ * remember` wraps a session-capture hook's file in its own frontmatter, the
+ * hook's `---\nakm_memory_kind: …\n---` block survives at the top of the
+ * body. Returns the open/close line indexes, or `null` when no block opens.
+ * Location only — callers apply their own interior checks (marker scan in
+ * {@link hasSessionMemoryMarker}, shape test in {@link isFrontmatterShaped}).
+ */
+function findInnerFrontmatterBlock(lines: string[]): { open: number; close: number } | null {
+  let i = 0;
+  while (i < lines.length && i < 3 && lines[i].trim() === "") i += 1;
+  if (lines[i] !== "---") return null;
+  for (let j = i + 1; j < lines.length; j += 1) {
+    if (lines[j] === "---") return { open: i, close: j };
+  }
+  return null;
+}
+
+/**
+ * True when the document carries the session-capture `akm_memory_kind`
+ * marker — in the outer frontmatter data OR in a nested inner block at the
+ * top of the body (both producer layouts exist; see base-linter's
+ * `extractFrontmatterRefs`). Session bodies are raw transcripts, never a
+ * self-situating opening.
+ */
+function hasSessionMemoryMarker(fmData: Record<string, unknown>, body: string): boolean {
+  if (typeof fmData.akm_memory_kind === "string") return true;
+  const lines = body.split(/\r?\n/);
+  const block = findInnerFrontmatterBlock(lines);
+  if (!block) return false;
+  for (let i = block.open + 1; i < block.close; i += 1) {
+    if (/^akm_memory_kind:\s*\S/.test(lines[i])) return true;
+  }
+  return false;
+}
+
+/**
+ * True when the interior of a candidate inner block (located by
+ * {@link findInnerFrontmatterBlock}) actually reads as YAML frontmatter:
+ * every line is blank, indented (a continuation or nested value), or shaped
+ * like a top-level `key:` mapping entry. Ordinary prose bracketed by two
+ * thematic-break `---` lines fails this test, so a decorative opening
+ * callout is treated as the paragraph it is instead of being discarded
+ * (review finding on SPEC-8 — the block finder alone accepts ANY content up
+ * to an arbitrarily distant closing `---`).
+ */
+function isFrontmatterShaped(lines: string[], block: { open: number; close: number }): boolean {
+  for (let i = block.open + 1; i < block.close; i += 1) {
+    const line = lines[i];
+    if (line.trim() === "") continue;
+    if (/^\s/.test(line)) continue; // indented continuation / nested value
+    if (/^[A-Za-z0-9_.-]+:(\s|$)/.test(line)) continue; // top-level key
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Extract the first prose paragraph of a markdown body (frontmatter already
+ * stripped by the caller): skip blank lines, ATX headings, setext `=`
+ * underlines (discarding the heading text above them), thematic breaks,
+ * fenced code blocks (``` or ~~~, including their contents), and a leading
+ * nested frontmatter block — skipped only when its interior is actually
+ * frontmatter-shaped, so prose wrapped in decorative `---` lines is still
+ * captured; then collect consecutive non-blank lines until the paragraph
+ * ends. Deliberate asymmetry: a `---` row after captured prose ENDS the
+ * paragraph and keeps it (favoring the callout/thematic-break reading over
+ * CommonMark's setext-H2), while a `=+` row can only be a setext underline
+ * and so discards the pending lines as heading text. The result is capped at
+ * {@link BODY_OPENING_MAX_CHARS} chars — truncated at the last word boundary
+ * that still retains a substantial prefix, with a trailing ellipsis. Returns
+ * `undefined` when the body has no prose (frontmatter-only files,
+ * headings/fences-only bodies).
+ */
+export function extractBodyOpening(body: string): string | undefined {
+  const lines = body.split(/\r?\n/);
+  const innerBlock = findInnerFrontmatterBlock(lines);
+  const start = innerBlock && isFrontmatterShaped(lines, innerBlock) ? innerBlock.close + 1 : 0;
+
+  const paragraph: string[] = [];
+  let inFence = false;
+  let fenceChar = "";
+  for (let i = start; i < lines.length; i += 1) {
+    const trimmed = lines[i].trim();
+    const fenceMatch = trimmed.match(/^(`{3,}|~{3,})/);
+    if (inFence) {
+      // Fence interiors are never prose (and may be secrets-adjacent command
+      // text); skip until the matching closing marker.
+      if (fenceMatch && fenceMatch[1][0] === fenceChar) inFence = false;
+      continue;
+    }
+    if (fenceMatch) {
+      if (paragraph.length > 0) break; // a fence ends an open paragraph
+      inFence = true;
+      fenceChar = fenceMatch[1][0];
+      continue;
+    }
+    if (/^=+$/.test(trimmed)) {
+      // A row of `=` is a setext H1 underline: the pending lines are heading
+      // text, not prose — discard them and keep searching. (A bare `=` row
+      // with nothing pending is skipped like any other non-prose divider.)
+      paragraph.length = 0;
+      continue;
+    }
+    const isBlank = trimmed === "";
+    const isHeading = /^#{1,6}(\s|$)/.test(trimmed);
+    const isThematicBreak = /^(-{3,}|\*{3,}|_{3,})$/.test(trimmed);
+    if (isBlank || isHeading || isThematicBreak) {
+      if (paragraph.length > 0) break; // paragraph complete
+      continue; // still searching for the first prose line
+    }
+    paragraph.push(trimmed);
+  }
+
+  const text = paragraph.join("\n");
+  if (!text) return undefined;
+  if (text.length <= BODY_OPENING_MAX_CHARS) return text;
+  // Cap: prefer a word-boundary cut (never mid-token), but only when it keeps
+  // a substantial prefix; append a one-char ellipsis inside the budget.
+  const slice = text.slice(0, BODY_OPENING_MAX_CHARS - 1);
+  const lastBoundary = Math.max(slice.lastIndexOf(" "), slice.lastIndexOf("\n"), slice.lastIndexOf("\t"));
+  const cut = lastBoundary >= BODY_OPENING_MIN_RETAINED_CHARS ? slice.slice(0, lastBoundary) : slice;
+  return `${cut.trimEnd()}…`;
+}
+
 // ── Metadata Generation ─────────────────────────────────────────────────────
 
 /**
@@ -1083,6 +1262,16 @@ async function buildEntryFromFile(
     if (fmParams) entry.parameters = fmParams;
     // Pass wiki-pattern frontmatter through onto the entry
     applyWikiFrontmatter(entry, parsed.data);
+    // Stash-organization conventions (SPEC-8): config-gated capture of the
+    // self-situating body opening. Default off — enabling it changes indexed
+    // text (collapse-detector canary baselines shift, and embeddings for
+    // already-embedded entries are NOT regenerated; see docs/configuration.md).
+    // Session-kind memories are raw transcripts and are never captured;
+    // secrets never reach this branch (guard above) and env files are not .md.
+    if (isBodyOpeningIndexingEnabled() && !hasSessionMemoryMarker(parsed.data, parsed.content)) {
+      const bodyOpening = extractBodyOpening(parsed.content);
+      if (bodyOpening) entry.bodyOpening = bodyOpening;
+    }
     // Extract parameters from template placeholders ($1, $ARGUMENTS, {{named}})
     if (entry.type === "command") {
       const cmdParams = extractCommandParameters(parsed.content);

--- a/src/indexer/passes/metadata.ts
+++ b/src/indexer/passes/metadata.ts
@@ -1114,6 +1114,18 @@ async function buildEntryFromFile(
     entry.tags = extractTagsFromPath(file, dirPath);
   }
 
+  // Stash-organization conventions (SPEC-2): directory (scope/domain) tokens
+  // always reach the tags column, even when the author set explicit tags, so
+  // nested assets keep the exact-tag ranking boost for their scope token.
+  // Derived from canonicalName (the ref subpath) rather than the filesystem
+  // path so the stash-walk and flat-walk indexing paths agree (the flat walk
+  // passes `path.dirname(file)` as dirPath, which strips directory segments
+  // from the fallback above). Filename tokens are deliberately NOT merged when
+  // explicit tags exist — they already live in the FTS name column and in
+  // aliases, and merging them would inflate exact-tag matches for every
+  // filename word. `normalizeTerms` below dedupes author-restated tokens.
+  entry.tags = [...(entry.tags ?? []), ...extractDirTagsFromName(canonicalName)];
+
   entry.tags = normalizeTerms(entry.tags ?? []);
   entry.aliases = mergeAliases(entry.aliases, buildAliases(canonicalName, entry.tags));
 
@@ -1347,5 +1359,28 @@ export function extractTagsFromPath(filePath: string, rootDir: string): string[]
     }
   }
 
+  return Array.from(tags);
+}
+
+/**
+ * Extract scope/domain tags from the DIRECTORY segments of a canonical asset
+ * name (the ref subpath — e.g. `"projectA/auth-tip"` → `["projecta"]`).
+ *
+ * Unlike {@link extractTagsFromPath} this never tokenizes the filename
+ * segment: it exists so a nested asset's directory (scope/domain) tokens can
+ * be merged into explicit author tags without dragging every filename word
+ * into exact-tag matching (SPEC-2, docs/design/stash-conventions-code-spec.md).
+ * Tokenization mirrors `extractTagsFromPath`: each segment splits on `-`/`_`/
+ * `.`, lowercased, single-character tokens dropped. A name with no directory
+ * segments yields no tags.
+ */
+export function extractDirTagsFromName(name: string): string[] {
+  const tags = new Set<string>();
+  for (const segment of name.split("/").slice(0, -1)) {
+    for (const token of segment.split(/[-_.]+/)) {
+      const clean = token.toLowerCase().trim();
+      if (clean && clean.length > 1) tags.add(clean);
+    }
+  }
   return Array.from(tags);
 }

--- a/src/indexer/passes/metadata.ts
+++ b/src/indexer/passes/metadata.ts
@@ -1152,6 +1152,7 @@ export function extractBodyOpening(body: string): string | undefined {
   const paragraph: string[] = [];
   let inFence = false;
   let fenceChar = "";
+  let inHtmlComment = false;
   for (let i = start; i < lines.length; i += 1) {
     const trimmed = lines[i].trim();
     const fenceMatch = trimmed.match(/^(`{3,}|~{3,})/);
@@ -1161,10 +1162,21 @@ export function extractBodyOpening(body: string): string | undefined {
       if (fenceMatch && fenceMatch[1][0] === fenceChar) inFence = false;
       continue;
     }
+    if (inHtmlComment) {
+      // Comment interiors are machinery (the skeleton convention facts open
+      // with a <!-- SOFT guidance --> block), never orientation prose.
+      if (trimmed.includes("-->")) inHtmlComment = false;
+      continue;
+    }
     if (fenceMatch) {
       if (paragraph.length > 0) break; // a fence ends an open paragraph
       inFence = true;
       fenceChar = fenceMatch[1][0];
+      continue;
+    }
+    if (trimmed.startsWith("<!--")) {
+      if (paragraph.length > 0) break; // a comment ends an open paragraph
+      if (!trimmed.includes("-->")) inHtmlComment = true;
       continue;
     }
     if (/^=+$/.test(trimmed)) {
@@ -1191,7 +1203,12 @@ export function extractBodyOpening(body: string): string | undefined {
   // a substantial prefix; append a one-char ellipsis inside the budget.
   const slice = text.slice(0, BODY_OPENING_MAX_CHARS - 1);
   const lastBoundary = Math.max(slice.lastIndexOf(" "), slice.lastIndexOf("\n"), slice.lastIndexOf("\t"));
-  const cut = lastBoundary >= BODY_OPENING_MIN_RETAINED_CHARS ? slice.slice(0, lastBoundary) : slice;
+  let cut = lastBoundary >= BODY_OPENING_MIN_RETAINED_CHARS ? slice.slice(0, lastBoundary) : slice;
+  // slice() counts UTF-16 code units, so the no-boundary fallback can end on
+  // the high half of a surrogate pair — a lone surrogate that corrupts the
+  // FTS/embedding text. Drop it rather than emit invalid UTF-16.
+  const lastCode = cut.charCodeAt(cut.length - 1);
+  if (lastCode >= 0xd800 && lastCode <= 0xdbff) cut = cut.slice(0, -1);
   return `${cut.trimEnd()}…`;
 }
 

--- a/src/indexer/passes/metadata.ts
+++ b/src/indexer/passes/metadata.ts
@@ -113,6 +113,15 @@ export interface StashEntry {
   xrefs?: string[];
   /** Source identifiers this page was distilled from (typically `raw/<slug>` files). */
   sources?: string[];
+  /**
+   * Asset category, surfaced from the `category:` frontmatter key. Primarily
+   * used by fact assets: `convention` marks house-rule facts delivered via
+   * resolveStashStandards prompt injection; `meta` marks stash-about-itself
+   * canon (e.g. active-projects slug lists). Any non-empty string is accepted
+   * — this is descriptive metadata, not a validated enum. Captured into
+   * entry_json so category-keyed policies (SPEC-6) are implementable.
+   */
+  category?: string;
   beliefState?: "active" | "asserted" | "deprecated" | "superseded" | "contradicted" | "archived" | (string & {});
   supersededBy?: string[];
   contradictedBy?: string[];
@@ -339,6 +348,12 @@ export function validateStashEntry(entry: unknown): StashEntry | null {
   if (xrefs) result.xrefs = xrefs;
   const sources = normalizeNonEmptyStringList(e.sources);
   if (sources) result.sources = sources;
+  // SPEC-6: `category` must survive the whitelist or .stash.json-declared
+  // facts lose their convention/meta marker on the round-trip. Non-string
+  // values are dropped, not coerced.
+  if (typeof e.category === "string" && e.category.trim().length > 0) {
+    result.category = e.category.trim();
+  }
   if (typeof e.beliefState === "string" && e.beliefState.trim().length > 0) {
     result.beliefState = e.beliefState.trim() as StashEntry["beliefState"];
   }
@@ -484,6 +499,12 @@ export function applyCuratedFrontmatter(entry: StashEntry, fmData: Record<string
 
   const quality = asNonEmptyString(fmData.quality);
   if (quality) entry.quality = normalizeQuality(quality);
+
+  // SPEC-6 capture step: the `category:` frontmatter key (e.g. `convention`,
+  // `meta` on facts) must land on the indexed entry so category-keyed
+  // policies can see it. Trimmed; blank/non-string values are ignored.
+  const category = asNonEmptyString(fmData.category);
+  if (category) entry.category = category;
 
   const beliefState = asNonEmptyString(fmData.beliefState);
   if (beliefState) entry.beliefState = beliefState as StashEntry["beliefState"];

--- a/src/indexer/search/db-search.ts
+++ b/src/indexer/search/db-search.ts
@@ -478,9 +478,15 @@ async function searchDatabase(
   // Drop semantic-only hits (cosine-only, no FTS match) whose score falls
   // below the configured floor. FTS hits and hybrid hits are always kept.
   // Default floor: 0.2. Set search.minScore = 0 in config to disable.
+  // Judged on the PRE-ceiling score when a demoting belief state clamped the
+  // item (`preCeilingScore`): the belief ceilings can sit below this floor
+  // (archived 0.15 < 0.2), and a demotion must rank the hit last, not
+  // silently remove a result that would otherwise have listed.
   const minScore = config.search?.minScore ?? 0.2;
   const preFilter =
-    minScore > 0 ? scored.filter((item) => item.rankingMode !== "semantic" || item.score >= minScore) : scored;
+    minScore > 0
+      ? scored.filter((item) => item.rankingMode !== "semantic" || (item.preCeilingScore ?? item.score) >= minScore)
+      : scored;
 
   // Deterministic tiebreaker on equal scores.
   //

--- a/src/indexer/search/db-search.ts
+++ b/src/indexer/search/db-search.ts
@@ -19,6 +19,7 @@ import fs from "node:fs";
 import { buildActionFromContributors, defaultActionContributors } from "../../core/action-contributors";
 import { makeAssetRef } from "../../core/asset/asset-ref";
 import { defaultRendererRegistry, type RendererRegistry } from "../../core/asset/asset-registry";
+import { getAssetTypes } from "../../core/asset/asset-spec";
 import type { AkmAssetType } from "../../core/common";
 import type { AkmConfig, ImproveConfig } from "../../core/config/config";
 import { getDbPath } from "../../core/paths";
@@ -48,6 +49,7 @@ import {
 } from "../graph/graph-boost";
 import { isProposedQuality, type StashEntry, type StashEntryScope } from "../passes/metadata";
 import { resolveProjectContext } from "../walk/project-context";
+import { parseRefPrefixQuery } from "./fts-query";
 import { applyRankingRules, combineSearchScores, normalizeFtsScores } from "./ranking";
 import { enrichSearchHit } from "./search-hit-enrichers";
 import { buildEditHint, findSourceForPath, isEditable, type SearchSource } from "./search-source";
@@ -308,61 +310,54 @@ async function searchDatabase(
   const defaultExcludes =
     searchType === "any" && !includeExcludedTypes ? (config.search?.defaultExcludeTypes ?? ["session"]) : [];
 
+  // SPEC-4 — ref-prefix queries (`<type>:` / `<type>:<prefix>/`) translate to
+  // a typed enumeration narrowed by name prefix, instead of degenerating into
+  // the AND-token FTS query their sanitized form would produce ("memory
+  // projecta" — noise). The branch fires only on the untyped path: an explicit
+  // `--type` flag expresses stronger intent and wins. The PARSED type is
+  // itself explicit intent, so `defaultExcludeTypes` does not apply — a bare
+  // `session:` enumerates sessions exactly like `--type session` does.
+  const refPrefix = searchType === "any" ? parseRefPrefixQuery(query, getAssetTypes()) : null;
+  if (refPrefix) {
+    return enumerateEntries({
+      db,
+      query,
+      typeFilter: refPrefix.type,
+      excludeTypes: [],
+      namePrefix: refPrefix.namePrefix,
+      limit,
+      stashDir,
+      allSourceDirs,
+      sources,
+      config,
+      rendererRegistry,
+      filters,
+      includeProposed,
+      beliefFilter,
+      restrictToSources,
+    });
+  }
+
   // Empty queries — including ones that sanitize down to no searchable FTS
   // tokens such as "." — should enumerate matching entries instead of
   // returning an empty result set from FTS.
   if (!hasSearchableTokens) {
-    const typeFilter = searchType === "any" ? undefined : searchType;
-    const allEntries = getAllEntries(db, typeFilter, defaultExcludes);
-    // Deduplicate by file path — multiple entries can share the same file
-    const seenFilePaths = new Set<string>();
-    const uniqueEntries = allEntries.filter((ie) => {
-      if (seenFilePaths.has(ie.filePath)) return false;
-      seenFilePaths.add(ie.filePath);
-      return true;
+    return enumerateEntries({
+      db,
+      query,
+      typeFilter: searchType === "any" ? undefined : searchType,
+      excludeTypes: defaultExcludes,
+      limit,
+      stashDir,
+      allSourceDirs,
+      sources,
+      config,
+      rendererRegistry,
+      filters,
+      includeProposed,
+      beliefFilter,
+      restrictToSources,
     });
-    // Source filter: when the caller narrowed `sources` via `--source <name>`,
-    // drop entries whose filePath does not live under any of the requested
-    // sources. The FTS index spans every configured source, so without this
-    // filter a narrowed --source request would still leak results.
-    const sourceFiltered = restrictToSources
-      ? uniqueEntries.filter((ie) => findSourceForPath(ie.filePath, sources) !== undefined)
-      : uniqueEntries;
-    // Scope filter: drop entries whose stored scope does not satisfy every
-    // supplied scope key. Filtering happens BEFORE the limit slice so a
-    // restrictive filter still returns up to `limit` results.
-    const scopeFiltered = filters
-      ? sourceFiltered.filter((ie) => entryMatchesScope(ie.entry.scope, filters))
-      : sourceFiltered;
-    // Proposed-quality filter (v1 spec §4.2): exclude entries with
-    // `quality: "proposed"` unless the caller explicitly opts in.
-    const qualityFiltered = includeProposed
-      ? scopeFiltered
-      : scopeFiltered.filter((ie) => !isProposedQuality(ie.entry.quality));
-    // 03-R3: derived twins inherit their base's demoting belief state here too,
-    // so the belief FILTER (and the reported hit state) stays consistent on the
-    // enumerate/browse path — not only on the FTS-scored path below.
-    inheritDerivedTwinBeliefStates(db, qualityFiltered);
-    const beliefFiltered = qualityFiltered.filter((ie) => matchBeliefFilter(ie.entry.beliefState, beliefFilter));
-    const selected = beliefFiltered.slice(0, limit);
-    const hits = await Promise.all(
-      selected.map((ie) =>
-        buildDbHit({
-          entry: ie.entry,
-          path: ie.filePath,
-          score: 1,
-          query,
-          rankingMode: "fts",
-          defaultStashDir: stashDir,
-          allSourceDirs,
-          sources,
-          config,
-          rendererRegistry,
-          db,
-        }),
-      ),
-    );
-    return { hits };
   }
 
   // Start the async embedding request without awaiting, then run FTS
@@ -564,6 +559,101 @@ async function searchDatabase(
   );
 
   return { embedMs, rankMs, hits };
+}
+
+// ── Enumeration (browse) path ────────────────────────────────────────────────
+
+/**
+ * Enumerate index entries without FTS scoring — the browse path shared by
+ * empty/unsearchable queries and SPEC-4 ref-prefix queries (`<type>:` /
+ * `<type>:<prefix>/`). Applies the same post-ranking filters as the scored
+ * path (source narrowing, scope, proposed-quality, belief) before the limit
+ * slice. Hits carry the fixed browse score 1 in insertion order — this is a
+ * deterministic listing, not a relevance ranking.
+ */
+async function enumerateEntries(opts: {
+  db: Database;
+  query: string;
+  /** Restrict enumeration to a single asset type; undefined enumerates all. */
+  typeFilter?: string;
+  /** Types hidden from untyped enumeration (config `defaultExcludeTypes`). */
+  excludeTypes: string[];
+  /**
+   * SPEC-4 name-prefix narrowing (e.g. `"projecta/"`, trailing slash retained
+   * for exact `/`-boundary subtree semantics). Compared case-insensitively:
+   * the command layer lowercases queries while on-disk directory names — and
+   * therefore entry names — may carry mixed case. Empty/undefined keeps every
+   * entry of the type.
+   */
+  namePrefix?: string;
+  limit: number;
+  stashDir: string;
+  allSourceDirs: string[];
+  sources: SearchSource[];
+  config: AkmConfig;
+  rendererRegistry: RendererRegistry;
+  filters?: StashEntryScope;
+  includeProposed: boolean;
+  beliefFilter: BeliefFilterMode;
+  restrictToSources: boolean;
+}): Promise<{ hits: SourceSearchHit[] }> {
+  const { db, query, sources, config, rendererRegistry, filters, beliefFilter } = opts;
+  const allEntries = getAllEntries(db, opts.typeFilter, opts.excludeTypes);
+  // SPEC-4: narrow to the requested subtree. `startsWith` on the full
+  // slash-retaining prefix is exact — "projecta/" cannot match a sibling
+  // "projectalpha/…" scope.
+  const namePrefix = opts.namePrefix?.toLowerCase() ?? "";
+  const prefixFiltered =
+    namePrefix.length > 0 ? allEntries.filter((ie) => ie.entry.name.toLowerCase().startsWith(namePrefix)) : allEntries;
+  // Deduplicate by file path — multiple entries can share the same file
+  const seenFilePaths = new Set<string>();
+  const uniqueEntries = prefixFiltered.filter((ie) => {
+    if (seenFilePaths.has(ie.filePath)) return false;
+    seenFilePaths.add(ie.filePath);
+    return true;
+  });
+  // Source filter: when the caller narrowed `sources` via `--source <name>`,
+  // drop entries whose filePath does not live under any of the requested
+  // sources. The FTS index spans every configured source, so without this
+  // filter a narrowed --source request would still leak results.
+  const sourceFiltered = opts.restrictToSources
+    ? uniqueEntries.filter((ie) => findSourceForPath(ie.filePath, sources) !== undefined)
+    : uniqueEntries;
+  // Scope filter: drop entries whose stored scope does not satisfy every
+  // supplied scope key. Filtering happens BEFORE the limit slice so a
+  // restrictive filter still returns up to `limit` results.
+  const scopeFiltered = filters
+    ? sourceFiltered.filter((ie) => entryMatchesScope(ie.entry.scope, filters))
+    : sourceFiltered;
+  // Proposed-quality filter (v1 spec §4.2): exclude entries with
+  // `quality: "proposed"` unless the caller explicitly opts in.
+  const qualityFiltered = opts.includeProposed
+    ? scopeFiltered
+    : scopeFiltered.filter((ie) => !isProposedQuality(ie.entry.quality));
+  // 03-R3: derived twins inherit their base's demoting belief state here too,
+  // so the belief FILTER (and the reported hit state) stays consistent on the
+  // enumerate/browse path — not only on the FTS-scored path.
+  inheritDerivedTwinBeliefStates(db, qualityFiltered);
+  const beliefFiltered = qualityFiltered.filter((ie) => matchBeliefFilter(ie.entry.beliefState, beliefFilter));
+  const selected = beliefFiltered.slice(0, opts.limit);
+  const hits = await Promise.all(
+    selected.map((ie) =>
+      buildDbHit({
+        entry: ie.entry,
+        path: ie.filePath,
+        score: 1,
+        query,
+        rankingMode: "fts",
+        defaultStashDir: opts.stashDir,
+        allSourceDirs: opts.allSourceDirs,
+        sources,
+        config,
+        rendererRegistry,
+        db,
+      }),
+    ),
+  );
+  return { hits };
 }
 
 /**

--- a/src/indexer/search/fts-query.ts
+++ b/src/indexer/search/fts-query.ts
@@ -7,6 +7,8 @@
  *
  * These transform a raw user query into an FTS5-safe MATCH expression. They
  * touch no database state, so they are unit-testable with zero DB setup.
+ * `parseRefPrefixQuery` is the one non-FTS helper: it decides whether a raw
+ * query should bypass FTS entirely (SPEC-4 ref-prefix enumeration).
  */
 
 /**
@@ -56,4 +58,45 @@ export function buildPrefixQuery(ftsQuery: string): string | null {
   if (!hasPrefix) return null;
 
   return prefixTokens.join(" ");
+}
+
+/**
+ * SPEC-4 — parse a ref-prefix query (`akm search "<type>:<prefix>/"`).
+ *
+ * Decides whether a raw query is a typed subtree-enumeration request rather
+ * than an ordinary keyword search. Matching is deliberately conservative: the
+ * trimmed query must be EXACTLY
+ *
+ *   - `<known-type>:`           → enumerate the whole type (namePrefix `""`), or
+ *   - `<known-type>:<prefix>/`  → enumerate names under `<prefix>/`.
+ *
+ * The trailing slash is REQUIRED for a non-empty prefix — and is RETAINED in
+ * the returned `namePrefix` — so that a plain `entry.name.startsWith(namePrefix)`
+ * check gives exact `/`-boundary subtree semantics (`"projecta/"` cannot match
+ * a sibling `projectalpha/…` scope). Bare refs like `memory:a/b` therefore
+ * stay ordinary searches (resolving one ref is `akm show` territory), and any
+ * interior whitespace disqualifies (prose mentioning a ref is still prose).
+ *
+ * `knownTypes` is passed in by the caller (e.g. `getAssetTypes()`) to keep
+ * this module dependency-free.
+ *
+ * Returns `null` when the query is not a ref-prefix request.
+ */
+export function parseRefPrefixQuery(
+  query: string,
+  knownTypes: readonly string[],
+): { type: string; namePrefix: string } | null {
+  const trimmed = query.trim();
+  if (trimmed.length === 0 || /\s/.test(trimmed)) return null;
+
+  const colon = trimmed.indexOf(":");
+  if (colon <= 0) return null;
+
+  const type = trimmed.slice(0, colon);
+  if (!knownTypes.includes(type)) return null;
+
+  const rest = trimmed.slice(colon + 1);
+  if (rest === "") return { type, namePrefix: "" };
+  if (rest.endsWith("/")) return { type, namePrefix: rest };
+  return null;
 }

--- a/src/indexer/search/ranking-contributors.ts
+++ b/src/indexer/search/ranking-contributors.ts
@@ -122,6 +122,56 @@ function beliefStateBoost(item: RankedEntryInput): number {
   return 0;
 }
 
+/**
+ * Post-boost score ceilings for the demoting belief states (SPEC-5,
+ * stash-conventions-code-spec.md — corrections demotion).
+ *
+ * Why the additive {@link beliefStateBoost} penalties alone are not enough:
+ * keyword base scores are min-max normalized into [0.3, 1.0]
+ * (`normalizeFtsScores`), so the spread between the best FTS hit and its
+ * runner-up can be as large as 0.7 — and the boost sum then MULTIPLIES the
+ * base (`score *= 1 + boostSum`, {@link applyScoreContributors}). A
+ * superseded incumbent that is the best keyword match for a query therefore
+ * stays clamp-pinned at 1.0 above its own correction no matter what additive
+ * penalty it receives — defeating the corrections pattern's point ("so the
+ * ranker demotes the stale version instead of letting it outrank your fix").
+ *
+ * The ceilings guarantee the demotion while keeping flagged entries VISIBLE:
+ * un-demoted keyword hits floor at a 0.3 base, so any un-demoted hit outranks
+ * a ceilinged one; demoted entries still list (belief FILTERING stays a
+ * separate opt-in axis, `--belief`), and scores already below a ceiling keep
+ * their relative ordering. Ceiling order mirrors the additive-penalty
+ * severity order pinned in tests/belief-state-phase1a.test.ts:
+ * deprecated (mildest) > superseded > contradicted > archived.
+ */
+const BELIEF_STATE_SCORE_CEILINGS: Record<string, number> = {
+  deprecated: 0.28,
+  superseded: 0.25,
+  contradicted: 0.2,
+  archived: 0.15,
+};
+
+/**
+ * Clamp a ranked entry's FINAL score (after every additive and utility boost)
+ * to its demoting belief state's ceiling. No-op for `asserted`/`active`/unset
+ * entries. Applied once per item at the end of `applyRankingRules` so sort
+ * order and displayed scores stay consistent (single scoring pipeline).
+ *
+ * When the ceiling clamps, the pre-clamp score is recorded as
+ * `preCeilingScore` so db-search's semantic-only `minScore` floor can judge
+ * the hit by what it would have scored WITHOUT the demotion — a ceiling below
+ * the floor (archived 0.15 < default minScore 0.2) must demote a hit to last
+ * place, never silently drop it from the results.
+ */
+export function applyBeliefStateScoreCeiling(item: RankedEntryInput): void {
+  const state = item.entry.beliefState;
+  const ceiling = state !== undefined ? BELIEF_STATE_SCORE_CEILINGS[state] : undefined;
+  if (ceiling !== undefined && item.score > ceiling) {
+    item.preCeilingScore = item.score;
+    item.score = ceiling;
+  }
+}
+
 const exactNameRankingContributor: RankingContributor = {
   name: "exact-name-ranking",
   appliesTo: () => true,

--- a/src/indexer/search/ranking.ts
+++ b/src/indexer/search/ranking.ts
@@ -12,6 +12,7 @@ import type { GraphBoostContext } from "../graph/graph-boost";
 import type { StashEntry } from "../passes/metadata";
 import type { ProjectContext } from "../walk/project-context";
 import {
+  applyBeliefStateScoreCeiling,
   applyContributorAblation,
   applyScoreContributors,
   applyUtilityContributors,
@@ -26,6 +27,15 @@ export interface RankedEntryInput {
   score: number;
   rankingMode: "hybrid" | "semantic" | "fts";
   utilityBoosted?: boolean;
+  /**
+   * Set by `applyBeliefStateScoreCeiling` when a demoting belief state's
+   * ceiling clamped this item: the score BEFORE the clamp. The semantic-only
+   * `minScore` floor in db-search checks this instead of the clamped score,
+   * so a ceiling that sits below the floor (e.g. archived 0.15 < default
+   * minScore 0.2) demotes the hit to last place instead of silently DROPPING
+   * a result that would otherwise have listed.
+   */
+  preCeilingScore?: number;
 }
 
 export interface RankEntriesOptions {
@@ -237,6 +247,12 @@ export function applyRankingRules(options: RankEntriesOptions): RankedEntryInput
   };
   for (const item of options.items) {
     applyUtilityContributors(item, utilityContext, activeUtilityContributors);
+    // SPEC-5: demoting belief states (superseded/contradicted/archived/
+    // deprecated) cap the FINAL score. The additive belief penalty inside the
+    // multiplicative boost sum cannot overcome the FTS min-max normalization
+    // spread, so without the ceiling a superseded incumbent that is the best
+    // keyword match outranks its own correction forever.
+    applyBeliefStateScoreCeiling(item);
   }
 
   return options.items;

--- a/src/indexer/search/search-fields.ts
+++ b/src/indexer/search/search-fields.ts
@@ -22,7 +22,8 @@ import type { StashEntry } from "../passes/metadata";
  *  - description: entry description
  *  - tags: tags + aliases joined
  *  - hints: searchHints + examples + usage + intent fields
- *  - content: TOC headings (lowest-weight catch-all)
+ *  - content: TOC headings + parameters + the config-gated body opening
+ *    (lowest-weight catch-all)
  */
 // NOTE (R5): the collapse detector's frozen canary queries are built from the
 // same surface this function indexes (name tokens / tags / description) and
@@ -70,6 +71,14 @@ export function buildSearchFields(entry: StashEntry): {
       if (param.description) contentParts.push(param.description);
     }
   }
+  // Stash-organization conventions (SPEC-8): the self-situating body opening
+  // (captured by the metadata pass only when `index.indexBodyOpening` is on)
+  // folds into the lowest-weight catch-all column — never name/description/
+  // tags/hints — so orientation prose is retrievable without outranking
+  // structured-field matches. The fold is unconditional on the entry field:
+  // `rebuildFts` rebuilds FTS rows from stored entry_json and must reproduce
+  // the same fields without re-reading config.
+  if (entry.bodyOpening) contentParts.push(entry.bodyOpening);
   const content = contentParts.join(" ").toLowerCase();
 
   return { name, description, tags, hints, content };

--- a/src/output/shapes/passthrough.ts
+++ b/src/output/shapes/passthrough.ts
@@ -54,6 +54,7 @@ const PASSTHROUGH_COMMANDS = [
   "init",
   "lint",
   "list",
+  "mv",
   "proposal-accept-batch",
   "proposal-drain",
   "proposal-reject-batch",

--- a/tests/commands/mv.test.ts
+++ b/tests/commands/mv.test.ts
@@ -46,12 +46,14 @@ import { akmLint } from "../../src/commands/lint/index";
 import { parseFrontmatter } from "../../src/core/asset/frontmatter";
 import { readEvents } from "../../src/core/events";
 import { getDbPath } from "../../src/core/paths";
+import { getStateDbPath, openStateDatabase } from "../../src/core/state-db";
 import {
   applyFeedbackToUtilityScore,
   closeDatabase,
   getUtilityScore,
   openExistingDatabase,
 } from "../../src/indexer/db/db";
+import { ensureUsageEventsSchema, insertUsageEvent } from "../../src/indexer/usage/usage-events";
 import type { Database } from "../../src/storage/database";
 import { runCliCapture } from "../_helpers/cli";
 import {
@@ -114,6 +116,8 @@ interface MvOutput {
   rewrote: RewroteItem[];
   readOnlyCiters: RewroteItem[];
   utilityPreserved: boolean;
+  /** Additive: present only when a re-key could not be completed. */
+  warnings?: string[];
 }
 
 interface ErrorEnvelope {
@@ -548,8 +552,10 @@ describe("akm mv — the utilityPreserved flag is honest", () => {
     const json = JSON.parse(stdout) as MvOutput;
     expect(json.ok).toBe(true);
     expect(fs.existsSync(path.join(stashDir, "memories/stranded-note-renamed.md"))).toBe(true);
-    // The command must not claim it preserved history it never re-keyed.
+    // The command must not claim it preserved history it never re-keyed, and
+    // the report carries the reason.
     expect(json.utilityPreserved).toBe(false);
+    expect(json.warnings?.some((w) => w.includes("re-key"))).toBe(true);
 
     // The ghost row is still there under the odd key — disclosed, not hidden.
     db = openExistingDatabase(getDbPath());
@@ -574,8 +580,10 @@ describe("akm mv — the utilityPreserved flag is honest", () => {
     // Fail-open: the rename itself lands...
     expect(json.ok).toBe(true);
     expect(fs.existsSync(path.join(stashDir, "memories/blocked-note-renamed.md"))).toBe(true);
-    // ...but the command must NOT claim it verified a re-key it could not run.
+    // ...but the command must NOT claim it verified a re-key it could not run,
+    // and the REPORT (not just --verbose stderr) must say why history resets.
     expect(json.utilityPreserved).toBe(false);
+    expect(json.warnings?.some((w) => w.includes("re-key"))).toBe(true);
   });
 });
 
@@ -731,6 +739,362 @@ describe("akm mv — events stream", () => {
     const bad = await runCliCapture(["mv", "memory:ghost", "ghost-renamed"]);
     expect(bad.code).toBe(2);
     expect(readEvents({ type: "mv" }).events).toHaveLength(1);
+  });
+});
+
+// ── usage-event history (finding #2) ─────────────────────────────────────────
+
+describe("akm mv — usage_events.entry_ref is re-pointed so history survives a full reindex", () => {
+  test("bare and origin-qualified event refs are rewritten; events relink after `akm index --full`", async () => {
+    seedAsset(stashDir, "memories/hist-note.md", "A memory with usage history.\n");
+    await buildIndex();
+
+    let db = openExistingDatabase(getDbPath());
+    let entryId: number;
+    try {
+      const row = entryByKeySuffix(db, ":memory:hist-note");
+      expect(row).toBeDefined();
+      entryId = (row as { id: number }).id;
+      ensureUsageEventsSchema(db);
+      // Both spellings writers persist: bare and origin-qualified.
+      insertUsageEvent(db, { event_type: "show", entry_id: entryId, entry_ref: "memory:hist-note" });
+      insertUsageEvent(db, {
+        event_type: "feedback",
+        signal: "positive",
+        entry_id: entryId,
+        entry_ref: "memory:hist-note",
+      });
+      insertUsageEvent(db, { event_type: "search", entry_id: entryId, entry_ref: "local//memory:hist-note" });
+    } finally {
+      closeDatabase(db);
+    }
+
+    const mv = await runCliCapture(["mv", "memory:hist-note", "hist-note-renamed"]);
+    expect(mv.code).toBe(0);
+    expect((JSON.parse(mv.stdout) as MvOutput).utilityPreserved).toBe(true);
+
+    // The events carry the NEW ref immediately (origin spelling preserved).
+    db = openExistingDatabase(getDbPath());
+    try {
+      const refs = (
+        db.prepare("SELECT entry_ref FROM usage_events WHERE entry_ref LIKE '%hist-note%' ORDER BY id").all() as Array<{
+          entry_ref: string;
+        }>
+      ).map((r) => r.entry_ref);
+      expect(refs).toEqual(["memory:hist-note-renamed", "memory:hist-note-renamed", "local//memory:hist-note-renamed"]);
+    } finally {
+      closeDatabase(db);
+    }
+
+    // The load-bearing path: a FULL rebuild re-mints entry ids, detaches every
+    // event, and relinks by entry_ref. With the old ref left behind, relink
+    // finds nothing and utility resets — the exact loss mv exists to prevent.
+    const reindex = await runCliCapture(["index", "--full"]);
+    expect(reindex.code).toBe(0);
+    db = openExistingDatabase(getDbPath());
+    try {
+      const entry = entryByKeySuffix(db, ":memory:hist-note-renamed");
+      expect(entry).toBeDefined();
+      const linked = db
+        .prepare("SELECT COUNT(*) AS cnt FROM usage_events WHERE entry_id = ? AND entry_ref LIKE '%hist-note-renamed%'")
+        .get((entry as { id: number }).id) as { cnt: number };
+      expect(linked.cnt).toBe(3);
+      // Utility recomputed FROM the relinked events (show + positive feedback)
+      // — the history stayed attached across the rebuild.
+      expect(getUtilityScore(db, (entry as { id: number }).id)).toBeDefined();
+    } finally {
+      closeDatabase(db);
+    }
+  });
+});
+
+// ── displaced-row eviction (finding #4) ──────────────────────────────────────
+
+describe("akm mv — displaced stale index row with FK children", () => {
+  test("a stale row at the target key WITH an embeddings child is evicted cleanly and the re-key succeeds", async () => {
+    seedAsset(stashDir, "memories/keeper.md", "The memory being renamed.\n");
+    const vacatedPath = seedAsset(stashDir, "memories/vacated.md", "Deleted on disk later; index row lingers.\n");
+    await buildIndex();
+
+    let db = openExistingDatabase(getDbPath());
+    let keeperId: number;
+    let staleId: number;
+    let utilityBefore: number;
+    try {
+      keeperId = (entryByKeySuffix(db, ":memory:keeper") as { id: number }).id;
+      staleId = (entryByKeySuffix(db, ":memory:vacated") as { id: number }).id;
+      applyFeedbackToUtilityScore(db, keeperId, 1, 0);
+      utilityBefore = (getUtilityScore(db, keeperId) as { utility: number }).utility;
+      // A NON-CASCADE FK child on the stale row: with foreign_keys = ON, a
+      // bare `DELETE FROM entries` throws and rolls back the whole re-key.
+      db.prepare("INSERT OR REPLACE INTO embeddings (id, embedding) VALUES (?, ?)").run(
+        staleId,
+        new Uint8Array([1, 2, 3, 4]),
+      );
+    } finally {
+      closeDatabase(db);
+    }
+    // The target's FILE is gone (mv's target check passes) but its row lingers.
+    fs.rmSync(vacatedPath);
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:keeper", "vacated"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+    expect(json.ok).toBe(true);
+    expect(json.utilityPreserved).toBe(true);
+    expect(json.warnings).toBeUndefined();
+
+    db = openExistingDatabase(getDbPath());
+    try {
+      // The moved row kept its id under the new key; history intact.
+      expect(entryById(db, keeperId)?.entry_key).toBe(`${stashDir}:memory:vacated`);
+      expect(getUtilityScore(db, keeperId)?.utility).toBeCloseTo(utilityBefore, 10);
+      // The displaced row AND its child rows are gone (no orphans).
+      expect(entryById(db, staleId)).toBeFalsy();
+      expect(db.prepare("SELECT id FROM embeddings WHERE id = ?").get(staleId)).toBeFalsy();
+      expect(db.prepare("SELECT entry_id FROM utility_scores WHERE entry_id = ?").get(staleId)).toBeFalsy();
+    } finally {
+      closeDatabase(db);
+    }
+  });
+});
+
+// ── state.db salience / outcome re-key (finding #5) ──────────────────────────
+
+describe("akm mv — state.db asset_salience / asset_outcome re-key", () => {
+  test("salience and outcome rows move to the new asset_ref; an orphan row at the new ref loses to the live row", async () => {
+    seedAsset(stashDir, "memories/salient-note.md", "Salience-carrying note.\n");
+    const now = Date.now();
+    const stateDb = openStateDatabase();
+    try {
+      stateDb
+        .prepare(
+          `INSERT INTO asset_salience
+             (asset_ref, encoding_salience, outcome_salience, retrieval_salience, rank_score, consecutive_no_ops, updated_at, encoding_source)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run("memory:salient-note", 0.9, 0.1, 0.2, 0.8, 0, now, "content");
+      // An orphan row already squatting on the target ref (its asset was
+      // deleted — mv verified no file exists at the target). The LIVE
+      // asset's history must win.
+      stateDb
+        .prepare(
+          `INSERT INTO asset_salience
+             (asset_ref, encoding_salience, outcome_salience, retrieval_salience, rank_score, consecutive_no_ops, updated_at, encoding_source)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run("memory:salient-renamed", 0.5, 0, 0, 0.1, 0, now - 1000, "type-stub");
+      stateDb
+        .prepare(
+          `INSERT INTO asset_outcome
+             (asset_ref, last_retrieved_at, retrieval_count, expected_retrieval_rate, negative_feedback_count, accepted_change_count, review_pressure, outcome_score, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run("memory:salient-note", now, 7, 1.5, 2, 1, 3, 0.4, now);
+    } finally {
+      stateDb.close();
+    }
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:salient-note", "salient-renamed"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+    expect(json.ok).toBe(true);
+    expect(json.warnings).toBeUndefined();
+
+    const after = openStateDatabase();
+    try {
+      // Exactly ONE salience row remains for this asset, at the new ref,
+      // carrying the moved (content-derived) values — not the orphan's stub.
+      const sal = after
+        .prepare(
+          "SELECT asset_ref, encoding_salience, rank_score, encoding_source FROM asset_salience WHERE asset_ref LIKE '%salient%'",
+        )
+        .all() as Array<{ asset_ref: string; encoding_salience: number; rank_score: number; encoding_source: string }>;
+      expect(sal).toEqual([
+        { asset_ref: "memory:salient-renamed", encoding_salience: 0.9, rank_score: 0.8, encoding_source: "content" },
+      ]);
+      const outcome = after
+        .prepare(
+          "SELECT asset_ref, retrieval_count, review_pressure FROM asset_outcome WHERE asset_ref LIKE '%salient%'",
+        )
+        .all() as Array<{ asset_ref: string; retrieval_count: number; review_pressure: number }>;
+      expect(outcome).toEqual([{ asset_ref: "memory:salient-renamed", retrieval_count: 7, review_pressure: 3 }]);
+    } finally {
+      after.close();
+    }
+  });
+
+  test("no state.db: mv succeeds and does not create one", async () => {
+    seedAsset(stashDir, "memories/no-state.md", "No improve loop ever ran.\n");
+    expect(fs.existsSync(getStateDbPath())).toBe(false);
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:no-state", "no-state-renamed"]);
+    expect(code).toBe(0);
+    expect((JSON.parse(stdout) as MvOutput).ok).toBe(true);
+    // The salience re-key must not have minted a state.db on its own — but a
+    // successful mv appends an `mv` event, which legitimately creates it. So
+    // assert the move landed and no salience rows were invented.
+    if (fs.existsSync(getStateDbPath())) {
+      const stateDb = openStateDatabase();
+      try {
+        const rows = stateDb.prepare("SELECT asset_ref FROM asset_salience").all();
+        expect(rows).toEqual([]);
+      } finally {
+        stateDb.close();
+      }
+    }
+  });
+});
+
+// ── workflow refs (finding #3) ───────────────────────────────────────────────
+
+describe("akm mv — workflow refs are rejected (v1 scope)", () => {
+  test("a YAML workflow cannot be moved (exit 2, file byte-identical, error names the manual procedure)", async () => {
+    const wfBody = "steps:\n  - run: echo hi\n";
+    const wfPath = seedAsset(stashDir, "workflows/deploy.yaml", wfBody);
+
+    const { code, stderr } = await runCliCapture(["mv", "workflow:deploy", "release"]);
+    expect(code).toBe(2);
+
+    const json = JSON.parse(stderr) as ErrorEnvelope;
+    expect(json.ok).toBe(false);
+    expect(json.error.toLowerCase()).toContain("workflow");
+    expect(json.error).toContain("akm lint");
+    expect(typeof json.code).toBe("string");
+    // Nothing moved, nothing corrupted: no YAML-bodied workflows/release.md.
+    expect(fs.readFileSync(wfPath, "utf8")).toBe(wfBody);
+    expect(fs.existsSync(path.join(stashDir, "workflows/release.md"))).toBe(false);
+    expect(fs.existsSync(path.join(stashDir, "workflows/release.yaml"))).toBe(false);
+  });
+});
+
+// ── orphaned target twin (finding #8) ────────────────────────────────────────
+
+describe("akm mv — orphaned .derived.md at the target name", () => {
+  test("renaming a TWIN-LESS memory onto a name with an orphaned .derived.md is rejected (no silent adoption)", async () => {
+    const srcPath = seedAsset(stashDir, "memories/twinless.md", "No twin here.\n");
+    const orphanBody = "---\nderived_from: memory:occupied\n---\n\nStale distillation of a deleted memory.\n";
+    const orphanPath = seedAsset(stashDir, "memories/occupied.derived.md", orphanBody);
+
+    const { code, stderr } = await runCliCapture(["mv", "memory:twinless", "occupied"]);
+    expect(code).toBe(2);
+
+    const json = JSON.parse(stderr) as ErrorEnvelope;
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain(".derived");
+    expect(json.code).toBe("RESOURCE_ALREADY_EXISTS");
+    // Nothing moved; the orphan was not adopted.
+    expect(fs.readFileSync(srcPath, "utf8")).toBe("No twin here.\n");
+    expect(fs.existsSync(path.join(stashDir, "memories/occupied.md"))).toBe(false);
+    expect(fs.readFileSync(orphanPath, "utf8")).toBe(orphanBody);
+  });
+});
+
+// ── task .yml citers (finding #9) ────────────────────────────────────────────
+
+describe("akm mv — task YAML citers", () => {
+  test("refs in tasks/*.yml and tasks/*.yaml are rewritten and reported; yml outside tasks/ is not scanned", async () => {
+    seedAsset(stashDir, "memories/task-target.md", "Cited from scheduled tasks.\n");
+    const ymlPath = seedAsset(stashDir, "tasks/nightly.yml", 'schedule: "0 9 * * *"\nprompt: memory:task-target\n');
+    const yamlPath = seedAsset(stashDir, "tasks/weekly.yaml", 'schedule: "0 9 * * 1"\nprompt: memory:task-target\n');
+    const otherYml = seedAsset(stashDir, "knowledge/data.yml", "ref: memory:task-target\n");
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:task-target", "task-target-v2"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+
+    expect(fs.readFileSync(ymlPath, "utf8")).toBe('schedule: "0 9 * * *"\nprompt: memory:task-target-v2\n');
+    expect(fs.readFileSync(yamlPath, "utf8")).toBe('schedule: "0 9 * * 1"\nprompt: memory:task-target-v2\n');
+    expect(json.rewrote.find((r) => r.file.endsWith("tasks/nightly.yml"))?.count).toBe(1);
+    expect(json.rewrote.find((r) => r.file.endsWith("tasks/weekly.yaml"))?.count).toBe(1);
+    // Outside tasks/: not scanned (lint's missing-ref pass doesn't scan it
+    // either) — untouched and unreported.
+    expect(fs.readFileSync(otherYml, "utf8")).toBe("ref: memory:task-target\n");
+    expect(json.rewrote.some((r) => r.file.endsWith("knowledge/data.yml"))).toBe(false);
+  });
+});
+
+// ── flow-style lists and bracketed refs (finding #10) ────────────────────────
+
+describe("akm mv — flow-style YAML lists and bracketed body refs", () => {
+  test("[-preceded refs are rewritten: single-element flow list, bracketed body ref, first element of a multi-element list", async () => {
+    seedAsset(stashDir, "memories/projectA/flow-note.md", "The note being renamed.\n");
+    seedAsset(stashDir, "memories/projectA/flow-sibling.md", "A neighbor that must stay untouched.\n");
+    const flowCiter = seedAsset(
+      stashDir,
+      "knowledge/flow-citer.md",
+      "---\ndescription: Flow-style citer\nxrefs: [memory:projectA/flow-note]\n---\n\nsee [memory:projectA/flow-note] for details.\n",
+    );
+    const multiCiter = seedAsset(
+      stashDir,
+      "knowledge/multi-flow-citer.md",
+      "---\ndescription: Multi-element flow list\nxrefs: [memory:projectA/flow-note, memory:projectA/flow-sibling]\n---\n\nBody.\n",
+    );
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:projectA/flow-note", "projectA/flow-note-v2"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+
+    // Single-element flow list AND bracketed body ref: both rewritten.
+    const flowAfter = fs.readFileSync(flowCiter, "utf8");
+    expect(flowAfter).toContain("xrefs: [memory:projectA/flow-note-v2]");
+    expect(flowAfter).toContain("see [memory:projectA/flow-note-v2] for details.");
+    expect(json.rewrote.find((r) => r.file.endsWith("knowledge/flow-citer.md"))?.count).toBe(2);
+
+    // Multi-element flow list: the `[`-preceded FIRST element is rewritten
+    // (the legacy grammar skipped it), the space-preceded neighbor keeps its
+    // own ref untouched.
+    const multiAfter = fs.readFileSync(multiCiter, "utf8");
+    expect(multiAfter).toContain("xrefs: [memory:projectA/flow-note-v2, memory:projectA/flow-sibling]");
+    expect(json.rewrote.find((r) => r.file.endsWith("knowledge/multi-flow-citer.md"))?.count).toBe(1);
+
+    // The rename dangles nothing lint can see.
+    const lint = akmLint({ dir: stashDir });
+    expect(lint.flagged.filter((i) => i.issue === "missing-ref")).toEqual([]);
+  });
+});
+
+// ── alias-spelling citers (finding #11) ──────────────────────────────────────
+
+describe("akm mv — alias-spelling citers are rewritten to the new canonical ref", () => {
+  test(".md-suffixed, local//-prefixed, and knowledge-subdir basename aliases", async () => {
+    seedAsset(stashDir, "knowledge/guides/old-guide.md", "# Guide\n");
+    const mdCiter = seedAsset(stashDir, "memories/md-citer.md", "See knowledge:guides/old-guide.md for details.\n");
+    const localCiter = seedAsset(stashDir, "memories/local-citer.md", "See local//knowledge:guides/old-guide too.\n");
+    // The knowledge-subdir alias: `knowledge:old-guide` resolves (via lint's
+    // shared resolver fallback) to knowledge/guides/old-guide.md.
+    const subdirCiter = seedAsset(stashDir, "memories/subdir-citer.md", "See knowledge:old-guide (basename alias).\n");
+
+    const { code, stdout } = await runCliCapture(["mv", "knowledge:guides/old-guide", "guides/renamed-guide"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+
+    // Every alias spelling is rewritten to the new CANONICAL ref.
+    expect(fs.readFileSync(mdCiter, "utf8")).toBe("See knowledge:guides/renamed-guide for details.\n");
+    expect(fs.readFileSync(localCiter, "utf8")).toBe("See knowledge:guides/renamed-guide too.\n");
+    expect(fs.readFileSync(subdirCiter, "utf8")).toBe("See knowledge:guides/renamed-guide (basename alias).\n");
+    for (const rel of ["memories/md-citer.md", "memories/local-citer.md", "memories/subdir-citer.md"]) {
+      expect(json.rewrote.find((r) => r.file.endsWith(rel))?.count).toBe(1);
+    }
+    const lint = akmLint({ dir: stashDir });
+    expect(lint.flagged.filter((i) => i.issue === "missing-ref")).toEqual([]);
+  });
+
+  test("alias citers in a READ-ONLY source are detected and reported, never written", async () => {
+    const roDir = makeDir("akm-mv-alias-readonly");
+    const roCiter = seedAsset(roDir, "knowledge/shared.md", "Team doc cites knowledge:guides/alias-note.md here.\n");
+    const roRaw = fs.readFileSync(roCiter, "utf8");
+    writeSandboxConfig({
+      semanticSearchMode: "off",
+      sources: [{ type: "filesystem", name: "shared", path: roDir, writable: false }],
+    });
+    seedAsset(stashDir, "knowledge/guides/alias-note.md", "# Aliased note\n");
+
+    const { code, stdout } = await runCliCapture(["mv", "knowledge:guides/alias-note", "guides/alias-note-v2"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+    expect(json.readOnlyCiters).toEqual([{ file: roCiter, count: 1 }]);
+    expect(fs.readFileSync(roCiter, "utf8")).toBe(roRaw);
   });
 });
 

--- a/tests/commands/mv.test.ts
+++ b/tests/commands/mv.test.ts
@@ -43,6 +43,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
 import { akmLint } from "../../src/commands/lint/index";
+import { deriveOnDiskCasedRelPath } from "../../src/commands/mv-cli";
 import { parseFrontmatter } from "../../src/core/asset/frontmatter";
 import { readEvents } from "../../src/core/events";
 import { getDbPath } from "../../src/core/paths";
@@ -806,6 +807,66 @@ describe("akm mv — usage_events.entry_ref is re-pointed so history survives a 
       closeDatabase(db);
     }
   });
+
+  test("DETACHED orphan events already AT the target ref are evicted — the moved asset never adopts a deleted stranger's history (R2-1)", async () => {
+    seedAsset(stashDir, "memories/live-note.md", "The live asset being renamed.\n");
+    await buildIndex();
+
+    let db = openExistingDatabase(getDbPath());
+    let entryId: number;
+    try {
+      const row = entryByKeySuffix(db, ":memory:live-note");
+      expect(row).toBeDefined();
+      entryId = (row as { id: number }).id;
+      ensureUsageEventsSchema(db);
+      // The moved asset's own (attached) history.
+      insertUsageEvent(db, { event_type: "show", entry_id: entryId, entry_ref: "memory:live-note" });
+      // A deleted stranger's DETACHED history already sitting at the TARGET
+      // ref (entry_id NULL — what a full rebuild leaves behind when the file
+      // is gone). No entries row exists for memory:dead-note, so the
+      // stale-row eviction path never runs; the re-key itself must evict
+      // these (live asset's history wins) or getRetrievalCounts reads the
+      // stranger's counts immediately and the next `index --full` relinks
+      // the stranger's whole history onto the moved asset by entry_ref.
+      insertUsageEvent(db, { event_type: "show", entry_ref: "memory:dead-note" });
+      insertUsageEvent(db, { event_type: "feedback", signal: "positive", entry_ref: "memory:dead-note" });
+      insertUsageEvent(db, { event_type: "search", entry_ref: "local//memory:dead-note" });
+    } finally {
+      closeDatabase(db);
+    }
+
+    const mv = await runCliCapture(["mv", "memory:live-note", "dead-note"]);
+    expect(mv.code).toBe(0);
+    expect((JSON.parse(mv.stdout) as MvOutput).utilityPreserved).toBe(true);
+
+    db = openExistingDatabase(getDbPath());
+    try {
+      // Exactly ONE event survives at the target ref: the moved asset's own,
+      // still attached and re-pointed. Every detached stranger event is gone.
+      const rows = db
+        .prepare("SELECT entry_id, entry_ref FROM usage_events WHERE entry_ref LIKE '%dead-note%' ORDER BY id")
+        .all() as Array<{ entry_id: number | null; entry_ref: string }>;
+      expect(rows).toEqual([{ entry_id: entryId, entry_ref: "memory:dead-note" }]);
+    } finally {
+      closeDatabase(db);
+    }
+
+    // The permanent-contamination path: a full rebuild relinks by entry_ref.
+    // Only the asset's own event may attach to the re-minted row.
+    const reindex = await runCliCapture(["index", "--full"]);
+    expect(reindex.code).toBe(0);
+    db = openExistingDatabase(getDbPath());
+    try {
+      const entry = entryByKeySuffix(db, ":memory:dead-note");
+      expect(entry).toBeDefined();
+      const linked = db
+        .prepare("SELECT COUNT(*) AS cnt FROM usage_events WHERE entry_id = ?")
+        .get((entry as { id: number }).id) as { cnt: number };
+      expect(linked.cnt).toBe(1);
+    } finally {
+      closeDatabase(db);
+    }
+  });
 });
 
 // ── displaced-row eviction (finding #4) ──────────────────────────────────────
@@ -1252,6 +1313,10 @@ describe("akm mv — target parent is created before any citer edit", () => {
 // ── state.db re-key failure honesty ──────────────────────────────────────────
 
 describe("akm mv — state.db re-key failures are surfaced, missing tables stay silent", () => {
+  // The inner catch swallows ONLY /no such table/i (legacy state.db without
+  // the salience tables); every other shape — including a lock timeout's
+  // "database is locked" (R2-2, verified against a held BEGIN IMMEDIATE) —
+  // takes the same tableFailures -> warnings path this test pins.
   test("a NON-missing-table failure (incompatible schema) lands in warnings; the move itself still succeeds", async () => {
     seedAsset(stashDir, "memories/state-broken.md", "Salience fate unknown.\n");
     const stateDb = openStateDatabase();
@@ -1369,5 +1434,96 @@ describe("akm mv — command registration and help meta", () => {
     const { main } = await import("../../src/cli");
     const subCommands = (main as { subCommands?: Record<string, unknown> }).subCommands ?? {};
     expect(Object.keys(subCommands)).toContain("mv");
+  });
+});
+
+// ── no-space flow-list citers (R2-5) ─────────────────────────────────────────
+
+describe("akm mv — refs after a bare comma in a no-space flow list are rewritten", () => {
+  test("xrefs: [memory:other,memory:old] — the post-comma ref is rewritten like the spaced form", async () => {
+    seedAsset(stashDir, "memories/comma-note.md", "Cited from a no-space flow list.\n");
+    // Valid YAML: flow list with no space after the comma. `,` terminates a
+    // slug but was missing from the boundary prefix class, so the second ref
+    // could never start a match — mv reported `rewrote: []` and the ref
+    // dangled silently.
+    const citer = seedAsset(
+      stashDir,
+      "memories/comma-citer.md",
+      "---\ndescription: no-space flow list citer\nxrefs: [memory:elsewhere,memory:comma-note]\n---\n\nBody.\n",
+    );
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:comma-note", "comma-note-v2"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+
+    expect(fs.readFileSync(citer, "utf8")).toContain("xrefs: [memory:elsewhere,memory:comma-note-v2]");
+    expect(json.rewrote.find((r) => r.file.endsWith("memories/comma-citer.md"))?.count).toBe(1);
+  });
+});
+
+// ── empty target path segments (R2-6) ────────────────────────────────────────
+
+describe("akm mv — targets with empty path segments are rejected", () => {
+  test.each([
+    "bar/",
+    "bar\\",
+  ])("target %j exits 2, moves nothing, rewrites no citer (a trailing separator would mint a hidden <dir>/.md)", async (target) => {
+    const srcPath = seedAsset(stashDir, "memories/slash-note.md", "Must not become a hidden dotfile.\n");
+    const citer = seedAsset(stashDir, "knowledge/slash-citer.md", "Cites memory:slash-note here.\n");
+
+    const { code, stderr } = await runCliCapture(["mv", "memory:slash-note", target]);
+    expect(code).toBe(2);
+    const json = JSON.parse(stderr) as ErrorEnvelope;
+    expect(json.ok).toBe(false);
+    expect(typeof json.code).toBe("string");
+
+    // Nothing moved, nothing rewritten, no hidden memories/bar/.md minted.
+    expect(fs.readFileSync(srcPath, "utf8")).toBe("Must not become a hidden dotfile.\n");
+    expect(fs.readFileSync(citer, "utf8")).toBe("Cites memory:slash-note here.\n");
+    expect(fs.existsSync(path.join(stashDir, "memories/bar"))).toBe(false);
+  });
+});
+
+// ── on-disk casing guard (R2-7) ──────────────────────────────────────────────
+
+describe("akm mv — deriveOnDiskCasedRelPath (the wrong-case source-ref guard)", () => {
+  // On case-INSENSITIVE filesystems (macOS/Windows defaults) existsSync
+  // matches a wrong-case ref spelling and resolveRefPathInStash returns the
+  // user-cased join verbatim, so resolveMoveSourcePath's byte-equality
+  // compares the string against itself. The guard reads each segment's TRUE
+  // name from its parent's directory listing; a mismatch is rejected through
+  // the alias-rejection path naming the canonical ref. This CI filesystem is
+  // case-SENSITIVE (a wrong-case ref simply fails to resolve here), so the
+  // guard's decision logic is pinned directly at the helper seam.
+  test("returns the byte-identical rel path for an exact-case hit", () => {
+    seedAsset(stashDir, "memories/projectA/case-note.md", "Body.\n");
+    expect(deriveOnDiskCasedRelPath(stashDir, "memories/projectA/case-note.md")).toBe("memories/projectA/case-note.md");
+  });
+
+  test("returns the on-disk casing for a wrong-case LEAF (what a case-insensitive existsSync hit hides)", () => {
+    seedAsset(stashDir, "memories/case-note.md", "Body.\n");
+    expect(deriveOnDiskCasedRelPath(stashDir, "memories/Case-Note.md")).toBe("memories/case-note.md");
+  });
+
+  test("returns the on-disk casing for a wrong-case DIRECTORY segment", () => {
+    seedAsset(stashDir, "memories/projectA/nested-note.md", "Body.\n");
+    expect(deriveOnDiskCasedRelPath(stashDir, "memories/projecta/Nested-Note.md")).toBe(
+      "memories/projectA/nested-note.md",
+    );
+  });
+
+  test("returns null for a path with no case-insensitive match (unverifiable — caller keeps the existsSync verdict)", () => {
+    seedAsset(stashDir, "memories/present.md", "Body.\n");
+    expect(deriveOnDiskCasedRelPath(stashDir, "memories/absent.md")).toBeNull();
+    expect(deriveOnDiskCasedRelPath(stashDir, "ghosts/present.md")).toBeNull();
+  });
+
+  test("exact-case mv is unaffected by the guard (control)", async () => {
+    seedAsset(stashDir, "memories/projectA/guarded-note.md", "Exact-case control.\n");
+    const { code, stdout } = await runCliCapture(["mv", "memory:projectA/guarded-note", "projectA/guarded-note-v2"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+    expect(json.ok).toBe(true);
+    expect(json.to).toBe("memory:projectA/guarded-note-v2");
   });
 });

--- a/tests/commands/mv.test.ts
+++ b/tests/commands/mv.test.ts
@@ -1098,6 +1098,256 @@ describe("akm mv — alias-spelling citers are rewritten to the new canonical re
   });
 });
 
+// ── .md alias spellings of source and target ─────────────────────────────────
+
+describe("akm mv — .md alias spellings are accepted but canonicalized throughout", () => {
+  test(".md-suffixed SOURCE: canonical citers rewritten, canonical index row re-keyed with utility intact, salience moved", async () => {
+    seedAsset(stashDir, "memories/alias-src.md", "Moved via its .md alias spelling.\n");
+    const citer = seedAsset(stashDir, "knowledge/alias-src-citer.md", "Cites memory:alias-src canonically.\n");
+    await buildIndex();
+
+    let db = openExistingDatabase(getDbPath());
+    let entryId: number;
+    let utilityBefore: number;
+    try {
+      const row = entryByKeySuffix(db, ":memory:alias-src");
+      expect(row).toBeDefined();
+      entryId = (row as { id: number }).id;
+      applyFeedbackToUtilityScore(db, entryId, 1, 0);
+      utilityBefore = (getUtilityScore(db, entryId) as { utility: number }).utility;
+    } finally {
+      closeDatabase(db);
+    }
+    // Salience history is keyed by the CANONICAL bare ref — a fromRef keyed
+    // to the alias spelling would silently miss it.
+    const stateDb = openStateDatabase();
+    try {
+      stateDb
+        .prepare(
+          `INSERT INTO asset_salience
+             (asset_ref, encoding_salience, outcome_salience, retrieval_salience, rank_score, consecutive_no_ops, updated_at, encoding_source)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run("memory:alias-src", 0.9, 0.1, 0.2, 0.8, 0, Date.now(), "content");
+    } finally {
+      stateDb.close();
+    }
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:alias-src.md", "alias-src-v2"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+    expect(json.ok).toBe(true);
+    // The alias spelling is accepted as INPUT but never leaks into the
+    // report, the citer rewrites, or any re-keyed row.
+    expect(json.from).toBe("memory:alias-src");
+    expect(json.to).toBe("memory:alias-src-v2");
+    expect(json.utilityPreserved).toBe(true);
+    expect(json.warnings).toBeUndefined();
+
+    expect(fs.readFileSync(citer, "utf8")).toBe("Cites memory:alias-src-v2 canonically.\n");
+
+    db = openExistingDatabase(getDbPath());
+    try {
+      // The CANONICAL row was re-keyed in place (same id, history attached) —
+      // not skipped in favor of a nonexistent `alias-src.md`-keyed row.
+      const after = entryById(db, entryId);
+      expect(after?.entry_key).toBe(`${stashDir}:memory:alias-src-v2`);
+      expect(getUtilityScore(db, entryId)?.utility).toBeCloseTo(utilityBefore, 10);
+      expect(entryByKeySuffix(db, ":memory:alias-src")).toBeUndefined();
+    } finally {
+      closeDatabase(db);
+    }
+
+    const stateAfter = openStateDatabase();
+    try {
+      const rows = stateAfter
+        .prepare("SELECT asset_ref FROM asset_salience WHERE asset_ref LIKE '%alias-src%'")
+        .all() as Array<{ asset_ref: string }>;
+      expect(rows).toEqual([{ asset_ref: "memory:alias-src-v2" }]);
+    } finally {
+      stateAfter.close();
+    }
+  });
+
+  test(".md-suffixed TARGET: file written once as <name>.md, citers get the canonical ref, ONE index row at the canonical key", async () => {
+    seedAsset(stashDir, "memories/target-alias.md", "Moved onto a .md-spelled target.\n");
+    const citer = seedAsset(stashDir, "knowledge/target-alias-citer.md", "Cites memory:target-alias here.\n");
+    await buildIndex();
+
+    let db = openExistingDatabase(getDbPath());
+    let entryId: number;
+    try {
+      const row = entryByKeySuffix(db, ":memory:target-alias");
+      expect(row).toBeDefined();
+      entryId = (row as { id: number }).id;
+      applyFeedbackToUtilityScore(db, entryId, 1, 0);
+    } finally {
+      closeDatabase(db);
+    }
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:target-alias", "target-alias-v2.md"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+    expect(json.to).toBe("memory:target-alias-v2");
+    expect(json.utilityPreserved).toBe(true);
+
+    // The file carries the extension ONCE; citers carry the canonical ref,
+    // never `memory:target-alias-v2.md`.
+    expect(fs.existsSync(path.join(stashDir, "memories/target-alias-v2.md"))).toBe(true);
+    expect(fs.existsSync(path.join(stashDir, "memories/target-alias-v2.md.md"))).toBe(false);
+    expect(fs.readFileSync(citer, "utf8")).toBe("Cites memory:target-alias-v2 here.\n");
+
+    db = openExistingDatabase(getDbPath());
+    try {
+      // Exactly ONE row for the moved asset, at the canonical key, still under
+      // the original id — a `…:memory:target-alias-v2.md` re-key would leave
+      // the history stranded behind a row the write-path index pass (which
+      // derives the canonical name from the file) immediately duplicates.
+      const rows = db
+        .prepare("SELECT id, entry_key FROM entries WHERE entry_key LIKE '%:memory:target-alias%'")
+        .all() as Array<{ id: number; entry_key: string }>;
+      expect(rows).toEqual([{ id: entryId, entry_key: `${stashDir}:memory:target-alias-v2` }]);
+      expect(getUtilityScore(db, entryId)).toBeDefined();
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("a twin's .md alias spelling (memory:x.derived.md) is still rejected as a twin ref (exit 2)", async () => {
+    seedAsset(stashDir, "memories/md-coupled.md", "Base memory body.\n");
+    seedAsset(stashDir, "memories/md-coupled.derived.md", "Distilled twin body.\n");
+
+    const { code, stderr } = await runCliCapture(["mv", "memory:md-coupled.derived.md", "free-twin"]);
+    expect(code).toBe(2);
+    const json = JSON.parse(stderr) as ErrorEnvelope;
+    expect(json.ok).toBe(false);
+    // The error steers to the base ref, exactly like the extensionless twin spelling.
+    expect(json.error).toContain("memory:md-coupled");
+    expect(fs.existsSync(path.join(stashDir, "memories/md-coupled.derived.md"))).toBe(true);
+    expect(fs.existsSync(path.join(stashDir, "memories/free-twin.md"))).toBe(false);
+  });
+});
+
+// ── target-parent validation ordering ────────────────────────────────────────
+
+describe("akm mv — target parent is created before any citer edit", () => {
+  test("a target parent blocked by an existing FILE fails the command with every citer byte-identical", async () => {
+    seedAsset(stashDir, "memories/parent-src.md", "Source body.\n");
+    const citer = seedAsset(stashDir, "knowledge/parent-citer.md", "Cites memory:parent-src today.\n");
+    const citerRaw = fs.readFileSync(citer, "utf8");
+    // memories/blocked exists as a FILE, so the target's parent directory
+    // (memories/blocked/) can never be created.
+    fs.writeFileSync(path.join(stashDir, "memories/blocked"), "a file squatting on the dir name", "utf8");
+
+    const { code } = await runCliCapture(["mv", "memory:parent-src", "blocked/new-src"]);
+    expect(code).not.toBe(0);
+
+    // Validate-before-write held: no citer was modified (they would otherwise
+    // point at a ref whose file never arrived), nothing moved.
+    expect(fs.readFileSync(citer, "utf8")).toBe(citerRaw);
+    expect(fs.readFileSync(path.join(stashDir, "memories/parent-src.md"), "utf8")).toBe("Source body.\n");
+  });
+});
+
+// ── state.db re-key failure honesty ──────────────────────────────────────────
+
+describe("akm mv — state.db re-key failures are surfaced, missing tables stay silent", () => {
+  test("a NON-missing-table failure (incompatible schema) lands in warnings; the move itself still succeeds", async () => {
+    seedAsset(stashDir, "memories/state-broken.md", "Salience fate unknown.\n");
+    const stateDb = openStateDatabase();
+    try {
+      stateDb.exec("DROP TABLE asset_salience");
+      stateDb.exec("CREATE TABLE asset_salience (nope TEXT)");
+    } finally {
+      stateDb.close();
+    }
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:state-broken", "state-broken-renamed"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+    expect(json.ok).toBe(true);
+    expect(fs.existsSync(path.join(stashDir, "memories/state-broken-renamed.md"))).toBe(true);
+    // The failure names the table in the REPORT — not swallowed as if it were
+    // the known legacy missing-table case.
+    expect(json.warnings?.some((w) => w.includes("state.db") && w.includes("asset_salience"))).toBe(true);
+  });
+
+  test("a genuinely MISSING table (legacy state.db) is skipped silently — no warning", async () => {
+    seedAsset(stashDir, "memories/state-legacy.md", "Legacy state.db without salience tables.\n");
+    const stateDb = openStateDatabase();
+    try {
+      stateDb.exec("DROP TABLE asset_salience");
+      stateDb.exec("DROP TABLE asset_outcome");
+    } finally {
+      stateDb.close();
+    }
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:state-legacy", "state-legacy-renamed"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+    expect(json.ok).toBe(true);
+    expect(json.warnings).toBeUndefined();
+  });
+});
+
+// ── sentence-terminal punctuation (resolver retry) ───────────────────────────
+
+describe("akm mv — refs followed by sentence punctuation are rewritten, punctuation preserved", () => {
+  test('"See memory:old." forms are rewritten; a genuinely dotted name that resolves is never mangled', async () => {
+    seedAsset(stashDir, "memories/punct-note.md", "The moved note.\n");
+    seedAsset(stashDir, "memories/v1.2-notes.md", "A genuinely dotted neighbor.\n");
+    const citer = seedAsset(
+      stashDir,
+      "knowledge/punct-citer.md",
+      "See memory:punct-note. Read memory:punct-note; also (memory:punct-note!) twice.\n" +
+        "Suffix form memory:punct-note.md.\n" +
+        "Dotted neighbor stays: memory:v1.2-notes. And plain memory:v1.2-notes too.\n",
+    );
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:punct-note", "punct-note-v2"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+
+    const after = fs.readFileSync(citer, "utf8");
+    // Every punctuation-terminated spelling rewritten, punctuation preserved.
+    expect(after).toContain("See memory:punct-note-v2. Read memory:punct-note-v2; also (memory:punct-note-v2!) twice.");
+    expect(after).toContain("Suffix form memory:punct-note-v2.\n");
+    // The dotted neighbor resolves as its own asset — untouched in both the
+    // sentence-terminal and plain spellings.
+    expect(after).toContain("Dotted neighbor stays: memory:v1.2-notes. And plain memory:v1.2-notes too.");
+    expect(json.rewrote.find((r) => r.file.endsWith("knowledge/punct-citer.md"))?.count).toBe(4);
+  });
+});
+
+// ── workflow YAML citers ─────────────────────────────────────────────────────
+
+describe("akm mv — workflow YAML citers", () => {
+  test("refs in workflows/*.yaml and workflows/*.yml are rewritten and reported", async () => {
+    seedAsset(stashDir, "memories/wf-cited.md", "Cited from workflow programs.\n");
+    const yamlPath = seedAsset(
+      stashDir,
+      "workflows/deploy.yaml",
+      "steps:\n  - instructions: Use memory:wf-cited before deploying\n",
+    );
+    const ymlPath = seedAsset(
+      stashDir,
+      "workflows/release.yml",
+      "steps:\n  - instructions: Read memory:wf-cited notes\n",
+    );
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:wf-cited", "wf-cited-v2"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+
+    expect(fs.readFileSync(yamlPath, "utf8")).toBe(
+      "steps:\n  - instructions: Use memory:wf-cited-v2 before deploying\n",
+    );
+    expect(fs.readFileSync(ymlPath, "utf8")).toBe("steps:\n  - instructions: Read memory:wf-cited-v2 notes\n");
+    expect(json.rewrote.find((r) => r.file.endsWith("workflows/deploy.yaml"))?.count).toBe(1);
+    expect(json.rewrote.find((r) => r.file.endsWith("workflows/release.yml"))?.count).toBe(1);
+  });
+});
+
 // ── command registration + help meta ─────────────────────────────────────────
 
 describe("akm mv — command registration and help meta", () => {

--- a/tests/commands/mv.test.ts
+++ b/tests/commands/mv.test.ts
@@ -1,0 +1,759 @@
+/**
+ * SPEC-7 (stash-conventions-code-spec.md): `akm mv <ref> <new-name>` — rename
+ * with inbound-xref rewrite and utility-history preservation.
+ *
+ * Pins the rename procedure the conventions make agent-executable EXCEPT for
+ * the index part only the CLI can do:
+ *   - A rename within a type dir moves the file on disk and reports the
+ *     JSON shape `{ok, from, to, rewrote, readOnlyCiters}` (from/to are refs;
+ *     rewrote is `[{file, count}]`).
+ *   - Inbound refs are rewritten across the WRITABLE stash's md files — in
+ *     body prose, in frontmatter ref-list keys (xrefs/refs/...), AND inside
+ *     fenced code blocks (a rename must not leave stale examples; note lint's
+ *     missing-ref scan strips fences, the rewriter must not). Rewrites use
+ *     complete-ref boundary matching: a longer ref sharing the old ref as a
+ *     prefix is untouched.
+ *   - `akm lint` reports zero missing-ref findings afterwards (SPEC-1 synergy:
+ *     the "grep and fix inbound xrefs in the same pass" convention rule).
+ *   - Read-only sources are scanned but never written: their citing files are
+ *     byte-identical afterwards and reported in `readOnlyCiters` as manual
+ *     follow-ups.
+ *   - Memory renames move the `.derived.md` twin together, and the index
+ *     re-key preserves BOTH row ids with the twin `entry_key` staying exactly
+ *     `<base entry_key>.derived` (the coupling pinned at db.ts
+ *     getBaseBeliefStatesForDerivedTwins).
+ *   - The entries row is re-keyed IN PLACE: the row id survives the rename, so
+ *     the `utility_scores` row keyed by entry_id (accumulated usage-ranking
+ *     history) survives; entry_key/file_path reflect the new name, the old
+ *     entry_key is gone, and search immediately reflects the new name (moved
+ *     row FTS refresh + rewritten citers reindexed via indexWrittenAssets).
+ *   - Bad input fails with the standard `{ok:false,error,code}` envelope and
+ *     exit 2, moving nothing: wiki refs (wiki has its own xref+lint system),
+ *     cross-type targets, existing targets, unresolvable source refs, and
+ *     type-root escapes (`../`).
+ *   - A successful mv appends an `mv` event to the state.db events stream; a
+ *     failed mv appends none.
+ *
+ * Uses the in-process CLI harness (tests/_helpers/cli.ts) with the composite
+ * isolation fixture (fresh stash + XDG dirs per test, so index.db/state.db
+ * assertions are hermetic), following tests/commands/remember-import-*.test.ts.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { akmLint } from "../../src/commands/lint/index";
+import { parseFrontmatter } from "../../src/core/asset/frontmatter";
+import { readEvents } from "../../src/core/events";
+import { getDbPath } from "../../src/core/paths";
+import {
+  applyFeedbackToUtilityScore,
+  closeDatabase,
+  getUtilityScore,
+  openExistingDatabase,
+} from "../../src/indexer/db/db";
+import type { Database } from "../../src/storage/database";
+import { runCliCapture } from "../_helpers/cli";
+import {
+  type IsolatedAkmStorage,
+  makeSandboxDir,
+  type SandboxedDir,
+  withIsolatedAkmStorage,
+  writeSandboxConfig,
+} from "../_helpers/sandbox";
+
+const disposers: SandboxedDir[] = [];
+let storage: IsolatedAkmStorage;
+let stashDir = "";
+
+beforeEach(() => {
+  storage = withIsolatedAkmStorage();
+  stashDir = storage.stashDir;
+  writeSandboxConfig({ semanticSearchMode: "off" });
+});
+
+afterEach(() => {
+  storage.cleanup();
+  stashDir = "";
+  for (const d of disposers.splice(0)) d.cleanup();
+});
+
+/** Create an isolated dir (auto-cleaned) for extra read-only stashes. */
+function makeDir(prefix: string): string {
+  const d = makeSandboxDir(prefix);
+  disposers.push(d);
+  return d.dir;
+}
+
+/** Seed an asset file under a stash root (e.g. "memories/projectA/old.md"). */
+function seedAsset(root: string, relPath: string, content: string): string {
+  const abs = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, "utf8");
+  return abs;
+}
+
+/** Every .md file under `root` (relative paths), for whole-stash grep asserts. */
+function allMarkdownFiles(root: string): string[] {
+  if (!fs.existsSync(root)) return [];
+  return fs
+    .readdirSync(root, { recursive: true })
+    .map(String)
+    .filter((p) => p.endsWith(".md"));
+}
+
+interface RewroteItem {
+  file: string;
+  count: number;
+}
+
+interface MvOutput {
+  ok: boolean;
+  from: string;
+  to: string;
+  rewrote: RewroteItem[];
+  readOnlyCiters: RewroteItem[];
+  utilityPreserved: boolean;
+}
+
+interface ErrorEnvelope {
+  ok: boolean;
+  error: string;
+  code?: string;
+}
+
+/** Build the local index by driving a real read (ensureIndex bootstrap). */
+async function buildIndex(): Promise<void> {
+  const { code } = await runCliCapture(["search", "bootstrap-index-probe"]);
+  expect(code).toBe(0);
+}
+
+/**
+ * Look up an entries row whose entry_key ends with `:type:name`. Normalizes
+ * the driver's no-row result to `undefined` (bun:sqlite `get()` returns
+ * `null`, better-sqlite3 returns `undefined` — the storage boundary's
+ * `Statement.get` is typed `Row | null | undefined`) so absent-row
+ * assertions can use `toBeUndefined()` on either driver.
+ */
+function entryByKeySuffix(
+  db: Database,
+  suffix: string,
+): { id: number; entry_key: string; file_path: string } | undefined {
+  return (
+    (db.prepare("SELECT id, entry_key, file_path FROM entries WHERE entry_key LIKE ?").get(`%${suffix}`) as
+      | { id: number; entry_key: string; file_path: string }
+      | null
+      | undefined) ?? undefined
+  );
+}
+
+/** Look up an entries row by its (stable) row id. */
+function entryById(db: Database, id: number): { id: number; entry_key: string; file_path: string } | undefined {
+  return db.prepare("SELECT id, entry_key, file_path FROM entries WHERE id = ?").get(id) as
+    | { id: number; entry_key: string; file_path: string }
+    | undefined;
+}
+
+// ── rename within a type dir ─────────────────────────────────────────────────
+
+describe("akm mv — rename within a type dir", () => {
+  test("moves the file and reports the {ok,from,to,rewrote,readOnlyCiters} shape", async () => {
+    const body = "---\ndescription: A note worth renaming\n---\n\nKeep this exact body.\n";
+    const oldPath = seedAsset(stashDir, "memories/projectA/old-note.md", body);
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:projectA/old-note", "projectA/new-note"]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as MvOutput;
+    expect(json.ok).toBe(true);
+    expect(json.from).toBe("memory:projectA/old-note");
+    expect(json.to).toBe("memory:projectA/new-note");
+    // No citers in this stash: both report lists are present and empty.
+    expect(json.rewrote).toEqual([]);
+    expect(json.readOnlyCiters).toEqual([]);
+
+    // The file moved byte-for-byte within the type dir.
+    expect(fs.existsSync(oldPath)).toBe(false);
+    const newPath = path.join(stashDir, "memories/projectA/new-note.md");
+    expect(fs.existsSync(newPath)).toBe(true);
+    expect(fs.readFileSync(newPath, "utf8")).toBe(body);
+  });
+
+  test("accepts a SAME-type ref-shaped target (what makes cross-type rejection expressible)", async () => {
+    seedAsset(stashDir, "memories/solo.md", "A standalone note.\n");
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:solo", "memory:renamed-solo"]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as MvOutput;
+    expect(json.ok).toBe(true);
+    expect(json.to).toBe("memory:renamed-solo");
+    expect(fs.existsSync(path.join(stashDir, "memories/solo.md"))).toBe(false);
+    expect(fs.existsSync(path.join(stashDir, "memories/renamed-solo.md"))).toBe(true);
+  });
+});
+
+// ── inbound ref rewrite ──────────────────────────────────────────────────────
+
+describe("akm mv — inbound ref rewrite across the writable stash", () => {
+  test("rewrites body refs AND frontmatter ref-list keys; lint reports zero missing-ref afterwards", async () => {
+    seedAsset(stashDir, "knowledge/guides/old-guide.md", "# Guide\n\nThe canonical guide content.\n");
+    // Citer 1: two body occurrences (prose + inline code span).
+    const bodyCiter = seedAsset(
+      stashDir,
+      "knowledge/citing-doc.md",
+      "---\ndescription: Cites the guide twice\n---\n\nSee knowledge:guides/old-guide for details.\nRun `akm show knowledge:guides/old-guide` to read it.\n",
+    );
+    // Citer 2: frontmatter xrefs list only — the conventions' provenance channel.
+    const xrefCiter = seedAsset(
+      stashDir,
+      "memories/citer-note.md",
+      "---\ndescription: Derived from the guide\nxrefs:\n  - knowledge:guides/old-guide\n---\n\nDerived note body (no inline ref).\n",
+    );
+    // Citer 3: frontmatter refs list (the authoritative refs channel lint scans).
+    const refsCiter = seedAsset(
+      stashDir,
+      "knowledge/refs-citer.md",
+      "---\ndescription: Lists the guide in refs\nrefs:\n  - knowledge:guides/old-guide\n---\n\nRefs-list citer body.\n",
+    );
+
+    const { code, stdout } = await runCliCapture(["mv", "knowledge:guides/old-guide", "guides/renamed-guide"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+    expect(json.ok).toBe(true);
+    expect(json.to).toBe("knowledge:guides/renamed-guide");
+
+    // Body citer: BOTH occurrences rewritten.
+    const bodyAfter = fs.readFileSync(bodyCiter, "utf8");
+    expect(bodyAfter).toContain("See knowledge:guides/renamed-guide for details.");
+    expect(bodyAfter).toContain("`akm show knowledge:guides/renamed-guide`");
+    expect(bodyAfter).not.toContain("old-guide");
+
+    // Frontmatter xrefs citer: the list entry is rewritten, everything else
+    // (other keys, body, single frontmatter block) is preserved.
+    const xrefRaw = fs.readFileSync(xrefCiter, "utf8");
+    const xrefParsed = parseFrontmatter(xrefRaw);
+    expect(xrefParsed.data.xrefs).toEqual(["knowledge:guides/renamed-guide"]);
+    expect(xrefParsed.data.description).toBe("Derived from the guide");
+    expect(xrefParsed.content).toContain("Derived note body (no inline ref).");
+    expect(xrefRaw.match(/^---\s*$/gm)?.length).toBe(2);
+
+    // Frontmatter refs citer: ref-list keys beyond xrefs are rewritten too.
+    const refsParsed = parseFrontmatter(fs.readFileSync(refsCiter, "utf8"));
+    expect(refsParsed.data.refs).toEqual(["knowledge:guides/renamed-guide"]);
+
+    // Report: every rewritten citer appears with its occurrence count.
+    const findRewrote = (rel: string): RewroteItem | undefined => json.rewrote.find((r) => r.file.endsWith(rel));
+    expect(findRewrote("knowledge/citing-doc.md")?.count).toBe(2);
+    expect(findRewrote("memories/citer-note.md")?.count).toBe(1);
+    expect(findRewrote("knowledge/refs-citer.md")?.count).toBe(1);
+
+    // The convention's whole point: the rename dangles NOTHING. The old ref is
+    // gone from every md file, and lint's missing-ref check (SPEC-1, which
+    // covers body text, refs: and xrefs:) comes back clean.
+    for (const rel of allMarkdownFiles(stashDir)) {
+      expect(fs.readFileSync(path.join(stashDir, rel), "utf8")).not.toContain("knowledge:guides/old-guide");
+    }
+    const lint = akmLint({ dir: stashDir });
+    expect(lint.flagged.filter((i) => i.issue === "missing-ref")).toEqual([]);
+  });
+
+  test("rewrites occurrences inside fenced code blocks (stale examples must not survive)", async () => {
+    seedAsset(stashDir, "memories/projectA/fenced-target.md", "The target memory.\n");
+    const fencedCiter = seedAsset(
+      stashDir,
+      "knowledge/fenced.md",
+      "---\ndescription: Fenced example citer\n---\n\n# Usage\n\n```bash\nakm show memory:projectA/fenced-target\n```\n",
+    );
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:projectA/fenced-target", "projectA/fenced-target-v2"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+
+    const after = fs.readFileSync(fencedCiter, "utf8");
+    // The occurrence lives ONLY inside the fence: lint's missing-ref scan
+    // strips fences, but the rewriter must not.
+    expect(after).toContain("```bash\nakm show memory:projectA/fenced-target-v2\n```");
+    expect(after).not.toContain("memory:projectA/fenced-target\n```");
+    expect(json.rewrote.find((r) => r.file.endsWith("knowledge/fenced.md"))?.count).toBe(1);
+  });
+
+  test("boundary matching: a longer ref sharing the old ref as a prefix is NOT rewritten", async () => {
+    seedAsset(stashDir, "memories/projectA/base-note.md", "The note being renamed.\n");
+    seedAsset(stashDir, "memories/projectA/base-note-extra.md", "A neighbor whose ref extends the old one.\n");
+    const citer = seedAsset(
+      stashDir,
+      "knowledge/prefix-citer.md",
+      "---\ndescription: Cites both\nxrefs:\n  - memory:projectA/base-note-extra\n---\n\nPrimary: memory:projectA/base-note\nNeighbor: memory:projectA/base-note-extra\n",
+    );
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:projectA/base-note", "projectA/base-note-v2"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+
+    const after = fs.readFileSync(citer, "utf8");
+    // The exact old ref was rewritten...
+    expect(after).toContain("Primary: memory:projectA/base-note-v2");
+    // ...the prefix-sharing neighbor was NOT (body and frontmatter): complete-ref
+    // boundary matching, not substring replacement.
+    expect(after).toContain("Neighbor: memory:projectA/base-note-extra");
+    expect(parseFrontmatter(after).data.xrefs).toEqual(["memory:projectA/base-note-extra"]);
+    // No bare occurrence of the old ref remains (the two survivors continue
+    // with `-v2` / `-extra`, which the boundary regex excludes).
+    expect(after.match(/memory:projectA\/base-note(?![\w.-])/)).toBeNull();
+    // Exactly ONE occurrence was replaced in this file.
+    expect(json.rewrote.find((r) => r.file.endsWith("knowledge/prefix-citer.md"))?.count).toBe(1);
+  });
+});
+
+// ── read-only citers ─────────────────────────────────────────────────────────
+
+describe("akm mv — read-only citers are reported, never written", () => {
+  test("a citer in a read-only source stays byte-identical and lands in readOnlyCiters", async () => {
+    const roDir = makeDir("akm-mv-readonly");
+    const roCiter = seedAsset(
+      roDir,
+      "knowledge/shared-note.md",
+      "Shared doc citing memory:projectA/ro-note from the team stash.\n",
+    );
+    const roRaw = fs.readFileSync(roCiter, "utf8");
+    writeSandboxConfig({
+      semanticSearchMode: "off",
+      sources: [{ type: "filesystem", name: "shared", path: roDir, writable: false }],
+    });
+    seedAsset(stashDir, "memories/projectA/ro-note.md", "The note being renamed.\n");
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:projectA/ro-note", "projectA/ro-note-renamed"]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as MvOutput;
+    expect(json.ok).toBe(true);
+    // The read-only citing file is reported as a manual follow-up, with the
+    // {file, count} element shape (file is the citer's ABSOLUTE path — it
+    // lives outside the writable stash, so no stash-relative form exists)...
+    expect(json.readOnlyCiters).toEqual([{ file: roCiter, count: 1 }]);
+    // ...and is NOT in the rewrote list, NOT touched on disk.
+    expect(json.rewrote.some((r) => r.file.endsWith("shared-note.md"))).toBe(false);
+    expect(fs.readFileSync(roCiter, "utf8")).toBe(roRaw);
+  });
+});
+
+// ── memory .derived twin ─────────────────────────────────────────────────────
+
+describe("akm mv — memory .derived.md twin coupling", () => {
+  test("moves the .derived.md twin together on disk", async () => {
+    seedAsset(stashDir, "memories/projectA/twin-note.md", "Base memory body.\n");
+    seedAsset(stashDir, "memories/projectA/twin-note.derived.md", "Distilled twin body.\n");
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:projectA/twin-note", "projectA/twin-note-renamed"]);
+    expect(code).toBe(0);
+    expect((JSON.parse(stdout) as MvOutput).ok).toBe(true);
+
+    expect(fs.existsSync(path.join(stashDir, "memories/projectA/twin-note.md"))).toBe(false);
+    expect(fs.existsSync(path.join(stashDir, "memories/projectA/twin-note.derived.md"))).toBe(false);
+    expect(fs.readFileSync(path.join(stashDir, "memories/projectA/twin-note-renamed.md"), "utf8")).toBe(
+      "Base memory body.\n",
+    );
+    expect(fs.readFileSync(path.join(stashDir, "memories/projectA/twin-note-renamed.derived.md"), "utf8")).toBe(
+      "Distilled twin body.\n",
+    );
+  });
+
+  test("an explicit .derived twin ref cannot be moved alone (exit 2, both files intact)", async () => {
+    const basePath = seedAsset(stashDir, "memories/coupled.md", "Base memory body.\n");
+    const twinPath = seedAsset(stashDir, "memories/coupled.derived.md", "Distilled twin body.\n");
+
+    const { code, stderr } = await runCliCapture(["mv", "memory:coupled.derived", "orphan-twin"]);
+    expect(code).toBe(2);
+
+    const json = JSON.parse(stderr) as ErrorEnvelope;
+    expect(json.ok).toBe(false);
+    // The error steers to renaming the base (the twin moves with it).
+    expect(json.error).toContain("memory:coupled");
+    expect(typeof json.code).toBe("string");
+    expect(fs.readFileSync(basePath, "utf8")).toBe("Base memory body.\n");
+    expect(fs.readFileSync(twinPath, "utf8")).toBe("Distilled twin body.\n");
+    expect(fs.existsSync(path.join(stashDir, "memories/orphan-twin.md"))).toBe(false);
+  });
+
+  test("a target name ending in .derived is rejected (reserved twin suffix; exit 2, nothing moved)", async () => {
+    const srcPath = seedAsset(stashDir, "memories/plain-note.md", "A base memory.\n");
+
+    const { code, stderr } = await runCliCapture(["mv", "memory:plain-note", "evil.derived"]);
+    expect(code).toBe(2);
+
+    const json = JSON.parse(stderr) as ErrorEnvelope;
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain(".derived");
+    expect(typeof json.code).toBe("string");
+    expect(fs.readFileSync(srcPath, "utf8")).toBe("A base memory.\n");
+    expect(fs.existsSync(path.join(stashDir, "memories/evil.derived.md"))).toBe(false);
+    expect(fs.existsSync(path.join(stashDir, "memories/evil.derived.derived.md"))).toBe(false);
+  });
+
+  test("re-keys base AND twin in place: both row ids survive and the entry_key suffix relation holds", async () => {
+    seedAsset(stashDir, "memories/projectA/twin-note.md", "Base memory body.\n");
+    seedAsset(stashDir, "memories/projectA/twin-note.derived.md", "Distilled twin body.\n");
+    await buildIndex();
+
+    let db = openExistingDatabase(getDbPath());
+    let baseId: number;
+    let twinId: number;
+    try {
+      const base = entryByKeySuffix(db, ":memory:projectA/twin-note");
+      const twin = entryByKeySuffix(db, ":memory:projectA/twin-note.derived");
+      expect(base).toBeDefined();
+      expect(twin).toBeDefined();
+      baseId = (base as { id: number }).id;
+      twinId = (twin as { id: number }).id;
+    } finally {
+      closeDatabase(db);
+    }
+
+    const { code } = await runCliCapture(["mv", "memory:projectA/twin-note", "projectA/twin-note-renamed"]);
+    expect(code).toBe(0);
+
+    db = openExistingDatabase(getDbPath());
+    try {
+      // Same row ids — the belief-inheritance coupling (twin entry_key ===
+      // base entry_key + ".derived", db.ts getBaseBeliefStatesForDerivedTwins)
+      // must survive the rename without minting new rows.
+      const baseAfter = entryById(db, baseId);
+      const twinAfter = entryById(db, twinId);
+      expect(baseAfter?.entry_key.endsWith(":memory:projectA/twin-note-renamed")).toBe(true);
+      expect(twinAfter?.entry_key).toBe(`${baseAfter?.entry_key}.derived`);
+      // The old keys are gone (re-key, not insert-alongside).
+      expect(entryByKeySuffix(db, ":memory:projectA/twin-note")).toBeUndefined();
+      expect(entryByKeySuffix(db, ":memory:projectA/twin-note.derived")).toBeUndefined();
+    } finally {
+      closeDatabase(db);
+    }
+  });
+});
+
+// ── utility-history preservation ─────────────────────────────────────────────
+
+describe("akm mv — utility history and index re-key", () => {
+  test("the entries row id and utility_scores row survive; search reflects the new name and reindexed citers", async () => {
+    seedAsset(stashDir, "memories/projectA/util-note.md", "A memory with earned ranking history.\n");
+    // A citer whose ONLY connection to the moved asset is its xrefs entry —
+    // findable via FTS hints only after the rewritten file is reindexed.
+    seedAsset(
+      stashDir,
+      "memories/citer-of-util.md",
+      "---\ndescription: Cites the util note\nxrefs:\n  - memory:projectA/util-note\n---\n\nDerived from the util note.\n",
+    );
+    await buildIndex();
+
+    // Accumulate utility history on the entry (the "learned ranking" a rename
+    // must not reset — the verified cost the conventions warn about).
+    let db = openExistingDatabase(getDbPath());
+    let entryId: number;
+    let utilityBefore: number;
+    try {
+      const row = entryByKeySuffix(db, ":memory:projectA/util-note");
+      expect(row).toBeDefined();
+      entryId = (row as { id: number }).id;
+      applyFeedbackToUtilityScore(db, entryId, 1, 0);
+      const score = getUtilityScore(db, entryId);
+      expect(score).toBeDefined();
+      utilityBefore = (score as { utility: number }).utility;
+    } finally {
+      closeDatabase(db);
+    }
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:projectA/util-note", "projectA/util-note-renamed"]);
+    expect(code).toBe(0);
+    const mvJson = JSON.parse(stdout) as MvOutput;
+    expect(mvJson.ok).toBe(true);
+    // The command CLAIMS the history survived — pinned here against the DB
+    // assertions below that prove it actually did.
+    expect(mvJson.utilityPreserved).toBe(true);
+
+    db = openExistingDatabase(getDbPath());
+    try {
+      // Re-keyed IN PLACE: same row id, new entry_key + file_path.
+      const after = entryById(db, entryId);
+      expect(after).toBeDefined();
+      expect(after?.entry_key).toBe(`${stashDir}:memory:projectA/util-note-renamed`);
+      expect(after?.file_path.endsWith(path.join("memories", "projectA", "util-note-renamed.md"))).toBe(true);
+      // No row remains under the old key (no orphan duplicate was minted).
+      expect(
+        db.prepare("SELECT id FROM entries WHERE entry_key = ?").get(`${stashDir}:memory:projectA/util-note`),
+      ).toBeNull();
+      // The utility row keyed by entry_id survived with its accumulated value.
+      const scoreAfter = getUtilityScore(db, entryId);
+      expect(scoreAfter).toBeDefined();
+      expect(scoreAfter?.utility).toBeCloseTo(utilityBefore, 10);
+    } finally {
+      closeDatabase(db);
+    }
+
+    // Search is immediately consistent: the token unique to the NEW name finds
+    // the moved asset (moved row's FTS text refreshed) AND the citer (its
+    // rewritten xref folded into hints via write-path reindexing).
+    const search = await runCliCapture(["search", "renamed", "--type", "memory"]);
+    expect(search.code).toBe(0);
+    const refs = ((JSON.parse(search.stdout).hits ?? []) as Array<{ ref: string }>).map((h) => h.ref);
+    expect(refs).toContain("memory:projectA/util-note-renamed");
+    expect(refs).toContain("memory:citer-of-util");
+    expect(refs).not.toContain("memory:projectA/util-note");
+  });
+});
+
+// ── utilityPreserved honesty ─────────────────────────────────────────────────
+
+describe("akm mv — the utilityPreserved flag is honest", () => {
+  test("an existing index with an UNINDEXED source file: mv succeeds fail-open, utilityPreserved stays true, no ghost row", async () => {
+    seedAsset(stashDir, "memories/indexed-note.md", "Indexed before the newcomer.\n");
+    await buildIndex();
+    // Created AFTER the index build — no entries row exists for it.
+    seedAsset(stashDir, "memories/late-note.md", "Not yet indexed.\n");
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:late-note", "late-note-renamed"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+    expect(json.ok).toBe(true);
+    // Nothing was indexed under the old name, so nothing was lost: true.
+    expect(json.utilityPreserved).toBe(true);
+    expect(fs.existsSync(path.join(stashDir, "memories/late-note-renamed.md"))).toBe(true);
+
+    const db = openExistingDatabase(getDbPath());
+    try {
+      // No stale row under the old key (there never was one).
+      expect(entryByKeySuffix(db, ":memory:late-note")).toBeUndefined();
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("the file's row sits under an UNEXPECTED entry_key: the move succeeds but utilityPreserved reports false", async () => {
+    seedAsset(stashDir, "memories/stranded-note.md", "History under a weird key.\n");
+    await buildIndex();
+    // Simulate a row indexed under a differently-normalized key (e.g. a
+    // symlinked stash path at index time): the re-key by the canonical old
+    // key finds nothing, but the file WAS indexed — history is stranded.
+    let db = openExistingDatabase(getDbPath());
+    try {
+      db.prepare("UPDATE entries SET entry_key = ? WHERE entry_key = ?").run(
+        `/somewhere/else:memory:stranded-note`,
+        `${stashDir}:memory:stranded-note`,
+      );
+    } finally {
+      closeDatabase(db);
+    }
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:stranded-note", "stranded-note-renamed"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+    expect(json.ok).toBe(true);
+    expect(fs.existsSync(path.join(stashDir, "memories/stranded-note-renamed.md"))).toBe(true);
+    // The command must not claim it preserved history it never re-keyed.
+    expect(json.utilityPreserved).toBe(false);
+
+    // The ghost row is still there under the odd key — disclosed, not hidden.
+    db = openExistingDatabase(getDbPath());
+    try {
+      expect(entryByKeySuffix(db, "/somewhere/else:memory:stranded-note")?.entry_key).toBe(
+        "/somewhere/else:memory:stranded-note",
+      );
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("an unreadable index.db: the move still succeeds but utilityPreserved reports false", async () => {
+    seedAsset(stashDir, "memories/blocked-note.md", "History fate unknown.\n");
+    const dbPath = getDbPath();
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    fs.writeFileSync(dbPath, "definitely not a sqlite database", "utf8");
+
+    const { code, stdout } = await runCliCapture(["mv", "memory:blocked-note", "blocked-note-renamed"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as MvOutput;
+    // Fail-open: the rename itself lands...
+    expect(json.ok).toBe(true);
+    expect(fs.existsSync(path.join(stashDir, "memories/blocked-note-renamed.md"))).toBe(true);
+    // ...but the command must NOT claim it verified a re-key it could not run.
+    expect(json.utilityPreserved).toBe(false);
+  });
+});
+
+// ── canonical spelling ───────────────────────────────────────────────────────
+
+describe("akm mv — non-canonical source spellings are rejected (exit 2, nothing moved)", () => {
+  test("a knowledge-subdir alias is rejected naming the canonical ref; canonical citers stay intact", async () => {
+    // `knowledge:alias-guide` resolves for LINT via the knowledge-subdir
+    // fallback, but the canonical ref is knowledge:guides/alias-guide. A move
+    // keyed to the alias would rewrite only alias-spelling citers, strand the
+    // index row (its entry_key derives from the canonical spelling), and
+    // dangle every canonical citer — so mv must refuse it.
+    const guidePath = seedAsset(stashDir, "knowledge/guides/alias-guide.md", "# Aliased guide\n");
+    const citer = seedAsset(
+      stashDir,
+      "memories/canonical-citer.md",
+      "Cites knowledge:guides/alias-guide canonically.\n",
+    );
+    const citerRaw = fs.readFileSync(citer, "utf8");
+
+    const { code, stderr } = await runCliCapture(["mv", "knowledge:alias-guide", "guides/alias-renamed"]);
+    expect(code).toBe(2);
+
+    const json = JSON.parse(stderr) as ErrorEnvelope;
+    expect(json.ok).toBe(false);
+    // The error steers to the canonical spelling.
+    expect(json.error).toContain("knowledge:guides/alias-guide");
+    expect(typeof json.code).toBe("string");
+    // Nothing moved, nothing rewritten.
+    expect(fs.existsSync(guidePath)).toBe(true);
+    expect(fs.existsSync(path.join(stashDir, "knowledge/guides/alias-renamed.md"))).toBe(false);
+    expect(fs.readFileSync(citer, "utf8")).toBe(citerRaw);
+  });
+
+  test("a direct-path fallback (file outside the type root) is rejected instead of relocated", async () => {
+    // `knowledge:prompts/stray` resolves for LINT via the direct-path
+    // fallback to <stash>/prompts/stray.md — a file NOT under knowledge/.
+    // A move would RELOCATE it into knowledge/, so mv must refuse.
+    const strayPath = seedAsset(stashDir, "prompts/stray.md", "Lives outside the knowledge/ type root.\n");
+
+    const { code, stderr } = await runCliCapture(["mv", "knowledge:prompts/stray", "prompts/stray-renamed"]);
+    expect(code).toBe(2);
+
+    const json = JSON.parse(stderr) as ErrorEnvelope;
+    expect(json.ok).toBe(false);
+    expect(json.error.toLowerCase()).toContain("type root");
+    expect(typeof json.code).toBe("string");
+    expect(fs.existsSync(strayPath)).toBe(true);
+    expect(fs.existsSync(path.join(stashDir, "knowledge/prompts/stray-renamed.md"))).toBe(false);
+  });
+});
+
+// ── rejections ───────────────────────────────────────────────────────────────
+
+describe("akm mv — rejections (error envelope + exit codes)", () => {
+  test("wiki refs are rejected with exit 2 (wiki has its own xref+lint system)", async () => {
+    const wikiPath = seedAsset(stashDir, "wikis/main.md", "# Wiki root page\n");
+
+    const { code, stderr } = await runCliCapture(["mv", "wiki:main", "main-renamed"]);
+    expect(code).toBe(2);
+
+    const json = JSON.parse(stderr) as ErrorEnvelope;
+    expect(json.ok).toBe(false);
+    expect(json.error.toLowerCase()).toContain("wiki");
+    expect(typeof json.code).toBe("string");
+    expect(fs.existsSync(wikiPath)).toBe(true);
+  });
+
+  test("cross-type targets are rejected with exit 2 and nothing moves", async () => {
+    const srcPath = seedAsset(stashDir, "memories/cross-note.md", "A memory that must stay a memory.\n");
+
+    const { code, stderr } = await runCliCapture(["mv", "memory:cross-note", "knowledge:cross-note"]);
+    expect(code).toBe(2);
+
+    const json = JSON.parse(stderr) as ErrorEnvelope;
+    expect(json.ok).toBe(false);
+    expect(json.error.toLowerCase()).toContain("type");
+    expect(typeof json.code).toBe("string");
+    expect(fs.existsSync(srcPath)).toBe(true);
+    expect(fs.existsSync(path.join(stashDir, "knowledge/cross-note.md"))).toBe(false);
+  });
+
+  test("an existing target is rejected with exit 2; neither file changes and no citer is rewritten", async () => {
+    const srcPath = seedAsset(stashDir, "memories/projectA/src-note.md", "Source body.\n");
+    const takenPath = seedAsset(stashDir, "memories/projectA/taken.md", "Pre-existing target body.\n");
+    const citer = seedAsset(stashDir, "knowledge/exists-citer.md", "Cites memory:projectA/src-note here.\n");
+    const citerRaw = fs.readFileSync(citer, "utf8");
+
+    const { code, stderr } = await runCliCapture(["mv", "memory:projectA/src-note", "projectA/taken"]);
+    expect(code).toBe(2);
+
+    const json = JSON.parse(stderr) as ErrorEnvelope;
+    expect(json.ok).toBe(false);
+    expect(json.error.toLowerCase()).toContain("exist");
+    expect(typeof json.code).toBe("string");
+
+    // Nothing moved, nothing clobbered, nothing rewritten.
+    expect(fs.readFileSync(srcPath, "utf8")).toBe("Source body.\n");
+    expect(fs.readFileSync(takenPath, "utf8")).toBe("Pre-existing target body.\n");
+    expect(fs.readFileSync(citer, "utf8")).toBe(citerRaw);
+  });
+
+  test("an unresolvable source ref is rejected with exit 2 naming the ref", async () => {
+    const { code, stderr } = await runCliCapture(["mv", "memory:projectA/ghost", "projectA/anything"]);
+    expect(code).toBe(2);
+
+    const json = JSON.parse(stderr) as ErrorEnvelope;
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain("memory:projectA/ghost");
+    expect(typeof json.code).toBe("string");
+    expect(fs.existsSync(path.join(stashDir, "memories/projectA/anything.md"))).toBe(false);
+  });
+
+  test("a target escaping the type root (../) is rejected with exit 2 and writes nothing outside it", async () => {
+    const srcPath = seedAsset(stashDir, "memories/esc-note.md", "Must stay inside memories/.\n");
+
+    const { code, stderr } = await runCliCapture(["mv", "memory:esc-note", "../../evil"]);
+    expect(code).toBe(2);
+
+    const json = JSON.parse(stderr) as ErrorEnvelope;
+    expect(json.ok).toBe(false);
+    expect(typeof json.code).toBe("string");
+    expect(fs.readFileSync(srcPath, "utf8")).toBe("Must stay inside memories/.\n");
+    expect(fs.existsSync(path.join(stashDir, "evil.md"))).toBe(false);
+    expect(fs.existsSync(path.join(storage.root, "evil.md"))).toBe(false);
+  });
+
+  test("a missing target argument fails without moving anything (NOTE: passes trivially pre-implementation)", async () => {
+    const srcPath = seedAsset(stashDir, "memories/lonely-note.md", "Untouched.\n");
+
+    const { code } = await runCliCapture(["mv", "memory:lonely-note"]);
+    expect(code).not.toBe(0);
+    expect(fs.readFileSync(srcPath, "utf8")).toBe("Untouched.\n");
+  });
+});
+
+// ── events ───────────────────────────────────────────────────────────────────
+
+describe("akm mv — events stream", () => {
+  test("a successful mv appends exactly one 'mv' event carrying both refs; a failed mv appends none", async () => {
+    seedAsset(stashDir, "memories/ev-note.md", "Event-stream probe note.\n");
+
+    const ok = await runCliCapture(["mv", "memory:ev-note", "ev-note-renamed"]);
+    expect(ok.code).toBe(0);
+
+    const after = readEvents({ type: "mv" });
+    expect(after.events).toHaveLength(1);
+    const envelope = JSON.stringify(after.events[0]);
+    expect(envelope).toContain("memory:ev-note");
+    expect(envelope).toContain("memory:ev-note-renamed");
+
+    // A failed mv (unresolvable source) records no mutation event.
+    const bad = await runCliCapture(["mv", "memory:ghost", "ghost-renamed"]);
+    expect(bad.code).toBe(2);
+    expect(readEvents({ type: "mv" }).events).toHaveLength(1);
+  });
+});
+
+// ── command registration + help meta ─────────────────────────────────────────
+
+describe("akm mv — command registration and help meta", () => {
+  // Dynamic import through a string-typed specifier so the not-yet-existing
+  // module fails THESE tests at runtime (clear red) without breaking the whole
+  // file's module graph or `tsc --noEmit` for unrelated stages.
+  const MV_CLI_MODULE: string = "../../src/commands/mv-cli";
+
+  test("src/commands/mv-cli.ts exports mvCommand with a described meta", async () => {
+    const mod = (await import(MV_CLI_MODULE)) as Record<string, unknown>;
+    expect(mod.mvCommand).toBeDefined();
+    const meta = (mod.mvCommand as { meta?: { name?: string; description?: string } }).meta;
+    const resolvedMeta = typeof meta === "function" ? await (meta as () => unknown)() : meta;
+    expect((resolvedMeta as { name?: string })?.name).toBe("mv");
+    expect(((resolvedMeta as { description?: string })?.description ?? "").length).toBeGreaterThan(0);
+  });
+
+  test("mv is registered as a top-level CLI verb", async () => {
+    const { main } = await import("../../src/cli");
+    const subCommands = (main as { subCommands?: Record<string, unknown> }).subCommands ?? {};
+    expect(Object.keys(subCommands)).toContain("mv");
+  });
+});

--- a/tests/commands/remember-import-supersedes.test.ts
+++ b/tests/commands/remember-import-supersedes.test.ts
@@ -755,6 +755,47 @@ describe("writeSupersededEdge — sibling of writeContradictEdge in memory-belie
     expect(parsed.data.beliefState).toBe("contradicted");
   });
 
+  test("writeContradictEdge repairs a MISSING demotion: edge already present but no beliefState (R2-4)", () => {
+    // Regression from the #14 scalar promotion: the guard fired on
+    // `existing.includes(ref)` ALONE, so a file carrying the edge without the
+    // demotion (hand-written scalar, beliefState lost to a partial edit) was
+    // a permanent no-op — while consolidate's handleContradictOp counted the
+    // op as applied. The guard must be state-aware like writeSupersededEdge.
+    const dir = makeDir("akm-contradict-edge");
+    const filePath = path.join(dir, "old.md");
+    fs.writeFileSync(filePath, ["---", "contradictedBy: memory:disputer", "---", "", "Body.", ""].join("\n"), "utf8");
+
+    writeContradictEdge(filePath, "memory:disputer");
+
+    const parsed = parseFrontmatter(fs.readFileSync(filePath, "utf8"));
+    expect(parsed.data.beliefState).toBe("contradicted");
+    expect(parsed.data.contradictedBy).toEqual(["memory:disputer"]);
+
+    // Idempotent once repaired: a repeat call leaves the file byte-identical.
+    const afterFirst = fs.readFileSync(filePath, "utf8");
+    writeContradictEdge(filePath, "memory:disputer");
+    expect(fs.readFileSync(filePath, "utf8")).toBe(afterFirst);
+  });
+
+  test("writeContradictEdge never weakens archived: the edge appends, beliefState stays archived (R2-4)", () => {
+    // Severity parity with writeSupersededEdge: archived (0.15) ranks BELOW
+    // contradicted (0.2) — overwriting it would RAISE the incumbent's rank.
+    const dir = makeDir("akm-contradict-edge");
+    const filePath = path.join(dir, "old.md");
+    fs.writeFileSync(filePath, ["---", "beliefState: archived", "---", "", "Body.", ""].join("\n"), "utf8");
+
+    writeContradictEdge(filePath, "memory:new-dispute");
+
+    const parsed = parseFrontmatter(fs.readFileSync(filePath, "utf8"));
+    expect(parsed.data.beliefState).toBe("archived");
+    expect(parsed.data.contradictedBy).toEqual(["memory:new-dispute"]);
+
+    // Idempotent under the kept state too.
+    const afterFirst = fs.readFileSync(filePath, "utf8");
+    writeContradictEdge(filePath, "memory:new-dispute");
+    expect(fs.readFileSync(filePath, "utf8")).toBe(afterFirst);
+  });
+
   test("never weakens a stronger demotion: contradicted/archived keep their state, edge still appends", async () => {
     // Severity order (BELIEF_STATE_SCORE_CEILINGS, ranking-contributors.ts):
     // superseded 0.25 > contradicted 0.2 > archived 0.15 — overwriting

--- a/tests/commands/remember-import-supersedes.test.ts
+++ b/tests/commands/remember-import-supersedes.test.ts
@@ -616,6 +616,40 @@ describe("import --supersedes", () => {
 // AND the demoted old asset) needs real git fixtures, so it lives in
 // tests/integration/supersedes-git-target.test.ts per the isolation lint.
 
+// ── canonical persistence of alias spellings ─────────────────────────────────
+
+describe("--supersedes alias spellings are persisted canonically", () => {
+  test("a local//-prefixed ref is planned, reported, and folded into xrefs as the canonical bare ref", async () => {
+    // Validation resolves the PARSED components; persisting the raw spelling
+    // would put a `local//`-prefixed string into the report and the
+    // correction's xrefs while the demotion targeted the canonical asset.
+    const old = await rememberSeed("The legacy endpoint note.", "old-endpoint-alias");
+
+    const { code, stdout } = await runCliCapture([
+      "remember",
+      "The corrected endpoint note.",
+      "--name",
+      "new-endpoint-alias",
+      "--supersedes",
+      "local//memory:old-endpoint-alias",
+    ]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as WriteOutput;
+    expect(json.ref).toBe("memory:new-endpoint-alias");
+    expect(json.superseded).toEqual([{ ref: "memory:old-endpoint-alias", applied: true }]);
+
+    // Provenance xref on the correction: canonical bare form.
+    const newParsed = parseFrontmatter(fs.readFileSync(json.path, "utf8"));
+    expect(newParsed.data.xrefs).toEqual(["memory:old-endpoint-alias"]);
+
+    // The demotion landed on the old asset with the canonical NEW ref
+    // (writeSupersededEdge receives the write result's canonical ref).
+    const oldParsed = parseFrontmatter(fs.readFileSync(old.path, "utf8"));
+    expect(oldParsed.data.beliefState).toBe("superseded");
+    expect(oldParsed.data.supersededBy).toEqual(["memory:new-endpoint-alias"]);
+  });
+});
+
 // ── writeSupersededEdge (unit) ───────────────────────────────────────────────
 
 describe("writeSupersededEdge — sibling of writeContradictEdge in memory-belief", () => {

--- a/tests/commands/remember-import-supersedes.test.ts
+++ b/tests/commands/remember-import-supersedes.test.ts
@@ -1,0 +1,614 @@
+/**
+ * SPEC-5 (stash-conventions-code-spec.md): `--supersedes <ref>` on
+ * `akm remember` and `akm import` — atomic correction + demotion of the
+ * superseded asset.
+ *
+ * Pins the two-write corrections pattern the conventions mandate:
+ *   - `--supersedes <ref>` writes the NEW correction asset with the old ref
+ *     folded into its frontmatter `xrefs:` list (correction provenance), AND
+ *     mutates the OLD asset's frontmatter to `beliefState: superseded` +
+ *     `supersededBy: [<new ref>]` — a metadata edit only: every other
+ *     frontmatter key and the body are preserved byte-for-byte.
+ *   - The demotion is immediately live: the mutated old asset is reindexed,
+ *     so `--belief current` hides it and the beliefStateBoost (-0.25) ranks
+ *     the correction above the stale incumbent.
+ *   - Re-running the correction is idempotent (no duplicated supersededBy
+ *     entry); `writeSupersededEdge` sorted-set-appends across corrections.
+ *   - An unresolvable ref is INPUT VALIDATION: UsageError → exit 2 with the
+ *     standard `{ok:false,error,code}` envelope, and NOTHING is written or
+ *     demoted (no partial correction).
+ *   - An old asset that resolves only in a READ-ONLY source is not mutated:
+ *     the new asset is still written, stderr warns, and the JSON output
+ *     reports `superseded: [{ref, applied: false, reason}]`.
+ *   - Git write targets batch BOTH files (new correction + demoted old) into
+ *     the single boundary commit — pinned in
+ *     tests/integration/supersedes-git-target.test.ts (real git fixture).
+ *   - The flag is declared in each command's help meta (citty args def →
+ *     rendered usage).
+ *   - New helper `writeSupersededEdge(filePath, supersededByRef)` lives as a
+ *     sibling of `writeContradictEdge` in
+ *     src/commands/improve/memory/memory-belief.ts (loaded via dynamic import
+ *     below so its absence fails only the unit tests, not the module graph).
+ *
+ * Uses the in-process CLI harness (tests/_helpers/cli.ts) with the sandboxed
+ * stash/config helpers, following tests/commands/remember-import-xref.test.ts
+ * (the SPEC-3 surface this extends).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { renderUsage } from "citty";
+import { rememberCommand } from "../../src/commands/read/remember-cli";
+import { importKnowledgeCommand } from "../../src/commands/sources/stash-cli";
+import { parseFrontmatter } from "../../src/core/asset/frontmatter";
+import { runCliCapture } from "../_helpers/cli";
+import {
+  type Cleanup,
+  makeSandboxDir,
+  type SandboxedDir,
+  sandboxStashDir,
+  writeSandboxConfig,
+} from "../_helpers/sandbox";
+
+const disposers: SandboxedDir[] = [];
+let stashCleanup: Cleanup = () => {};
+let stashDir = "";
+
+beforeEach(() => {
+  const stash = sandboxStashDir();
+  stashDir = stash.dir;
+  stashCleanup = stash.cleanup;
+  writeSandboxConfig({ semanticSearchMode: "off" });
+});
+
+afterEach(() => {
+  stashCleanup();
+  stashCleanup = () => {};
+  stashDir = "";
+  for (const d of disposers.splice(0)) d.cleanup();
+});
+
+/** Create an isolated dir (auto-cleaned) for import sources / extra stashes. */
+function makeDir(prefix: string): string {
+  const d = makeSandboxDir(prefix);
+  disposers.push(d);
+  return d.dir;
+}
+
+/** Seed an asset file under a stash root (e.g. "memories/old-note.md"). */
+function seedAsset(root: string, relPath: string, content: string): string {
+  const abs = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, "utf8");
+  return abs;
+}
+
+/** Write an import-source markdown file into a fresh sandbox dir. */
+function makeSourceFile(name: string, body: string): string {
+  const dir = makeDir("akm-supersedes-import-src");
+  const filePath = path.join(dir, name);
+  fs.writeFileSync(filePath, body, "utf8");
+  return filePath;
+}
+
+function listDirRecursive(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { recursive: true }).map(String);
+}
+
+interface SupersededReport {
+  ref: string;
+  applied: boolean;
+  reason?: string;
+}
+
+interface WriteOutput {
+  ok: boolean;
+  ref: string;
+  path: string;
+  superseded?: SupersededReport[];
+}
+
+/** Seed a memory through the real CLI so it carries the generated hot-path frontmatter. */
+async function rememberSeed(content: string, name: string, subPath?: string): Promise<WriteOutput> {
+  const args = ["remember", content, "--name", name];
+  if (subPath) args.push("--path", subPath);
+  const { code, stdout } = await runCliCapture(args);
+  expect(code).toBe(0);
+  return JSON.parse(stdout) as WriteOutput;
+}
+
+// ── remember --supersedes ────────────────────────────────────────────────────
+
+describe("remember --supersedes", () => {
+  test("writes the correction with an xref to the old ref AND demotes the old asset (metadata-only edit)", async () => {
+    const old = await rememberSeed(
+      "The staging deploy requires the legacy quantum-rotation VPN endpoint.",
+      "old-endpoint",
+      "projectA",
+    );
+    expect(old.ref).toBe("memory:projectA/old-endpoint");
+    const oldRawBefore = fs.readFileSync(old.path, "utf8");
+    const oldParsedBefore = parseFrontmatter(oldRawBefore);
+    // The hot-path seed carries beliefState: asserted — the demotion must
+    // overwrite it, not merely fill an absent key.
+    expect(oldParsedBefore.data.beliefState).toBe("asserted");
+
+    const { code, stdout } = await runCliCapture([
+      "remember",
+      "The staging deploy now uses the new quantum-rotation gateway endpoint.",
+      "--name",
+      "new-endpoint",
+      "--path",
+      "projectA",
+      "--supersedes",
+      "memory:projectA/old-endpoint",
+    ]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as WriteOutput;
+    expect(json.ok).toBe(true);
+    expect(json.ref).toBe("memory:projectA/new-endpoint");
+
+    // Additive output key: the demotion is reported as applied.
+    expect(Array.isArray(json.superseded)).toBe(true);
+    expect(json.superseded).toHaveLength(1);
+    expect(json.superseded?.[0]?.ref).toBe("memory:projectA/old-endpoint");
+    expect(json.superseded?.[0]?.applied).toBe(true);
+
+    // Correction provenance: the superseded ref folds into the NEW asset's
+    // xrefs automatically (no --xref flag was passed).
+    const newParsed = parseFrontmatter(fs.readFileSync(json.path, "utf8"));
+    expect(newParsed.data.xrefs).toContain("memory:projectA/old-endpoint");
+
+    // The OLD asset gains exactly the two demotion keys...
+    const oldParsedAfter = parseFrontmatter(fs.readFileSync(old.path, "utf8"));
+    expect(oldParsedAfter.data.beliefState).toBe("superseded");
+    expect(oldParsedAfter.data.supersededBy).toEqual(["memory:projectA/new-endpoint"]);
+    // ...while every other frontmatter key survives (metadata edit, not a rewrite)...
+    expect(oldParsedAfter.data.captureMode).toBe("hot");
+    // ...and the body is untouched.
+    expect(oldParsedAfter.content).toBe(oldParsedBefore.content);
+  });
+
+  test("demotion is live: --belief current hides the old asset and the correction outranks it", async () => {
+    // The shared token lives in the asset NAMES (body prose is not
+    // FTS-indexed), so both memories are findable by the same query.
+    await rememberSeed("Deploy to staging through the legacy endpoint.", "quantum-rotation-old-endpoint");
+
+    const { code, stdout } = await runCliCapture([
+      "remember",
+      "Deploy to staging through the new gateway.",
+      "--name",
+      "quantum-rotation-new-endpoint",
+      "--supersedes",
+      "memory:quantum-rotation-old-endpoint",
+    ]);
+    expect(code).toBe(0);
+    const newRef = (JSON.parse(stdout) as WriteOutput).ref;
+    expect(newRef).toBe("memory:quantum-rotation-new-endpoint");
+
+    // The demoted incumbent must drop out of `--belief current` immediately —
+    // this only holds if the mutated old file was reindexed by the writer.
+    const current = await runCliCapture(["search", "quantum rotation", "--type", "memory", "--belief", "current"]);
+    expect(current.code).toBe(0);
+    const currentRefs = ((JSON.parse(current.stdout).hits ?? []) as Array<{ ref: string }>).map((h) => h.ref);
+    expect(currentRefs).toContain(newRef);
+    expect(currentRefs).not.toContain("memory:quantum-rotation-old-endpoint");
+
+    // Unfiltered search still returns both, with the correction ranked above
+    // the superseded incumbent (beliefStateBoost demotion, -0.25).
+    const all = await runCliCapture(["search", "quantum rotation", "--type", "memory"]);
+    expect(all.code).toBe(0);
+    const allRefs = ((JSON.parse(all.stdout).hits ?? []) as Array<{ ref: string }>).map((h) => h.ref);
+    expect(allRefs).toContain(newRef);
+    expect(allRefs).toContain("memory:quantum-rotation-old-endpoint");
+    expect(allRefs.indexOf(newRef)).toBeLessThan(allRefs.indexOf("memory:quantum-rotation-old-endpoint"));
+  });
+
+  test("re-running the correction is idempotent: supersededBy is not duplicated", async () => {
+    const old = await rememberSeed("Old rotation cadence: every 90 days.", "rotation-cadence-old");
+
+    const first = await runCliCapture([
+      "remember",
+      "New rotation cadence: every 30 days.",
+      "--name",
+      "rotation-cadence-new",
+      "--supersedes",
+      "memory:rotation-cadence-old",
+    ]);
+    expect(first.code).toBe(0);
+
+    const second = await runCliCapture([
+      "remember",
+      "New rotation cadence: every 30 days.",
+      "--name",
+      "rotation-cadence-new",
+      "--force",
+      "--supersedes",
+      "memory:rotation-cadence-old",
+    ]);
+    expect(second.code).toBe(0);
+
+    const oldParsed = parseFrontmatter(fs.readFileSync(old.path, "utf8"));
+    expect(oldParsed.data.beliefState).toBe("superseded");
+    expect(oldParsed.data.supersededBy).toEqual(["memory:rotation-cadence-new"]);
+  });
+
+  test("unresolvable --supersedes fails with exit 2 usage envelope; nothing written, nothing demoted", async () => {
+    const goodOldPath = seedAsset(stashDir, "memories/good-old.md", "A resolvable incumbent memory.\n");
+    const goodOldRaw = fs.readFileSync(goodOldPath, "utf8");
+
+    const { code, stderr } = await runCliCapture([
+      "remember",
+      "This correction must not be written",
+      "--supersedes",
+      "memory:good-old",
+      "--supersedes",
+      "memory:ghost-note",
+    ]);
+    expect(code).toBe(2);
+
+    const json = JSON.parse(stderr) as { ok: boolean; error: string; code?: string };
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain("memory:ghost-note");
+    expect(typeof json.code).toBe("string");
+
+    // Validation happens BEFORE any write: no new asset landed AND the
+    // resolvable target was not partially demoted.
+    expect(listDirRecursive(path.join(stashDir, "memories"))).toEqual(["good-old.md"]);
+    expect(fs.readFileSync(goodOldPath, "utf8")).toBe(goodOldRaw);
+  });
+
+  test("--supersedes composes with --xref (deduped) and adds a frontmatter block to a frontmatter-less old asset", async () => {
+    seedAsset(stashDir, "knowledge/auth-flow.md", "# Auth flow\n\nReference doc.\n");
+    const oldPath = seedAsset(stashDir, "memories/vpn-note.md", "VPN is required for staging.\n");
+
+    const { code, stdout } = await runCliCapture([
+      "remember",
+      "Staging no longer needs the VPN after the gateway migration.",
+      "--name",
+      "vpn-note-correction",
+      "--xref",
+      "knowledge:auth-flow",
+      "--supersedes",
+      "memory:vpn-note",
+    ]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as WriteOutput;
+    const newParsed = parseFrontmatter(fs.readFileSync(json.path, "utf8"));
+    const xrefs = (newParsed.data.xrefs ?? []) as string[];
+    expect(xrefs).toContain("knowledge:auth-flow");
+    expect(xrefs).toContain("memory:vpn-note");
+    // No duplicates when a ref arrives through both channels or repeats.
+    expect(xrefs.filter((r) => r === "memory:vpn-note")).toHaveLength(1);
+
+    // A frontmatter-less old asset gains a metadata block; the body text is
+    // preserved (assembleAsset only strips leading blank lines).
+    const oldRaw = fs.readFileSync(oldPath, "utf8");
+    expect(oldRaw.startsWith("---")).toBe(true);
+    const oldParsed = parseFrontmatter(oldRaw);
+    expect(oldParsed.data.beliefState).toBe("superseded");
+    expect(oldParsed.data.supersededBy).toEqual([json.ref]);
+    expect(oldParsed.content.replace(/^\n+/, "")).toBe("VPN is required for staging.\n");
+  });
+
+  test("self-supersede (--force overwrite of the same name) is rejected with exit 2; the original asset is untouched", async () => {
+    const orig = await rememberSeed("The flux capacitor needs the legacy calibration.", "flux-note");
+    expect(orig.ref).toBe("memory:flux-note");
+    const origRaw = fs.readFileSync(orig.path, "utf8");
+
+    const { code, stderr } = await runCliCapture([
+      "remember",
+      "The flux capacitor calibration was corrected.",
+      "--name",
+      "flux-note",
+      "--force",
+      "--supersedes",
+      "memory:flux-note",
+    ]);
+    expect(code).toBe(2);
+
+    const json = JSON.parse(stderr) as { ok: boolean; error: string; code?: string };
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain("memory:flux-note");
+    expect(json.error).toContain("cannot supersede itself");
+    expect(json.code).toBe("INVALID_FLAG_VALUE");
+
+    // Rejected BEFORE any write: the incumbent keeps its original bytes — no
+    // overwrite, no self-demotion, no self-xref.
+    expect(fs.readFileSync(orig.path, "utf8")).toBe(origRaw);
+    expect(listDirRecursive(path.join(stashDir, "memories"))).toEqual(["flux-note.md"]);
+  });
+
+  test("old asset with malformed frontmatter: demotion skipped (applied:false), file byte-identical, correction still written", async () => {
+    const oldPath = seedAsset(
+      stashDir,
+      "knowledge/broken-fm.md",
+      [
+        "---",
+        'description: "unterminated quote',
+        "tags:",
+        "  - auth",
+        "  - vpn",
+        "---",
+        "",
+        "Broken frontmatter, precious values.",
+        "",
+      ].join("\n"),
+    );
+    const oldRaw = fs.readFileSync(oldPath, "utf8");
+
+    const { code, stdout, stderr } = await runCliCapture([
+      "remember",
+      "The corrected guidance replacing the broken doc.",
+      "--name",
+      "fixed-guidance",
+      "--supersedes",
+      "knowledge:broken-fm",
+    ]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as WriteOutput;
+    expect(json.ok).toBe(true);
+    expect(json.superseded).toHaveLength(1);
+    expect(json.superseded?.[0]?.ref).toBe("knowledge:broken-fm");
+    expect(json.superseded?.[0]?.applied).toBe(false);
+    expect(json.superseded?.[0]?.reason ?? "").toContain("YAML");
+    expect(stderr).toContain("knowledge:broken-fm");
+
+    // No lossy rewrite: the lenient-parser fallback would have flattened the
+    // tags list to "" — the file must stay byte-identical instead.
+    expect(fs.readFileSync(oldPath, "utf8")).toBe(oldRaw);
+    // The correction still writes and cites the incumbent.
+    const newParsed = parseFrontmatter(fs.readFileSync(json.path, "utf8"));
+    expect(newParsed.data.xrefs).toContain("knowledge:broken-fm");
+  });
+
+  test("old asset in a WRITABLE non-target source: demotion skipped with a --target remedy (not misreported as read-only)", async () => {
+    const teamDir = makeDir("akm-supersedes-writable-team");
+    const oldPath = seedAsset(teamDir, "memories/team-note.md", "Team note from the shared writable stash.\n");
+    const oldRaw = fs.readFileSync(oldPath, "utf8");
+    writeSandboxConfig({
+      semanticSearchMode: "off",
+      sources: [{ type: "filesystem", name: "team", path: teamDir, writable: true }],
+    });
+
+    const { code, stdout } = await runCliCapture([
+      "remember",
+      "Corrected team note recorded in my own stash.",
+      "--name",
+      "team-note-fix",
+      "--supersedes",
+      "memory:team-note",
+    ]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as WriteOutput;
+    // Written to the PRIMARY stash; the incumbent lives in the writable
+    // non-target source and is NOT demoted (that would dirty a source outside
+    // its own boundary commit).
+    expect(json.path.startsWith(stashDir)).toBe(true);
+    expect(json.superseded).toHaveLength(1);
+    expect(json.superseded?.[0]?.applied).toBe(false);
+    const reason = json.superseded?.[0]?.reason ?? "";
+    // Eligibility is write-target-or-working-stash, not source writability:
+    // the reason must not misdiagnose the source as read-only, and must name
+    // the actual remedy.
+    expect(reason).not.toContain("read-only");
+    expect(reason).toContain("--target team");
+    expect(fs.readFileSync(oldPath, "utf8")).toBe(oldRaw);
+  });
+
+  test("old asset in a read-only source: correction still written, demotion reported applied:false, file untouched", async () => {
+    const extraDir = makeDir("akm-supersedes-readonly");
+    const oldPath = seedAsset(extraDir, "memories/stale-tip.md", "Stale tip from the shared stash.\n");
+    const oldRaw = fs.readFileSync(oldPath, "utf8");
+    writeSandboxConfig({
+      semanticSearchMode: "off",
+      sources: [{ type: "filesystem", name: "readonly-extra", path: extraDir, writable: false }],
+    });
+
+    const { code, stdout, stderr } = await runCliCapture([
+      "remember",
+      "Fresh tip replacing the shared stale one.",
+      "--name",
+      "fresh-tip",
+      "--supersedes",
+      "memory:stale-tip",
+    ]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as WriteOutput;
+    expect(json.ok).toBe(true);
+    // Written to the PRIMARY stash while citing the read-only incumbent.
+    expect(json.path.startsWith(stashDir)).toBe(true);
+    const newParsed = parseFrontmatter(fs.readFileSync(json.path, "utf8"));
+    expect(newParsed.data.xrefs).toContain("memory:stale-tip");
+
+    // The demotion could not be applied: reported, warned, and the read-only
+    // file stays byte-identical.
+    expect(json.superseded).toHaveLength(1);
+    expect(json.superseded?.[0]?.ref).toBe("memory:stale-tip");
+    expect(json.superseded?.[0]?.applied).toBe(false);
+    expect((json.superseded?.[0]?.reason ?? "").length).toBeGreaterThan(0);
+    expect(stderr).toContain("memory:stale-tip");
+    expect(fs.readFileSync(oldPath, "utf8")).toBe(oldRaw);
+  });
+});
+
+// ── import --supersedes ──────────────────────────────────────────────────────
+
+describe("import --supersedes", () => {
+  test("imported correction xrefs the old doc and demotes it, preserving its other frontmatter and body", async () => {
+    const oldPath = seedAsset(
+      stashDir,
+      "knowledge/legacy-guide.md",
+      [
+        "---",
+        "description: Legacy auth guide",
+        "tags:",
+        "  - auth",
+        "---",
+        "",
+        "# Legacy guide",
+        "",
+        "Old advice.",
+        "",
+      ].join("\n"),
+    );
+    const oldParsedBefore = parseFrontmatter(fs.readFileSync(oldPath, "utf8"));
+    const sourcePath = makeSourceFile("modern-guide.md", "# Modern guide\n\nNew advice replacing the legacy doc.\n");
+
+    const { code, stdout } = await runCliCapture([
+      "import",
+      sourcePath,
+      "--name",
+      "modern-guide",
+      "--supersedes",
+      "knowledge:legacy-guide",
+    ]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as WriteOutput;
+    expect(json.ok).toBe(true);
+    expect(json.ref).toBe("knowledge:modern-guide");
+    expect(json.superseded).toHaveLength(1);
+    expect(json.superseded?.[0]?.ref).toBe("knowledge:legacy-guide");
+    expect(json.superseded?.[0]?.applied).toBe(true);
+
+    // The imported doc carries the correction provenance in ONE frontmatter block.
+    const newRaw = fs.readFileSync(json.path, "utf8");
+    const newParsed = parseFrontmatter(newRaw);
+    expect(newParsed.data.xrefs).toContain("knowledge:legacy-guide");
+    expect(newParsed.content).toContain("# Modern guide");
+    expect(newRaw.match(/^---\s*$/gm)?.length).toBe(2);
+
+    // The old doc: demoted, other keys preserved, body untouched.
+    const oldParsedAfter = parseFrontmatter(fs.readFileSync(oldPath, "utf8"));
+    expect(oldParsedAfter.data.beliefState).toBe("superseded");
+    expect(oldParsedAfter.data.supersededBy).toEqual(["knowledge:modern-guide"]);
+    expect(oldParsedAfter.data.description).toBe("Legacy auth guide");
+    expect(oldParsedAfter.data.tags).toEqual(["auth"]);
+    expect(oldParsedAfter.content).toBe(oldParsedBefore.content);
+  });
+
+  test("unresolvable --supersedes fails with exit 2 usage envelope and imports nothing", async () => {
+    const sourcePath = makeSourceFile("doomed-correction.md", "# Doomed\n\nMust not land in the stash.\n");
+
+    const { code, stderr } = await runCliCapture(["import", sourcePath, "--supersedes", "knowledge:ghost-doc"]);
+    expect(code).toBe(2);
+
+    const json = JSON.parse(stderr) as { ok: boolean; error: string; code?: string };
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain("knowledge:ghost-doc");
+    expect(typeof json.code).toBe("string");
+
+    expect(listDirRecursive(path.join(stashDir, "knowledge"))).toEqual([]);
+  });
+});
+
+// The git-write-target case (single boundary commit batching the correction
+// AND the demoted old asset) needs real git fixtures, so it lives in
+// tests/integration/supersedes-git-target.test.ts per the isolation lint.
+
+// ── writeSupersededEdge (unit) ───────────────────────────────────────────────
+
+describe("writeSupersededEdge — sibling of writeContradictEdge in memory-belief", () => {
+  /**
+   * Dynamic import so a missing export fails THESE tests with a clear
+   * assertion instead of breaking the whole file's module graph.
+   */
+  async function loadWriteSupersededEdge(): Promise<(filePath: string, supersededByRef: string) => void> {
+    const mod = (await import("../../src/commands/improve/memory/memory-belief")) as Record<string, unknown>;
+    expect(typeof mod.writeSupersededEdge).toBe("function");
+    return mod.writeSupersededEdge as (filePath: string, supersededByRef: string) => void;
+  }
+
+  test("sets beliefState: superseded + supersededBy while preserving other keys and the body", async () => {
+    const writeSupersededEdge = await loadWriteSupersededEdge();
+    const dir = makeDir("akm-superseded-edge");
+    const filePath = path.join(dir, "old.md");
+    fs.writeFileSync(
+      filePath,
+      [
+        "---",
+        "description: An incumbent memory",
+        "tags:",
+        "  - ops",
+        "beliefState: asserted",
+        "---",
+        "",
+        "Incumbent body.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    writeSupersededEdge(filePath, "memory:corrections/new-note");
+
+    const parsed = parseFrontmatter(fs.readFileSync(filePath, "utf8"));
+    expect(parsed.data.beliefState).toBe("superseded");
+    expect(parsed.data.supersededBy).toEqual(["memory:corrections/new-note"]);
+    expect(parsed.data.description).toBe("An incumbent memory");
+    expect(parsed.data.tags).toEqual(["ops"]);
+    expect(parsed.content.replace(/^\n+/, "")).toBe("Incumbent body.\n");
+  });
+
+  test("idempotent: a repeat call with the same ref leaves the file byte-identical", async () => {
+    const writeSupersededEdge = await loadWriteSupersededEdge();
+    const dir = makeDir("akm-superseded-edge");
+    const filePath = path.join(dir, "old.md");
+    fs.writeFileSync(filePath, "Plain incumbent body.\n", "utf8");
+
+    writeSupersededEdge(filePath, "memory:new-note");
+    const afterFirst = fs.readFileSync(filePath, "utf8");
+    writeSupersededEdge(filePath, "memory:new-note");
+    expect(fs.readFileSync(filePath, "utf8")).toBe(afterFirst);
+  });
+
+  test("sorted-set-appends refs across multiple corrections", async () => {
+    const writeSupersededEdge = await loadWriteSupersededEdge();
+    const dir = makeDir("akm-superseded-edge");
+    const filePath = path.join(dir, "old.md");
+    fs.writeFileSync(filePath, "Twice-corrected body.\n", "utf8");
+
+    writeSupersededEdge(filePath, "memory:zeta-fix");
+    writeSupersededEdge(filePath, "memory:alpha-fix");
+
+    const parsed = parseFrontmatter(fs.readFileSync(filePath, "utf8"));
+    expect(parsed.data.beliefState).toBe("superseded");
+    expect(parsed.data.supersededBy).toEqual(["memory:alpha-fix", "memory:zeta-fix"]);
+  });
+});
+
+// ── help meta ────────────────────────────────────────────────────────────────
+
+describe("--supersedes in command help meta", () => {
+  /** Resolve a citty args def that may be a value, promise, or thunk. */
+  async function resolveArgs(command: unknown): Promise<Record<string, { type?: string; description?: string }>> {
+    const raw = (command as { args?: unknown }).args;
+    const resolved = typeof raw === "function" ? await raw() : await raw;
+    return (resolved ?? {}) as Record<string, { type?: string; description?: string }>;
+  }
+
+  test("remember declares --supersedes with a description and renders it in usage", async () => {
+    const args = await resolveArgs(rememberCommand);
+    expect(Object.keys(args)).toContain("supersedes");
+    expect((args.supersedes?.description ?? "").length).toBeGreaterThan(0);
+
+    const usage = await renderUsage(rememberCommand as Parameters<typeof renderUsage>[0]);
+    expect(usage).toContain("--supersedes");
+  });
+
+  test("import declares --supersedes with a description and renders it in usage", async () => {
+    const args = await resolveArgs(importKnowledgeCommand);
+    expect(Object.keys(args)).toContain("supersedes");
+    expect((args.supersedes?.description ?? "").length).toBeGreaterThan(0);
+
+    const usage = await renderUsage(importKnowledgeCommand as Parameters<typeof renderUsage>[0]);
+    expect(usage).toContain("--supersedes");
+  });
+});

--- a/tests/commands/remember-import-supersedes.test.ts
+++ b/tests/commands/remember-import-supersedes.test.ts
@@ -39,6 +39,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
 import { renderUsage } from "citty";
+import { writeContradictEdge } from "../../src/commands/improve/memory/memory-belief";
+import { writeMarkdownAsset } from "../../src/commands/read/knowledge";
 import { rememberCommand } from "../../src/commands/read/remember-cli";
 import { importKnowledgeCommand } from "../../src/commands/sources/stash-cli";
 import { parseFrontmatter } from "../../src/core/asset/frontmatter";
@@ -439,6 +441,106 @@ describe("remember --supersedes", () => {
   });
 });
 
+// ── raw-asset corruption gate (finding #1) ───────────────────────────────────
+
+describe("--supersedes refuses non-markdown demotion targets before any write", () => {
+  test("secret:/env:/task:/script: refs exit 2 and leave the raw files byte-identical", async () => {
+    // The demotion prepends a YAML frontmatter block when the target has none —
+    // on a secret the frontmatter-prefixed blob would BECOME the credential
+    // value, and a task .yml would become an unparseable multi-document YAML.
+    const secretBytes = "-----BEGIN PRIVATE KEY-----\nabc123\n-----END PRIVATE KEY-----\n";
+    const envBytes = "API_KEY=abc\n# commented-out: OLD_KEY=zzz\n";
+    const taskBytes = "schedule: '0 2 * * *'\nworkflow: workflow:daily-backup\n";
+    const secretPath = seedAsset(stashDir, "secrets/clientX/api-key", secretBytes);
+    const envPath = seedAsset(stashDir, "env/staging.env", envBytes);
+    const taskPath = seedAsset(stashDir, "tasks/nightly.yml", taskBytes);
+    seedAsset(stashDir, "scripts/rotate.sh", "#!/bin/sh\necho rotate\n");
+
+    for (const ref of ["secret:clientX/api-key", "env:staging", "task:nightly", "script:rotate.sh"]) {
+      const { code, stderr } = await runCliCapture(["remember", "key rotated", "--supersedes", ref]);
+      expect(code).toBe(2);
+      const json = JSON.parse(stderr) as { ok: boolean; error: string; code?: string };
+      expect(json.ok).toBe(false);
+      expect(json.code).toBe("INVALID_FLAG_VALUE");
+      expect(json.error).toContain(ref);
+    }
+
+    // Nothing demoted, nothing written.
+    expect(fs.readFileSync(secretPath, "utf8")).toBe(secretBytes);
+    expect(fs.readFileSync(envPath, "utf8")).toBe(envBytes);
+    expect(fs.readFileSync(taskPath, "utf8")).toBe(taskBytes);
+    expect(listDirRecursive(path.join(stashDir, "memories"))).toEqual([]);
+  });
+
+  test("a YAML workflow program is rejected (resolved file is not markdown), for both ref spellings", async () => {
+    const wfBytes = "steps:\n  - run: echo hi\n";
+    const wfPath = seedAsset(stashDir, "workflows/deploy.yaml", wfBytes);
+
+    for (const ref of ["workflow:deploy", "workflow:deploy.yaml"]) {
+      const { code, stderr } = await runCliCapture(["remember", "deploy changed", "--supersedes", ref]);
+      expect(code).toBe(2);
+      const json = JSON.parse(stderr) as { ok: boolean; error: string; code?: string };
+      expect(json.code).toBe("INVALID_FLAG_VALUE");
+      expect(json.error).toContain(ref);
+    }
+    expect(fs.readFileSync(wfPath, "utf8")).toBe(wfBytes);
+    expect(listDirRecursive(path.join(stashDir, "memories"))).toEqual([]);
+  });
+
+  test("a MARKDOWN workflow still demotes (resolved stash-rooted, independent of the cwd)", async () => {
+    const wfPath = seedAsset(stashDir, "workflows/release.md", "# Release\n\nManual steps.\n");
+
+    const { code, stdout } = await runCliCapture([
+      "remember",
+      "The release flow was replaced.",
+      "--name",
+      "release-flow-fix",
+      "--supersedes",
+      "workflow:release",
+    ]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as WriteOutput;
+    expect(json.superseded?.[0]?.applied).toBe(true);
+    const parsed = parseFrontmatter(fs.readFileSync(wfPath, "utf8"));
+    expect(parsed.data.beliefState).toBe("superseded");
+    expect(parsed.data.supersededBy).toEqual([json.ref]);
+  });
+});
+
+// ── demotion failure does not abort the correction (finding #13) ─────────────
+
+describe("a demotion fs error still commits and indexes the correction", () => {
+  test("deleted-underneath target: correction written + indexed, target reported applied:false", async () => {
+    // The plan resolved this file, then it vanished before the demotion — the
+    // fs error must degrade to the applied:false report shape, NOT abort the
+    // write before commitWriteTargetBoundary/indexWrittenAssets.
+    const ghostPath = path.join(stashDir, "memories", "ghost-note.md");
+
+    const result = await writeMarkdownAsset({
+      type: "memory",
+      content: "---\nbeliefState: asserted\n---\nCorrected fact body.",
+      name: "corrected-fact",
+      fallbackPrefix: "memory",
+      supersedes: [{ ref: "memory:ghost-note", filePath: ghostPath, stashRoot: stashDir, writable: true }],
+    });
+
+    expect(result.ref).toBe("memory:corrected-fact");
+    expect(result.superseded).toHaveLength(1);
+    expect(result.superseded?.[0]?.ref).toBe("memory:ghost-note");
+    expect(result.superseded?.[0]?.applied).toBe(false);
+    expect(result.superseded?.[0]?.reason ?? "").toContain("demotion failed");
+
+    // The correction is on disk AND searchable immediately (write-path indexing
+    // ran despite the demotion failure).
+    expect(fs.existsSync(result.path)).toBe(true);
+    const search = await runCliCapture(["search", "corrected fact", "--type", "memory"]);
+    expect(search.code).toBe(0);
+    const refs = ((JSON.parse(search.stdout).hits ?? []) as Array<{ ref: string }>).map((h) => h.ref);
+    expect(refs).toContain("memory:corrected-fact");
+  });
+});
+
 // ── import --supersedes ──────────────────────────────────────────────────────
 
 describe("import --supersedes", () => {
@@ -581,6 +683,71 @@ describe("writeSupersededEdge — sibling of writeContradictEdge in memory-belie
     const parsed = parseFrontmatter(fs.readFileSync(filePath, "utf8"));
     expect(parsed.data.beliefState).toBe("superseded");
     expect(parsed.data.supersededBy).toEqual(["memory:alpha-fix", "memory:zeta-fix"]);
+  });
+
+  test("a pre-existing SCALAR supersededBy edge is preserved, not dropped (finding #14)", async () => {
+    // Scalar edges are live data: the indexer's normalizeNonEmptyStringList
+    // accepts them and lint never flags them. Merging must promote the scalar
+    // to a list, mirroring mergeXrefsIntoContent.
+    const writeSupersededEdge = await loadWriteSupersededEdge();
+    const dir = makeDir("akm-superseded-edge");
+    const filePath = path.join(dir, "old.md");
+    fs.writeFileSync(
+      filePath,
+      ["---", "supersededBy: memory:first-fix", "beliefState: superseded", "---", "", "Body.", ""].join("\n"),
+      "utf8",
+    );
+
+    writeSupersededEdge(filePath, "memory:second-fix");
+
+    const parsed = parseFrontmatter(fs.readFileSync(filePath, "utf8"));
+    expect(parsed.data.supersededBy).toEqual(["memory:first-fix", "memory:second-fix"]);
+    expect(parsed.data.beliefState).toBe("superseded");
+  });
+
+  test("writeContradictEdge preserves a pre-existing SCALAR contradictedBy edge (finding #14)", () => {
+    const dir = makeDir("akm-contradict-edge");
+    const filePath = path.join(dir, "old.md");
+    fs.writeFileSync(
+      filePath,
+      ["---", "contradictedBy: memory:first-dispute", "beliefState: contradicted", "---", "", "Body.", ""].join("\n"),
+      "utf8",
+    );
+
+    writeContradictEdge(filePath, "memory:second-dispute");
+
+    const parsed = parseFrontmatter(fs.readFileSync(filePath, "utf8"));
+    expect(parsed.data.contradictedBy).toEqual(["memory:first-dispute", "memory:second-dispute"]);
+    expect(parsed.data.beliefState).toBe("contradicted");
+  });
+
+  test("never weakens a stronger demotion: contradicted/archived keep their state, edge still appends", async () => {
+    // Severity order (BELIEF_STATE_SCORE_CEILINGS, ranking-contributors.ts):
+    // superseded 0.25 > contradicted 0.2 > archived 0.15 — overwriting
+    // contradicted/archived with superseded would RAISE the incumbent's rank.
+    const writeSupersededEdge = await loadWriteSupersededEdge();
+    for (const state of ["contradicted", "archived"] as const) {
+      const dir = makeDir("akm-superseded-edge-state");
+      const filePath = path.join(dir, "old.md");
+      fs.writeFileSync(
+        filePath,
+        ["---", `beliefState: ${state}`, "contradictedBy:", "  - memory:disputer", "---", "", "Body.", ""].join("\n"),
+        "utf8",
+      );
+
+      writeSupersededEdge(filePath, "memory:new-fix");
+
+      const parsed = parseFrontmatter(fs.readFileSync(filePath, "utf8"));
+      expect(parsed.data.beliefState).toBe(state);
+      expect(parsed.data.supersededBy).toEqual(["memory:new-fix"]);
+      // The contradiction edges stay consistent with the kept state.
+      expect(parsed.data.contradictedBy).toEqual(["memory:disputer"]);
+
+      // Idempotent under the kept state too: a repeat call does not rewrite.
+      const afterFirst = fs.readFileSync(filePath, "utf8");
+      writeSupersededEdge(filePath, "memory:new-fix");
+      expect(fs.readFileSync(filePath, "utf8")).toBe(afterFirst);
+    }
   });
 });
 

--- a/tests/commands/remember-import-xref.test.ts
+++ b/tests/commands/remember-import-xref.test.ts
@@ -1,0 +1,522 @@
+/**
+ * SPEC-3 (stash-conventions-code-spec.md): `--xref <ref>` on `akm remember`
+ * and `akm import`.
+ *
+ * Pins the write-time cross-reference surface the conventions mandate:
+ *   - `--xref <ref>` is repeatable and lands in the written asset's
+ *     frontmatter `xrefs:` list (folded into FTS hints by the indexer).
+ *   - An unresolvable ref is INPUT VALIDATION: UsageError → exit 2 with the
+ *     standard `{ok:false,error,code}` envelope, and NOTHING is written.
+ *   - Refs resolvable only in a configured extra stash root (cross-stash)
+ *     are accepted — resolution mirrors lint's [writeTarget, ...sources].
+ *   - `akm import` merges xrefs into a document's EXISTING frontmatter
+ *     (dedupe-append) instead of nesting a second frontmatter block.
+ *   - More than 5 xrefs stays a SOFT cap: stderr warn, write still happens.
+ *   - Written xrefs fold into FTS hints: the new asset is findable by
+ *     searching its cited ref's slug (the conventions' provenance channel,
+ *     verified end-to-end through the write-path indexer).
+ *   - Merging into MALFORMED frontmatter fails loudly (exit 2, nothing
+ *     written) instead of silently flattening list/nested values through the
+ *     lenient parser fallback; without --xref the same doc imports verbatim.
+ *   - Type-root writes into a stash with convention facts emit the additive
+ *     `hint` output key (spec test-plan item 6); nested/--path writes and
+ *     convention-less stashes do not, and the canonical
+ *     `fact:conventions/organization` pointer only appears when that fact
+ *     actually exists.
+ *   - The flag is declared in each command's help meta (citty args def →
+ *     rendered usage).
+ *
+ * Uses the in-process CLI harness (tests/_helpers/cli.ts) with the sandboxed
+ * stash/config helpers, following tests/commands/remember.test.ts.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { renderUsage } from "citty";
+import { mergeXrefsIntoContent } from "../../src/commands/read/knowledge";
+import { rememberCommand } from "../../src/commands/read/remember-cli";
+import { importKnowledgeCommand } from "../../src/commands/sources/stash-cli";
+import { parseFrontmatter } from "../../src/core/asset/frontmatter";
+import { UsageError } from "../../src/core/errors";
+import { runCliCapture } from "../_helpers/cli";
+import {
+  type Cleanup,
+  makeSandboxDir,
+  type SandboxedDir,
+  sandboxStashDir,
+  writeSandboxConfig,
+} from "../_helpers/sandbox";
+
+const disposers: SandboxedDir[] = [];
+let stashCleanup: Cleanup = () => {};
+let stashDir = "";
+
+beforeEach(() => {
+  const stash = sandboxStashDir();
+  stashDir = stash.dir;
+  stashCleanup = stash.cleanup;
+  writeSandboxConfig({ semanticSearchMode: "off" });
+});
+
+afterEach(() => {
+  stashCleanup();
+  stashCleanup = () => {};
+  stashDir = "";
+  for (const d of disposers.splice(0)) d.cleanup();
+});
+
+/** Create an isolated dir (auto-cleaned) for import sources / extra stashes. */
+function makeDir(prefix: string): string {
+  const d = makeSandboxDir(prefix);
+  disposers.push(d);
+  return d.dir;
+}
+
+/** Seed a resolvable asset file under a stash root (e.g. "knowledge/auth-flow.md"). */
+function seedAsset(root: string, relPath: string, content = "# Seed\n\nSeed content.\n"): void {
+  const abs = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, "utf8");
+}
+
+/** Write an import-source markdown file into a fresh sandbox dir. */
+function makeSourceFile(name: string, body: string): string {
+  const dir = makeDir("akm-xref-import-src");
+  const filePath = path.join(dir, name);
+  fs.writeFileSync(filePath, body, "utf8");
+  return filePath;
+}
+
+function listDirRecursive(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { recursive: true }).map(String);
+}
+
+// ── remember --xref ──────────────────────────────────────────────────────────
+
+describe("remember --xref", () => {
+  test("single resolvable --xref lands in the written frontmatter xrefs list", async () => {
+    seedAsset(stashDir, "knowledge/auth-flow.md");
+
+    // No --tag: --xref counts as structured metadata but must NOT trigger the
+    // tags-required check (spec: provenance without tags is a valid write).
+    const { code, stdout } = await runCliCapture([
+      "remember",
+      "Derived note about the auth flow",
+      "--xref",
+      "knowledge:auth-flow",
+    ]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as { ok: boolean; ref: string; path: string };
+    expect(json.ok).toBe(true);
+
+    const parsed = parseFrontmatter(fs.readFileSync(json.path, "utf8"));
+    expect(parsed.data.xrefs).toEqual(["knowledge:auth-flow"]);
+    // The hot-path markers still ride along in the SAME frontmatter block —
+    // xrefs merge into the generated frontmatter, they don't replace it.
+    expect(parsed.data.captureMode).toBe("hot");
+    expect(parsed.data.beliefState).toBe("asserted");
+    expect(parsed.content).toContain("Derived note about the auth flow");
+  });
+
+  test("--xref is repeatable and preserves argv order", async () => {
+    seedAsset(stashDir, "knowledge/auth-flow.md");
+    seedAsset(stashDir, "memories/vpn-note.md", "VPN is required for staging.\n");
+
+    const { code, stdout } = await runCliCapture([
+      "remember",
+      "Synthesis of auth flow and VPN notes",
+      "--xref",
+      "knowledge:auth-flow",
+      "--xref",
+      "memory:vpn-note",
+    ]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as { path: string };
+    const parsed = parseFrontmatter(fs.readFileSync(json.path, "utf8"));
+    expect(parsed.data.xrefs).toEqual(["knowledge:auth-flow", "memory:vpn-note"]);
+  });
+
+  test("--xref composes with --tag in one frontmatter block", async () => {
+    seedAsset(stashDir, "knowledge/auth-flow.md");
+
+    const { code, stdout } = await runCliCapture([
+      "remember",
+      "Tagged derived note",
+      "--tag",
+      "ops",
+      "--xref",
+      "knowledge:auth-flow",
+    ]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as { path: string };
+    const raw = fs.readFileSync(json.path, "utf8");
+    const parsed = parseFrontmatter(raw);
+    expect(parsed.data.tags).toEqual(["ops"]);
+    expect(parsed.data.xrefs).toEqual(["knowledge:auth-flow"]);
+    // Exactly one frontmatter block: opening + closing fence only.
+    expect(raw.match(/^---\s*$/gm)?.length).toBe(2);
+  });
+
+  test("unresolvable --xref fails with exit 2 usage envelope and writes nothing", async () => {
+    const { code, stderr } = await runCliCapture([
+      "remember",
+      "This must not be written",
+      "--xref",
+      "knowledge:does-not-exist",
+    ]);
+    expect(code).toBe(2);
+
+    const json = JSON.parse(stderr) as { ok: boolean; error: string; code?: string };
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain("knowledge:does-not-exist");
+    expect(typeof json.code).toBe("string");
+
+    // Validation happens BEFORE any write: the stash stays empty.
+    expect(listDirRecursive(path.join(stashDir, "memories"))).toEqual([]);
+  });
+
+  test("one bad ref among resolvable ones still fails and writes nothing", async () => {
+    seedAsset(stashDir, "knowledge/auth-flow.md");
+
+    const { code, stderr } = await runCliCapture([
+      "remember",
+      "Mixed refs must not be written",
+      "--tag",
+      "ops",
+      "--xref",
+      "knowledge:auth-flow",
+      "--xref",
+      "memory:ghost-note",
+    ]);
+    expect(code).toBe(2);
+
+    const json = JSON.parse(stderr) as { ok: boolean; error: string };
+    expect(json.ok).toBe(false);
+    // The error names the ref(s) that failed to resolve.
+    expect(json.error).toContain("memory:ghost-note");
+
+    expect(listDirRecursive(path.join(stashDir, "memories"))).toEqual([]);
+  });
+
+  test("cross-stash ref resolvable only in a configured extra source is accepted", async () => {
+    const extraDir = makeDir("akm-xref-extra-stash");
+    seedAsset(extraDir, "knowledge/shared-doc.md");
+    writeSandboxConfig({
+      semanticSearchMode: "off",
+      sources: [{ type: "filesystem", name: "extra-stash", path: extraDir, writable: false }],
+    });
+
+    const { code, stdout } = await runCliCapture([
+      "remember",
+      "Derived from the shared cross-stash doc",
+      "--xref",
+      "knowledge:shared-doc",
+    ]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as { ok: boolean; path: string };
+    expect(json.ok).toBe(true);
+    // Written to the PRIMARY stash while citing the extra-stash asset.
+    expect(json.path.startsWith(stashDir)).toBe(true);
+    const parsed = parseFrontmatter(fs.readFileSync(json.path, "utf8"));
+    expect(parsed.data.xrefs).toEqual(["knowledge:shared-doc"]);
+  });
+
+  test("more than 5 xrefs warns on stderr but still writes (soft cap)", async () => {
+    for (let i = 1; i <= 6; i++) {
+      seedAsset(stashDir, `knowledge/doc-${i}.md`);
+    }
+    const args = ["remember", "Heavily cited note"];
+    for (let i = 1; i <= 6; i++) {
+      args.push("--xref", `knowledge:doc-${i}`);
+    }
+
+    const { code, stdout, stderr } = await runCliCapture(args);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as { ok: boolean; path: string };
+    expect(json.ok).toBe(true);
+    const parsed = parseFrontmatter(fs.readFileSync(json.path, "utf8"));
+    expect(parsed.data.xrefs).toEqual([
+      "knowledge:doc-1",
+      "knowledge:doc-2",
+      "knowledge:doc-3",
+      "knowledge:doc-4",
+      "knowledge:doc-5",
+      "knowledge:doc-6",
+    ]);
+    // Soft cap: a warning is emitted, not an error.
+    expect(stderr.toLowerCase()).toContain("xref");
+  });
+
+  test("written xrefs fold into FTS hints: the memory is findable by its cited ref slug", async () => {
+    seedAsset(stashDir, "knowledge/oauth-refresh-dance.md");
+
+    const remember = await runCliCapture([
+      "remember",
+      "Token rotation gotcha worth keeping",
+      "--xref",
+      "knowledge:oauth-refresh-dance",
+    ]);
+    expect(remember.code).toBe(0);
+    const written = JSON.parse(remember.stdout) as { ref: string };
+
+    // The cited slug appears ONLY in the xref (not in the memory's body, name,
+    // or tags), so a search hit proves the indexer folded the frontmatter
+    // xrefs into the FTS hints — the conventions' provenance channel.
+    const search = await runCliCapture(["search", "oauth-refresh-dance", "--type", "memory"]);
+    expect(search.code).toBe(0);
+    const hits = (JSON.parse(search.stdout).hits ?? []) as Array<{ ref: string }>;
+    expect(hits.map((h) => h.ref)).toContain(written.ref);
+  });
+});
+
+// ── import --xref ────────────────────────────────────────────────────────────
+
+describe("import --xref", () => {
+  test("--xref adds a frontmatter block to a frontmatter-less document", async () => {
+    seedAsset(stashDir, "knowledge/auth-flow.md");
+    const sourcePath = makeSourceFile("auth-notes.md", "# Auth notes\n\nOAuth details worth keeping.\n");
+
+    const { code, stdout } = await runCliCapture(["import", sourcePath, "--xref", "knowledge:auth-flow"]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as { ok: boolean; ref: string; path: string };
+    expect(json.ok).toBe(true);
+
+    const raw = fs.readFileSync(json.path, "utf8");
+    expect(raw.startsWith("---")).toBe(true);
+    const parsed = parseFrontmatter(raw);
+    expect(parsed.data.xrefs).toEqual(["knowledge:auth-flow"]);
+    // Body intact and no frontmatter leaked into it.
+    expect(parsed.content).toContain("# Auth notes");
+    expect(parsed.content).toContain("OAuth details worth keeping.");
+    expect(parsed.content).not.toContain("xrefs:");
+    expect(raw.match(/^---\s*$/gm)?.length).toBe(2);
+  });
+
+  test("--xref merges into existing frontmatter without nesting a second block", async () => {
+    seedAsset(stashDir, "knowledge/auth-flow.md");
+    const sourcePath = makeSourceFile(
+      "existing-fm.md",
+      [
+        "---",
+        "description: Existing description",
+        "tags:",
+        "  - auth",
+        "---",
+        "",
+        "# Body heading",
+        "",
+        "Body text stays intact.",
+        "",
+      ].join("\n"),
+    );
+
+    const { code, stdout } = await runCliCapture(["import", sourcePath, "--xref", "knowledge:auth-flow"]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as { path: string };
+    const raw = fs.readFileSync(json.path, "utf8");
+    const parsed = parseFrontmatter(raw);
+
+    // Existing keys preserved, xrefs appended — one merged block.
+    expect(parsed.data.description).toBe("Existing description");
+    expect(parsed.data.tags).toEqual(["auth"]);
+    expect(parsed.data.xrefs).toEqual(["knowledge:auth-flow"]);
+
+    // No nested-frontmatter corruption: the body carries no fence or key
+    // leftovers from a second block.
+    expect(parsed.content).toContain("# Body heading");
+    expect(parsed.content).toContain("Body text stays intact.");
+    expect(parsed.content).not.toMatch(/^---\s*$/m);
+    expect(parsed.content).not.toContain("description:");
+    expect(raw.match(/^---\s*$/gm)?.length).toBe(2);
+  });
+
+  test("--xref dedupe-appends into a document that already lists xrefs", async () => {
+    seedAsset(stashDir, "knowledge/auth-flow.md");
+    seedAsset(stashDir, "memories/vpn-note.md", "VPN is required for staging.\n");
+    const sourcePath = makeSourceFile(
+      "already-cited.md",
+      ["---", "xrefs:", "  - knowledge:auth-flow", "---", "", "Body citing prior work.", ""].join("\n"),
+    );
+
+    const { code, stdout } = await runCliCapture([
+      "import",
+      sourcePath,
+      "--xref",
+      "knowledge:auth-flow",
+      "--xref",
+      "memory:vpn-note",
+    ]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as { path: string };
+    const parsed = parseFrontmatter(fs.readFileSync(json.path, "utf8"));
+    // The duplicate ref appears once; the new ref is appended.
+    expect(parsed.data.xrefs).toEqual(["knowledge:auth-flow", "memory:vpn-note"]);
+  });
+
+  test("unresolvable --xref fails with exit 2 usage envelope and writes nothing", async () => {
+    const sourcePath = makeSourceFile("doomed.md", "# Doomed\n\nMust not land in the stash.\n");
+
+    const { code, stderr } = await runCliCapture(["import", sourcePath, "--xref", "knowledge:ghost-doc"]);
+    expect(code).toBe(2);
+
+    const json = JSON.parse(stderr) as { ok: boolean; error: string; code?: string };
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain("knowledge:ghost-doc");
+    expect(typeof json.code).toBe("string");
+
+    expect(listDirRecursive(path.join(stashDir, "knowledge"))).toEqual([]);
+  });
+
+  test("--xref onto malformed frontmatter fails loudly instead of silently flattening values", async () => {
+    seedAsset(stashDir, "knowledge/auth-flow.md");
+    const malformed = [
+      "---",
+      'description: "unterminated quote',
+      "tags:",
+      "  - auth",
+      "  - oauth",
+      "---",
+      "",
+      "Body that must not land in the stash when --xref is passed.",
+      "",
+    ].join("\n");
+    const sourcePath = makeSourceFile("broken-fm.md", malformed);
+
+    // With --xref: merging would round-trip the block through the lenient
+    // scalar-only fallback and rewrite `tags: [auth, oauth]` as `tags: ""` —
+    // fail (exit 2) BEFORE any write instead of corrupting the copy.
+    const { code, stderr } = await runCliCapture(["import", sourcePath, "--xref", "knowledge:auth-flow"]);
+    expect(code).toBe(2);
+    const json = JSON.parse(stderr) as { ok: boolean; error: string; code?: string };
+    expect(json.ok).toBe(false);
+    expect(json.error.toLowerCase()).toContain("frontmatter");
+    expect(typeof json.code).toBe("string");
+    expect(listDirRecursive(path.join(stashDir, "knowledge"))).toEqual(["auth-flow.md"]);
+
+    // WITHOUT --xref the same document imports verbatim — malformed
+    // frontmatter is preserved byte-for-byte for a human to repair.
+    const plain = await runCliCapture(["import", sourcePath]);
+    expect(plain.code).toBe(0);
+    const plainJson = JSON.parse(plain.stdout) as { path: string };
+    expect(fs.readFileSync(plainJson.path, "utf8")).toBe(malformed);
+  });
+});
+
+// ── mergeXrefsIntoContent safety (unit) ──────────────────────────────────────
+
+describe("mergeXrefsIntoContent refuses non-mergeable frontmatter", () => {
+  test("malformed YAML (lenient-fallback territory) throws UsageError", () => {
+    const doc = ["---", 'description: "unterminated', "tags:", "  - auth", "---", "", "Body.", ""].join("\n");
+    expect(() => mergeXrefsIntoContent(doc, ["knowledge:auth-flow"])).toThrow(UsageError);
+  });
+
+  test("a non-mapping frontmatter block (comments only) throws instead of being dropped", () => {
+    const doc = ["---", "# a comment-only block parses to null", "---", "", "Body.", ""].join("\n");
+    expect(() => mergeXrefsIntoContent(doc, ["knowledge:auth-flow"])).toThrow(UsageError);
+  });
+
+  test("empty xrefs list returns the content untouched, malformed or not", () => {
+    const doc = ["---", 'description: "unterminated', "---", "", "Body.", ""].join("\n");
+    expect(mergeXrefsIntoContent(doc, [])).toBe(doc);
+  });
+});
+
+// ── type-root placement hint ─────────────────────────────────────────────────
+
+describe("type-root placement hint", () => {
+  /** Seed a convention fact (category: convention frontmatter) under facts/. */
+  function seedConventionFact(relPath: string, body: string): void {
+    seedAsset(stashDir, `facts/${relPath}`, `---\ncategory: convention\n---\n\n${body}\n`);
+  }
+
+  test("type-root remember on a stash with the organization fact emits the canonical hint", async () => {
+    seedConventionFact("conventions/organization.md", "Scope-born memories live under memories/<project>/.");
+
+    const { code, stdout } = await runCliCapture(["remember", "Root-level note for the hint check"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as { ok: boolean; hint?: string };
+    expect(json.ok).toBe(true);
+    expect(json.hint ?? "").toContain("placement conventions");
+    expect(json.hint ?? "").toContain("fact:conventions/organization");
+  });
+
+  test("convention facts WITHOUT the organization fact fall back to generic wording (no dead ref)", async () => {
+    seedConventionFact("naming.md", "Use kebab-case asset names.");
+
+    const { code, stdout } = await runCliCapture(["remember", "Root-level note, custom conventions only"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as { hint?: string };
+    expect(json.hint ?? "").toContain("placement conventions");
+    // The canonical fact does not exist in this stash — the hint must not
+    // point `akm show` at a ref that would return not-found.
+    expect(json.hint ?? "").not.toContain("fact:conventions/organization");
+  });
+
+  test("a --path (non-root) write emits no hint", async () => {
+    seedConventionFact("conventions/organization.md", "Scope-born memories live under memories/<project>/.");
+
+    const { code, stdout } = await runCliCapture(["remember", "Nested note", "--path", "projects/demo"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as Record<string, unknown>;
+    expect(json.ok).toBe(true);
+    expect("hint" in json).toBe(false);
+  });
+
+  test("a stash without convention facts emits no hint", async () => {
+    const { code, stdout } = await runCliCapture(["remember", "Plain stash note"]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as Record<string, unknown>;
+    expect(json.ok).toBe(true);
+    expect("hint" in json).toBe(false);
+  });
+
+  test("type-root import emits the hint too (shared write pipeline)", async () => {
+    seedConventionFact("conventions/organization.md", "Reference docs live under knowledge/<area>/.");
+    const sourcePath = makeSourceFile("root-doc.md", "# Root doc\n\nLands at the knowledge root.\n");
+
+    const { code, stdout } = await runCliCapture(["import", sourcePath]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as { ok: boolean; hint?: string };
+    expect(json.ok).toBe(true);
+    expect(json.hint ?? "").toContain("knowledge root");
+  });
+});
+
+// ── help meta ────────────────────────────────────────────────────────────────
+
+describe("--xref in command help meta", () => {
+  /** Resolve a citty args def that may be a value, promise, or thunk. */
+  async function resolveArgs(command: unknown): Promise<Record<string, { type?: string; description?: string }>> {
+    const raw = (command as { args?: unknown }).args;
+    const resolved = typeof raw === "function" ? await raw() : await raw;
+    return (resolved ?? {}) as Record<string, { type?: string; description?: string }>;
+  }
+
+  test("remember declares --xref with a description and renders it in usage", async () => {
+    const args = await resolveArgs(rememberCommand);
+    expect(Object.keys(args)).toContain("xref");
+    expect((args.xref?.description ?? "").length).toBeGreaterThan(0);
+
+    const usage = await renderUsage(rememberCommand as Parameters<typeof renderUsage>[0]);
+    expect(usage).toContain("--xref");
+  });
+
+  test("import declares --xref with a description and renders it in usage", async () => {
+    const args = await resolveArgs(importKnowledgeCommand);
+    expect(Object.keys(args)).toContain("xref");
+    expect((args.xref?.description ?? "").length).toBeGreaterThan(0);
+
+    const usage = await renderUsage(importKnowledgeCommand as Parameters<typeof renderUsage>[0]);
+    expect(usage).toContain("--xref");
+  });
+});

--- a/tests/commands/remember-import-xref.test.ts
+++ b/tests/commands/remember-import-xref.test.ts
@@ -276,6 +276,117 @@ describe("remember --xref", () => {
   });
 });
 
+// ── root set + resolver parity with lint (findings #6/#7) ───────────────────
+
+describe("--xref root set and resolver parity", () => {
+  test("resolves working-stash refs when defaultWriteTarget routes the write to a named source", async () => {
+    // The primary working stash (AKM_STASH_DIR) is NOT in config.sources here,
+    // and the write goes to the named "team" source — the root set must still
+    // include the working stash (--supersedes already did; --xref did not).
+    const teamDir = makeDir("akm-xref-team-target");
+    seedAsset(stashDir, "memories/local-note.md", "Working-stash note.\n");
+    writeSandboxConfig({
+      semanticSearchMode: "off",
+      defaultWriteTarget: "team",
+      sources: [{ type: "filesystem", name: "team", path: teamDir, writable: true }],
+    });
+
+    const { code, stdout } = await runCliCapture([
+      "remember",
+      "Note derived from the working-stash one",
+      "--xref",
+      "memory:local-note",
+    ]);
+    expect(code).toBe(0);
+
+    const json = JSON.parse(stdout) as { path: string };
+    // Written to the named target while citing the working-stash asset.
+    expect(json.path.startsWith(teamDir)).toBe(true);
+    const parsed = parseFrontmatter(fs.readFileSync(json.path, "utf8"));
+    expect(parsed.data.xrefs).toEqual(["memory:local-note"]);
+  });
+
+  test("script: refs are accepted without existence validation (fail-open, mirrors lint)", async () => {
+    // script: is contract-pinned unresolvable by the slug resolver
+    // (refToRelPath returns null); lint fails OPEN on it, and the PR's own
+    // convention docs instruct agents to write `--xref script:build/release`.
+    seedAsset(stashDir, "scripts/build/release.sh", "#!/bin/sh\necho release\n");
+
+    const seeded = await runCliCapture(["remember", "Release script tip", "--xref", "script:build/release.sh"]);
+    expect(seeded.code).toBe(0);
+    const seededParsed = parseFrontmatter(
+      fs.readFileSync((JSON.parse(seeded.stdout) as { path: string }).path, "utf8"),
+    );
+    expect(seededParsed.data.xrefs).toEqual(["script:build/release.sh"]);
+
+    // Fail-open means no existence check at all — same as lint's body scan.
+    const ghost = await runCliCapture(["remember", "Ghost script tip", "--xref", "script:no-such-script.sh"]);
+    expect(ghost.code).toBe(0);
+  });
+
+  test("workflow: refs resolve YAML workflow programs against the stash roots, not the cwd", async () => {
+    // The cwd here is the repo root, NOT the stash root — the old cwd-relative
+    // `workflowSpec.toAssetPath` probe made this exit 2 from any other cwd.
+    seedAsset(stashDir, "workflows/deploy.yaml", "steps:\n  - run: echo hi\n");
+
+    const { code, stdout } = await runCliCapture(["remember", "Deploy workflow tip", "--xref", "workflow:deploy"]);
+    expect(code).toBe(0);
+    const parsed = parseFrontmatter(fs.readFileSync((JSON.parse(stdout) as { path: string }).path, "utf8"));
+    expect(parsed.data.xrefs).toEqual(["workflow:deploy"]);
+
+    // workflow: does NOT blanket fail-open: a ref resolving nowhere still fails.
+    const ghost = await runCliCapture(["remember", "Ghost workflow tip", "--xref", "workflow:ghost-flow"]);
+    expect(ghost.code).toBe(2);
+    expect((JSON.parse(ghost.stderr) as { error: string }).error).toContain("workflow:ghost-flow");
+  });
+
+  test("origin-prefixed and malformed refs get a structured parse error, not 'did not resolve'", async () => {
+    seedAsset(stashDir, "knowledge/auth-flow.md");
+
+    const remote = await runCliCapture(["remember", "x", "--xref", "npm:pkg//knowledge:auth-flow"]);
+    expect(remote.code).toBe(2);
+    const remoteJson = JSON.parse(remote.stderr) as { error: string; code?: string };
+    expect(remoteJson.code).toBe("INVALID_FLAG_VALUE");
+    expect(remoteJson.error).toContain("origin");
+    expect(remoteJson.error).not.toContain("did not resolve");
+
+    const badType = await runCliCapture(["remember", "x", "--xref", "notatype:foo"]);
+    expect(badType.code).toBe(2);
+    expect((JSON.parse(badType.stderr) as { error: string }).error.toLowerCase()).toContain("invalid asset type");
+
+    // local// names the same local resolution this validator performs — accepted.
+    const local = await runCliCapture(["remember", "Locally cited note", "--xref", "local//knowledge:auth-flow"]);
+    expect(local.code).toBe(0);
+    const localParsed = parseFrontmatter(fs.readFileSync((JSON.parse(local.stdout) as { path: string }).path, "utf8"));
+    expect(localParsed.data.xrefs).toEqual(["local//knowledge:auth-flow"]);
+  });
+});
+
+// ── slug stability under --xref/--supersedes (finding #12) ───────────────────
+
+describe("--xref/--supersedes do not change the inferred slug", () => {
+  test("remember: the same content produces the same slug with and without --xref", async () => {
+    seedAsset(stashDir, "knowledge/auth-flow.md");
+    const content = "the deploy process now uses blue-green rollout";
+
+    const plain = await runCliCapture(["remember", content]);
+    expect(plain.code).toBe(0);
+    const plainRef = (JSON.parse(plain.stdout) as { ref: string }).ref;
+    expect(plainRef).toBe("memory:the-deploy-process-now-uses-blue-green-rollout");
+
+    // The structured path (forced by --xref) must derive the identical slug
+    // from the body — not a random memory-<epoch>-<rand> fallback taken from
+    // the generated frontmatter fence. --force proves the name collides.
+    const structured = await runCliCapture(["remember", content, "--force", "--xref", "knowledge:auth-flow"]);
+    expect(structured.code).toBe(0);
+    expect((JSON.parse(structured.stdout) as { ref: string }).ref).toBe(plainRef);
+  });
+
+  // The stdin variant (`akm import -`) needs a REAL subprocess (stdin cannot
+  // be injected into the in-process harness), so it lives in
+  // tests/integration/import-stdin-xref-slug.test.ts per the isolation lint.
+});
+
 // ── import --xref ────────────────────────────────────────────────────────────
 
 describe("import --xref", () => {

--- a/tests/commands/remember-import-xref.test.ts
+++ b/tests/commands/remember-import-xref.test.ts
@@ -354,11 +354,46 @@ describe("--xref root set and resolver parity", () => {
     expect(badType.code).toBe(2);
     expect((JSON.parse(badType.stderr) as { error: string }).error.toLowerCase()).toContain("invalid asset type");
 
-    // local// names the same local resolution this validator performs — accepted.
+    // local// names the same local resolution this validator performs —
+    // accepted, and persisted in the canonical bare form (the prefix is
+    // stripped, mirroring lint's local// strip) so later ref scanners see
+    // the same spelling the resolver validated.
     const local = await runCliCapture(["remember", "Locally cited note", "--xref", "local//knowledge:auth-flow"]);
     expect(local.code).toBe(0);
     const localParsed = parseFrontmatter(fs.readFileSync((JSON.parse(local.stdout) as { path: string }).path, "utf8"));
-    expect(localParsed.data.xrefs).toEqual(["local//knowledge:auth-flow"]);
+    expect(localParsed.data.xrefs).toEqual(["knowledge:auth-flow"]);
+  });
+
+  test("alias spellings parseAssetRef normalizes are persisted CANONICALLY, validated and deduped as one ref", async () => {
+    // `environment:` is the accepted alias of the canonical `env:` type
+    // (asset-ref.ts TYPE_ALIASES). Validation resolves the parsed components,
+    // so persisting the RAW spelling would store an xref string later
+    // scanners (lint's registry-derived REF_RE, mv's rewriter) never match.
+    seedAsset(stashDir, "env/prod.env", "API_URL=https://example.test\n");
+
+    const { code, stdout } = await runCliCapture([
+      "remember",
+      "Note citing the prod environment",
+      "--xref",
+      "environment:prod",
+    ]);
+    expect(code).toBe(0);
+    const parsed = parseFrontmatter(fs.readFileSync((JSON.parse(stdout) as { path: string }).path, "utf8"));
+    expect(parsed.data.xrefs).toEqual(["env:prod"]);
+
+    // Two spellings of the SAME asset dedupe into one canonical entry.
+    seedAsset(stashDir, "knowledge/auth-flow.md");
+    const dupe = await runCliCapture([
+      "remember",
+      "Note citing one asset twice",
+      "--xref",
+      "local//knowledge:auth-flow",
+      "--xref",
+      "knowledge:auth-flow",
+    ]);
+    expect(dupe.code).toBe(0);
+    const dupeParsed = parseFrontmatter(fs.readFileSync((JSON.parse(dupe.stdout) as { path: string }).path, "utf8"));
+    expect(dupeParsed.data.xrefs).toEqual(["knowledge:auth-flow"]);
   });
 });
 

--- a/tests/commands/show-argv.test.ts
+++ b/tests/commands/show-argv.test.ts
@@ -95,6 +95,10 @@ describe("normalizeShowArgv preserves global output flags on the view-mode path"
 describe("entrypoint global --shape=summary ordering", () => {
   test("allows global --shape=summary before show", async () => {
     const storage = useStorage();
+    // Semantic off keeps stderr empty as asserted below: with the default
+    // ("auto") the local embedder fetches its model from huggingface.co
+    // during auto-index, and an offline/blocked fetch warns on stderr.
+    fs.writeFileSync(path.join(storage.configDir, "akm", "config.json"), JSON.stringify({ semanticSearchMode: "off" }));
     writeFixture(
       path.join(storage.stashDir, "commands", "release.md"),
       "---\ndescription: Release\n---\nRun release {{version}}\n",

--- a/tests/config-auto-migrate.test.ts
+++ b/tests/config-auto-migrate.test.ts
@@ -26,6 +26,11 @@ import { runConfigValidate } from "../src/cli/config-validate";
 import { loadUserConfig, resetConfigCache, saveConfig } from "../src/core/config/config";
 import { ConfigError } from "../src/core/errors";
 
+// chmod-based write-failure simulation is a no-op when running as root
+// (permission bits are not enforced for uid 0), so these tests can only
+// exercise the failure path as a non-root user. CI runners are non-root.
+const runningAsRoot = typeof process.getuid === "function" && process.getuid() === 0;
+
 // ── Test isolation ────────────────────────────────────────────────────────────
 
 function makeTmpDir(): string {
@@ -234,31 +239,34 @@ describe("auto-migration banner (WS-2)", () => {
     expect(disk.configVersion).toBeUndefined();
   });
 
-  test("migration write failure throws ConfigError with AKM_NO_AUTO_MIGRATE=1 in the message", () => {
-    writeConfig(legacyConfig());
-    // Make the config dir read-only so the write fails
-    const configDir = path.dirname(configPath());
-    let chmodDone = false;
-    try {
-      fs.chmodSync(configDir, 0o500); // r-x: cannot write
-      chmodDone = true;
-      expect(() => {
-        resetConfigCache();
-        loadUserConfig();
-      }).toThrow(ConfigError);
-      // Also assert that hint or message contains AKM_NO_AUTO_MIGRATE=1
+  test.skipIf(runningAsRoot)(
+    "migration write failure throws ConfigError with AKM_NO_AUTO_MIGRATE=1 in the message",
+    () => {
+      writeConfig(legacyConfig());
+      // Make the config dir read-only so the write fails
+      const configDir = path.dirname(configPath());
+      let chmodDone = false;
       try {
-        resetConfigCache();
-        loadUserConfig();
-      } catch (err) {
-        const e = err as ConfigError;
-        const combined = `${e.message} ${e.hint() ?? ""}`;
-        expect(combined).toContain("AKM_NO_AUTO_MIGRATE=1");
+        fs.chmodSync(configDir, 0o500); // r-x: cannot write
+        chmodDone = true;
+        expect(() => {
+          resetConfigCache();
+          loadUserConfig();
+        }).toThrow(ConfigError);
+        // Also assert that hint or message contains AKM_NO_AUTO_MIGRATE=1
+        try {
+          resetConfigCache();
+          loadUserConfig();
+        } catch (err) {
+          const e = err as ConfigError;
+          const combined = `${e.message} ${e.hint() ?? ""}`;
+          expect(combined).toContain("AKM_NO_AUTO_MIGRATE=1");
+        }
+      } finally {
+        if (chmodDone) fs.chmodSync(configDir, 0o700);
       }
-    } finally {
-      if (chmodDone) fs.chmodSync(configDir, 0o700);
-    }
-  });
+    },
+  );
 
   test("no banner for an already-migrated 0.8.0 config", () => {
     writeConfig({ configVersion: "0.8.0", stashDir: "/my/stash" });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -19,6 +19,11 @@ import { ConfigError } from "../src/core/errors";
 import { getCacheDir, getConfigDir, getConfigPath } from "../src/core/paths";
 import { setQuiet } from "../src/core/warn";
 
+// chmod-based write-failure simulation is a no-op when running as root
+// (permission bits are not enforced for uid 0), so these tests can only
+// exercise the failure path as a non-root user. CI runners are non-root.
+const runningAsRoot = typeof process.getuid === "function" && process.getuid() === 0;
+
 function makeTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "akm-config-test-"));
 }
@@ -1142,7 +1147,7 @@ describe("auto-migration in loadConfig", () => {
     expect(loaded.profiles?.llm?.default?.endpoint).toBe("http://localhost:11434");
   });
 
-  test("throws ConfigError when migrated write fails (no infinite re-run loop) (#461)", () => {
+  test.skipIf(runningAsRoot)("throws ConfigError when migrated write fails (no infinite re-run loop) (#461)", () => {
     delete process.env.AKM_NO_AUTO_MIGRATE;
 
     const configPath = getConfigPath();

--- a/tests/contracts/config-schema-drift.test.ts
+++ b/tests/contracts/config-schema-drift.test.ts
@@ -35,6 +35,10 @@ describe("config schema drift pins", () => {
     const index = props.index as { properties?: Record<string, unknown> };
     expect(Object.keys(index.properties ?? {})).toContain("metadataEnhance");
     expect(Object.keys(index.properties ?? {})).toContain("stalenessDetection");
+    // SPEC-8: reserved boolean feature flag gating body-opening indexing.
+    expect(Object.keys(index.properties ?? {})).toContain("indexBodyOpening");
+    const indexBodyOpening = index.properties?.indexBodyOpening as { type?: string };
+    expect(indexBodyOpening.type).toBe("boolean");
     const search = props.search as { properties?: Record<string, unknown> };
     expect(Object.keys(search.properties ?? {})).toContain("graphBoost");
   });

--- a/tests/contracts/v1-spec-section-9-4-cli-surface.test.ts
+++ b/tests/contracts/v1-spec-section-9-4-cli-surface.test.ts
@@ -31,6 +31,11 @@ const SHIPPED_COMMANDS = [
   "help",
   "hints",
   "config",
+  // SPEC-7 (stash organization conventions): `mv` shipped post-0.9 as an
+  // Experimental-tier ADDITIVE entry on the frozen surface (§9.4 allows new
+  // top-level commands in v1.x provided they register an output shape;
+  // renaming/removing later is still major). See STABILITY.md.
+  "mv",
 ] as const;
 
 // The proposal queue is exposed as the `proposal` noun group (0.8 CLI

--- a/tests/curate-command.test.ts
+++ b/tests/curate-command.test.ts
@@ -208,11 +208,18 @@ describe("curate command", () => {
 
   test("--shape summary is rejected on curate (only valid on show)", async () => {
     const stashDir = makeStash();
+    // Semantic off keeps stderr limited to the error envelope this test
+    // parses: with the default ("auto") the local embedder fetches its model
+    // from huggingface.co during auto-index, and an offline/blocked fetch
+    // prepends an "Embedding generation failed" warning to stderr.
+    const xdgConfig = makeTempDir("akm-curate-config-");
+    fs.mkdirSync(path.join(xdgConfig, "akm"), { recursive: true });
+    fs.writeFileSync(path.join(xdgConfig, "akm", "config.json"), JSON.stringify({ semanticSearchMode: "off" }));
     const res = await withEnv(
       {
         AKM_STASH_DIR: stashDir,
         XDG_CACHE_HOME: makeTempDir("akm-curate-cache-"),
-        XDG_CONFIG_HOME: makeTempDir("akm-curate-config-"),
+        XDG_CONFIG_HOME: xdgConfig,
         XDG_DATA_HOME: makeTempDir("akm-curate-data-"),
       },
       async () => {

--- a/tests/fact-asset.test.ts
+++ b/tests/fact-asset.test.ts
@@ -26,7 +26,7 @@ import {
   TYPE_DIRS,
 } from "../src/core/asset/asset-spec";
 import { ASSET_TYPE_SET, ASSET_TYPES, isAssetType } from "../src/core/common";
-import type { StashEntry } from "../src/indexer/passes/metadata";
+import { generateMetadata, type StashEntry } from "../src/indexer/passes/metadata";
 import type { RankedEntryInput } from "../src/indexer/search/ranking";
 import { applyScoreContributors, type RankingContext } from "../src/indexer/search/ranking-contributors";
 
@@ -96,6 +96,48 @@ describe("pinned facts rank above ordinary facts", () => {
     applyScoreContributors(pinned, ctx);
     applyScoreContributors(plain, ctx);
     expect(pinned.score).toBeGreaterThan(plain.score);
+  });
+});
+
+describe("fact category is captured into the index entry (SPEC-6)", () => {
+  // SPEC-6 (docs/design/stash-conventions-code-spec.md): the `category:`
+  // frontmatter key — which already drives resolveStashStandards' prompt
+  // injection and the fact linter — must also land on the indexed StashEntry
+  // so category-keyed policies (e.g. rank-time handling of convention facts)
+  // are implementable at all. Read through a typed accessor so this file
+  // compiles before the `category?: string` field lands on StashEntry.
+  function entryCategory(entry: StashEntry | undefined): string | undefined {
+    return (entry as (StashEntry & { category?: string }) | undefined)?.category;
+  }
+
+  test("convention and meta categories land on entry.category; a fact without one stays undefined", async () => {
+    const stashRoot = makeTempStash();
+    const factsRoot = path.join(stashRoot, "facts");
+    const files: Record<string, string> = {
+      "conventions/organization.md":
+        "---\ncategory: convention\ndescription: house placement rules\n---\n\n# Org\n\nBody.\n",
+      "active-projects.md":
+        "---\ncategory: meta\ndescription: canonical project slugs\n---\n\n# Projects\n\n- projectA\n",
+      "team/tool-stack.md": "---\ndescription: team stack\n---\n\nWe use Bun.\n",
+    };
+    for (const [rel, body] of Object.entries(files)) {
+      const full = path.join(factsRoot, rel);
+      fs.mkdirSync(path.dirname(full), { recursive: true });
+      fs.writeFileSync(full, body, "utf8");
+    }
+
+    const stash = await generateMetadata(
+      factsRoot,
+      "fact",
+      Object.keys(files).map((rel) => path.join(factsRoot, rel)),
+    );
+    const byName = new Map(stash.entries.map((e) => [e.name, e]));
+    expect(byName.size).toBe(3);
+    expect(entryCategory(byName.get("conventions/organization"))).toBe("convention");
+    expect(entryCategory(byName.get("active-projects"))).toBe("meta");
+    // No default is invented — a category-less fact carries no category.
+    expect(entryCategory(byName.get("team/tool-stack"))).toBeUndefined();
+    cleanup();
   });
 });
 

--- a/tests/frontmatter.test.ts
+++ b/tests/frontmatter.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, test } from "bun:test";
-import { parseFrontmatter, parseFrontmatterBlock, parseYamlScalar } from "../src/core/asset/frontmatter";
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  mutateFrontmatter,
+  parseFrontmatter,
+  parseFrontmatterBlock,
+  parseYamlScalar,
+} from "../src/core/asset/frontmatter";
 import { asNonEmptyString } from "../src/core/common";
+import { makeSandboxDir, type SandboxedDir } from "./_helpers/sandbox";
 
 // ── parseFrontmatter ────────────────────────────────────────────────────────
 
@@ -187,6 +195,84 @@ describe("parseFrontmatterBlock", () => {
     expect(result).not.toBeNull();
     expect(result?.frontmatter).toBe("key: val");
     expect(result?.content).toBe("");
+  });
+});
+
+// ── mutateFrontmatter ───────────────────────────────────────────────────────
+//
+// SPEC-5 (stash-conventions-code-spec.md): a frontmatter mutation is a
+// METADATA edit, not a content edit. When the file already has a frontmatter
+// block, only the block is replaced and the body bytes are kept verbatim —
+// including a writer's single-newline fence-to-body separator and a missing
+// trailing newline, both of which routing through `assembleAsset` would
+// silently re-normalize. Files gaining their FIRST block still take the
+// canonical `assembleAsset` shape.
+
+describe("mutateFrontmatter", () => {
+  const disposers: SandboxedDir[] = [];
+
+  afterEach(() => {
+    for (const d of disposers.splice(0)) d.cleanup();
+  });
+
+  function writeTmpFile(content: string): string {
+    const sandbox = makeSandboxDir("akm-mutate-fm");
+    disposers.push(sandbox);
+    const filePath = path.join(sandbox.dir, "asset.md");
+    fs.writeFileSync(filePath, content, "utf8");
+    return filePath;
+  }
+
+  test("existing block: body bytes preserved verbatim (single-newline separator, no trailing newline)", () => {
+    // Hot-path writer shape: one newline after the closing fence, body does
+    // not end in a newline. assembleAsset would insert a blank-line separator
+    // and force a trailing newline — a whitespace content edit.
+    const body = "Body line without trailing newline";
+    const filePath = writeTmpFile(`---\ncaptureMode: hot\n---\n${body}`);
+
+    const wrote = mutateFrontmatter(filePath, (parsed) => ({ ...parsed.data, beliefState: "superseded" }));
+    expect(wrote).toBe(true);
+
+    const raw = fs.readFileSync(filePath, "utf8");
+    const block = parseFrontmatterBlock(raw);
+    expect(block?.content).toBe(body);
+    expect(raw.endsWith("\n")).toBe(false);
+    const parsed = parseFrontmatter(raw);
+    expect(parsed.data.captureMode).toBe("hot");
+    expect(parsed.data.beliefState).toBe("superseded");
+  });
+
+  test("existing block: leading blank lines in the body survive the round-trip", () => {
+    const filePath = writeTmpFile("---\nk: v\n---\n\n\nSpaced body.\n");
+    const before = parseFrontmatterBlock(fs.readFileSync(filePath, "utf8"));
+
+    mutateFrontmatter(filePath, (parsed) => ({ ...parsed.data, extra: 1 }));
+
+    const after = parseFrontmatterBlock(fs.readFileSync(filePath, "utf8"));
+    expect(after?.content).toBe(before?.content);
+  });
+
+  test("file gaining its FIRST block uses the canonical assembleAsset shape", () => {
+    const filePath = writeTmpFile("Plain incumbent body.\n");
+
+    const wrote = mutateFrontmatter(filePath, (parsed) => ({ ...parsed.data, beliefState: "superseded" }));
+    expect(wrote).toBe(true);
+
+    const raw = fs.readFileSync(filePath, "utf8");
+    expect(raw.startsWith("---\n")).toBe(true);
+    expect(raw.endsWith("\n")).toBe(true);
+    const parsed = parseFrontmatter(raw);
+    expect(parsed.data.beliefState).toBe("superseded");
+    expect(parsed.content.replace(/^\n+/, "")).toBe("Plain incumbent body.\n");
+  });
+
+  test("mutator returning null skips the write and leaves the file byte-identical", () => {
+    const original = "---\nk: v\n---\nBody.\n";
+    const filePath = writeTmpFile(original);
+
+    const wrote = mutateFrontmatter(filePath, () => null);
+    expect(wrote).toBe(false);
+    expect(fs.readFileSync(filePath, "utf8")).toBe(original);
   });
 });
 

--- a/tests/fts-field-weighting.test.ts
+++ b/tests/fts-field-weighting.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { closeDatabase, openIndexDatabase, rebuildFts, searchFts, upsertEntry } from "../src/indexer/db/db";
 import { DB_VERSION } from "../src/indexer/db/schema";
 import type { StashEntry } from "../src/indexer/passes/metadata";
-import { buildSearchFields } from "../src/indexer/search/search-fields";
+import { buildSearchFields, buildSearchText } from "../src/indexer/search/search-fields";
 import type { Database } from "../src/storage/database";
 import { type Cleanup, sandboxXdgCacheHome, sandboxXdgConfigHome } from "./_helpers/sandbox";
 
@@ -295,5 +295,134 @@ describe("buildSearchFields", () => {
     expect(fields.tags).toBe("");
     expect(fields.hints).toBe("");
     expect(fields.content).toBe("");
+  });
+});
+
+// ── SPEC-8: bodyOpening folds into the FTS content field ────────────────────
+//
+// docs/design/stash-conventions-code-spec.md SPEC-8: when the metadata pass
+// (gated by `index.indexBodyOpening`) has put the first body paragraph on
+// StashEntry.bodyOpening, buildSearchFields folds it into the lowest-weight
+// `content` column (bm25 weight 1.0) — NOT `hints` — so orientation prose is
+// retrievable without outranking name/description/tag matches. Entries
+// without bodyOpening must keep byte-identical search fields.
+
+/**
+ * SPEC-8 adds `bodyOpening?: string` to StashEntry. Attach it via a cast so
+ * this file compiles before the field exists; the tests then go red on the
+ * runtime search-field/FTS behavior instead of a compile error.
+ */
+function withBodyOpening(entry: StashEntry, bodyOpening: string): StashEntry {
+  return { ...entry, bodyOpening } as StashEntry;
+}
+
+describe("SPEC-8 bodyOpening indexing", () => {
+  test("buildSearchFields folds bodyOpening into content (lowercased), not hints", () => {
+    const entry = withBodyOpening(
+      makeEntry({
+        name: "project-orienter",
+        type: "memory",
+        description: "Where auth work lives",
+        tags: ["auth"],
+        searchHints: ["auth refresh"],
+        toc: [{ text: "Decisions", level: 2, line: 3 }],
+      }),
+      "This page situates the Quokka onboarding ledger workstream.",
+    );
+
+    const fields = buildSearchFields(entry);
+    // Folded verbatim (lowercased) into the catch-all content column…
+    expect(fields.content).toContain("this page situates the quokka onboarding ledger workstream.");
+    // …appended to the existing content parts, not replacing them.
+    expect(fields.content).toContain("decisions");
+    // The designated field is content — no higher-weight column may pick it up.
+    expect(fields.hints).not.toContain("quokka");
+    expect(fields.name).not.toContain("quokka");
+    expect(fields.description).not.toContain("quokka");
+    expect(fields.tags).not.toContain("quokka");
+    // The concatenated search/embedding text inherits it via content.
+    expect(buildSearchText(entry)).toContain("quokka onboarding ledger");
+  });
+
+  test("entries without bodyOpening keep byte-identical search fields (default pin)", () => {
+    // Pins today's exact field bytes for a representative fully-populated
+    // entry. SPEC-8's default-off promise is that this never shifts: the fold
+    // may only add text when bodyOpening is present on the entry.
+    const entry = makeEntry({
+      name: "deploy-tool",
+      type: "script",
+      description: "Deploy applications to production",
+      tags: ["deploy", "production"],
+      aliases: ["release"],
+      searchHints: ["release management"],
+      toc: [{ text: "Getting Started", level: 1, line: 1 }],
+      parameters: [{ name: "service", description: "Service slug" }],
+    });
+
+    expect(buildSearchFields(entry)).toEqual({
+      name: "deploy tool",
+      description: "deploy applications to production",
+      tags: "deploy production release",
+      hints: "release management",
+      content: "getting started service service slug",
+    });
+  });
+
+  test("an orientation-only phrase matches via the FTS content column", () => {
+    const db = openIndexDatabase(tmpDbPath("spec8"));
+    try {
+      const entry = withBodyOpening(
+        makeEntry({ name: "project-orienter", type: "memory", description: "Notes about the platform" }),
+        "This memory situates the quokka onboarding ledger workstream.",
+      );
+      // search_text deliberately omits the phrase: the FTS columns are built
+      // by rebuildFts from entry_json via buildSearchFields, so a hit proves
+      // the fold — not a legacy search_text leak.
+      const id = insertEntry(db, "orienter", entry, "project orienter notes about the platform");
+      rebuildFts(db);
+
+      const results = searchFts(db, "quokka", 10);
+      expect(results.length).toBe(1);
+      expect(results[0].entry.name).toBe("project-orienter");
+
+      // Column-level pin: the token landed in `content`, and only there.
+      const row = db.prepare("SELECT content, hints FROM entries_fts WHERE entry_id = ?").get(id) as
+        | { content: string; hints: string }
+        | undefined;
+      expect(row).toBeDefined();
+      expect(row?.content ?? "").toContain("quokka");
+      expect(row?.hints ?? "").not.toContain("quokka");
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("name match still outranks a bodyOpening-only match", () => {
+    const db = openIndexDatabase(tmpDbPath("spec8-rank"));
+    try {
+      const nameEntry = makeEntry({
+        name: "quokka-runbook",
+        type: "knowledge",
+        description: "Operational runbook",
+      });
+      insertEntry(db, "name-quokka", nameEntry, "quokka runbook");
+
+      const bodyEntry = withBodyOpening(
+        makeEntry({ name: "unrelated-notes", type: "memory", description: "General project notes" }),
+        "Mentions the quokka rollout only in its body opening.",
+      );
+      insertEntry(db, "body-quokka", bodyEntry, "unrelated notes");
+
+      rebuildFts(db);
+
+      const results = searchFts(db, "quokka", 10);
+      // The body-opening match IS retrievable (that's the feature)…
+      expect(results.length).toBe(2);
+      // …but the name match wins: content carries the lowest bm25 weight
+      // (name 10.0 vs content 1.0), so orientation prose never outranks names.
+      expect(results[0].entry.name).toBe("quokka-runbook");
+    } finally {
+      closeDatabase(db);
+    }
   });
 });

--- a/tests/fts-query.test.ts
+++ b/tests/fts-query.test.ts
@@ -3,10 +3,13 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import { describe, expect, test } from "bun:test";
-import { buildPrefixQuery, sanitizeFtsQuery } from "../src/indexer/search/fts-query";
+import { getAssetTypes } from "../src/core/asset/asset-spec";
+import * as ftsQueryModule from "../src/indexer/search/fts-query";
 
 // These are pure string helpers extracted out of indexer/db/db.ts — they touch
 // no database state, so they are tested here in complete isolation.
+
+const { buildPrefixQuery, sanitizeFtsQuery } = ftsQueryModule;
 
 describe("sanitizeFtsQuery", () => {
   test("splits compound identifiers into AND-joined tokens", () => {
@@ -46,5 +49,108 @@ describe("buildPrefixQuery", () => {
   test("returns null when no token qualifies for prefix expansion", () => {
     expect(buildPrefixQuery("ai ml")).toBeNull();
     expect(buildPrefixQuery("")).toBeNull();
+  });
+});
+
+// ── SPEC-4: parseRefPrefixQuery ──────────────────────────────────────────────
+//
+// Pure parser behind the ref-prefix search idiom `akm search "<type>:<prefix>/"`
+// (docs/design/stash-conventions-code-spec.md, SPEC-4). It decides whether a raw
+// query is a typed subtree-enumeration request or an ordinary keyword search.
+// The export is looked up dynamically (instead of a named import) so that while
+// the implementation does not exist yet only THESE tests fail — with a message
+// naming the missing export — rather than the whole file erroring at load time.
+
+type RefPrefixParse = { type: string; namePrefix: string } | null;
+type ParseRefPrefixQueryFn = (query: string, knownTypes: readonly string[]) => RefPrefixParse;
+
+function parseRefPrefixQuery(query: string, knownTypes: readonly string[]): RefPrefixParse {
+  const fn = (ftsQueryModule as Record<string, unknown>).parseRefPrefixQuery;
+  if (typeof fn !== "function") {
+    throw new Error(
+      "parseRefPrefixQuery is not exported from src/indexer/search/fts-query (SPEC-4 not implemented yet)",
+    );
+  }
+  return (fn as ParseRefPrefixQueryFn)(query, knownTypes);
+}
+
+describe("parseRefPrefixQuery", () => {
+  const KNOWN_TYPES: readonly string[] = ["memory", "knowledge", "wiki", "fact"];
+
+  test("parses '<known-type>:<prefix>/' — trailing slash kept in namePrefix", () => {
+    // The trailing slash MUST survive into namePrefix: the search branch feeds
+    // it straight into `entry.name.startsWith(namePrefix)`, and "projecta/"
+    // is what guarantees exact subtree semantics — a slashless "projecta"
+    // would also match a sibling "projectalpha/..." subtree.
+    expect(parseRefPrefixQuery("memory:projecta/", KNOWN_TYPES)).toEqual({
+      type: "memory",
+      namePrefix: "projecta/",
+    });
+  });
+
+  test("parses nested directory prefixes", () => {
+    expect(parseRefPrefixQuery("memory:projecta/nested/", KNOWN_TYPES)).toEqual({
+      type: "memory",
+      namePrefix: "projecta/nested/",
+    });
+  });
+
+  test("bare '<known-type>:' enumerates the whole type (empty namePrefix)", () => {
+    expect(parseRefPrefixQuery("wiki:", KNOWN_TYPES)).toEqual({ type: "wiki", namePrefix: "" });
+    expect(parseRefPrefixQuery("memory:", KNOWN_TYPES)).toEqual({ type: "memory", namePrefix: "" });
+  });
+
+  test("a non-empty prefix REQUIRES the trailing slash", () => {
+    expect(parseRefPrefixQuery("memory:projecta", KNOWN_TYPES)).toBeNull();
+  });
+
+  test("bare refs like memory:a/b stay ordinary searches (that's `akm show` territory)", () => {
+    expect(parseRefPrefixQuery("memory:a/b", KNOWN_TYPES)).toBeNull();
+    expect(parseRefPrefixQuery("knowledge:auth/oauth-refresh", KNOWN_TYPES)).toBeNull();
+  });
+
+  test("unknown types are not matched", () => {
+    expect(parseRefPrefixQuery("bogus:stuff/", KNOWN_TYPES)).toBeNull();
+    expect(parseRefPrefixQuery(":stuff/", KNOWN_TYPES)).toBeNull();
+  });
+
+  test("type validity comes from the caller-supplied list, not a baked-in set", () => {
+    // Keeps fts-query dependency-free: the caller passes getAssetTypes().
+    expect(parseRefPrefixQuery("memory:x/", ["knowledge"])).toBeNull();
+    expect(parseRefPrefixQuery("customtype:x/", ["customtype"])).toEqual({
+      type: "customtype",
+      namePrefix: "x/",
+    });
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(parseRefPrefixQuery("  memory:projecta/  ", KNOWN_TYPES)).toEqual({
+      type: "memory",
+      namePrefix: "projecta/",
+    });
+    expect(parseRefPrefixQuery("\tknowledge:\n", KNOWN_TYPES)).toEqual({ type: "knowledge", namePrefix: "" });
+  });
+
+  test("interior whitespace disqualifies — prose mentioning a ref stays an ordinary search", () => {
+    expect(parseRefPrefixQuery("memory:proj a/", KNOWN_TYPES)).toBeNull();
+    expect(parseRefPrefixQuery("find memory:projecta/ now", KNOWN_TYPES)).toBeNull();
+  });
+
+  test("plain queries, empty strings, and lone colons are not matched", () => {
+    expect(parseRefPrefixQuery("", KNOWN_TYPES)).toBeNull();
+    expect(parseRefPrefixQuery("memory", KNOWN_TYPES)).toBeNull();
+    expect(parseRefPrefixQuery("deploy prod", KNOWN_TYPES)).toBeNull();
+    expect(parseRefPrefixQuery(":", KNOWN_TYPES)).toBeNull();
+  });
+
+  test("accepts the real asset-type registry as the known-type list", () => {
+    expect(parseRefPrefixQuery("fact:conventions/", getAssetTypes())).toEqual({
+      type: "fact",
+      namePrefix: "conventions/",
+    });
+    expect(parseRefPrefixQuery("memory:projecta/", getAssetTypes())).toEqual({
+      type: "memory",
+      namePrefix: "projecta/",
+    });
   });
 });

--- a/tests/indexer/body-opening-index-state.test.ts
+++ b/tests/indexer/body-opening-index-state.test.ts
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, test } from "bun:test";
+import { getMeta, setMeta } from "../../src/indexer/db/db";
+import { reconcileBodyOpeningIndexState } from "../../src/indexer/indexer";
+import type { Database as AkmDatabase } from "../../src/storage/database";
+
+/**
+ * SPEC-8 finalize-phase state tracking: the index_meta key `indexBodyOpening`
+ * records which `index.indexBodyOpening` state the index was last FULLY built
+ * with, and {@link reconcileBodyOpeningIndexState} returns a warning message
+ * on every incremental run while the current flag diverges from it (the index
+ * is MIXED until `akm index --full`).
+ *
+ * Review-fix pin: a missing meta key on an INCREMENTAL run means the index
+ * predates the feature and was therefore built with the flag off — it must be
+ * read and seeded as "0", never as the current flag value, so the real-world
+ * upgrade-then-enable path warns instead of silently recording "1".
+ */
+describe("reconcileBodyOpeningIndexState (SPEC-8)", () => {
+  let db: AkmDatabase;
+
+  beforeEach(() => {
+    db = new Database(":memory:") as unknown as AkmDatabase;
+    db.exec("CREATE TABLE index_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);");
+  });
+
+  test("first build (full walk, no meta key): records the current flag, no warning", () => {
+    expect(reconcileBodyOpeningIndexState(db, true, true)).toBeUndefined();
+    expect(getMeta(db, "indexBodyOpening")).toBe("1");
+  });
+
+  test("first build with the flag off records '0', no warning", () => {
+    expect(reconcileBodyOpeningIndexState(db, false, true)).toBeUndefined();
+    expect(getMeta(db, "indexBodyOpening")).toBe("0");
+  });
+
+  test("pre-feature index + flag enabled + incremental run: warns and seeds '0' (review fix)", () => {
+    // No meta key at all — the index was built by a pre-SPEC-8 version, i.e.
+    // with the flag necessarily off. Enabling the flag and running a plain
+    // incremental `akm index` must warn, not silently record '1'.
+    const warning = reconcileBodyOpeningIndexState(db, true, false);
+    expect(warning).toBeDefined();
+    expect(warning).toContain("index.indexBodyOpening is enabled");
+    expect(warning).toContain("akm index --full");
+    expect(getMeta(db, "indexBodyOpening")).toBe("0");
+
+    // Repeat-until-full semantics: the next incremental run warns again.
+    expect(reconcileBodyOpeningIndexState(db, true, false)).toBeDefined();
+    expect(getMeta(db, "indexBodyOpening")).toBe("0");
+  });
+
+  test("pre-feature index + flag disabled + incremental run: silent, seeds '0'", () => {
+    expect(reconcileBodyOpeningIndexState(db, false, false)).toBeUndefined();
+    expect(getMeta(db, "indexBodyOpening")).toBe("0");
+  });
+
+  test("recorded '0' + flag enabled + incremental run: warns and preserves '0'", () => {
+    setMeta(db, "indexBodyOpening", "0");
+    const warning = reconcileBodyOpeningIndexState(db, true, false);
+    expect(warning).toContain("index.indexBodyOpening is enabled");
+    expect(warning).toContain("built with it disabled");
+    expect(getMeta(db, "indexBodyOpening")).toBe("0");
+  });
+
+  test("recorded '1' + flag disabled + incremental run: warns in the opposite direction, preserves '1'", () => {
+    setMeta(db, "indexBodyOpening", "1");
+    const warning = reconcileBodyOpeningIndexState(db, false, false);
+    expect(warning).toContain("index.indexBodyOpening is disabled");
+    expect(warning).toContain("built with it enabled");
+    expect(getMeta(db, "indexBodyOpening")).toBe("1");
+  });
+
+  test("a full walk applies the new state and clears the divergence", () => {
+    setMeta(db, "indexBodyOpening", "0");
+    expect(reconcileBodyOpeningIndexState(db, true, true)).toBeUndefined();
+    expect(getMeta(db, "indexBodyOpening")).toBe("1");
+    // Subsequent incremental runs with the same flag stay silent.
+    expect(reconcileBodyOpeningIndexState(db, true, false)).toBeUndefined();
+    expect(getMeta(db, "indexBodyOpening")).toBe("1");
+  });
+
+  test("matching flag and recorded state stay silent on incremental runs", () => {
+    setMeta(db, "indexBodyOpening", "1");
+    expect(reconcileBodyOpeningIndexState(db, true, false)).toBeUndefined();
+    setMeta(db, "indexBodyOpening", "0");
+    expect(reconcileBodyOpeningIndexState(db, false, false)).toBeUndefined();
+  });
+});

--- a/tests/indexer/index-written-assets.test.ts
+++ b/tests/indexer/index-written-assets.test.ts
@@ -110,4 +110,45 @@ describe("indexWrittenAssets", () => {
     const idx = queryIndex();
     expect(idx.entryNames).toEqual(["seed-memory"]);
   });
+
+  test("indexes a workflow entry AND its workflow_documents side-table row (PR-715 review)", async () => {
+    // `akm mv` rewrites citer files that can be workflows, so the fast path
+    // must mirror the full walk: upsert the entry, then the parsed document.
+    const filePath = path.join(stashDir, "workflows", "rewritten-citer.md");
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      [
+        "---",
+        "description: workflow citing a moved xylophone memory",
+        "---",
+        "",
+        "# Workflow: Rewritten Citer",
+        "",
+        "## Step: First",
+        "Step ID: first",
+        "",
+        "### Instructions",
+        "Read memory:xylophone-note and act.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await indexWrittenAssets(stashDir, [filePath]);
+
+    const db = openExistingDatabase(getDbPath());
+    try {
+      const row = db
+        .prepare("SELECT id, entry_json FROM entries WHERE file_path = ?")
+        .get(filePath) as { id: number; entry_json: string } | null;
+      expect(row).not.toBeNull();
+      expect((JSON.parse((row as { entry_json: string }).entry_json) as { type: string }).type).toBe("workflow");
+      const doc = db
+        .prepare("SELECT COUNT(*) AS c FROM workflow_documents WHERE entry_id = ?")
+        .get((row as { id: number }).id) as { c: number };
+      expect(doc.c).toBe(1);
+    } finally {
+      closeDatabase(db);
+    }
+  });
 });

--- a/tests/indexer/index-written-assets.test.ts
+++ b/tests/indexer/index-written-assets.test.ts
@@ -138,9 +138,10 @@ describe("indexWrittenAssets", () => {
 
     const db = openExistingDatabase(getDbPath());
     try {
-      const row = db
-        .prepare("SELECT id, entry_json FROM entries WHERE file_path = ?")
-        .get(filePath) as { id: number; entry_json: string } | null;
+      const row = db.prepare("SELECT id, entry_json FROM entries WHERE file_path = ?").get(filePath) as {
+        id: number;
+        entry_json: string;
+      } | null;
       expect(row).not.toBeNull();
       expect((JSON.parse((row as { entry_json: string }).entry_json) as { type: string }).type).toBe("workflow");
       const doc = db

--- a/tests/integration/e2e.test.ts
+++ b/tests/integration/e2e.test.ts
@@ -317,9 +317,14 @@ describe("Scenario: Full lifecycle (index → search → show)", () => {
     expect(topHit.description).toBeTruthy();
   });
 
-  test.skipIf(!!process.env.CI)("search ranks keyword-relevant results higher (FTS-only)", async () => {
+  test("search ranks keyword-relevant results higher (FTS-only)", async () => {
     // NOTE: This test uses FTS keyword matching (BM25), not semantic/vector search.
-    const result = await akmSearch({ query: "summarize commit changes", type: "any" });
+    // The query tokens must all appear in the fixture's indexed fields (FTS5
+    // AND-joins tokens): summarize-diff's description is "Summarize git diff
+    // changes into a concise developer-friendly report". The previous query
+    // ("summarize commit changes") only ever matched via semantic embeddings,
+    // so it returned 0 hits on offline machines despite the FTS-only intent.
+    const result = await akmSearch({ query: "summarize git diff changes", type: "any" });
 
     expect(result.hits.length).toBeGreaterThan(0);
     // Git scripts should rank higher than docker scripts for this query
@@ -419,12 +424,19 @@ describe("Scenario: Agent discovers capabilities for task", () => {
     fs.rmSync(scenarioStateDir, { recursive: true, force: true });
   });
 
-  test.skipIf(!!process.env.CI)("agent asks 'set up local dev environment' → docker-compose ranks high", async () => {
-    const result = await akmSearch({ query: "set up local development environment" });
-    const names = result.hits.map((h) => h.name.toLowerCase());
-    // Docker compose should appear because its intent says "start local development services"
-    expect(names.some((n) => n.includes("compose") || n.includes("docker"))).toBe(true);
-  });
+  // Needs semantic embeddings: the natural-language query tokens are not all
+  // present in the fixture's indexed fields, so FTS (AND-joined tokens) alone
+  // returns nothing. Opt in with AKM_SEMANTIC_TESTS=1 (downloads the local
+  // embedding model on first run — see AGENTS.md).
+  test.skipIf(!process.env.AKM_SEMANTIC_TESTS)(
+    "agent asks 'set up local dev environment' → docker-compose ranks high",
+    async () => {
+      const result = await akmSearch({ query: "set up local development environment" });
+      const names = result.hits.map((h) => h.name.toLowerCase());
+      // Docker compose should appear because its intent says "start local development services"
+      expect(names.some((n) => n.includes("compose") || n.includes("docker"))).toBe(true);
+    },
+  );
 
   test("agent asks 'check code quality' → lint script ranks high", async () => {
     const result = await akmSearch({ query: "check code quality style" });
@@ -433,22 +445,36 @@ describe("Scenario: Agent discovers capabilities for task", () => {
     expect(names.some((n) => n.includes("lint") || n.includes("eslint"))).toBe(true);
   });
 
-  test.skipIf(!!process.env.CI)("agent asks 'review my pull request' → code-review skill found", async () => {
-    const result = await akmSearch({ query: "review pull request code changes" });
-    expect(result.hits.length).toBeGreaterThan(0);
-    // Skill ref contains "code-review" (directory name), even though display name is "SKILL"
-    expect(
-      result.hits.some(
-        (h) => (isLocalHit(h) && h.ref.includes("code-review")) || h.description?.toLowerCase().includes("review"),
-      ),
-    ).toBe(true);
-  });
+  // Needs semantic embeddings: the natural-language query tokens are not all
+  // present in the fixture's indexed fields, so FTS (AND-joined tokens) alone
+  // returns nothing. Opt in with AKM_SEMANTIC_TESTS=1 (downloads the local
+  // embedding model on first run — see AGENTS.md).
+  test.skipIf(!process.env.AKM_SEMANTIC_TESTS)(
+    "agent asks 'review my pull request' → code-review skill found",
+    async () => {
+      const result = await akmSearch({ query: "review pull request code changes" });
+      expect(result.hits.length).toBeGreaterThan(0);
+      // Skill ref contains "code-review" (directory name), even though display name is "SKILL"
+      expect(
+        result.hits.some(
+          (h) => (isLocalHit(h) && h.ref.includes("code-review")) || h.description?.toLowerCase().includes("review"),
+        ),
+      ).toBe(true);
+    },
+  );
 
-  test.skipIf(!!process.env.CI)("agent asks 'help me design the system' → architect agent found", async () => {
-    const result = await akmSearch({ query: "system design architecture" });
-    expect(result.hits.length).toBeGreaterThan(0);
-    expect(result.hits.some((h) => h.name.includes("architect"))).toBe(true);
-  });
+  // Needs semantic embeddings: the natural-language query tokens are not all
+  // present in the fixture's indexed fields, so FTS (AND-joined tokens) alone
+  // returns nothing. Opt in with AKM_SEMANTIC_TESTS=1 (downloads the local
+  // embedding model on first run — see AGENTS.md).
+  test.skipIf(!process.env.AKM_SEMANTIC_TESTS)(
+    "agent asks 'help me design the system' → architect agent found",
+    async () => {
+      const result = await akmSearch({ query: "system design architecture" });
+      expect(result.hits.length).toBeGreaterThan(0);
+      expect(result.hits.some((h) => h.name.includes("architect"))).toBe(true);
+    },
+  );
 
   test("agent workflow: search → show (end-to-end)", async () => {
     // Step 1: Agent searches for a script to run tests
@@ -1566,14 +1592,21 @@ describe("Scenario: Zero-config progressive improvement", () => {
     expect(reloaded.entries[0].quality).not.toBe("generated");
   });
 
-  test("semantic search finds user-edited metadata after re-index", async () => {
-    // Re-index to pick up manual edits in the search index
-    await akmIndex({ stashDir });
+  // Needs semantic embeddings: the natural-language query tokens are not all
+  // present in the fixture's indexed fields, so FTS (AND-joined tokens) alone
+  // returns nothing. Opt in with AKM_SEMANTIC_TESTS=1 (downloads the local
+  // embedding model on first run — see AGENTS.md).
+  test.skipIf(!process.env.AKM_SEMANTIC_TESTS)(
+    "semantic search finds user-edited metadata after re-index",
+    async () => {
+      // Re-index to pick up manual edits in the search index
+      await akmIndex({ stashDir });
 
-    const result = await akmSearch({ query: "format code style" });
-    expect(result.hits.length).toBeGreaterThan(0);
-    expect(result.hits.some((h) => h.name.includes("prettier"))).toBe(true);
-  });
+      const result = await akmSearch({ query: "format code style" });
+      expect(result.hits.length).toBeGreaterThan(0);
+      expect(result.hits.some((h) => h.name.includes("prettier"))).toBe(true);
+    },
+  );
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/tests/integration/import-stdin-xref-slug.test.ts
+++ b/tests/integration/import-stdin-xref-slug.test.ts
@@ -1,0 +1,74 @@
+/**
+ * SPEC-3/5 slug stability for `akm import -` (stdin): the same piped content
+ * must produce the SAME inferred slug with and without `--xref`.
+ *
+ * Stdin imports have no filename-derived preferredName, so the slug comes
+ * from the content's first non-empty line — which `mergeXrefsIntoContent`
+ * used to bury under the leading `---` frontmatter fence, sending
+ * `inferAssetName` to its random `knowledge-<epoch>-<rand>` fallback. The fix
+ * infers the name from the ORIGINAL pre-merge content.
+ *
+ * INTEGRATION TEST — lives in tests/integration/ because stdin cannot be
+ * injected into the in-process harness (tests/_helpers/cli.ts); each `akm`
+ * invocation is a real `bun src/cli.ts` subprocess fed via `input`. The
+ * non-stdin slug-stability surface is pinned in
+ * tests/commands/remember-import-xref.test.ts.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { type Cleanup, sandboxStashDir, writeSandboxConfig } from "../_helpers/sandbox";
+
+let stashCleanup: Cleanup = () => {};
+let stashDir = "";
+
+beforeEach(() => {
+  const stash = sandboxStashDir();
+  stashDir = stash.dir;
+  stashCleanup = stash.cleanup;
+  writeSandboxConfig({ semanticSearchMode: "off" });
+});
+
+afterEach(() => {
+  stashCleanup();
+  stashCleanup = () => {};
+  stashDir = "";
+});
+
+const CLI_PATH = path.resolve(import.meta.dir, "../../src/cli.ts");
+
+/** Run `akm <args>` as a real subprocess with `input` piped to stdin. */
+function akmWithStdin(args: string[], input: string): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync("bun", [CLI_PATH, ...args], {
+    input,
+    encoding: "utf8",
+    // The sandboxed AKM_STASH_DIR / XDG_* vars are already in process.env
+    // (set by the preload + sandbox helpers above).
+    env: process.env,
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+describe("import - (stdin) slug stability under --xref", () => {
+  test("the same stdin content produces the same slug with and without --xref", () => {
+    const seedPath = path.join(stashDir, "knowledge", "auth-flow.md");
+    fs.mkdirSync(path.dirname(seedPath), { recursive: true });
+    fs.writeFileSync(seedPath, "# Seed\n\nSeed content.\n", "utf8");
+    const body = "# Auth notes\n\nOAuth details worth keeping.\n";
+
+    const plain = akmWithStdin(["import", "-"], body);
+    expect(plain.status, plain.stderr).toBe(0);
+    const plainRef = (JSON.parse(plain.stdout) as { ref: string }).ref;
+    expect(plainRef).toBe("knowledge:auth-notes");
+
+    // The structured path (forced by --xref) must derive the identical slug
+    // from the pre-merge content — not a random knowledge-<epoch>-<rand>
+    // fallback taken from the merged frontmatter fence. --force proves the
+    // name collides with the plain-path write.
+    const structured = akmWithStdin(["import", "-", "--force", "--xref", "knowledge:auth-flow"], body);
+    expect(structured.status, structured.stderr).toBe(0);
+    expect((JSON.parse(structured.stdout) as { ref: string }).ref).toBe(plainRef);
+  });
+});

--- a/tests/integration/import-stdin-xref-slug.test.ts
+++ b/tests/integration/import-stdin-xref-slug.test.ts
@@ -71,4 +71,24 @@ describe("import - (stdin) slug stability under --xref", () => {
     expect(structured.status, structured.stderr).toBe(0);
     expect((JSON.parse(structured.stdout) as { ref: string }).ref).toBe(plainRef);
   });
+
+  test("a stdin doc CARRYING ITS OWN frontmatter derives its slug from the parsed body — same with and without --xref (R2-3)", () => {
+    // Exactly the doc class mergeXrefsIntoContent's merge branch exists for:
+    // the raw content's first non-empty line is the `---` fence, which sent
+    // inferAssetName to its random knowledge-<epoch>-<rand> fallback on BOTH
+    // paths. The name must come from the parsed body's heading instead.
+    const seedPath = path.join(stashDir, "knowledge", "legacy-guide.md");
+    fs.mkdirSync(path.dirname(seedPath), { recursive: true });
+    fs.writeFileSync(seedPath, "# Seed\n\nSeed content.\n", "utf8");
+    const body = "---\ndescription: carried frontmatter\n---\n\n# Frontmattered Guide\n\nBody worth keeping.\n";
+
+    const plain = akmWithStdin(["import", "-"], body);
+    expect(plain.status, plain.stderr).toBe(0);
+    const plainRef = (JSON.parse(plain.stdout) as { ref: string }).ref;
+    expect(plainRef).toBe("knowledge:frontmattered-guide");
+
+    const structured = akmWithStdin(["import", "-", "--force", "--xref", "knowledge:legacy-guide"], body);
+    expect(structured.status, structured.stderr).toBe(0);
+    expect((JSON.parse(structured.stdout) as { ref: string }).ref).toBe(plainRef);
+  });
 });

--- a/tests/integration/install-script.test.ts
+++ b/tests/integration/install-script.test.ts
@@ -5,6 +5,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+// chmod-ing the install dir read-only is a no-op when running as root
+// (permission bits are not enforced for uid 0), so install.sh's writability
+// probe never selects the sudo branch. CI runners are non-root.
+const runningAsRoot = typeof process.getuid === "function" && process.getuid() === 0;
+
 const PROJECT_ROOT = path.resolve(import.meta.dirname, "..", "..");
 const INSTALL_SCRIPT = path.join(PROJECT_ROOT, "install.sh");
 const BASH_PATH = resolveCommand("bash");
@@ -248,7 +253,7 @@ describe("install.sh", () => {
     expect(result.stdout + result.stderr).toContain("curl or wget is required");
   });
 
-  test("uses sudo mv when install dir is not writable", () => {
+  test.skipIf(runningAsRoot)("uses sudo mv when install dir is not writable", () => {
     const harness = createHarness({ installDirWritable: false, useSudo: true });
     const result = harness.run();
 
@@ -290,7 +295,7 @@ describe("install.sh", () => {
     expect(fs.existsSync(path.join(harness.installDir, "akm"))).toBe(true);
   });
 
-  test("fails clearly when sudo is required but unavailable", () => {
+  test.skipIf(runningAsRoot)("fails clearly when sudo is required but unavailable", () => {
     const harness = createHarness({ installDirWritable: false, useSudo: true, sudoSucceeds: false });
     const result = harness.run();
 

--- a/tests/integration/output-baseline-graph.test.ts
+++ b/tests/integration/output-baseline-graph.test.ts
@@ -70,7 +70,12 @@ async function runCliAsync(stashDir: string, args: string[], config?: Record<str
   const xdgConfig = makeTempDir("akm-output-config-");
   const xdgData = makeTempDir("akm-output-data-");
   const xdgState = makeTempDir("akm-output-state-");
-  if (config) writeConfig(xdgConfig, config);
+  // Semantic off keeps auto-index stderr deterministic: with the default
+  // ("auto") the local embedder fetches its model from huggingface.co and a
+  // blocked/offline fetch emits "Embedding generation failed" on stderr,
+  // tripping the stderr-cleanliness check below. This test suite pins output
+  // shapes, not semantic ranking.
+  writeConfig(xdgConfig, { semanticSearchMode: "off", ...(config ?? {}) });
 
   const child = spawn("bun", [CLI, ...args], {
     stdio: ["ignore", "pipe", "pipe"],

--- a/tests/integration/supersedes-git-target.test.ts
+++ b/tests/integration/supersedes-git-target.test.ts
@@ -1,0 +1,103 @@
+/**
+ * SPEC-5 (stash-conventions-code-spec.md), git-target case: `--supersedes`
+ * on a git write target batches BOTH files — the new correction asset and
+ * the demoted old asset — into the SINGLE boundary commit (0.9.0
+ * batch-at-boundary, issue #507). The old asset's frontmatter mutation
+ * (`beliefState: superseded` + `supersededBy`) must therefore be ordered
+ * BEFORE `commitWriteTargetBoundary`, or the commit ships incomplete and the
+ * working tree is left dirty.
+ *
+ * INTEGRATION TEST — lives in tests/integration/ because it builds and
+ * asserts against a real git fixture repo (spawnSync git), like
+ * tests/integration/write-source.test.ts. The `akm` invocation itself uses
+ * the in-process harness (tests/_helpers/cli.ts).
+ *
+ * The rest of the SPEC-5 surface (frontmatter demotion, xref folding,
+ * validation, read-only sources, help meta, writeSupersededEdge unit) is
+ * pinned in tests/commands/remember-import-supersedes.test.ts.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { parseFrontmatter } from "../../src/core/asset/frontmatter";
+import { getCachePaths, parseGitRepoUrl } from "../../src/sources/providers/git";
+import { runCliCapture } from "../_helpers/cli";
+import { type Cleanup, sandboxStashDir, writeSandboxConfig } from "../_helpers/sandbox";
+
+const cleanups: Cleanup[] = [];
+let stashCleanup: Cleanup = () => {};
+
+beforeEach(() => {
+  const stash = sandboxStashDir();
+  stashCleanup = stash.cleanup;
+  writeSandboxConfig({ semanticSearchMode: "off" });
+});
+
+afterEach(() => {
+  stashCleanup();
+  stashCleanup = () => {};
+  for (const c of cleanups.splice(0)) c();
+});
+
+function git(args: string[], failMessage: string): string {
+  const result = spawnSync("git", args, { encoding: "utf8" });
+  expect(result.status, `${failMessage}: ${result.stderr}`).toBe(0);
+  return result.stdout;
+}
+
+describe("--supersedes on a git write target", () => {
+  test("the boundary commit batches BOTH the correction and the demoted old asset, leaving a clean tree", async () => {
+    // A git source's on-disk path is the cache mirror keyed by its URL.
+    const repoUrl = "https://github.com/acme/supersedes-stash";
+    const cache = getCachePaths(parseGitRepoUrl(repoUrl).canonicalUrl);
+    const repoDir = cache.repoDir;
+    // The git cache lives under the per-process XDG_CACHE_HOME sandbox —
+    // clean it after this test so no other test sees the fixture repo.
+    cleanups.push(() => fs.rmSync(cache.rootDir, { recursive: true, force: true }));
+
+    git(["init", repoDir], "git init");
+    git(["-C", repoDir, "config", "user.name", "akm-test"], "git config user.name");
+    git(["-C", repoDir, "config", "user.email", "akm@test"], "git config user.email");
+    git(["-C", repoDir, "config", "commit.gpgsign", "false"], "git config gpgsign");
+    const oldPath = path.join(repoDir, "memories", "old-note.md");
+    fs.mkdirSync(path.dirname(oldPath), { recursive: true });
+    fs.writeFileSync(oldPath, "Old team note that is being corrected.\n", "utf8");
+    git(["-C", repoDir, "add", "-A"], "git add seed");
+    git(["-C", repoDir, "commit", "-m", "seed"], "git commit seed");
+
+    writeSandboxConfig({
+      semanticSearchMode: "off",
+      sources: [{ type: "git", name: "team", url: repoUrl, writable: true }],
+    });
+
+    const { code, stdout } = await runCliCapture([
+      "remember",
+      "Corrected team note superseding the old one.",
+      "--name",
+      "new-note",
+      "--target",
+      "team",
+      "--supersedes",
+      "memory:old-note",
+    ]);
+    expect(code).toBe(0);
+    const json = JSON.parse(stdout) as { superseded?: Array<{ ref: string; applied: boolean }> };
+    expect(json.superseded?.[0]?.applied).toBe(true);
+
+    // Exactly ONE boundary commit on top of the seed...
+    expect(git(["-C", repoDir, "rev-list", "--count", "HEAD"], "git rev-list").trim()).toBe("2");
+    // ...containing BOTH files (the demotion is ordered before the boundary)...
+    const committed = git(["-C", repoDir, "show", "--name-only", "--format=", "HEAD"], "git show");
+    expect(committed).toContain("memories/new-note.md");
+    expect(committed).toContain("memories/old-note.md");
+    // ...and no dirty residue: the metadata edit did not land after the commit.
+    expect(git(["-C", repoDir, "status", "--porcelain"], "git status").trim()).toBe("");
+
+    // The demotion itself is on disk in the git working tree.
+    const oldParsed = parseFrontmatter(fs.readFileSync(oldPath, "utf8"));
+    expect(oldParsed.data.beliefState).toBe("superseded");
+    expect(oldParsed.data.supersededBy).toEqual(["memory:new-note"]);
+  });
+});

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -526,6 +526,43 @@ describe("missing-ref check", () => {
     expect(result.flagged.filter((i) => i.issue === "missing-ref")).toHaveLength(0);
   });
 
+  test("missing-ref: flags a bracketed body ref (`see [memory:gone]`)", () => {
+    // Regression: `[` was missing from REF_RE's prefix boundary class, so a
+    // ref opening a markdown-link-style bracket was never matched — dangling
+    // bracketed refs were silently ignored.
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "memories",
+      "bracketed.md",
+      "---\nname: bracketed\ntype: memory\nupdated: 2025-01-01\n---\n\nsee [memory:gone-bracketed] for details.\n",
+    );
+
+    const result = akmLint({ dir: stashDir });
+    const missing = result.flagged.filter((i) => i.issue === "missing-ref");
+    expect(missing).toHaveLength(1);
+    expect(missing[0].detail).toContain("missing ref: memory:gone-bracketed");
+  });
+
+  test("missing-ref: does NOT flag a bracketed ref whose target exists", () => {
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "memories",
+      "target-note.md",
+      "---\nname: target-note\ntype: memory\nupdated: 2025-01-01\n---\n\nTarget.\n",
+    );
+    writeFile(
+      stashDir,
+      "memories",
+      "linker.md",
+      "---\nname: linker\ntype: memory\nupdated: 2025-01-01\n---\n\nsee [memory:target-note] for details.\n",
+    );
+
+    const result = akmLint({ dir: stashDir });
+    expect(result.flagged.filter((i) => i.issue === "missing-ref")).toHaveLength(0);
+  });
+
   test("missing-ref: outer-frontmatter `refs:` array suppresses body scan", () => {
     const stashDir = makeTempStash();
     // The referenced asset DOES exist, so a frontmatter-listed ref does
@@ -925,10 +962,11 @@ describe("missing-ref frontmatter xref channels (xrefs/supersededBy/contradicted
 
   test("task .yml with a dangling xrefs entry is flagged exactly once (body scan only)", () => {
     // Tasks are pure YAML: lint/index.ts sets body = raw and frontmatter =
-    // null, so ref values under `xrefs:` are already caught by the BODY scan.
-    // The frontmatter-xref pass must skip that path or every dangling task
-    // xref would be double-reported (one plain + one `frontmatter xrefs`
-    // finding for a single on-disk occurrence).
+    // null. When there is NO authoritative `refs:` array, ref values under
+    // `xrefs:` are already caught by the BODY scan, so the frontmatter-xref
+    // pass must skip that path or every dangling task xref would be
+    // double-reported (one plain + one `frontmatter xrefs` finding for a
+    // single on-disk occurrence).
     const stashDir = makeTempStash();
     writeFile(
       stashDir,
@@ -945,17 +983,84 @@ describe("missing-ref frontmatter xref channels (xrefs/supersededBy/contradicted
     expect(missing[0].detail).not.toContain("frontmatter");
   });
 
-  test("scalar-valued supersededBy (no list syntax) is silently skipped", () => {
-    // readRefsArray only accepts arrays; a scalar `supersededBy: <ref>` is
-    // neither scanned nor crashed on. The conventions and writeContradictEdge
-    // both use the array form — this pins the skip so a regression that
-    // started false-flagging (or throwing on) scalars would be caught.
+  test("task .yml with authoritative `refs:` still validates dangling xrefs (exactly once)", () => {
+    // Regression: an authoritative `refs:` array suppresses the body scan,
+    // and the frontmatter-xref pass used to be gated on `ctx.frontmatter !==
+    // null` (always null for tasks) — so `refs: [memory:exists]` + a
+    // dangling `xrefs:` entry produced ZERO findings. The xref pass now
+    // also runs when an explicit `refs:` list was extracted; since that
+    // suppresses the body scan, the dangling xref is reported exactly once,
+    // with the frontmatter-keyed detail.
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "memories",
+      "exists.md",
+      "---\nname: exists\ntype: memory\nupdated: 2025-01-01\n---\n\nStill here.\n",
+    );
+    writeFile(stashDir, "tasks", "t2.yml", "name: t2\nrefs:\n  - memory:exists\nxrefs:\n  - memory:gone-xref\n");
+
+    const result = akmLint({ dir: stashDir });
+    const missing = result.flagged.filter((i) => i.issue === "missing-ref");
+    expect(missing).toHaveLength(1);
+    expect(missing[0].file).toContain("t2.yml");
+    expect(missing[0].detail).toContain("missing ref: memory:gone-xref");
+    expect(missing[0].detail).toContain("frontmatter xrefs");
+  });
+
+  test("task .yml with `refs:` and a dangling SCALAR supersededBy is flagged", () => {
+    // Compound regression for both gaps: the YAML path (frontmatter === null,
+    // explicit refs present) plus the scalar shape.
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "memories",
+      "exists.md",
+      "---\nname: exists\ntype: memory\nupdated: 2025-01-01\n---\n\nStill here.\n",
+    );
+    writeFile(stashDir, "tasks", "t3.yml", "name: t3\nrefs:\n  - memory:exists\nsupersededBy: task:replacement\n");
+
+    const result = akmLint({ dir: stashDir });
+    const missing = result.flagged.filter((i) => i.issue === "missing-ref");
+    expect(missing).toHaveLength(1);
+    expect(missing[0].detail).toContain("missing ref: task:replacement");
+    expect(missing[0].detail).toContain("frontmatter supersededBy");
+  });
+
+  test("scalar-valued supersededBy (no list syntax) is validated like the array form", () => {
+    // The indexer's normalizeNonEmptyStringList accepts a bare scalar
+    // (`supersededBy: memory:x`) as live data, so lint must validate that
+    // shape too — a dangling scalar was previously skipped silently because
+    // the xref reader only accepted arrays.
     const stashDir = makeTempStash();
     writeFile(
       stashDir,
       "memories",
       "scalar-superseded.md",
       "---\nname: scalar-superseded\ntype: memory\nupdated: 2025-01-01\nbeliefState: superseded\nsupersededBy: memory:corrections/never-written\n---\n\nOld guidance.\n",
+    );
+
+    const result = akmLint({ dir: stashDir });
+    const missing = result.flagged.filter((i) => i.issue === "missing-ref");
+    expect(missing).toHaveLength(1);
+    expect(missing[0].detail).toContain("missing ref: memory:corrections/never-written");
+    expect(missing[0].detail).toContain("frontmatter supersededBy");
+  });
+
+  test("scalar-valued xref that resolves produces no finding", () => {
+    // Scalar acceptance must not false-flag valid refs.
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "memories",
+      "newer-tip.md",
+      "---\nname: newer-tip\ntype: memory\nupdated: 2025-01-01\n---\n\nNewer guidance.\n",
+    );
+    writeFile(
+      stashDir,
+      "memories",
+      "scalar-ok.md",
+      "---\nname: scalar-ok\ntype: memory\nupdated: 2025-01-01\nbeliefState: superseded\nsupersededBy: memory:newer-tip\n---\n\nOld guidance.\n",
     );
 
     const result = akmLint({ dir: stashDir });

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -1027,6 +1027,39 @@ describe("missing-ref frontmatter xref channels (xrefs/supersededBy/contradicted
     expect(missing[0].detail).toContain("frontmatter supersededBy");
   });
 
+  test("task .yml without `refs:` — a NO-SPACE flow list flags the ref after the bare comma too (R2-5)", () => {
+    // `xrefs: [memory:a,memory:b]` is valid YAML. A task .yml WITHOUT an
+    // authoritative `refs:` key relies on the BODY scan, and `,` — already a
+    // slug terminator — was missing from the boundary prefix class, so the
+    // post-comma ref could never start a match and dangled invisibly.
+    const stashDir = makeTempStash();
+    writeFile(stashDir, "tasks", "t4.yml", "name: t4\nxrefs: [memory:gone-one,memory:gone-two]\n");
+
+    const result = akmLint({ dir: stashDir });
+    const missing = result.flagged.filter((i) => i.issue === "missing-ref");
+    expect(missing).toHaveLength(2);
+    const details = missing.map((i) => i.detail).join("\n");
+    expect(details).toContain("memory:gone-one");
+    expect(details).toContain("memory:gone-two");
+  });
+
+  test("md BODY refs immediately after a bare comma are scanned (R2-5)", () => {
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "memories",
+      "comma-body.md",
+      "---\nname: comma-body\ntype: memory\nupdated: 2025-01-01\n---\n\nCompare memory:gone-a,memory:gone-b in one breath.\n",
+    );
+
+    const result = akmLint({ dir: stashDir });
+    const missing = result.flagged.filter((i) => i.issue === "missing-ref");
+    expect(missing).toHaveLength(2);
+    const details = missing.map((i) => i.detail).join("\n");
+    expect(details).toContain("memory:gone-a");
+    expect(details).toContain("memory:gone-b");
+  });
+
   test("scalar-valued supersededBy (no list syntax) is validated like the array form", () => {
     // The indexer's normalizeNonEmptyStringList accepts a bare scalar
     // (`supersededBy: memory:x`) as live data, so lint must validate that

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { akmLint } from "../src/commands/lint/index";
+import type { AkmConfig } from "../src/core/config/config";
 import { runCliCapture } from "./_helpers/cli";
 import { withEnv } from "./_helpers/sandbox";
 
@@ -654,6 +655,335 @@ describe("missing-ref check", () => {
     );
     const result = akmLint({ dir: stashDir });
     expect(result.flagged.filter((i) => i.issue === "missing-ref")).toHaveLength(0);
+  });
+});
+
+// ── SPEC-1: missing-ref frontmatter xref channels ────────────────────────────
+//
+// The stash conventions route provenance and correction links through the
+// `xrefs:`, `supersededBy:`, and `contradictedBy:` frontmatter keys. The
+// missing-ref check scans those keys for dangling refs in ADDITION to the
+// existing body / `refs:` scan. The frontmatter-key pass:
+//   - flags dangling refs with a detail naming the frontmatter key,
+//   - runs regardless of the `refs:` body-scan carve-out (`refs: []` is
+//     authoritative for the BODY only),
+//   - ignores non-ref-shaped values (URLs, raw/<slug>, `<placeholder>`
+//     templates, shell vars) via the existing checkMissingRefs guards,
+//   - resolves refs against the primary stash AND extraStashRoots,
+//   - is suppressed by `lint_skip: [missing-ref]`,
+//   - applies to all md linters (memory/knowledge/lesson/fact); wikis stay
+//     out of `akm lint` entirely.
+
+describe("missing-ref frontmatter xref channels (xrefs/supersededBy/contradictedBy)", () => {
+  test("flags a dangling ref in `xrefs:` with the frontmatter-key detail", () => {
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "memories",
+      "derived-tip.md",
+      "---\nname: derived-tip\ntype: memory\nupdated: 2025-01-01\nxrefs:\n  - knowledge:auth/nonexistent\n---\n\nDistilled from the auth doc.\n",
+    );
+
+    const result = akmLint({ dir: stashDir });
+    const missing = result.flagged.filter((i) => i.issue === "missing-ref");
+    expect(missing).toHaveLength(1);
+    expect(missing[0].file).toContain("derived-tip.md");
+    expect(missing[0].detail).toContain("knowledge:auth/nonexistent");
+    expect(missing[0].detail).toContain("frontmatter xrefs");
+    expect(missing[0].detail).toContain(path.join("knowledge", "auth", "nonexistent.md"));
+    expect(missing[0].fixed).toBe(false);
+  });
+
+  test("does NOT flag resolvable xrefs (same stash, incl. knowledge subdir layout)", () => {
+    // NOTE: passes pre-implementation too (no frontmatter pass exists yet);
+    // kept as the over-flagging guard once the pass lands.
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "knowledge/auth",
+      "oauth-flow.md",
+      "---\nname: auth/oauth-flow\ntype: knowledge\nupdated: 2025-01-01\n---\n\nOAuth flow doc.\n",
+    );
+    writeFile(
+      stashDir,
+      "memories",
+      "source-note.md",
+      "---\nname: source-note\ntype: memory\nupdated: 2025-01-01\n---\n\nSource note.\n",
+    );
+    writeFile(
+      stashDir,
+      "memories",
+      "derived-tip.md",
+      "---\nname: derived-tip\ntype: memory\nupdated: 2025-01-01\nxrefs:\n  - knowledge:auth/oauth-flow\n  - memory:source-note\n---\n\nDerived from both.\n",
+    );
+
+    const result = akmLint({ dir: stashDir });
+    expect(result.flagged.filter((i) => i.issue === "missing-ref")).toHaveLength(0);
+  });
+
+  test("mixed valid + dangling xrefs: only the dangling ref is flagged", () => {
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "knowledge/auth",
+      "oauth-flow.md",
+      "---\nname: auth/oauth-flow\ntype: knowledge\nupdated: 2025-01-01\n---\n\nOAuth flow doc.\n",
+    );
+    writeFile(
+      stashDir,
+      "memories",
+      "derived-tip.md",
+      "---\nname: derived-tip\ntype: memory\nupdated: 2025-01-01\nxrefs:\n  - knowledge:auth/oauth-flow\n  - memory:vanished-note\n---\n\nDerived.\n",
+    );
+
+    const result = akmLint({ dir: stashDir });
+    const missing = result.flagged.filter((i) => i.issue === "missing-ref");
+    expect(missing).toHaveLength(1);
+    expect(missing[0].detail).toContain("memory:vanished-note");
+    expect(missing[0].detail).not.toContain("knowledge:auth/oauth-flow");
+  });
+
+  test("flags a dangling `supersededBy:` ref with the frontmatter-key detail", () => {
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "memories",
+      "stale-tip.md",
+      "---\nname: stale-tip\ntype: memory\nupdated: 2025-01-01\nbeliefState: superseded\nsupersededBy:\n  - memory:corrections/newer-tip\n---\n\nOld guidance.\n",
+    );
+
+    const result = akmLint({ dir: stashDir });
+    const missing = result.flagged.filter((i) => i.issue === "missing-ref");
+    expect(missing).toHaveLength(1);
+    expect(missing[0].detail).toContain("memory:corrections/newer-tip");
+    expect(missing[0].detail).toContain("frontmatter supersededBy");
+    expect(missing[0].fixed).toBe(false);
+  });
+
+  test("flags a dangling `contradictedBy:` ref (inline-flow YAML list)", () => {
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "memories",
+      "shaky-tip.md",
+      '---\nname: shaky-tip\ntype: memory\nupdated: 2025-01-01\ncontradictedBy: ["memory:conflicts/other-take"]\n---\n\nContested guidance.\n',
+    );
+
+    const result = akmLint({ dir: stashDir });
+    const missing = result.flagged.filter((i) => i.issue === "missing-ref");
+    expect(missing).toHaveLength(1);
+    expect(missing[0].detail).toContain("memory:conflicts/other-take");
+    expect(missing[0].detail).toContain("frontmatter contradictedBy");
+  });
+
+  test("authoritative-empty `refs: []` does NOT suppress the xrefs scan", () => {
+    const stashDir = makeTempStash();
+    // `refs: []` suppresses the BODY scan (the literal memory:foo below must
+    // stay unflagged) but the frontmatter xrefs channel is still checked.
+    writeFile(
+      stashDir,
+      "memories",
+      "captured.md",
+      "---\nname: captured\ntype: memory\nupdated: 2025-01-01\nrefs: []\nxrefs:\n  - knowledge:pipelines/gone\n---\n\nTranscript mentions a literal memory:foo token.\n",
+    );
+
+    const result = akmLint({ dir: stashDir });
+    const missing = result.flagged.filter((i) => i.issue === "missing-ref");
+    expect(missing).toHaveLength(1);
+    expect(missing[0].detail).toContain("knowledge:pipelines/gone");
+    expect(missing[0].detail).toContain("frontmatter xrefs");
+    expect(missing.some((i) => i.detail.includes("memory:foo"))).toBe(false);
+  });
+
+  test("non-ref values in xrefs are ignored (URL, raw/<slug>, placeholder, shell vars)", () => {
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "memories",
+      "linky.md",
+      "---\nname: linky\ntype: memory\nupdated: 2025-01-01\nxrefs:\n" +
+        '  - "https://example.com/upstream-doc"\n' +
+        "  - raw/2026-06-01-session-transcript\n" +
+        "  - knowledge:<slug>\n" +
+        "  - memory:$(git rev-parse HEAD)\n" +
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: literal shell-var placeholder the linter must skip
+        '  - "knowledge:${DOCS_ROOT}/setup"\n' +
+        "  - workflow:definitely-gone\n" +
+        "---\n\nBody without refs.\n",
+    );
+
+    const result = akmLint({ dir: stashDir });
+    const missing = result.flagged.filter((i) => i.issue === "missing-ref");
+    // Only the real dangling ref is flagged; every non-ref value falls out.
+    expect(missing).toHaveLength(1);
+    expect(missing[0].detail).toContain("workflow:definitely-gone");
+    for (const skipped of ["example.com", "raw/2026-06-01", "<slug>", "$(", "${"]) {
+      expect(missing.some((i) => i.detail.includes(skipped))).toBe(false);
+    }
+  });
+
+  test("`lint_skip: [missing-ref]` suppresses the frontmatter xref pass too", () => {
+    // NOTE: passes pre-implementation (nothing scans xrefs yet); pins that the
+    // new pass lives inside the same shouldRun("missing-ref") gate.
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "memories",
+      "skipped.md",
+      "---\nname: skipped\ntype: memory\nupdated: 2025-01-01\nlint_skip: [missing-ref]\nxrefs:\n  - knowledge:void/gone\n---\n\nBody cites workflow:also-gone here.\n",
+    );
+
+    const result = akmLint({ dir: stashDir });
+    expect(result.flagged.filter((i) => i.issue === "missing-ref")).toHaveLength(0);
+  });
+
+  test("wikis stay untouched: dangling xrefs in wikis/ produce no lint findings", () => {
+    // NOTE: passes pre-implementation ("wikis" is not a linted stash subdir);
+    // guards that the frontmatter pass does not pull wikis into akm lint.
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "wikis",
+      "hub.md",
+      "---\nname: hub\ntype: wiki\nupdated: 2025-01-01\nxrefs:\n  - knowledge:void/gone\n---\n\nWiki hub page.\n",
+    );
+
+    const result = akmLint({ dir: stashDir });
+    expect(result.flagged.filter((i) => i.file.includes("hub.md"))).toHaveLength(0);
+  });
+
+  test("frontmatter xref pass runs for memory, knowledge, lesson, and fact linters", () => {
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "memories",
+      "mem-derived.md",
+      "---\nname: mem-derived\ntype: memory\nupdated: 2025-01-01\nxrefs:\n  - knowledge:origins/gone-a\n---\n\nBody.\n",
+    );
+    writeFile(
+      stashDir,
+      "knowledge",
+      "kn-derived.md",
+      "---\nname: kn-derived\ntype: knowledge\nupdated: 2025-01-01\nxrefs:\n  - memory:origins/gone-b\n---\n\nBody.\n",
+    );
+    writeFile(
+      stashDir,
+      "lessons",
+      "ls-derived.md",
+      "---\nname: ls-derived\ntype: lesson\nupdated: 2025-01-01\nxrefs:\n  - knowledge:origins/gone-c\n---\n\nBody.\n",
+    );
+    writeFile(
+      stashDir,
+      "facts",
+      "team-glossary.md",
+      "---\nname: team-glossary\ntype: fact\ncategory: team\nupdated: 2025-01-01\nxrefs:\n  - fact:conventions/gone-d\n---\n\nBody.\n",
+    );
+
+    const result = akmLint({ dir: stashDir });
+    const missing = result.flagged.filter((i) => i.issue === "missing-ref");
+    expect(missing).toHaveLength(4);
+    const byFile = (name: string) => missing.filter((i) => i.file.includes(name));
+    expect(byFile("mem-derived.md")).toHaveLength(1);
+    expect(byFile("mem-derived.md")[0].detail).toContain("knowledge:origins/gone-a");
+    expect(byFile("kn-derived.md")).toHaveLength(1);
+    expect(byFile("kn-derived.md")[0].detail).toContain("memory:origins/gone-b");
+    expect(byFile("ls-derived.md")).toHaveLength(1);
+    expect(byFile("ls-derived.md")[0].detail).toContain("knowledge:origins/gone-c");
+    expect(byFile("team-glossary.md")).toHaveLength(1);
+    expect(byFile("team-glossary.md")[0].detail).toContain("fact:conventions/gone-d");
+    for (const issue of missing) {
+      expect(issue.detail).toContain("frontmatter xrefs");
+    }
+  });
+
+  test("xref resolvable only in an extraStashRoot is clean; dangling sibling still flagged", () => {
+    const stashDir = makeTempStash();
+    const extraStash = makeTempStash("akm-lint-extra-");
+    writeFile(
+      extraStash,
+      "knowledge/shared",
+      "present.md",
+      "---\nname: shared/present\ntype: knowledge\nupdated: 2025-01-01\n---\n\nShared doc in the extra stash.\n",
+    );
+    writeFile(
+      stashDir,
+      "memories",
+      "cross-stash.md",
+      "---\nname: cross-stash\ntype: memory\nupdated: 2025-01-01\nxrefs:\n  - knowledge:shared/present\n  - memory:vanished-note\n---\n\nDerived from the shared doc.\n",
+    );
+
+    const config: AkmConfig = {
+      semanticSearchMode: "off",
+      sources: [{ type: "filesystem", path: extraStash }],
+    };
+    const result = akmLint({ dir: stashDir, config });
+    const missing = result.flagged.filter((i) => i.issue === "missing-ref");
+    expect(missing).toHaveLength(1);
+    expect(missing[0].detail).toContain("memory:vanished-note");
+    expect(missing.some((i) => i.detail.includes("knowledge:shared/present"))).toBe(false);
+  });
+
+  test("task .yml with a dangling xrefs entry is flagged exactly once (body scan only)", () => {
+    // Tasks are pure YAML: lint/index.ts sets body = raw and frontmatter =
+    // null, so ref values under `xrefs:` are already caught by the BODY scan.
+    // The frontmatter-xref pass must skip that path or every dangling task
+    // xref would be double-reported (one plain + one `frontmatter xrefs`
+    // finding for a single on-disk occurrence).
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "tasks",
+      "t1.yml",
+      "name: t1\ndescription: task citing a vanished memory\nxrefs:\n  - memory:gone-task-ref\n",
+    );
+
+    const result = akmLint({ dir: stashDir });
+    const missing = result.flagged.filter((i) => i.issue === "missing-ref");
+    expect(missing).toHaveLength(1);
+    expect(missing[0].file).toContain("t1.yml");
+    expect(missing[0].detail).toContain("memory:gone-task-ref");
+    expect(missing[0].detail).not.toContain("frontmatter");
+  });
+
+  test("scalar-valued supersededBy (no list syntax) is silently skipped", () => {
+    // readRefsArray only accepts arrays; a scalar `supersededBy: <ref>` is
+    // neither scanned nor crashed on. The conventions and writeContradictEdge
+    // both use the array form — this pins the skip so a regression that
+    // started false-flagging (or throwing on) scalars would be caught.
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "memories",
+      "scalar-superseded.md",
+      "---\nname: scalar-superseded\ntype: memory\nupdated: 2025-01-01\nbeliefState: superseded\nsupersededBy: memory:corrections/never-written\n---\n\nOld guidance.\n",
+    );
+
+    const result = akmLint({ dir: stashDir });
+    expect(result.flagged.filter((i) => i.issue === "missing-ref")).toHaveLength(0);
+  });
+
+  test("same dangling ref in body AND xrefs frontmatter yields two findings (one per channel)", () => {
+    // Each channel reports independently for md files: the body occurrence
+    // gets the plain detail, the frontmatter occurrence gets the keyed
+    // detail. Two on-disk occurrences, two findings — a dedupe refactor must
+    // not silently collapse (or further inflate) this.
+    const stashDir = makeTempStash();
+    writeFile(
+      stashDir,
+      "memories",
+      "doubled.md",
+      "---\nname: doubled\ntype: memory\nupdated: 2025-01-01\nxrefs:\n  - knowledge:void/gone\n---\n\nDerived from knowledge:void/gone which no longer exists.\n",
+    );
+
+    const result = akmLint({ dir: stashDir });
+    const missing = result.flagged.filter((i) => i.issue === "missing-ref");
+    expect(missing).toHaveLength(2);
+    const plain = missing.filter((i) => !i.detail.includes("frontmatter"));
+    const keyed = missing.filter((i) => i.detail.includes("frontmatter xrefs"));
+    expect(plain).toHaveLength(1);
+    expect(plain[0].detail).toContain("knowledge:void/gone");
+    expect(keyed).toHaveLength(1);
+    expect(keyed[0].detail).toContain("knowledge:void/gone");
   });
 });
 

--- a/tests/llm-feature-gate.test.ts
+++ b/tests/llm-feature-gate.test.ts
@@ -52,7 +52,10 @@ function configWith(features: Partial<Record<FeatureKey, boolean>>): AkmConfig {
         processes.graphExtraction = { enabled: val };
         break;
       case "metadata_enhance":
-        cfg.index = { ...(cfg.index ?? {}), metadataEnhance: { enabled: val } };
+        // Cast: IndexConfig mixes reserved scalar keys (indexBodyOpening,
+        // SPEC-8) with a per-pass object catchall; TS cannot re-verify a
+        // spread-rebuilt literal against that intersection.
+        cfg.index = { ...(cfg.index ?? {}), metadataEnhance: { enabled: val } } as AkmConfig["index"];
         break;
       case "lesson_quality_gate":
         processes.distill = { ...(processes.distill ?? {}), qualityGate: { enabled: val } };

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -18,6 +18,7 @@ import {
   validateStashEntry,
   writeStashFile,
 } from "../src/indexer/passes/metadata";
+import { buildSearchFields, buildSearchText } from "../src/indexer/search/search-fields";
 
 // Renderers auto-register via ensureBuiltinsRegistered in file-context.ts
 
@@ -656,6 +657,108 @@ test("validateStashEntry preserves captureMode, whenToUse, lessonStrength, evide
   expect(result?.whenToUse).toBe("for triage");
   expect(result?.lessonStrength).toBe(4);
   expect(result?.evidenceSources).toEqual(["memory:x"]);
+});
+
+// ── SPEC-6: fact `category` capture into the index ───────────────────────────
+//
+// Convention facts are selected for prompt injection by their `category:`
+// frontmatter (resolveStashStandards), but the indexer never captured that key
+// onto StashEntry — so no rank-time or filter policy can see it. SPEC-6 step 1
+// (docs/design/stash-conventions-code-spec.md) captures it in
+// applyCuratedFrontmatter (alongside beliefState) and whitelists it through
+// validateStashEntry so it survives the .stash.json / entry_json round-trip.
+
+/**
+ * SPEC-6 adds `category?: string` to StashEntry. Read it through a typed
+ * accessor so this file still compiles before the implementation lands; the
+ * dependent tests then go red on the runtime value instead of a compile error.
+ */
+function entryCategory(entry: StashEntry | null | undefined): string | undefined {
+  return (entry as (StashEntry & { category?: string }) | null | undefined)?.category;
+}
+
+test("applyCuratedFrontmatter captures category frontmatter onto the entry (SPEC-6)", () => {
+  const entry: StashEntry = { name: "conventions/backlinks", type: "fact" };
+  applyCuratedFrontmatter(entry, { category: "convention" });
+  expect(entryCategory(entry)).toBe("convention");
+});
+
+test("applyCuratedFrontmatter trims category and ignores blank or non-string values (SPEC-6)", () => {
+  const trimmed: StashEntry = { name: "f", type: "fact" };
+  applyCuratedFrontmatter(trimmed, { category: "  meta  " });
+  expect(entryCategory(trimmed)).toBe("meta");
+
+  const blank: StashEntry = { name: "f", type: "fact" };
+  applyCuratedFrontmatter(blank, { category: "   " });
+  expect(entryCategory(blank)).toBeUndefined();
+
+  const nonString: StashEntry = { name: "f", type: "fact" };
+  applyCuratedFrontmatter(nonString, { category: 42 });
+  expect(entryCategory(nonString)).toBeUndefined();
+
+  const absent: StashEntry = { name: "f", type: "fact" };
+  applyCuratedFrontmatter(absent, {});
+  expect(entryCategory(absent)).toBeUndefined();
+});
+
+test("validateStashEntry whitelists category (SPEC-6)", () => {
+  const result = validateStashEntry({ name: "team/tool-stack", type: "fact", category: "convention" });
+  expect(result).not.toBeNull();
+  expect(entryCategory(result)).toBe("convention");
+
+  // Non-string values are dropped, not coerced.
+  const bad = validateStashEntry({ name: "team/tool-stack", type: "fact", category: ["convention"] });
+  expect(bad).not.toBeNull();
+  expect(entryCategory(bad)).toBeUndefined();
+});
+
+test("loadStashFile preserves category on entries (SPEC-6 whitelist round-trip)", () => {
+  const dir = tmpDir();
+  writeFile(
+    path.join(dir, ".stash.json"),
+    JSON.stringify({
+      entries: [{ name: "active-projects", type: "fact", category: "meta", filename: "active-projects.md" }],
+    }),
+  );
+  const result = loadStashFile(dir);
+  expect(result).not.toBeNull();
+  expect(entryCategory(result?.entries[0])).toBe("meta");
+});
+
+test("generateMetadata populates entry.category from fact frontmatter (SPEC-6 end-to-end)", async () => {
+  const factsRoot = tmpDir();
+  const file = path.join(factsRoot, "conventions", "organization.md");
+  writeFile(
+    file,
+    ["---", "category: convention", "description: House placement rules", "---", "", "# Org", "", "Body.", ""].join(
+      "\n",
+    ),
+  );
+
+  const stash = await generateMetadata(factsRoot, "fact", [file]);
+  expect(stash.entries).toHaveLength(1);
+  expect(stash.entries[0].name).toBe("conventions/organization");
+  expect(entryCategory(stash.entries[0])).toBe("convention");
+});
+
+test("category is NOT folded into FTS search fields — capture only (SPEC-6 pin)", () => {
+  // SPEC-6 shipped `category` as capture-only metadata: the CHANGELOG claims
+  // "search results and ranking are unchanged". Pin that claim directly so a
+  // future buildSearchFields edit (e.g. SPEC-8's content-field work) cannot
+  // silently start indexing the category value. The sentinel token appears
+  // nowhere else on the entry, so any leak into a field is unambiguous.
+  const base: StashEntry = {
+    name: "conventions/backlinks",
+    type: "fact",
+    description: "how backlinks are declared",
+    tags: ["conventions"],
+  };
+  const withCategory: StashEntry = { ...base, category: "sentinelcategorytoken" };
+
+  // Adding a category leaves every FTS field byte-identical…
+  expect(buildSearchFields(withCategory)).toEqual(buildSearchFields(base));
+  // …and the value never reaches the concatenated search/embedding text.
+  expect(buildSearchText(withCategory)).not.toContain("sentinelcategorytoken");
 });
 
 // ── SPEC-2: merge path-derived scope/domain tokens into tags ─────────────────

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -10,6 +10,7 @@ import {
   extractTagsFromPath,
   fileNameToDescription,
   generateMetadata,
+  generateMetadataFlat,
   isEnrichmentComplete,
   loadStashFile,
   type StashEntry,
@@ -655,4 +656,202 @@ test("validateStashEntry preserves captureMode, whenToUse, lessonStrength, evide
   expect(result?.whenToUse).toBe("for triage");
   expect(result?.lessonStrength).toBe(4);
   expect(result?.evidenceSources).toEqual(["memory:x"]);
+});
+
+// ── SPEC-2: merge path-derived scope/domain tokens into tags ─────────────────
+//
+// The stash-organization conventions require the directory (scope/domain)
+// tokens of a nested asset to reach the tags column even when the author set
+// explicit tags. Tokens are derived from the canonical ref subpath
+// (canonicalName), so the stash-walk (generateMetadata) and flat-walk
+// (generateMetadataFlat) paths behave identically. Filename tokens are
+// deliberately NOT merged when explicit tags exist (they already live in the
+// FTS name column and aliases). See
+// docs/design/stash-conventions-code-spec.md SPEC-2.
+
+/** Frontmatter memory doc with an explicit tags list. */
+function memoryDocWithTags(tags: string[]): string {
+  return ["---", "tags:", ...tags.map((t) => `  - ${t}`), "---", "Plain memory body prose."].join("\n");
+}
+
+function sortedTags(entry: StashEntry | undefined): string[] {
+  return [...(entry?.tags ?? [])].sort();
+}
+
+/**
+ * SPEC-2 introduces an exported pure helper on the metadata pass. Loaded
+ * dynamically so this file still compiles (and unrelated tests still run)
+ * before the implementation lands; each dependent test goes red with a clear
+ * missing-export error instead of a module-load failure.
+ */
+async function loadExtractDirTagsFromName(): Promise<(name: string) => string[]> {
+  const mod = (await import("../src/indexer/passes/metadata")) as unknown as Record<string, unknown>;
+  const fn = mod.extractDirTagsFromName;
+  if (typeof fn !== "function") {
+    throw new Error(
+      "SPEC-2 not implemented: expected src/indexer/passes/metadata to export extractDirTagsFromName(name: string): string[]",
+    );
+  }
+  return fn as (name: string) => string[];
+}
+
+test("extractDirTagsFromName tokenizes directory segments of a ref subpath (SPEC-2)", async () => {
+  const extractDirTagsFromName = await loadExtractDirTagsFromName();
+  // Single directory segment, lowercased.
+  expect([...extractDirTagsFromName("projectA/auth-tip")].sort()).toEqual(["projecta"]);
+  // Multiple segments; each split on -/_/. with single-char tokens dropped
+  // (same tokenization as extractTagsFromPath).
+  expect([...extractDirTagsFromName("team-alpha/projectA/note")].sort()).toEqual(["alpha", "projecta", "team"]);
+  expect([...extractDirTagsFromName("client-x/note")].sort()).toEqual(["client"]);
+});
+
+test("extractDirTagsFromName returns no tokens for a name at the type root (SPEC-2)", async () => {
+  const extractDirTagsFromName = await loadExtractDirTagsFromName();
+  // No directory segments: the filename itself must contribute nothing.
+  expect(extractDirTagsFromName("auth-tip")).toEqual([]);
+});
+
+test("generateMetadata merges directory tokens into explicit tags for nested assets (SPEC-2)", async () => {
+  const memRoot = tmpDir();
+  const file = path.join(memRoot, "projectA", "auth-tip.md");
+  writeFile(file, memoryDocWithTags(["auth"]));
+
+  const stash = await generateMetadata(memRoot, "memory", [file]);
+  expect(stash.entries).toHaveLength(1);
+  expect(stash.entries[0].name).toBe("projectA/auth-tip");
+  // Explicit tag kept AND the directory scope token added; filename tokens
+  // ("auth-tip" -> "tip") must NOT be merged when explicit tags exist.
+  expect(sortedTags(stash.entries[0])).toEqual(["auth", "projecta"]);
+});
+
+test("generateMetadata adds no directory tokens for an explicit-tags asset at the type root (SPEC-2)", async () => {
+  const memRoot = tmpDir();
+  const file = path.join(memRoot, "root-note.md");
+  writeFile(file, memoryDocWithTags(["auth"]));
+
+  const stash = await generateMetadata(memRoot, "memory", [file]);
+  expect(stash.entries).toHaveLength(1);
+  // No directory segments at the type root: explicit tags stay exact — no
+  // filename tokens ("root", "note") sneak in.
+  expect(stash.entries[0].tags).toEqual(["auth"]);
+});
+
+test("generateMetadata keeps the empty-tags path-derived fallback unchanged for nested assets (SPEC-2)", async () => {
+  const memRoot = tmpDir();
+  const file = path.join(memRoot, "projectA", "auth-tip.md");
+  writeFile(file, "Plain memory body prose with no frontmatter.\n");
+
+  const stash = await generateMetadata(memRoot, "memory", [file]);
+  expect(stash.entries).toHaveLength(1);
+  // Byte-compat with today's extractTagsFromPath fallback: directory AND
+  // filename tokens, deduped.
+  expect(sortedTags(stash.entries[0])).toEqual(["auth", "projecta", "tip"]);
+});
+
+test("generateMetadata keeps the empty-tags fallback unchanged at the type root (SPEC-2)", async () => {
+  const memRoot = tmpDir();
+  const file = path.join(memRoot, "auth-tip.md");
+  writeFile(file, "Plain memory body prose with no frontmatter.\n");
+
+  const stash = await generateMetadata(memRoot, "memory", [file]);
+  expect(stash.entries).toHaveLength(1);
+  expect(sortedTags(stash.entries[0])).toEqual(["auth", "tip"]);
+});
+
+test("generateMetadataFlat merges directory tokens from the canonical ref subpath into explicit tags (SPEC-2)", async () => {
+  const stashRoot = tmpDir();
+  const file = path.join(stashRoot, "memories", "projectA", "auth-tip.md");
+  writeFile(file, memoryDocWithTags(["auth"]));
+
+  const stash = await generateMetadataFlat(stashRoot, [file]);
+  expect(stash.entries).toHaveLength(1);
+  expect(stash.entries[0].type).toBe("memory");
+  // canonicalName is the ref subpath relative to the TYPE root ("memories"),
+  // so "memories" itself is not a tag — only the scope dir "projectA" is.
+  expect(stash.entries[0].name).toBe("projectA/auth-tip");
+  expect(sortedTags(stash.entries[0])).toEqual(["auth", "projecta"]);
+});
+
+test("flat-walk and stash-walk derive identical tags for a nested asset without explicit tags (SPEC-2)", async () => {
+  // Today the flat walk passes path.dirname(file) as the tag root, so even the
+  // empty-tags fallback loses directory segments there. Deriving tokens from
+  // canonicalName makes both walks agree — and both must carry the scope token.
+  const stashRoot = tmpDir();
+  const memRoot = path.join(stashRoot, "memories");
+  const file = path.join(memRoot, "projectA", "auth-tip.md");
+  writeFile(file, "Plain memory body prose with no frontmatter.\n");
+
+  const flat = await generateMetadataFlat(stashRoot, [file]);
+  const walked = await generateMetadata(memRoot, "memory", [file]);
+  expect(flat.entries).toHaveLength(1);
+  expect(walked.entries).toHaveLength(1);
+  expect(sortedTags(flat.entries[0])).toContain("projecta");
+  expect(sortedTags(flat.entries[0])).toEqual(sortedTags(walked.entries[0]));
+});
+
+test("author-restated scope token is deduped by normalizeTerms after the merge (SPEC-2)", async () => {
+  const memRoot = tmpDir();
+  const file = path.join(memRoot, "projectA", "pin.md");
+  writeFile(file, memoryDocWithTags(["projectA", "auth"]));
+
+  const stash = await generateMetadata(memRoot, "memory", [file]);
+  expect(stash.entries).toHaveLength(1);
+  const tags = stash.entries[0].tags ?? [];
+  expect(tags.filter((t) => t === "projecta")).toHaveLength(1);
+  expect(sortedTags(stash.entries[0])).toEqual(["auth", "projecta"]);
+});
+
+test("generateMetadata merges directory tokens into package.json-keyword tags for nested non-md assets (SPEC-2)", async () => {
+  // The other explicit-tags channel: non-md assets get tags from package.json
+  // keywords (Priority 1). A NESTED script must gain its directory token on
+  // top of the keywords, while the root-level case stays exact (pinned by the
+  // "extracts metadata from package.json" test above).
+  const dir = tmpDir();
+  const tool = path.join(dir, "tools", "run.ts");
+  writeFile(tool, `console.log("run")\n`);
+  writeFile(
+    path.join(dir, "package.json"),
+    JSON.stringify({ description: "Git diff summarizer", keywords: ["git", "diff"] }),
+  );
+
+  const stash = await generateMetadata(dir, "script", [tool]);
+  expect(stash.entries).toHaveLength(1);
+  expect(stash.entries[0].name).toBe("tools/run.ts");
+  expect(sortedTags(stash.entries[0])).toEqual(["diff", "git", "tools"]);
+});
+
+test("loadStashFile keeps literal tags for nested-name entries — no dir-token merge (SPEC-2)", () => {
+  // .stash.json-declared entries are hand-curated manifests: the SPEC-2 merge
+  // applies only to file-derived entries via buildEntryFromFile. A nested ref
+  // subpath in a declared entry's name must NOT grow directory tokens.
+  const dir = tmpDir();
+  const stash: StashFile = {
+    entries: [
+      {
+        name: "projectA/deploy",
+        type: "script",
+        description: "deploy projectA services",
+        tags: ["auth"],
+        filename: "deploy.sh",
+      },
+    ],
+  };
+  writeFile(path.join(dir, ".stash.json"), JSON.stringify(stash));
+
+  const result = loadStashFile(dir);
+  expect(result?.entries).toHaveLength(1);
+  expect(result?.entries[0].name).toBe("projectA/deploy");
+  expect(result?.entries[0].tags).toEqual(["auth"]);
+});
+
+test("multi-token directory segments tokenize like extractTagsFromPath in the merge (SPEC-2)", async () => {
+  const memRoot = tmpDir();
+  const file = path.join(memRoot, "client-x", "billing-tip.md");
+  writeFile(file, memoryDocWithTags(["billing"]));
+
+  const stash = await generateMetadata(memRoot, "memory", [file]);
+  expect(stash.entries).toHaveLength(1);
+  // "client-x" splits to ["client", "x"]; single-char "x" is dropped, and the
+  // raw segment must not survive as a "client x" phrase tag.
+  expect(sortedTags(stash.entries[0])).toEqual(["billing", "client"]);
 });

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -2,8 +2,10 @@ import { afterAll, expect, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { resetConfigCache } from "../src/core/config/config";
 import {
   applyCuratedFrontmatter,
+  extractBodyOpening,
   extractCommentMetadata,
   extractDescriptionFromComments,
   extractPackageMetadata,
@@ -19,6 +21,7 @@ import {
   writeStashFile,
 } from "../src/indexer/passes/metadata";
 import { buildSearchFields, buildSearchText } from "../src/indexer/search/search-fields";
+import { sandboxXdgConfigHome, writeSandboxConfig } from "./_helpers/sandbox";
 
 // Renderers auto-register via ensureBuiltinsRegistered in file-context.ts
 
@@ -957,4 +960,420 @@ test("multi-token directory segments tokenize like extractTagsFromPath in the me
   // "client-x" splits to ["client", "x"]; single-char "x" is dropped, and the
   // raw segment must not survive as a "client x" phrase tag.
   expect(sortedTags(stash.entries[0])).toEqual(["billing", "client"]);
+});
+
+// ── SPEC-8: config-gated indexing of the self-situating body opening ─────────
+//
+// With `index.indexBodyOpening: true` in the user config, buildEntryFromFile's
+// md branch extracts the first non-heading, non-fence, non-empty paragraph of
+// the body (capped at 280 chars) into a new StashEntry field `bodyOpening`,
+// and buildSearchFields folds it into the lowest-weight `content` FTS field.
+// Default (flag absent or explicitly false) keeps entries and search fields
+// byte-identical to today. Secret/env file bodies are never read; session-kind
+// memories (the `akm_memory_kind` marker in outer OR inner nested frontmatter,
+// the same patterns base-linter recognises) are excluded. See
+// docs/design/stash-conventions-code-spec.md SPEC-8.
+
+/**
+ * SPEC-8 adds `bodyOpening?: string` to StashEntry. Read it through a typed
+ * accessor so this file still compiles before the implementation lands; the
+ * dependent tests then go red on the runtime value instead of a compile error.
+ */
+function entryBodyOpening(entry: StashEntry | null | undefined): string | undefined {
+  return (entry as (StashEntry & { bodyOpening?: string }) | null | undefined)?.bodyOpening;
+}
+
+/**
+ * Run `fn` with an isolated XDG_CONFIG_HOME whose akm config sets
+ * `index.indexBodyOpening` to `flag` (the key — and the whole config file — is
+ * omitted when `flag` is `undefined`, exercising the true default). Resets the
+ * config cache on both sides so the sandboxed value is actually read and
+ * nothing leaks into later tests.
+ */
+async function withIndexBodyOpeningConfig<T>(flag: boolean | undefined, fn: () => Promise<T>): Promise<T> {
+  const cfg = sandboxXdgConfigHome();
+  try {
+    if (flag !== undefined) writeSandboxConfig({ index: { indexBodyOpening: flag } });
+    resetConfigCache();
+    return await fn();
+  } finally {
+    resetConfigCache();
+    cfg.cleanup();
+  }
+}
+
+const OPENING_PARA = "This memory situates the auth-refresh work inside the payments-platform project.";
+
+/** Markdown memory doc with a fixed frontmatter block and the given body lines. */
+function memoryDocWithBody(bodyLines: string[]): string {
+  return ["---", "description: Auth refresh notes", "tags:", "  - auth", "---", "", ...bodyLines, ""].join("\n");
+}
+
+test("flag on: first body paragraph lands in entry.bodyOpening (SPEC-8)", async () => {
+  await withIndexBodyOpeningConfig(true, async () => {
+    const memRoot = tmpDir();
+    const file = path.join(memRoot, "auth-notes.md");
+    writeFile(file, memoryDocWithBody([OPENING_PARA, "", "Second paragraph pangolin prose must not be captured."]));
+
+    const stash = await generateMetadata(memRoot, "memory", [file]);
+    expect(stash.entries).toHaveLength(1);
+    // Short paragraph (< 280 chars): captured whole, byte-exact — and ONLY the
+    // first paragraph (the pangolin paragraph stays out).
+    expect(entryBodyOpening(stash.entries[0])).toBe(OPENING_PARA);
+  });
+});
+
+test("flag on: bodyOpening folds into the content search field, not hints (SPEC-8)", async () => {
+  await withIndexBodyOpeningConfig(true, async () => {
+    const memRoot = tmpDir();
+    const file = path.join(memRoot, "auth-notes.md");
+    writeFile(file, memoryDocWithBody([OPENING_PARA]));
+
+    const stash = await generateMetadata(memRoot, "memory", [file]);
+    const fields = buildSearchFields(stash.entries[0]);
+    // Lowest-weight catch-all column carries the (lowercased) opening…
+    expect(fields.content).toContain("situates the auth-refresh work");
+    // …and no higher-weight column picks it up (SPEC-8 explicitly rejects
+    // folding into hints, which carries xrefs/when_to_use).
+    expect(fields.hints).not.toContain("situates");
+    expect(fields.name).not.toContain("situates");
+    expect(fields.description).not.toContain("situates");
+    expect(fields.tags).not.toContain("situates");
+    // The concatenated search/embedding text picks it up via content.
+    expect(buildSearchText(stash.entries[0])).toContain("situates the auth-refresh work");
+  });
+});
+
+test("flag on: a paragraph spanning multiple lines is captured up to the paragraph break (SPEC-8)", async () => {
+  await withIndexBodyOpeningConfig(true, async () => {
+    const memRoot = tmpDir();
+    const file = path.join(memRoot, "wrapped.md");
+    writeFile(
+      file,
+      memoryDocWithBody([
+        "First line of the opening paragraph continues onto",
+        "a second physical line before the paragraph break.",
+        "",
+        "Trailing paragraph stays out.",
+      ]),
+    );
+
+    const stash = await generateMetadata(memRoot, "memory", [file]);
+    const opening = entryBodyOpening(stash.entries[0]);
+    expect(opening).toBeDefined();
+    // Whitespace-normalized comparison: the join character between the two
+    // physical lines (newline vs space) is not pinned, the content is.
+    expect((opening ?? "").replace(/\s+/g, " ").trim()).toBe(
+      "First line of the opening paragraph continues onto a second physical line before the paragraph break.",
+    );
+    expect(opening).not.toContain("Trailing paragraph");
+  });
+});
+
+test("flag on: heading-first bodies skip headings and capture the first prose paragraph (SPEC-8)", async () => {
+  await withIndexBodyOpeningConfig(true, async () => {
+    const memRoot = tmpDir();
+    const file = path.join(memRoot, "heading-first.md");
+    writeFile(
+      file,
+      memoryDocWithBody([
+        "# Auth notes",
+        "",
+        "## Context",
+        "",
+        "The orientation paragraph situates this memory under projectA.",
+        "",
+        "More prose afterwards.",
+      ]),
+    );
+
+    const stash = await generateMetadata(memRoot, "memory", [file]);
+    expect(entryBodyOpening(stash.entries[0])).toBe("The orientation paragraph situates this memory under projectA.");
+  });
+});
+
+test("flag on: fenced-first bodies skip the fence and capture the first prose paragraph (SPEC-8)", async () => {
+  await withIndexBodyOpeningConfig(true, async () => {
+    const memRoot = tmpDir();
+    const file = path.join(memRoot, "fence-first.md");
+    writeFile(
+      file,
+      memoryDocWithBody([
+        "```bash",
+        "echo fence interior prose that must never be extracted",
+        "```",
+        "",
+        "Fence-follower paragraph provides the orientation prose.",
+      ]),
+    );
+
+    const stash = await generateMetadata(memRoot, "memory", [file]);
+    const opening = entryBodyOpening(stash.entries[0]);
+    expect(opening).toBe("Fence-follower paragraph provides the orientation prose.");
+    expect(opening).not.toContain("fence interior");
+  });
+});
+
+test("flag on: bodyOpening is capped at 280 chars (SPEC-8)", async () => {
+  await withIndexBodyOpeningConfig(true, async () => {
+    // 70 distinct 7-char words joined by spaces = 559 chars, well over the cap.
+    const words = Array.from({ length: 70 }, (_, i) => `token${String(i).padStart(2, "0")}`);
+    const longPara = words.join(" ");
+    const memRoot = tmpDir();
+    const file = path.join(memRoot, "long-opening.md");
+    writeFile(file, memoryDocWithBody([longPara]));
+
+    const stash = await generateMetadata(memRoot, "memory", [file]);
+    const opening = entryBodyOpening(stash.entries[0]);
+    expect(opening).toBeDefined();
+    const text = opening ?? "";
+    expect(text.length).toBeLessThanOrEqual(280);
+    // A cap, not a gutting: after allowing for word-boundary trimming and an
+    // optional ellipsis, a substantial prefix of the paragraph must survive
+    // and must be a literal prefix (no reordering / summarising).
+    const stripped = text.replace(/(\.{3}|…)\s*$/, "").trimEnd();
+    expect(stripped.length).toBeGreaterThanOrEqual(250);
+    expect(longPara.startsWith(stripped)).toBe(true);
+  });
+});
+
+test("flag on: frontmatter-only files yield no bodyOpening (SPEC-8)", async () => {
+  await withIndexBodyOpeningConfig(true, async () => {
+    const memRoot = tmpDir();
+    const file = path.join(memRoot, "fm-only.md");
+    writeFile(file, ["---", "description: Facts only", "tags:", "  - auth", "---", ""].join("\n"));
+
+    const stash = await generateMetadata(memRoot, "memory", [file]);
+    expect(stash.entries).toHaveLength(1);
+    expect(entryBodyOpening(stash.entries[0])).toBeUndefined();
+  });
+});
+
+test("flag on: a body with only headings and fences yields no bodyOpening (SPEC-8)", async () => {
+  await withIndexBodyOpeningConfig(true, async () => {
+    const memRoot = tmpDir();
+    const file = path.join(memRoot, "no-prose.md");
+    writeFile(file, memoryDocWithBody(["# Title", "", "## Section", "", "```ts", "const x = 1;", "```"]));
+
+    const stash = await generateMetadata(memRoot, "memory", [file]);
+    expect(stash.entries).toHaveLength(1);
+    expect(entryBodyOpening(stash.entries[0])).toBeUndefined();
+  });
+});
+
+test("flag on: session-kind memories are excluded via the outer akm_memory_kind marker (SPEC-8)", async () => {
+  await withIndexBodyOpeningConfig(true, async () => {
+    const memRoot = tmpDir();
+    const file = path.join(memRoot, "session-outer.md");
+    writeFile(
+      file,
+      [
+        "---",
+        "description: Session checkpoint 2026-07-10",
+        "akm_memory_kind: session_checkpoint",
+        "---",
+        "",
+        "Raw transcript paragraph that must not become bodyOpening.",
+        "",
+      ].join("\n"),
+    );
+
+    const stash = await generateMetadata(memRoot, "memory", [file]);
+    // Still indexed as a memory — only the body-opening capture is skipped.
+    expect(stash.entries).toHaveLength(1);
+    expect(entryBodyOpening(stash.entries[0])).toBeUndefined();
+    expect(buildSearchText(stash.entries[0])).not.toContain("transcript paragraph");
+  });
+});
+
+test("flag on: session-kind memories are excluded via the inner nested akm_memory_kind marker (SPEC-8)", async () => {
+  await withIndexBodyOpeningConfig(true, async () => {
+    // `akm remember` wraps the session-capture hook's file in its own
+    // frontmatter; the hook's `akm_memory_kind` block survives at the top of
+    // the body (the nested pattern base-linter's parseInnerFrontmatterBlock
+    // recognises). Neither the marker block nor the transcript may be captured.
+    const memRoot = tmpDir();
+    const file = path.join(memRoot, "session-inner.md");
+    writeFile(
+      file,
+      [
+        "---",
+        "description: Session checkpoint",
+        "---",
+        "",
+        "---",
+        "akm_memory_kind: session_checkpoint",
+        "refs: []",
+        "---",
+        "",
+        "Raw transcript prose that must not become bodyOpening.",
+        "",
+      ].join("\n"),
+    );
+
+    const stash = await generateMetadata(memRoot, "memory", [file]);
+    expect(stash.entries).toHaveLength(1);
+    expect(entryBodyOpening(stash.entries[0])).toBeUndefined();
+    expect(buildSearchText(stash.entries[0])).not.toContain("transcript prose");
+  });
+});
+
+test("flag on: secret files are never read for bodyOpening (SPEC-8)", async () => {
+  await withIndexBodyOpeningConfig(true, async () => {
+    // Whole-file secret with a .md extension — the strongest temptation for an
+    // md-branch extractor. The existing guard (assetType !== "secret") must
+    // keep the file bytes out of the entry entirely.
+    const stashRoot = tmpDir();
+    const secretFile = path.join(stashRoot, "secrets", "deploy-key.md");
+    writeFile(secretFile, "walrus-credential value paragraph that must never be indexed.\n");
+
+    const stash = await generateMetadataFlat(stashRoot, [secretFile]);
+    expect(stash.entries).toHaveLength(1);
+    expect(stash.entries[0].type).toBe("secret");
+    expect(entryBodyOpening(stash.entries[0])).toBeUndefined();
+    expect(JSON.stringify(stash.entries[0])).not.toContain("walrus");
+    expect(buildSearchText(stash.entries[0])).not.toContain("walrus");
+  });
+});
+
+test("flag on: env files are never read for bodyOpening (SPEC-8)", async () => {
+  await withIndexBodyOpeningConfig(true, async () => {
+    const stashRoot = tmpDir();
+    const envFile = path.join(stashRoot, "env", "ci.env");
+    writeFile(envFile, ["# staging credentials walrus paragraph", "API_KEY=walrus-value-token", ""].join("\n"));
+
+    const stash = await generateMetadataFlat(stashRoot, [envFile]);
+    expect(stash.entries).toHaveLength(1);
+    expect(stash.entries[0].type).toBe("env");
+    expect(entryBodyOpening(stash.entries[0])).toBeUndefined();
+    // Key NAMES may surface (existing behavior); comment text and values never.
+    expect(JSON.stringify(stash.entries[0])).not.toContain("walrus");
+    expect(buildSearchText(stash.entries[0])).not.toContain("walrus");
+  });
+});
+
+test("flag on: flat-walk memories gain bodyOpening through the shared pipeline (SPEC-8)", async () => {
+  await withIndexBodyOpeningConfig(true, async () => {
+    const stashRoot = tmpDir();
+    const file = path.join(stashRoot, "memories", "projectA", "auth-tip.md");
+    writeFile(file, memoryDocWithBody([OPENING_PARA]));
+
+    const stash = await generateMetadataFlat(stashRoot, [file]);
+    expect(stash.entries).toHaveLength(1);
+    expect(stash.entries[0].type).toBe("memory");
+    expect(entryBodyOpening(stash.entries[0])).toBe(OPENING_PARA);
+  });
+});
+
+test("default (flag absent): no bodyOpening and body prose reaches no search field (SPEC-8)", async () => {
+  await withIndexBodyOpeningConfig(undefined, async () => {
+    const memRoot = tmpDir();
+    const file = path.join(memRoot, "plain-note.md");
+    writeFile(
+      file,
+      memoryDocWithBody(["The zebrafish opening paragraph situates this memory in the payments platform."]),
+    );
+
+    const stash = await generateMetadata(memRoot, "memory", [file]);
+    const entry = stash.entries[0];
+    expect(entryBodyOpening(entry)).toBeUndefined();
+    // Byte-identical-to-today pin: the sentinel body token appears in NO FTS
+    // field and not in the concatenated search/embedding text.
+    const fields = buildSearchFields(entry);
+    for (const value of Object.values(fields)) {
+      expect(value).not.toContain("zebrafish");
+    }
+    expect(buildSearchText(entry)).not.toContain("zebrafish");
+  });
+});
+
+test("index.indexBodyOpening: false behaves exactly like the default (SPEC-8)", async () => {
+  await withIndexBodyOpeningConfig(false, async () => {
+    const memRoot = tmpDir();
+    const file = path.join(memRoot, "plain-note.md");
+    writeFile(
+      file,
+      memoryDocWithBody(["The zebrafish opening paragraph situates this memory in the payments platform."]),
+    );
+
+    const stash = await generateMetadata(memRoot, "memory", [file]);
+    const entry = stash.entries[0];
+    expect(entryBodyOpening(entry)).toBeUndefined();
+    expect(buildSearchText(entry)).not.toContain("zebrafish");
+  });
+});
+
+// ── SPEC-8 review fixes: extractBodyOpening leading-block + setext handling ──
+//
+// A leading `---`…`---` block is skipped ONLY when its interior actually
+// reads as YAML frontmatter (blank / indented / `key:` lines). Ordinary prose
+// bracketed by decorative thematic breaks is the self-situating opening the
+// feature exists to index and must be captured, not discarded.
+
+test("extractBodyOpening captures prose wrapped in decorative thematic breaks (SPEC-8 review fix)", () => {
+  const body = "---\nThis orientation paragraph situates the work.\n---\n\nDetails follow here.\n";
+  expect(extractBodyOpening(body)).toBe("This orientation paragraph situates the work.");
+});
+
+test("extractBodyOpening still skips a frontmatter-shaped inner block without the session marker (SPEC-8)", () => {
+  const body = [
+    "---",
+    "title: Wrapped doc",
+    "tags:",
+    "  - auth",
+    "created: 2026-07-11",
+    "---",
+    "",
+    "Real opening prose after the nested block.",
+    "",
+  ].join("\n");
+  expect(extractBodyOpening(body)).toBe("Real opening prose after the nested block.");
+});
+
+test("extractBodyOpening treats a lone unclosed leading --- as a thematic break (SPEC-8)", () => {
+  expect(extractBodyOpening("---\n\nOpening prose after a lone break.\n")).toBe("Opening prose after a lone break.");
+});
+
+test("extractBodyOpening skips setext '=' headings instead of capturing underline + title (SPEC-8 review fix)", () => {
+  const body = "Title Of Doc\n=====\n\nProse after the setext heading.\n";
+  expect(extractBodyOpening(body)).toBe("Prose after the setext heading.");
+});
+
+test("extractBodyOpening keeps prose above a dash row (setext-H2 reading deliberately not applied) (SPEC-8)", () => {
+  // Deliberate pin: a `---` row after captured lines ENDS the paragraph and
+  // keeps it. Dash rows in stash bodies are overwhelmingly decorative breaks
+  // or callout borders (the case the review fix above serves), so CommonMark's
+  // setext-H2 interpretation is not applied to them — unlike `=` rows, which
+  // can only be setext underlines.
+  expect(extractBodyOpening("Ambiguous Title\n---\n\nFollowing prose.\n")).toBe("Ambiguous Title");
+});
+
+test("flag on: a decorative-callout opening is captured end-to-end (SPEC-8 review fix)", async () => {
+  await withIndexBodyOpeningConfig(true, async () => {
+    const memRoot = tmpDir();
+    const file = path.join(memRoot, "callout.md");
+    writeFile(
+      file,
+      memoryDocWithBody(["---", "This orientation paragraph situates the work.", "---", "", "Details follow here."]),
+    );
+
+    const stash = await generateMetadata(memRoot, "memory", [file]);
+    expect(stash.entries).toHaveLength(1);
+    // The callout is NOT mistaken for nested frontmatter (no session marker,
+    // not frontmatter-shaped), so the orientation prose is the capture.
+    expect(entryBodyOpening(stash.entries[0])).toBe("This orientation paragraph situates the work.");
+  });
+});
+
+// ── SPEC-8: bodyOpening survives the .stash.json whitelist ──────────────────
+
+test("validateStashEntry preserves bodyOpening verbatim for .stash.json round-trips (SPEC-8)", () => {
+  const result = validateStashEntry({ name: "auth-notes", type: "memory", bodyOpening: OPENING_PARA });
+  expect(result?.bodyOpening).toBe(OPENING_PARA);
+});
+
+test("validateStashEntry drops blank or non-string bodyOpening (SPEC-8)", () => {
+  expect(validateStashEntry({ name: "a", type: "memory", bodyOpening: "   " })?.bodyOpening).toBeUndefined();
+  expect(validateStashEntry({ name: "b", type: "memory", bodyOpening: 42 })?.bodyOpening).toBeUndefined();
+  expect(validateStashEntry({ name: "c", type: "memory" })?.bodyOpening).toBeUndefined();
 });

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -1339,6 +1339,44 @@ test("extractBodyOpening skips setext '=' headings instead of capturing underlin
   expect(extractBodyOpening(body)).toBe("Prose after the setext heading.");
 });
 
+test("extractBodyOpening skips leading HTML comment blocks (PR-715 review)", () => {
+  // The stash skeleton's own convention facts open with a multi-line
+  // <!-- SOFT guidance --> block: comment text is not orientation prose.
+  const body = [
+    "<!--",
+    "  SOFT guidance only — advice, not a contract. Editing this file cannot",
+    "  weaken the gate.",
+    "-->",
+    "",
+    "# Title",
+    "",
+    "The real orientation paragraph.",
+    "",
+  ].join("\n");
+  expect(extractBodyOpening(body)).toBe("The real orientation paragraph.");
+});
+
+test("extractBodyOpening skips single-line HTML comments and comment-ending paragraph boundaries (PR-715 review)", () => {
+  expect(extractBodyOpening("<!-- one-line note -->\n\nActual prose here.\n")).toBe("Actual prose here.");
+  // A comment opening after prose ends the paragraph rather than absorbing it.
+  expect(extractBodyOpening("Lead sentence.\n<!-- trailing machinery -->\nMore text.\n")).toBe("Lead sentence.");
+});
+
+test("extractBodyOpening never splits a surrogate pair at the cap (PR-715 review)", () => {
+  // One long unbroken token forces the no-word-boundary fallback slice; align
+  // an astral-plane char across the cut so a naive slice leaves a lone
+  // high surrogate.
+  const prefix = "x".repeat(278); // next slot (index 278, cap-1=279) lands mid-pair
+  const body = `${prefix}\u{1F600}\u{1F600}after`;
+  const opening = extractBodyOpening(body);
+  expect(opening).toBeDefined();
+  const text = opening as string;
+  const lastBeforeEllipsis = text.charCodeAt(text.length - 2);
+  expect(lastBeforeEllipsis >= 0xd800 && lastBeforeEllipsis <= 0xdbff).toBe(false);
+  // Round-trip through the encoder must not produce a replacement char.
+  expect(new TextDecoder().decode(new TextEncoder().encode(text))).toBe(text);
+});
+
 test("extractBodyOpening keeps prose above a dash row (setext-H2 reading deliberately not applied) (SPEC-8)", () => {
   // Deliberate pin: a `---` row after captured lines ENDS the paragraph and
   // keeps it. Dash rows in stash bodies are overwhelmingly decorative breaks

--- a/tests/ranking-contributor-ablation.test.ts
+++ b/tests/ranking-contributor-ablation.test.ts
@@ -2,11 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { generateMetadata, type StashEntry } from "../src/indexer/passes/metadata";
+import type { RankedEntryInput } from "../src/indexer/search/ranking";
 import {
   applyContributorAblation,
   defaultRankingContributors,
   defaultUtilityRankingContributors,
+  type RankingContext,
 } from "../src/indexer/search/ranking-contributors";
 
 describe("applyContributorAblation (eval-only AKM_ABLATE_CONTRIBUTORS filter)", () => {
@@ -47,5 +53,99 @@ describe("applyContributorAblation (eval-only AKM_ABLATE_CONTRIBUTORS filter)", 
     const before = all.length;
     applyContributorAblation(all, "belief-state-ranking");
     expect(all.length).toBe(before);
+  });
+});
+
+// ── SPEC-2: tag-ranking fires for path-derived scope tokens ─────────────────
+//
+// The metadata pass now merges directory (scope/domain) tokens from the
+// canonical ref subpath into tags even when explicit tags exist
+// (docs/design/stash-conventions-code-spec.md SPEC-2), so a scoped memory
+// with author tags earns the exact-tag ranking boost (+0.15/token) for its
+// path token. These tests pin that end-to-end delta at the contributor level
+// (the shared ranking-baseline fixture is byte-frozen per its MANIFEST, so
+// the case lives here rather than in tests/ranking-regression.test.ts).
+
+describe("tag-ranking boost for path-derived scope tokens (SPEC-2)", () => {
+  const createdTmpDirs: string[] = [];
+
+  afterAll(() => {
+    for (const dir of createdTmpDirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  const tagRanking = defaultRankingContributors.find((c) => c.name === "tag-ranking");
+
+  function makeCtx(query: string): RankingContext {
+    return {
+      // tag-ranking never touches the database — a null placeholder keeps
+      // this a pure unit test of the contributor.
+      db: null as unknown as RankingContext["db"],
+      query,
+      queryLower: query.toLowerCase(),
+      queryTokens: query.toLowerCase().split(/\s+/).filter(Boolean),
+      graphContext: null,
+    };
+  }
+
+  function makeItem(entry: StashEntry): RankedEntryInput {
+    return { id: 1, entry, filePath: "/stash/memories/projectA/auth-tip.md", score: 1, rankingMode: "fts" };
+  }
+
+  test("scoped memory with explicit tags earns the exact-tag boost for its directory token", async () => {
+    const memRoot = fs.mkdtempSync(path.join(os.tmpdir(), "akm-rank-spec2-"));
+    createdTmpDirs.push(memRoot);
+    const file = path.join(memRoot, "projectA", "auth-tip.md");
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, ["---", "tags:", "  - auth", "---", "Scoped memory body."].join("\n"));
+
+    const stash = await generateMetadata(memRoot, "memory", [file]);
+    expect(stash.entries).toHaveLength(1);
+    const item = makeItem(stash.entries[0]);
+    const ctx = makeCtx("projecta");
+
+    expect(tagRanking).toBeDefined();
+    expect(tagRanking?.appliesTo(item, ctx)).toBe(true);
+    // The path token reached tags via the SPEC-2 merge, so the exact-tag
+    // match boost (+0.15 per token) fires for the scope slug.
+    expect(tagRanking?.adjust(item, ctx)).toBeCloseTo(0.15);
+  });
+
+  test("multiple merged directory tokens hit the 0.3 cap, not 0.15 per token unbounded", async () => {
+    // Pre-existing contributor behavior (+0.15/token, Math.min 0.3 cap), but
+    // the SPEC-2 merge is what makes a multi-dir-token entry with explicit
+    // tags reachable at all — pin the interaction end-to-end.
+    const memRoot = fs.mkdtempSync(path.join(os.tmpdir(), "akm-rank-spec2-"));
+    createdTmpDirs.push(memRoot);
+    const file = path.join(memRoot, "team-alpha", "projectA", "note.md");
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, ["---", "tags:", "  - auth", "---", "Scoped memory body."].join("\n"));
+
+    const stash = await generateMetadata(memRoot, "memory", [file]);
+    expect(stash.entries).toHaveLength(1);
+    // Merge produced three dir tokens on top of the explicit tag.
+    expect([...(stash.entries[0].tags ?? [])].sort()).toEqual(["alpha", "auth", "projecta", "team"]);
+    const item = makeItem(stash.entries[0]);
+
+    // All three dir tokens match: 3 × 0.15 = 0.45, capped at 0.3.
+    expect(tagRanking?.adjust(item, makeCtx("team alpha projecta"))).toBeCloseTo(0.3);
+    // Two matches sit exactly at the cap boundary.
+    expect(tagRanking?.adjust(item, makeCtx("team projecta"))).toBeCloseTo(0.3);
+  });
+
+  test("author tags alone (pre-merge shape) earn no boost for the path token — pins the SPEC-2 delta", () => {
+    // The pre-SPEC-2 entry shape: explicit tags suppressed path derivation,
+    // so the scope token lived only in the name field and the tag boost
+    // never fired for it.
+    const item = makeItem({
+      name: "projectA/auth-tip",
+      type: "memory",
+      description: "scoped memory",
+      tags: ["auth"],
+      filename: "auth-tip.md",
+    });
+    const ctx = makeCtx("projecta");
+    expect(tagRanking?.adjust(item, ctx)).toBe(0);
   });
 });

--- a/tests/ranking-contributor-ablation.test.ts
+++ b/tests/ranking-contributor-ablation.test.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import { generateMetadata, type StashEntry } from "../src/indexer/passes/metadata";
 import type { RankedEntryInput } from "../src/indexer/search/ranking";
 import {
+  applyBeliefStateScoreCeiling,
   applyContributorAblation,
   defaultRankingContributors,
   defaultUtilityRankingContributors,
@@ -147,5 +148,89 @@ describe("tag-ranking boost for path-derived scope tokens (SPEC-2)", () => {
     });
     const ctx = makeCtx("projecta");
     expect(tagRanking?.adjust(item, ctx)).toBe(0);
+  });
+});
+
+// ── SPEC-5: demoting-belief-state final-score ceilings ──────────────────────
+//
+// The additive beliefStateBoost penalties multiply a min-max-normalized FTS
+// base ([0.3, 1.0]), so a demoted incumbent that is the best keyword match
+// stays clamp-pinned at 1.0 above its own correction — the ceilings are what
+// actually guarantee "subsequent search ranks new above old". These unit
+// tests pin the mechanism directly (constants, severity order, no-op states,
+// below-ceiling relative order, and the preCeilingScore handoff to
+// db-search's semantic minScore floor), independent of any bm25 delta in the
+// e2e fixtures.
+
+describe("applyBeliefStateScoreCeiling (SPEC-5 demoting-state ceilings)", () => {
+  function makeBeliefItem(beliefState: string | undefined, score: number): RankedEntryInput {
+    const entry: StashEntry = {
+      name: "belief-item",
+      type: "memory",
+      description: "ceiling unit fixture",
+      filename: "belief-item.md",
+      ...(beliefState !== undefined ? { beliefState } : {}),
+    } as StashEntry;
+    return { id: 1, entry, filePath: "/stash/memories/belief-item.md", score, rankingMode: "fts" };
+  }
+
+  test("pins the ceiling constants and the severity order deprecated > superseded > contradicted > archived", () => {
+    const expected: Array<[string, number]> = [
+      ["deprecated", 0.28],
+      ["superseded", 0.25],
+      ["contradicted", 0.2],
+      ["archived", 0.15],
+    ];
+    const clamped: number[] = [];
+    for (const [state, ceiling] of expected) {
+      const item = makeBeliefItem(state, 1.0);
+      applyBeliefStateScoreCeiling(item);
+      expect(item.score).toBe(ceiling);
+      clamped.push(item.score);
+    }
+    // Severity order mirrors the additive-penalty order (phase 1A): each
+    // demoting state sits strictly below the previous, and every ceiling sits
+    // below the 0.3 un-demoted keyword floor from normalizeFtsScores, so any
+    // un-demoted keyword hit outranks a ceilinged one.
+    for (let i = 1; i < clamped.length; i++) {
+      expect(clamped[i]).toBeLessThan(clamped[i - 1]);
+    }
+    for (const ceiling of clamped) {
+      expect(ceiling).toBeLessThan(0.3);
+    }
+  });
+
+  test("no-op for asserted, active, and unset belief states", () => {
+    for (const state of ["asserted", "active", undefined]) {
+      const item = makeBeliefItem(state, 1.37);
+      applyBeliefStateScoreCeiling(item);
+      expect(item.score).toBe(1.37);
+      expect(item.preCeilingScore).toBeUndefined();
+    }
+  });
+
+  test("scores already below the ceiling are untouched — relative order among demoted entries survives", () => {
+    const low = makeBeliefItem("superseded", 0.1);
+    const high = makeBeliefItem("superseded", 0.2);
+    applyBeliefStateScoreCeiling(low);
+    applyBeliefStateScoreCeiling(high);
+    expect(low.score).toBe(0.1);
+    expect(high.score).toBe(0.2);
+    expect(low.score).toBeLessThan(high.score);
+    // Not clamped → no preCeilingScore, so db-search's minScore floor judges
+    // these by their real score exactly as before.
+    expect(low.preCeilingScore).toBeUndefined();
+    expect(high.preCeilingScore).toBeUndefined();
+  });
+
+  test("records the pre-clamp score so a semantic-only hit is floored on what it WOULD have scored", () => {
+    // Archived ceiling (0.15) sits below the default semantic minScore floor
+    // (0.2): db-search must consult preCeilingScore so the demotion ranks the
+    // hit last instead of silently dropping it.
+    const item = makeBeliefItem("archived", 0.6);
+    item.rankingMode = "semantic";
+    applyBeliefStateScoreCeiling(item);
+    expect(item.score).toBe(0.15);
+    expect(item.preCeilingScore).toBe(0.6);
   });
 });

--- a/tests/search-convention-fact-demotion.test.ts
+++ b/tests/search-convention-fact-demotion.test.ts
@@ -1,0 +1,245 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * SPEC-6 (docs/design/stash-conventions-code-spec.md) — deterministic
+ * MEASUREMENT + regression test for convention-fact crowding of domain-term
+ * queries, plus the index-capture (entry_json) round-trip for the fact
+ * `category:` frontmatter key.
+ *
+ * Fixture: a sandbox stash containing the FULL shipped stash-skeleton
+ * convention facts (src/assets/stash-skeleton/facts — every file carries
+ * `category: convention`) plus one real domain asset at knowledge/auth/.
+ *
+ * The measurement: for the untyped query "auth", the real knowledge/auth
+ * asset must outrank every category:convention fact. If this fails on a tree
+ * without the SPEC-6 demotion, crowding is CONFIRMED and this test doubles as
+ * the demotion regression test. No LLM, no embeddings (semanticSearchMode
+ * "off") — pure FTS + ranking contributors.
+ *
+ * MEASUREMENT RESULT (2026-07-11, pre-implementation tree): the headline
+ * measurement PASSES without any demotion. searchFts is exact-first — the
+ * prefix fallback ("auth*" → the facts' "authoring…" tokens) only runs when
+ * the exact token query matches NOTHING, and a real knowledge/auth asset
+ * always matches "auth" exactly (name + path-derived tag). So convention
+ * facts never even co-rank with a real domain asset; they fill the results
+ * only when the stash has NO exact match at all (see the companion
+ * "facts-only stash" test below). Crowding as hypothesized by the intake item
+ * is therefore NOT confirmed. These tests stay as regression pins for that
+ * invariant; the capture test (entry.category → entry_json) is the RED
+ * groundwork SPEC-6/SPEC-8 need either way.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+import { resetConfigCache, saveConfig } from "../src/core/config/config";
+import { closeDatabase, getAllEntries, openExistingDatabase } from "../src/indexer/db/db";
+import { akmIndex } from "../src/indexer/indexer";
+import type { StashEntry } from "../src/indexer/passes/metadata";
+import { runCliCapture } from "./_helpers/cli";
+import {
+  type Cleanup,
+  sandboxStashDir,
+  sandboxXdgCacheHome,
+  sandboxXdgConfigHome,
+  sandboxXdgDataHome,
+  sandboxXdgStateHome,
+  withEnv,
+} from "./_helpers/sandbox";
+
+/** The shipped skeleton convention facts — the exact files `akm init` installs. */
+const SKELETON_FACTS_DIR = path.join(import.meta.dir, "..", "src", "assets", "stash-skeleton", "facts");
+
+const KNOWLEDGE_REF = "knowledge:auth/oauth-refresh-races";
+
+let stashDir = "";
+let envCleanup: Cleanup = () => {};
+
+interface Hit {
+  type: string;
+  name: string;
+  ref: string;
+  score?: number;
+}
+
+/**
+ * SPEC-6 adds `category?: string` to StashEntry. Read it through a typed
+ * accessor so this file compiles before the implementation lands; the capture
+ * test then goes red on the runtime value instead of a compile error.
+ */
+function entryCategory(entry: StashEntry): string | undefined {
+  return (entry as StashEntry & { category?: string }).category;
+}
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function listMarkdownFilesRecursive(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listMarkdownFilesRecursive(full));
+    else if (entry.name.endsWith(".md")) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Copy the full shipped skeleton convention facts into the sandbox stash and
+ * return the copied .md file paths. Also verifies the fixture premise: every
+ * skeleton fact carries `category: convention` frontmatter (the boundary the
+ * init tests pin), so "every fact hit in this stash" ≡ "every
+ * category:convention fact".
+ */
+function installSkeletonConventionFacts(stash: string): string[] {
+  fs.cpSync(SKELETON_FACTS_DIR, path.join(stash, "facts"), { recursive: true });
+  const copied = listMarkdownFilesRecursive(path.join(stash, "facts"));
+  expect(copied.length).toBeGreaterThanOrEqual(12);
+  for (const file of copied) {
+    const content = fs.readFileSync(file, "utf8");
+    expect(content).toMatch(/^category:\s*convention\s*$/m);
+  }
+  return copied;
+}
+
+/** Build the fixture: skeleton convention facts + one real knowledge/auth asset, indexed. */
+async function buildFixture(): Promise<void> {
+  installSkeletonConventionFacts(stashDir);
+  writeFile(
+    path.join(stashDir, "knowledge", "auth", "oauth-refresh-races.md"),
+    [
+      "---",
+      "description: OAuth refresh-token rotation race — concurrent workers refreshing the same token cause intermittent 401s; serialize the refresh",
+      "tags:",
+      "  - auth",
+      "  - oauth",
+      "---",
+      "",
+      "# OAuth refresh-token races",
+      "",
+      "Two workers holding the same refresh token race on rotation: the loser",
+      "presents an already-rotated token and the provider revokes the grant.",
+      "Serialize refresh through a single flight lock per token.",
+      "",
+    ].join("\n"),
+  );
+  saveConfig({ semanticSearchMode: "off" });
+  await akmIndex({ stashDir, full: true });
+}
+
+async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+  return withEnv({ AKM_STASH_DIR: stashDir }, async () => {
+    resetConfigCache();
+    return runCliCapture(args);
+  });
+}
+
+async function searchHits(args: string[]): Promise<Hit[]> {
+  const res = await runCli(args);
+  expect(res.code).toBe(0);
+  return (JSON.parse(res.stdout).hits as Hit[]) ?? [];
+}
+
+beforeEach(() => {
+  const cacheResult = sandboxXdgCacheHome();
+  const cfgResult = sandboxXdgConfigHome(cacheResult.cleanup);
+  const dataResult = sandboxXdgDataHome(cfgResult.cleanup);
+  const stateResult = sandboxXdgStateHome(dataResult.cleanup);
+  const stashResult = sandboxStashDir(stateResult.cleanup);
+  stashDir = stashResult.dir;
+  envCleanup = stashResult.cleanup;
+});
+
+afterEach(() => {
+  envCleanup();
+  envCleanup = () => {};
+  stashDir = "";
+});
+
+describe("SPEC-6 measurement: convention facts vs a real domain asset on an untyped query", () => {
+  test("untyped 'auth' query — the real knowledge/auth asset outranks every category:convention fact", async () => {
+    await buildFixture();
+
+    const hits = await searchHits(["search", "auth", "--format=json", "--limit", "25"]);
+
+    // The real domain asset must be found at all…
+    const knowledgeIdx = hits.findIndex((h) => h.ref === KNOWLEDGE_REF);
+    expect(knowledgeIdx).toBeGreaterThanOrEqual(0);
+
+    // …and must rank ABOVE every convention fact that also matched. Every
+    // fact in this fixture is a category:convention skeleton fact (premise
+    // asserted in installSkeletonConventionFacts), so any fact hit ranked at
+    // or above the knowledge asset is convention-fact crowding.
+    const factIndexes = hits.map((h, i) => (h.type === "fact" ? i : -1)).filter((i) => i >= 0);
+    for (const factIdx of factIndexes) {
+      expect(knowledgeIdx).toBeLessThan(factIdx);
+    }
+  });
+
+  test("measurement evidence: with NO real auth asset, the untyped 'auth' query falls back to prefix expansion and returns the convention facts", async () => {
+    // The one crowding mode the measurement actually found: in a stash where
+    // nothing matches the exact token "auth", the prefix fallback surfaces the
+    // skeleton facts (via their "authoring…" tokens). Rank-time demotion
+    // (SPEC-6's chosen remedy over exclusion) keeps every hit LISTED, so this
+    // fail-open behavior must survive any demotion implementation — facts
+    // remain reachable when they are all there is.
+    installSkeletonConventionFacts(stashDir);
+    saveConfig({ semanticSearchMode: "off" });
+    await akmIndex({ stashDir, full: true });
+
+    const hits = await searchHits(["search", "auth", "--format=json", "--limit", "25"]);
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits.every((h) => h.type === "fact")).toBe(true);
+    expect(hits.some((h) => h.ref.startsWith("fact:conventions/"))).toBe(true);
+  });
+
+  test("index captures category: convention onto fact entries (entry_json round-trip)", async () => {
+    await buildFixture();
+
+    // Read the freshly built index back: every skeleton convention fact must
+    // carry its frontmatter `category` on the persisted StashEntry. This is
+    // the SPEC-6 capture prerequisite — without it neither demotion nor any
+    // category-keyed policy is implementable.
+    const db = openExistingDatabase();
+    try {
+      const facts = getAllEntries(db, "fact");
+      expect(facts.length).toBeGreaterThanOrEqual(12);
+      for (const fact of facts) {
+        expect(entryCategory(fact.entry)).toBe("convention");
+      }
+    } finally {
+      closeDatabase(db);
+    }
+  });
+
+  test("convention facts stay reachable via typed search (--type fact wins over demotion)", async () => {
+    await buildFixture();
+
+    // Typed search is the sanctioned opt-back-in: `--type fact` must surface
+    // the convention facts for the same domain-term query regardless of any
+    // untyped-rank demotion. ("auth" prefix-expands to the facts' "authoring"
+    // tokens once no exact fact match exists.)
+    const hits = await searchHits(["search", "auth", "--type", "fact", "--format=json", "--limit", "25"]);
+    expect(hits.length).toBeGreaterThan(0);
+    for (const hit of hits) {
+      expect(hit.type).toBe("fact");
+    }
+    expect(hits.some((h) => h.ref.startsWith("fact:conventions/"))).toBe(true);
+  });
+
+  test("exact-name query still surfaces a convention fact in the top 3", async () => {
+    await buildFixture();
+
+    // The demotion must NOT hide convention facts from users who ask for them
+    // by name: the exact-name boost (+2.0) dominates the category demotion.
+    const hits = await searchHits(["search", "backlinks", "--format=json", "--limit", "25"]);
+    const idx = hits.findIndex((h) => h.ref === "fact:conventions/backlinks");
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(idx).toBeLessThan(3);
+  });
+});

--- a/tests/search-ref-prefix.test.ts
+++ b/tests/search-ref-prefix.test.ts
@@ -1,0 +1,363 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * SPEC-4 (docs/design/stash-conventions-code-spec.md) — real ref-prefix filter.
+ *
+ * `akm search "<type>:<prefix>/"` must translate into a typed enumeration of
+ * the index narrowed to entry names under `<prefix>/`, instead of degenerating
+ * into the AND-token FTS query it is today (`"memory:projecta/"` sanitizes to
+ * "memory projecta", which matches nothing because `entry_type` is not an FTS
+ * column). These tests drive the `akm search` command layer (akmSearch) over a
+ * real indexed stash and pin:
+ *
+ *   - `memory:<scope>/` returns exactly that subtree (recursive, type-scoped,
+ *     `/`-boundary exact — a sibling `projectalpha/` scope must not leak);
+ *   - bare `memory:` equals the existing empty-query `--type memory` enumeration;
+ *   - an explicit `--type` flag wins over the parsed type (branch fires only on
+ *     the untyped path);
+ *   - ordinary keyword queries and bare refs (no trailing slash) are unaffected;
+ *   - belief / named-source filters and `limit` compose with the enumeration;
+ *   - the parsed type expresses explicit intent, so the default `session`
+ *     type-exclusion does not apply to `session:`.
+ *
+ * Fixture discipline: no fixture puts the token "memory" (or any "memor…"
+ * prefix) into an indexed field, so the legacy AND/prefix FTS fallback can
+ * never accidentally satisfy a `memory:…` query — a hit can only come from the
+ * new enumeration branch.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { akmSearch } from "../src/commands/read/search";
+import { saveConfig } from "../src/core/config/config";
+import { akmIndex } from "../src/indexer/indexer";
+import type { SourceSearchHit } from "../src/sources/types";
+import {
+  type Cleanup,
+  makeSandboxDir,
+  sandboxStashDir,
+  sandboxXdgCacheHome,
+  sandboxXdgConfigHome,
+  sandboxXdgDataHome,
+} from "./_helpers/sandbox";
+
+let stashDir = "";
+let cleanup: Cleanup = () => {};
+
+function writeMd(root: string, relPath: string, frontmatter: Record<string, string>, body: string): void {
+  const fullPath = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  const fmLines = Object.entries(frontmatter).map(([key, value]) => `${key}: ${value}`);
+  fs.writeFileSync(fullPath, ["---", ...fmLines, "---", "", body, ""].join("\n"), "utf8");
+}
+
+async function reindex(): Promise<void> {
+  await akmIndex({ stashDir, full: true });
+}
+
+/** Run akmSearch with test-friendly defaults and return only the local hits. */
+async function search(input: Parameters<typeof akmSearch>[0]): Promise<SourceSearchHit[]> {
+  const result = await akmSearch({
+    skipLogging: true,
+    disableProjectContext: true,
+    disableScopedUtility: true,
+    ...input,
+  });
+  return result.hits.filter((h): h is SourceSearchHit => h.type !== "registry");
+}
+
+const PROJECTA_MEMORIES = ["projecta/auth-tip", "projecta/deploy-note", "projecta/nested/db-tip"] as const;
+const ALL_MEMORIES = [
+  ...PROJECTA_MEMORIES,
+  "ProjCase/case-note",
+  "projectalpha/stray-note",
+  "projectb/other-note",
+  "root-note",
+].sort();
+
+beforeEach(async () => {
+  const dataResult = sandboxXdgDataHome();
+  const cacheResult = sandboxXdgCacheHome(dataResult.cleanup);
+  const cfgResult = sandboxXdgConfigHome(cacheResult.cleanup);
+  const stashResult = sandboxStashDir(cfgResult.cleanup);
+  stashDir = stashResult.dir;
+  cleanup = stashResult.cleanup;
+
+  writeMd(
+    stashDir,
+    "memories/root-note.md",
+    { description: "Root level tip about shell aliases" },
+    "Shell alias tips live at the top level.",
+  );
+  writeMd(
+    stashDir,
+    "memories/projecta/auth-tip.md",
+    { description: "OAuth token refresh gotcha for the auth service" },
+    "Refresh tokens rotate; re-read the keychain after rotation.",
+  );
+  writeMd(
+    stashDir,
+    "memories/projecta/deploy-note.md",
+    { description: "Deploy pipeline flake workaround" },
+    "Retry the flaky smoke stage once before failing the release.",
+  );
+  writeMd(
+    stashDir,
+    "memories/projecta/nested/db-tip.md",
+    { description: "Postgres pool sizing hint" },
+    "Keep the pool under twenty connections in staging.",
+  );
+  // Sibling scope sharing "projecta" as a STRING prefix — pins the `/`
+  // boundary: `memory:projecta/` must not leak `projectalpha/…`.
+  writeMd(
+    stashDir,
+    "memories/projectalpha/stray-note.md",
+    { description: "Stray alpha observation" },
+    "The alpha stack still uses the old queue.",
+  );
+  writeMd(
+    stashDir,
+    "memories/projectb/other-note.md",
+    { description: "Beta stack observation" },
+    "The beta stack migrated to the new queue.",
+  );
+  writeMd(
+    stashDir,
+    "memories/ProjCase/case-note.md",
+    { description: "Mixed case scope observation" },
+    "Scope directories can carry mixed case on disk.",
+  );
+  // Same subpath under a DIFFERENT type — pins that `memory:projecta/` is a
+  // typed enumeration, not a path-only one.
+  writeMd(
+    stashDir,
+    "knowledge/projecta/setup-guide.md",
+    { description: "Build setup guide for the alpha stack" },
+    "Install the toolchain, then run the bootstrap script.",
+  );
+  writeMd(
+    stashDir,
+    "sessions/claude/fixture-session.md",
+    { description: "Recorded harness transcript fixture" },
+    "Transcript summary body.",
+  );
+
+  saveConfig({ semanticSearchMode: "off" });
+  await reindex();
+});
+
+afterEach(() => {
+  cleanup();
+  cleanup = () => {};
+  stashDir = "";
+});
+
+describe("akm search ref-prefix enumeration (SPEC-4)", () => {
+  test('"memory:projecta/" enumerates exactly that subtree, typed and recursive', async () => {
+    const hits = await search({ query: "memory:projecta/", source: "local" });
+    const names = hits.map((h) => h.name).sort();
+
+    expect(names).toEqual([...PROJECTA_MEMORIES].sort());
+    // `/`-boundary exactness: the sibling scope sharing the string prefix and
+    // the same-subpath knowledge doc must both stay out.
+    expect(names).not.toContain("projectalpha/stray-note");
+    for (const hit of hits) {
+      expect(hit.type).toBe("memory");
+      expect(hit.ref).toBe(`memory:${hit.name}`);
+      // Enumeration is a deterministic listing, not a relevance ranking — hits
+      // carry the fixed browse score (same contract as the empty-query path).
+      expect(hit.score).toBe(1);
+    }
+  });
+
+  test('bare "memory:" equals the empty-query --type memory enumeration', async () => {
+    const enumHits = await search({ query: "", type: "memory", source: "local" });
+    // Fixture sanity (existing behavior): the empty-query typed enumeration
+    // sees every memory fixture. If THIS line fails the fixtures are broken,
+    // not the feature.
+    expect(enumHits.map((h) => h.name).sort()).toEqual(ALL_MEMORIES);
+
+    const prefixHits = await search({ query: "memory:", source: "local" });
+    expect(prefixHits.map((h) => h.name).sort()).toEqual(ALL_MEMORIES);
+  });
+
+  test("limit caps ref-prefix enumeration", async () => {
+    const hits = await search({ query: "memory:projecta/", source: "local", limit: 2 });
+    expect(hits).toHaveLength(2);
+    for (const hit of hits) {
+      expect(hit.name.startsWith("projecta/")).toBe(true);
+    }
+  });
+
+  test("an explicit --type wins over the parsed ref-prefix type", async () => {
+    // Discriminating fixtures: if the branch fired with the PARSED type the
+    // three projecta memories would come back; if it fired with the EXPLICIT
+    // type, knowledge:projecta/setup-guide would come back (score 1). The
+    // specified behavior — branch fires only on the untyped path — leaves an
+    // ordinary FTS query ("memory projecta") against knowledge entries, none
+    // of which carries a "memory" token: zero hits.
+    const hits = await search({ query: "memory:projecta/", type: "knowledge", source: "local" });
+    expect(hits).toHaveLength(0);
+  });
+
+  test("ordinary keyword queries are unaffected", async () => {
+    const hits = await search({ query: "oauth", source: "local" });
+    const names = hits.map((h) => h.name);
+    expect(names).toContain("projecta/auth-tip");
+    expect(names).not.toContain("projecta/deploy-note");
+  });
+
+  test("a bare ref without the trailing slash does NOT enumerate the subtree", async () => {
+    // `memory:projecta/auth-tip` is `akm show` territory — it must stay an
+    // ordinary keyword search and never fan out into the subtree listing.
+    const hits = await search({ query: "memory:projecta/auth-tip", source: "local" });
+    const names = hits.map((h) => h.name);
+    expect(names).not.toContain("projecta/deploy-note");
+    expect(names).not.toContain("projecta/nested/db-tip");
+  });
+
+  test("mixed-case scope dirs enumerate through the command layer", async () => {
+    // akmSearch lowercases the query before it reaches the database layer, so
+    // the subtree match must not be defeated by on-disk mixed case — this is
+    // the exact spelling an agent copies out of a ref like
+    // `memory:ProjCase/case-note`.
+    const hits = await search({ query: "memory:ProjCase/", source: "local" });
+    expect(hits.map((h) => h.name)).toEqual(["ProjCase/case-note"]);
+  });
+
+  test("belief filter composes with ref-prefix enumeration", async () => {
+    writeMd(
+      stashDir,
+      "memories/projecta/deploy-note.md",
+      { description: "Deploy pipeline flake workaround", beliefState: "superseded" },
+      "Retry the flaky smoke stage once before failing the release.",
+    );
+    await reindex();
+
+    // Fixture sanity (existing behavior): the empty-query enumerate path
+    // already honors the belief filter, proving the frontmatter was captured.
+    const sanity = await search({ query: "", type: "memory", belief: "current", source: "local" });
+    expect(sanity.map((h) => h.name)).not.toContain("projecta/deploy-note");
+
+    const current = await search({ query: "memory:projecta/", belief: "current", source: "local" });
+    expect(current.map((h) => h.name).sort()).toEqual(["projecta/auth-tip", "projecta/nested/db-tip"]);
+
+    const historical = await search({ query: "memory:projecta/", belief: "historical", source: "local" });
+    expect(historical.map((h) => h.name)).toEqual(["projecta/deploy-note"]);
+  });
+
+  test("named --source filter composes with ref-prefix enumeration", async () => {
+    const extra = makeSandboxDir("akm-ref-prefix-extra");
+    try {
+      writeMd(
+        extra.dir,
+        "memories/projecta/extra-note.md",
+        { description: "Companion observation from the extra stash" },
+        "Extra stash body.",
+      );
+      saveConfig({
+        semanticSearchMode: "off",
+        sources: [{ type: "filesystem", path: extra.dir, name: "extra" }],
+      });
+      await reindex();
+
+      // Fixture sanity (existing behavior): the extra source is indexed and
+      // the named-source filter narrows the empty-query enumeration to it.
+      const sanity = await search({ query: "", type: "memory", source: "extra" });
+      expect(sanity.map((h) => h.name)).toEqual(["projecta/extra-note"]);
+
+      // Ref-prefix enumeration must honor the same narrowing…
+      const narrowed = await search({ query: "memory:projecta/", source: "extra" });
+      expect(narrowed.map((h) => h.name)).toEqual(["projecta/extra-note"]);
+
+      // …while the unnarrowed search spans both sources.
+      const all = await search({ query: "memory:projecta/", source: "local" });
+      const allNames = all.map((h) => h.name);
+      expect(allNames).toContain("projecta/auth-tip");
+      expect(allNames).toContain("projecta/extra-note");
+    } finally {
+      extra.cleanup();
+    }
+  });
+
+  test("scope --filter composes with ref-prefix enumeration", async () => {
+    writeMd(
+      stashDir,
+      "memories/projecta/alice-context.md",
+      { description: "Alice-scoped deployment context", scope_user: "alice" },
+      "Alice-only deployment context body.",
+    );
+    writeMd(
+      stashDir,
+      "memories/projecta/bob-context.md",
+      { description: "Bob-scoped deployment context", scope_user: "bob" },
+      "Bob-only deployment context body.",
+    );
+    await reindex();
+
+    // Fixture sanity (existing behavior): the empty-query enumerate path
+    // already honors the scope filter, proving the frontmatter was captured
+    // (scope-less fixtures are excluded once any filter key is supplied).
+    const sanity = await search({ query: "", type: "memory", filters: { user: "alice" }, source: "local" });
+    expect(sanity.map((h) => h.name)).toEqual(["projecta/alice-context"]);
+
+    // The ref-prefix branch must pass the same `filters` through its
+    // enumerateEntries call site — a regression that special-cases that one
+    // invocation (dropping the filters field) would return every projecta/
+    // entry here instead of just the alice-scoped one.
+    const hits = await search({ query: "memory:projecta/", filters: { user: "alice" }, source: "local" });
+    expect(hits.map((h) => h.name)).toEqual(["projecta/alice-context"]);
+  });
+
+  test("proposed-quality exclusion composes with ref-prefix enumeration", async () => {
+    writeMd(
+      stashDir,
+      "memories/projecta/draft-note.md",
+      { description: "Draft observation awaiting curation", quality: "proposed" },
+      "Draft body awaiting curation.",
+    );
+    await reindex();
+
+    // Fixture sanity (existing behavior): the empty-query enumerate path
+    // already hides `quality: proposed` by default, proving the frontmatter
+    // was captured.
+    const sanity = await search({ query: "", type: "memory", source: "local" });
+    expect(sanity.map((h) => h.name)).not.toContain("projecta/draft-note");
+
+    // Default-off on the ref-prefix branch too…
+    const defaults = await search({ query: "memory:projecta/", source: "local" });
+    expect(defaults.map((h) => h.name).sort()).toEqual([...PROJECTA_MEMORIES].sort());
+
+    // …and `--include-proposed` restores it through the same branch.
+    const opted = await search({ query: "memory:projecta/", source: "local", includeProposed: true });
+    expect(opted.map((h) => h.name).sort()).toEqual([...PROJECTA_MEMORIES, "projecta/draft-note"].sort());
+  });
+
+  test('"session:" typed enumeration bypasses the default session exclusion', async () => {
+    // Fixture sanity (existing behavior): --type session already bypasses the
+    // default exclusion, so the fixture is reachable via typed enumeration.
+    const sanity = await search({ query: "", type: "session", source: "local" });
+    expect(sanity.map((h) => h.name)).toEqual(["claude/fixture-session"]);
+
+    // The parsed type is explicit intent, exactly like --type session — the
+    // untyped-path defaultExcludeTypes policy must not hide the result.
+    const hits = await search({ query: "session:", source: "local" });
+    expect(hits.map((h) => h.name)).toEqual(["claude/fixture-session"]);
+  });
+
+  test("an empty subtree returns no hits with the standard tip", async () => {
+    const result = await akmSearch({
+      query: "memory:doesnotexist/",
+      source: "local",
+      skipLogging: true,
+      disableProjectContext: true,
+      disableScopedUtility: true,
+    });
+    const hits = result.hits.filter((h): h is SourceSearchHit => h.type !== "registry");
+    expect(hits).toHaveLength(0);
+    expect(result.tip ?? "").toContain("No matching stash assets");
+  });
+});


### PR DESCRIPTION
## Summary

This PR implements the stash organization and back-linking conventions (SPEC-1 through SPEC-8) as defined in `docs/design/stash-organization-conventions.md` and `docs/design/stash-conventions-code-spec.md`. The changes enable agents to organize assets hierarchically, cross-link them for improved retrieval, and maintain referential integrity across the stash.

### Key Features

**SPEC-1: Frontmatter xref channels in lint**
- Extended `akm lint` missing-ref check to scan `xrefs:`, `supersededBy:`, and `contradictedBy:` frontmatter keys
- Dangling refs in these channels are now flagged with detail naming the key
- Applies to all markdown asset types (memories, knowledge, lessons, facts, agents, commands, skills, workflows)

**SPEC-3: Cross-references on write (`--xref`)**
- Added `--xref <ref>` repeatable flag to `akm remember` and `akm import` commands
- Validates refs before any write happens; unresolvable refs cause exit 2 with standard error envelope
- Merges xrefs into existing frontmatter on import (deduplicating)
- Soft cap of 5 xrefs with stderr warning (non-blocking)
- Written xrefs fold into FTS hints for discoverability

**SPEC-4: Ref-prefix enumeration in search**
- Implemented `<type>:<prefix>/` and bare `<type>:` query syntax for typed subtree enumeration
- `akm search "memory:projectA/"` now lists exactly that subtree (recursive, `/`-boundary exact)
- Bare `memory:` enumerates the whole type
- Composes with belief/source filters and limit

**SPEC-5: Supersession with `--supersedes`**
- Added `--supersedes <ref>` flag to `akm remember` and `akm import`
- Atomically writes new correction asset with old ref in `xrefs:` AND demotes old asset to `beliefState: superseded` with `supersededBy:` list
- Demotion is immediately live via reindexing; beliefStateBoost ranks corrections above stale incumbents
- Idempotent: re-running doesn't duplicate supersededBy entries
- Git targets batch both files into single boundary commit

**SPEC-6: Fact category capture**
- Added `category?: string` field to StashEntry for frontmatter `category:` key
- Captured in `applyCuratedFrontmatter` and whitelisted through `validateStashEntry`
- Survives .stash.json round-trip for rank-time and filter policies
- Convention facts marked with `category: convention` in shipped stash skeleton

**SPEC-7: Asset rename with xref rewriting (`akm mv`)**
- Implemented `akm mv <ref> <new-name>` command for renaming assets within type directories
- Rewrites inbound refs across writable stash's markdown files (body, frontmatter keys, fenced code blocks)
- Uses complete-ref boundary matching to avoid rewriting longer refs sharing old ref as prefix
- Memory `.derived.md` twins move together, preserving `entry_key === <base>.derived` coupling
- Re-keys index row IN PLACE to preserve utility_scores history
- Read-only sources scanned but never written; reported in `readOnlyCiters` for manual follow-up
- Appends `mv` event to state.db events stream on success

**SPEC-8: Ref-prefix search with body-opening index**
- Added optional `indexBodyOpening` config to index first paragraph of assets
- Enables better ranking for ref-prefix queries by including opening context in search fields

### Supporting Changes

- Added convention facts to stash skeleton: `organization.md`, `backlinks.md`, `domains.md`
- Updated asset-type convention facts with maintenance strategies
- Extended frontmatter mutation utilities for belief-state transitions
- Added comprehensive test suites for all specs (759 lines for mv, 614 for supersedes, 522 for xref, 363 for ref-prefix search, 245 for

https://claude.ai/code/session_01QvPuW7VMxWgmeQTm8RxK78