### PR TITLE
refactor(state): extract salience/outcome repositories and guard state-table SQL (#672)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -373,6 +373,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   removed. The contributor stays in the codebase (unwired) for a future
   gated, outcome-backed experiment.
 
+- **Internal: `asset_salience` / `asset_outcome` state.db access moved behind
+  `src/storage/repositories/{salience,outcome}-repository.ts`** (#672 part 2).
+  Mirrors the existing state.db repository precedents
+  (`proposals-repository.ts`, `improve-runs-repository.ts`,
+  `events-repository.ts`): the raw SQL, row-mapping, and the #644
+  encoding-provenance CASE guards are extracted verbatim, only relocated —
+  `commands/improve/salience.ts` and `outcome-loop.ts` re-export the moved
+  functions, so no importer or test churns. A new `state-table-sql` rule in
+  `scripts/lint-repository-sql.ts` now fails the build if raw
+  `asset_salience`/`asset_outcome` SQL reappears outside the repository
+  directory (or `core/state/migrations.ts`). Not a user-visible behavior
+  change: `rank_score`, `outcome_score`, and everything `improve`/`health`
+  compute from them are identical.
+
 ### Fixed
 
 - **The compiled standalone binary can run `akm migrate`.** Release binaries

--- a/scripts/lint-repository-sql.ts
+++ b/scripts/lint-repository-sql.ts
@@ -17,15 +17,33 @@
  * D5 (WorkflowDocuments reader) removed those inversions; this guard ratchets
  * them shut so they cannot regrow.
  *
- * Scope is intentionally NARROW. Raw SQL legitimately lives in many other
- * modules (health, indexer, usage-telemetry, the improve read-side, …) and the
- * codebase does NOT funnel all SQL through one repository directory — so a
- * blanket "no SQL outside repositories" rule would be a large status-quo
- * allowlist, not a real boundary. This guard enforces only the boundary that
- * was actually inverted and actually regressed.
+ * Scope for `db-owner-import` / `db-open-call` is intentionally NARROW. Raw
+ * SQL legitimately lives in many other modules (health, indexer,
+ * usage-telemetry, the improve read-side, …) and the codebase does NOT funnel
+ * all SQL through one repository directory — so a blanket "no SQL outside
+ * repositories" rule would be a large status-quo allowlist, not a real
+ * boundary. Those two rules enforce only the boundary that was actually
+ * inverted and actually regressed.
  *
- * Comments and string literals are stripped before matching, so prose that
- * merely mentions these names does not trip the guard — only real code does.
+ * A third rule, `state-table-sql` (#672 part 2), is scoped differently and
+ * much more broadly: raw SQL naming the `asset_salience` / `asset_outcome`
+ * state.db tables is guarded EVERYWHERE under `src/` except
+ * `src/storage/repositories/**` (their new home,
+ * salience-repository.ts / outcome-repository.ts) and
+ * `src/core/state/migrations.ts` (schema DDL, not application read/write
+ * SQL — migrations are append-only history and are never refactored to use
+ * a repository). Unlike the first two rules, a widened `GUARDED_PREFIXES`
+ * would not express this: `salience.ts` and `outcome-loop.ts` take `db`
+ * parameters and import no DB-owner module, so they pass the first two rules
+ * today with their SQL fully intact — unlike `db-owner-import`/`db-open-call`,
+ * this is a raw-SQL-content rule, not an import/open-call rule, so it needs
+ * its own pattern and its own scope predicate (`isStateTableSqlScope` below),
+ * not just a wider prefix list.
+ *
+ * Comments and string literals are stripped before matching (except for rules
+ * that opt into `keepStrings`, which need to see string content — import
+ * specifiers and SQL text both live inside string literals), so prose that
+ * merely mentions these names does not trip any rule — only real code does.
  *
  * Exit codes: 0 — clean; 1 — violations (or internal error).
  * Usage: bun scripts/lint-repository-sql.ts
@@ -41,15 +59,49 @@ const srcDir = path.join(repoRoot, "src");
  * Subsystems that must use repositories rather than DB internals. POSIX-relative
  * directory prefixes. Add a new boundary here only when its inversions are
  * already cleared (the guard must stay at 0 violations).
+ *
+ * Scope for `db-owner-import` and `db-open-call` ONLY — the `state-table-sql`
+ * rule (#672 part 2) has its own, much broader scope; see
+ * `isStateTableSqlScope` below. Left unchanged by #672 part 2 on purpose.
  */
 const GUARDED_PREFIXES: readonly string[] = ["src/registry/", "src/workflows/runtime/"];
+
+/**
+ * `state-table-sql` scope (#672 part 2): applies everywhere under `src/`
+ * except these directory prefixes …
+ */
+const STATE_TABLE_SQL_EXCLUDED_PREFIXES: readonly string[] = ["src/storage/repositories/"];
+
+/** … and except these exact files (POSIX-relative to repo root). */
+const STATE_TABLE_SQL_EXCLUDED_FILES: readonly string[] = ["src/core/state/migrations.ts"];
+
+/** Scope predicate for the original two rules: registry + workflow-runtime only. */
+function isGuardedPrefix(rel: string): boolean {
+  return GUARDED_PREFIXES.some((p) => rel.startsWith(p));
+}
+
+/**
+ * Scope predicate for `state-table-sql`: everywhere under `src/` except the
+ * repository directory (the new home for this SQL) and the migrations file
+ * (schema DDL, append-only, never behind a repository).
+ */
+function isStateTableSqlScope(rel: string): boolean {
+  if (!rel.startsWith("src/")) return false;
+  if (STATE_TABLE_SQL_EXCLUDED_FILES.includes(rel)) return false;
+  return !STATE_TABLE_SQL_EXCLUDED_PREFIXES.some((p) => rel.startsWith(p));
+}
 
 interface Rule {
   id: string;
   pattern: RegExp;
   message: string;
-  /** Match against string-preserving text (for import-specifier rules). */
+  /** Match against string-preserving text (for import-specifier / SQL-text rules). */
   keepStrings?: boolean;
+  /**
+   * Which files this rule applies to, given a repo-relative POSIX path.
+   * Defaults to `isGuardedPrefix` (the original two rules' scope) when absent.
+   */
+  appliesTo?: (rel: string) => boolean;
 }
 
 const RULES: readonly Rule[] = [
@@ -67,6 +119,15 @@ const RULES: readonly Rule[] = [
       /\b(?:openExistingDatabase|openIndexDatabase|openStateDatabase|openManagedDatabase)\s*\(|\bnew\s+Database\s*\(/,
     message:
       "opens a database directly — registry/workflow-runtime code must query through a repository in src/storage/repositories/**",
+  },
+  {
+    id: "state-table-sql",
+    // Raw SQL (or any code) naming the asset_salience / asset_outcome tables.
+    pattern: /\basset_salience\b|\basset_outcome\b/,
+    message:
+      "raw SQL names a state-table (asset_salience/asset_outcome) outside src/storage/repositories/** — move the query behind salience-repository.ts / outcome-repository.ts (repository-owns-SQL boundary, #672)",
+    keepStrings: true,
+    appliesTo: isStateTableSqlScope,
   },
 ];
 
@@ -162,7 +223,11 @@ interface Violation {
 
 /** Pure matcher: lint one file's content given its repo-relative POSIX path. */
 export function lintContent(rel: string, raw: string): Violation[] {
-  if (!GUARDED_PREFIXES.some((p) => rel.startsWith(p))) return [];
+  // Each rule has its own scope (appliesTo, default isGuardedPrefix). Skip the
+  // (relatively expensive) comment/string stripping entirely when NO rule
+  // could possibly apply to this file.
+  const applicableRules = RULES.filter((rule) => (rule.appliesTo ?? isGuardedPrefix)(rel));
+  if (applicableRules.length === 0) return [];
 
   const noStrings = stripCommentsAndStrings(raw, false).split("\n");
   const withStrings = stripCommentsAndStrings(raw, true).split("\n");
@@ -170,7 +235,7 @@ export function lintContent(rel: string, raw: string): Violation[] {
 
   const violations: Violation[] = [];
   for (let i = 0; i < rawLines.length; i++) {
-    for (const rule of RULES) {
+    for (const rule of applicableRules) {
       const subject = rule.keepStrings ? withStrings[i] : noStrings[i];
       if (subject !== undefined && rule.pattern.test(subject)) {
         violations.push({
@@ -203,7 +268,8 @@ if (import.meta.main) {
   const violations = lintRepositorySql();
   if (violations.length === 0) {
     console.log(
-      "lint-repository-sql: OK — registry + workflow-runtime reach storage only through src/storage/repositories",
+      "lint-repository-sql: OK — registry + workflow-runtime reach storage only through src/storage/repositories, " +
+        "and no raw asset_salience/asset_outcome SQL lives outside it",
     );
     process.exit(0);
   }

--- a/src/commands/health/metrics.ts
+++ b/src/commands/health/metrics.ts
@@ -15,6 +15,7 @@ import type { Database } from "../../storage/database";
 import { insertEvent } from "../../storage/repositories/events-repository";
 import { queryImproveRuns } from "../../storage/repositories/improve-runs-repository";
 import { listStateProposals } from "../../storage/repositories/proposals-repository";
+import { getTopRetrievalSalience } from "../../storage/repositories/salience-repository";
 import { roundRate, toFiniteNumber } from "./improve-metrics";
 import {
   ENRICHMENT_LANES,
@@ -243,12 +244,10 @@ export function computeDegradationMetrics(
   let entrenchmentFlagged: boolean | undefined;
   let salienceUniformityFlagged: boolean | undefined;
   try {
-    const rows = db
-      .prepare(
-        `SELECT retrieval_salience FROM asset_salience
-         ORDER BY rank_score DESC LIMIT 100`,
-      )
-      .all() as Array<{ retrieval_salience: number }>;
+    // Fail-open: the asset_salience table may not exist yet (pre-WS-1 install).
+    // getTopRetrievalSalience (storage/repositories/salience-repository.ts,
+    // #672 part 2) owns the raw SQL; this call site's try/catch is unchanged.
+    const rows = getTopRetrievalSalience(db, 100);
     if (rows.length >= 5) {
       const vals = rows.map((r) => r.retrieval_salience).sort((a, b) => a - b);
       const n = vals.length;

--- a/src/commands/improve/outcome-loop.ts
+++ b/src/commands/improve/outcome-loop.ts
@@ -66,6 +66,7 @@
 
 import type { Database } from "../../storage/database";
 import {
+  type AssetOutcomeRow,
   getAllAssetOutcomes,
   getAssetOutcome,
   getOutcomeScoresByRef,
@@ -121,17 +122,14 @@ export const OUTCOME_SCORE_MAX = 1.5;
 export const DIVERSITY_FLOOR_FRACTION = 0.1;
 
 // ── Row shape ─────────────────────────────────────────────────────────────────
+//
+// AssetOutcomeRow moved verbatim to storage/repositories/outcome-repository.ts
+// (#672 part 2) — re-exported here so existing importers of this module
+// resolve unchanged (see that file's module-level note for why the row type
+// lives there rather than here: it keeps the repository free of any import
+// back into this file, avoiding a 2-node import cycle).
 
-export interface AssetOutcomeRow {
-  asset_ref: string;
-  last_retrieved_at: number;
-  retrieval_count: number;
-  expected_retrieval_rate: number;
-  negative_feedback_count: number;
-  accepted_change_count: number;
-  outcome_score: number;
-  updated_at: number;
-}
+export type { AssetOutcomeRow };
 
 // ── Writer ────────────────────────────────────────────────────────────────────
 

--- a/src/commands/improve/outcome-loop.ts
+++ b/src/commands/improve/outcome-loop.ts
@@ -65,6 +65,12 @@
  */
 
 import type { Database } from "../../storage/database";
+import {
+  getAllAssetOutcomes,
+  getAssetOutcome,
+  getOutcomeScoresByRef,
+  upsertAssetOutcome,
+} from "../../storage/repositories/outcome-repository";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -237,90 +243,31 @@ export function updateAssetOutcome(db: Database, inputs: OutcomeUpdateInputs): O
     outcomeScore = Math.min(OUTCOME_SCORE_MAX, Math.max(OUTCOME_SCORE_MIN, newScore));
   }
 
-  // Upsert the row. `review_pressure` is intentionally omitted from both the
-  // INSERT column list and the ON CONFLICT SET clause: the column's DEFAULT 0
-  // seeds fresh rows, and omitting it from SET leaves an existing row's value
-  // untouched on update (never written going forward). The column itself is
-  // dropped in migration 018.
-  db.prepare(
-    `INSERT INTO asset_outcome
-       (asset_ref, last_retrieved_at, retrieval_count, expected_retrieval_rate,
-        negative_feedback_count, accepted_change_count,
-        outcome_score, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(asset_ref) DO UPDATE SET
-       last_retrieved_at      = excluded.last_retrieved_at,
-       retrieval_count        = excluded.retrieval_count,
-       expected_retrieval_rate= excluded.expected_retrieval_rate,
-       negative_feedback_count= excluded.negative_feedback_count,
-       accepted_change_count  = excluded.accepted_change_count,
-       outcome_score          = excluded.outcome_score,
-       updated_at             = excluded.updated_at`,
-  ).run(
-    inputs.ref,
-    inputs.lastRetrievedAt,
-    inputs.currentRetrievalCount,
+  // Upsert the row. See `upsertAssetOutcome` in
+  // storage/repositories/outcome-repository.ts (#672 part 2) for the SQL text
+  // and the `review_pressure` omission rationale — this call site is
+  // unchanged in intent, just no longer inline.
+  upsertAssetOutcome(db, {
+    ref: inputs.ref,
+    lastRetrievedAt: inputs.lastRetrievedAt,
+    retrievalCount: inputs.currentRetrievalCount,
     expectedRetrievalRate,
-    inputs.negativeFeedbackCount,
-    inputs.acceptedChangeCount,
+    negativeFeedbackCount: inputs.negativeFeedbackCount,
+    acceptedChangeCount: inputs.acceptedChangeCount,
     outcomeScore,
-    now,
-  );
+    updatedAt: now,
+  });
 
   return { outcomeScore, isNewRow };
 }
 
 // ── Reader ────────────────────────────────────────────────────────────────────
+//
+// getAssetOutcome / getAllAssetOutcomes / getOutcomeScoresByRef moved verbatim
+// to storage/repositories/outcome-repository.ts (#672 part 2) — re-exported
+// here so existing importers of this module resolve unchanged.
 
-/**
- * Load the outcome row for one asset, or `undefined` if not yet written.
- */
-export function getAssetOutcome(db: Database, ref: string): AssetOutcomeRow | undefined {
-  const row = db
-    .prepare(
-      `SELECT asset_ref, last_retrieved_at, retrieval_count, expected_retrieval_rate,
-              negative_feedback_count, accepted_change_count,
-              outcome_score, updated_at
-       FROM asset_outcome WHERE asset_ref = ?`,
-    )
-    .get(ref);
-  return row == null ? undefined : (row as AssetOutcomeRow);
-}
-
-/**
- * Load ALL asset_outcome rows. Used for the proxy-adequacy tripwire computation.
- */
-export function getAllAssetOutcomes(db: Database): AssetOutcomeRow[] {
-  return db
-    .prepare(
-      `SELECT asset_ref, last_retrieved_at, retrieval_count, expected_retrieval_rate,
-              negative_feedback_count, accepted_change_count,
-              outcome_score, updated_at
-       FROM asset_outcome ORDER BY asset_ref`,
-    )
-    .all() as AssetOutcomeRow[];
-}
-
-/**
- * Build a Map<ref, outcome_score> for a set of refs in one query.
- * Used by `salience.ts` to populate `outcomeSalience`.
- */
-export function getOutcomeScoresByRef(db: Database, refs: string[]): Map<string, number> {
-  const result = new Map<string, number>();
-  if (refs.length === 0) return result;
-  const CHUNK = 500;
-  for (let i = 0; i < refs.length; i += CHUNK) {
-    const chunk = refs.slice(i, i + CHUNK);
-    const placeholders = chunk.map(() => "?").join(",");
-    const rows = db
-      .prepare(`SELECT asset_ref, outcome_score FROM asset_outcome WHERE asset_ref IN (${placeholders})`)
-      .all(...chunk) as Array<{ asset_ref: string; outcome_score: number }>;
-    for (const row of rows) {
-      result.set(row.asset_ref, row.outcome_score);
-    }
-  }
-  return result;
-}
+export { getAllAssetOutcomes, getAssetOutcome, getOutcomeScoresByRef };
 
 // ── outcomeSalience projection ────────────────────────────────────────────────
 

--- a/src/commands/improve/salience.ts
+++ b/src/commands/improve/salience.ts
@@ -49,9 +49,10 @@
 
 import path from "node:path";
 import { conceptIdFromTypeName } from "../../core/asset/resolve-ref";
-import type { Database, Database as IndexDatabase } from "../../storage/database";
+import type { Database as IndexDatabase } from "../../storage/database";
 import { getAllEntries } from "../../storage/repositories/index-entries-repository";
 import { getUtilityScoresByIds } from "../../storage/repositories/index-utility-repository";
+import type { AssetSalienceRow } from "../../storage/repositories/salience-repository";
 import { WARM_START_CAP } from "./outcome-loop";
 
 // ── One day in ms ─────────────────────────────────────────────────────────────
@@ -374,23 +375,21 @@ export function computeSalience(inputs: SalienceInputs): SalienceVector {
 
 // ── state.db persistence ─────────────────────────────────────────────────────
 //
-// The three sub-scores live in state.db::asset_salience. This module owns the
-// read/write helpers; migrations live in state-db.ts (migration 009).
+// The three sub-scores live in state.db::asset_salience. Raw SQL now lives in
+// storage/repositories/salience-repository.ts (#672 part 2) — extracted
+// verbatim, only relocated behind the repository boundary. Re-exported here so
+// existing importers of this module resolve unchanged. Migrations live in
+// state-db.ts (migration 009).
 
-export interface AssetSalienceRow {
-  asset_ref: string;
-  encoding_salience: number;
-  outcome_salience: number;
-  retrieval_salience: number;
-  rank_score: number;
-  consecutive_no_ops: number;
-  updated_at: number;
-  /**
-   * Provenance of `encoding_salience` (#644). `"content"` = real content-derived
-   * score; `"type-stub"` = type-weight fallback; `null` = unknown provenance.
-   */
-  encoding_source: EncodingSource | null;
-}
+export {
+  getAllRankScores,
+  getAssetSalience,
+  getConsecutiveNoOps,
+  recordNoOp,
+  resetConsecutiveNoOps,
+  upsertAssetSalience,
+} from "../../storage/repositories/salience-repository";
+export type { AssetSalienceRow };
 
 /**
  * Does this row carry a genuine content-derived `encoding_salience` (#644)?
@@ -399,139 +398,6 @@ export interface AssetSalienceRow {
  */
 export function isContentEncodingRow(row: AssetSalienceRow): boolean {
   return row.encoding_source === "content";
-}
-
-/**
- * Upsert salience scores for one asset into state.db.
- *
- * Idempotent: safe to call every run; updates the outcome / retrieval / rank
- * columns on conflict.
- *
- * #644 — encoding provenance guard: the `encoding_salience` + `encoding_source`
- * columns are NOT lowered from a real content-derived score to a type-weight
- * stub. When the stored row is `encoding_source = 'content'` and the incoming
- * vector is a `type-stub` fallback, the stored encoding score and its provenance
- * are preserved (only the other sub-scores and `rank_score` advance). A `content`
- * write always wins; a `type-stub` write only seeds a row that has no content
- * score yet. This stops the improve loop's type-weight fallback re-asserting the
- * stub over a distill-written score on every run.
- *
- * NOTE: when the guard preserves the stored encoding score, the incoming
- * `vector.rankScore` (computed from the stub encoding) is still written. Callers
- * that want the rank_score to reflect the preserved content score should pass the
- * stored content score back in as `inputs.encodingSalience` to `computeSalience`
- * — which the improve loop does. The guard here is the defensive backstop.
- */
-export function upsertAssetSalience(db: Database, ref: string, vector: SalienceVector, now?: number): void {
-  const ts = now ?? Date.now();
-  db.prepare(
-    `INSERT INTO asset_salience
-       (asset_ref, encoding_salience, outcome_salience, retrieval_salience, rank_score, consecutive_no_ops, updated_at, encoding_source)
-     VALUES (?, ?, ?, ?, ?, 0, ?, ?)
-     ON CONFLICT(asset_ref) DO UPDATE SET
-       -- #644: never lower a real content-derived score to a type-weight stub.
-       -- Keep the stored encoding score + provenance when the stored row is
-       -- 'content' and the incoming write is a 'type-stub' fallback.
-       encoding_salience  = CASE
-         WHEN asset_salience.encoding_source = 'content' AND excluded.encoding_source = 'type-stub'
-           THEN asset_salience.encoding_salience
-           ELSE excluded.encoding_salience
-       END,
-       encoding_source    = CASE
-         WHEN asset_salience.encoding_source = 'content' AND excluded.encoding_source = 'type-stub'
-           THEN asset_salience.encoding_source
-           ELSE excluded.encoding_source
-       END,
-       outcome_salience   = excluded.outcome_salience,
-       retrieval_salience = excluded.retrieval_salience,
-       rank_score         = excluded.rank_score,
-       updated_at         = excluded.updated_at`,
-  ).run(
-    ref,
-    vector.encoding,
-    vector.outcome,
-    vector.retrieval,
-    vector.rankScore,
-    ts,
-    vector.encodingSource ?? "type-stub",
-  );
-}
-
-/**
- * Load the salience row for one asset, or undefined if not yet computed.
- */
-export function getAssetSalience(db: Database, ref: string): AssetSalienceRow | undefined {
-  const row = db
-    .prepare(
-      `SELECT asset_ref, encoding_salience, outcome_salience, retrieval_salience,
-              rank_score, consecutive_no_ops, updated_at, encoding_source
-       FROM asset_salience WHERE asset_ref = ?`,
-    )
-    .get(ref);
-  // Bun SQLite returns null (not undefined) when no row found.
-  return row == null ? undefined : (row as AssetSalienceRow);
-}
-
-/**
- * Load ALL rank scores from the asset_salience table (full-stash query).
- *
- * Used by the forgetting-safety report (plan §WS-1 step 7) to compute stash-wide
- * rank positions rather than pool-relative positions. Returns an empty Map when the
- * table is empty (first WS-1 run = no pre-existing rows).
- *
- * Order is unspecified; callers must sort before assigning 1-indexed positions.
- */
-export function getAllRankScores(db: Database): Map<string, number> {
-  const rows = db.prepare("SELECT asset_ref, rank_score FROM asset_salience").all() as Array<{
-    asset_ref: string;
-    rank_score: number;
-  }>;
-  const result = new Map<string, number>();
-  for (const row of rows) {
-    result.set(row.asset_ref, row.rank_score);
-  }
-  return result;
-}
-
-// ── Plasticity helpers ────────────────────────────────────────────────────────
-
-/**
- * Increment `consecutive_no_ops` for an asset. Called after a no-op reflect/distill.
- * Has NO effect on `rank_score` — the plasticity counter only dampens consolidation
- * selection, not retrieval ranking. See plan §WS-1 step 8.
- *
- * Invariant: recordNoOp must never originate rank_score semantics. If the asset has
- * no salience row yet (persistence's best-effort try/catch may have swallowed an
- * error), we do nothing — a no-op counter is meaningless without a rank_score row,
- * and a synthetic INSERT would fabricate a rank_score=0 entry that could produce
- * false catastrophic-forgetting signals in buildRankChangeReport.
- */
-export function recordNoOp(db: Database, ref: string): void {
-  db.prepare(
-    `UPDATE asset_salience SET consecutive_no_ops = consecutive_no_ops + 1, updated_at = ? WHERE asset_ref = ?`,
-  ).run(Date.now(), ref);
-  // If changes === 0 the asset has no salience row yet — leave the table unchanged.
-}
-
-/**
- * Reset `consecutive_no_ops` to 0 when an asset produces an accepted change.
- * Call after a successful proposal acceptance or detected mutation.
- */
-export function resetConsecutiveNoOps(db: Database, ref: string): void {
-  db.prepare(`UPDATE asset_salience SET consecutive_no_ops = 0, updated_at = ? WHERE asset_ref = ?`).run(
-    Date.now(),
-    ref,
-  );
-}
-
-/**
- * Return the `consecutive_no_ops` count for one asset. 0 when unknown.
- */
-export function getConsecutiveNoOps(db: Database, ref: string): number {
-  const row = db.prepare(`SELECT consecutive_no_ops FROM asset_salience WHERE asset_ref = ?`).get(ref) as
-    | { consecutive_no_ops: number }
-    | undefined;
-  return row?.consecutive_no_ops ?? 0;
 }
 
 // ── Consolidation-selection dampener constants ────────────────────────────────

--- a/src/storage/repositories/outcome-repository.ts
+++ b/src/storage/repositories/outcome-repository.ts
@@ -12,11 +12,34 @@
  * score clipping) stays in outcome-loop.ts's `updateAssetOutcome` — only the
  * upsert SQL that function issued moves here, as `upsertAssetOutcome`.
  *
+ * `AssetOutcomeRow` lives here (not in outcome-loop.ts) so this file imports
+ * NOTHING from commands/improve/outcome-loop.ts: outcome-loop.ts re-exports
+ * this module's functions (a mandatory edge in that direction), so an import
+ * back from here would form a 2-node cycle —
+ * `tests/architecture/import-cycle-ratchet.test.ts` enforces a zero-tolerance,
+ * shrink-only baseline (currently empty) over the whole `src/` import graph,
+ * counting type-only imports as graph edges same as value imports.
+ * outcome-loop.ts imports `AssetOutcomeRow` back from here (one direction
+ * only) and re-exports it, so external importers are unaffected.
+ *
  * @module outcome-repository
  */
 
-import type { AssetOutcomeRow } from "../../commands/improve/outcome-loop";
 import type { Database } from "../database";
+
+/**
+ * Raw SQLite row shape for the `asset_outcome` table.
+ */
+export interface AssetOutcomeRow {
+  asset_ref: string;
+  last_retrieved_at: number;
+  retrieval_count: number;
+  expected_retrieval_rate: number;
+  negative_feedback_count: number;
+  accepted_change_count: number;
+  outcome_score: number;
+  updated_at: number;
+}
 
 /**
  * Column values for one `asset_outcome` upsert. Mirrors the INSERT column

--- a/src/storage/repositories/outcome-repository.ts
+++ b/src/storage/repositories/outcome-repository.ts
@@ -1,0 +1,122 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Repository for the state.db `asset_outcome` table. Extracted verbatim from
+ * commands/improve/outcome-loop.ts (#672 part 2) — queries and row-mapping
+ * unchanged, only relocated behind the repository boundary. Re-exported by
+ * commands/improve/outcome-loop.ts so existing importers resolve.
+ *
+ * The differential-update business logic (warm-start seeding, EMA advance,
+ * score clipping) stays in outcome-loop.ts's `updateAssetOutcome` — only the
+ * upsert SQL that function issued moves here, as `upsertAssetOutcome`.
+ *
+ * @module outcome-repository
+ */
+
+import type { AssetOutcomeRow } from "../../commands/improve/outcome-loop";
+import type { Database } from "../database";
+
+/**
+ * Column values for one `asset_outcome` upsert. Mirrors the INSERT column
+ * list of {@link upsertAssetOutcome} verbatim.
+ */
+export interface AssetOutcomeUpsertValues {
+  ref: string;
+  lastRetrievedAt: number;
+  retrievalCount: number;
+  expectedRetrievalRate: number;
+  negativeFeedbackCount: number;
+  acceptedChangeCount: number;
+  outcomeScore: number;
+  updatedAt: number;
+}
+
+/**
+ * Upsert one `asset_outcome` row. Extracted verbatim from the tail of
+ * `updateAssetOutcome` in outcome-loop.ts — same SQL text, same bind order;
+ * the business logic that computes these values (warm-start seed vs.
+ * differential update) stays in outcome-loop.ts and calls this function.
+ *
+ * `review_pressure` is intentionally omitted from both the INSERT column list
+ * and the ON CONFLICT SET clause: the column's DEFAULT 0 seeds fresh rows, and
+ * omitting it from SET leaves an existing row's value untouched on update
+ * (never written going forward). The column itself is dropped in migration 018.
+ */
+export function upsertAssetOutcome(db: Database, values: AssetOutcomeUpsertValues): void {
+  db.prepare(
+    `INSERT INTO asset_outcome
+       (asset_ref, last_retrieved_at, retrieval_count, expected_retrieval_rate,
+        negative_feedback_count, accepted_change_count,
+        outcome_score, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(asset_ref) DO UPDATE SET
+       last_retrieved_at      = excluded.last_retrieved_at,
+       retrieval_count        = excluded.retrieval_count,
+       expected_retrieval_rate= excluded.expected_retrieval_rate,
+       negative_feedback_count= excluded.negative_feedback_count,
+       accepted_change_count  = excluded.accepted_change_count,
+       outcome_score          = excluded.outcome_score,
+       updated_at             = excluded.updated_at`,
+  ).run(
+    values.ref,
+    values.lastRetrievedAt,
+    values.retrievalCount,
+    values.expectedRetrievalRate,
+    values.negativeFeedbackCount,
+    values.acceptedChangeCount,
+    values.outcomeScore,
+    values.updatedAt,
+  );
+}
+
+/**
+ * Load the outcome row for one asset, or `undefined` if not yet written.
+ */
+export function getAssetOutcome(db: Database, ref: string): AssetOutcomeRow | undefined {
+  const row = db
+    .prepare(
+      `SELECT asset_ref, last_retrieved_at, retrieval_count, expected_retrieval_rate,
+              negative_feedback_count, accepted_change_count,
+              outcome_score, updated_at
+       FROM asset_outcome WHERE asset_ref = ?`,
+    )
+    .get(ref);
+  return row == null ? undefined : (row as AssetOutcomeRow);
+}
+
+/**
+ * Load ALL asset_outcome rows. Used for the proxy-adequacy tripwire computation.
+ */
+export function getAllAssetOutcomes(db: Database): AssetOutcomeRow[] {
+  return db
+    .prepare(
+      `SELECT asset_ref, last_retrieved_at, retrieval_count, expected_retrieval_rate,
+              negative_feedback_count, accepted_change_count,
+              outcome_score, updated_at
+       FROM asset_outcome ORDER BY asset_ref`,
+    )
+    .all() as AssetOutcomeRow[];
+}
+
+/**
+ * Build a Map<ref, outcome_score> for a set of refs in one query.
+ * Used by `salience.ts` to populate `outcomeSalience`.
+ */
+export function getOutcomeScoresByRef(db: Database, refs: string[]): Map<string, number> {
+  const result = new Map<string, number>();
+  if (refs.length === 0) return result;
+  const CHUNK = 500;
+  for (let i = 0; i < refs.length; i += CHUNK) {
+    const chunk = refs.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => "?").join(",");
+    const rows = db
+      .prepare(`SELECT asset_ref, outcome_score FROM asset_outcome WHERE asset_ref IN (${placeholders})`)
+      .all(...chunk) as Array<{ asset_ref: string; outcome_score: number }>;
+    for (const row of rows) {
+      result.set(row.asset_ref, row.outcome_score);
+    }
+  }
+  return result;
+}

--- a/src/storage/repositories/salience-repository.ts
+++ b/src/storage/repositories/salience-repository.ts
@@ -1,0 +1,191 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Repository for the state.db `asset_salience` table. Extracted verbatim from
+ * commands/improve/salience.ts (#672 part 2) — queries and row-mapping
+ * unchanged, only relocated behind the repository boundary. Re-exported by
+ * commands/improve/salience.ts so existing importers resolve.
+ *
+ * `getTopRetrievalSalience` is new behavior added here (not a move): it
+ * absorbs the health read formerly inlined in commands/health/metrics.ts.
+ *
+ * @module salience-repository
+ */
+
+import type { EncodingSource, SalienceVector } from "../../commands/improve/salience";
+import type { Database } from "../database";
+
+/**
+ * Raw SQLite row shape for the `asset_salience` table.
+ */
+export interface AssetSalienceRow {
+  asset_ref: string;
+  encoding_salience: number;
+  outcome_salience: number;
+  retrieval_salience: number;
+  rank_score: number;
+  consecutive_no_ops: number;
+  updated_at: number;
+  /**
+   * Provenance of `encoding_salience` (#644). `"content"` = real content-derived
+   * score; `"type-stub"` = type-weight fallback; `null` = unknown provenance.
+   */
+  encoding_source: EncodingSource | null;
+}
+
+/**
+ * Upsert salience scores for one asset into state.db.
+ *
+ * Idempotent: safe to call every run; updates the outcome / retrieval / rank
+ * columns on conflict.
+ *
+ * #644 — encoding provenance guard: the `encoding_salience` + `encoding_source`
+ * columns are NOT lowered from a real content-derived score to a type-weight
+ * stub. When the stored row is `encoding_source = 'content'` and the incoming
+ * vector is a `type-stub` fallback, the stored encoding score and its provenance
+ * are preserved (only the other sub-scores and `rank_score` advance). A `content`
+ * write always wins; a `type-stub` write only seeds a row that has no content
+ * score yet. This stops the improve loop's type-weight fallback re-asserting the
+ * stub over a distill-written score on every run.
+ *
+ * NOTE: when the guard preserves the stored encoding score, the incoming
+ * `vector.rankScore` (computed from the stub encoding) is still written. Callers
+ * that want the rank_score to reflect the preserved content score should pass the
+ * stored content score back in as `inputs.encodingSalience` to `computeSalience`
+ * — which the improve loop does. The guard here is the defensive backstop.
+ */
+export function upsertAssetSalience(db: Database, ref: string, vector: SalienceVector, now?: number): void {
+  const ts = now ?? Date.now();
+  db.prepare(
+    `INSERT INTO asset_salience
+       (asset_ref, encoding_salience, outcome_salience, retrieval_salience, rank_score, consecutive_no_ops, updated_at, encoding_source)
+     VALUES (?, ?, ?, ?, ?, 0, ?, ?)
+     ON CONFLICT(asset_ref) DO UPDATE SET
+       -- #644: never lower a real content-derived score to a type-weight stub.
+       -- Keep the stored encoding score + provenance when the stored row is
+       -- 'content' and the incoming write is a 'type-stub' fallback.
+       encoding_salience  = CASE
+         WHEN asset_salience.encoding_source = 'content' AND excluded.encoding_source = 'type-stub'
+           THEN asset_salience.encoding_salience
+           ELSE excluded.encoding_salience
+       END,
+       encoding_source    = CASE
+         WHEN asset_salience.encoding_source = 'content' AND excluded.encoding_source = 'type-stub'
+           THEN asset_salience.encoding_source
+           ELSE excluded.encoding_source
+       END,
+       outcome_salience   = excluded.outcome_salience,
+       retrieval_salience = excluded.retrieval_salience,
+       rank_score         = excluded.rank_score,
+       updated_at         = excluded.updated_at`,
+  ).run(
+    ref,
+    vector.encoding,
+    vector.outcome,
+    vector.retrieval,
+    vector.rankScore,
+    ts,
+    vector.encodingSource ?? "type-stub",
+  );
+}
+
+/**
+ * Load the salience row for one asset, or undefined if not yet computed.
+ */
+export function getAssetSalience(db: Database, ref: string): AssetSalienceRow | undefined {
+  const row = db
+    .prepare(
+      `SELECT asset_ref, encoding_salience, outcome_salience, retrieval_salience,
+              rank_score, consecutive_no_ops, updated_at, encoding_source
+       FROM asset_salience WHERE asset_ref = ?`,
+    )
+    .get(ref);
+  // Bun SQLite returns null (not undefined) when no row found.
+  return row == null ? undefined : (row as AssetSalienceRow);
+}
+
+/**
+ * Load ALL rank scores from the asset_salience table (full-stash query).
+ *
+ * Used by the forgetting-safety report (plan §WS-1 step 7) to compute stash-wide
+ * rank positions rather than pool-relative positions. Returns an empty Map when the
+ * table is empty (first WS-1 run = no pre-existing rows).
+ *
+ * Order is unspecified; callers must sort before assigning 1-indexed positions.
+ */
+export function getAllRankScores(db: Database): Map<string, number> {
+  const rows = db.prepare("SELECT asset_ref, rank_score FROM asset_salience").all() as Array<{
+    asset_ref: string;
+    rank_score: number;
+  }>;
+  const result = new Map<string, number>();
+  for (const row of rows) {
+    result.set(row.asset_ref, row.rank_score);
+  }
+  return result;
+}
+
+// ── Plasticity helpers ────────────────────────────────────────────────────────
+
+/**
+ * Increment `consecutive_no_ops` for an asset. Called after a no-op reflect/distill.
+ * Has NO effect on `rank_score` — the plasticity counter only dampens consolidation
+ * selection, not retrieval ranking. See plan §WS-1 step 8.
+ *
+ * Invariant: recordNoOp must never originate rank_score semantics. If the asset has
+ * no salience row yet (persistence's best-effort try/catch may have swallowed an
+ * error), we do nothing — a no-op counter is meaningless without a rank_score row,
+ * and a synthetic INSERT would fabricate a rank_score=0 entry that could produce
+ * false catastrophic-forgetting signals in buildRankChangeReport.
+ */
+export function recordNoOp(db: Database, ref: string): void {
+  db.prepare(
+    `UPDATE asset_salience SET consecutive_no_ops = consecutive_no_ops + 1, updated_at = ? WHERE asset_ref = ?`,
+  ).run(Date.now(), ref);
+  // If changes === 0 the asset has no salience row yet — leave the table unchanged.
+}
+
+/**
+ * Reset `consecutive_no_ops` to 0 when an asset produces an accepted change.
+ * Call after a successful proposal acceptance or detected mutation.
+ */
+export function resetConsecutiveNoOps(db: Database, ref: string): void {
+  db.prepare(`UPDATE asset_salience SET consecutive_no_ops = 0, updated_at = ? WHERE asset_ref = ?`).run(
+    Date.now(),
+    ref,
+  );
+}
+
+/**
+ * Return the `consecutive_no_ops` count for one asset. 0 when unknown.
+ */
+export function getConsecutiveNoOps(db: Database, ref: string): number {
+  const row = db.prepare(`SELECT consecutive_no_ops FROM asset_salience WHERE asset_ref = ?`).get(ref) as
+    | { consecutive_no_ops: number }
+    | undefined;
+  return row?.consecutive_no_ops ?? 0;
+}
+
+// ── New in #672 part 2 ────────────────────────────────────────────────────────
+
+/**
+ * Load the `retrieval_salience` column for the top `limit` assets ordered by
+ * `rank_score` descending.
+ *
+ * Absorbs the health read formerly inlined in `commands/health/metrics.ts`
+ * (`computeDegradationMetrics`'s corpus-diversity Gini calculation) — same
+ * query, now parameterised on `limit` instead of a hardcoded 100. This is new
+ * behavior (a named, parameterised repository entry point), not a verbatim
+ * move; callers that need fail-open behaviour on a missing table (pre-WS-1
+ * installs) must wrap the call in their own try/catch, matching the existing
+ * call site.
+ */
+export function getTopRetrievalSalience(db: Database, limit: number): Array<{ retrieval_salience: number }> {
+  return db
+    .prepare(`SELECT retrieval_salience FROM asset_salience ORDER BY rank_score DESC LIMIT ?`)
+    .all(limit) as Array<{
+    retrieval_salience: number;
+  }>;
+}

--- a/src/storage/repositories/salience-repository.ts
+++ b/src/storage/repositories/salience-repository.ts
@@ -11,10 +11,22 @@
  * `getTopRetrievalSalience` is new behavior added here (not a move): it
  * absorbs the health read formerly inlined in commands/health/metrics.ts.
  *
+ * This file deliberately imports NOTHING from commands/improve/salience.ts.
+ * salience.ts re-exports this module's functions (a mandatory edge in that
+ * direction), so an import back from here would form a 2-node cycle —
+ * `tests/architecture/import-cycle-ratchet.test.ts` enforces a zero-tolerance,
+ * shrink-only baseline (currently empty) over the whole `src/` import graph,
+ * counting type-only imports as graph edges same as value imports. The two
+ * places that would otherwise need `SalienceVector` / `EncodingSource` from
+ * salience.ts instead use a structurally-equivalent local shape: the literal
+ * union `"content" | "type-stub"` and the {@link SalienceVectorLike}
+ * interface below. Both are call-site compatible with the real domain types
+ * (any `SalienceVector` value satisfies `SalienceVectorLike`) — this is a
+ * type-shape adjustment only, not a behavior change.
+ *
  * @module salience-repository
  */
 
-import type { EncodingSource, SalienceVector } from "../../commands/improve/salience";
 import type { Database } from "../database";
 
 /**
@@ -31,8 +43,24 @@ export interface AssetSalienceRow {
   /**
    * Provenance of `encoding_salience` (#644). `"content"` = real content-derived
    * score; `"type-stub"` = type-weight fallback; `null` = unknown provenance.
+   * Structurally identical to (but not imported from) salience.ts's
+   * `EncodingSource` — see the module-level note on the import-cycle ratchet.
    */
-  encoding_source: EncodingSource | null;
+  encoding_source: "content" | "type-stub" | null;
+}
+
+/**
+ * Structural mirror of `SalienceVector` (commands/improve/salience.ts), used
+ * instead of importing that type — see the module-level note on the
+ * import-cycle ratchet. Any real `SalienceVector` value is assignable here;
+ * this interface only lists the fields {@link upsertAssetSalience} reads.
+ */
+interface SalienceVectorLike {
+  encoding: number;
+  outcome: number;
+  retrieval: number;
+  rankScore: number;
+  encodingSource?: "content" | "type-stub";
 }
 
 /**
@@ -56,7 +84,7 @@ export interface AssetSalienceRow {
  * stored content score back in as `inputs.encodingSalience` to `computeSalience`
  * — which the improve loop does. The guard here is the defensive backstop.
  */
-export function upsertAssetSalience(db: Database, ref: string, vector: SalienceVector, now?: number): void {
+export function upsertAssetSalience(db: Database, ref: string, vector: SalienceVectorLike, now?: number): void {
   const ts = now ?? Date.now();
   db.prepare(
     `INSERT INTO asset_salience

--- a/tests/integration/lint-repository-sql.test.ts
+++ b/tests/integration/lint-repository-sql.test.ts
@@ -6,11 +6,15 @@
  * Meta-test for the X4 repository-owns-SQL boundary guard
  * (`scripts/lint-repository-sql.ts`).
  *
- * Pins two things together: (1) the live `src/` tree is clean — registry and
- * workflow-runtime never reach into DB internals — so the ratchet baseline is 0;
- * and (2) the guard actually fires on the inversions it is meant to prevent
- * (direct DB-owner import + direct database open), so it can never silently
- * degrade into a no-op.
+ * Pins three things together: (1) the live `src/` tree is clean — registry and
+ * workflow-runtime never reach into DB internals, and no raw state-table SQL
+ * survives outside the repository boundary — so the ratchet baseline is 0;
+ * (2) the `db-owner-import` / `db-open-call` rules actually fire on the
+ * inversions they are meant to prevent (direct DB-owner import + direct
+ * database open), so they can never silently degrade into a no-op; and (3) the
+ * `state-table-sql` rule (#672 part 2) fires on raw `asset_salience` /
+ * `asset_outcome` SQL anywhere under `src/` except the repository directory
+ * and the migrations file, while leaving prose/comments alone.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -45,17 +49,71 @@ describe("lint-repository-sql (X4 boundary ratchet)", () => {
     expect(v.map((x) => x.ruleId)).toContain("db-open-call");
   });
 
-  test("does NOT flag the same patterns outside guarded subsystems", () => {
-    // Command/indexer modules legitimately open index.db — only registry +
-    // workflow-runtime are guarded.
+  test("does NOT flag db-owner-import/db-open-call outside guarded subsystems, but DOES flag state-table SQL there", () => {
+    // Command/indexer modules legitimately open index.db and import DB owners —
+    // only registry + workflow-runtime are guarded for those two rules.
     const cmd = lintContent("src/commands/improve/preparation.ts", "const db = openExistingDatabase();");
     expect(cmd.length).toBe(0);
+
+    // The state-table-sql rule (#672 part 2) covers this file, though: raw
+    // asset_salience/asset_outcome SQL is guarded everywhere under src/ except
+    // src/storage/repositories/** and the migrations file — "unguarded" for
+    // the first two rules no longer means "immune from every rule".
+    const stateTableSql = lintContent(
+      "src/commands/improve/preparation.ts",
+      'db.prepare("SELECT * FROM asset_salience WHERE asset_ref = ?").get(ref);',
+    );
+    expect(stateTableSql.map((x) => x.ruleId)).toContain("state-table-sql");
   });
 
   test("does NOT flag prose mentioning the names in comments/strings", () => {
     const v = lintContent(
       "src/registry/providers/example.ts",
       "// registry must not call openExistingDatabase or import indexer/db directly\nconst note = 'openIndexDatabase';",
+    );
+    expect(v.length).toBe(0);
+  });
+
+  test("flags raw asset_salience SQL under src/commands/improve/", () => {
+    const v = lintContent(
+      "src/commands/improve/example.ts",
+      'db.prepare("SELECT * FROM asset_salience WHERE asset_ref = ?").get(ref);',
+    );
+    expect(v.map((x) => x.ruleId)).toContain("state-table-sql");
+  });
+
+  test("flags raw asset_outcome SQL under src/commands/health/", () => {
+    const v = lintContent(
+      "src/commands/health/example.ts",
+      "db.prepare(`SELECT outcome_score FROM asset_outcome WHERE asset_ref = ?`).get(ref);",
+    );
+    expect(v.map((x) => x.ruleId)).toContain("state-table-sql");
+  });
+
+  test("does NOT flag the identical asset_salience SQL inside src/storage/repositories/", () => {
+    const v = lintContent(
+      "src/storage/repositories/salience-repository.ts",
+      'db.prepare("SELECT * FROM asset_salience WHERE asset_ref = ?").get(ref);',
+    );
+    expect(v.length).toBe(0);
+  });
+
+  test("does NOT flag state-table DDL in src/core/state/migrations.ts", () => {
+    const v = lintContent(
+      "src/core/state/migrations.ts",
+      "CREATE TABLE IF NOT EXISTS asset_outcome (asset_ref TEXT PRIMARY KEY);",
+    );
+    expect(v.length).toBe(0);
+  });
+
+  test("does NOT flag asset_salience/asset_outcome mentioned only in prose/comments", () => {
+    const v = lintContent(
+      "src/commands/improve/example.ts",
+      [
+        "// asset_outcome is updated by the WS-2 outcome loop.",
+        "/** state.db :: asset_salience is the canonical store. */",
+        "const x = 1;",
+      ].join("\n"),
     );
     expect(v.length).toBe(0);
   });


### PR DESCRIPTION
## Summary

Part 2 of #672 (part 1 shipped at `028cc3de`). Extracts the raw `asset_salience` /
`asset_outcome` SQL out of `src/commands/improve/{salience,outcome-loop}.ts` into
new `src/storage/repositories/{salience,outcome}-repository.ts` files, mirroring
the existing state.db repository precedents (`proposals-repository.ts`,
`improve-runs-repository.ts`, `events-repository.ts`): queries and row-mapping
extracted verbatim, only relocated behind the repository boundary. A new
`getTopRetrievalSalience(db, limit)` repository entry point absorbs the health
read in `src/commands/health/metrics.ts` (previously an inline, hardcoded
`LIMIT 100`). `salience.ts` and `outcome-loop.ts` re-export the moved symbols so
existing importers and tests resolve unchanged. A new third `state-table-sql`
rule is added to `scripts/lint-repository-sql.ts` guarding raw SQL naming these
two tables everywhere under `src/` except the repository directory and
`src/core/state/migrations.ts`.

**Two corrections to the issue text**, discovered against the tree (also called
out in `docs/architecture/specs/0.9.0-close-out-plan.md`, Workstream B):

1. **Location.** The issue proposes `src/core/state/salience-repo.ts` /
   `outcome-repo.ts`. The tree's actual convention is
   `src/storage/repositories/*-repository.ts` (22 files at plan-authoring time,
   24 now with this PR's 2 additions — including the state.db precedents
   named above). This PR follows the tree, not the issue.
2. **Guard mechanism.** The issue calls the widening "a one-line allowlist
   change" (add `improve/**` to the X4 guard's `GUARDED_PREFIXES`). That's
   incorrect: the existing two rules (`db-owner-import`, `db-open-call`)
   detect DB-owner imports and direct database opens — not raw SQL.
   `salience.ts` / `outcome-loop.ts` take a `db` parameter and import no
   DB-owner module, so they already pass both existing rules today with their
   SQL fully intact; widening the prefix list would enforce nothing against
   them. A third rule that inspects raw SQL text was required instead
   (`state-table-sql`, reusing the existing comment/string-stripping
   machinery with `keepStrings: true` so it can see SQL text and import
   specifiers, the same way string content is inspected today).

### RED → GREEN commit order for the lint rule

1. `63df6c6` **test(lint)** — add `state-table-sql` fixtures to
   `tests/integration/lint-repository-sql.test.ts` (RED: 8 pass / 3 fail,
   `ruleId "state-table-sql" not found`).
2. `a55a3ff` **feat(lint)** — implement the rule itself, with per-rule scoping
   (`Rule.appliesTo`) since its scope (everywhere under `src/` except the
   repository dir and `migrations.ts`) is fundamentally different from the
   other two rules' narrow `GUARDED_PREFIXES` (GREEN: 11 pass / 0 fail).

### The import-cycle fix (commit `a8a0471`)

The first refactor commit (`d90eddd`) introduced a real regression that
`bun run test:unit` caught: `tests/architecture/import-cycle-ratchet.test.ts`
enforces a zero-tolerance, shrink-only baseline (`CYCLE_PARTICIPANT_BASELINE`
is empty) over the whole `src/` static import graph, and it counts type-only
imports as graph edges the same as value imports. The initial repository
files each imported a type back from the domain module they re-export from —
`salience-repository.ts` imported `EncodingSource`/`SalienceVector` from
`commands/improve/salience.ts`, and `outcome-repository.ts` imported
`AssetOutcomeRow` from `commands/improve/outcome-loop.ts` — while the domain
modules import the repositories' functions for re-export. Two 2-node cycles.
The baseline can't be widened to admit them (the ratchet is deliberately
absolute).

**Fix:** make both repository files import nothing from the domain modules
they serve, so the mandatory domain→repository edge (for re-export) stays
one-directional:

- `salience-repository.ts`: `AssetSalienceRow.encoding_source` now uses the
  inline literal union `"content" | "type-stub" | null` (structurally
  identical to `EncodingSource`) instead of importing the type; a local
  `SalienceVectorLike` interface (listing only the fields
  `upsertAssetSalience` reads) replaces the `SalienceVector` import — any
  real `SalienceVector` value is still structurally assignable, so callers
  are unaffected.
- `outcome-repository.ts`: `AssetOutcomeRow` (plain string/number fields, no
  cross-type dependency) now lives here instead of in `outcome-loop.ts`,
  which imports it back and re-exports it — mirroring the `AssetSalienceRow`
  precedent (already living in its repository) exactly.

**Consequence — the one real scope change worth flagging honestly:**
`AssetOutcomeRow`'s canonical *definition* moved from `outcome-loop.ts` into
`outcome-repository.ts` (the same place `AssetSalienceRow` was already defined
from the first commit). This is an internal detail, not a contract change: I
independently verified (grep across `src/` and `tests/`, not just trusting the
commit message) that **no importer or test import path changed** — 6 improve
importers of `salience.ts` (`collapse-detector.ts`, `distill.ts`,
`distill/quality-gate.ts`, `loop-stages.ts`, `preparation.ts`,
`proactive-maintenance.ts`), 9 test files importing `.../improve/salience` and
4 importing `.../improve/outcome-loop` (12 unique files — consistent with the
commits' "~11 dependent test files"), and zero test files import the new
`storage/repositories/*-repository` paths directly except the lint meta-test
itself (which references them as string literals, not imports). Both new type
declarations are pure `interface`/type-alias shapes with no runtime
initialization, so removing the import doesn't introduce a
partially-initialized-module hazard — there is now no cycle at all between
these four files (independently confirmed: `bun scripts/lint-import-cycles.ts`
→ "0 cycle participant(s)", and `bun test
tests/architecture/import-cycle-ratchet.test.ts` → 4 pass / 0 fail).

Behavior is unchanged by the fix: both changes are pure type-shape
adjustments, not logic changes. The CASE guards, SQL text, and bind order
from the first commit are untouched (independently re-verified below, not
just taken on the commit messages' word).

### Verbatim-move spot checks (re-diffed directly against the pre-refactor originals)

- `upsertAssetSalience`'s two `#644` `CASE WHEN asset_salience.encoding_source
  = 'content' AND excluded.encoding_source = 'type-stub' …` guards (preserving
  `encoding_salience` / `encoding_source` provenance) are present in
  `salience-repository.ts`, byte-for-byte identical to the pre-refactor SQL in
  `commands/improve/salience.ts`, including bind order.
- `upsertAssetOutcome`'s `review_pressure` column is (still) omitted from both
  the `INSERT` column list and the `ON CONFLICT ... DO UPDATE SET` clause in
  `outcome-repository.ts`, byte-for-byte identical to the pre-refactor SQL,
  with the same doc-comment rationale (`DEFAULT 0` seeds fresh rows; omitting
  it from `SET` leaves an existing row's value untouched going forward).
- `getTopRetrievalSalience(db, limit)` is genuinely new (not a move): the
  pre-refactor `commands/health/metrics.ts` had the identical query
  hardcoded at `LIMIT 100`; the repository version parameterises `limit` and
  the call site passes `100`, preserving the existing fail-open try/catch.
- Confirmed Workstream A (#692, already merged to `main` at `03b3a305`)
  already removed the only other raw-SQL site the plan flagged
  (`ranking.ts`'s `loadSalienceRankScores`) — nothing left for this PR to
  relocate there.

## Test plan

**Verification was performed post-hoc by a second agent**, after the original
implementer's container was suspended mid-task (before it could verify, push,
or open a PR). The 5 commits were reviewed against the diff and the close-out
plan, then the following was actually run against this branch:

- `bun run lint` — **exit 0**. `lint-repository-sql: OK — … no raw
  asset_salience/asset_outcome SQL lives outside it`. ~1459 pre-existing biome
  `noNonNullAssertion` warnings are present but unrelated to this PR (verified
  none land in any file this PR touches; `bun run lint`'s exit code, not
  warning count, gates the script).
- **Proved the new rule actually bites**, rather than trusting a zero count:
  added a scratch file under `src/commands/` containing raw
  `db.prepare("SELECT * FROM asset_salience WHERE asset_ref = ?")`, ran
  `bun scripts/lint-repository-sql.ts` directly → 1 violation,
  `[state-table-sql]`, exit 1. Removed the scratch file → back to OK, exit 0,
  clean tree confirmed via `git status`.
- `bunx tsc --noEmit` — clean, no output, exit 0.
- `bun run test:unit` — **2986 pass / 0 fail** (238/238 files, 4 shards) —
  matches the implementer's commit-message claim exactly.
- The refactor's safety-net suites, run explicitly together — **164 pass / 0
  fail** (370 `expect()` calls, 9 files):
  `tests/integration/commands/improve/{salience,salience-wiring,outcome-loop,outcome-loop-wiring,outcome-invariance}.test.ts`,
  `tests/integration/health-ws5-observability.test.ts`,
  `tests/commands/improve/encoding-salience.test.ts` (note: this lives at
  `tests/commands/improve/encoding-salience.test.ts`, not
  `tests/encoding-salience.test.ts`),
  `tests/integration/ranking-salience-boost.test.ts`,
  `tests/integration/lint-repository-sql.test.ts`.
- `git diff origin/main...HEAD -- tests/` — confirmed the **only** test file
  touched is `tests/integration/lint-repository-sql.test.ts` (new
  `state-table-sql` fixtures + the renamed assertion that
  `commands/improve/preparation.ts` is unguarded *for the first two rules but
  not the third*). No other pre-existing test was edited — verified directly,
  not assumed.
- `bun run test:integration` (full suite, all 380 files, 4 shards): **5093
  pass / 2 fail** / 13 skip (6422 `expect()` calls). Both failures are
  **pre-existing host-contention flakes, unrelated to this PR**:
  `tests/integration/three-db-cutover.test.ts` ("resumes after crashing
  immediately after current proposal repair commit") and
  `tests/integration/workflows/native-executor.test.ts` ("the lifetime unit
  cap is seeded from the run's journal") timed out at 30s. Neither file is
  touched by this PR's diff (`git diff origin/main...HEAD --stat` confirms
  both are absent). A second full `test:integration` run was independently
  executing concurrently on the same host for the duration of this run (a
  sibling agent's worktree, confirmed via `ps`, whose own shard included both
  of these exact files at the same time) — matching this project's own
  documented host-load-flake pattern (see the `#499` note referenced in
  `docs/architecture/specs/0.9.0-close-out-plan.md`). I re-ran both failing
  files in isolation immediately after: both are **clean** —
  `three-db-cutover.test.ts` 32 pass / 0 fail, `native-executor.test.ts` 66
  pass / 0 fail. Total pass+fail count (5095) matches the original
  implementer's commit-message claim (`5095 pass / 0 fail`) exactly; only the
  pass/fail split differs, consistent with a load-induced flake rather than a
  regression.
- Independently re-verified `bun scripts/lint-import-cycles.ts` (→ 0
  participants) and `bun test tests/architecture/import-cycle-ratchet.test.ts`
  (→ 4 pass / 0 fail) rather than relying on the commit message's claim.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Lint passes (`bun run lint`)
- [ ] Docs updated (if applicable) — n/a, internal-only refactor;
      `docs/architecture/specs/0.9.0-close-out-plan.md` (Workstream B) already
      documents the intended shape and is unchanged by this PR. CHANGELOG
      updated under `### Changed`, placed next to the sibling #692 entry per
      existing precedent for internal-only bullets.

Fixes #672

---
_Generated by [Claude Code](https://claude.ai/code/session_017jtbyq5gSTzNRFH3Ker8u7)_