### PR TITLE
fix(migrate): handle historical retired refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akm-cli",
-  "version": "0.9.0-rc.7",
+  "version": "0.9.0-rc.8",
   "type": "module",
   "description": "akm (Agent Knowledge Management) — A package manager for AI agent skills, commands, tools, and knowledge. Works with Claude Code, OpenCode, Cursor, and any AI coding assistant.",
   "keywords": [

--- a/src/cli/config-migrate.ts
+++ b/src/cli/config-migrate.ts
@@ -941,6 +941,16 @@ function assertRollbackTransitionAllowed(journal: ApplyJournal, current: Migrati
             : (["config", "state", "workflow"] as const);
   for (const name of unchanged) {
     if (!sameArtifactFingerprint(journal.generation[name], current[name])) {
+      if (
+        name === "state" &&
+        (journal.phase === "state-applied" || journal.phase === "workflow-applied") &&
+        readSingleFileBoundStateMarker(journal)?.phase === "state-applied"
+      ) {
+        // SQLite rollback preserves the logical generation but may rewrite
+        // physical pages. The operation-bound canonical digest covers the full
+        // schema and every row, so it safely authenticates that rollback.
+        continue;
+      }
       throw new ConfigError(
         `Refusing migration rollback because ${name} changed outside the journaled ${journal.phase} transition.`,
         "INVALID_CONFIG_FILE",

--- a/src/migrate/legacy-ref-grammar.ts
+++ b/src/migrate/legacy-ref-grammar.ts
@@ -83,8 +83,7 @@ export function refToString(ref: AssetRef): string {
 
 // ── Parsing ──────────────────────────────────────────────────────────────────
 
-/** Parse a legacy ref string in the format `[origin//]type:name`. */
-export function parseAssetRef(ref: string): AssetRef {
+function parseLegacyAssetRef(ref: string, allowRetiredTypes: boolean): AssetRef {
   const trimmed = ref.trim();
   if (!trimmed) throw new UsageError("Empty ref.", "MISSING_REQUIRED_ARGUMENT");
 
@@ -111,7 +110,7 @@ export function parseAssetRef(ref: string): AssetRef {
 
   // The `vault` asset type was removed in 0.9.0. Point callers at its
   // replacements rather than failing with a generic unknown-type error.
-  if (rawType === "vault") {
+  if (!allowRetiredTypes && rawType === "vault") {
     throw new UsageError(
       "The `vault` asset type was removed in 0.9.0 — use `env:` (whole .env config) or `secret:` (a single value).",
       "MISSING_REQUIRED_ARGUMENT",
@@ -123,7 +122,7 @@ export function parseAssetRef(ref: string): AssetRef {
 
   // Open type token (chunk 1.5, D1.5-6): any other non-empty type is valid ref
   // data (foreign/adapter types included) EXCEPT the deliberately-removed set.
-  if (DEPRECATED_REJECTED_TYPES.has(resolvedType)) {
+  if (!allowRetiredTypes && DEPRECATED_REJECTED_TYPES.has(resolvedType)) {
     throw new UsageError(`Invalid asset type: "${rawType}".`, "MISSING_REQUIRED_ARGUMENT");
   }
 
@@ -131,6 +130,11 @@ export function parseAssetRef(ref: string): AssetRef {
   const name = normalizeName(rawName);
 
   return { type: resolvedType, name, origin: origin || undefined };
+}
+
+/** Parse a legacy ref string in the format `[origin//]type:name`. */
+export function parseAssetRef(ref: string): AssetRef {
+  return parseLegacyAssetRef(ref, false);
 }
 
 // ── Validation (private copies — kept self-contained) ────────────────────────
@@ -245,14 +249,16 @@ export function legacyRefToBundleRef(raw: string): BundleRef {
  * this is the safe superset of `parseRefInput` (input boundaries are new-only).
  *
  * Mapping mirrors the pre-flip input bridge exactly:
- *   - legacy input      → `parseAssetRef` (byte-identical).
+ *   - legacy input      → historical syntax parser (including retired types).
  *   - new `conceptId`   → `type`/`name` via the D-R2 reverse table.
  *   - new `bundle`      → `origin`.
  *   - `#fragment`       → rejected (no stored ref carries one).
  */
 export function parseStoredRef(raw: string): AssetRef {
   if (classifyRefGrammar(raw) === "legacy") {
-    return parseAssetRef(raw);
+    // Durable state may predate the removal of a type. Retired but structurally
+    // valid refs are expected orphans; current user input remains strict.
+    return parseLegacyAssetRef(raw, true);
   }
   const ref = parseBundleRef(raw);
   if (ref.fragment !== undefined) {

--- a/tests/core/type-token-contract.test.ts
+++ b/tests/core/type-token-contract.test.ts
@@ -27,7 +27,7 @@ import { DEPRECATED_REJECTED_TYPES, isKnownType, KNOWN_TYPES, type KnownType } f
 import { presentationFor, TYPE_PRESENTATION } from "../../src/core/type-presentation";
 import { validateStashEntry } from "../../src/indexer/passes/metadata";
 import { TYPE_BOOST, typeBoostFor } from "../../src/indexer/search/ranking-contributors";
-import { parseAssetRef } from "../../src/migrate/legacy-ref-grammar";
+import { parseAssetRef, parseStoredRef } from "../../src/migrate/legacy-ref-grammar";
 
 // ── (a) open-token acceptance as DATA ───────────────────────────────────────
 
@@ -155,6 +155,16 @@ describe("DEPRECATED_REJECTED_TYPES deny-list — tool/vault stay rejected", () 
 
   test("parseAssetRef rejects vault with its migration-hint message (checked before the deny-list)", () => {
     expect(() => parseAssetRef("vault:prod")).toThrow(/vault.*removed in 0\.9\.0.*env.*secret/i);
+  });
+
+  test("parseStoredRef accepts retired types only for historical durable state", () => {
+    expect(parseStoredRef("vault:default")).toEqual({ type: "vault", name: "default" });
+    expect(parseStoredRef("local//tool:deploy.sh")).toEqual({
+      type: "tool",
+      name: "deploy.sh",
+      origin: "local",
+    });
+    expect(() => parseStoredRef(":bad")).toThrow();
   });
 
   test("validateStashEntry rejects tool/vault even though they are otherwise well-formed entries", () => {

--- a/tests/integration/three-db-cutover.test.ts
+++ b/tests/integration/three-db-cutover.test.ts
@@ -358,6 +358,32 @@ describe("WI-8.2 (b) — orphan-bearing state completes with quarantine", () => 
       db.close();
     }
   }, 30_000);
+
+  test("historical events for a retired asset type are quarantined as expected orphans", async () => {
+    const state = openStateDbAtCeiling(getStateDbPathInDataDir(), PRE_CUTOVER_STATE_CEILING);
+    const insert = state.prepare("INSERT INTO events (event_type, ts, ref) VALUES ('show', ?, 'vault:default')");
+    insert.run("2026-01-01T00:00:00.000Z");
+    insert.run("2026-01-02T00:00:00.000Z");
+    state.close();
+    seedOldIndexDb();
+
+    const applied = await runCliCapture(["migrate", "apply", "--config", writeConfigs()]);
+    expect(applied.code, applied.stderr).toBe(0);
+
+    const migrated = readState();
+    try {
+      expect(
+        (migrated.query("SELECT COUNT(*) AS n FROM events WHERE ref = 'vault:default'").get() as { n: number }).n,
+      ).toBe(0);
+      expect(
+        migrated
+          .query("SELECT row_count, reason FROM legacy_state WHERE surface = 'events' AND old_ref = 'vault:default'")
+          .get(),
+      ).toEqual({ row_count: 2, reason: "orphan" });
+    } finally {
+      migrated.close();
+    }
+  }, 30_000);
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -435,8 +461,9 @@ describe("WI-8.2 (e) — an integrity failure fails closed to restore", () => {
     db.prepare(`INSERT INTO asset_salience (asset_ref, encoding_salience, updated_at) VALUES (?, 0.5, 100)`).run(
       RC_TRAIN_LIVE_REFS.skill,
     );
-    // An unparseable legacy-grammar ref (colon at position 0) — an integrity failure.
-    db.prepare(`INSERT INTO asset_salience (asset_ref, encoding_salience, updated_at) VALUES (':bad', 0.5, 100)`).run();
+    // Fail late, after the scalar-table pass has physically mutated pages. A
+    // logical SQL rollback need not restore byte-identical database pages.
+    db.prepare("INSERT INTO events (event_type, ts, ref) VALUES ('show', '2026-01-01T00:00:00.000Z', ':bad')").run();
     db.close();
     seedOldIndexDb();
     const treatmentFile = path.join(getDataDir(), "stash", ".akm", "measurement", "treatment-pilot-2026-06-14.txt");
@@ -448,20 +475,24 @@ describe("WI-8.2 (e) — an integrity failure fails closed to restore", () => {
     // fresh fixture, so assert the pre-state rows + ledger survive intact).
     const pre = readState();
     const preSalience = refsIn(pre, "asset_salience", "asset_ref");
+    const preEvents = refsIn(pre, "events", "ref");
     const preLedger = ledgerIds(pre);
     pre.close();
 
     const applied = await runCliCapture(["migrate", "apply", "--config", prepared]);
     expect(applied.code).not.toBe(0);
     expect(applied.stderr).toMatch(/restored|unparseable|integrity/i);
+    expect(applied.stderr).not.toMatch(/rollback could not complete/i);
+    expect(fs.existsSync(getMigrationApplyJournalPath())).toBe(false);
 
     const post = readState();
     try {
-      // Pre-state preserved: the same asset_ref set (including the injected ':bad',
-      // NOT re-keyed), and the ledger rolled back to the pre-cutover ceiling.
+      // Pre-state preserved: the live scalar ref was not re-keyed, the malformed
+      // event remains present, and the ledger rolled back to the pre-cutover ceiling.
       expect(refsIn(post, "asset_salience", "asset_ref").sort()).toEqual(preSalience.sort());
-      expect(refsIn(post, "asset_salience", "asset_ref")).toContain(":bad");
       expect(refsIn(post, "asset_salience", "asset_ref")).toContain(RC_TRAIN_LIVE_REFS.skill);
+      expect(refsIn(post, "events", "ref")).toEqual(preEvents);
+      expect(refsIn(post, "events", "ref")).toContain(":bad");
       expect(ledgerIds(post)).toEqual(preLedger);
       expect(ledgerIds(post).at(-1)).toBe(PRE_CUTOVER_STATE_CEILING); // 020 rolled back
       expect(fs.readFileSync(treatmentFile, "utf8")).toBe(`${RC_TRAIN_LIVE_REFS.skill}\n`);


### PR DESCRIPTION
## Summary
- classify structurally valid retired stored refs as expected migration orphans while keeping current input strict
- authenticate logically unchanged state after SQL rollback with the operation-bound canonical digest
- add retired-vault and late-cutover-failure regressions
- bump the immutable release candidate to 0.9.0-rc.8

## Verification
- `bun test tests/core/type-token-contract.test.ts tests/integration/three-db-cutover.test.ts tests/integration/migration-lifecycle-regression.test.ts` (114 passed)
- `./tests/release-check.sh --skip-docker` (7,595 passed, 53 skipped)