### PR TITLE
fix(migrate): unblock pre-cutover hosts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akm-cli",
-  "version": "0.9.0-rc.6",
+  "version": "0.9.0-rc.7",
   "type": "module",
   "description": "akm (Agent Knowledge Management) — A package manager for AI agent skills, commands, tools, and knowledge. Works with Claude Code, OpenCode, Cursor, and any AI coding assistant.",
   "keywords": [

--- a/src/core/migration-backup.ts
+++ b/src/core/migration-backup.ts
@@ -694,12 +694,13 @@ function sampleLockDirectory(directory: string): { paths: string[]; overflow: bo
     while (true) {
       const entry = handle.readSync();
       if (!entry) break;
+      if (!entry.isFile() || !entry.name.endsWith(".lock")) continue;
       inspected += 1;
       if (inspected > MAX_BLOCKER_DIRECTORY_SAMPLES) {
         overflow = true;
         break;
       }
-      if (entry.isFile() && entry.name.endsWith(".lock")) paths.push(path.join(directory, entry.name));
+      paths.push(path.join(directory, entry.name));
     }
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return { paths: [], overflow: false };

--- a/src/migrate/legacy/three-db-cutover.ts
+++ b/src/migrate/legacy/three-db-cutover.ts
@@ -137,7 +137,8 @@ export function buildCutoverRefMap(opts: BuildCutoverRefMapOptions): Map<string,
   if (fs.existsSync(opts.oldIndexDbPath)) {
     const db = openDatabaseFinalizing(opts.oldIndexDbPath, { readonly: true });
     try {
-      if (tableExists(db, "main", "entries")) {
+      const entryColumns = tableExists(db, "main", "entries") ? new Set(columnNames(db, "main", "entries")) : undefined;
+      if (["entry_key", "item_ref", "entry_type", "stash_dir"].every((column) => entryColumns?.has(column))) {
         const rows = db
           .prepare(
             "SELECT entry_key AS entryKey, item_ref AS itemRef, entry_type AS entryType, stash_dir AS stashDir " +

--- a/tests/integration/migration-backup.test.ts
+++ b/tests/integration/migration-backup.test.ts
@@ -263,6 +263,17 @@ describe("0.9 migration backup", () => {
     expect((message.match(/oversized-directory-/g) ?? []).length).toBeLessThanOrEqual(100);
   });
 
+  test("operation mutex databases do not count toward the lock sample cap", () => {
+    createMigrationBackup();
+    const lockDir = path.join(getDataDir(), "extract-locks");
+    fs.mkdirSync(lockDir, { recursive: true });
+    for (let index = 0; index < 500; index += 1) {
+      fs.writeFileSync(path.join(lockDir, `.extract-${index}.lock.operations.sensitive`), "mutex");
+    }
+
+    expect(() => restoreMigrationBackup(true)).not.toThrow();
+  });
+
   test("maintenance barrier excludes new lock starts and restore contenders", async () => {
     createMigrationBackup();
     const release = acquireMaintenanceBarrier();

--- a/tests/integration/three-db-cutover.test.ts
+++ b/tests/integration/three-db-cutover.test.ts
@@ -30,7 +30,11 @@ import { type ContentMigrationReport, runContentMigration } from "../../src/migr
 import { getLegacyWorkflowDbPath } from "../../src/migrate/legacy/legacy-paths";
 import { writeLegacyStashFile } from "../../src/migrate/legacy/legacy-stash-json";
 import { importLegacyProposalsIntoState } from "../../src/migrate/legacy/proposal-fs-import";
-import { migratePilotTreatmentFiles, quarantineIndexDb } from "../../src/migrate/legacy/three-db-cutover";
+import {
+  buildCutoverRefMap,
+  migratePilotTreatmentFiles,
+  quarantineIndexDb,
+} from "../../src/migrate/legacy/three-db-cutover";
 import { withWorkflowRunsRepo } from "../../src/storage/repositories/workflow-runs-repository";
 import {
   buildOrphanBearingStateDb,
@@ -161,6 +165,26 @@ function refsIn(db: Database, table: string, keyColumn: string): string[] {
 function ledgerIds(db: Database): string[] {
   return (db.query("SELECT id FROM schema_migrations ORDER BY rowid").all() as Array<{ id: string }>).map((r) => r.id);
 }
+
+test("cutover ref map tolerates a pre-provenance index without item_ref", () => {
+  fs.mkdirSync(path.dirname(getDbPath()), { recursive: true });
+  const index = new Database(getDbPath());
+  index.exec(`
+    CREATE TABLE entries (
+      id INTEGER PRIMARY KEY,
+      entry_key TEXT NOT NULL,
+      entry_type TEXT NOT NULL,
+      stash_dir TEXT NOT NULL
+    )
+  `);
+  index.close();
+
+  const mapPath = path.join(getDataDir(), "cutover-ref-map.json");
+  const refMap = buildCutoverRefMap({ oldIndexDbPath: getDbPath(), mapOutputPath: mapPath });
+
+  expect(refMap.size).toBe(0);
+  expect(fs.existsSync(mapPath)).toBe(true);
+});
 
 // ─────────────────────────────────────────────────────────────────────────────
 // (a) rc-train FROM-state round-trip


### PR DESCRIPTION
## Summary
- fall back to the frozen filesystem ref map when a pre-provenance index lacks item_ref
- exclude internal SQLite operation-mutex files from the bounded real-lock sample
- bump the immutable release candidate to 0.9.0-rc.7

## Live reproduction
- rc.6 migration reached the journaled cutover and failed on a legitimate pre-cutover entries schema without item_ref
- coordinator restored config and databases from its verified recovery run
- 67,725 maintenance mutex databases also reproduced the lock-scan overflow

## Verification
- bun test tests/integration/three-db-cutover.test.ts tests/integration/migration-backup.test.ts (37 passed)
- bun run check:changed (92 passed)