### PR TITLE
fix(search): remove the R2 salience boost from default ranking (#692)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,6 +350,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   installed scheduler entries are byte-identical to before, so upgrading shows no
   spurious drift.
 
+- **The R2 salience ranking boost no longer applies to default `search`/`curate`
+  ranking** (#692). `asset_salience.rank_score` (an encoding + outcome +
+  retrieval projection, recomputed every `improve` run) previously composed
+  into every default search as a bounded multiplicative boost
+  (`salience-ranking`, ×[1.0–1.2]), loaded best-effort from `state.db` on the
+  hot path. On live data it measured as noise (max observed multiplier
+  ×1.071, mean ×1.016): the boost was retrieval-dominated with no source
+  filter — double-counting the same `usage_events` the utility-score
+  contributor already reinforces — warm-started non-zero with no outcome
+  evidence, and had zero pack coverage, so it could only ever favor
+  self-generated personal assets over an equally-relevant pack asset.
+  Removing the default `state.db` load also fixes a confirmed hot-path
+  defect: whenever `state.db` already existed, every default search
+  synchronously waited on the maintenance-activity barrier before ranking
+  could even start — up to a 5-second stall on a blocking wait loop, plus a
+  lock-file create, before the load's own 250ms SQLite `busy_timeout` ever
+  applied. No config gate was added: a key for a term being removed would be
+  dead surface for the upcoming 1.0 contract freeze to carry forever.
+  `rank_score` itself, and everything `improve` computes and does with it
+  internally, are unchanged — only its promotion into user-facing ranking is
+  removed. The contributor stays in the codebase (unwired) for a future
+  gated, outcome-backed experiment.
+
 ### Fixed
 
 - **The compiled standalone binary can run `akm migrate`.** Release binaries

--- a/src/indexer/search/ranking-contributors.ts
+++ b/src/indexer/search/ranking-contributors.ts
@@ -60,13 +60,19 @@ const UTILITY_WEIGHT = 0.5;
 const UTILITY_MAX_BOOST = 1.5;
 
 /**
- * R2 — weight of the improve
- * loop's `asset_salience.rank_score` in user-facing ranking. Bounded well
- * below the utility boost so the composed signal refines, never dominates,
- * lexical/semantic relevance. rank_score ∈ [0,1] → boost ∈ [1, 1.2].
+ * R2 / #692 — weight of the improve loop's `asset_salience.rank_score`.
+ * rank_score ∈ [0,1] → boost ∈ [1, 1.2]. Bounded well below the utility boost
+ * so the composed signal would refine, never dominate, lexical/semantic
+ * relevance.
+ *
+ * As of #692 this is NOT wired into default user-facing ranking — see
+ * {@link salienceRankingContributor}'s doc comment. Kept exported (with the
+ * contributor) for a future gated experiment; do not reintroduce it into
+ * {@link defaultUtilityRankingContributors} without a measured
+ * curate-golden-bench delta and an explicit config gate.
  */
-const SALIENCE_WEIGHT = 0.2;
-const SALIENCE_MAX_BOOST = 1.2;
+export const SALIENCE_WEIGHT = 0.2;
+export const SALIENCE_MAX_BOOST = 1.2;
 
 /**
  * Phase 2A / Rec 5: default recency half-life (days) used when no
@@ -527,15 +533,31 @@ export const defaultRankingContributors: RankingContributor[] = [
 ];
 
 /**
- * R2 — compose the improve loop's salience core into user-facing ranking.
+ * R2 — the improve loop's salience core, as a bounded multiplicative ranking
+ * boost. `asset_salience.rank_score` (encoding + outcome + retrieval
+ * projection, maintained every improve run) otherwise drives only improve's
+ * INTERNAL maintenance selection.
  *
- * `asset_salience.rank_score` (encoding + outcome + retrieval projection,
- * maintained every improve run) previously drove only improve's INTERNAL
- * maintenance selection — the "better assets surface more" loop ran solely
- * through the utility EMA. This bounded multiplicative boost closes the outer
- * loop: usage/outcome-reinforced assets rank higher in `search`/`curate`.
+ * **#692 — NOT in {@link defaultUtilityRankingContributors}.** Removed from
+ * default user-facing ranking (search/curate): the boost was
+ * retrieval-dominated (`w_r = 0.60` in salience.ts, with no source filter, so
+ * it double-counted the same `usage_events` the utility EMA contributor
+ * already reinforces), warm-started non-zero with no outcome evidence, had
+ * zero pack coverage (favoring only self-generated personal assets), and
+ * measured as noise on live data (max observed multiplier ×1.071). Removing
+ * its default state.db load also deleted a confirmed hot-path defect — see
+ * the now-deleted `loadSalienceRankScores` in `ranking.ts` git history.
+ *
+ * `rank_score` itself is UNCHANGED as improve's internal selection signal.
+ * This contributor, and its weight/cap constants, stay exported so a FUTURE
+ * gated experiment (config-gated, outcome-gated) can wire it back in
+ * explicitly — see `RankEntriesOptions.salienceRankScores`'s doc comment in
+ * `ranking.ts`. Reachable today only via explicit contributor-list injection
+ * (tests / eval harnesses calling `applyUtilityContributors` directly with a
+ * list that includes it) — never through `applyRankingRules` / `akm search` /
+ * `akm curate`.
  */
-const salienceRankingContributor: UtilityRankingContributor = {
+export const salienceRankingContributor: UtilityRankingContributor = {
   name: "salience-ranking",
   appliesTo(item, ctx) {
     const rank = ctx.salienceRankScores?.get(item.id);
@@ -548,10 +570,10 @@ const salienceRankingContributor: UtilityRankingContributor = {
   },
 };
 
-export const defaultUtilityRankingContributors: UtilityRankingContributor[] = [
-  utilityRankingContributor,
-  salienceRankingContributor,
-];
+// #692 — salienceRankingContributor deliberately excluded; see its doc
+// comment. Do not add it back here without a config gate + a measured
+// curate-golden-bench delta justifying it.
+export const defaultUtilityRankingContributors: UtilityRankingContributor[] = [utilityRankingContributor];
 
 /**
  * EVAL/DEBUG ONLY — remove named ranking contributors from a list.

--- a/src/indexer/search/ranking.ts
+++ b/src/indexer/search/ranking.ts
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import fs from "node:fs";
-import { acquireMaintenanceActivitySync } from "../../core/maintenance-barrier";
-import { getStateDbPath } from "../../core/state-db";
-import { type Database, openDatabase } from "../../storage/database";
+import type { Database } from "../../storage/database";
 import type { DbSearchResult } from "../../storage/repositories/index-entry-types";
 import { getUtilityScoresByIds } from "../../storage/repositories/index-utility-repository";
 import type { GraphBoostContext } from "../graph/graph-boost";
@@ -56,10 +53,17 @@ export interface RankEntriesOptions {
    */
   scopeKey?: string;
   /**
-   * R2 — improve-loop salience scores (`asset_salience.rank_score`) keyed by
-   * entry id. `undefined` (default) = load best-effort from state.db;
-   * `null` = explicitly disabled; a Map = injected (tests / callers that
-   * already hold the data).
+   * R2 / #692 — improve-loop salience scores (`asset_salience.rank_score`)
+   * keyed by entry id. `salience-ranking` is NOT in
+   * `defaultUtilityRankingContributors` (#692 removed it from default
+   * user-facing ranking — see that contributor's doc comment), so this field
+   * is consumed only by a caller that explicitly builds its own
+   * utility-contributor list including it: `undefined`/`null` (default) mean
+   * no data / off; a `Map` is the injected input (tests / a future gated
+   * experiment). There is no state.db fallback load anymore — the prior
+   * best-effort `loadSalienceRankScores` was deleted outright, along with the
+   * hot-path defect it caused (a synchronous wait on the maintenance-activity
+   * barrier, up to 5s, before the SQLite `busy_timeout` even applied).
    */
   salienceRankScores?: Map<number, number> | null;
   /**
@@ -79,63 +83,6 @@ export interface RankEntriesOptions {
    * fallback so this field is the only path.
    */
   ablateContributors?: string;
-}
-
-/**
- * R2 — best-effort load of `asset_salience.rank_score` from state.db for the
- * ranked items. Fail-open: any error (state.db locked by a concurrent improve
- * run, missing table, unreadable path) returns an empty map, which makes the
- * salience contributor a no-op — byte-identical to pre-R2 ranking.
- *
- * Deliberately NOT `openStateDatabase()`: that helper runs migrations and sets
- * a 30 s busy timeout — too heavy for a search hot path. This opens read-only,
- * never creates or migrates state.db (missing file / missing table = empty
- * map), and caps lock waits at 250 ms so a concurrent improve run can only
- * ever cost the search a quarter second, not a stall.
- */
-export function loadSalienceRankScores(items: RankedEntryInput[]): Map<number, number> {
-  const result = new Map<number, number>();
-  if (items.length === 0) return result;
-  try {
-    const dbPath = getStateDbPath();
-    if (!fs.existsSync(dbPath)) return result; // improve loop has never run here
-    const releaseActivity = acquireMaintenanceActivitySync("state-db");
-    const idByRef = new Map<string, number>();
-    try {
-      for (const item of items) {
-        if (item.itemRef) idByRef.set(item.itemRef, item.id);
-      }
-      if (idByRef.size === 0) return result;
-      const stateDb = openDatabase(dbPath, { readonly: true });
-      try {
-        try {
-          stateDb.exec("PRAGMA busy_timeout = 250");
-        } catch {
-          // pragma failure on a readonly handle is fine — default timeout applies
-        }
-        const refs = [...idByRef.keys()];
-        const CHUNK = 500;
-        for (let i = 0; i < refs.length; i += CHUNK) {
-          const chunk = refs.slice(i, i + CHUNK);
-          const placeholders = chunk.map(() => "?").join(",");
-          const rows = stateDb
-            .prepare(`SELECT asset_ref, rank_score FROM asset_salience WHERE asset_ref IN (${placeholders})`)
-            .all(...chunk) as Array<{ asset_ref: string; rank_score: number }>;
-          for (const row of rows) {
-            const id = idByRef.get(row.asset_ref);
-            if (id !== undefined) result.set(id, row.rank_score);
-          }
-        }
-      } finally {
-        stateDb.close();
-      }
-    } finally {
-      releaseActivity();
-    }
-  } catch {
-    // Fail open — search must never break because state.db is unavailable.
-  }
-  return result;
 }
 
 export function normalizeFtsScores(results: DbSearchResult[]): Map<number, { score: number; result: DbSearchResult }> {
@@ -255,12 +202,12 @@ export function applyRankingRules(options: RankEntriesOptions): RankedEntryInput
     options.items.map((item) => item.id),
     options.scopeKey,
   );
-  // R2 — compose the improve loop's salience into user-facing ranking.
-  // undefined = load from state.db (default); null = explicitly disabled.
-  const salienceRankScores =
-    options.salienceRankScores === null
-      ? new Map<number, number>()
-      : (options.salienceRankScores ?? loadSalienceRankScores(options.items));
+  // R2 / #692 — salience-ranking is not in defaultUtilityRankingContributors
+  // (see ranking-contributors.ts), so this is never consumed by the default
+  // ranking path below; it exists only for a caller that explicitly builds a
+  // contributor list including salienceRankingContributor. undefined/null
+  // both normalize to "no data" — there is no state.db fallback load.
+  const salienceRankScores = options.salienceRankScores ?? new Map<number, number>();
   const utilityContext = {
     ...rankingContext,
     utilityScores: utilScoresMap,

--- a/tests/integration/ranking-contributor-ablation.test.ts
+++ b/tests/integration/ranking-contributor-ablation.test.ts
@@ -15,6 +15,7 @@ import {
   defaultRankingContributors,
   defaultUtilityRankingContributors,
   type RankingContext,
+  salienceRankingContributor,
   typeBoostFor,
 } from "../../src/indexer/search/ranking-contributors";
 import type { RankedEntryInput } from "../../src/indexer/search/ranking-types";
@@ -48,8 +49,25 @@ describe("applyContributorAblation (eval-only AKM_ABLATE_CONTRIBUTORS filter)", 
     expect(out.length).toBe(all.length - 2);
   });
 
-  test("works on the utility contributor list too (salience/utility)", () => {
-    const out = applyContributorAblation(defaultUtilityRankingContributors, "salience-ranking");
+  // #692 — `salience-ranking` was dropped from `defaultUtilityRankingContributors`
+  // (the R2 salience boost is no longer part of default user-facing ranking;
+  // `rank_score` keeps its improve-internal role unchanged). The contributor
+  // itself stays exported, unwired, for a future gated experiment.
+  test("defaultUtilityRankingContributors is the one-entry post-#692 list — salience is not in it", () => {
+    expect(defaultUtilityRankingContributors.length).toBe(1);
+    expect(defaultUtilityRankingContributors.map((c) => c.name)).toEqual(["utility-ranking"]);
+  });
+
+  test("ablation of 'salience-ranking' still works against an explicitly supplied list containing it", () => {
+    // Proves the ablation MECHANISM still works for a contributor no longer in
+    // the default list — e.g. a future gated experiment that re-adds
+    // `salienceRankingContributor` to a custom list would still be ablatable.
+    // Asserting against the (now salience-free) default list alone would be
+    // vacuous: "salience-ranking" would already be absent with or without
+    // ablation working correctly.
+    const explicitList = [...defaultUtilityRankingContributors, salienceRankingContributor];
+    const out = applyContributorAblation(explicitList, "salience-ranking");
+    expect(out.length).toBe(explicitList.length - 1);
     expect(out.some((c) => c.name === "salience-ranking")).toBe(false);
     expect(out.some((c) => c.name === "utility-ranking")).toBe(true);
   });

--- a/tests/integration/ranking-salience-boost.test.ts
+++ b/tests/integration/ranking-salience-boost.test.ts
@@ -135,6 +135,14 @@ describe("R2 removal (#692) — default search no longer touches state.db", () =
   test("default search never creates state.db (stronger form: it touches state.db not at all)", async () => {
     await seedAndIndex();
     const dbPath = getStateDbPath();
+    // akmIndex itself legitimately touches state.db (index-run bookkeeping,
+    // unrelated to search/ranking) via `withStateDb`, so a fresh sandbox is
+    // not guaranteed to still be state.db-less after indexing. Force absence
+    // right before the search call — that isolates the property this test
+    // actually cares about: SEARCH, not indexing, must not create it.
+    for (const suffix of ["", "-wal", "-shm", "-journal"]) {
+      fs.rmSync(`${dbPath}${suffix}`, { force: true });
+    }
     expect(fs.existsSync(dbPath)).toBe(false);
 
     const result = await search();
@@ -146,47 +154,43 @@ describe("R2 removal (#692) — default search no longer touches state.db", () =
     expect(fs.existsSync(dbPath)).toBe(false);
   });
 
-  test(
-    "search completes promptly even while the maintenance barrier is held (regression guard for the pre-#692 5s stall)",
-    async () => {
-      await seedAndIndex();
+  // Regression guard for the pre-#692 5s stall. Deliberately asserts ONLY the
+  // observable result (hits were returned), not a manual wall-clock delta —
+  // this repo's lint-tests-isolation.ts (Rule 3) forbids `expect(elapsed)
+  // .toBeLessThan(...)` patterns as flaky under a loaded CI scheduler. The
+  // promptness assertion instead IS the tight test-level timeout below (2.5s,
+  // well under the old 5s stall): pre-#692, this call chain (searchLocal ->
+  // applyRankingRules -> loadSalienceRankScores ->
+  // acquireMaintenanceActivitySync) synchronously polled the held barrier via
+  // a blocking Atomics.wait loop for up to 5s before falling back, which
+  // would blow this budget and report as a hard timeout failure — loud, not
+  // just "slower".
+  test("search completes promptly even while the maintenance barrier is held (regression guard for the pre-#692 5s stall)", async () => {
+    await seedAndIndex();
 
-      // Mirror a realistic installation that has run `improve` before: state.db
-      // already exists and holds a legacy salience row for this asset. Before
-      // #692 this was exactly the precondition needed to reach the buggy
-      // acquireMaintenanceActivitySync("state-db") call in loadSalienceRankScores
-      // (it short-circuited before that call when state.db was absent).
-      const stateDb = openStateDatabase();
-      try {
-        upsertAssetSalience(stateDb, "stash//lessons/hot", {
-          encoding: 0.8,
-          outcome: 0.5,
-          retrieval: 0.9,
-          rankScore: 0.77,
-        });
-      } finally {
-        stateDb.close();
-      }
+    // Mirror a realistic installation that has run `improve` before: state.db
+    // already exists and holds a legacy salience row for this asset. Before
+    // #692 this was exactly the precondition needed to reach the buggy
+    // acquireMaintenanceActivitySync("state-db") call in loadSalienceRankScores
+    // (it short-circuited before that call when state.db was absent).
+    const stateDb = openStateDatabase();
+    try {
+      upsertAssetSalience(stateDb, "stash//lessons/hot", {
+        encoding: 0.8,
+        outcome: 0.5,
+        retrieval: 0.9,
+        rankScore: 0.77,
+      });
+    } finally {
+      stateDb.close();
+    }
 
-      const releaseBarrier = acquireMaintenanceBarrier();
-      try {
-        const start = Date.now();
-        const result = await search();
-        const elapsed = Date.now() - start;
-
-        expect(result.hits.length).toBeGreaterThan(0);
-        // Pre-#692 this call chain (searchLocal -> applyRankingRules ->
-        // loadSalienceRankScores -> acquireMaintenanceActivitySync) polled
-        // against the held barrier for up to 5s before falling back. Assert
-        // well under that old deadline.
-        expect(elapsed).toBeLessThan(2000);
-      } finally {
-        releaseBarrier();
-      }
-    },
-    // Tight test-level timeout: a reintroduced 5s stall must be killed and
-    // reported as a hard timeout failure, not merely observed as "slower" via
-    // the elapsed-time assertion above.
-    4000,
-  );
+    const releaseBarrier = acquireMaintenanceBarrier();
+    try {
+      const result = await search();
+      expect(result.hits.length).toBeGreaterThan(0);
+    } finally {
+      releaseBarrier();
+    }
+  }, 2500);
 });

--- a/tests/integration/ranking-salience-boost.test.ts
+++ b/tests/integration/ranking-salience-boost.test.ts
@@ -3,23 +3,46 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 /**
- * R2 — the improve loop's
- * `asset_salience.rank_score` composes into user-facing ranking as a bounded
- * multiplicative boost, loaded fail-open from state.db.
+ * R2 / #692 — the salience ranking contributor.
+ *
+ * `asset_salience.rank_score` no longer composes into DEFAULT user-facing
+ * ranking (search/curate) as of #692: `salienceRankingContributor` was
+ * dropped from `defaultUtilityRankingContributors`, and the state.db
+ * best-effort load (`loadSalienceRankScores`) was deleted outright — it was
+ * both retrieval-dominated noise on live data (rationale: w_r = 0.60 in
+ * salience.ts, warm-starts non-zero with no outcome evidence, zero pack
+ * coverage, max observed multiplier ×1.071) AND the cause of a confirmed
+ * hot-path defect: every default search synchronously waited on the
+ * maintenance-activity barrier (up to a 5s spin) before the 250ms SQLite
+ * `busy_timeout` even applied.
+ *
+ * `rank_score` is UNCHANGED as improve's own internal selection signal — only
+ * its promotion into user-facing ranking is removed. The contributor itself,
+ * and its weight/cap constants, stay exported (unwired) for a future gated
+ * experiment; the tests below drive it via EXPLICIT injection — building a
+ * contributor list that includes it and calling `applyUtilityContributors`
+ * directly — since it is no longer reachable through the default ranking path
+ * (`applyRankingRules` / `akm search` / `akm curate`).
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import fs from "node:fs";
+import path from "node:path";
 import { upsertAssetSalience } from "../../src/commands/improve/salience";
 import { conceptIdFromTypeName } from "../../src/core/asset/resolve-ref";
 import { acquireMaintenanceBarrier } from "../../src/core/maintenance-barrier";
 import { getStateDbPath, openStateDatabase } from "../../src/core/state-db";
+import { akmIndex } from "../../src/indexer/indexer";
 import type { IndexDocument } from "../../src/indexer/passes/metadata";
-import { loadSalienceRankScores } from "../../src/indexer/search/ranking";
-import { applyUtilityContributors, type UtilityRankingContext } from "../../src/indexer/search/ranking-contributors";
+import { searchLocal } from "../../src/indexer/search/db-search";
+import {
+  applyUtilityContributors,
+  salienceRankingContributor,
+  type UtilityRankingContext,
+} from "../../src/indexer/search/ranking-contributors";
 import type { RankedEntryInput } from "../../src/indexer/search/ranking-types";
 import type { Database } from "../../src/storage/database";
-import { type Cleanup, withIsolatedAkmStorage } from "../_helpers/sandbox";
+import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../_helpers/sandbox";
 
 function makeRanked(id: number, name: string, type = "lesson"): RankedEntryInput {
   const entry: IndexDocument = { name, type: type as IndexDocument["type"] };
@@ -45,155 +68,125 @@ function makeCtx(salienceRankScores?: Map<number, number>): UtilityRankingContex
   };
 }
 
-describe("R2 — salience ranking contributor", () => {
+describe("R2 — salience ranking contributor (explicit injection only — not in the default list)", () => {
   test("rank_score boosts the item score, bounded at 1.2×", () => {
     const item = makeRanked(1, "hot");
-    applyUtilityContributors(item, makeCtx(new Map([[1, 1.0]])));
+    applyUtilityContributors(item, makeCtx(new Map([[1, 1.0]])), [salienceRankingContributor]);
     expect(item.score).toBeCloseTo(1.2, 9); // 1 + 1.0 × 0.2, capped
 
     const half = makeRanked(2, "warm");
-    applyUtilityContributors(half, makeCtx(new Map([[2, 0.5]])));
+    applyUtilityContributors(half, makeCtx(new Map([[2, 0.5]])), [salienceRankingContributor]);
     expect(half.score).toBeCloseTo(1.1, 9);
   });
 
   test("absent/zero rank_score leaves the score untouched (fail-open parity)", () => {
     const missing = makeRanked(1, "unknown");
-    applyUtilityContributors(missing, makeCtx(new Map()));
+    applyUtilityContributors(missing, makeCtx(new Map()), [salienceRankingContributor]);
     expect(missing.score).toBe(1);
 
     const zero = makeRanked(2, "zero");
-    applyUtilityContributors(zero, makeCtx(new Map([[2, 0]])));
+    applyUtilityContributors(zero, makeCtx(new Map([[2, 0]])), [salienceRankingContributor]);
     expect(zero.score).toBe(1);
 
     const noMap = makeRanked(3, "nomap");
-    applyUtilityContributors(noMap, makeCtx(undefined));
+    applyUtilityContributors(noMap, makeCtx(undefined), [salienceRankingContributor]);
     expect(noMap.score).toBe(1);
   });
+
+  test("NOT applied via the default contributor list, even with a populated map (the #692 removal itself)", () => {
+    // Same populated map that produced a 1.2× boost above, but this time run
+    // through applyUtilityContributors with NO explicit contributors list —
+    // i.e. exactly how applyRankingRules / akm search / akm curate call it.
+    // defaultUtilityRankingContributors no longer contains salience-ranking,
+    // so this must be a no-op.
+    const item = makeRanked(1, "hot");
+    applyUtilityContributors(item, makeCtx(new Map([[1, 1.0]])));
+    expect(item.score).toBe(1);
+  });
 });
 
-describe("R2 — loadSalienceRankScores (state.db read path)", () => {
-  let cleanup: Cleanup;
+describe("R2 removal (#692) — default search no longer touches state.db", () => {
+  let storage: IsolatedAkmStorage;
 
   beforeEach(() => {
-    ({ cleanup } = withIsolatedAkmStorage());
+    storage = withIsolatedAkmStorage();
   });
 
-  afterEach(() => cleanup());
+  afterEach(() => storage.cleanup());
 
-  test("maps stored asset_salience rank scores back to entry ids by ref", () => {
-    const db = openStateDatabase();
-    try {
-      upsertAssetSalience(db, "stash//lessons/hot", {
-        encoding: 0.8,
-        outcome: 0.5,
-        retrieval: 0.9,
-        rankScore: 0.77,
-      });
-    } finally {
-      db.close();
-    }
-    const items = [makeRanked(11, "hot"), makeRanked(12, "cold")];
-    const scores = loadSalienceRankScores(items);
-    expect(scores.get(11)).toBeCloseTo(0.77, 9);
-    expect(scores.has(12)).toBe(false);
-  });
-
-  test("missing state.db → empty map, and the search path never CREATES the file", () => {
-    // No openStateDatabase() call in this test: state.db does not exist yet.
-    const dbPath = getStateDbPath();
-    expect(fs.existsSync(dbPath)).toBe(false);
-    const scores = loadSalienceRankScores([makeRanked(1, "anything")]);
-    expect(scores.size).toBe(0);
-    // The read-only search path must not have created or migrated state.db.
-    expect(fs.existsSync(dbPath)).toBe(false);
-  });
-
-  test("coordinates the canonical read-only handle with the maintenance barrier", () => {
-    const db = openStateDatabase();
-    try {
-      upsertAssetSalience(db, "stash//lessons/hot", {
-        encoding: 0.8,
-        outcome: 0.5,
-        retrieval: 0.9,
-        rankScore: 0.77,
-      });
-    } finally {
-      db.close();
-    }
-    const items = [makeRanked(11, "hot")];
-    const releaseBarrier = acquireMaintenanceBarrier();
-    try {
-      expect(loadSalienceRankScores(items).size).toBe(0);
-    } finally {
-      releaseBarrier();
-    }
-    expect(loadSalienceRankScores(items).get(11)).toBeCloseTo(0.77, 9);
-  }, 10_000);
-});
-
-describe("salience current item_ref read", () => {
-  let cleanup: Cleanup;
-
-  beforeEach(() => {
-    ({ cleanup } = withIsolatedAkmStorage());
-  });
-
-  afterEach(() => cleanup());
-
-  function makeRankedWithItemRef(id: number, name: string, itemRef: string, type = "lesson"): RankedEntryInput {
-    return { ...makeRanked(id, name, type), itemRef };
+  /** Seed one searchable lesson asset and build the real index for it. */
+  async function seedAndIndex(): Promise<void> {
+    const lessonPath = path.join(storage.stashDir, "lessons", "hot.md");
+    fs.writeFileSync(lessonPath, "---\ndescription: a hot lesson\n---\n\n# hot\n\nBody text about hot.\n", "utf8");
+    await akmIndex({ stashDir: storage.stashDir });
   }
 
-  test("ignores bare stored keys and reads fully-qualified item_ref keys", () => {
-    const db = openStateDatabase();
-    try {
-      upsertAssetSalience(db, "lessons/retired-hot", {
-        encoding: 0.8,
-        outcome: 0.5,
-        retrieval: 0.9,
-        rankScore: 0.66,
-      });
-      upsertAssetSalience(db, "stash//lessons/new-hot", {
-        encoding: 0.8,
-        outcome: 0.5,
-        retrieval: 0.9,
-        rankScore: 0.66,
-      });
-    } finally {
-      db.close();
-    }
+  function search() {
+    return searchLocal({
+      query: "hot",
+      searchType: "any",
+      limit: 5,
+      stashDir: storage.stashDir,
+      sources: [{ path: storage.stashDir }],
+      config: { semanticSearchMode: "off" },
+    });
+  }
 
-    const retiredItem = makeRankedWithItemRef(21, "retired-hot", "stash//lessons/retired-hot");
-    const newItem = makeRankedWithItemRef(22, "new-hot", "stash//lessons/new-hot");
+  test("default search never creates state.db (stronger form: it touches state.db not at all)", async () => {
+    await seedAndIndex();
+    const dbPath = getStateDbPath();
+    expect(fs.existsSync(dbPath)).toBe(false);
 
-    const scores = loadSalienceRankScores([retiredItem, newItem]);
-    expect(scores.has(21)).toBe(false);
-    expect(scores.get(22)).toBeCloseTo(0.66, 9);
+    const result = await search();
+    expect(result.hits.length).toBeGreaterThan(0);
+
+    // The default search path must not have created (or opened) state.db —
+    // loadSalienceRankScores, the only reason the search path ever touched
+    // state.db, is deleted outright, not merely made conditional.
+    expect(fs.existsSync(dbPath)).toBe(false);
   });
 
-  test("a fully-qualified item_ref row is not affected by a bare sibling", () => {
-    const db = openStateDatabase();
-    try {
-      upsertAssetSalience(db, "lessons/dual", { encoding: 0, outcome: 0, retrieval: 0, rankScore: 0.1 });
-      upsertAssetSalience(db, "stash//lessons/dual", { encoding: 0, outcome: 0, retrieval: 0, rankScore: 0.9 });
-    } finally {
-      db.close();
-    }
+  test(
+    "search completes promptly even while the maintenance barrier is held (regression guard for the pre-#692 5s stall)",
+    async () => {
+      await seedAndIndex();
 
-    const item = makeRankedWithItemRef(30, "dual", "stash//lessons/dual");
-    const scores = loadSalienceRankScores([item]);
-    expect(scores.get(30)).toBeCloseTo(0.9, 9);
-  });
+      // Mirror a realistic installation that has run `improve` before: state.db
+      // already exists and holds a legacy salience row for this asset. Before
+      // #692 this was exactly the precondition needed to reach the buggy
+      // acquireMaintenanceActivitySync("state-db") call in loadSalienceRankScores
+      // (it short-circuited before that call when state.db was absent).
+      const stateDb = openStateDatabase();
+      try {
+        upsertAssetSalience(stateDb, "stash//lessons/hot", {
+          encoding: 0.8,
+          outcome: 0.5,
+          retrieval: 0.9,
+          rankScore: 0.77,
+        });
+      } finally {
+        stateDb.close();
+      }
 
-  test("an item_ref-bearing asset does not read a bare stored key", () => {
-    const db = openStateDatabase();
-    try {
-      upsertAssetSalience(db, "lessons/straggler", { encoding: 0, outcome: 0, retrieval: 0, rankScore: 0.42 });
-    } finally {
-      db.close();
-    }
-    const item = makeRankedWithItemRef(40, "straggler", "stash//lessons/straggler");
-    const scores = loadSalienceRankScores([item]);
-    expect(scores.has(40)).toBe(false);
-  });
+      const releaseBarrier = acquireMaintenanceBarrier();
+      try {
+        const start = Date.now();
+        const result = await search();
+        const elapsed = Date.now() - start;
+
+        expect(result.hits.length).toBeGreaterThan(0);
+        // Pre-#692 this call chain (searchLocal -> applyRankingRules ->
+        // loadSalienceRankScores -> acquireMaintenanceActivitySync) polled
+        // against the held barrier for up to 5s before falling back. Assert
+        // well under that old deadline.
+        expect(elapsed).toBeLessThan(2000);
+      } finally {
+        releaseBarrier();
+      }
+    },
+    // Tight test-level timeout: a reintroduced 5s stall must be killed and
+    // reported as a hard timeout failure, not merely observed as "slower" via
+    // the elapsed-time assertion above.
+    4000,
+  );
 });


### PR DESCRIPTION
## Summary

Fixes #692.

- **Removes** the R2 salience ranking contributor from *default* user-facing ranking. `salienceRankingContributor` is dropped from `defaultUtilityRankingContributors` (`src/indexer/search/ranking-contributors.ts`), which is now the one-entry list `[utilityRankingContributor]`. No config gate was added — a key for a term being removed would be dead surface the upcoming 1.0 contract freeze would have to carry.
- **Deletes** `loadSalienceRankScores` outright (`src/indexer/search/ranking.ts`), along with the now-dead `maintenance-barrier`/`state-db` imports. `src/indexer/search/` has zero remaining `maintenance-barrier`/`state-db` dependency and opens no `state.db` handle on the search path (verified by grep).
- **Keeps** `salienceRankingContributor` and its `SALIENCE_WEIGHT` / `SALIENCE_MAX_BOOST` constants exported (now unwired) for a future gated, outcome-backed experiment.
- **Does not touch** `rank_score`'s computation, storage, or improve-internal consumption (`src/commands/improve/salience.ts` is untouched) — only its promotion into user-facing ranking is removed.
- `RankEntriesOptions.salienceRankScores` keeps its shape; its doc comment now says explicitly that `undefined`/`null` mean "no data" and a `Map` only matters to a caller that explicitly builds its own utility-contributor list including the contributor (there is no state.db fallback load anymore).

### Rationale (from the issue / 0.9.0-rc.5 triage)

- The boost is retrieval-dominated (`w_r = 0.60`, `src/commands/improve/salience.ts:356-360`) with no source filter, so it double-counts the same `usage_events` the utility-score contributor already reinforces.
- It warm-starts non-zero with no outcome evidence (`salience.ts:293-297`).
- `asset_salience` has zero pack coverage — the boost could only ever favor self-generated personal assets over an equally-relevant pack asset.
- It measures as noise on live data: max observed `rank_score` 0.356 → max multiplier ×1.071, mean ×1.016.
- Removing the default `state.db` load also fixes a confirmed hot-path defect: whenever `state.db` already existed, every default search synchronously called `acquireMaintenanceActivitySync("state-db")` (`src/core/maintenance-barrier.ts:91-107`) — a blocking `Atomics.wait` poll loop, up to 5s — plus a lock-file create, before the load's own 250ms SQLite `busy_timeout` ever applied.

## Test-first discipline (RED → GREEN, not squashed)

1. `2cb6d07` **test(search): pin salience-removal contract for #692 (RED)** — rewrote `tests/integration/ranking-salience-boost.test.ts` and `tests/integration/ranking-contributor-ablation.test.ts` against the *old* production code. Confirmed RED for the right reason (both files fail to import a symbol the implementation doesn't export yet):
   ```
   SyntaxError: Export named 'salienceRankingContributor' not found in module
   '.../src/indexer/search/ranking-contributors.ts'
   0 pass / 2 fail / 2 errors
   ```
2. `7a2ae78` **test(search): fix two test bugs found while confirming RED (still RED)** — fixed two bugs discovered while iterating (see commit body: an `akmIndex`-touches-`state.db` false assumption, and a wall-clock `expect(elapsed).toBeLessThan(...)` pattern this repo's own `scripts/lint-tests-isolation.ts` forbids as CI-flaky). Re-confirmed RED at this exact commit by stashing the (still-uncommitted) production fix and re-running — same import error, 0 pass / 2 fail.
3. `8dac8e3` **fix(search): remove the R2 salience boost from default ranking (#692)** — the production change. Turns the same two files GREEN: 21 pass / 0 fail.
4. `a30ffe5` **docs(changelog): note the R2 salience boost removal (#692)**.

## Golden-eval deltas

`tests/integration/curate-golden-eval.test.ts` run against the pre-fix code (git-checked-out parent commit, same test file) vs. post-fix (this branch), same deterministic-embedder fixture:

| metric | before (with boost) | after (this PR) | delta |
|---|---|---|---|
| meanScore | 0.890 | 0.890 | 0.000 |
| meanNdcg | 0.854 | 0.854 | 0.000 |
| meanRecall | 0.867 | 0.867 | 0.000 |
| meanMrr | 0.900 | 0.900 | 0.000 |
| meanNoBannedAboveRequired | 1.000 | 1.000 | 0.000 |
| totalBannedLeapfrog | 0 | 0 | 0 |

Every one of the 10 per-case rows (docker-homelab-deploy, release-coordination, testing-practices, git-workflow, code-review, ci-pipeline, deploy-production, seo-marketing, residue-docker, residue-release) is bit-for-bit identical before/after. **Exactly neutral, as expected** — the golden suite already floors below this value and this change removes a signal that measured as noise on live data. No rebaselining needed or done.

## Test plan

- [x] `bun test tests/integration/ranking-salience-boost.test.ts tests/integration/ranking-contributor-ablation.test.ts` → 21 pass, 0 fail (confirmed RED beforehand, see above)
- [x] Blast radius: `bun test tests/integration/curate-golden-eval.test.ts tests/integration/ranking-regression.test.ts tests/integration/graph-boost-ranking.test.ts tests/integration/scoped-utility.test.ts tests/integration/downstream-value-attribution.test.ts tests/ranking-capture-mode.test.ts tests/ranking-lesson-strength.test.ts tests/ranking-utility-decay.test.ts` (plus the two files above) → **111 pass, 0 fail across 10 files**
- [x] `bun run test:unit` → **2986 pass, 0 fail across 238 files**
- [x] `bun run test:integration` (full suite) → **5090 pass, 0 fail across 4 process-shards (380/380 files)**
- [x] `bun run lint` → exit 0 (pre-existing repo-wide `noNonNullAssertion` warnings only, unrelated to this change; `lint-tests-isolation`, `lint-runtime-boundary`, and every other custom lint script report OK)
- [x] `bunx tsc --noEmit` → clean, no output
- [x] Manually verified (scratch script, not committed) that `acquireMaintenanceActivitySync` really blocks ~5003ms under barrier contention before failing open, confirming the regression guard's premise

## Checklist

- [x] Tests pass (`bun test`)
- [x] Lint passes (`bun run lint`)
- [x] Docs updated (`CHANGELOG.md` — `## [Unreleased]` → `### Changed`)


---
_Generated by [Claude Code](https://claude.ai/code/session_017jtbyq5gSTzNRFH3Ker8u7)_