### PR TITLE
fix(release): pin cmd-shim for launcher tests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "@types/node": "^22.19.17",
         "@types/semver": "^7.5.8",
         "bun-types": "^1.3.13",
+        "cmd-shim": "9.0.2",
         "typescript": "^5.9.3",
       },
       "optionalDependencies": {
@@ -157,6 +158,8 @@
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "citty": ["citty@0.2.2", "", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
+
+    "cmd-shim": ["cmd-shim@9.0.2", "", {}, "sha512-xVHoI+wNrM4tDB9iC1idf/8D0tYnVimlBp/5zHW+x1sGjjRD69NvR9th3Z1JAYGN/BTW4he6aZFYV6kzy+k+jw=="],
 
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
 

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@types/node": "^22.19.17",
     "@types/semver": "^7.5.8",
     "bun-types": "^1.3.13",
+    "cmd-shim": "9.0.2",
     "typescript": "^5.9.3"
   },
   "optionalDependencies": {

--- a/tests/integration/package-launcher.test.ts
+++ b/tests/integration/package-launcher.test.ts
@@ -58,11 +58,8 @@ function fakeBun(dir: string, version: string, versionExitCode = 0): string {
   return executable;
 }
 
-async function generateWindowsShims(npm: string): Promise<void> {
-  const npmCli = fs.realpathSync(npm);
-  const npmPackageDir = path.dirname(path.dirname(npmCli));
-  const cmdShimPath = path.join(npmPackageDir, "node_modules", "cmd-shim");
-  const cmdShim = createRequire(import.meta.url)(cmdShimPath) as (from: string, to: string) => Promise<void>;
+async function generateWindowsShims(): Promise<void> {
+  const cmdShim = createRequire(import.meta.url)("cmd-shim") as (from: string, to: string) => Promise<void>;
 
   fs.mkdirSync(windowsShimDir, { recursive: true });
   await Promise.all(
@@ -138,7 +135,7 @@ beforeAll(async () => {
 
   fakeBun(oldBunPathDir, "0.9.9");
   fakeBun(unusableBunPathDir, "bun probe failed", 1);
-  await generateWindowsShims(npm);
+  await generateWindowsShims();
 });
 
 afterAll(() => {


### PR DESCRIPTION
## Summary
- stop resolving cmd-shim from npm's private global dependency tree
- pin cmd-shim as a direct dev dependency for the cross-platform launcher contract
- restore release checks under hosted Node 24/npm latest

## Verification
- bun test tests/integration/package-launcher.test.ts
- bunx tsc --noEmit
- bun run check