### PR TITLE
chore(release): bump version to 0.9.0-rc.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akm-cli",
-  "version": "0.9.0-rc.5",
+  "version": "0.9.0-rc.6",
   "type": "module",
   "description": "akm (Agent Knowledge Management) — A package manager for AI agent skills, commands, tools, and knowledge. Works with Claude Code, OpenCode, Cursor, and any AI coding assistant.",
   "keywords": [


### PR DESCRIPTION
## Summary
- bump the package version from 0.9.0-rc.5 to 0.9.0-rc.6
- align the committed version with the release workflow candidate

## Verification
- bun install --frozen-lockfile
- bun run check:changed (92 passed)
- node -p "require('./package.json').version"