### PR TITLE
0.9.0 final pass: unblock the 0.8→0.9 upgrade, wire adapter validate(), UX and docs honesty

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -70,8 +70,8 @@ enumeration of the whole `proposal` noun group.
 | `akm registry list` | Evolving | |
 | `akm registry add` | Evolving | |
 | `akm registry remove` | Evolving | |
-| `akm migrate status` | Internal | Thin forwarder to the standalone `akm-migrate` tool; `hidden: true` in `--help`. |
-| `akm migrate apply` | Internal | Thin forwarder to the standalone `akm-migrate` tool; `hidden: true` in `--help`. |
+| `akm migrate status` | Internal | Forwards to the standalone `akm-migrate` tool; renders its result through the normal `--format` pipeline (not exempt — see below). Listed (not hidden) in `--help`/completions. |
+| `akm migrate apply` | Internal | Forwards to the standalone `akm-migrate` tool; renders its result through the normal `--format` pipeline (not exempt — see below). Listed (not hidden) in `--help`/completions. |
 | `akm config path` | Stable | |
 | `akm config list` | Stable | |
 | `akm config get` | Stable | |
@@ -190,16 +190,23 @@ enumeration of the whole `proposal` noun group.
   `--shape` (`human|agent|summary`) is the output-projection axis (see
   Experimental). A small set of commands is **format-exempt** because their
   output is not a result envelope at all: `completions` (shell script source),
-  child-process passthrough in `env run` / `secret run` / `migrate` (`status`
-  and `apply` both spawn the
-  standalone `akm-migrate` tool), a bare-path payload from `env path`, and
-  document payloads from `help` (bare, `help agents`, and `help migrate`). The
-  set is declared in
+  child-process passthrough in `env run` / `secret run`, a bare-path payload
+  from `env path`, and document payloads from `help` (bare, `help agents`, and
+  `help migrate`). The set is declared in
   `src/output/format-exempt.ts`, and
   passing `--format` to one of them warns rather than silently doing something
   else. Scripted `setup` modes emit a normal format-aware result; interactive
   `setup` is a terminal UI and emits no result document. `agent` leaves
   inherited child streams raw and formats its final result envelope.
+  `migrate status`/`apply` both spawn the standalone `akm-migrate` tool but are
+  NOT in the exempt set: `src/commands/migrate-cli.ts` parses the child's
+  final JSON result line and renders it through the same `output()` pipeline
+  (registered shape `src/output/shapes/migrate.ts`, text renderer
+  `src/output/text/migrate.ts`), so all six `--format` values work on them
+  like any other command. Any progress-event lines the child prints during a
+  real `apply` (content migration, proposal-ref repair) still print verbatim,
+  ahead of the formatted result — those are operational logging, not part of
+  the result envelope.
 
   | Exit code | Meaning |
   | --- | --- |

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -459,6 +459,15 @@ Internal replacement for the one capability nothing else covered.
   a separately published `akm-migrate` package (see Internal above).
 - **0.10 — `--auto-accept` hard error.** It is currently accepted-and-warned;
   see the Improvement loop entry.
+- **0.10 — `BundleAdapter.placeNew()` wiring.** The interface declares
+  `placeNew()` as an optional capability method, and 8 of the built-in
+  adapters already implement it, but nothing in the write path calls it —
+  writes still resolve through AKM's native flat type→directory table.
+  Placement for every existing bundle is already correct today; this is a
+  deliberately sequenced routing change, not unfinished behavior. See
+  [D12](./docs/architecture/specs/0.9.0-decisions.md#d12--bundleadapterplacenew-stays-unwired-until-010)
+  for why it is scoped out of 0.9.0. Nothing user-visible changes in 0.10 for
+  this alone.
 - **1.0 contract freeze** — the `[bundle//]conceptId[#fragment]` ref grammar,
   the supported source model, search behavior, and write-target rules are
   frozen at 1.0. The SDK and in-process plugin story ship on top of that

--- a/docs/architecture/specs/0.9.0-decisions.md
+++ b/docs/architecture/specs/0.9.0-decisions.md
@@ -34,6 +34,7 @@ removing a half-built surface over shipping it behind a label.
 | D9 `--auto-accept` warn-and-ignore | **Shipped** (warns, and no longer poisons the scope positional) |
 | D10 extract migration machinery | Partial (`akm-migrate` bin exists; code still in-repo) |
 | D11 OKF foundational | Partial (the `okf` adapter has landed) |
+| D12 `placeNew()` wiring | **Deferred to 0.10** |
 
 ---
 
@@ -485,3 +486,43 @@ without changing AKM-native refs or classification.
 **Normative text.** [`okf-support.md`](./okf-support.md);
 [`akm-0.9.0-bundle-adapter-spec.md`](./akm-0.9.0-bundle-adapter-spec.md);
 [`ref.md`](./ref.md).
+
+---
+
+## D12 — `BundleAdapter.placeNew()` stays unwired until 0.10
+
+**Status: DEFERRED to 0.10.** The interface declares `placeNew(c, conceptId)`
+OPTIONAL (`src/core/adapter/bundle-adapter.ts`), and 8 of the built-in adapter
+modules already implement it — `generic-files`, `akm`, `llm-wiki`,
+`agent-skills`, `dotenv`, `akm-workflow`, `akm-task`, and the shared
+`tool-dir-shared` factory (consumed by the `claude` and `opencode` adapters).
+`website-snapshot` deliberately has none — it is read-only (Mode A); export
+(Mode B) is a separate, also-deferred facet. Nothing in `src/` calls
+`.placeNew(` anywhere.
+
+**Decided.** 0.9.0 leaves placement on AKM's existing flat
+type→directory table: `resolveAssetFilePath` resolves
+`stashDirFor(ref.type)` (`src/core/write-source.ts`) against the
+`PLACEMENT_SPECS` table (`src/core/asset/asset-placement.ts`). Routing writes
+through per-adapter `placeNew()` instead is deferred to 0.10 as its own
+change.
+
+**Why.** `stashDirFor(` has 36 call sites across 19 files — the indexer,
+storage repositories, sources, core, and 7 command modules. That is the write
+path this release rests on. Cutting it over to per-adapter placement is a
+large, separable refactor; sequencing it after the rest of the 0.9.0 adapter
+cutover keeps this release's blast radius bounded. Placement for every existing bundle is already correct
+today — this is a routing change, not a bug fix, and not unfinished work
+so much as a deliberately later chunk of the same refactor. (Compare the
+interface's own closing comment on the Tier-B authoring/export/memory
+facets, similarly flagged rather than stubbed.)
+
+**Breaks.** None. No user-visible change: nothing calls `placeNew()` before
+0.10, so write behavior for every existing bundle is unchanged. The 8
+adapters that already implement it get no exercise from that code path yet —
+treat those method bodies as unwired, not battle-tested, until 0.10 routes
+writes through them.
+
+**Normative text.** [`akm-0.9.0-bundle-adapter-spec.md`](./akm-0.9.0-bundle-adapter-spec.md)
+§2; `src/core/adapter/bundle-adapter.ts` (interface + its closing comment on
+deferred facets, same framing).

--- a/docs/architecture/testing/manual-testing-checklist.md
+++ b/docs/architecture/testing/manual-testing-checklist.md
@@ -604,18 +604,42 @@ checklist did not exercise.
       report the initially absent database as corruption.
 - [ ] `akm health --since 24h` filters telemetry to the last 24 hours.
 
-#### `akm migrate` recovery
+#### `akm migrate` recovery and legacy-config migration
 
-- [ ] With no config file, `akm migrate status` reports `status: "blocked"`,
-      includes the missing source and target config states, exits nonzero, and
-      does not create one.
+<!-- This section verifies migration OF retired 0.8 configuration, so it names
+     retired keys (`profiles.*`, `defaults.agent`, ...) on purpose. The
+     "legacy"/"migration" heading marks it exempt from the active-docs retired-
+     selector scan in tests/contracts/configuration.test.ts, matching how
+     docs/reference/configuration.md and docs/migration/v0.8-to-v0.9.md scope
+     the same references. -->
+
+
+- [ ] With no config file at all, `akm migrate status` reports `status:
+      "blocked"`, includes the missing source and target config states, exits
+      nonzero, and does not create one (no `generatedConfig` field — there is
+      nothing to derive a target from).
 - [ ] With a valid 0.9 config, `akm migrate status` reports `status: "current"`
       and leaves the file byte-for-byte unchanged.
-- [ ] With a pre-0.9 profile config and no target, `akm migrate status` reports
-      `status: "blocked"`, explains that profile-to-engine conversion is manual,
-      exits nonzero, and does not rewrite or back up the file.
+- [ ] With a pre-0.9 config (`stashDir`/`sources[]`/`installed[]`) and no
+      `--config`, `akm migrate status` reports `status: "blocked"` with a
+      `generatedConfig` field (`status: "pending"`, the predictable path,
+      `droppedKeys`), exits nonzero, and does not write anything.
+- [ ] `akm migrate apply` with no `--config` against that same pre-0.9 config
+      WRITES the generated config at `generatedConfig.path`, reports `status:
+      "ready"` with a `message` pointing at the file, and leaves the live 0.8
+      config.json/state.db/workflow.db byte-for-byte unchanged (no backup run
+      created yet). A second, identical `akm migrate apply` (still no
+      `--config`) then picks the generated file up and completes the cutover.
+- [ ] With a pre-0.9 config carrying `profiles.llm`/`profiles.agent`/
+      `defaults.llm`/`defaults.agent`/`defaults.improve` and no `--config`,
+      the generated config's `droppedKeys` names each one exactly (not a
+      generic "manual" message), the written file omits `profiles`/those
+      `defaults` sub-keys entirely, and the second `apply` still completes
+      the cutover without them.
 - [ ] `akm migrate apply --config <prepared> --dry-run` performs the same checks
-      as status and leaves config and databases unchanged.
+      as status and leaves config and databases unchanged; passing `--config`
+      never triggers generation, even if a generated file already exists at
+      the predictable path.
 - [ ] `akm migrate apply --config <prepared>` creates a unique verified backup
       run, applies each pending database migration transactionally, and installs
       the prepared config last.
@@ -746,6 +770,9 @@ explicitly marked as gated.
       exit 2 because `summary` is valid only for `show`.
 - [ ] `akm env path env/test-env --format yaml` still prints one raw path and
       warns on stderr that this command is format-exempt.
+- [ ] `akm migrate status --format text` (and `md`/`html`/`yaml`) renders the
+      plan as that format — no `'--format' has no effect` warning on stderr,
+      and `--format text`'s output is not JSON.
 - [ ] `akm search docker --format jsonl --output "$AKM_SANDBOX/ignored"`
       continues to stream JSONL to stdout and does not create the output file.
 

--- a/docs/migration/release-notes/0.9.0.md
+++ b/docs/migration/release-notes/0.9.0.md
@@ -14,35 +14,49 @@ and minor releases. See STABILITY.md for the full policy.
 Key operator-facing changes:
 
 - **This release is the format-neutral bundle-adapter refactor — for
-  recognition, indexing, and presentation.** The flat asset-type registry is
-  replaced by per-format adapters that decide what a file *is* (11 adapters
-  behind a static registry) and how it is indexed and shown, and refs move
-  from the old `type:name` grammar to `[bundle//]conceptId` — a
-  subdir-qualified concept id such as `skills/code-review`,
-  `memories/vpn-note`, or `env/prod`, with an optional `bundle//` installation
-  prefix and an optional `#fragment`. Durable state is stored fully-qualified;
-  the short bundle-omitted form is input sugar (resolved against
-  `defaultBundle`, then installation-priority order). `akm migrate apply`
-  re-keys all durable state, folds the former `workflow.db` into `state.db`
-  (three tracked databases: `state.db` / `index.db` / a separate `logs.db`,
-  down from four — `logs.db` itself sits outside migration control entirely,
-  see [the migration guide](../v0.8-to-v0.9.md#what-migration-control-does-not-cover)),
+  recognition, indexing, presentation, and validation.** The flat asset-type
+  registry is replaced by per-format adapters that decide what a file *is*
+  (11 adapters behind a static registry), how it is indexed and shown, and
+  how it validates. Refs move from the old `type:name` grammar to
+  `[bundle//]conceptId` — a subdir-qualified concept id such as
+  `skills/code-review`, `memories/vpn-note`, or `env/prod`, with an optional
+  `bundle//` installation prefix and an optional `#fragment`. Durable state
+  is stored fully-qualified; the short bundle-omitted form is input sugar
+  (resolved against `defaultBundle`, then installation-priority order).
+  `akm migrate apply` re-keys all durable state, folds the former
+  `workflow.db` into `state.db` (three tracked databases: `state.db` /
+  `index.db` / a separate `logs.db`, down from four — `logs.db` itself sits
+  outside migration control entirely, see
+  [the migration guide](../v0.8-to-v0.9.md#what-migration-control-does-not-cover)),
   and migrates config from the flat `stashDir` / `sources` / `installed` /
   `wikiName` keys to `bundles` / `defaultBundle`. In AKM stashes, `index.md` /
   `log.md` are reserved structural files — never indexed as items and never
   valid item-write targets. Other bundle formats use their adapter's own
   structural-file rules.
-  **What this refactor does not (yet) touch: placement and validation.**
-  `adapter.placeNew()` and `adapter.validate()` are defined on the interface
-  and implemented by several adapters, but nothing in the write or lint path
-  calls them in 0.9.0 — writes still route through AKM's native
-  type→directory placement table, and `akm lint` re-implements OKF's
-  structural checks inline rather than dispatching to `okfAdapter.validate()`
-  (and does not call the `llm-wiki` adapter's checks at all). The adapter
-  layer's `index()`/`affectedItems()` capability hooks also have no
-  implementors yet — every 0.9.0 adapter is scanned through the shared core
-  walk. None of this blocks normal use; it means "adapter-driven" in this
-  release describes reading a bundle, not writing to or validating one.
+  **What this refactor does not (yet) touch: placement.**
+  `adapter.placeNew()` is defined on the interface
+  (`src/core/adapter/bundle-adapter.ts`) as an optional capability method and
+  already implemented by 8 of the built-in adapters, but nothing in the write
+  path calls it in 0.9.0 — writes still route through AKM's native flat
+  type→directory placement table (`stashDirFor` in
+  `src/core/asset/asset-placement.ts`). That wiring is deferred to 0.10 as
+  its own change (see
+  [STABILITY.md](../../../STABILITY.md#on-the-horizon) and
+  [D12](../../architecture/specs/0.9.0-decisions.md#d12--bundleadapterplacenew-stays-unwired-until-010));
+  placement is already correct for every existing bundle today, this only
+  changes which code computes it. `adapter.validate()`, by contrast, is a
+  REQUIRED interface member and each adapter owns its own checks in 0.9.0:
+  `akm lint` dispatches to the bundle's own adapter rather than
+  re-implementing its rules. One caveat worth knowing: the proposal
+  pre-commit path also runs `validate()`, but **advisory only** — it reports
+  findings via a warning and does not reject the write. Making it blocking
+  needs the adapter and legacy ref resolvers reconciled first, so a proposal
+  that trips an adapter diagnostic still applies in 0.9.0.
+  The adapter layer's `index()`/`affectedItems()` capability hooks also have
+  no implementors yet — every 0.9.0 adapter is scanned through the shared
+  core walk. None of this blocks normal use; it means "adapter-driven" in
+  this release now covers reading and validating a bundle, but not yet
+  writing to one.
 - **Installed non-akm bundles reclassify on your next `akm index`.** The
   indexer now dispatches each installed bundle's *detected* adapter instead of
   recognizing everything with the akm-stash adapter. No action needed — the
@@ -73,9 +87,9 @@ Key operator-facing changes:
   The Karpathy-style LLM wiki structure (`schema.md` + `pages/`) is now a
   first-class **bundle format** recognized and indexed directly by `akm
   index`/`akm search`/`akm show` — no dedicated verb surface needed. `akm
-  lint` still runs (it falls back to the generic AKM structural scan rather
-  than the adapter's own wiki-shaped checks — see above); it is a read
-  surface in 0.9.0, not a write target.
+  lint` still runs, now dispatching to the adapter's own wiki-shaped checks
+  through `validate()` (see above); it is a read surface in 0.9.0, not a
+  write target — placement isn't wired to the adapter until 0.10.
 - `akm-migrate storage` performs the non-destructive
   `vaults/` -> `env/` copy for older stashes. Run it before indexing if you are
   upgrading from a stash that still stores `.env` files only under `vaults/`.

--- a/docs/migration/release-notes/0.9.0.md
+++ b/docs/migration/release-notes/0.9.0.md
@@ -13,32 +13,52 @@ and minor releases. See STABILITY.md for the full policy.
 
 Key operator-facing changes:
 
-- **This release is the format-neutral bundle-adapter refactor.** The flat
-  asset-type registry is replaced by per-format adapters, and refs move from the
-  old `type:name` grammar to `[bundle//]conceptId` — a subdir-qualified concept
-  id such as `skills/code-review`, `memories/vpn-note`, or `env/prod`, with an
-  optional `bundle//` installation prefix and an optional `#fragment`. Durable
-  state is stored fully-qualified; the short bundle-omitted form is input sugar
-  (resolved against `defaultBundle`, then installation-priority order).
-  `akm migrate apply` re-keys all durable state, folds the former `workflow.db`
-  into `state.db` (three databases: `state.db` / `index.db` / a separate
-  `logs.db`, down from four), and migrates config from the flat `stashDir` /
-  `sources` / `installed` / `wikiName` keys to `bundles` / `defaultBundle`.
-  In AKM stashes, `index.md` / `log.md` are reserved structural files — never
-  indexed as items and never valid item-write targets. Other bundle formats
-  use their adapter's own structural-file rules.
+- **This release is the format-neutral bundle-adapter refactor — for
+  recognition, indexing, and presentation.** The flat asset-type registry is
+  replaced by per-format adapters that decide what a file *is* (11 adapters
+  behind a static registry) and how it is indexed and shown, and refs move
+  from the old `type:name` grammar to `[bundle//]conceptId` — a
+  subdir-qualified concept id such as `skills/code-review`,
+  `memories/vpn-note`, or `env/prod`, with an optional `bundle//` installation
+  prefix and an optional `#fragment`. Durable state is stored fully-qualified;
+  the short bundle-omitted form is input sugar (resolved against
+  `defaultBundle`, then installation-priority order). `akm migrate apply`
+  re-keys all durable state, folds the former `workflow.db` into `state.db`
+  (three tracked databases: `state.db` / `index.db` / a separate `logs.db`,
+  down from four — `logs.db` itself sits outside migration control entirely,
+  see [the migration guide](../v0.8-to-v0.9.md#what-migration-control-does-not-cover)),
+  and migrates config from the flat `stashDir` / `sources` / `installed` /
+  `wikiName` keys to `bundles` / `defaultBundle`. In AKM stashes, `index.md` /
+  `log.md` are reserved structural files — never indexed as items and never
+  valid item-write targets. Other bundle formats use their adapter's own
+  structural-file rules.
+  **What this refactor does not (yet) touch: placement and validation.**
+  `adapter.placeNew()` and `adapter.validate()` are defined on the interface
+  and implemented by several adapters, but nothing in the write or lint path
+  calls them in 0.9.0 — writes still route through AKM's native
+  type→directory placement table, and `akm lint` re-implements OKF's
+  structural checks inline rather than dispatching to `okfAdapter.validate()`
+  (and does not call the `llm-wiki` adapter's checks at all). The adapter
+  layer's `index()`/`affectedItems()` capability hooks also have no
+  implementors yet — every 0.9.0 adapter is scanned through the shared core
+  walk. None of this blocks normal use; it means "adapter-driven" in this
+  release describes reading a bundle, not writing to or validating one.
 - **Installed non-akm bundles reclassify on your next `akm index`.** The
   indexer now dispatches each installed bundle's *detected* adapter instead of
   recognizing everything with the akm-stash adapter. No action needed — the
   index is a regenerable cache — but searches/saved refs into those bundles may
   resolve to new ref spellings afterwards.
-- **OKF is the generic Markdown baseline.** Arbitrary OKF `type` values remain
-  searchable and showable with heading fragments, while the selected adapter
-  decides which types receive specialized behavior. AKM-authored Markdown now
-  emits its native `type` field and remains OKF-compatible; commands, scripts,
-  workflows, tasks, environments, and secrets retain AKM's progressively
-  enhanced native handling. The `okf` adapter is consumer-only in 0.9.0, so
-  AKM-native write commands reject OKF targets before modifying them.
+- **OKF and llm-wiki are both consumer/read-only in 0.9.0.** Arbitrary OKF
+  `type` values remain searchable and showable with heading fragments, while
+  the selected adapter decides which types receive specialized behavior.
+  AKM-authored Markdown now emits its native `type` field and remains
+  OKF-compatible; commands, scripts, workflows, tasks, environments, and
+  secrets retain AKM's progressively enhanced native handling. Both the `okf`
+  adapter and the `llm-wiki` adapter are consumer-only in 0.9.0 — AKM-native
+  write commands (`akm remember`, `akm import`, proposal-accept, …) reject
+  OKF **and llm-wiki** targets before modifying them. Author llm-wiki `pages/`
+  content the way the Karpathy pattern always intended: your agent writes the
+  files directly, and akm indexes and serves the result.
 - The published npm package requires Node.js >= 22 as its cross-platform
   bootstrap. The `akm` launcher prefers a working Bun >= 1.0 and otherwise
   falls back to Node.js; `akm-migrate` follows the same model, with Bun optional
@@ -51,8 +71,11 @@ Key operator-facing changes:
   pushes, and `akm events` is replaced by `akm log`.
 - The entire `akm wiki ...` command family and the `wiki` asset type are gone.
   The Karpathy-style LLM wiki structure (`schema.md` + `pages/`) is now a
-  first-class **bundle format** recognized directly by `akm index`/`akm
-  search`/`akm lint` — no dedicated verb surface needed.
+  first-class **bundle format** recognized and indexed directly by `akm
+  index`/`akm search`/`akm show` — no dedicated verb surface needed. `akm
+  lint` still runs (it falls back to the generic AKM structural scan rather
+  than the adapter's own wiki-shaped checks — see above); it is a read
+  surface in 0.9.0, not a write target.
 - `akm-migrate storage` performs the non-destructive
   `vaults/` -> `env/` copy for older stashes. Run it before indexing if you are
   upgrading from a stash that still stores `.env` files only under `vaults/`.
@@ -81,32 +104,38 @@ Primary public command family for 0.9.0:
 
 ## Release validation
 
+> Unit/integration test counts below are point-in-time snapshots from the
+> validation passes named next to each figure, not a promise about the count
+> on any later commit — the suite keeps growing after each pass. Run
+> `bun run check` yourself for the current count; do not treat a number below
+> as still accurate.
+
 Release validation was repeated on 2026-07-31. An isolated manual pass covered
 114 first-run, CLI, indexing, search/show, output-format, strict-flag,
 tools-only agent classification, multi-bundle write/lint, workflow, task,
 llm-wiki, env/secret, feedback/log, config/migration, health, upgrade, and
-registry checks with no failures. `bun run release:check` verified the packed
-npm installation, Node fallback and Bun launcher paths, migration and task
-execution from published 0.8.14, the Linux standalone scheduler artifact,
-3,003 unit tests, 5,071 integration tests, and all seven Docker install targets.
-The gated semantic-search suite passed 9 tests; Node 24 passed all 9 fallback
-smoke steps and 25 compatibility tests.
+registry checks with no failures. `bun run release:check`, as run on
+2026-07-31, verified the packed npm installation, Node fallback and Bun
+launcher paths, migration and task execution from published 0.8.14, the Linux
+standalone scheduler artifact, its then-current unit/integration test counts,
+and all seven Docker install targets. The gated semantic-search suite passed
+9 tests; Node 24 passed all 9 fallback smoke steps and 25 compatibility tests.
 
 The post-release checklist audit added a separate 125-check deterministic pass
 for cross-bundle identity, write fidelity, output destinations, lint/task
 behavior, env secrecy, durable log cursors, workflow transitions, proposal
 dry-runs, setup recovery, fresh health initialization, and source-install
-safety. It passed 125/125 on Linux. The current branch also passed
-`bun run check` (3,005 unit and 5,072 integration tests) and `bun run build`.
+safety. It passed 125/125 on Linux. The branch as of that same pass also
+passed `bun run check` and `bun run build`.
 
 A container-isolated follow-up passed 188 destructive crash/recovery checks,
 including real `SIGKILL` windows across proposal, workflow, and lock journals,
 plus deterministic interruption replay across phase-free migration sentinels.
 The container also passed `release:check --skip-docker`, the seven-image
 Docker install matrix, 9 semantic-search tests, all 9 Node 22 smoke steps, all
-25 Node compatibility tests, and the offline full gate (3,005 unit and 5,070
-integration tests). This pass exposed and fixed host-scheduler and co-located
-Node/Bun assumptions in three tests; no production behavior changed.
+25 Node compatibility tests, and the offline full gate. This pass exposed and
+fixed host-scheduler and co-located Node/Bun assumptions in three tests; no
+production behavior changed.
 
 Live credential-backed agent/LLM calls and native macOS/Windows execution were
 not run from this Linux host. Their deterministic paths remain covered by the
@@ -149,8 +178,10 @@ scripts, task YAML, prompts, and agent instructions (CLAUDE.md quick
 references) using this table, then run `akm task sync --rebind` once so
 installed schedules re-emit the new spellings. `akm hints` prints the complete
 agent guide (`--detail brief` selects the compact version), while `akm help
-agents` is short by default; the root `akm --help` groups the surviving surface into
-AGENT LOOP / ASSETS / AUTOMATION / SYSTEM sections.
+agents` is short by default; the root `akm --help` groups the surviving surface
+into AGENT LOOP / ASSETS / AUTOMATION / SYSTEM sections, including `migrate`
+under SYSTEM. For migration usage details rather than the bare `--help`
+listing, see [the migration guide](../v0.8-to-v0.9.md).
 
 Command renames and moves:
 
@@ -195,7 +226,7 @@ Flag and value renames:
 | Old | New |
 | --- | --- |
 | `search`/`curate` `--source stash\|registry\|both` | `--from local\|registry\|all` |
-| `remember`/`clone`/`improve`/the `task` group `--target <bundle>` | `--bundle <bundle>` (`import`, `proposal accept`, `env create`, `secret set` keep `--target`) |
+| `remember`/`clone`/`improve`/the `task` group `--target <bundle>` | `--bundle <bundle>` (`import`, `proposal accept`, `env create`, `env remove`, `secret set` keep `--target`) |
 
 Environment and JSON-payload renames ("stash" is retired; the noun is
 "bundle" everywhere):

--- a/docs/migration/v0.8-to-v0.9.md
+++ b/docs/migration/v0.8-to-v0.9.md
@@ -64,6 +64,9 @@ It:
   lands in `legacy_state` (surface, ref, row count) and the complete original
   rows are preserved as JSON in `legacy_state_rows` in the migrated
   `state.db`, so nothing the migration cannot re-key is destroyed.
+- Generates the target config for you when no `--config` is given and none
+  exists yet, instead of requiring one hand-authored from a blank page — see
+  [Auto-generating the 0.9 config](#auto-generating-the-09-config).
 
 ### The 0.8 binary cannot do this
 
@@ -73,10 +76,18 @@ The 0.8 binary does not contain `akm migrate` or the `upgrade
 package-manager/manual boundary procedure instead:
 
 1. Stop AKM writers, schedulers, and workflow drivers.
-2. Prepare the complete 0.9 config in a separate file (see
-   [Prepare the 0.9 config](#preparing-the-09-config) below for a minimal
-   working example and the full key-mapping table). Do not replace the live
-   0.8 config; AKM cannot infer names when old LLM and agent profiles collide.
+2. Decide how the 0.9 target config gets prepared. You usually don't need to
+   hand-write one: `akm migrate apply` (step 5) generates the mechanical part
+   — `bundles`/`defaultBundle` — from your existing `stashDir`/`sources[]`/
+   `installed[]` automatically when no `--config` is given and no target
+   config exists yet (see
+   [Auto-generating the 0.9 config](#auto-generating-the-09-config) below).
+   Write one by hand instead (see
+   [Preparing the 0.9 config](#preparing-the-09-config)) only if you want full
+   control, or already know your 0.8 config configured LLM/agent profiles —
+   AKM never guesses those. Either way, never replace the live 0.8 config
+   directly; a generated or hand-written target config always lives in a
+   separate file.
 3. Take an independent filesystem backup of the live 0.8 `config.json`,
    `state.db`, and `workflow.db` (including any SQLite `-wal`/`-shm` files).
    Store it outside AKM's data directory and verify it before continuing.
@@ -90,12 +101,54 @@ package-manager/manual boundary procedure instead:
    before restarting schedulers. The explicit rebind replaces 0.8 native
    scheduler definitions with current context-bound invocations.
 
+### Auto-generating the 0.9 config
+
+Run `akm migrate status` (or `akm migrate apply`) with **no** `--config`. If
+the active 0.8 config still carries `stashDir`/`sources[]`/`installed[]` and no
+target config exists yet, the plan's `generatedConfig` field previews what a
+`migrate apply` will write: `path` (a predictable location next to the
+migration's recovery backups — never the live `config.json`) and
+`droppedKeys` — any `profiles.llm.<name>`/`profiles.agent.<name>`/
+`profiles.improve.<name>`/`defaults.llm`/`defaults.agent`/`defaults.improve`
+keys it will leave out, named exactly rather than guessed at (see
+[Engine And Task Assets](#engine-and-task-assets) for why).
+
+A `migrate apply` with no `--config` and no target config yet WRITES that
+file and stops — it deliberately does not proceed to back up or mutate
+anything on that run, so you get a real chance to review the generated
+config (and hand-add `engines`/`defaults` for anything `droppedKeys` named)
+before a second, explicit `akm migrate apply` — still no `--config` — picks
+the file up and completes the cutover:
+
+```sh
+akm migrate status   # previews: generatedConfig.status "pending", droppedKeys []
+akm migrate apply    # writes the starter config, stops (status "ready")
+# review/edit the file named in the JSON result's generatedConfig.path if
+# droppedKeys named anything you need engines for, then:
+akm migrate apply    # picks up the generated file, applies it (status "current")
+```
+
+The generated file's `bundles`/`defaultBundle` come from the exact same
+transform (`migrateConfigSourcesToBundles`) [the key-mapping table
+below](#08-key--09-key) describes for a hand-written target — generation just
+runs it for you. When your 0.8 config had no `profiles`/`defaults.llm`/
+`defaults.agent`/`defaults.improve` to translate, `droppedKeys` comes back
+empty and the generated config is complete on its own: the second `apply` is
+a plain confirming re-run, no editing required.
+
+An explicit `--config` always wins over this and is never second-guessed — if
+you pass one, generation never runs, exactly as if this section did not
+exist. Use it for full control, or when you already know your 0.8 config
+configured LLM/agent profiles and would rather write `engines`/`defaults`
+yourself up front instead of re-running `apply` a second time.
+
 ### Preparing the 0.9 config
 
-There is no automatic translator for step 2 — a 0.9 config is a plain JSON
-file you write yourself before running `migrate apply`. This is the minimum
-that is sufficient to drive a successful `akm migrate apply`: one writable
-bundle and a `defaultBundle` naming it.
+A 0.9 config is a plain JSON file; nothing stops you from writing one
+yourself instead of letting `migrate apply` generate it (see above) — you
+still point `--config` at it exactly as before. This is the minimum that is
+sufficient to drive a successful `akm migrate apply`: one writable bundle and
+a `defaultBundle` naming it.
 
 ```json
 {
@@ -162,23 +215,59 @@ target config that already speaks the 0.9 shape) and
 | `profiles.agent.<name>` / `defaults.agent` | `engines.<name>` (`kind: "agent"`) / `defaults.engine` | Not migrated automatically — see the name-collision note below |
 | `profiles.improve.<name>` / `defaults.improve` | `improve.strategies.<name>` / `defaults.improveStrategy` | Not migrated automatically |
 
-The engine/task-asset keys are **not** touched by `migrate apply` — see
-[Engine And Task Assets](#engine-and-task-assets) below for why AKM cannot
-safely auto-generate `engines` names when a 0.8 LLM profile and agent
-profile shared one. Everything else in the table above (bundles, defaultBundle,
-`wikiName` removal) *is* handled by `migrate apply` once you hand it a target
-config — `migrate apply` moves the durable state and databases, not the config
-keys you write by hand as the migration target.
+The engine/task-asset keys are **not** translated to `engines`/`defaults` by
+`migrate apply` — see [Engine And Task Assets](#engine-and-task-assets) below
+for why AKM cannot safely auto-generate `engines` names when a 0.8 LLM
+profile and agent profile shared one. In a hand-written target config passed
+via `--config`, leaving these keys in is a hard schema-validation error (same
+as before 0.9.0's config generation existed) — [Preparing the 0.9
+config](#preparing-the-09-config) above never touches them for you. The
+auto-generation path ([above](#auto-generating-the-09-config)) instead
+actively STRIPS them and reports exactly what it stripped via
+`generatedConfig.droppedKeys`, so the config it writes is valid on its own;
+either way, you still add `engines`/`defaults` by hand afterward if you want
+LLM/agent execution to keep working. Everything else in the table above
+(bundles, defaultBundle, `wikiName` removal) *is* handled — by `migrate apply`
+once you hand it a target config, or by the generator on your behalf —
+`migrate apply` moves the durable state and databases, not the config keys
+themselves.
 
 #### End-to-end happy path
 
 The complete sequence, in the order you actually hit it, assuming a single
-0.8 `stashDir` and no LLM/agent profiles to carry over:
+0.8 `stashDir` and no LLM/agent profiles to carry over — letting `migrate
+apply` generate the target config instead of hand-writing one:
 
 ```sh
 # 1. Stop schedulers and any running akm process first (see step 1 above).
 
-# 2. Write the target config (see the minimal example above).
+# 2. Back up the live 0.8 data directory independently (outside AKM's own dirs).
+cp -a ~/.local/share/akm ~/akm-0.8-backup-"$(date +%Y%m%d)"
+
+# 3. Install 0.9.
+npm install -g akm-cli@0.9.0
+
+# 4. Check eligibility (previews the config apply would generate), then apply
+#    TWICE: the first apply only writes the generated config and stops; the
+#    second, unchanged, invocation picks it up and performs the cutover.
+akm migrate status
+akm migrate apply --dry-run
+akm migrate apply
+akm migrate apply
+
+# 5. Rebind the scheduler to the new binary and rebuild the index.
+akm task sync --rebind
+akm index
+akm migrate status   # now reports current with no --config needed
+```
+
+If your 0.8 config configured LLM/agent profiles, or you'd simply rather
+write the target config yourself, replace step 4 with the hand-authored
+`--config` form instead:
+
+```sh
+# 4'. Write the target config (see the minimal example above), then check
+#     eligibility, dry-run, and apply against it explicitly.
 cat > ./prepared-0.9.json << 'EOF'
 {
   "configVersion": "0.9.0",
@@ -186,22 +275,9 @@ cat > ./prepared-0.9.json << 'EOF'
   "defaultBundle": "primary"
 }
 EOF
-
-# 3. Back up the live 0.8 data directory independently (outside AKM's own dirs).
-cp -a ~/.local/share/akm ~/akm-0.8-backup-"$(date +%Y%m%d)"
-
-# 4. Install 0.9.
-npm install -g akm-cli@0.9.0
-
-# 5. Check eligibility, dry-run, then apply.
 akm migrate status --config ./prepared-0.9.json
 akm migrate apply --config ./prepared-0.9.json --dry-run
 akm migrate apply --config ./prepared-0.9.json
-
-# 6. Rebind the scheduler to the new binary and rebuild the index.
-akm task sync --rebind
-akm index
-akm migrate status   # now reports current with no --config needed
 ```
 
 Package-manager installation examples for step 4:

--- a/docs/migration/v0.8-to-v0.9.md
+++ b/docs/migration/v0.8-to-v0.9.md
@@ -1,13 +1,14 @@
 # Migrating from akm 0.8.x to 0.9.0
 
 0.9.0 is the format-neutral **bundle / adapter** refactor. It replaces the flat
-asset-type registry with per-format adapters for *recognition, indexing, and
-presentation* — placement and validation still route through AKM's native
-tables (see [Removed surfaces](#3-removed-surfaces) and the 0.9.0 release
-notes for the exact boundary) — adopts one canonical ref grammar, consolidates
-the durable databases and config, and completes several 0.8-era deprecations
-(the CLI aliases and the `vault` asset type). This guide is ordered the way
-you'll need it:
+asset-type registry with per-format adapters for *recognition, indexing,
+presentation, and validation* — placement alone still routes through AKM's
+native type→directory table; wiring it through the adapter interface is
+deferred to 0.10 (see [Removed surfaces](#3-removed-surfaces) and the 0.9.0
+release notes for the exact boundary) — adopts one canonical ref grammar,
+consolidates the durable databases and config, and completes several
+0.8-era deprecations (the CLI aliases and the `vault` asset type). This
+guide is ordered the way you'll need it:
 
 > **Heads-up on the 0.9.x series:** 0.9.x is a refactoring and clean-up
 > series — patch releases may include further breaking changes (each with a
@@ -443,15 +444,20 @@ instead of a bespoke command surface: `schema.md` (the per-wiki rulebook) +
 to recognize it, index its pages, and present them through `akm show`.
 `raw/`, `index.md`, and `log.md` stay reserved infrastructure.
 
-**llm-wiki is consumer/read-only in 0.9.0, the same as OKF.** The adapter
-defines its own `validate`/`placeNew` logic, but nothing in the write or lint
-path calls it yet: `akm remember`/`akm import`/proposal-accept into an
-llm-wiki bundle are rejected before they reach the adapter (the same
-`assertAkmAssetWrite` allowlist that rejects OKF targets), and `akm lint`
-does not run the adapter's own wiki-shaped checks — it falls back to the
-generic AKM subdirectory scan, which does not know about `pages/`. Author
-llm-wiki content through your agent writing directly into `pages/` (as the
-Karpathy pattern always intended), not through akm's native write commands.
+**llm-wiki is consumer/read-only for writes in 0.9.0, the same as OKF.** The
+adapter defines its own `validate` and `placeNew` logic. Validation is
+adapter-driven in 0.9.0: `akm lint` runs the `llm-wiki` adapter's own
+wiki-shaped checks through `validate()` rather than falling back to the
+generic AKM subdirectory scan. Placement is not — nothing in the write path
+calls `placeNew()` yet for any adapter, llm-wiki included; that wiring is
+deferred to 0.10 (see
+[D12 in the 0.9.0 decision record](../architecture/specs/0.9.0-decisions.md#d12--bundleadapterplacenew-stays-unwired-until-010)).
+Separately, `akm remember`/`akm import`/proposal-accept into an llm-wiki
+bundle are rejected before they reach the adapter at all — the same
+`assertAkmAssetWrite` allowlist that rejects OKF targets, unrelated to the
+`placeNew` deferral. Author llm-wiki content through your agent writing
+directly into `pages/` (as the Karpathy pattern always intended), not
+through akm's native write commands.
 
 There is no `akm wiki ...` compatibility shim — an installed non-akm wiki
 directory reclassifies under the `llm-wiki` adapter on your next `akm index`

--- a/docs/migration/v0.8-to-v0.9.md
+++ b/docs/migration/v0.8-to-v0.9.md
@@ -1,10 +1,13 @@
 # Migrating from akm 0.8.x to 0.9.0
 
 0.9.0 is the format-neutral **bundle / adapter** refactor. It replaces the flat
-asset-type registry with per-format adapters, adopts one canonical ref grammar,
-consolidates the durable databases and config, and completes several 0.8-era
-deprecations (the CLI aliases and the `vault` asset type). This guide is
-ordered the way you'll need it:
+asset-type registry with per-format adapters for *recognition, indexing, and
+presentation* — placement and validation still route through AKM's native
+tables (see [Removed surfaces](#3-removed-surfaces) and the 0.9.0 release
+notes for the exact boundary) — adopts one canonical ref grammar, consolidates
+the durable databases and config, and completes several 0.8-era deprecations
+(the CLI aliases and the `vault` asset type). This guide is ordered the way
+you'll need it:
 
 > **Heads-up on the 0.9.x series:** 0.9.x is a refactoring and clean-up
 > series — patch releases may include further breaking changes (each with a
@@ -24,7 +27,10 @@ the crash-resumable `akm migrate apply` coordinator. It also rewrites
 legacy `workflow:` target refs in valid 0.8 task files after resolving them
 against their containing/configured bundle while preserving each YAML file's
 permission mode; it does not translate profile-based configuration or workflow
-definitions automatically. Create the recovery backup
+definitions automatically — a 0.8 workflow document keeps its 0.8 structure
+verbatim and needs a manual rewrite (see
+[0.8 workflow assets after migration](#08-workflow-assets-after-migration) for
+the concrete symptom and the fix). Create the recovery backup
 before changing a live installation, then migrate other affected assets deliberately.
 
 ## 1. Cross the boundary: `akm migrate status` / `akm migrate apply`
@@ -67,7 +73,9 @@ The 0.8 binary does not contain `akm migrate` or the `upgrade
 package-manager/manual boundary procedure instead:
 
 1. Stop AKM writers, schedulers, and workflow drivers.
-2. Prepare the complete 0.9 config in a separate file. Do not replace the live
+2. Prepare the complete 0.9 config in a separate file (see
+   [Prepare the 0.9 config](#preparing-the-09-config) below for a minimal
+   working example and the full key-mapping table). Do not replace the live
    0.8 config; AKM cannot infer names when old LLM and agent profiles collide.
 3. Take an independent filesystem backup of the live 0.8 `config.json`,
    `state.db`, and `workflow.db` (including any SQLite `-wal`/`-shm` files).
@@ -81,6 +89,120 @@ package-manager/manual boundary procedure instead:
 6. After apply succeeds, run `akm task sync --rebind` with that same 0.9 binary
    before restarting schedulers. The explicit rebind replaces 0.8 native
    scheduler definitions with current context-bound invocations.
+
+### Preparing the 0.9 config
+
+There is no automatic translator for step 2 — a 0.9 config is a plain JSON
+file you write yourself before running `migrate apply`. This is the minimum
+that is sufficient to drive a successful `akm migrate apply`: one writable
+bundle and a `defaultBundle` naming it.
+
+```json
+{
+  "configVersion": "0.9.0",
+  "bundles": {
+    "primary": { "path": "/abs/path/to/your/stash", "writable": true }
+  },
+  "defaultBundle": "primary"
+}
+```
+
+Point `path` at the same directory your 0.8 `stashDir` used — that is what
+turns your existing assets into the migrated installation's working bundle. If
+your 0.8 config also had `sources[]` or `installed[]` entries, add one
+`bundles` entry per source (see the mapping table below); each one becomes
+searchable the same way it was in 0.8.
+
+If your 0.8 config configured LLM or agent profiles, add `engines` and
+`defaults` too:
+
+```jsonc
+{
+  "configVersion": "0.9.0",
+  "bundles": {
+    "primary": { "path": "/abs/path/to/your/stash", "writable": true }
+  },
+  "defaultBundle": "primary",
+  "engines": {
+    "fast": {
+      "kind": "llm",
+      "endpoint": "http://localhost:11434/v1/chat/completions",
+      "model": "qwen3"
+    },
+    "reviewer": { "kind": "agent", "platform": "opencode" }
+  },
+  "defaults": {
+    "engine": "reviewer",
+    "llmEngine": "fast"
+  }
+}
+```
+
+This is a minimal illustration, not the full schema — see
+[Configuration](../reference/configuration.md) for every `engines`/`defaults`/
+`improve.strategies` field, and point your editor's JSON schema support at
+`$schema: "https://itlackey.github.io/akm/schemas/akm-config.json"` (or the
+local `schemas/akm-config.json` in a source checkout) for autocomplete and
+inline validation while you write it.
+
+#### 0.8 key → 0.9 key
+
+Verified against `scripts/akm-migrate/migrate/legacy/config-source-migration.ts`
+(the transform `akm migrate apply` runs on your behalf once you give it a
+target config that already speaks the 0.9 shape) and
+`src/core/config/config-walker.ts`'s retired-key hints:
+
+| 0.8 key | 0.9 key | Notes |
+| --- | --- | --- |
+| `stashDir` | `bundles.<id>.path` + `defaultBundle` | The `primary: true` source (or the top-level `stashDir` if none was marked primary) becomes the bundle named by `defaultBundle` |
+| `sources[]` | `bundles` | One `bundles.<id>` entry per source; `id` is derived from the source's `name`/`registryId` or a slug of its path |
+| `installed[]` | `bundles` + lockfile | The config entry keeps only the desired locator (`git`/`npm` + `registryId`); the materialized cache path and revision move to the lockfile, not the config |
+| `wikiName` | (gone — no replacement) | The wiki subsystem was removed in 0.9; a Karpathy-style wiki is recognized automatically as an `llm-wiki` bundle, and ordinary content goes through `akm import` |
+| `profiles.llm.<name>` / `defaults.llm` | `engines.<name>` (`kind: "llm"`) / `defaults.llmEngine` | Not migrated automatically — you choose the new engine names |
+| `profiles.agent.<name>` / `defaults.agent` | `engines.<name>` (`kind: "agent"`) / `defaults.engine` | Not migrated automatically — see the name-collision note below |
+| `profiles.improve.<name>` / `defaults.improve` | `improve.strategies.<name>` / `defaults.improveStrategy` | Not migrated automatically |
+
+The engine/task-asset keys are **not** touched by `migrate apply` — see
+[Engine And Task Assets](#engine-and-task-assets) below for why AKM cannot
+safely auto-generate `engines` names when a 0.8 LLM profile and agent
+profile shared one. Everything else in the table above (bundles, defaultBundle,
+`wikiName` removal) *is* handled by `migrate apply` once you hand it a target
+config — `migrate apply` moves the durable state and databases, not the config
+keys you write by hand as the migration target.
+
+#### End-to-end happy path
+
+The complete sequence, in the order you actually hit it, assuming a single
+0.8 `stashDir` and no LLM/agent profiles to carry over:
+
+```sh
+# 1. Stop schedulers and any running akm process first (see step 1 above).
+
+# 2. Write the target config (see the minimal example above).
+cat > ./prepared-0.9.json << 'EOF'
+{
+  "configVersion": "0.9.0",
+  "bundles": { "primary": { "path": "/home/you/akm", "writable": true } },
+  "defaultBundle": "primary"
+}
+EOF
+
+# 3. Back up the live 0.8 data directory independently (outside AKM's own dirs).
+cp -a ~/.local/share/akm ~/akm-0.8-backup-"$(date +%Y%m%d)"
+
+# 4. Install 0.9.
+npm install -g akm-cli@0.9.0
+
+# 5. Check eligibility, dry-run, then apply.
+akm migrate status --config ./prepared-0.9.json
+akm migrate apply --config ./prepared-0.9.json --dry-run
+akm migrate apply --config ./prepared-0.9.json
+
+# 6. Rebind the scheduler to the new binary and rebuild the index.
+akm task sync --rebind
+akm index
+akm migrate status   # now reports current with no --config needed
+```
 
 Package-manager installation examples for step 4:
 
@@ -149,6 +271,54 @@ published. `akm-migrate backup
 snapshot. Routine config writes, telemetry, and already-current database opens
 do not depend on any historical run.
 
+### What migration control does not cover
+
+Migration control tracks exactly four artifacts — `config.json`, `state.db`,
+`workflow.db`, `index.db` — because that is the literal list the backup/restore
+manifest enumerates. Two boundaries follow from that list that are worth
+stating plainly rather than discovering by accident:
+
+- **`logs.db` is entirely outside the migration system.** It is never backed
+  up, never restored, and never version-checked; `src/core/logs-db.ts`
+  bootstraps its own schema the first time it is opened, independent of the
+  migration coordinator. This is fine in practice — task and index logs are
+  purgeable operational data, not state you need a rollback path for — but it
+  means an `akm-migrate restore` rolls back `config.json`, `state.db`,
+  `workflow.db`, and `index.db` to a prior run while `logs.db` is left exactly
+  as the newer binary wrote it. Do not expect `logs.db` to move with a
+  restore.
+- **`index.db` is only checked with `PRAGMA quick_check`**, never inspected
+  for a schema/migration version the way `state.db` and `workflow.db` are. A
+  `index.db` written by a release newer than the one currently running cannot
+  be detected as "newer" — the runtime instead quarantines and rebuilds it
+  from scratch on the next `akm index`. This is safe because the index is a
+  fully regenerable search cache; it is called out here only so "migration
+  status: current" is not read as "index.db is exactly what this binary
+  expects."
+
+### Two different `migrate` surfaces
+
+`akm migrate` — the subcommand on the everyday `akm` binary — exposes only
+`status` and `apply`: the two commands you need to cross the boundary and to
+check or apply any future in-place migration. It does **not** expose `backup`,
+`restore`, or `storage`.
+
+The standalone `akm-migrate` program (`scripts/akm-migrate.ts` in a source
+checkout; shipped as its own `dist/akm-migrate` release artifact — see the
+`bin` entry in `package.json`) is a separate binary with a larger surface:
+`status`, `apply`, `backup`, `restore`, and `storage`. `backup` and `restore`
+exist **only** here — there is no `akm migrate restore`. If your install does
+not ship `akm-migrate` (some minimal or hand-rolled installs omit it), you have
+no restore path from that install; every `akm-migrate restore ...` /
+`akm-migrate backup ...` command in this guide and in
+[the troubleshooting guide](v0.9.0-troubleshooting.md) refers to that separate
+binary, not the `akm migrate` subcommand.
+
+There is also no `plan` subcommand on either surface. What some other tools
+call "planning" is `akm migrate status` (read-only eligibility check) or
+`akm migrate apply --dry-run` (the same transforms, run without writing) — do
+not look for a separate plan step.
+
 ## 2. Ref grammar: `type:name` → `[bundle//]conceptId`
 
 Refs are now subdir-qualified concept ids inside their bundle —
@@ -190,17 +360,27 @@ the index and renamed by the content migration if they hold a real item.
 
 0.9.0 removes the entire `akm wiki` verb family (`create`, `register`, `list`,
 `show`, `remove`, `pages`, `search`, `stash`, `lint`, `ingest`) and the `wiki`
-asset type. The Karpathy-style LLM wiki structure stays first-class, but as a
-**bundle format** owned by the `llm-wiki` adapter instead of a bespoke command
-surface: `schema.md` (the per-wiki rulebook) + `pages/` (agent-authored pages)
-at a bundle's root is enough for the indexer to recognize and lint it like any
-other bundle. `raw/`, `index.md`, and `log.md` stay reserved infrastructure.
+asset type. The Karpathy-style LLM wiki structure stays first-class for
+*reading*, now as a **bundle format** recognized by the `llm-wiki` adapter
+instead of a bespoke command surface: `schema.md` (the per-wiki rulebook) +
+`pages/` (agent-authored pages) at a bundle's root is enough for the indexer
+to recognize it, index its pages, and present them through `akm show`.
+`raw/`, `index.md`, and `log.md` stay reserved infrastructure.
+
+**llm-wiki is consumer/read-only in 0.9.0, the same as OKF.** The adapter
+defines its own `validate`/`placeNew` logic, but nothing in the write or lint
+path calls it yet: `akm remember`/`akm import`/proposal-accept into an
+llm-wiki bundle are rejected before they reach the adapter (the same
+`assertAkmAssetWrite` allowlist that rejects OKF targets), and `akm lint`
+does not run the adapter's own wiki-shaped checks — it falls back to the
+generic AKM subdirectory scan, which does not know about `pages/`. Author
+llm-wiki content through your agent writing directly into `pages/` (as the
+Karpathy pattern always intended), not through akm's native write commands.
 
 There is no `akm wiki ...` compatibility shim — an installed non-akm wiki
 directory reclassifies under the `llm-wiki` adapter on your next `akm index`
 (see [adapter dispatch reclassification](#4-behavioral-notes)); wiki pages are
-found through `akm search`/`akm show` like any other asset, and lint runs
-through `akm lint`.
+found through `akm search`/`akm show` like any other asset.
 
 ### `akm vault` → `env` / `secret`
 
@@ -489,18 +669,63 @@ regenerable cache and rebuilds itself — but searches or saved refs into those
 bundles may resolve to the new spellings afterwards. Reindex with `akm index`
 right after the cutover so this settles before you rely on saved refs.
 
+### 0.8 workflow assets after migration
+
+A workflow document created by 0.8's own `akm workflow create` used
+heading-based steps (`## Step name` sections). 0.9.0 requires the step graph
+in frontmatter (`steps:`) instead — see
+[Ref grammar](#2-ref-grammar-typename--bundleconceptid) for the related
+`index.md`/`log.md` reservation, and the workflow authoring reference for the
+current shape. `migrate apply` does not rewrite workflow *definitions* (only
+`workflow:` target refs inside task files), so a 0.8-authored workflow
+document keeps its 0.8 heading structure verbatim after migration.
+
+The concrete end state, if you leave such a document unconverted:
+
+- `akm lint` reports structural validation errors against it (missing
+  frontmatter `steps:`, plus one error per heading that no longer matches a
+  declared step id).
+- It is **not indexed** as a workflow: `akm search --type workflow` and
+  `akm show <ref>` will not find it.
+- Any run already started against it before the upgrade is unaffected by the
+  document rewrite and **stays `active`** — 0.9 does not silently fail or
+  auto-close it — and pollutes unrelated `akm show` output for other assets
+  with a `WORKFLOW ACTIVE` banner (workflow status is looked up by target,
+  not by whether the definition still validates).
+
+Fix either by rewriting the asset with a frontmatter `steps:` list (see the
+workflow reference for the schema, or run `akm workflow create --print` for a
+fresh template to copy the shape from), or, if the run is no longer wanted, by
+retiring it explicitly:
+
+```sh
+akm workflow list --active     # find the stale run-id
+akm workflow abandon <run-id>  # marks it failed; resume can still reopen it
+```
+
+`akm workflow abandon` only changes the run's status — it does not touch the
+workflow document. Rewrite the document separately if you want the asset
+itself to lint clean and be searchable again.
+
 ### `env`/`secret` writes now honor `--target` / `defaultWriteTarget`
 
 Previously, `env create`/`set`/`unset`/`remove` and `secret set`/`remove`
 selected a write destination independently of `--target` and
 `defaultWriteTarget`, ignoring writability and git commit boundaries. 0.9.0
-routes these mutations through the same `resolveWriteTarget` selection every
-other write command uses: explicit `--target` wins, else `defaultWriteTarget`,
-else the working stash — and a non-writable target is refused. A git-backed
-writable target now lands the change in the same batch-at-boundary commit as
-any other write (see [below](#single-batch-at-boundary-git-commit)). Reads
-(`env run`/`show`/`list`/`path`/`export`, `secret run`/`path`/`list`) are
-unaffected — they still search every configured source.
+routes the surviving mutating subcommands (`env create`/`remove`, `secret
+set`) through the same `resolveWriteTarget` selection every other write
+command uses: explicit `--target` wins, else `defaultWriteTarget`, else the
+working stash — and a non-writable target is refused. A git-backed writable
+target now lands the change in the same batch-at-boundary commit as any other
+write (see [below](#single-batch-at-boundary-git-commit)). Reads (`env
+run`/`list`/`path`/`export`, `secret run`/`list`) are unaffected — they still
+search every configured source.
+
+`env set`/`env unset` and `secret path`/`secret remove` are not merely
+unaffected — they no longer exist in 0.9.0 (see the
+[CLI rename table](#cli-surface-overhaul-rename-table-090-hard-break) and
+[`akm secret`'s removal note](../reference/cli.md#secret) for why `secret
+path`/`secret remove` specifically were dropped rather than fixed).
 
 ### LLM enrichment concurrency defaults
 
@@ -584,7 +809,7 @@ there was no 0.8.x warn-and-delegate period for these.
 | `akm setup --detect-only` / `--reset-recommended` | (removed) | environment detection runs inside `akm setup`; `akm info` reports the *configured* capabilities, not a detection scan |
 | `akm env set` / `akm env unset` | (removed) | edit the `.env` file directly, or ingest one with `env create --from-file` |
 | `--source` on `search` / `curate` | `--from` | value rename too: `stash` → `local`, `both` → `all` |
-| `--target` on `remember` / `clone` / `improve` / `task add`/`run`/`sync`/`history` | `--bundle` | `import` and `proposal accept`/`diff`/`revert` **keep** `--target` |
+| `--target` on `remember` / `clone` / `improve` / `task add`/`run`/`sync`/`history` | `--bundle` | `import`, `proposal accept`/`diff`/`revert`, `env create`/`remove`, and `secret set` **keep** `--target` |
 | `AKM_STASH_DIR` | `AKM_BUNDLE_DIR` | no fallback to the old name |
 | JSON field `stashDir` | `bundleDir` | in command results (`akm info`, `akm bundle create`, `akm config path --all`'s `stash` key → `bundle`); internal DB columns and type names are unaffected |
 | "stash" wording in help text, hints, and docs | "bundle" | user-visible surface only — internal identifiers, DB schema, and historical CHANGELOG/release-notes text are unaffected |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -49,15 +49,18 @@ self-contained document with no external references, so it can be redirected to
 a file and opened directly.
 
 A small set of commands is **format-exempt** because their output is not a
-result envelope at all — `completions`, child-process passthrough (`env run`,
-`secret run`, and `migrate`
-`status`/`apply`, which spawn the standalone migration tool and print its
-fixed JSON verbatim), document payloads (`help`,
+result envelope at all — `completions`, child-process passthrough (`env run`
+and `secret run`), document payloads (`help`,
 `help migrate`), and `env path` (a bare filesystem path is the payload, the
 documented shell-substitution primitive — wrapping it in an envelope would
 break `$(akm env path <ref>)` substitutions). Passing `--format` to one of
 those **warns on stderr** and is otherwise ignored; the exempt set is declared
-in `src/output/format-exempt.ts`.
+in `src/output/format-exempt.ts`. `migrate status`/`apply` also spawn a
+standalone tool (the migration tool) but are NOT exempt: the CLI parses that
+child's final JSON result line and renders it through the normal `--format`
+pipeline, so `text`/`md`/`html`/`yaml` genuinely reformat it; any progress
+lines the child printed along the way still print verbatim, ahead of the
+formatted result.
 
 Scripted `setup` modes emit a normal format-aware result. Interactive `setup`
 is a terminal UI and emits no result document. `agent` leaves inherited child

--- a/scripts/akm-migrate/config-migrate.ts
+++ b/scripts/akm-migrate/config-migrate.ts
@@ -7,6 +7,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { EXIT_CODES } from "../../src/cli/shared";
+import { workflowStructureDiagnostics } from "../../src/core/adapter/adapters/akm-lint";
+import { assetPathForName, stashDirFor } from "../../src/core/asset/asset-placement";
+import { parseBundleRef } from "../../src/core/asset/asset-ref";
+import { typeNameFromConceptId } from "../../src/core/asset/resolve-ref";
 import { MAX_CONFIG_FILE_BYTES, MAX_LOCAL_METADATA_BYTES, readTextFileWithLimit, writeFileAtomic } from "../../src/core/common";
 import {
   type AkmConfig,
@@ -19,6 +23,7 @@ import { ConfigError } from "../../src/core/errors";
 import { withMaintenanceStartBarrier } from "../../src/core/maintenance-barrier";
 import { getConfigPath, getDbPath, getStateDbPathInDataDir } from "../../src/core/paths";
 import { runMigrations as runStateMigrations } from "../../src/core/state/migrations";
+import { warn } from "../../src/core/warn";
 import {
   assertMigrationLockfileReadable,
   isValidLockfileEntry,
@@ -90,10 +95,19 @@ export interface MigrationTargetState {
 }
 
 export interface MigrationPlan {
-  status: "current" | "ready" | "blocked";
+  // R-090: `not-applicable` is a DISTINCT, non-error outcome from `blocked` —
+  // it means "there is nothing on this machine to migrate", not "migration
+  // cannot proceed". Consumers that gate on `status !== "blocked"` (e.g. the
+  // self-update preflight, which only inspects the CLI's exit code) keep
+  // working unchanged; only a consumer that narrowly matched `=== "ready"` to
+  // mean "proceed" would need to widen to also treat `not-applicable` as
+  // proceed-safe — grepped for that pattern across the tree and found none.
+  status: "current" | "ready" | "blocked" | "not-applicable";
   artifacts: MigrationState;
   targetConfig: MigrationTargetState;
   blockers: string[];
+  /** Human-readable context for a non-error `status` that isn't self-explanatory (currently only `not-applicable`). */
+  message?: string;
   activeOperation?: { kind: "apply" | "restore"; sentinelPath: string };
 }
 
@@ -293,6 +307,30 @@ function buildMigrationPlan(
 ): MigrationPlan {
   const artifacts = inspectMigrationState();
   const restorePending = fs.existsSync(getMigrationRestoreJournalPath());
+
+  // R-090: a genuinely fresh machine — no config.json, no state/workflow/index
+  // databases, and no in-flight apply/restore operation — has nothing to
+  // migrate. Report that as a distinct, non-error outcome instead of routing
+  // it through the "provide an operator-prepared config" blocker below: that
+  // message is correct advice for an existing pre-cutover install but reads
+  // as a failure ("blocked", exit 1) for a user who has nothing to upgrade.
+  const nothingToMigrate =
+    !active.sentinel &&
+    !restorePending &&
+    artifacts.config.status === "missing" &&
+    artifacts.state.status === "missing" &&
+    artifacts.workflow.status === "missing" &&
+    artifacts.index.status === "missing";
+  if (nothingToMigrate) {
+    return {
+      status: "not-applicable",
+      artifacts,
+      targetConfig: { status: "missing", source: "none" },
+      blockers: [],
+      message: "No akm installation found; nothing to migrate.",
+    };
+  }
+
   const target = active.sentinel
     ? {
         state: {
@@ -794,6 +832,79 @@ function requireSemanticCompletion(config: AkmConfig, sentinel: ApplySentinel, f
   };
 }
 
+/**
+ * R-091: an active/resumable (`status IN ('active','blocked')`) workflow run
+ * can target a workflow asset that fails 0.9's structural validation — most
+ * commonly a heading-based 0.8 workflow definition, since 0.9 requires
+ * frontmatter `steps:` and does NOT auto-translate the old format (the docs
+ * say so explicitly; building a converter here would be dishonest scope
+ * creep). Such an asset silently drops out of the 0.9 index (`akm search
+ * --type workflow` finds nothing for it) while its run row stays `active`, so
+ * `akm show` on UNRELATED assets keeps prefixing a "WORKFLOW ACTIVE" banner
+ * that names a run the operator can no longer advance. The minimal honest fix
+ * is detection + a clear pointer, not a fix: tell the operator to update the
+ * asset or abandon the stale run. Reuses `workflowStructureDiagnostics` — the
+ * exact same check `akm lint`'s `invalid-workflow-structure` uses — so this
+ * can never disagree with what `akm lint`/`akm search` report.
+ *
+ * Purely diagnostic: reads state.db read-only and writes to stderr via
+ * `warn()`, never to the migration's stdout JSON result. Every failure mode
+ * (missing table, unreadable file, resolution miss) is swallowed — this must
+ * never turn a completed migration into a failure.
+ */
+function warnOrphanedActiveWorkflowRuns(
+  statePath: string,
+  roots: readonly CutoverStashRoot[],
+  defaultBundle: string | undefined,
+): void {
+  try {
+    if (!fs.existsSync(statePath)) return;
+    let rows: Array<{ id: string; workflow_ref: string }>;
+    const db = openDatabaseFinalizing(statePath, { readonly: true, create: false });
+    try {
+      const hasRuns = db.prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name='workflow_runs'").get();
+      if (!hasRuns) return;
+      rows = db
+        .prepare("SELECT id, workflow_ref FROM workflow_runs WHERE status IN ('active', 'blocked')")
+        .all() as Array<{ id: string; workflow_ref: string }>;
+    } finally {
+      db.close();
+    }
+    if (rows.length === 0) return;
+
+    const rootById = new Map(roots.map((root) => [root.bundleId, root]));
+    for (const row of rows) {
+      const parsed = parseBundleRef(row.workflow_ref);
+      const parts = typeNameFromConceptId(parsed.conceptId);
+      if (!parts || parts.type !== "workflow") continue;
+      const root = rootById.get(parsed.bundle ?? defaultBundle ?? "");
+      if (!root) continue;
+      // `assetPathForName`'s `typeRoot` is the TYPE's stash subdir, not the
+      // bundle root — mirrors how every real caller (indexer install
+      // resolution) builds it: `<bundleRoot>/<stashDirFor(type)>`.
+      const typeRoot = path.join(root.path, stashDirFor("workflow") ?? "workflows");
+      const filePath = assetPathForName("workflow", typeRoot, parts.name);
+      if (!fs.existsSync(filePath)) continue;
+      let raw: string;
+      try {
+        raw = readTextFileWithLimit(filePath, MAX_CONFIG_FILE_BYTES, "Workflow asset");
+      } catch {
+        continue;
+      }
+      const diagnostics = workflowStructureDiagnostics(path.relative(root.path, filePath) || filePath, raw, filePath);
+      if (diagnostics.length === 0) continue;
+      warn(
+        `WORKFLOW ACTIVE run ${row.id} targets "${row.workflow_ref}" (${filePath}), which fails 0.9 workflow ` +
+          `structural validation and can no longer be run: ${diagnostics.map((d) => d.detail).join("; ")}. ` +
+          "AKM does not auto-translate workflow definitions between formats — update the asset to declare " +
+          `frontmatter \`steps:\`, or run \`akm workflow abandon ${row.id}\` to clear the stale run.`,
+      );
+    }
+  } catch {
+    // Purely diagnostic — never let this block or fail a completed migration.
+  }
+}
+
 function requireEligiblePlan(
   preparedConfigPath: string | undefined,
   active: ApplySentinelRead,
@@ -819,14 +930,17 @@ export async function runMigrationApply(options: MigrationCommandOptions = {}): 
       recoverInterruptedRestoreWithLocksHeld();
       const existing = readApplySentinel();
       if (existing.error) throw new ConfigError(existing.error, "INVALID_CONFIG_FILE");
+      // R-090: `not-applicable` (nothing on this machine to migrate) has no
+      // target config to load by design — short-circuit before
+      // `requireEligiblePlan`, which would otherwise read that absent target
+      // as `blocked` and throw.
+      const preflightPlan = buildMigrationPlan(options.preparedConfigPath, existing);
+      if (preflightPlan.status === "not-applicable") return { plan: preflightPlan };
       const { plan, target, migrationLockEntries } = requireEligiblePlan(options.preparedConfigPath, existing);
       if (plan.status === "current" && !existing.sentinel) return { plan };
       const pathResolutionBase = existing.sentinel?.pathResolutionBase ?? path.resolve(process.cwd());
-      assertNoArtifactReplacementBlockers(undefined, {
-        stashRoots: cutoverStashRootsFromConfig(target, migrationLockEntries, [], pathResolutionBase).map(
-          (root) => root.path,
-        ),
-      });
+      const stashRoots = cutoverStashRootsFromConfig(target, migrationLockEntries, [], pathResolutionBase);
+      assertNoArtifactReplacementBlockers(undefined, { stashRoots: stashRoots.map((root) => root.path) });
       assertMigrationLockfileReadable();
 
       const backup = existing.sentinel
@@ -858,6 +972,7 @@ export async function runMigrationApply(options: MigrationCommandOptions = {}): 
         }
         publishConfigLast(target, sentinel, backup.manifest);
         const completed = requireSemanticCompletion(target, sentinel, !taskOnly && !postCutoverState);
+        warnOrphanedActiveWorkflowRuns(getStateDbPathInDataDir(), stashRoots, target.defaultBundle);
         clearApplySentinel();
         return { plan: completed, backup };
       } catch (error) {

--- a/scripts/akm-migrate/config-migrate.ts
+++ b/scripts/akm-migrate/config-migrate.ts
@@ -19,6 +19,7 @@ import {
   sanitizeConfigForWrite,
 } from "../../src/core/config/config";
 import { parseConfigText, withConfigLock } from "../../src/core/config/config-io";
+import { CURRENT_CONFIG_VERSION } from "../../src/core/config/config-schema";
 import { ConfigError } from "../../src/core/errors";
 import { withMaintenanceStartBarrier } from "../../src/core/maintenance-barrier";
 import { getConfigPath, getDbPath, getStateDbPathInDataDir } from "../../src/core/paths";
@@ -33,7 +34,9 @@ import {
 import { type Database, openDatabaseFinalizing } from "../../src/storage/database";
 import { runMigrations as runSqliteMigrations } from "../../src/storage/engines/sqlite-migrations";
 import { deriveLegacyBundleIds, inferLegacyBundleIds } from "./migrate/legacy/bundle-id";
+import { detectLegacyEngineKeys, generateTargetConfig } from "./migrate/legacy/config-generate";
 import {
+  hasOldSourceShape,
   migrateConfigSourcesToBundles,
   migratedLockEntries,
   oldConfigToSearchSources,
@@ -68,6 +71,7 @@ import {
   getMigrationApplyJournalPath,
   getMigrationBackupDir,
   getMigrationBackupRoot,
+  getMigrationGeneratedConfigPath,
   getMigrationRestoreJournalPath,
   inspectMigrationState,
   MIGRATION_BACKUP_VERSION,
@@ -80,6 +84,17 @@ import {
 
 const MANUAL_GUIDANCE =
   "Provide a complete operator-prepared 0.9 config with --config. AKM does not guess profile-to-engine mappings.";
+// Used instead of MANUAL_GUIDANCE whenever the active config still carries
+// old-shape source keys (stashDir/sources[]/installed[]) — the mechanical part
+// (bundles/defaultBundle) IS derivable in that case, so the message points at
+// `migrate apply` generating a starter config instead of asking the operator
+// to hand-write one from a blank page. See `generatedConfig` on
+// {@link MigrationPlan} for the structured version of this same information.
+const GENERATED_CONFIG_GUIDANCE =
+  "No 0.9 config found, but the active 0.8 stashDir/sources/installed keys are enough to derive one. " +
+  "Run `akm migrate apply` (no --config) to write a starter config, review it (see `generatedConfig.droppedKeys` " +
+  "for anything it could not translate), then re-run `akm migrate apply` to apply it. " +
+  "Or provide a complete operator-prepared 0.9 config with --config instead.";
 const APPLY_SENTINEL_FORMAT = 1 as const;
 
 export interface MigrationCommandOptions {
@@ -89,9 +104,31 @@ export interface MigrationCommandOptions {
 
 export interface MigrationTargetState {
   status: "current" | "missing" | "corrupt";
-  source: "active" | "prepared" | "none";
+  source: "active" | "prepared" | "generated" | "none";
   path?: string;
   detail?: string;
+}
+
+/**
+ * Describes the config `akm migrate apply` will (or already did) auto-generate
+ * when no `--config` is given and the active 0.8 config has old-shape source
+ * keys to derive `bundles`/`defaultBundle` from. Present on {@link MigrationPlan}
+ * whenever that applies — independent of whether the file has actually been
+ * written yet, so `migrate status` shows the SAME information before `apply`
+ * acts on it (never guessed at run-to-run: `droppedKeys` is recomputed from the
+ * live active config every time, not cached).
+ */
+export interface GeneratedConfigInfo {
+  /** The predictable path (see `getMigrationGeneratedConfigPath`). */
+  path: string;
+  /** `"pending"` — not written yet; the next no-`--config` `migrate apply` writes it. `"written"` — already on disk. */
+  status: "pending" | "written";
+  /**
+   * Exact dotted 0.8 key paths (e.g. `"profiles.llm.fast"`, `"defaults.agent"`)
+   * the generator could not translate and left out — `engines`/`defaults` for
+   * these need hand-authoring. Empty when there was nothing ambiguous.
+   */
+  droppedKeys: string[];
 }
 
 export interface MigrationPlan {
@@ -106,9 +143,17 @@ export interface MigrationPlan {
   artifacts: MigrationState;
   targetConfig: MigrationTargetState;
   blockers: string[];
-  /** Human-readable context for a non-error `status` that isn't self-explanatory (currently only `not-applicable`). */
+  /**
+   * Human-readable context for a status that isn't self-explanatory on its
+   * own: `not-applicable` (nothing to migrate), and a `ready`/`current` result
+   * from `migrate apply` that just finished WRITING a generated config rather
+   * than applying it (see `generatedConfig` — that invocation deliberately
+   * stops there so the operator can review the file before a second, explicit
+   * `migrate apply` actually mutates anything).
+   */
   message?: string;
   activeOperation?: { kind: "apply" | "restore"; sentinelPath: string };
+  generatedConfig?: GeneratedConfigInfo;
 }
 
 interface ApplySentinel {
@@ -221,6 +266,55 @@ function parseMigrationTargetConfig(text: string, sourcePath?: string): AkmConfi
   return parseAndValidateConfigText(JSON.stringify(migrated), sourcePath);
 }
 
+function loadTargetConfigFrom(
+  targetPath: string,
+  source: "active" | "prepared" | "generated",
+): {
+  state: MigrationTargetState;
+  config?: AkmConfig;
+  migrationLockEntries?: LockfileEntry[];
+} {
+  let text: string;
+  try {
+    text = readTextFileWithLimit(targetPath, MAX_CONFIG_FILE_BYTES, "Prepared migration config");
+  } catch (error) {
+    return {
+      state: { status: "corrupt", source, path: targetPath, detail: error instanceof Error ? error.message : String(error) },
+    };
+  }
+
+  try {
+    return {
+      state: { status: "current", source, path: targetPath },
+      config: parseMigrationTargetConfig(text, targetPath),
+      migrationLockEntries: migratedLockEntries(parseConfigText(text, targetPath)),
+    };
+  } catch (error) {
+    return {
+      state: { status: "corrupt", source, path: targetPath, detail: error instanceof Error ? error.message : String(error) },
+    };
+  }
+}
+
+/**
+ * The active config's raw parsed JSON, but ONLY when it still carries the
+ * pre-cutover `stashDir`/`sources[]`/`installed[]` shape — i.e. only when
+ * there is something a generated target config could actually derive.
+ * Returns `undefined` for a missing/unreadable/unparseable file (those cases
+ * are already covered by `artifacts.config`'s own blocker) or a config that
+ * has no old-shape source keys to translate at all.
+ */
+function readActiveLegacyConfigRaw(): Record<string, unknown> | undefined {
+  const configPath = getConfigPath();
+  if (!fs.existsSync(configPath)) return undefined;
+  try {
+    const raw = parseConfigText(readTextFileWithLimit(configPath, MAX_CONFIG_FILE_BYTES, "Config file"), configPath);
+    return hasOldSourceShape(raw) ? raw : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function loadTargetConfig(
   preparedConfigPath: string | undefined,
   artifacts: MigrationState,
@@ -229,43 +323,47 @@ function loadTargetConfig(
   config?: AkmConfig;
   migrationLockEntries?: LockfileEntry[];
 } {
-  const targetPath = preparedConfigPath ?? (artifacts.config.status === "current" ? getConfigPath() : undefined);
-  if (!targetPath) return { state: { status: "missing", source: "none", detail: MANUAL_GUIDANCE } };
+  // An explicit --config always wins and is never second-guessed against a
+  // generated file, even if one already exists at the predictable path.
+  if (preparedConfigPath) return loadTargetConfigFrom(preparedConfigPath, "prepared");
+  if (artifacts.config.status === "current") return loadTargetConfigFrom(getConfigPath(), "active");
 
-  let text: string;
-  try {
-    text = readTextFileWithLimit(targetPath, MAX_CONFIG_FILE_BYTES, "Prepared migration config");
-  } catch (error) {
-    return {
-      state: {
-        status: "corrupt",
-        source: preparedConfigPath ? "prepared" : "active",
-        path: targetPath,
-        detail: error instanceof Error ? error.message : String(error),
-      },
-    };
-  }
+  // No explicit --config, and the active config isn't 0.9-current: an earlier
+  // no-`--config` `migrate apply` may have already generated a starter config
+  // at the predictable path (see writeGeneratedTargetConfig below) — treat it
+  // exactly like an operator-prepared file so a second no-`--config` run
+  // converges instead of asking the operator to pass --config to their own
+  // auto-generated file.
+  const generatedPath = getMigrationGeneratedConfigPath();
+  if (fs.existsSync(generatedPath)) return loadTargetConfigFrom(generatedPath, "generated");
 
-  try {
-    return {
-      state: {
-        status: "current",
-        source: preparedConfigPath ? "prepared" : "active",
-        path: targetPath,
-      },
-      config: parseMigrationTargetConfig(text, targetPath),
-      migrationLockEntries: migratedLockEntries(parseConfigText(text, targetPath)),
-    };
-  } catch (error) {
-    return {
-      state: {
-        status: "corrupt",
-        source: preparedConfigPath ? "prepared" : "active",
-        path: targetPath,
-        detail: error instanceof Error ? error.message : String(error),
-      },
-    };
-  }
+  const detail = readActiveLegacyConfigRaw() ? GENERATED_CONFIG_GUIDANCE : MANUAL_GUIDANCE;
+  return { state: { status: "missing", source: "none", detail } };
+}
+
+/**
+ * The `generatedConfig` plan field: present whenever no explicit --config was
+ * given, there is no in-flight apply sentinel, and the active config still
+ * has old-shape source keys to derive a target from — regardless of whether
+ * the generated file has been written yet, so the SAME information is visible
+ * both before generation (`status: "pending"`) and after (`"written"`, still
+ * naming anything left out). `droppedKeys` is recomputed from the live active
+ * config every call, never cached, so it can never go stale relative to a
+ * config the operator edited between `migrate status` calls.
+ */
+function describeGeneratedConfig(
+  preparedConfigPath: string | undefined,
+  hasSentinel: boolean,
+): GeneratedConfigInfo | undefined {
+  if (preparedConfigPath || hasSentinel) return undefined;
+  const raw = readActiveLegacyConfigRaw();
+  if (!raw) return undefined;
+  const generatedPath = getMigrationGeneratedConfigPath();
+  return {
+    path: generatedPath,
+    status: fs.existsSync(generatedPath) ? "written" : "pending",
+    droppedKeys: detectLegacyEngineKeys(raw),
+  };
 }
 
 function unsafeArtifact(name: string, state: MigrationArtifactState): string | undefined {
@@ -378,6 +476,8 @@ function buildMigrationPlan(
     taskRewrites > 0 ||
     proposalRepair.count > 0;
 
+  const generatedConfig = describeGeneratedConfig(preparedConfigPath, !!active.sentinel);
+
   return {
     status: blockers.length > 0 ? "blocked" : needsApply ? "ready" : "current",
     artifacts,
@@ -398,6 +498,7 @@ function buildMigrationPlan(
             },
           }
         : {}),
+    ...(generatedConfig ? { generatedConfig } : {}),
   };
 }
 
@@ -905,6 +1006,26 @@ function warnOrphanedActiveWorkflowRuns(
   }
 }
 
+/**
+ * The write-side counterpart to `describeGeneratedConfig`: derives a starter
+ * 0.9 config from the ACTIVE 0.8 config (`raw`, read-only — this function
+ * never mutates or touches the live `config.json`) and writes it to the
+ * predictable generated-config path, validating it FIRST so a broken
+ * derivation can never land a corrupt file there for a later run to trust.
+ * Called only from `runMigrationApply`'s real (non-dry-run) path, while the
+ * config lock and maintenance barrier are already held.
+ */
+function writeGeneratedTargetConfig(raw: Record<string, unknown>): GeneratedConfigInfo {
+  const { config, droppedKeys } = generateTargetConfig(raw, CURRENT_CONFIG_VERSION);
+  const generatedPath = getMigrationGeneratedConfigPath();
+  // Validate before writing so a broken derivation never lands a corrupt file
+  // at the predictable path a later run would otherwise trust as "written".
+  parseAndValidateConfigText(JSON.stringify(config), generatedPath);
+  fs.mkdirSync(path.dirname(generatedPath), { recursive: true, mode: 0o700 });
+  writeFileAtomic(generatedPath, `${JSON.stringify(config, null, 2)}\n`, 0o600);
+  return { path: generatedPath, status: "written", droppedKeys };
+}
+
 function requireEligiblePlan(
   preparedConfigPath: string | undefined,
   active: ApplySentinelRead,
@@ -936,6 +1057,40 @@ export async function runMigrationApply(options: MigrationCommandOptions = {}): 
       // as `blocked` and throw.
       const preflightPlan = buildMigrationPlan(options.preparedConfigPath, existing);
       if (preflightPlan.status === "not-applicable") return { plan: preflightPlan };
+      // Nothing to apply against yet (no --config, no in-flight sentinel, and
+      // the ONLY reason apply is blocked is a missing target config) but the
+      // active config's old-shape source keys are enough to derive one:
+      // write it now and STOP — this invocation deliberately does not
+      // proceed to backup/apply, so the operator gets a real chance to
+      // review (and hand-add engines/defaults for anything `generatedConfig`
+      // names as dropped) before anything mutates. A second, explicit
+      // `migrate apply` (still no --config) picks the generated file up
+      // automatically via `loadTargetConfig`, exactly like an operator-
+      // prepared --config would.
+      if (
+        !options.preparedConfigPath &&
+        !existing.sentinel &&
+        preflightPlan.status === "blocked" &&
+        preflightPlan.blockers.length === 1 &&
+        preflightPlan.targetConfig.status !== "current" &&
+        preflightPlan.generatedConfig?.status === "pending"
+      ) {
+        const legacyRaw = readActiveLegacyConfigRaw();
+        if (legacyRaw) {
+          const generated = writeGeneratedTargetConfig(legacyRaw);
+          return {
+            plan: {
+              ...buildMigrationPlan(options.preparedConfigPath, existing),
+              message:
+                `Generated a starter 0.9 config at ${generated.path} from the active 0.8 stashDir/sources/installed keys.` +
+                (generated.droppedKeys.length > 0
+                  ? ` It does not include ${generated.droppedKeys.join(", ")} — add engines/defaults for those if you need them.`
+                  : "") +
+                " Nothing has been applied yet — review the file, then re-run `akm migrate apply` to apply it.",
+            },
+          };
+        }
+      }
       const { plan, target, migrationLockEntries } = requireEligiblePlan(options.preparedConfigPath, existing);
       if (plan.status === "current" && !existing.sentinel) return { plan };
       const pathResolutionBase = existing.sentinel?.pathResolutionBase ?? path.resolve(process.cwd());

--- a/scripts/akm-migrate/migrate/legacy/config-generate.ts
+++ b/scripts/akm-migrate/migrate/legacy/config-generate.ts
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Auto-generates a starter 0.9.0 target config from a pre-cutover 0.8 config,
+ * for `akm migrate apply`'s no-`--config` path (see `config-migrate.ts`'s
+ * `buildMigrationPlan`/`writeGeneratedTargetConfig`).
+ *
+ * Split into two independent, honest halves:
+ *
+ * - The MECHANICAL half (`bundles`/`defaultBundle`) is a pure function of the
+ *   0.8 `stashDir`/`sources[]`/`installed[]` keys — {@link migrateConfigSourcesToBundles}
+ *   (`./config-source-migration.ts`) already computes exactly this, well
+ *   tested on its own; this module reuses it rather than reimplementing it.
+ * - The AMBIGUOUS half (`profiles.llm`/`profiles.agent`/`profiles.improve`/
+ *   `defaults.llm`/`defaults.agent`/`defaults.improve`) is never guessed at.
+ *   0.9's `AkmConfigSchema` HARD-REJECTS every one of these keys when present
+ *   (`src/core/config/config-schema.ts`'s top-level `superRefine`: `profiles`
+ *   is a retired top-level key, and `defaults.llm`/`defaults.agent`/
+ *   `defaults.improve` are individually rejected too) — so generation MUST
+ *   strip them for the mechanical half to validate at all. This module names,
+ *   by exact dotted 0.8 key path, every key it drops, so `migrate status`/
+ *   `apply` can tell the operator precisely what still needs a hand-authored
+ *   `engines`/`defaults` block instead of silently producing a config with a
+ *   quietly-vanished agent or LLM profile.
+ */
+
+import { migrateConfigSourcesToBundles } from "./config-source-migration";
+
+function objectAt(raw: Record<string, unknown>, key: string): Record<string, unknown> | undefined {
+  const value = raw[key];
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+/**
+ * Every 0.8 `profiles.*`/`defaults.llm`/`defaults.agent`/`defaults.improve`
+ * key present on `raw`, named by its exact dotted 0.8 path (e.g.
+ * `"profiles.llm.fast"`, `"defaults.agent"`) — the same names the 0.8→0.9
+ * migration guide's key-mapping table uses. Empty when there is nothing
+ * ambiguous to translate, in which case generation is complete on its own.
+ */
+export function detectLegacyEngineKeys(raw: Record<string, unknown>): string[] {
+  const dropped: string[] = [];
+  const profiles = objectAt(raw, "profiles");
+  for (const kind of ["llm", "agent", "improve"] as const) {
+    const map = profiles ? objectAt(profiles, kind) : undefined;
+    if (map) for (const name of Object.keys(map)) dropped.push(`profiles.${kind}.${name}`);
+  }
+  const defaults = objectAt(raw, "defaults");
+  for (const key of ["llm", "agent", "improve"] as const) {
+    if (defaults && defaults[key] !== undefined) dropped.push(`defaults.${key}`);
+  }
+  return dropped;
+}
+
+/**
+ * Remove the hard-rejected `profiles` key and `defaults.llm`/`defaults.agent`/
+ * `defaults.improve` sub-keys from `raw`. Never mutates `raw`. Returns the
+ * stripped object alongside {@link detectLegacyEngineKeys}'s report over the
+ * SAME input, so the caller can both write a schema-valid file and tell the
+ * operator exactly what it left out.
+ */
+export function stripLegacyEngineKeys(raw: Record<string, unknown>): {
+  config: Record<string, unknown>;
+  droppedKeys: string[];
+} {
+  const droppedKeys = detectLegacyEngineKeys(raw);
+  const config: Record<string, unknown> = { ...raw };
+  delete config.profiles;
+  const defaults = objectAt(raw, "defaults");
+  if (defaults) {
+    const nextDefaults = { ...defaults };
+    delete nextDefaults.llm;
+    delete nextDefaults.agent;
+    delete nextDefaults.improve;
+    if (Object.keys(nextDefaults).length > 0) config.defaults = nextDefaults;
+    else delete config.defaults;
+  }
+  return { config, droppedKeys };
+}
+
+/**
+ * Derive a complete-for-the-mechanical-part 0.9.0 target config from a
+ * pre-cutover 0.8 raw config object: `bundles`/`defaultBundle` via
+ * {@link migrateConfigSourcesToBundles}, `configVersion` stamped to
+ * `currentConfigVersion` (a pure constant, never ambiguous), and every
+ * `profiles`/legacy-`defaults` key stripped and reported via `droppedKeys`.
+ * The returned `config` still needs schema validation by the caller — this
+ * function only shapes the object, it does not assert it is valid.
+ */
+export function generateTargetConfig(
+  raw: Record<string, unknown>,
+  currentConfigVersion: string,
+): { config: Record<string, unknown>; droppedKeys: string[] } {
+  const bundleShaped = migrateConfigSourcesToBundles(raw);
+  const { config: stripped, droppedKeys } = stripLegacyEngineKeys(bundleShaped);
+  return { config: { ...stripped, configVersion: currentConfigVersion }, droppedKeys };
+}

--- a/scripts/akm-migrate/migration-backup.ts
+++ b/scripts/akm-migrate/migration-backup.ts
@@ -187,7 +187,23 @@ function inspectConfig(configPath: string): MigrationArtifactState {
   try {
     const raw = parseConfigText(readTextFileWithLimit(configPath, MAX_CONFIG_FILE_BYTES, "Config file"), configPath);
     const comparison = compareConfigVersion(raw.configVersion as string | number | undefined, CURRENT_CONFIG_VERSION);
-    if (comparison === undefined) return { status: "inconsistent", detail: "configVersion is missing or invalid" };
+    if (comparison === undefined) {
+      // 0.8.x only stamps `configVersion` when a 0.7-era migration actually did
+      // something (`if (changed)`); a config freshly written by 0.8 itself
+      // (`akm setup`/`akm init`, no legacy keys to carry forward) has no
+      // legacy-migration work to trigger that stamp and so ships with NO
+      // `configVersion` key at all — not an invalid one, an absent one. Read
+      // that specific case as pre-cutover `old`, the same status a config
+      // explicitly versioned "0.8.0" would get below, rather than the
+      // unconditional-blocker `inconsistent` status: every fresh-0.8 install
+      // would otherwise be permanently unable to run `migrate apply`.
+      // Gate tightly on the shape actually being pre-cutover 0.8 (no
+      // `bundles`, plus a legacy source key) so this cannot silently swallow
+      // a config whose `configVersion` is merely garbage/unparseable — that
+      // must stay `inconsistent`.
+      if (raw.configVersion === undefined && isPreCutoverSourceShape(raw)) return { status: "old" };
+      return { status: "inconsistent", detail: "configVersion is missing or invalid" };
+    }
     if (comparison < 0) return { status: "old" };
     if (comparison > 0) return { status: "newer" };
     if (isPreCutoverSourceShape(raw)) {

--- a/scripts/akm-migrate/migration-backup.ts
+++ b/scripts/akm-migrate/migration-backup.ts
@@ -28,6 +28,7 @@ import {
 import { acquireMaintenanceActivitySync, withMaintenanceStartBarrier } from "../../src/core/maintenance-barrier";
 import {
   getMigrationApplyJournalPath,
+  getMigrationGeneratedConfigPath,
   getMigrationOperationRoot,
   getMigrationRestoreJournalPath,
 } from "../../src/core/migration-operation";
@@ -110,7 +111,7 @@ export function getMigrationBackupRoot(): string {
   return getMigrationOperationRoot();
 }
 
-export { getMigrationApplyJournalPath, getMigrationRestoreJournalPath };
+export { getMigrationApplyJournalPath, getMigrationGeneratedConfigPath, getMigrationRestoreJournalPath };
 
 export function getMigrationBackupDir(runId?: string): string {
   if (!runId) return getMigrationBackupRoot();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -516,6 +516,12 @@ function commandHelpTopic(name: string, command: AnyCittyCommand): AnyCittyComma
   });
 }
 
+// `migrate` is excluded here even though it's a normal, now-visible SYSTEM
+// command (see HELP_SECTIONS below): `help`'s own `migrate` subcommand
+// (registered below) intentionally shadows this generic command-usage
+// renderer with release-notes lookup instead — `akm help migrate 0.9.0`
+// prints migration guidance, not `migrate`'s own `--help` usage block. That
+// usage block is still reachable directly via `akm migrate --help`.
 const commandHelpTopics = Object.fromEntries(
   Object.entries(commands)
     .filter(([name]) => name !== "migrate")
@@ -635,9 +641,20 @@ export function shouldBypassConfigStartup(argv: readonly string[]): boolean {
   const separator = userArgs.indexOf("--");
   const args = separator === -1 ? userArgs : userArgs.slice(0, separator);
   if (args.includes("--help") || args.includes("-h") || args.includes("--version") || args.includes("-v")) return true;
+  // Bare `akm` (no subcommand at all) renders the same sectioned root-help
+  // text as `akm help` — never touches config either.
+  if (args.length === 0) return true;
   const commandIndex = findCittyTopLevelCommandIndex(args, MAIN_TOP_LEVEL_ARGS);
   const command = commandIndex >= 0 ? args[commandIndex] : undefined;
   if (command === "setup" || command === "migrate") return true;
+  // `help` and `hints` are pure-text surfaces (bundled release notes, static
+  // agent-guide text, command usage rendered from `meta` alone) — none of
+  // their run bodies read config. The documented recovery path
+  // (`akm help migrate 0.9.0`) is only ever run against a config that
+  // startup's own load would reject, so both must bypass it the same way
+  // `setup`/`migrate` do, or the recovery instructions are themselves
+  // unreachable.
+  if (command === "help" || command === "hints") return true;
   if (isTaskRunWithId(argv)) return true;
   if (command !== "config") return false;
   const configIndex = args.indexOf("config");
@@ -797,6 +814,7 @@ const HELP_SECTIONS: ReadonlyArray<{
       "registry",
       "info",
       "log",
+      "migrate",
       "help",
       "hints",
       "upgrade",

--- a/src/cli/retired-commands.ts
+++ b/src/cli/retired-commands.ts
@@ -54,6 +54,8 @@ const RETIRED_COMMAND_HINTS: Record<string, string> = {
   // Pre-0.9 removals agents still trip over.
   wiki: "the `akm wiki` family was removed in 0.9 — wikis are ordinary knowledge assets; ingest with `akm import <url> --path <subdir>`.",
   backup: "`akm backup` was removed in 0.9 — backups belong to the standalone `akm-migrate backup` tool.",
+  vault:
+    "the `akm vault ...` family was removed in 0.9 — use `akm env list`/`akm env create` for a whole `.env` group, or `akm secret set <name>` for a single sensitive value.",
 
   // Group-scoped retirements.
   "env set": "`akm env set` was removed in 0.9 — edit the `.env` file directly; akm loads it as-is.",
@@ -81,7 +83,13 @@ const RETIRED_COMMAND_HINTS: Record<string, string> = {
     "`akm task disable` was removed in 0.9 — set `enabled: false` in the task YAML, then `akm task sync`.",
   "task init": "`akm task init` was removed in 0.9 — `akm setup` seeds the default schedules.",
   "task list": "there is no `task list` — task files are indexed assets; use `akm search --type task`.",
+  "task show": "there is no `task show` — task files are indexed assets; use `akm show <ref>`.",
   "task remove": "there is no `task remove` — delete the task YAML, then run `akm task sync` to unbind it.",
+  // `improve canary` is NOT here: `akm improve` is a leaf command (a
+  // positional `ref`, not a subcommand group), so "canary" never reaches the
+  // unknown-command path this table serves — `improve-cli.ts` already
+  // self-diagnoses it with a more specific, correct message before this
+  // table would ever be consulted.
   "log tail": "`akm log tail` was removed in 0.9 — poll `akm log --since @offset:<id>` (the durable cursor).",
   "log list": "`akm log list` was flattened in 0.9 — bare `akm log` is the same surface.",
 };
@@ -97,5 +105,42 @@ const MIGRATION_POINTER = "Full rename table: `akm help migrate 0.9.0`.";
 export function retiredCommandHint(parentPath: readonly string[], attempted: string): string | undefined {
   const key = parentPath.length === 0 ? attempted : `${parentPath[parentPath.length - 1]} ${attempted}`;
   const entry = RETIRED_COMMAND_HINTS[key];
+  return entry === undefined ? undefined : `${entry} ${MIGRATION_POINTER}`;
+}
+
+/**
+ * Same idea as {@link RETIRED_COMMAND_HINTS}, but for FLAGS the 0.9 overhaul
+ * removed outright rather than commands. Consulted by
+ * `src/cli/unknown-flags.ts` BEFORE its own edit-distance did-you-mean, for
+ * the same reason: a distance-based suggestion on a retired flag can point at
+ * an unrelated survivor rather than the real replacement procedure.
+ *
+ * Keys are the FULL resolved command path joined with spaces, plus the flag
+ * exactly as the unknown-flag scanner reports it (leading dashes, long form
+ * only — `--background`, not `-b`): `"<cmd> [sub...] --flag"`. The command
+ * path is whatever `unknown-flags.ts`'s `KnownArgs.path` resolved (e.g.
+ * `["proposal", "extract"]` for the flag's CURRENT location, not any retired
+ * top-level spelling — that command-level retirement is already handled by
+ * {@link retiredCommandHint} before flag scanning ever runs).
+ */
+const RETIRED_FLAG_HINTS: Record<string, string> = {
+  "index --background": "`--background` was removed in 0.9 — the flag never actually backgrounded; use `--quiet`.",
+  "setup --detect-only":
+    "`--detect-only` was removed in 0.9 — environment detection runs inside `akm setup`; `akm info` reports the configured capabilities.",
+  "setup --reset-recommended":
+    "`--reset-recommended` was removed in 0.9 — `akm setup` now offers to apply recommended defaults interactively.",
+  "proposal extract --watch":
+    "`--watch` was removed in 0.9 — schedule `akm proposal extract --auto` as a task instead.",
+  "proposal extract --debounce-ms":
+    "`--debounce-ms` was removed in 0.9 — schedule `akm proposal extract --auto` as a task instead.",
+};
+
+/**
+ * Replacement hint for a retired flag on its current command path, or
+ * undefined when the attempted spelling isn't a known retirement.
+ */
+export function retiredFlagHint(path: readonly string[], attempted: string): string | undefined {
+  const key = `${path.join(" ")} ${attempted}`;
+  const entry = RETIRED_FLAG_HINTS[key];
   return entry === undefined ? undefined : `${entry} ${MIGRATION_POINTER}`;
 }

--- a/src/cli/unknown-flags.ts
+++ b/src/cli/unknown-flags.ts
@@ -34,6 +34,7 @@ import {
   findCittyTopLevelCommandIndex,
   toAliasArray,
 } from "./invocation";
+import { retiredFlagHint } from "./retired-commands";
 
 /** The structural subset of a citty command this module reads. */
 export interface FlagScanCommand {
@@ -192,6 +193,15 @@ export function closestMatch(attempted: string, candidates: readonly string[], t
  * @param attempted  The spelling to edit-distance against `--long` candidates.
  */
 function throwUnknownFlag(shown: string, attempted: string, known: KnownArgs): never {
+  // Flags the 0.9 overhaul removed outright get their retirement note, not a
+  // did-you-mean — same reasoning as `retiredCommandHint` in src/cli.ts:
+  // edit distance can point at an unrelated survivor rather than the real
+  // replacement procedure (e.g. `index --background` is closer to no other
+  // `index` flag than it is to any useful suggestion).
+  const retired = retiredFlagHint(known.path, attempted);
+  if (retired) {
+    throw new UsageError(`Unknown flag "${shown}".`, "UNKNOWN_FLAG", retired);
+  }
   const threshold = Math.max(2, Math.ceil(attempted.length / 3));
   const suggestion = closestMatch(attempted, known.displayNames, threshold);
   throw new UsageError(

--- a/src/commands/agent/contribute-cli.ts
+++ b/src/commands/agent/contribute-cli.ts
@@ -207,7 +207,7 @@ export const lintCommand = defineCommand({
   },
   async run({ args }) {
     await runWithJsonErrors(async () => {
-      const result = akmLint({
+      const result = await akmLint({
         fix: args.fix === true || getHyphenatedBoolean(args, "auto-fix"),
         dir: getStringArg(args, "dir"),
         typeFilter: getStringArg(args, "type"),

--- a/src/commands/improve/preparation.ts
+++ b/src/commands/improve/preparation.ts
@@ -845,7 +845,7 @@ export async function runImprovePreparationStage(args: {
   let lintSummary: { fixed: number; flagged: number } | undefined;
   if (primaryStashDir) {
     try {
-      const lintResult = akmLint({ fix: false, dir: primaryStashDir });
+      const lintResult = await akmLint({ fix: false, dir: primaryStashDir });
       lintSummary = { fixed: lintResult.summary.fixed, flagged: lintResult.summary.flagged };
     } catch {
       // lint is best-effort; never block improve

--- a/src/commands/lint/index.ts
+++ b/src/commands/lint/index.ts
@@ -15,16 +15,21 @@ import {
   workflowStructureDiagnostics,
 } from "../../core/adapter/adapters/akm-lint";
 import { detectAdapterId } from "../../core/adapter/detect-adapter";
+import { adapterForId } from "../../core/adapter/registry";
+import type { Diagnostic } from "../../core/adapter/types";
+import { createValidateContext } from "../../core/adapter/validate-context";
 import { stashDirFor } from "../../core/asset/asset-placement";
-import { parseFrontmatter, parseFrontmatterBlock } from "../../core/asset/frontmatter";
+import { parseFrontmatter } from "../../core/asset/frontmatter";
 import { conceptIdForStashFile, displayRefForConceptId } from "../../core/asset/resolve-ref";
+import { deriveBundleIds } from "../../core/bundle-id";
 import { resolveStashDir } from "../../core/common";
 import type { AkmConfig } from "../../core/config/config";
 import { loadConfig, primaryBundlePath } from "../../core/config/config";
-import { resolveSourceEntries } from "../../indexer/search/search-source";
+import type { FileChange } from "../../core/file-change";
+import { resolveSourceEntries, type SearchSource } from "../../indexer/search/search-source";
 import { runBaseChecks } from "./base-linter";
 import { checkEnvForDangerousKeys } from "./env-key-rules";
-import type { LintContext, LintIssue } from "./types";
+import type { LintContext, LintIssue, LintIssueType } from "./types";
 
 // ── Public API types (re-exported for consumers) ──────────────────────────────
 
@@ -89,37 +94,155 @@ function collectMarkdownFiles(dir: string, caseInsensitive = false): string[] {
   return results;
 }
 
-function lintOkfBundle(stashRoot: string): AkmLintResult {
-  const flagged: LintIssue[] = [];
-  for (const filePath of collectMarkdownFiles(stashRoot, true)) {
-    const basename = path.basename(filePath).toLowerCase();
-    if (basename === "index.md" || basename === "log.md") continue;
-    const relPath = path.relative(stashRoot, filePath);
-    let validMappingWithType = false;
+// ── Non-akm adapter dispatch (real `adapter.validate()`, not a re-implementation) ──
+//
+// akm 0.9.0 lint/adapter-dispatch wiring: `akm lint` used to special-case
+// exactly one non-akm adapter (`okf`, via a hand-rolled `missing-type`-only
+// `lintOkfBundle` re-implementation this change deletes) and silently route
+// every OTHER non-akm bundle (llm-wiki, dotenv, claude, opencode,
+// agent-skills, website-snapshot, generic-files, akm-task, akm-workflow)
+// through the AKM-shaped STASH_SUBDIRS sweep — the wrong linter for the wrong
+// format, and the reason those adapters' own `validate()` checks (OKF's
+// `missing-ref`; llm-wiki's `uncited-raw`/`missing-description`/`broken-xref`/
+// `broken-source`) were unreachable dead code. Every bundle is now linted by
+// its OWN configured/detected adapter's `validate()` — the single definition
+// of that format's rules, shared with the (now also wired, advisory-only)
+// change-transaction pre-commit gate in `commands/proposal/repository.ts`.
+// This is intentionally the ONLY branch this module adds: the `akm` sweep
+// below is completely untouched (pinned by the goldens/test suite —
+// CRITICAL: akm findings/`--fix` must not move).
+
+/**
+ * Case-insensitive SUFFIX match against an adapter's declared `extensions`
+ * hint. Deliberately NOT `path.extname()`: Node's `extname(".env")` is `""`
+ * (a leading-dot-only basename has no "extension" by that definition), which
+ * would silently skip every bare `env/.env` file — exactly the shape
+ * `dotenvAdapter`'s own `classify()` (and the akm adapter's env recognition)
+ * match by plain `endsWith`, not `path.extname`. A suffix match is also a
+ * strict superset of the `path.extname` behavior for a normal `name.ext`
+ * file, so nothing that matched before stops matching.
+ */
+function matchesAdapterExtension(fileName: string, extensions: readonly string[]): boolean {
+  const lower = fileName.toLowerCase();
+  return extensions.some((candidate) => lower.endsWith(candidate.toLowerCase()));
+}
+
+/** Walk the whole bundle tree, collecting every file whose extension the adapter recognizes (skip `.git`, symlinks, cache/registry copies). */
+function collectAdapterFiles(root: string, extensions: readonly string[]): string[] {
+  if (!fs.existsSync(root)) return [];
+  const results: string[] = [];
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
     try {
-      const block = parseFrontmatterBlock(fs.readFileSync(filePath, "utf8"));
-      if (block) {
-        const data = parseYaml(block.frontmatter) as unknown;
-        validMappingWithType =
-          typeof data === "object" &&
-          data !== null &&
-          !Array.isArray(data) &&
-          typeof (data as Record<string, unknown>).type === "string" &&
-          ((data as Record<string, unknown>).type as string).trim().length > 0;
-      }
+      entries = fs.readdirSync(dir, { withFileTypes: true });
     } catch {
-      validMappingWithType = false;
+      return;
     }
-    if (!validMappingWithType) {
-      flagged.push({
-        file: relPath,
-        issue: "missing-type",
-        detail: "OKF concepts require parseable mapping frontmatter with a non-empty type.",
-        fixed: false,
-      });
+    for (const entry of entries) {
+      if (entry.name === ".git" || entry.isSymbolicLink()) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && matchesAdapterExtension(entry.name, extensions)) {
+        if (full.includes("/.cache/") || full.includes("/registry/")) continue;
+        results.push(full);
+      }
+    }
+  };
+  walk(root);
+  return results;
+}
+
+/**
+ * Every closed {@link LintIssueType} member a current adapter `validate()` can
+ * legitimately emit. Anything outside this set folds onto `"adapter-diagnostic"`
+ * (see `types.ts`'s doc comment on that member) rather than being dropped.
+ */
+const KNOWN_ADAPTER_ISSUE_TYPES: ReadonlySet<string> = new Set<LintIssueType>([
+  "unquoted-colon",
+  "missing-updated",
+  "stale-path",
+  "missing-ref",
+  "missing-type",
+  "missing-name-or-type",
+  "missing-skill-md",
+  "dangerous-env-key",
+  "uncited-raw",
+  "missing-description",
+  "broken-xref",
+  "broken-source",
+]);
+
+/** Map one adapter {@link Diagnostic} onto a {@link LintIssue} — see `types.ts`'s `"adapter-diagnostic"` doc comment for the open→closed reconciliation. */
+export function diagnosticToLintIssue(diag: Diagnostic): LintIssue {
+  if (KNOWN_ADAPTER_ISSUE_TYPES.has(diag.issue)) {
+    return { file: diag.file, issue: diag.issue as LintIssueType, detail: diag.detail, fixed: diag.fixed };
+  }
+  return { file: diag.file, issue: "adapter-diagnostic", detail: `[${diag.issue}] ${diag.detail}`, fixed: diag.fixed };
+}
+
+/**
+ * Lint a bundle through its OWN adapter's `validate()` (spec §12.1): the
+ * adapter never writes, so every finding lands in `flagged` — `fixed` is
+ * always `false`/`"failed"` for a non-akm bundle regardless of `--fix`
+ * (the CLI option is silently a no-op here, exactly as it already was for
+ * `okf` before this change).
+ */
+async function lintViaAdapter(
+  adapterId: string,
+  stashRoot: string,
+  extraStashRoots: string[],
+  sources: SearchSource[],
+  cfg: AkmConfig,
+  options: AkmLintOptions,
+): Promise<AkmLintResult> {
+  const adapter = adapterForId(adapterId);
+  // Defensive fallback (shouldn't happen via `detectAdapterId`/a valid config
+  // — both only ever name a registered built-in): an unregistered adapter id
+  // falls back to the akm-shaped sweep, the same default `akm lint` has
+  // always applied to a bundle it can't otherwise place.
+  if (!adapter) return lintAkmSweep(stashRoot, extraStashRoots, cfg, sources, options);
+
+  const files = collectAdapterFiles(stashRoot, adapter.extensions);
+  const changes: FileChange[] = files.map((filePath) => ({
+    path: path.relative(stashRoot, filePath).replace(/\\/g, "/"),
+    op: "update",
+  }));
+  const ids = deriveBundleIds(sources);
+  const sourceIndex = sources.findIndex((s) => path.resolve(s.path) === path.resolve(stashRoot));
+  const componentId = sourceIndex >= 0 ? (ids[sourceIndex] as string) : stashRoot;
+
+  const ctx = createValidateContext({ root: stashRoot, extraRoots: extraStashRoots });
+  const diagnostics = await adapter.validate(
+    { id: componentId, adapter: adapterId, root: stashRoot, writable: true },
+    changes,
+    ctx,
+  );
+
+  const flagged = diagnostics.map(diagnosticToLintIssue);
+  // The cross-bundle env dangerous-key sweep (see `runEnvDangerousKeyPass`'s
+  // doc comment) ran for every non-akm adapter via the STASH_SUBDIRS
+  // fallthrough this dispatch replaces — EXCEPT `okf`, which the old code
+  // special-cased out before ever reaching that pass. Preserve both halves of
+  // that history exactly: skip only for `okf`. Some adapters (`dotenv`) ALSO
+  // find the same `dangerous-env-key` findings natively through their own
+  // `validate()` (reusing the same `dangerousEnvKeyDiagnostics` rule) — dedupe
+  // by `(file, issue, detail)` so a bundle covered both ways reports each
+  // finding once, not twice.
+  if (adapterId !== "okf") {
+    const seen = new Set(flagged.map(lintIssueDedupeKey));
+    for (const issue of runEnvDangerousKeyPass(stashRoot, extraStashRoots, sources, cfg)) {
+      const key = lintIssueDedupeKey(issue);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      flagged.push(issue);
     }
   }
   return { ok: true, fixed: [], flagged, summary: { fixed: 0, flagged: flagged.length } };
+}
+
+function lintIssueDedupeKey(issue: LintIssue): string {
+  return `${issue.file} ${issue.issue} ${issue.detail}`;
 }
 
 function collectEnvFiles(dir: string): string[] {
@@ -134,6 +257,50 @@ function collectEnvFiles(dir: string): string[] {
     /* dir may not exist */
   }
   return results;
+}
+
+/**
+ * Scan every `env/`/`secrets/` `.env` file across `[stashRoot, ...extraStashRoots]`
+ * for keys that are known to enable process-execution hijacking. This is a
+ * cross-bundle SECURITY sweep, not per-adapter validation — it has always run
+ * regardless of which format family a given root's OWN files are (verbatim
+ * extraction of the pass `lintAkmSweep` still runs inline; kept byte-identical
+ * there per the CRITICAL akm-path constraint, and reused here for the
+ * non-akm dispatch path so a non-akm PRIMARY bundle keeps the exact
+ * cross-bundle coverage it already had — the pass previously reached every
+ * non-akm adapter's bundle via the accidental STASH_SUBDIRS fallthrough this
+ * change replaces with real dispatch).
+ */
+function runEnvDangerousKeyPass(
+  stashRoot: string,
+  extraStashRoots: string[],
+  sources: SearchSource[],
+  cfg: AkmConfig,
+): LintIssue[] {
+  const flagged: LintIssue[] = [];
+  const envRoots = [stashRoot, ...extraStashRoots];
+  const bundleIdByRoot = new Map(sources.map((source) => [path.resolve(source.path), source.registryId]));
+  for (const root of envRoots) {
+    const bundleId = bundleIdByRoot.get(path.resolve(root));
+    // `env` assets live under `env/`, whole-file `secret` assets under
+    // `secrets/`. `displayRefForConceptId` owns the short-default /
+    // qualified-secondary `Ref:` spelling `akm show` emits — the old
+    // hand-built `env:<base>` colon grammar is rejected by the 0.9.0 ref
+    // parser, which dead-ended a user copying the ref off a security finding.
+    for (const assetType of ["env", "secret"] as const) {
+      const dir = path.join(root, stashDirFor(assetType) as string);
+      if (!fs.existsSync(dir)) continue;
+      for (const envPath of collectEnvFiles(dir)) {
+        const conceptId = conceptIdForStashFile(assetType, root, envPath);
+        const ref = displayRefForConceptId(conceptId, bundleId, cfg.defaultBundle);
+        const relPath = path.relative(root, envPath);
+        for (const issue of checkEnvForDangerousKeys(envPath, relPath, ref)) {
+          flagged.push(issue);
+        }
+      }
+    }
+  }
+  return flagged;
 }
 
 /** True when the issue represents a file deletion that was successfully applied. */
@@ -255,20 +422,23 @@ export function lintAssetFile(ctx: LintContext, subdir: string): LintIssue[] {
 
 // ── Main ──────────────────────────────────────────────────────────────────────
 
-export function akmLint(options: AkmLintOptions = {}): AkmLintResult {
-  // Collect secondary stash roots from configured filesystem sources so that
-  // cross-stash refs (e.g. referencing assets in dimm-city/agent-stash) are
-  // not falsely flagged as missing-ref.
-  const cfg = options.config ?? loadConfig();
-  // 0.9.0 (spec §10.1): the primary stash is the defaultBundle's path.
-  const stashRoot = options.dir ?? primaryBundlePath(cfg) ?? resolveStashDir();
-  const sources = resolveSourceEntries(stashRoot, cfg);
-  const configuredAdapter = sources.find((source) => path.resolve(source.path) === path.resolve(stashRoot))?.adapterId;
-  const adapterId = configuredAdapter ?? detectAdapterId(stashRoot);
-  if (adapterId === "okf") return lintOkfBundle(stashRoot);
-  const extraStashRoots = sources.map((s) => s.path).filter((p) => p !== stashRoot && fs.existsSync(p));
-
-  const fix = adapterId === "akm" && options.fix === true;
+/**
+ * The `akm`-adapter sweep: STASH_SUBDIRS walk + per-file `lintAssetFile` +
+ * the env dangerous-key pass. UNTOUCHED by the adapter-dispatch wiring above
+ * (CRITICAL CONSTRAINT — the overwhelming majority of real bundles use `akm`,
+ * and its findings / `--fix` behavior / exact `LintIssueType` codes are
+ * pinned by goldens + a large test suite). Only reached when the resolved
+ * adapter id is `"akm"` (or, defensively, an unregistered adapter id —
+ * see {@link lintViaAdapter}'s fallback).
+ */
+function lintAkmSweep(
+  stashRoot: string,
+  extraStashRoots: string[],
+  cfg: AkmConfig,
+  sources: SearchSource[],
+  options: AkmLintOptions,
+): AkmLintResult {
+  const fix = options.fix === true;
   const fixed: LintIssue[] = [];
   const flagged: LintIssue[] = [];
 
@@ -356,28 +526,7 @@ export function akmLint(options: AkmLintOptions = {}): AkmLintResult {
   // Scan every `.env` file under <stashRoot>/env/ across all stash roots for
   // keys that are known to enable process-execution hijacking. Warn-only —
   // findings go into `flagged`, never `fixed`.
-  const envRoots = [stashRoot, ...extraStashRoots];
-  const bundleIdByRoot = new Map(sources.map((source) => [path.resolve(source.path), source.registryId]));
-  for (const root of envRoots) {
-    const bundleId = bundleIdByRoot.get(path.resolve(root));
-    // `env` assets live under `env/`, whole-file `secret` assets under
-    // `secrets/`. `displayRefForConceptId` owns the short-default /
-    // qualified-secondary `Ref:` spelling `akm show` emits — the old
-    // hand-built `env:<base>` colon grammar is rejected by the 0.9.0 ref
-    // parser, which dead-ended a user copying the ref off a security finding.
-    for (const assetType of ["env", "secret"] as const) {
-      const dir = path.join(root, stashDirFor(assetType) as string);
-      if (!fs.existsSync(dir)) continue;
-      for (const envPath of collectEnvFiles(dir)) {
-        const conceptId = conceptIdForStashFile(assetType, root, envPath);
-        const ref = displayRefForConceptId(conceptId, bundleId, cfg.defaultBundle);
-        const relPath = path.relative(root, envPath);
-        for (const issue of checkEnvForDangerousKeys(envPath, relPath, ref)) {
-          flagged.push(issue);
-        }
-      }
-    }
-  }
+  flagged.push(...runEnvDangerousKeyPass(stashRoot, extraStashRoots, sources, cfg));
 
   // `ok` reflects whether the lint run completed successfully — NOT whether
   // it found anything. Findings are surfaced via `summary.flagged`; the CLI
@@ -394,4 +543,31 @@ export function akmLint(options: AkmLintOptions = {}): AkmLintResult {
     flagged,
     summary: { fixed: fixed.length, flagged: flagged.length },
   };
+}
+
+/**
+ * Lint the resolved bundle at `options.dir` (default: the primary bundle).
+ * Dispatches to the bundle's OWN adapter: the `akm` sweep for `"akm"`
+ * (unchanged), or {@link lintViaAdapter} — a real `adapter.validate()` call —
+ * for every other configured/detected adapter id (OKF, llm-wiki, dotenv,
+ * claude, opencode, agent-skills, website-snapshot, generic-files, akm-task,
+ * akm-workflow). `async` because `BundleAdapter.validate()` is async by
+ * interface contract (`core/adapter/bundle-adapter.ts`); every existing
+ * caller already runs inside an async context (`commands/agent/contribute-cli.ts`,
+ * `commands/improve/preparation.ts`) or is a test that can `await` it.
+ */
+export async function akmLint(options: AkmLintOptions = {}): Promise<AkmLintResult> {
+  // Collect secondary stash roots from configured filesystem sources so that
+  // cross-stash refs (e.g. referencing assets in dimm-city/agent-stash) are
+  // not falsely flagged as missing-ref.
+  const cfg = options.config ?? loadConfig();
+  // 0.9.0 (spec §10.1): the primary stash is the defaultBundle's path.
+  const stashRoot = options.dir ?? primaryBundlePath(cfg) ?? resolveStashDir();
+  const sources = resolveSourceEntries(stashRoot, cfg);
+  const configuredAdapter = sources.find((source) => path.resolve(source.path) === path.resolve(stashRoot))?.adapterId;
+  const adapterId = configuredAdapter ?? detectAdapterId(stashRoot);
+  const extraStashRoots = sources.map((s) => s.path).filter((p) => p !== stashRoot && fs.existsSync(p));
+
+  if (adapterId !== "akm") return lintViaAdapter(adapterId, stashRoot, extraStashRoots, sources, cfg, options);
+  return lintAkmSweep(stashRoot, extraStashRoots, cfg, sources, options);
 }

--- a/src/commands/lint/index.ts
+++ b/src/commands/lint/index.ts
@@ -144,7 +144,11 @@ function collectAdapterFiles(root: string, extensions: readonly string[]): strin
       if (entry.isDirectory()) {
         walk(full);
       } else if (entry.isFile() && matchesAdapterExtension(entry.name, extensions)) {
-        if (full.includes("/.cache/") || full.includes("/registry/")) continue;
+        // Compare PATH SEGMENTS, not raw substrings: `path.join` yields `\` on
+        // Windows so a `"/.cache/"` substring test never matches there, and a
+        // substring test would also skip a legitimately-named `registry` file.
+        const segments = path.relative(root, full).split(/[\\/]/);
+        if (segments.includes(".cache") || segments.includes("registry")) continue;
         results.push(full);
       }
     }

--- a/src/commands/lint/types.ts
+++ b/src/commands/lint/types.ts
@@ -15,7 +15,30 @@ export type LintIssueType =
   | "missing-ref"
   | "dangerous-env-key"
   | "invalid-workflow-structure"
-  | "missing-category";
+  | "missing-category"
+  // ── non-akm adapter `validate()` codes (akm 0.9.0 lint/adapter-dispatch wiring) ──
+  //
+  // These four are `llm-wiki`'s native structural checks
+  // (`core/adapter/adapters/llm-wiki-adapter.ts`), reachable now that `akm lint`
+  // dispatches every non-akm bundle through its OWN adapter's `validate()`
+  // instead of the akm-shaped per-file sweep. `missing-type` / `missing-ref`
+  // above are shared with `okf` (already closed members of this union).
+  | "uncited-raw"
+  | "missing-description"
+  | "broken-xref"
+  | "broken-source"
+  /**
+   * Fallback for a `Diagnostic.issue` code this union does not (yet) name.
+   * `Diagnostic.issue` (`core/adapter/types.ts`) is deliberately an OPEN
+   * `string` — any current or future `BundleAdapter.validate()` may emit a
+   * code this closed lint-command union has never heard of. Rather than
+   * silently dropping that finding (or throwing at the CLI boundary), the
+   * lint→adapter mapping (`commands/lint/index.ts#diagnosticToLintIssue`)
+   * folds an unrecognized code onto this member and preserves the ORIGINAL
+   * code in `detail` (prefixed `[<issue>] `) so nothing an adapter reports is
+   * ever lost, even though the closed union can't type it precisely.
+   */
+  | "adapter-diagnostic";
 
 export interface LintIssue {
   file: string;

--- a/src/commands/migrate-cli.ts
+++ b/src/commands/migrate-cli.ts
@@ -11,11 +11,14 @@ const configArg = {
 };
 
 export const migrateCommand = defineGroupCommand({
-  // Hidden from `--help` and the completions walker (S11): this is the
-  // self-update contract's internal command, not a surface end users
-  // discover by browsing help. `akm migrate status`/`apply` still execute
-  // normally — `hidden` only affects listing.
-  meta: { name: "migrate", hidden: true, description: "Inspect or apply config and durable database migrations" },
+  // S11 originally hid this from `--help`/completions as an internal,
+  // self-update-only surface. That made it undiscoverable even though the
+  // 0.9.0 upgrade instructions tell users to run it first (`akm migrate
+  // status`, `akm migrate apply`) — the one command those instructions
+  // depend on was invisible. Listed in the SYSTEM section of HELP_SECTIONS
+  // (src/cli.ts) and in shell completions now; `akm migrate status`/`apply`
+  // always executed regardless of `hidden`.
+  meta: { name: "migrate", description: "Inspect or apply config and durable database migrations" },
   subCommands: {
     status: defineJsonCommand({
       meta: { name: "status", description: "Read-only cross-artifact migration eligibility check" },

--- a/src/commands/migrate-cli.ts
+++ b/src/commands/migrate-cli.ts
@@ -2,13 +2,71 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { defineGroupCommand, defineJsonCommand } from "../cli/shared";
+import { defineGroupCommand, defineJsonCommand, output } from "../cli/shared";
 import { runMigrationTool } from "./migration-tool";
 
 const configArg = {
   type: "string" as const,
   description: "Complete operator-prepared current config; optional when the active config is current",
 };
+
+/**
+ * Split the standalone `akm-migrate` tool's captured stdout into its
+ * progress-event lines (if any — `apply` prints one JSON line per completed
+ * sub-step, e.g. content migration / proposal-ref repair) and its final
+ * result line. `status` and `apply --dry-run` never print progress, so
+ * `progress` is empty for them; `apply` may print zero or more.
+ *
+ * Each `console.log` call in the child produces exactly one `\n`-terminated
+ * line, so splitting on `\n` and dropping the trailing empty entry from the
+ * final newline recovers exactly the lines it printed, in order.
+ */
+function splitToolStdout(stdout: string): { progress: string[]; resultLine?: string } {
+  const lines = stdout.split("\n");
+  if (lines.length > 0 && lines.at(-1) === "") lines.pop();
+  if (lines.length === 0) return { progress: [] };
+  return { progress: lines.slice(0, -1), resultLine: lines.at(-1) };
+}
+
+/**
+ * Runs the standalone `akm-migrate` tool and renders its result through the
+ * normal `--format` pipeline (D7) instead of a fixed JSON passthrough.
+ *
+ * The child's progress-event lines (if any) are not part of the result
+ * envelope — they print as-is, in order, regardless of `--format`, the same
+ * way `apply` always printed them before this change. Only the final result
+ * line — always a well-formed `MigrationPlan` JSON object — is parsed and
+ * handed to `output()`, so `text`/`md`/`html`/`yaml` render a real
+ * (registered or generic) rendering of it instead of silently staying JSON.
+ * `--format json` (the default) is therefore the only format whose BYTES can
+ * change here (pretty-printed via `output()` instead of the child's compact
+ * `JSON.stringify`) — every value stays identical, which is what the
+ * migration-lifecycle integration tests assert via `JSON.parse`.
+ */
+async function runMigrateSubcommand(command: "migrate-status" | "migrate-apply", args: string[]): Promise<void> {
+  const result = await runMigrationTool(args);
+  if (result.stderr) process.stderr.write(result.stderr);
+
+  const { progress, resultLine } = splitToolStdout(result.stdout);
+  for (const line of progress) console.log(line);
+  if (resultLine !== undefined) {
+    try {
+      output(command, JSON.parse(resultLine));
+    } catch {
+      // The child is expected to always print one well-formed JSON result
+      // line; if it somehow didn't, don't lose the line, just don't reshape it.
+      console.log(resultLine);
+    }
+  }
+
+  // R-067: `process.exitCode = …; return;` (not `process.exit()`) so the
+  // command's normal cleanup (`disposeDispatchResources()` in `runCommand`,
+  // src/cli.ts) still runs before the process exits with the child's status.
+  if (result.status !== 0) {
+    process.exitCode = result.status;
+    return;
+  }
+}
 
 export const migrateCommand = defineGroupCommand({
   // S11 originally hid this from `--help`/completions as an internal,
@@ -24,7 +82,7 @@ export const migrateCommand = defineGroupCommand({
       meta: { name: "status", description: "Read-only cross-artifact migration eligibility check" },
       args: { config: configArg },
       run({ args }) {
-        return runMigrationTool(["status", ...(args.config ? ["--config", args.config] : [])]);
+        return runMigrateSubcommand("migrate-status", ["status", ...(args.config ? ["--config", args.config] : [])]);
       },
     }),
     apply: defineJsonCommand({
@@ -45,7 +103,7 @@ export const migrateCommand = defineGroupCommand({
         },
       },
       run({ args }) {
-        return runMigrationTool([
+        return runMigrateSubcommand("migrate-apply", [
           "apply",
           ...(args.config ? ["--config", args.config] : []),
           ...(args.dryRun ? ["--dry-run"] : []),

--- a/src/commands/migration-tool.ts
+++ b/src/commands/migration-tool.ts
@@ -17,7 +17,21 @@ function migrationEntryPoint(): string | undefined {
   return candidates.find((candidate) => fs.existsSync(candidate));
 }
 
-export async function runMigrationTool(args: readonly string[]): Promise<void> {
+/** The standalone `akm-migrate` child process's captured exit status and output streams. */
+export interface MigrationToolResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Spawns the standalone `akm-migrate` tool and returns its captured exit
+ * status plus stdout/stderr — never writes them itself. `migrate-cli.ts`'s
+ * `status`/`apply` commands use this to reshape the child's final JSON result
+ * line through the normal `--format` pipeline (D7) while any earlier
+ * progress-event lines the child printed still go through verbatim.
+ */
+export async function runMigrationTool(args: readonly string[]): Promise<MigrationToolResult> {
   const entry = migrationEntryPoint();
   if (!entry && process.env.AKM_MIGRATE_ENTRY === "1") {
     // Re-exec loop guard: we ARE the marked child, yet no migrator entry
@@ -48,18 +62,5 @@ export async function runMigrationTool(args: readonly string[]): Promise<void> {
       "Reinstall akm-cli, or use a runtime-free standalone release binary.",
     );
   }
-  if (result.stdout) process.stdout.write(result.stdout);
-  if (result.stderr) process.stderr.write(result.stderr);
-  // R-067: was `process.exit(result.status ?? 1)` on the failure branch,
-  // which terminates the process synchronously and skips the `finally {
-  // await disposeDispatchResources(); }` cleanup in src/cli.ts's
-  // `runCommand`. The success path (status === 0) was already fine — it
-  // just returns and the process exits 0 naturally. Setting
-  // `process.exitCode` and returning still propagates the child's exact
-  // non-zero status once the event loop drains, but lets cleanup run first —
-  // same pattern `emitJsonError` (src/cli/shared.ts) already established.
-  if (result.status !== 0) {
-    process.exitCode = result.status ?? 1;
-    return;
-  }
+  return { status: result.status ?? 1, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
 }

--- a/src/commands/proposal/repository.ts
+++ b/src/commands/proposal/repository.ts
@@ -39,6 +39,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { parse as parseYaml } from "yaml";
+import { adapterForId } from "../../core/adapter/registry";
+import { createValidateContext } from "../../core/adapter/validate-context";
 import { ensureAkmMarkdownType } from "../../core/asset/akm-markdown";
 import { assetPathForName, placementTypes, stashDirFor } from "../../core/asset/asset-placement";
 import { isBundleSlug, parseBundleRef } from "../../core/asset/asset-ref";
@@ -2190,6 +2192,77 @@ export function preflightProposalPromotion(
   return { proposal: preparedProposal, repairedContent, ref, target, assetPath, stampedContent };
 }
 
+/**
+ * The change-transaction pre-commit gate — the `BundleAdapter.validate()`
+ * interface contract's OTHER stated consumer (`core/adapter/bundle-adapter.ts`
+ * doc comment, alongside `lint --fix`). Runs the target's OWN adapter's
+ * `validate()` over the ONE pending write `preflight` describes, with a
+ * {@link createValidateContext} overlay carrying the proposal's about-to-be-
+ * written bytes — so the adapter sees the bundle AS IT WOULD LOOK the instant
+ * after this transaction commits, without ever touching disk.
+ *
+ * DELIBERATELY ADVISORY, not blocking (see the report for the full
+ * rationale): the akm adapter's `missing-ref` check resolves prose refs
+ * through the SAME core overlay `resolveRef` that closes the OKF/llm-wiki
+ * lint gaps — and that resolver is proven to disagree with the legacy
+ * `commands/lint/base-linter.ts#checkMissingRefs` resolver in one specific,
+ * real case: a fully-qualified `bundle//conceptId` prose ref (or a bare
+ * frontmatter xref) whose leading segment does NOT name a registered AKM
+ * placement type. The legacy resolver treats an unrecognized type prefix as
+ * "not a locally-checkable ref, skip it, never flag missing" (whole-hearted
+ * leniency for cross-bundle / foreign-format refs); this module's core
+ * resolver additionally tries the ref as a literal on-disk path — the
+ * resolution non-akm adapters (OKF, llm-wiki) actually NEED for their own
+ * same-component conceptIds — which means it CAN report `missing-ref` for a
+ * foreign-typed prose ref the legacy checker always let through. Promoting a
+ * proposal is a live, user-facing write path; blocking it on a diagnostic
+ * that can disagree with the existing (already-tested, already-run)
+ * `promotionLintBlockers` gate a few lines above is not a change to make
+ * without a dedicated equivalence pass first. So: this computes and surfaces
+ * the finding (visible via `warn`, and never thrown) without changing whether
+ * ANY promotion succeeds or fails — proving the wiring end-to-end on real
+ * proposal data while leaving today's blocking behavior completely
+ * untouched. Never throws: a validate() failure here must not corrupt or
+ * half-apply the transaction that follows.
+ */
+async function runAdapterPreCommitCheck(config: AkmConfig, preflight: ProposalPromotionPreflight): Promise<void> {
+  try {
+    const adapterId = preflight.target.source.adapterId ?? "akm";
+    const adapter = adapterForId(adapterId);
+    if (!adapter) return;
+
+    const root = preflight.target.source.path;
+    const relPath = path.relative(root, preflight.assetPath).replace(/\\/g, "/");
+    if (!relPath || relPath.startsWith("..")) return; // resolved outside its own bundle root — nothing to check
+    const change: FileChange = {
+      path: relPath,
+      after: preflight.stampedContent,
+      op: fs.existsSync(preflight.assetPath) ? "update" : "create",
+    };
+    const extraRoots = resolveSourceEntries(root, config)
+      .map((source) => source.path)
+      .filter((sourcePath) => path.resolve(sourcePath) !== path.resolve(root));
+    const componentCtx = createValidateContext({ root, extraRoots, changes: [change] });
+    const diagnostics = await adapter.validate(
+      { id: preflight.target.selector ?? adapterId, adapter: adapterId, root, writable: true },
+      [change],
+      componentCtx,
+    );
+    if (diagnostics.length > 0) {
+      const summary = diagnostics.map((d) => `[${d.issue}] ${d.detail}`).join("; ");
+      warn(`[proposal] pre-commit adapter check for ${preflight.proposal.id} found (non-blocking): ${summary}`);
+    }
+  } catch (error) {
+    // Advisory only — never let a validate() failure interrupt or corrupt the
+    // promotion transaction that follows.
+    warn(
+      `[proposal] pre-commit adapter check for ${preflight.proposal.id} threw (ignored, non-blocking): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
 async function promoteProposalWithLease(
   stashDir: string,
   config: AkmConfig,
@@ -2262,6 +2335,7 @@ async function promoteProposalWithLease(
     );
   }
   const preflight = preflightProposalPromotion(config, proposal, { ...options, queueTarget: target }, ctx);
+  await runAdapterPreCommitCheck(config, preflight);
 
   const mutationTarget = prepareWriteTargetForMutation(target);
   const assetPath = resolveAssetFilePathSafe(mutationTarget.source, ref);

--- a/src/core/adapter/validate-context.ts
+++ b/src/core/adapter/validate-context.ts
@@ -85,12 +85,33 @@ function readDisk(absPath: string): string | null {
 
 function existsOnDiskOrOverlay(relPath: string, root: string, overlay: Map<string, OverlayValue> | null): boolean {
   const key = toPosix(relPath);
+  // Overlay entries are pending file contents by construction, so a present
+  // non-null entry is always a file.
   if (overlay?.has(key)) return overlay.get(key) !== null;
   try {
-    return fs.existsSync(path.join(root, relPath));
+    // `isFile()`, not `existsSync()`: a ref naming a DIRECTORY (e.g. a
+    // `pages/foo/` dir alongside no `pages/foo.md`) must not count as a
+    // resolved target — that would silently suppress a real
+    // `missing-ref`/`broken-xref` diagnostic.
+    return fs.statSync(path.join(root, relPath)).isFile();
   } catch {
     return false;
   }
+}
+
+/**
+ * Refs come from bundle CONTENT (link targets, xrefs, `sources:` entries), so
+ * they are untrusted input. A ref must stay inside the bundle root: reject
+ * absolute paths and any `..` segment before joining, so content can never
+ * probe for existence outside its own bundle (nor report a resolved `path`
+ * pointing there). Mirrors the `isWithin` containment rule the write path
+ * already enforces in `core/write-source.ts`.
+ */
+function refEscapesBundle(conceptId: string): boolean {
+  if (path.isAbsolute(conceptId) || conceptId.startsWith("/")) return true;
+  return toPosix(conceptId)
+    .split("/")
+    .some((segment) => segment === "..");
 }
 
 /**
@@ -185,6 +206,7 @@ export function createValidateContext(options: ValidateContextOptions): Validate
   async function resolveRef(ref: string): Promise<{ exists: boolean; path?: string }> {
     const conceptId = stripBundlePrefix(stripFragment(ref)).trim();
     if (!conceptId) return { exists: false };
+    if (refEscapesBundle(conceptId)) return { exists: false };
     const candidates = candidateRelPaths(conceptId);
     const roots: Array<{ root: string; usesOverlay: boolean }> = [
       { root, usesOverlay: true },

--- a/src/core/adapter/validate-context.ts
+++ b/src/core/adapter/validate-context.ts
@@ -1,0 +1,204 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * The ONE core {@link ValidateContext} implementation — akm 0.9.0 chunk-2/lint
+ * follow-up ("make `validate()` genuinely load-bearing").
+ *
+ * `BundleAdapter.validate()` (`./bundle-adapter.ts`) is a REQUIRED interface
+ * method whose contract is explicit and normative (`./bundle-adapter.ts:96-100`
+ * / the format-neutral spec §12.1): the adapter MUST NOT write and MUST NOT
+ * read the live filesystem — `ctx` serves the run's on-disk SNAPSHOT WITH the
+ * caller's pending {@link FileChange}s overlaid, plus a read-only `resolveRef`
+ * for link/xref existence. That overlay is meant to be built ONCE, centrally —
+ * "one core overlay implementation, not one per adapter" (the interface's own
+ * words) — so every `validate()` caller shares identical overlay semantics
+ * rather than each hand-rolling its own (as every adapter's own test suite has
+ * done up to now, see e.g. `tests/core/adapter/okf-adapter.test.ts`'s
+ * `overlayCtx`/`diskCtx`).
+ *
+ * The two production callers wired onto this factory:
+ *   - `akm lint`'s non-akm adapter dispatch (`commands/lint/index.ts`) — a
+ *     plain sweep with NO pending changes, so the overlay is empty and every
+ *     read falls straight through to disk.
+ *   - the proposal promotion preflight (`commands/proposal/repository.ts`
+ *     `preflightProposalPromotion`) — the one proposal's own `changes` are the
+ *     overlay, so `validate()` sees the bundle AS IT WOULD LOOK the instant
+ *     after the transaction commits, without that transaction ever touching
+ *     disk.
+ *
+ * ── resolveRef ──
+ *
+ * A bare (unqualified) `conceptId` is resolved as BOTH:
+ *   1. the AKM placement-derived path (`typeNameFromConceptId` + `stashDirFor`
+ *      + `assetPathForName` — the exact derivation `commands/lint/base-linter.ts
+ *      #refToRelPath` already uses for the akm-native `missing-ref` check); and
+ *   2. the DIRECT component-relative spelling (`<conceptId>.md`, and the bare
+ *      `<conceptId>` for an extensionless asset) — the form every non-akm
+ *      adapter's OWN conceptId already IS (OKF: path − `.md`; llm-wiki: same).
+ * A `bundle//conceptId`-qualified ref has its bundle prefix stripped before
+ * resolution — mirroring `base-linter.ts#classifyConceptRef`'s existing
+ * behavior (the legacy resolver has never scoped-by-bundle-name either; it
+ * searches every configured stash root for the bare conceptId). Existence is
+ * checked against the PRIMARY root (with the pending-changes overlay applied)
+ * first, then each extra root (disk only — a pending transaction never
+ * targets more than one bundle).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { assetPathForName, stashDirFor } from "../asset/asset-placement";
+import { typeNameFromConceptId } from "../asset/resolve-ref";
+import type { FileChange } from "../file-change";
+import type { ValidateContext } from "./types";
+
+function toPosix(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+/** `null` = the overlay DELETES this path (never satisfies a read/exists check). */
+type OverlayValue = string | null;
+
+/** Build the overlay map, keyed by POSIX path relative to `root`. */
+function buildOverlay(root: string, changes: readonly FileChange[]): Map<string, OverlayValue> {
+  const overlay = new Map<string, OverlayValue>();
+  for (const change of changes) {
+    const relKey = toPosix(path.isAbsolute(change.path) ? path.relative(root, change.path) : change.path);
+    if (!relKey || relKey.startsWith("..")) continue; // outside root — not this context's concern
+    if (change.op === "delete") {
+      overlay.set(relKey, null);
+      continue;
+    }
+    if (change.after !== undefined) overlay.set(relKey, change.after);
+  }
+  return overlay;
+}
+
+function readDisk(absPath: string): string | null {
+  try {
+    return fs.readFileSync(absPath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function existsOnDiskOrOverlay(relPath: string, root: string, overlay: Map<string, OverlayValue> | null): boolean {
+  const key = toPosix(relPath);
+  if (overlay?.has(key)) return overlay.get(key) !== null;
+  try {
+    return fs.existsSync(path.join(root, relPath));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Every on-disk relative path a bare `conceptId` might resolve to: the AKM
+ * placement-derived path (when the leading segment names a known placement
+ * stash-subdir) and the direct component-relative spellings every non-akm
+ * adapter's own conceptId already uses. Order doesn't matter — the caller
+ * checks all of them.
+ */
+function candidateRelPaths(conceptId: string): string[] {
+  const candidates: string[] = [];
+  const parts = typeNameFromConceptId(conceptId);
+  if (parts !== undefined) {
+    const typeDir = stashDirFor(parts.type);
+    if (typeDir !== undefined) candidates.push(assetPathForName(parts.type, typeDir, parts.name));
+  }
+  candidates.push(`${conceptId}.md`);
+  candidates.push(conceptId);
+  return candidates;
+}
+
+/** Strip an optional `#fragment` (export selector) — never part of the on-disk identity. */
+function stripFragment(ref: string): string {
+  const hashIdx = ref.indexOf("#");
+  return hashIdx >= 0 ? ref.slice(0, hashIdx) : ref;
+}
+
+/**
+ * Strip an optional `bundle//` qualifier. Mirrors `base-linter.ts
+ * #classifyConceptRef`'s existing behavior: the legacy missing-ref checker has
+ * never resolved a qualifier against a NAMED bundle either — it searches every
+ * configured stash root for the bare conceptId. Keeping that same leniency
+ * here means this resolver's answers agree with today's `akm lint` for every
+ * ref shape that already worked.
+ */
+function stripBundlePrefix(ref: string): string {
+  const boundary = ref.indexOf("//");
+  return boundary >= 0 ? ref.slice(boundary + 2) : ref;
+}
+
+export interface ValidateContextOptions {
+  /** The primary root `changes` paths are relative to (a component's root, or a lint sweep's stash root). */
+  root: string;
+  /** Additional stash roots consulted (disk only) for cross-bundle ref existence — mirrors `akmLint`'s `extraStashRoots`. */
+  extraRoots?: readonly string[];
+  /** Pending changes to overlay onto the snapshot. Empty (or omitted) for a plain sweep with nothing pending. */
+  changes?: readonly FileChange[];
+}
+
+/**
+ * Build the ONE core {@link ValidateContext}: reads/lookups served from the
+ * on-disk snapshot rooted at `options.root` (+ `options.extraRoots` for
+ * cross-bundle ref existence) WITH `options.changes` overlaid on `options.root`
+ * — never a write, never a live-FS read beyond that snapshot.
+ */
+export function createValidateContext(options: ValidateContextOptions): ValidateContext {
+  const root = options.root;
+  const extraRoots = options.extraRoots ?? [];
+  const overlay = buildOverlay(root, options.changes ?? []);
+
+  async function readFile(p: string): Promise<string | Uint8Array | null> {
+    // An absolute candidate (e.g. a `stale-path` scan hit, which is always an
+    // absolute host path) bypasses the overlay — it can never name a pending
+    // change's stash-relative path, and reads straight from disk (the base
+    // checks' existing "does this literal absolute path exist" question).
+    if (path.isAbsolute(p)) return readDisk(p);
+    const key = toPosix(p);
+    if (overlay.has(key)) return overlay.get(key) ?? null;
+    return readDisk(path.join(root, p));
+  }
+
+  async function list(dir: string): Promise<string[]> {
+    const abs = path.isAbsolute(dir) ? dir : path.join(root, dir);
+    const relDir = toPosix(path.isAbsolute(dir) ? path.relative(root, dir) : dir);
+    const names = new Set<string>();
+    try {
+      for (const entry of fs.readdirSync(abs)) names.add(entry);
+    } catch {
+      // directory may not exist on disk yet — the overlay can still populate it
+    }
+    const prefix = relDir === "." || relDir === "" ? "" : `${relDir}/`;
+    for (const [key, value] of overlay) {
+      if (prefix.length > 0 && !key.startsWith(prefix)) continue;
+      const rest = prefix.length > 0 ? key.slice(prefix.length) : key;
+      if (rest.length === 0 || rest.includes("/")) continue; // only direct children
+      if (value === null) names.delete(rest);
+      else names.add(rest);
+    }
+    return [...names];
+  }
+
+  async function resolveRef(ref: string): Promise<{ exists: boolean; path?: string }> {
+    const conceptId = stripBundlePrefix(stripFragment(ref)).trim();
+    if (!conceptId) return { exists: false };
+    const candidates = candidateRelPaths(conceptId);
+    const roots: Array<{ root: string; usesOverlay: boolean }> = [
+      { root, usesOverlay: true },
+      ...extraRoots.map((r) => ({ root: r, usesOverlay: false })),
+    ];
+    for (const { root: candidateRoot, usesOverlay } of roots) {
+      for (const relPath of candidates) {
+        if (existsOnDiskOrOverlay(relPath, candidateRoot, usesOverlay ? overlay : null)) {
+          return { exists: true, path: path.join(candidateRoot, relPath) };
+        }
+      }
+    }
+    return { exists: false };
+  }
+
+  return { readFile, list, resolveRef };
+}

--- a/src/core/migration-operation.ts
+++ b/src/core/migration-operation.ts
@@ -37,6 +37,23 @@ export function getMigrationApplyJournalPath(): string {
   return path.join(getMigrationOperationRoot(), "apply-active.json");
 }
 
+/**
+ * Predictable path for the config `akm migrate apply` auto-generates when no
+ * `--config` is given and the active config still carries the pre-cutover
+ * `stashDir`/`sources[]`/`installed[]` shape (see `config-migrate.ts`'s
+ * `buildMigrationPlan`/`writeGeneratedTargetConfig`). Deliberately NOT the
+ * live `config.json` — the live 0.8 file must stay byte-for-byte untouched
+ * until `publishConfigLast` performs its normal atomic install, so the
+ * generated draft lives here instead, next to the apply/restore sentinels.
+ * Stable across invocations (keyed only by installation id, not a run id) so
+ * a second `migrate apply`/`migrate status` with still no `--config` finds
+ * the same file an operator may have hand-edited (e.g. to add `engines`)
+ * after the first run generated it.
+ */
+export function getMigrationGeneratedConfigPath(): string {
+  return path.join(getMigrationOperationRoot(), "generated-config.json");
+}
+
 export function assertNoPendingMigrationOperation(): void {
   for (const [kind, journalPath] of [
     ["restore", getMigrationRestoreJournalPath()],

--- a/src/output/format-exempt.ts
+++ b/src/output/format-exempt.ts
@@ -26,17 +26,17 @@
 const EXEMPT_COMMANDS: ReadonlySet<string> = new Set([
   // Emits shell completion script source for eval.
   "completions",
-  // Both subcommands (`status`, `apply`) are also a child-process passthrough:
-  // `runMigrationTool` (src/commands/migration-tool.ts) spawns the standalone
-  // `scripts/akm-migrate.ts` tool and writes its stdout/stderr verbatim — the
-  // spawned script always emits its own fixed JSON shape and never consults
-  // `--format`. Found while verifying F1 (D7 B1): the finding's repro list
-  // named `akm migrate status --format text` alongside `secret list` as the
-  // SAME defect (missing text renderer inside `output()`), but `migrate
-  // status`/`apply` never reach `output()` at all, so that fix cannot and
-  // does not change their behavior — this is the `env run`/`secret run`
-  // passthrough pattern, not the generic-text-fallback one.
-  "migrate",
+  // `migrate status`/`apply` used to be exempt here too: `runMigrationTool`
+  // (src/commands/migration-tool.ts) spawns the standalone
+  // `scripts/akm-migrate.ts` tool, which always emitted its own fixed JSON
+  // shape and never consulted `--format`. `src/commands/migrate-cli.ts` now
+  // parses that child's final result line and renders it through the normal
+  // `output()` pipeline (registered shape: `src/output/shapes/migrate.ts`;
+  // text renderer: `src/output/text/migrate.ts`), so both subcommands honour
+  // `--format` like any other command and are no longer listed here. Any
+  // progress-event lines the child prints during a real `apply` still print
+  // verbatim ahead of the formatted result — those are operational logging,
+  // not part of the result envelope, the same way a progress spinner would be.
   // Document payload group: bare `help` prints the sectioned overview,
   // `help migrate <version>` prints release notes, and `help agents` prints
   // the embedded CLI-reference guide (`src/output/cli-hints.ts`) — none of

--- a/src/output/generic-render.ts
+++ b/src/output/generic-render.ts
@@ -226,8 +226,16 @@ export function renderGenericHtml(command: string, value: unknown): string {
  * inventing a second convention: the arrays that reach this generic
  * fallback are typically short id/tag lists, where one JSON-array line reads
  * better than N extra `path.0=`, `path.1=`, … lines.
+ *
+ * Exported so command-specific text formatters (e.g. `formatHealthPlain` in
+ * `src/output/text/health-format.ts`) can reuse the SAME scalar-tree
+ * convention for the parts of their envelope that are plain nested
+ * scalars/objects, while overriding just the parts that need bespoke
+ * handling (arrays of status-bearing records, where this function's
+ * one-JSON-line-per-array behavior is the exact defect those formatters
+ * exist to fix). Reuse beats a second flattener.
  */
-function flattenForText(value: unknown, path: string, lines: string[]): void {
+export function flattenForText(value: unknown, path: string, lines: string[]): void {
   if (value === null || value === undefined) {
     lines.push(`${path}=`);
   } else if (Array.isArray(value)) {

--- a/src/output/shapes.ts
+++ b/src/output/shapes.ts
@@ -24,6 +24,7 @@ import type { DetailLevel, ShapeMode } from "./context";
 import { curateShapes } from "./shapes/curate";
 import { envListShapes } from "./shapes/env-list";
 import { eventsShapes } from "./shapes/events";
+import { migrateShapes } from "./shapes/migrate";
 import { passthroughShapes } from "./shapes/passthrough";
 import { proposalAcceptShapes } from "./shapes/proposal/accept";
 import { proposalDiffShapes } from "./shapes/proposal/diff";
@@ -57,6 +58,7 @@ const BUILT_IN_OUTPUT_SHAPES: OutputShapeEntry[] = [
   ...proposalProducerShapes,
   ...envListShapes,
   ...secretListShapes,
+  ...migrateShapes,
   // Passthrough commands are registered last so an explicit dedicated handler
   // above always wins over the identity-stamp fallback for the same name.
   ...passthroughShapes,

--- a/src/output/shapes/migrate.ts
+++ b/src/output/shapes/migrate.ts
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `akm migrate status` / `akm migrate apply` output shape.
+ *
+ * The result is the standalone `akm-migrate` tool's `MigrationPlan` JSON,
+ * parsed straight through from its child-process stdout
+ * (`src/commands/migrate-cli.ts`). Identity — no field trimming and,
+ * deliberately, no `shape`/`schemaVersion` stamp the way
+ * `./passthrough.ts` adds for other identity commands: `migrate status` and
+ * `migrate apply --dry-run` report byte-identical plans for the same
+ * install, and integration tests assert that equality directly on the
+ * parsed JSON — stamping only one of the two command names would break it.
+ */
+import type { OutputShapeEntry } from "./registry";
+
+const identity: OutputShapeEntry["handler"] = (result) => result;
+
+export const migrateShapes: OutputShapeEntry[] = [
+  { command: "migrate-status", handler: identity },
+  { command: "migrate-apply", handler: identity },
+];

--- a/src/output/text.ts
+++ b/src/output/text.ts
@@ -36,9 +36,11 @@ import { curateFormatters } from "./text/curate";
 import { envFormatters } from "./text/env";
 import { eventsFormatters } from "./text/events";
 import { feedbackFormatters } from "./text/feedback";
+import { healthFormatters } from "./text/health";
 import { importFormatters } from "./text/import";
 import { indexFormatters } from "./text/index";
 import { infoFormatters } from "./text/info";
+import { lintFormatters } from "./text/lint";
 import { listFormatters } from "./text/list";
 import { proposalProducerFormatters } from "./text/proposal/producer";
 import { proposalFormatters } from "./text/proposal/proposal";
@@ -77,6 +79,8 @@ const BUILT_IN_TEXT_FORMATTERS: TextFormatterEntry[] = [
   ...proposalFormatters,
   ...proposalProducerFormatters,
   ...infoFormatters,
+  ...healthFormatters,
+  ...lintFormatters,
   ...configFormatters,
   ...feedbackFormatters,
   ...rememberFormatters,

--- a/src/output/text.ts
+++ b/src/output/text.ts
@@ -42,6 +42,7 @@ import { indexFormatters } from "./text/index";
 import { infoFormatters } from "./text/info";
 import { lintFormatters } from "./text/lint";
 import { listFormatters } from "./text/list";
+import { migrateFormatters } from "./text/migrate";
 import { proposalProducerFormatters } from "./text/proposal/producer";
 import { proposalFormatters } from "./text/proposal/proposal";
 import { getTextFormatterHandler, registerTextFormatters, type TextFormatterEntry } from "./text/registry";
@@ -88,6 +89,7 @@ const BUILT_IN_TEXT_FORMATTERS: TextFormatterEntry[] = [
   ...syncFormatters,
   ...registryCommandFormatters,
   ...envFormatters,
+  ...migrateFormatters,
 ];
 
 registerTextFormatters(BUILT_IN_TEXT_FORMATTERS);

--- a/src/output/text/command-format.ts
+++ b/src/output/text/command-format.ts
@@ -19,25 +19,78 @@
 import type { IndexResponse } from "../../indexer/indexer";
 import type { DetailLevel } from "../context";
 
+/**
+ * `akm info`'s real result (`InfoResponse`, `src/sources/types.ts`) carries
+ * `defaultBundle`/`assetTypes`/`searchModes`/`semanticSearch`/`registries`/
+ * `sourceProviders`/`indexStats` — this formatter used to check for
+ * `configPath`/`cacheDir`/`dbPath`/`capabilities`/`index` instead, none of
+ * which `InfoResponse` has ever had, so every one of those `if` guards was
+ * always false and those five real fields silently never appeared in
+ * `--format text` output (the plain fallthrough JSON check three lines below
+ * papered over it: `lines` was never empty because `version`/`bundleDir`
+ * always matched, so the "render everything" escape hatch never fired
+ * either — same class of bug as `akm health`/`akm lint`'s raw-JSON-array
+ * dump: `--format text` claiming to render a shape it wasn't actually
+ * rendering). The legacy field checks stay (harmless no-ops on the current
+ * shape) in case another producer still emits them; the real fields are
+ * added alongside.
+ */
 export function formatInfoPlain(r: Record<string, unknown>): string {
   const lines: string[] = [];
   if (r.version) lines.push(`version: ${String(r.version)}`);
   if (r.bundleDir) lines.push(`bundleDir: ${String(r.bundleDir)}`);
+  if (r.defaultBundle !== undefined) {
+    lines.push(`defaultBundle: ${r.defaultBundle === null ? "(none)" : String(r.defaultBundle)}`);
+  }
   if (r.configPath) lines.push(`configPath: ${String(r.configPath)}`);
   if (r.cacheDir) lines.push(`cacheDir: ${String(r.cacheDir)}`);
   if (r.dbPath) lines.push(`dbPath: ${String(r.dbPath)}`);
+  if (Array.isArray(r.assetTypes) && r.assetTypes.length > 0) {
+    lines.push(`assetTypes: ${(r.assetTypes as unknown[]).join(", ")}`);
+  }
+  if (Array.isArray(r.searchModes) && r.searchModes.length > 0) {
+    lines.push(`searchModes: ${(r.searchModes as unknown[]).join(", ")}`);
+  }
+  const semanticSearch = r.semanticSearch as Record<string, unknown> | undefined;
+  if (semanticSearch) {
+    lines.push("semanticSearch:");
+    for (const [k, v] of Object.entries(semanticSearch)) {
+      lines.push(`  ${k}: ${String(v)}`);
+    }
+  }
+  const registries = Array.isArray(r.registries) ? (r.registries as Array<Record<string, unknown>>) : undefined;
+  if (registries) {
+    lines.push(`registries (${registries.length}):`);
+    for (const reg of registries) {
+      const name = typeof reg.name === "string" ? `${reg.name}: ` : "";
+      const provider = typeof reg.provider === "string" ? ` (${reg.provider})` : "";
+      const disabled = reg.enabled === false ? " [disabled]" : "";
+      lines.push(`  ${name}${String(reg.url ?? "?")}${provider}${disabled}`);
+    }
+  }
+  const sourceProviders = Array.isArray(r.sourceProviders)
+    ? (r.sourceProviders as Array<Record<string, unknown>>)
+    : undefined;
+  if (sourceProviders) {
+    lines.push(`sourceProviders (${sourceProviders.length}):`);
+    for (const source of sourceProviders) {
+      const label = source.name ?? source.path ?? source.url ?? source.type ?? "?";
+      const disabled = source.enabled === false ? " [disabled]" : "";
+      lines.push(`  [${String(source.type ?? "?")}] ${String(label)}${disabled}`);
+    }
+  }
   const capabilities = r.capabilities as Record<string, unknown> | undefined;
   if (capabilities) {
     lines.push("capabilities:");
     for (const [k, v] of Object.entries(capabilities)) {
-      lines.push(`  ${k}: ${typeof v === "object" ? JSON.stringify(v) : String(v)}`);
+      lines.push(`  ${k}: ${typeof v === "object" && v !== null ? JSON.stringify(v) : String(v)}`);
     }
   }
-  const indexStats = r.index as Record<string, unknown> | undefined;
+  const indexStats = (r.indexStats ?? r.index) as Record<string, unknown> | undefined;
   if (indexStats) {
-    lines.push("index:");
+    lines.push("indexStats:");
     for (const [k, v] of Object.entries(indexStats)) {
-      lines.push(`  ${k}: ${typeof v === "object" ? JSON.stringify(v) : String(v)}`);
+      lines.push(`  ${k}: ${typeof v === "object" && v !== null ? JSON.stringify(v) : String(v)}`);
     }
   }
   if (lines.length === 0) return JSON.stringify(r, null, 2);

--- a/src/output/text/health-format.ts
+++ b/src/output/text/health-format.ts
@@ -1,0 +1,164 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `akm health` plain-text renderer.
+ *
+ * Before this module existed, `--format text` had no registered formatter
+ * for `health` at all, so every invocation fell through to
+ * `renderGenericText` — fine for the scalar fields (`ok=true`,
+ * `status=pass`, `metrics.taskFailRate=0`, …) but `hardChecks` and
+ * `advisories` are arrays of small uniform records, and the generic
+ * fallback's array handling JSON-dumps an array as ONE line. For the
+ * command whose entire job is "tell a human what's wrong," that made the
+ * two fields that actually carry diagnostic signal the least readable part
+ * of the output.
+ *
+ * This formatter renders those record-arrays (plus `sessionLogAdvisories`,
+ * the third one) via the shared `./status-list` helper — worst-status-first,
+ * one glyph-prefixed line per check, with `evidence` gated behind
+ * `--detail normal|full` (the default is `brief`; see `resolveOutputMode` in
+ * `../context.ts`) so the common case stays scannable while the full
+ * diagnostic payload is one flag away, never dropped. Every other field
+ * (`metrics`, `improve`, and the optional `runs`/`windows`/`deltas`/`report`
+ * datasets `--report`/`--group-by run`/`--window-compare` add) keeps the
+ * exact `dotted.path=value` rendering `renderGenericText` already used, via
+ * the exported `flattenForText` — those are mostly nested scalar trees, not
+ * the shape this formatter exists to fix, so reusing that convention keeps
+ * them unchanged rather than inventing a second style for no reason.
+ *
+ * `--format json`/`jsonl`/`yaml` are untouched: they serialize the envelope,
+ * not this rendering, and never call anything in this file. `--format md`
+ * keeps its own pre-existing bespoke tables for `--group-by run` /
+ * `--window-compare` (`../../commands/health/renderers.ts`) — this module is
+ * `text` only.
+ */
+
+import type { DetailLevel } from "../context";
+import { flattenForText } from "../generic-render";
+import { renderStatusEntries, type StatusEntry, summarizeCounts } from "./status-list";
+
+/** The subset of `HealthCheckResult` (`src/commands/health/types-checks.ts`) this formatter reads. */
+interface HealthCheckLike {
+  name: string;
+  kind?: string;
+  status?: string;
+  message?: string;
+  confidence?: string;
+  evidence?: Record<string, unknown>;
+}
+
+/** The subset of `SessionLogAdvisory` (`src/commands/health/types-session-log.ts`) this formatter reads. */
+interface SessionLogAdvisoryLike {
+  topic?: string;
+  frequency?: number;
+  source?: string;
+  isFailurePattern?: boolean;
+}
+
+const STATUS_GLYPH: Record<string, string> = { fail: "✗", warn: "⚠", unknown: "?", pass: "✓" };
+const STATUS_RANK: Record<string, number> = { fail: 0, warn: 1, unknown: 2, pass: 3 };
+/** Worst-first, for both the section summary and (via `STATUS_RANK`) row order. */
+const STATUS_ORDER = ["fail", "warn", "unknown", "pass"] as const;
+
+/** One evidence field per line, `key: value` — objects/arrays JSON-compact, matching `formatInfoPlain`'s nested-field convention. */
+function evidenceLines(evidence: Record<string, unknown> | undefined): string[] {
+  if (!evidence) return [];
+  return Object.entries(evidence).map(
+    ([key, value]) => `${key}: ${value !== null && typeof value === "object" ? JSON.stringify(value) : String(value)}`,
+  );
+}
+
+function checkStatusEntry(check: HealthCheckLike, detail: DetailLevel): StatusEntry {
+  const status = check.status ?? "unknown";
+  const meta = [check.kind, check.confidence].filter((v): v is string => !!v).join(", ");
+  return {
+    severityRank: STATUS_RANK[status] ?? 9,
+    glyph: STATUS_GLYPH[status] ?? "?",
+    headline: `${check.name}  [${status}${meta ? `, ${meta}` : ""}]  ${check.message ?? ""}`.trimEnd(),
+    // Evidence is diagnostic detail, not the headline signal — gated behind
+    // --detail the same way `formatSearchPlain`/`formatCuratePlain` gate
+    // their own verbose fields (full path/editHint/whyMatched, "why" reasoning).
+    detailLines: detail === "brief" ? [] : evidenceLines(check.evidence),
+  };
+}
+
+/** Render one `hardChecks`/`advisories` section: a count summary header, then worst-first rows. */
+function renderCheckSection(title: string, checks: readonly HealthCheckLike[], detail: DetailLevel): string[] {
+  if (checks.length === 0) return [`${title}: (none)`];
+  const counts: Record<string, number> = {};
+  for (const check of checks) {
+    const status = check.status ?? "unknown";
+    counts[status] = (counts[status] ?? 0) + 1;
+  }
+  const summary = summarizeCounts(counts, STATUS_ORDER);
+  const header = `${title} (${checks.length}${summary ? ` — ${summary}` : ""})`;
+  return [header, ...renderStatusEntries(checks.map((check) => checkStatusEntry(check, detail)))];
+}
+
+function sessionAdvisoryEntry(advisory: SessionLogAdvisoryLike): StatusEntry {
+  const isFailure = advisory.isFailurePattern === true;
+  return {
+    severityRank: isFailure ? 0 : 1,
+    glyph: (isFailure ? STATUS_GLYPH.warn : STATUS_GLYPH.pass) ?? "?",
+    headline: `${advisory.topic ?? "?"}  (x${advisory.frequency ?? 0}, source: ${advisory.source ?? "?"})`,
+  };
+}
+
+function renderSessionLogAdvisories(advisories: readonly SessionLogAdvisoryLike[]): string[] {
+  if (advisories.length === 0) return [];
+  return [`sessionLogAdvisories (${advisories.length})`, ...renderStatusEntries(advisories.map(sessionAdvisoryEntry))];
+}
+
+/** Fields already rendered explicitly above — everything else in `r` falls to the `flattenForText` sweep below. */
+const HANDLED_KEYS = new Set([
+  "ok",
+  "status",
+  "since",
+  "hardChecks",
+  "advisories",
+  "sessionLogAdvisories",
+  "shape",
+  "schemaVersion",
+]);
+
+export function formatHealthPlain(r: Record<string, unknown>, detail: DetailLevel): string | null {
+  if (r === null || typeof r !== "object") return null;
+
+  const lines: string[] = [];
+  if (typeof r.ok === "boolean") lines.push(`ok: ${r.ok}`);
+  if (typeof r.status === "string") lines.push(`status: ${r.status}`);
+  if (typeof r.since === "string") lines.push(`since: ${r.since}`);
+
+  const hardChecks = Array.isArray(r.hardChecks) ? (r.hardChecks as HealthCheckLike[]) : [];
+  const advisories = Array.isArray(r.advisories) ? (r.advisories as HealthCheckLike[]) : [];
+  const sessionLogAdvisories = Array.isArray(r.sessionLogAdvisories)
+    ? (r.sessionLogAdvisories as SessionLogAdvisoryLike[])
+    : [];
+
+  lines.push("", ...renderCheckSection("hardChecks", hardChecks, detail));
+  lines.push("", ...renderCheckSection("advisories", advisories, detail));
+  const sessionLines = renderSessionLogAdvisories(sessionLogAdvisories);
+  if (sessionLines.length > 0) lines.push("", ...sessionLines);
+
+  if (
+    detail === "brief" &&
+    [...hardChecks, ...advisories].some((c) => c.evidence && Object.keys(c.evidence).length > 0)
+  ) {
+    lines.push("", "(evidence omitted at --detail brief; re-run with --detail normal or --detail full to see it)");
+  }
+
+  // Everything else (metrics, improve, and the optional runs/windows/deltas/
+  // report datasets) is a nested scalar tree, not the array-of-records shape
+  // this formatter exists to fix — keep the existing dotted-path convention
+  // for it rather than inventing a second one.
+  for (const [key, value] of Object.entries(r)) {
+    if (HANDLED_KEYS.has(key) || value === undefined) continue;
+    const fieldLines: string[] = [];
+    flattenForText(value, key, fieldLines);
+    if (fieldLines.length > 0) lines.push("", ...fieldLines);
+  }
+
+  return lines.join("\n").trim();
+}

--- a/src/output/text/health.ts
+++ b/src/output/text/health.ts
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { formatHealthPlain } from "./helpers";
+import type { TextFormatterEntry } from "./registry";
+
+export const healthFormatters: TextFormatterEntry[] = [
+  { command: "health", handler: (r, detail) => formatHealthPlain(r, detail) },
+];

--- a/src/output/text/helpers.ts
+++ b/src/output/text/helpers.ts
@@ -8,11 +8,11 @@
  *
  * This module is a re-export BARREL: the actual implementations live in
  * cohesive sibling modules (`show-format.ts`, `show-directives.ts`,
- * `workflow-format.ts`, `proposal-format.ts`, `command-format.ts`) split out
- * of what used to be a single 1418-line / 59-function file. Every name that
- * was previously importable from `"./helpers"` (directly, or transitively via
- * `../text.ts`) stays importable from here unchanged — no import site needed
- * to move.
+ * `workflow-format.ts`, `proposal-format.ts`, `command-format.ts`,
+ * `health-format.ts`, `lint-format.ts`) split out of what used to be a
+ * single 1418-line / 59-function file. Every name that was previously
+ * importable from `"./helpers"` (directly, or transitively via `../text.ts`)
+ * stays importable from here unchanged — no import site needed to move.
  *
  * No registry imports — no circular dependencies.
  */
@@ -46,6 +46,8 @@ export {
   formatUpdatePlain,
   formatUpgradePlain,
 } from "./command-format";
+export { formatHealthPlain } from "./health-format";
+export { formatLintPlain } from "./lint-format";
 export {
   formatGateDecisionSummary,
   formatProposalAcceptPlain,

--- a/src/output/text/lint-format.ts
+++ b/src/output/text/lint-format.ts
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `akm lint` plain-text renderer.
+ *
+ * Same defect as `akm health` (see `./health-format.ts`'s header comment for
+ * the full writeup): `lint` had no registered text formatter, so
+ * `--format text` fell through to `renderGenericText`, which JSON-dumps the
+ * `fixed`/`flagged` arrays as one line each — e.g.
+ * `flagged=[{"file":"agents/x.md","issue":"missing-ref",...}, ...]`. Those
+ * are exactly the array-of-status-bearing-records shape `./status-list`
+ * exists to render, reused here rather than duplicated.
+ */
+
+import type { LintIssue } from "../../commands/lint/types";
+import { renderStatusEntries, type StatusEntry } from "./status-list";
+
+/** `fixed === true` succeeded; `"failed"` is an attempted-and-failed fix (worse than an unfixed, merely-flagged issue). */
+function glyphFor(fixed: LintIssue["fixed"]): { glyph: string; severityRank: number } {
+  if (fixed === true) return { glyph: "✓", severityRank: 0 };
+  if (fixed === "failed") return { glyph: "✗", severityRank: 0 };
+  return { glyph: "⚠", severityRank: 1 };
+}
+
+function issueEntry(issue: LintIssue): StatusEntry {
+  const { glyph, severityRank } = glyphFor(issue.fixed);
+  return { severityRank, glyph, headline: `${issue.file}  [${issue.issue}]  ${issue.detail}` };
+}
+
+function renderIssueSection(title: string, issues: readonly LintIssue[]): string[] {
+  if (issues.length === 0) return [`${title}: (none)`];
+  return [`${title} (${issues.length})`, ...renderStatusEntries(issues.map(issueEntry))];
+}
+
+export function formatLintPlain(r: Record<string, unknown>): string | null {
+  if (r === null || typeof r !== "object") return null;
+
+  const fixed = Array.isArray(r.fixed) ? (r.fixed as LintIssue[]) : [];
+  const flagged = Array.isArray(r.flagged) ? (r.flagged as LintIssue[]) : [];
+  const summary = r.summary as { fixed?: number; flagged?: number } | undefined;
+
+  const lines: string[] = [];
+  if (typeof r.ok === "boolean") lines.push(`ok: ${r.ok}`);
+  lines.push(`summary: fixed=${summary?.fixed ?? fixed.length} flagged=${summary?.flagged ?? flagged.length}`);
+
+  // Flagged (still needs attention) surfaces before fixed (already handled)
+  // so a scan of the output hits the actionable items first.
+  lines.push("", ...renderIssueSection("flagged", flagged));
+  lines.push("", ...renderIssueSection("fixed", fixed));
+
+  return lines.join("\n").trim();
+}

--- a/src/output/text/lint-format.ts
+++ b/src/output/text/lint-format.ts
@@ -17,10 +17,16 @@
 import type { LintIssue } from "../../commands/lint/types";
 import { renderStatusEntries, type StatusEntry } from "./status-list";
 
-/** `fixed === true` succeeded; `"failed"` is an attempted-and-failed fix (worse than an unfixed, merely-flagged issue). */
+/**
+ * `fixed === true` succeeded; `"failed"` is an attempted-and-failed fix (worse
+ * than an unfixed, merely-flagged issue, which in turn is worse than a clean
+ * success). `severityRank` ascends from most urgent — see
+ * {@link renderStatusEntries} — so the three states must get three DISTINCT
+ * ranks or a failed fix can sort behind a successful one in the same section.
+ */
 function glyphFor(fixed: LintIssue["fixed"]): { glyph: string; severityRank: number } {
-  if (fixed === true) return { glyph: "✓", severityRank: 0 };
   if (fixed === "failed") return { glyph: "✗", severityRank: 0 };
+  if (fixed === true) return { glyph: "✓", severityRank: 2 };
   return { glyph: "⚠", severityRank: 1 };
 }
 

--- a/src/output/text/lint.ts
+++ b/src/output/text/lint.ts
@@ -1,0 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { formatLintPlain } from "./helpers";
+import type { TextFormatterEntry } from "./registry";
+
+export const lintFormatters: TextFormatterEntry[] = [{ command: "lint", handler: (r) => formatLintPlain(r) }];

--- a/src/output/text/migrate.ts
+++ b/src/output/text/migrate.ts
@@ -1,0 +1,139 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Plain-text rendering of `akm migrate status` / `akm migrate apply`'s
+ * `MigrationPlan` result (`scripts/akm-migrate/config-migrate.ts`).
+ *
+ * Reuses `renderStatusEntries` (`./status-list.ts`) for the four-artifact
+ * breakdown — exactly the "worst-first, glyph-prefixed" shape that module
+ * exists for — rather than reinventing it for a third command.
+ */
+
+import type { TextFormatterEntry } from "./registry";
+import { renderStatusEntries, type StatusEntry } from "./status-list";
+
+interface ArtifactState {
+  status: string;
+  migrationIds?: string[];
+  detail?: string;
+}
+
+interface TargetConfigState {
+  status: string;
+  source: string;
+  path?: string;
+  detail?: string;
+}
+
+interface GeneratedConfigInfo {
+  path: string;
+  status: string;
+  droppedKeys: string[];
+}
+
+interface MigrationPlanResult {
+  status: string;
+  artifacts?: Record<string, ArtifactState>;
+  targetConfig?: TargetConfigState;
+  blockers?: string[];
+  message?: string;
+  generatedConfig?: GeneratedConfigInfo;
+  activeOperation?: { kind: string; sentinelPath: string };
+  backupPath?: string;
+  backupRunId?: string;
+}
+
+const ARTIFACT_ORDER = ["config", "state", "workflow", "index"] as const;
+const ARTIFACT_LABEL: Record<(typeof ARTIFACT_ORDER)[number], string> = {
+  config: "config.json",
+  state: "state.db",
+  workflow: "workflow.db",
+  index: "index.db",
+};
+
+/** Lower rank sorts first (worse-first) via `renderStatusEntries`. */
+function artifactSeverity(status: string): { rank: number; glyph: string } {
+  switch (status) {
+    case "corrupt":
+    case "inconsistent":
+    case "newer":
+      return { rank: 0, glyph: "✗" };
+    case "old":
+      return { rank: 1, glyph: "⚠" };
+    case "missing":
+      return { rank: 2, glyph: "?" };
+    default: // "current"
+      return { rank: 3, glyph: "✓" };
+  }
+}
+
+function planGlyph(status: string): string {
+  switch (status) {
+    case "current":
+      return "✓";
+    case "ready":
+      return "⚠";
+    case "not-applicable":
+      return "·";
+    default: // "blocked"
+      return "✗";
+  }
+}
+
+export function formatMigratePlain(result: unknown): string | null {
+  if (!result || typeof result !== "object") return null;
+  const plan = result as MigrationPlanResult;
+  if (typeof plan.status !== "string") return null;
+
+  const lines: string[] = [`${planGlyph(plan.status)} ${plan.status}`];
+  if (plan.message) lines.push(`    ${plan.message}`);
+  if (plan.activeOperation) {
+    lines.push(`    in-flight ${plan.activeOperation.kind} at ${plan.activeOperation.sentinelPath}`);
+  }
+
+  if (plan.artifacts) {
+    const entries: StatusEntry[] = ARTIFACT_ORDER.filter((name) => plan.artifacts?.[name]).map((name) => {
+      const artifact = plan.artifacts?.[name] as ArtifactState;
+      const { rank, glyph } = artifactSeverity(artifact.status);
+      const detailLines: string[] = [];
+      if (artifact.detail) detailLines.push(artifact.detail);
+      if (artifact.migrationIds?.length) detailLines.push(`migrations applied: ${artifact.migrationIds.length}`);
+      return { severityRank: rank, glyph, headline: `${ARTIFACT_LABEL[name]}: ${artifact.status}`, detailLines };
+    });
+    lines.push("", "artifacts:", ...renderStatusEntries(entries).map((line) => `  ${line}`));
+  }
+
+  if (plan.targetConfig) {
+    const target = plan.targetConfig;
+    lines.push(
+      "",
+      `target config: ${target.status} (source: ${target.source}${target.path ? `, ${target.path}` : ""})`,
+    );
+    if (target.detail) lines.push(`  ${target.detail}`);
+  }
+
+  if (plan.generatedConfig) {
+    const generated = plan.generatedConfig;
+    lines.push("", `generated config: ${generated.status} at ${generated.path}`);
+    if (generated.droppedKeys.length > 0) {
+      lines.push(`  drops (add engines/defaults yourself if needed): ${generated.droppedKeys.join(", ")}`);
+    }
+  }
+
+  if (plan.blockers?.length) {
+    lines.push("", "blockers:", ...plan.blockers.map((blocker) => `  - ${blocker}`));
+  }
+
+  if (plan.backupPath) {
+    lines.push("", `backup: ${plan.backupPath}${plan.backupRunId ? ` (run ${plan.backupRunId})` : ""}`);
+  }
+
+  return lines.join("\n");
+}
+
+export const migrateFormatters: TextFormatterEntry[] = [
+  { command: "migrate-status", handler: (r) => formatMigratePlain(r) },
+  { command: "migrate-apply", handler: (r) => formatMigratePlain(r) },
+];

--- a/src/output/text/status-list.ts
+++ b/src/output/text/status-list.ts
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Shared plain-text rendering for "list of status-bearing records" shapes.
+ *
+ * `akm health`'s `hardChecks`/`advisories`/`sessionLogAdvisories` and `akm
+ * lint`'s `fixed`/`flagged` issues are all, structurally, an array of small
+ * uniform records where one field names a severity and a human scanning the
+ * output needs the bad ones first, not buried below a wall of passing rows.
+ * `renderGenericText`'s flat `path=value` fallback (`../generic-render.ts`)
+ * JSON-dumps such an array as ONE line — accurate but unreadable for exactly
+ * this shape, which is why commands with this shape get a bespoke text
+ * formatter instead of falling through to it. This module is the one place
+ * the "worst-first, glyph-prefixed, optionally-detailed" rendering lives, so
+ * a third command with the same shape reuses it instead of reinventing it.
+ */
+
+/** One row rendered by {@link renderStatusEntries}. */
+export interface StatusEntry {
+  /** Ascending = more urgent. Entries are stably sorted by this field. */
+  severityRank: number;
+  /** Single-glyph status prefix, e.g. "✗" / "⚠" / "?" / "✓". */
+  glyph: string;
+  /** The summary line — no leading glyph or indentation; this function adds both. */
+  headline: string;
+  /** Extra lines rendered indented under the headline. Omit/empty to show none. */
+  detailLines?: string[];
+}
+
+/**
+ * Render entries worst-first (by `severityRank`, ties keep original order),
+ * each as a glyph-prefixed headline with its optional indented detail lines.
+ */
+export function renderStatusEntries(entries: readonly StatusEntry[]): string[] {
+  const ordered = entries
+    .map((entry, index) => ({ entry, index }))
+    .sort((a, b) => a.entry.severityRank - b.entry.severityRank || a.index - b.index)
+    .map(({ entry }) => entry);
+  const lines: string[] = [];
+  for (const entry of ordered) {
+    lines.push(`${entry.glyph} ${entry.headline}`);
+    for (const detail of entry.detailLines ?? []) {
+      lines.push(`    ${detail}`);
+    }
+  }
+  return lines;
+}
+
+/**
+ * Render a status→count map as `"2 fail, 1 warn, 5 pass"`, in `order` (worst
+ * first) with zero counts omitted. Shared by any section header that wants a
+ * one-line "what's in here" summary before the per-row detail.
+ */
+export function summarizeCounts(counts: Record<string, number>, order: readonly string[]): string {
+  return order
+    .filter((status) => (counts[status] ?? 0) > 0)
+    .map((status) => `${counts[status]} ${status}`)
+    .join(", ");
+}

--- a/src/setup/setup.ts
+++ b/src/setup/setup.ts
@@ -145,7 +145,32 @@ export interface SetupSummary {
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-/** Raw preflight used before setup performs prompts, initialization, or writes. */
+/**
+ * Raw preflight used before setup performs prompts, initialization, or writes.
+ *
+ * `setup` is allowlisted in `shouldBypassConfigStartup` (src/cli.ts) so it
+ * never dies on the CLI's own startup config load — but every entry point
+ * below (`runSetupWizard`, `runSetupWithDefaults`, `runSetupFromConfig`,
+ * `runResetRecommended`) still needs the CURRENT config as its merge base, so
+ * this is the first thing each one calls. When the on-disk config predates
+ * 0.9 (or is otherwise unparseable/invalid), `parseAndValidateConfigText`
+ * throws `ConfigError`; deliberately let that propagate rather than falling
+ * back to a fresh default config here.
+ *
+ * That fallback was considered and rejected: `mutateConfigWithPrecommit`
+ * (src/core/config/config.ts) re-reads and re-validates this SAME file
+ * inside its write lock before saving, so a wizard that "survived" this
+ * preflight by substituting `DEFAULT_CONFIG` would still crash with the
+ * identical error at the final save — after prompting the user through the
+ * entire wizard. Worse, making the save path itself tolerate an old config
+ * would mean writing a freshly-generated 0.9 config over the live 0.8 file
+ * `akm migrate apply` needs to read as ITS OWN input — replacing the user's
+ * real engine/source settings with the wizard's placeholder ones, silently,
+ * on the one path (`akm migrate ...`) the upgrade docs tell users to run
+ * first. Refusing here — before any prompt, detection, or write — is strictly
+ * safer: the file is left byte-for-byte untouched and the error message
+ * below points straight at the real recovery command.
+ */
 export function assertSetupConfigPreflight(): void {
   const configPath = getConfigPath();
   let text: string | undefined;
@@ -157,7 +182,21 @@ export function assertSetupConfigPreflight(): void {
       "INVALID_CONFIG_FILE",
     );
   }
-  if (text !== undefined) parseAndValidateConfigText(text, configPath);
+  if (text === undefined) return;
+  try {
+    parseAndValidateConfigText(text, configPath);
+  } catch (error) {
+    if (!(error instanceof ConfigError)) throw error;
+    if (error.code !== "UNSUPPORTED_CONFIG_VERSION" && error.code !== "INVALID_CONFIG_FILE") throw error;
+    throw new ConfigError(
+      `\`akm setup\` cannot run: the config at ${configPath} did not load (${error.message}). ` +
+        "It was left untouched — setup never writes over a config it cannot first read cleanly.",
+      error.code,
+      "Run `akm migrate status` to check what this config needs before continuing, or `akm help migrate 0.9.0` " +
+        "for the full upgrade checklist. To abandon it and start fresh instead, move it aside " +
+        `(e.g. \`mv ${configPath} ${configPath}.bak\`) and re-run \`akm setup\`.`,
+    );
+  }
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/tests/cli/exit-code-hints.test.ts
+++ b/tests/cli/exit-code-hints.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { retiredCommandHint } from "../../src/cli/retired-commands";
+import { retiredCommandHint, retiredFlagHint } from "../../src/cli/retired-commands";
 import { EMBEDDED_HINTS, EMBEDDED_HINTS_FULL } from "../../src/output/cli-hints";
 
 describe("embedded exit-code hints", () => {
@@ -55,5 +55,27 @@ describe("embedded exit-code hints", () => {
     expect(retiredCommandHint(["workflow"], "complete")).toContain("workflow run");
     expect(retiredCommandHint(["workflow"], "brief")).toContain("workflow run");
     expect(retiredCommandHint(["workflow"], "report")).toContain("workflow run");
+  });
+
+  // 0.9.0 release notes headline the removal of the whole `akm vault ...`
+  // family; `task show` is also named as a removed subcommand but previously
+  // had no hint entry. (`improve canary` is deliberately NOT here — `improve`
+  // is a leaf command, not a group, so it never reaches this table; it has
+  // its own more specific self-diagnosis in improve-cli.ts.)
+  test("the retired vault family and task show have explicit replacements", () => {
+    expect(retiredCommandHint([], "vault")).toContain("akm env list");
+    expect(retiredCommandHint([], "vault")).toContain("akm secret set");
+    expect(retiredCommandHint(["task"], "show")).toContain("akm show");
+  });
+
+  test("retired flags (as opposed to commands) hint their replacement procedure", () => {
+    expect(retiredFlagHint(["index"], "--background")).toContain("--quiet");
+    expect(retiredFlagHint(["setup"], "--detect-only")).toContain("akm setup");
+    expect(retiredFlagHint(["setup"], "--reset-recommended")).toContain("recommended defaults");
+    expect(retiredFlagHint(["proposal", "extract"], "--watch")).toContain("proposal extract --auto");
+    expect(retiredFlagHint(["proposal", "extract"], "--debounce-ms")).toContain("proposal extract --auto");
+    // Unretired flag / unrelated path: no hint.
+    expect(retiredFlagHint(["search"], "--background")).toBeUndefined();
+    expect(retiredFlagHint(["index"], "--full")).toBeUndefined();
   });
 });

--- a/tests/cli/setup-non-interactive.test.ts
+++ b/tests/cli/setup-non-interactive.test.ts
@@ -16,8 +16,18 @@
  * test — no stdin stubbing required.
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { getConfigPath } from "../../src/core/paths";
 import { runCliCapture } from "../_helpers/cli";
+import {
+  type Cleanup,
+  sandboxHome,
+  sandboxXdgCacheHome,
+  sandboxXdgConfigHome,
+  sandboxXdgDataHome,
+} from "../_helpers/sandbox";
 
 describe("akm setup without a TTY", () => {
   test("fails fast instead of hanging on the wizard prompt", async () => {
@@ -48,5 +58,90 @@ describe("akm setup without a TTY", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.code).toBe("INVALID_FLAG_VALUE");
     expect(parsed.error).toContain("Invalid JSON in --config");
+  });
+});
+
+/**
+ * `setup` is allowlisted in `shouldBypassConfigStartup` (src/cli.ts) so the
+ * CLI's own startup config load never blocks it — but its FIRST action was
+ * still `assertSetupConfigPreflight()` re-reading and re-validating that same
+ * config, dying with the generic "Unsupported configVersion" error the
+ * normal startup path throws. That is exactly the state a real upgrade
+ * leaves behind (a live pre-0.9 config), and `setup` is the natural "get me
+ * unstuck" command to reach for — so it must fail with something more useful
+ * than a dead end, without ever touching the file the migration tooling
+ * still needs to read.
+ */
+describe("akm setup against a config akm 0.9 cannot load", () => {
+  let cleanup: Cleanup | undefined;
+
+  beforeEach(() => {
+    const home = sandboxHome();
+    const config = sandboxXdgConfigHome(home.cleanup);
+    const cache = sandboxXdgCacheHome(config.cleanup);
+    cleanup = sandboxXdgDataHome(cache.cleanup).cleanup;
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  test("--yes refuses a pre-0.9 config with a setup-specific, actionable hint", async () => {
+    const configPath = getConfigPath();
+    const original = '{"configVersion":"0.8.0","stashDir":"/home/user/old-stash"}\n';
+    fs.writeFileSync(configPath, original);
+
+    const { code, stderr } = await runCliCapture(["setup", "--yes"]);
+
+    expect(code).toBe(78);
+    const parsed = JSON.parse(stderr.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.code).toBe("UNSUPPORTED_CONFIG_VERSION");
+    expect(parsed.error).toContain("did not load");
+    expect(parsed.error).toContain("left untouched");
+    expect(parsed.hint).toContain("akm migrate status");
+
+    // The file itself was never modified — critical safety property: the
+    // live 0.8 config is what `akm migrate apply` needs to read.
+    expect(fs.readFileSync(configPath, "utf8")).toBe(original);
+  });
+
+  test("an unparseable config refuses the same way", async () => {
+    const configPath = getConfigPath();
+    fs.writeFileSync(configPath, "{ not valid json");
+
+    const { code, stderr } = await runCliCapture(["setup", "--yes"]);
+
+    expect(code).toBe(78);
+    const parsed = JSON.parse(stderr.trim());
+    expect(parsed.code).toBe("INVALID_CONFIG_FILE");
+    expect(parsed.hint).toContain("akm migrate status");
+  });
+
+  test("every non-interactive entry point refuses before doing any work", async () => {
+    const configPath = getConfigPath();
+    fs.writeFileSync(configPath, '{"configVersion":"0.8.0"}\n');
+
+    for (const args of [
+      ["setup", "--yes"],
+      ["setup", "--config", "{}"],
+    ]) {
+      const { code, stderr } = await runCliCapture(args);
+      expect(code, args.join(" ")).toBe(78);
+      const parsed = JSON.parse(stderr.trim());
+      expect(parsed.hint, args.join(" ")).toContain("akm migrate status");
+    }
+  });
+
+  test("never creates a bundle directory or writes a config backup", async () => {
+    const configPath = getConfigPath();
+    fs.writeFileSync(configPath, '{"configVersion":"0.8.0"}\n');
+    const stash = path.join(process.env.HOME as string, "akm");
+
+    await runCliCapture(["setup", "--yes"]);
+
+    expect(fs.existsSync(stash)).toBe(false);
+    expect(fs.existsSync(path.join(process.env.XDG_CACHE_HOME as string, "akm", "config-backups"))).toBe(false);
   });
 });

--- a/tests/cli/unknown-flags.test.ts
+++ b/tests/cli/unknown-flags.test.ts
@@ -146,3 +146,29 @@ describe("stands down when the command itself is the problem", () => {
     expect(errorFor(["show", "knowledge/a", "--enrich"]).code).toBe("UNKNOWN_FLAG");
   });
 });
+
+describe("retired flags get their replacement, not a generic unknown-flag hint", () => {
+  // Unlike SELF_DIAGNOSED_FLAGS above (a rename the OWNING command answers
+  // itself), these flags were removed outright with no successor flag on the
+  // same command — `retiredFlagHint` (src/cli/retired-commands.ts) supplies
+  // the migration hint the generic edit-distance suggestion can't.
+  test.each([
+    [["index", "--background"], "--quiet"],
+    [["setup", "--detect-only"], "akm setup"],
+    [["setup", "--reset-recommended"], "recommended defaults"],
+    [["proposal", "extract", "--watch"], "proposal extract --auto"],
+    [["proposal", "extract", "--debounce-ms"], "proposal extract --auto"],
+  ] as const)("%s hints its replacement", (args, expected) => {
+    const err = errorFor([...args]);
+    expect(err.code).toBe("UNKNOWN_FLAG");
+    expect(err.hint()).toContain(expected);
+    expect(err.hint()).toContain("akm help migrate 0.9.0");
+    expect(err.hint()).not.toContain("Did you mean");
+  });
+
+  test("the same spelling on an unrelated command path is a plain unknown flag", () => {
+    // `--watch` is only retired on `proposal extract` — `search` never had it
+    // and shouldn't get a misleading migration hint for it.
+    expect(errorFor(["search", "foo", "--watch"]).hint()).not.toContain("proposal extract --auto");
+  });
+});

--- a/tests/commands/proposal/adapter-precommit-check.test.ts
+++ b/tests/commands/proposal/adapter-precommit-check.test.ts
@@ -1,0 +1,144 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * The proposal-promotion pre-commit gate — `BundleAdapter.validate()`'s OTHER
+ * stated consumer (`core/adapter/bundle-adapter.ts` doc comment, alongside
+ * `lint --fix`), wired in `commands/proposal/repository.ts#runAdapterPreCommitCheck`.
+ *
+ * Deliberately ADVISORY (see that function's doc comment for the full
+ * rationale): it runs the real `akmAdapter.validate()` — with a
+ * `createValidateContext` overlay carrying the proposal's about-to-be-written
+ * bytes — immediately before the write, and surfaces any finding via `warn()`,
+ * but never blocks promotion on it. This suite proves:
+ *
+ *   1. the wiring genuinely runs against a REAL proposal-accept transaction
+ *      (not a mock `ValidateContext`) and finds a real diagnostic the
+ *      EXISTING `promotionLintBlockers` gate does not catch;
+ *   2. that diagnostic does NOT block acceptance (the disclosed non-blocking
+ *      scope decision, proven empirically, not just asserted in a comment);
+ *   3. a clean proposal produces no adapter warning at all;
+ *   4. a proposal that already fails today's `promotionLintBlockers` gate
+ *      still fails exactly the same way (this addition changes nothing about
+ *      existing blocking behavior).
+ */
+
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { akmProposalAccept } from "../../../src/commands/proposal/proposal";
+import { createProposal as createProposalImpl, isProposalSkipped } from "../../../src/commands/proposal/repository";
+import { _setWarnSinkForTests } from "../../../src/core/warn";
+import { makeConfig } from "../../_helpers/factories";
+import { overrideSeam } from "../../_helpers/seams";
+
+const tempDirs: string[] = [];
+
+function makeStashDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-proposal-precommit-"));
+  tempDirs.push(dir);
+  for (const sub of ["lessons", "memories"]) fs.mkdirSync(path.join(dir, sub), { recursive: true });
+  return dir;
+}
+
+function createProposal(stashDir: string, input: Parameters<typeof createProposalImpl>[1]) {
+  return createProposalImpl(stashDir, {
+    ...input,
+    target: input.target ?? { source: "stash", root: path.resolve(stashDir) },
+  });
+}
+
+function captureWarnings(): string[] {
+  const calls: string[] = [];
+  overrideSeam(_setWarnSinkForTests, (level, args) => {
+    if (level !== "warn") return;
+    calls.push(args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" "));
+  });
+  return calls;
+}
+
+const CLEAN_LESSON =
+  "---\ndescription: Use ripgrep before grep\nwhen_to_use: Searching large repos for patterns\n---\n\nPrefer rg over grep when scanning large code repos.\n";
+
+// A body ref (`other//docs/readme`) whose leading segment ("docs") is NOT a
+// registered AKM placement type. The EXISTING `promotionLintBlockers` gate
+// (legacy `commands/lint/base-linter.ts#checkMissingRefs`) treats an
+// unrecognized type prefix as "not locally checkable, skip it" and never
+// flags it. The adapter pre-commit check's core `resolveRef` additionally
+// tries the ref as a literal on-disk path (the resolution OKF/llm-wiki need
+// for their own conceptIds) and DOES report it missing — the exact,
+// documented divergence this suite pins.
+const FOREIGN_REF_LESSON =
+  "---\ndescription: Cross-bundle pointer\nwhen_to_use: Testing the pre-commit adapter check\n---\n\n" +
+  "See other//docs/readme for background.\n";
+
+describe("proposal promotion pre-commit adapter check (advisory)", () => {
+  test("a diagnostic the legacy promotionLintBlockers gate does not catch is surfaced via warn(), but does not block acceptance", async () => {
+    const stash = makeStashDir();
+    const config = makeConfig(stash);
+    const warnings = captureWarnings();
+
+    const created = createProposal(stash, {
+      ref: "lessons/foreign-ref",
+      source: "distill",
+      sourceRun: "run-1",
+      force: true,
+      payload: { content: FOREIGN_REF_LESSON },
+    });
+    if (isProposalSkipped(created)) throw new Error("unexpected skip");
+
+    const accepted = await akmProposalAccept({ stashDir: stash, id: created.id, config });
+    expect(accepted.ok).toBe(true);
+    expect(fs.existsSync(accepted.assetPath)).toBe(true);
+
+    const hit = warnings.find((w) => w.includes("pre-commit adapter check") && w.includes(created.id));
+    expect(hit).toBeDefined();
+    expect(hit).toContain("missing-ref");
+    expect(hit).toContain("non-blocking");
+  });
+
+  test("a clean proposal produces no pre-commit adapter warning", async () => {
+    const stash = makeStashDir();
+    const config = makeConfig(stash);
+    const warnings = captureWarnings();
+
+    const created = createProposal(stash, {
+      ref: "lessons/clean",
+      source: "distill",
+      sourceRun: "run-2",
+      force: true,
+      payload: { content: CLEAN_LESSON },
+    });
+    if (isProposalSkipped(created)) throw new Error("unexpected skip");
+
+    const accepted = await akmProposalAccept({ stashDir: stash, id: created.id, config });
+    expect(accepted.ok).toBe(true);
+
+    expect(warnings.some((w) => w.includes("pre-commit adapter check"))).toBe(false);
+  });
+
+  test("an existing blocking finding (missing-ref via promotionLintBlockers) still rejects exactly as before", async () => {
+    const stash = makeStashDir();
+    const config = makeConfig(stash);
+
+    // A qualified ref whose leading segment IS a real AKM placement type
+    // (`memories`) but whose target does not exist — the legacy resolver DOES
+    // check this one (typeNameFromConceptId resolves it), so it was already a
+    // blocking `missing-ref` before this change.
+    const blockedContent =
+      "---\ndescription: Points at a real type, missing target\nwhen_to_use: Pinning the still-blocking case\n---\n\n" +
+      "See stash//memories/does-not-exist for context.\n";
+    const created = createProposal(stash, {
+      ref: "lessons/still-blocked",
+      source: "distill",
+      sourceRun: "run-3",
+      force: true,
+      payload: { content: blockedContent },
+    });
+    if (isProposalSkipped(created)) throw new Error("unexpected skip");
+
+    await expect(akmProposalAccept({ stashDir: stash, id: created.id, config })).rejects.toThrow(/failed lint/i);
+  });
+});

--- a/tests/completions.test.ts
+++ b/tests/completions.test.ts
@@ -85,6 +85,7 @@ describe("completions command", () => {
       "feedback",
       "registry",
       "config",
+      "migrate",
       "help",
       "hints",
       "completions",
@@ -94,11 +95,12 @@ describe("completions command", () => {
     }
   });
 
-  // `migrate` is `meta.hidden` (S11) — the self-update contract's internal
-  // command, not a surface end users discover by tab-completion. Still
-  // executes normally; only excluded from the completions walk.
-  test("does not suggest the hidden migrate command", () => {
-    expect(script).not.toContain('"akm migrate"');
+  // `migrate` was `meta.hidden` (S11) so tab-completion wouldn't surface the
+  // self-update contract's internal command. Unhidden: the 0.9.0 upgrade
+  // instructions tell users to run `akm migrate status`/`apply` first, so it
+  // needs to be as discoverable as any other command, completions included.
+  test("suggests the migrate command", () => {
+    expect(script).toContain('"akm migrate"');
   });
 
   test("contains nested bundle subcommands", () => {
@@ -118,6 +120,13 @@ describe("completions command", () => {
   test("contains nested registry subcommands", () => {
     expect(script).toContain('"akm registry"');
     for (const sub of ["list", "add", "remove", "search"]) {
+      expect(script).toContain(sub);
+    }
+  });
+
+  test("contains nested migrate subcommands", () => {
+    expect(script).toContain('"akm migrate"');
+    for (const sub of ["status", "apply"]) {
       expect(script).toContain(sub);
     }
   });

--- a/tests/core/adapter/validate-context.test.ts
+++ b/tests/core/adapter/validate-context.test.ts
@@ -1,0 +1,173 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * The ONE core `ValidateContext` implementation (`core/adapter/validate-context.ts`)
+ * — the overlay `BundleAdapter.validate()`'s interface contract mandates
+ * ("one core overlay implementation, not one per adapter"). Exercised in
+ * isolation here (real disk, a tmpdir per test) so the overlay semantics are
+ * pinned independently of any one adapter's own test suite.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createValidateContext } from "../../../src/core/adapter/validate-context";
+import type { FileChange } from "../../../src/core/file-change";
+
+function makeRoot(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-validate-ctx-"));
+  return dir;
+}
+
+function write(root: string, relPath: string, content: string): void {
+  const full = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, "utf8");
+}
+
+describe("createValidateContext — readFile", () => {
+  test("reads a file that exists on disk when there is no overlay", async () => {
+    const root = makeRoot();
+    write(root, "knowledge/foo.md", "hello from disk");
+    const ctx = createValidateContext({ root });
+    expect(await ctx.readFile("knowledge/foo.md")).toBe("hello from disk");
+  });
+
+  test("returns null for a path that exists on neither disk nor overlay", async () => {
+    const root = makeRoot();
+    const ctx = createValidateContext({ root });
+    expect(await ctx.readFile("nope.md")).toBeNull();
+  });
+
+  test("a pending `create`/`update` change overlays its `after` content OVER disk", async () => {
+    const root = makeRoot();
+    write(root, "knowledge/foo.md", "old disk content");
+    const changes: FileChange[] = [{ path: "knowledge/foo.md", after: "NEW pending content", op: "update" }];
+    const ctx = createValidateContext({ root, changes });
+    expect(await ctx.readFile("knowledge/foo.md")).toBe("NEW pending content");
+  });
+
+  test("a pending `create` for a file that does not yet exist on disk is served from the overlay", async () => {
+    const root = makeRoot();
+    const changes: FileChange[] = [{ path: "knowledge/brand-new.md", after: "freshly proposed", op: "create" }];
+    const ctx = createValidateContext({ root, changes });
+    expect(await ctx.readFile("knowledge/brand-new.md")).toBe("freshly proposed");
+    // Disk is untouched — validate() must never write.
+    expect(fs.existsSync(path.join(root, "knowledge/brand-new.md"))).toBe(false);
+  });
+
+  test("a pending `delete` makes the overlay report null even though the file still exists on disk", async () => {
+    const root = makeRoot();
+    write(root, "knowledge/doomed.md", "still here on disk");
+    const changes: FileChange[] = [{ path: "knowledge/doomed.md", op: "delete" }];
+    const ctx = createValidateContext({ root, changes });
+    expect(await ctx.readFile("knowledge/doomed.md")).toBeNull();
+    // The overlay is a READ projection only — the real file is never touched.
+    expect(fs.existsSync(path.join(root, "knowledge/doomed.md"))).toBe(true);
+  });
+
+  test("an absolute path bypasses the overlay and reads disk directly (the stale-path base check's shape)", async () => {
+    const root = makeRoot();
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "akm-validate-ctx-outside-"));
+    fs.writeFileSync(path.join(outside, "marker.txt"), "outside content", "utf8");
+    const ctx = createValidateContext({ root });
+    expect(await ctx.readFile(path.join(outside, "marker.txt"))).toBe("outside content");
+    expect(await ctx.readFile(path.join(outside, "does-not-exist.txt"))).toBeNull();
+  });
+});
+
+describe("createValidateContext — list", () => {
+  test("lists disk entries for a directory with no overlay", async () => {
+    const root = makeRoot();
+    write(root, "pages/a.md", "a");
+    write(root, "pages/b.md", "b");
+    const ctx = createValidateContext({ root });
+    expect((await ctx.list("pages")).sort()).toEqual(["a.md", "b.md"]);
+  });
+
+  test("merges pending creates into the disk listing and removes pending deletes", async () => {
+    const root = makeRoot();
+    write(root, "pages/a.md", "a");
+    write(root, "pages/b.md", "b");
+    const changes: FileChange[] = [
+      { path: "pages/c.md", after: "c", op: "create" },
+      { path: "pages/b.md", op: "delete" },
+    ];
+    const ctx = createValidateContext({ root, changes });
+    expect((await ctx.list("pages")).sort()).toEqual(["a.md", "c.md"]);
+  });
+
+  test("returns an empty list for a directory that exists on neither disk nor overlay", async () => {
+    const root = makeRoot();
+    const ctx = createValidateContext({ root });
+    expect(await ctx.list("nowhere")).toEqual([]);
+  });
+});
+
+describe("createValidateContext — resolveRef", () => {
+  test("resolves a bare conceptId to an existing direct on-disk path (the OKF/llm-wiki own-conceptId shape)", async () => {
+    const root = makeRoot();
+    write(root, "tables/customers.md", "---\ntype: table\n---\n");
+    const ctx = createValidateContext({ root });
+    expect((await ctx.resolveRef("tables/customers")).exists).toBe(true);
+    expect((await ctx.resolveRef("tables/missing")).exists).toBe(false);
+  });
+
+  test("resolves a bare conceptId through the AKM placement type table (the akm adapter's own shape)", async () => {
+    const root = makeRoot();
+    write(root, "memories/kept.md", "---\nupdated: 2026-01-01\n---\nbody\n");
+    const ctx = createValidateContext({ root });
+    expect((await ctx.resolveRef("memories/kept")).exists).toBe(true);
+    expect((await ctx.resolveRef("memories/absent")).exists).toBe(false);
+  });
+
+  test("strips a `bundle//` qualifier before resolving (mirrors the legacy resolver's bundle-agnostic leniency)", async () => {
+    const root = makeRoot();
+    write(root, "memories/kept.md", "---\nupdated: 2026-01-01\n---\nbody\n");
+    const ctx = createValidateContext({ root });
+    expect((await ctx.resolveRef("some-bundle//memories/kept")).exists).toBe(true);
+  });
+
+  test("strips a `#fragment` before resolving", async () => {
+    const root = makeRoot();
+    write(root, "memories/kept.md", "---\nupdated: 2026-01-01\n---\nbody\n");
+    const ctx = createValidateContext({ root });
+    expect((await ctx.resolveRef("memories/kept#some-heading")).exists).toBe(true);
+  });
+
+  test("a pending `create` overlay makes a previously-missing ref resolve", async () => {
+    const root = makeRoot();
+    const changes: FileChange[] = [{ path: "tables/new.md", after: "---\ntype: table\n---\n", op: "create" }];
+    const ctx = createValidateContext({ root, changes });
+    expect((await ctx.resolveRef("tables/new")).exists).toBe(true);
+  });
+
+  test("a pending `delete` overlay makes a previously-existing ref stop resolving", async () => {
+    const root = makeRoot();
+    write(root, "tables/gone.md", "---\ntype: table\n---\n");
+    const changes: FileChange[] = [{ path: "tables/gone.md", op: "delete" }];
+    const ctx = createValidateContext({ root, changes });
+    expect((await ctx.resolveRef("tables/gone")).exists).toBe(false);
+  });
+
+  test("checks extra (cross-bundle) roots on disk when the primary root does not resolve the ref", async () => {
+    const root = makeRoot();
+    const extra = makeRoot();
+    write(extra, "tables/elsewhere.md", "---\ntype: table\n---\n");
+    const ctx = createValidateContext({ root, extraRoots: [extra] });
+    expect((await ctx.resolveRef("tables/elsewhere")).exists).toBe(true);
+  });
+
+  test("never overlays a pending change onto an extra (non-primary) root", async () => {
+    const root = makeRoot();
+    const extra = makeRoot();
+    // The change targets a path relative to `root`; it must not leak into `extra`'s resolution.
+    const changes: FileChange[] = [{ path: "tables/only-in-primary.md", after: "x", op: "create" }];
+    const ctx = createValidateContext({ root, extraRoots: [extra], changes });
+    expect((await ctx.resolveRef("tables/only-in-primary")).exists).toBe(true); // resolves via the primary root's overlay
+    expect(fs.existsSync(path.join(extra, "tables/only-in-primary.md"))).toBe(false); // never written to the extra root
+  });
+});

--- a/tests/core/adapter/validate-context.test.ts
+++ b/tests/core/adapter/validate-context.test.ts
@@ -170,4 +170,32 @@ describe("createValidateContext — resolveRef", () => {
     expect((await ctx.resolveRef("tables/only-in-primary")).exists).toBe(true); // resolves via the primary root's overlay
     expect(fs.existsSync(path.join(extra, "tables/only-in-primary.md"))).toBe(false); // never written to the extra root
   });
+  // ── PR #745 review (Copilot) — resolveRef hardening ───────────────────────
+
+  test("a ref naming a DIRECTORY does not count as a resolved target", async () => {
+    const root = makeRoot();
+    // A directory named exactly like the ref, with no matching file. `existsSync`
+    // would call this resolved and silently suppress a real missing-ref.
+    fs.mkdirSync(path.join(root, "pages", "ghost-page"), { recursive: true });
+    const ctx = createValidateContext({ root });
+    expect((await ctx.resolveRef("pages/ghost-page")).exists).toBe(false);
+  });
+
+  test("rejects refs that escape the bundle root via `..`", async () => {
+    const root = makeRoot();
+    const outside = makeRoot();
+    write(outside, "secret.md", "---\ntype: knowledge\n---\n");
+    const rel = `${path.relative(root, outside).split(path.sep).join("/")}/secret`;
+    expect(rel.includes("..")).toBe(true); // precondition: this really does traverse out
+    const ctx = createValidateContext({ root });
+    expect((await ctx.resolveRef(rel)).exists).toBe(false);
+  });
+
+  test("rejects absolute-path refs", async () => {
+    const root = makeRoot();
+    write(root, "tables/real.md", "---\ntype: table\n---\n");
+    const ctx = createValidateContext({ root });
+    expect((await ctx.resolveRef("/etc/passwd")).exists).toBe(false);
+    expect((await ctx.resolveRef(`${root}/tables/real.md`)).exists).toBe(false);
+  });
 });

--- a/tests/integration/cli-errors.test.ts
+++ b/tests/integration/cli-errors.test.ts
@@ -496,6 +496,10 @@ describe("R-032: citty CLIError family exits 2, not 1", () => {
       [["history"], "akm log --ref"],
       [["mv", "a", "b"], "rekey-asset-ref.ts"],
       [["extract"], "akm proposal extract"],
+      // The removed `akm vault ...` family (0.9.0 release-notes headline)
+      // falls through to a generic did-you-mean without this hint.
+      [["vault", "list"], "akm env list"],
+      [["vault", "get", "x"], "akm secret set"],
     ];
     for (const [argv, expected] of cases) {
       const { status, stderr } = spawnCli(argv, { cwd: repoRoot });
@@ -516,6 +520,7 @@ describe("R-032: citty CLIError family exits 2, not 1", () => {
       [["workflow", "watch", "run-1"], "akm log --run"],
       [["config", "show"], "akm config list"],
       [["task", "enable", "t1"], "akm task sync"],
+      [["task", "show", "t1"], "akm show"],
       [["log", "tail"], "@offset:"],
     ];
     for (const [argv, expected] of cases) {
@@ -523,6 +528,34 @@ describe("R-032: citty CLIError family exits 2, not 1", () => {
       expect(status, argv.join(" ")).toBe(2);
       const parsed = JSON.parse(stderr.trim());
       expect(parsed.hint, argv.join(" ")).toContain(expected);
+    }
+  });
+
+  // Removed 0.9 flags (as opposed to removed commands) get no hint at all
+  // today — just a generic "unknown flag" from src/cli/unknown-flags.ts.
+  // `retiredFlagHint` (src/cli/retired-commands.ts) closes that gap. Uses a
+  // real subprocess (like the retired-spellings tests above), not the
+  // `runCli` in-process harness: a `UsageError` thrown by `assertKnownFlags`
+  // — BEFORE citty's own `runCommand` ever starts — escapes the harness's
+  // replicated startup contract without going through `emitJsonError`, so it
+  // lands in `stderr` as a raw message instead of the JSON envelope the real
+  // CLI always produces here (verified directly: `bun src/cli.ts index
+  // --background` prints the proper `{"ok":false,...}` envelope).
+  test("retired flags on their current command hint the replacement procedure", () => {
+    const cases: Array<[string[], string]> = [
+      [["index", "--background"], "--quiet"],
+      [["setup", "--detect-only"], "akm setup"],
+      [["setup", "--reset-recommended"], "recommended defaults"],
+      [["proposal", "extract", "--watch"], "proposal extract --auto"],
+      [["proposal", "extract", "--debounce-ms"], "proposal extract --auto"],
+    ];
+    for (const [argv, expected] of cases) {
+      const { status, stderr } = spawnCli(argv, { cwd: repoRoot });
+      expect(status, argv.join(" ")).toBe(2);
+      const parsed = JSON.parse(stderr.trim());
+      expect(parsed.code, argv.join(" ")).toBe("UNKNOWN_FLAG");
+      expect(parsed.hint, argv.join(" ")).toContain(expected);
+      expect(parsed.hint, argv.join(" ")).toContain("akm help migrate 0.9.0");
     }
   });
 });
@@ -568,6 +601,7 @@ describe("S11: sectioned root help", () => {
         "registry",
         "info",
         "log",
+        "migrate",
         "help",
         "hints",
         "upgrade",
@@ -578,18 +612,28 @@ describe("S11: sectioned root help", () => {
     expect(stdout).toContain("Agents: run `akm hints`");
   });
 
-  test("akm --help does not list the hidden migrate group", () => {
+  test("akm --help lists migrate in the SYSTEM section", () => {
+    // Previously hidden (S11): the upgrade instructions tell users to run
+    // `akm migrate status`/`apply` first, so the command needs to be
+    // discoverable from `akm --help` rather than a self-update-only secret.
     const { stdout } = spawnCli(["--help"], { cwd: repoRoot });
-    expect(stdout).not.toContain("  migrate ");
+    expect(stdout).toContain("  migrate ");
   });
 
-  test("akm migrate status still executes despite being hidden from help", () => {
+  test("akm migrate status still executes", () => {
     // Not asserting exit 0 — status depends on ambient config/DB state this
-    // suite doesn't sandbox for this one subprocess. What `hidden` must NOT
-    // do is make citty treat it as an unknown command.
+    // suite doesn't sandbox for this one subprocess.
     const { stdout, stderr } = spawnCli(["migrate", "status"], { cwd: repoRoot });
     expect(stderr).not.toContain("Unknown command");
     expect(stdout).toContain('"status"');
+  });
+
+  test("akm migrate --help renders its own usage", () => {
+    const { status, stdout, stderr } = spawnCli(["migrate", "--help"], { cwd: repoRoot });
+    expect(status).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("akm migrate");
+    expect(stdout).toContain("USAGE");
   });
 
   test("bare akm help prints the same sectioned overview and exits 0", () => {

--- a/tests/integration/config-recovery-concurrency.test.ts
+++ b/tests/integration/config-recovery-concurrency.test.ts
@@ -66,7 +66,7 @@ describe("raw recovery startup", () => {
       new Response(blockedChild.stdout).text(),
     ]);
     expect(blockedExit).toBe(1);
-    expect(blockedStdout).toContain('"status":"blocked"');
+    expect(JSON.parse(blockedStdout)).toMatchObject({ status: "blocked" });
 
     const child = Bun.spawn(["bun", "src/cli.ts", "migrate", "status", "--config", prepared], {
       cwd: path.resolve(import.meta.dir, "../.."),
@@ -80,7 +80,7 @@ describe("raw recovery startup", () => {
       new Response(child.stderr).text(),
     ]);
     expect(exitCode, stderr).toBe(0);
-    expect(stdout).toContain('"status":"ready"');
+    expect(JSON.parse(stdout)).toMatchObject({ status: "ready" });
   });
 
   test("setup rejects legacy config before creating the stash or backup", async () => {

--- a/tests/integration/goldens-lint-output.test.ts
+++ b/tests/integration/goldens-lint-output.test.ts
@@ -176,8 +176,8 @@ describe("lint parity: all 14 all-types fixture assets lint clean via the consol
     expect(issues).toEqual([]);
   });
 
-  test("akmLint({dir: STASH_ROOT}) full sweep is clean and does not error", () => {
-    const result = akmLint({ dir: STASH_ROOT });
+  test("akmLint({dir: STASH_ROOT}) full sweep is clean and does not error", async () => {
+    const result = await akmLint({ dir: STASH_ROOT });
     expect(result.ok).toBe(true);
     expect(result.flagged).toEqual([]);
     expect(result.fixed).toEqual([]);
@@ -190,7 +190,7 @@ describe("lint parity: all 14 all-types fixture assets lint clean via the consol
 // capture never depends on bun:test's within-file execution order.
 
 describe("golden fixture: lint output parity (WI-0b.4b)", () => {
-  test("golden fixture: lint/all-types.json", () => {
+  test("golden fixture: lint/all-types.json", async () => {
     const perType: Record<string, unknown> = {};
 
     for (const [type, subdir, relPath] of ALL_TYPE_CASES) {
@@ -201,7 +201,7 @@ describe("golden fixture: lint output parity (WI-0b.4b)", () => {
     const skillDirIssues = lintSkillDirectory(path.join(STASH_ROOT, "skills/all-types-skill"), STASH_ROOT);
     (perType.skill as { lintDirectoryIssues?: LintIssue[] }).lintDirectoryIssues = skillDirIssues;
 
-    const akmLintFullSweep: AkmLintResult = akmLint({ dir: STASH_ROOT });
+    const akmLintFullSweep: AkmLintResult = await akmLint({ dir: STASH_ROOT });
 
     expectGolden(LINT_GOLDEN_PATH, {
       scenario:

--- a/tests/integration/help-hints-config-bypass.test.ts
+++ b/tests/integration/help-hints-config-bypass.test.ts
@@ -1,0 +1,135 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `help` and `hints` are pure-text surfaces — bundled release notes, the
+ * embedded agent-guide text, and command usage rendered from `meta` alone —
+ * none of their run bodies read config. But before this fix, `shouldBypassConfigStartup`
+ * (src/cli.ts) only allowlisted `setup`/`migrate`/`config path`/`task run
+ * --id`/`--help`/`--version`, so the CLI's own startup config load ran first
+ * and threw `UNSUPPORTED_CONFIG_VERSION` against any pre-0.9 (or otherwise
+ * invalid) config — taking down `akm help`, `akm hints`, and even the
+ * documented recovery command the 0.9.0 release notes tell users to run
+ * first: "Run `akm help migrate 0.9.0` for the storage and command-surface
+ * checklist." That instruction was unreachable in exactly the state anyone
+ * would need it.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { getConfigPath } from "../../src/core/paths";
+import { runCliCapture } from "../_helpers/cli";
+import {
+  type Cleanup,
+  sandboxHome,
+  sandboxXdgCacheHome,
+  sandboxXdgConfigHome,
+  sandboxXdgDataHome,
+} from "../_helpers/sandbox";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..");
+
+/**
+ * Real subprocess, used ONLY for the bare-invocation case: the in-process
+ * harness (`runCliCapture`) drives `runCommand` directly and does not
+ * replicate `src/cli.ts`'s `rawArgs.length === 0` special case (printing the
+ * sectioned root help before citty's own dispatch ever runs) — every other
+ * case in this file goes through `runCliCapture`, matching the harness's own
+ * documented fidelity.
+ */
+function spawnCli(args: string[]): { stdout: string; stderr: string; status: number } {
+  const result = spawnSync("bun", [path.join(repoRoot, "src", "cli.ts"), ...args], {
+    encoding: "utf8",
+    timeout: 10_000,
+    cwd: repoRoot,
+    env: { ...process.env, AKM_BUNDLE_DIR: undefined },
+  });
+  return { stdout: result.stdout ?? "", stderr: result.stderr ?? "", status: result.status ?? 1 };
+}
+
+describe("shouldBypassConfigStartup allowlists help and hints", () => {
+  // Exercised indirectly below via the real CLI process (runCliCapture); this
+  // block pins the direct contract too, matching the style of the existing
+  // setup/migrate/config-path bypass tests.
+  test("help, hints, bare invocation, and their subcommands bypass the startup config load", async () => {
+    const { shouldBypassConfigStartup } = await import("../../src/cli");
+    for (const args of [
+      ["bun", "cli.ts"],
+      ["bun", "cli.ts", "help"],
+      ["bun", "cli.ts", "help", "migrate", "0.9.0"],
+      ["bun", "cli.ts", "help", "search"],
+      ["bun", "cli.ts", "help", "agents"],
+      ["bun", "cli.ts", "hints"],
+      ["bun", "cli.ts", "hints", "--detail", "brief"],
+    ]) {
+      expect(shouldBypassConfigStartup(args), args.join(" ")).toBe(true);
+    }
+  });
+
+  test("a command that needs config is NOT bypassed", async () => {
+    const { shouldBypassConfigStartup } = await import("../../src/cli");
+    expect(shouldBypassConfigStartup(["bun", "cli.ts", "search", "anything"])).toBe(false);
+  });
+});
+
+describe("akm help / akm hints against a config akm 0.9 cannot load", () => {
+  let cleanup: Cleanup | undefined;
+
+  beforeEach(() => {
+    const home = sandboxHome();
+    const config = sandboxXdgConfigHome(home.cleanup);
+    const cache = sandboxXdgCacheHome(config.cleanup);
+    cleanup = sandboxXdgDataHome(cache.cleanup).cleanup;
+    fs.writeFileSync(getConfigPath(), '{"configVersion":"0.8.0","stashDir":"/home/user/old-stash"}\n');
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  test("akm help renders the sectioned overview instead of a config error", async () => {
+    const { code, stdout, stderr } = await runCliCapture(["help"]);
+    expect(code, stderr).toBe(0);
+    expect(stdout).toContain("AGENT LOOP");
+    expect(stdout).toContain("SYSTEM");
+    expect(stderr).toBe("");
+  });
+
+  test("akm help migrate 0.9.0 — the documented recovery command — actually runs", async () => {
+    const { code, stdout, stderr } = await runCliCapture(["help", "migrate", "0.9.0"]);
+    expect(code, stderr).toBe(0);
+    expect(stdout).toContain("Migration notes for akm v0.9.0");
+    expect(stdout).toContain("akm migrate status");
+  });
+
+  test("akm help <command> renders that command's usage", async () => {
+    const { code, stdout, stderr } = await runCliCapture(["help", "search"]);
+    expect(code, stderr).toBe(0);
+    expect(stdout).toContain("akm search");
+    expect(stdout).toContain("USAGE");
+  });
+
+  test("akm hints prints the embedded agent guide", async () => {
+    const { code, stdout, stderr } = await runCliCapture(["hints"]);
+    expect(code, stderr).toBe(0);
+    expect(stdout.length).toBeGreaterThan(0);
+  });
+
+  test("bare akm (no subcommand) also renders help instead of a config error", () => {
+    const { status, stdout, stderr } = spawnCli([]);
+    expect(status, stderr).toBe(0);
+    expect(stdout).toContain("AGENT LOOP");
+  });
+
+  test("a command that DOES need config still reports the config error", async () => {
+    // Sanity check the fix is scoped to help/hints, not a blanket bypass.
+    const { code, stderr } = await runCliCapture(["search", "anything"]);
+    expect(code).toBe(78);
+    const parsed = JSON.parse(stderr.trim());
+    expect(parsed.code).toBe("UNSUPPORTED_CONFIG_VERSION");
+  });
+});

--- a/tests/integration/init.test.ts
+++ b/tests/integration/init.test.ts
@@ -196,7 +196,7 @@ describe("akmInit (akm bundle create)", () => {
     fs.rmSync(stashDir, { recursive: true, force: true });
     await akmInit({ dir: stashDir });
 
-    const result = akmLint({ dir: stashDir });
+    const result = await akmLint({ dir: stashDir });
     expect(result.flagged).toEqual([]);
     expect(result.summary.flagged).toBe(0);
   });

--- a/tests/integration/lint-adapter-dispatch.test.ts
+++ b/tests/integration/lint-adapter-dispatch.test.ts
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `akm lint`'s non-akm adapter dispatch (`commands/lint/index.ts#lintViaAdapter`)
+ * — GAP CLOSURE proof for llm-wiki.
+ *
+ * Before this change, `akm lint` special-cased exactly ONE non-akm adapter
+ * (`okf`) and routed every other non-akm bundle — including llm-wiki —
+ * through the AKM-shaped STASH_SUBDIRS sweep. A wiki root has no `knowledge/`,
+ * `memories/`, etc. subdirs, so that sweep visited NOTHING: llm-wiki's own
+ * four `validate()` checks (`uncited-raw` / `missing-description` /
+ * `broken-xref` / `broken-source`, `core/adapter/adapters/llm-wiki-adapter.ts`)
+ * were unreachable dead code from the CLI. `akm lint` now dispatches every
+ * non-akm bundle through its OWN adapter's `validate()`
+ * (`commands/lint/index.ts#lintViaAdapter`), closing that gap.
+ *
+ * This suite builds a fresh llm-wiki-shaped bundle at runtime (never touches
+ * the shared conformance fixture at `tests/fixtures/bundles/llm-wiki/`, which
+ * is deliberately clean) and drives it through the real `akm lint` CLI entry
+ * point — not `llmWikiAdapter.validate()` directly (that surface already has
+ * its own dedicated suite, `tests/core/adapter/llm-wiki-adapter.test.ts`).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { akmLint } from "../../src/commands/lint/index";
+import { detectAdapterId } from "../../src/core/adapter/detect-adapter";
+import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../_helpers/sandbox";
+
+function write(root: string, relPath: string, content: string): void {
+  const full = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, "utf8");
+}
+
+describe("akm lint dispatches an llm-wiki bundle through llmWikiAdapter.validate()", () => {
+  let storage: IsolatedAkmStorage;
+
+  afterEach(() => storage?.cleanup());
+
+  test("a dangling cross-reference trips broken-xref; an uncited raw source trips uncited-raw; a page with no description trips missing-description", async () => {
+    storage = withIsolatedAkmStorage();
+    const wikiRoot = path.join(storage.root, "my-wiki");
+
+    write(wikiRoot, "schema.md", "# Wiki schema\n\nConventions live here.\n");
+    write(wikiRoot, "index.md", "# Index\n");
+    write(wikiRoot, "log.md", "# Log\n");
+    // A raw ingested source that NO page cites — should trip `uncited-raw`.
+    write(wikiRoot, "raw/2026-source.md", "# Raw source\n\nSome ingested material.\n");
+    // A page with a description AND a cited source, but a body link to a page
+    // that does not exist — should trip `broken-xref` (non-blocking).
+    write(
+      wikiRoot,
+      "pages/http-caching.md",
+      "---\ndescription: HTTP caching notes\n---\n\nSee [Varnish](varnish.md) for details.\n",
+    );
+    // A page missing a frontmatter `description` — should trip `missing-description`.
+    write(wikiRoot, "pages/no-description.md", "# No description here\n\nJust body text.\n");
+
+    // Sanity: the fixture really auto-detects as `llm-wiki` (a real, live
+    // consumer of the same `looksLikeRoot` probe order `akm lint` uses) —
+    // failing this would mean the dispatch never even runs.
+    expect(detectAdapterId(wikiRoot)).toBe("llm-wiki");
+
+    const result = await akmLint({ dir: wikiRoot });
+    expect(result.ok).toBe(true);
+    expect(result.fixed).toEqual([]); // validate() never writes — nothing is ever auto-fixed for a non-akm bundle
+
+    const byIssue = (issue: string) => result.flagged.filter((f) => f.issue === issue);
+
+    const brokenXref = byIssue("broken-xref");
+    expect(brokenXref.length).toBeGreaterThan(0);
+    expect(brokenXref.some((f) => f.file === "pages/http-caching.md" && f.detail.includes("varnish"))).toBe(true);
+
+    const uncitedRaw = byIssue("uncited-raw");
+    expect(uncitedRaw.length).toBeGreaterThan(0);
+    expect(uncitedRaw.some((f) => f.file === "raw/2026-source.md")).toBe(true);
+
+    const missingDescription = byIssue("missing-description");
+    expect(missingDescription.some((f) => f.file === "pages/no-description.md")).toBe(true);
+
+    // Every llm-wiki finding is non-blocking (`fixed: false` — the adapter
+    // MUST NOT write; `core/adapter/bundle-adapter.ts`'s validate() contract).
+    for (const issue of result.flagged) expect(issue.fixed).toBe(false);
+  });
+
+  test("a clean llm-wiki bundle lints with zero findings", async () => {
+    storage = withIsolatedAkmStorage();
+    const wikiRoot = path.join(storage.root, "clean-wiki");
+
+    write(wikiRoot, "schema.md", "# Wiki schema\n");
+    write(wikiRoot, "pages/topic.md", "---\ndescription: A well-formed page\n---\n\nNo dangling links here.\n");
+
+    const result = await akmLint({ dir: wikiRoot });
+    expect(result.ok).toBe(true);
+    expect(result.flagged).toEqual([]);
+    expect(result.fixed).toEqual([]);
+  });
+});

--- a/tests/integration/lint-workflow-program.test.ts
+++ b/tests/integration/lint-workflow-program.test.ts
@@ -65,25 +65,25 @@ const CLEAN_WORKFLOW = [
 ].join("\n");
 
 describe("akm lint --type workflows", () => {
-  test("a well-formed unified workflow produces no findings", () => {
+  test("a well-formed unified workflow produces no findings", async () => {
     const stashDir = makeTempStash();
     writeWorkflowFile(stashDir, "clean.md", CLEAN_WORKFLOW);
 
-    const result = akmLint({ dir: stashDir, typeFilter: "workflows" });
+    const result = await akmLint({ dir: stashDir, typeFilter: "workflows" });
 
     expect(result.flagged).toHaveLength(0);
   });
 
-  test("README documentation in the workflows directory is not treated as a workflow asset", () => {
+  test("README documentation in the workflows directory is not treated as a workflow asset", async () => {
     const stashDir = makeTempStash();
     writeWorkflowFile(stashDir, "README.md", "# Workflow documentation\n");
 
-    const result = akmLint({ dir: stashDir, typeFilter: "workflows" });
+    const result = await akmLint({ dir: stashDir, typeFilter: "workflows" });
 
     expect(result.flagged).toHaveLength(0);
   });
 
-  test("a workflow missing the required `steps` list is a parse-stage finding", () => {
+  test("a workflow missing the required `steps` list is a parse-stage finding", async () => {
     const stashDir = makeTempStash();
     writeWorkflowFile(
       stashDir,
@@ -91,7 +91,7 @@ describe("akm lint --type workflows", () => {
       ["---", "type: workflow", "description: No steps", "---", ""].join("\n"),
     );
 
-    const result = akmLint({ dir: stashDir, typeFilter: "workflows" });
+    const result = await akmLint({ dir: stashDir, typeFilter: "workflows" });
 
     const structural = result.flagged.filter((i) => i.issue === "invalid-workflow-structure");
     expect(structural).toHaveLength(1);
@@ -99,7 +99,7 @@ describe("akm lint --type workflows", () => {
     expect(structural[0]!.detail).toContain('"steps" is required');
   });
 
-  test("a reference to a missing step is a compile-stage finding", () => {
+  test("a reference to a missing step is a compile-stage finding", async () => {
     const stashDir = makeTempStash();
     writeWorkflowFile(
       stashDir,
@@ -120,14 +120,14 @@ describe("akm lint --type workflows", () => {
       ].join("\n"),
     );
 
-    const result = akmLint({ dir: stashDir, typeFilter: "workflows" });
+    const result = await akmLint({ dir: stashDir, typeFilter: "workflows" });
 
     const structural = result.flagged.filter((i) => i.issue === "invalid-workflow-structure");
     expect(structural).toHaveLength(1);
     expect(structural[0]?.detail).toContain('"ghost" is not a step in this workflow');
   });
 
-  test("a reference to a later step is a compile-stage finding", () => {
+  test("a reference to a later step is a compile-stage finding", async () => {
     const stashDir = makeTempStash();
     writeWorkflowFile(
       stashDir,
@@ -153,14 +153,14 @@ describe("akm lint --type workflows", () => {
       ].join("\n"),
     );
 
-    const result = akmLint({ dir: stashDir, typeFilter: "workflows" });
+    const result = await akmLint({ dir: stashDir, typeFilter: "workflows" });
 
     const structural = result.flagged.filter((i) => i.issue === "invalid-workflow-structure");
     expect(structural).toHaveLength(1);
     expect(structural[0]?.detail).toContain("does not come before this step");
   });
 
-  test("a param declared as a step input is a compile-stage finding", () => {
+  test("a param declared as a step input is a compile-stage finding", async () => {
     const stashDir = makeTempStash();
     writeWorkflowFile(
       stashDir,
@@ -181,19 +181,19 @@ describe("akm lint --type workflows", () => {
       ].join("\n"),
     );
 
-    const result = akmLint({ dir: stashDir, typeFilter: "workflows" });
+    const result = await akmLint({ dir: stashDir, typeFilter: "workflows" });
 
     const structural = result.flagged.filter((i) => i.issue === "invalid-workflow-structure");
     expect(structural).toHaveLength(1);
     expect(structural[0]?.detail).toContain("names a param, not a step output");
   });
 
-  test("a clean workflow alongside a structurally-broken one: each is checked independently", () => {
+  test("a clean workflow alongside a structurally-broken one: each is checked independently", async () => {
     const stashDir = makeTempStash();
     writeWorkflowFile(stashDir, "release.md", CLEAN_WORKFLOW);
     writeWorkflowFile(stashDir, "broken.md", ["---", "type: workflow", "description: Broken", "---", ""].join("\n"));
 
-    const result = akmLint({ dir: stashDir, typeFilter: "workflows" });
+    const result = await akmLint({ dir: stashDir, typeFilter: "workflows" });
 
     const structural = result.flagged.filter((i) => i.issue === "invalid-workflow-structure");
     expect(structural).toHaveLength(1);

--- a/tests/integration/migrate-format.test.ts
+++ b/tests/integration/migrate-format.test.ts
@@ -1,0 +1,154 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `akm migrate status`/`apply` honouring `--format` (D7) instead of always
+ * emitting the standalone `akm-migrate` tool's fixed JSON and warning that
+ * `--format` "has no effect" (`src/commands/migrate-cli.ts`,
+ * `src/output/shapes/migrate.ts`, `src/output/text/migrate.ts`).
+ */
+
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import { getLegacyWorkflowDbPath } from "../../scripts/akm-migrate/migrate/legacy/legacy-paths";
+import { getConfigPath, getStateDbPathInDataDir } from "../../src/core/paths";
+import { isFormatExemptCommand } from "../../src/output/format-exempt";
+import { openStateDbAtCeiling, PRE_CUTOVER_STATE_CEILING } from "../_fixtures/migration/seed-rows";
+import { runCliCapture } from "../_helpers/cli";
+import { openLegacyWorkflowDb } from "../_helpers/legacy-workflow-db";
+import { withIsolatedAkmStorage } from "../_helpers/sandbox";
+
+function seedLegacyInstall(storage: ReturnType<typeof withIsolatedAkmStorage>) {
+  fs.writeFileSync(getConfigPath(), `${JSON.stringify({ stashDir: storage.stashDir, sources: [] })}\n`, {
+    mode: 0o600,
+  });
+  openStateDbAtCeiling(getStateDbPathInDataDir(), PRE_CUTOVER_STATE_CEILING).close();
+  openLegacyWorkflowDb(getLegacyWorkflowDbPath()).close();
+}
+
+/** Write one pre-0.9.0 `<stash>/.akm/proposals/<id>/proposal.json` — triggers the
+ * "content-migration" progress-event line during `migrate apply` (see
+ * `runContentMigrationStep`/`importLegacyProposalsIntoState`,
+ * `scripts/akm-migrate/config-migrate.ts`). */
+function writeLegacyProposal(stashDir: string, id: string): void {
+  const dir = `${stashDir}/.akm/proposals/${id}`;
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    `${dir}/proposal.json`,
+    `${JSON.stringify({
+      id,
+      ref: "lessons/legacy-pending",
+      status: "pending",
+      source: "reflect",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      payload: { content: "Prefer rg over grep for code search.\n" },
+    })}\n`,
+    "utf8",
+  );
+}
+
+test("migrate status/apply are no longer format-exempt", () => {
+  expect(isFormatExemptCommand(["migrate", "status"])).toBe(false);
+  expect(isFormatExemptCommand(["migrate", "apply"])).toBe(false);
+  expect(isFormatExemptCommand(["migrate"])).toBe(false);
+});
+
+test("migrate status --format text renders a real text document, no 'has no effect' warning", async () => {
+  const storage = withIsolatedAkmStorage();
+  try {
+    seedLegacyInstall(storage);
+    const result = await runCliCapture(["migrate", "status", "--format", "text"]);
+    expect(result.stderr).not.toContain("has no effect");
+    expect(() => JSON.parse(result.stdout)).toThrow();
+    expect(result.stdout).toContain("blocked");
+    expect(result.stdout).toContain("artifacts:");
+    expect(result.stdout).toContain("config.json: old");
+  } finally {
+    storage.cleanup();
+  }
+});
+
+test("migrate status --format md/html/yaml each render without the 'has no effect' warning", async () => {
+  const storage = withIsolatedAkmStorage();
+  try {
+    seedLegacyInstall(storage);
+    for (const format of ["md", "html", "yaml"]) {
+      const result = await runCliCapture(["migrate", "status", "--format", format]);
+      expect(result.stderr, format).not.toContain("has no effect");
+      expect(result.stdout, format).toContain("blocked");
+    }
+  } finally {
+    storage.cleanup();
+  }
+});
+
+test("migrate status --format json still parses to the same plan as the unflagged default", async () => {
+  const storage = withIsolatedAkmStorage();
+  try {
+    seedLegacyInstall(storage);
+    const bare = await runCliCapture(["migrate", "status"]);
+    const explicit = await runCliCapture(["migrate", "status", "--format", "json"]);
+    expect(JSON.parse(explicit.stdout)).toEqual(JSON.parse(bare.stdout));
+  } finally {
+    storage.cleanup();
+  }
+});
+
+test("migrate apply --format text renders both the generate-only stop and the completed cutover as text", async () => {
+  const storage = withIsolatedAkmStorage();
+  try {
+    seedLegacyInstall(storage);
+    // First apply: generates the starter config and stops (no --config given).
+    const first = await runCliCapture(["migrate", "apply", "--format", "text"]);
+    expect(first.code, first.stderr).toBe(0);
+    expect(first.stdout).toContain("ready");
+    expect(first.stdout).toContain("Generated a starter 0.9 config");
+
+    // Second apply completes the cutover — still renders as text, not JSON.
+    const second = await runCliCapture(["migrate", "apply", "--format", "text"]);
+    expect(second.code, second.stderr).toBe(0);
+    expect(second.stdout).toContain("current");
+    expect(() => JSON.parse(second.stdout)).toThrow();
+  } finally {
+    storage.cleanup();
+  }
+});
+
+test("migrate apply --format text prints a real progress-event line verbatim ahead of the formatted result", async () => {
+  const storage = withIsolatedAkmStorage();
+  try {
+    seedLegacyInstall(storage);
+    fs.mkdirSync(`${storage.stashDir}/lessons`, { recursive: true });
+    writeLegacyProposal(storage.stashDir, "11111111-1111-4111-8111-111111111111");
+    const prepared = `${storage.root}/prepared.json`;
+    fs.writeFileSync(
+      prepared,
+      `${JSON.stringify({
+        configVersion: "0.9.0",
+        bundles: { primary: { path: storage.stashDir, writable: true } },
+        defaultBundle: "primary",
+      })}\n`,
+      { mode: 0o600 },
+    );
+
+    const applied = await runCliCapture(["migrate", "apply", "--config", prepared, "--format", "text"]);
+    expect(applied.code, applied.stderr).toBe(0);
+    const lines = applied.stdout.split("\n").filter((line) => line.length > 0);
+
+    // The progress-event line is untouched raw JSON — never reformatted —
+    // and precedes the human-readable rendering of the final result.
+    const eventLineIndex = lines.findIndex((line) => line.includes('"event":"content-migration"'));
+    expect(eventLineIndex).toBeGreaterThanOrEqual(0);
+    expect(() => JSON.parse(lines[eventLineIndex] as string)).not.toThrow();
+    const parsedEvent = JSON.parse(lines[eventLineIndex] as string) as { legacyProposalsImported: number };
+    expect(parsedEvent.legacyProposalsImported).toBe(1);
+
+    const resultGlyphIndex = lines.findIndex((line) => line.includes("current"));
+    expect(resultGlyphIndex).toBeGreaterThan(eventLineIndex);
+    expect(() => JSON.parse(applied.stdout)).toThrow(); // whole stdout is not one JSON document
+  } finally {
+    storage.cleanup();
+  }
+});

--- a/tests/integration/migration-config-generation.test.ts
+++ b/tests/integration/migration-config-generation.test.ts
@@ -1,0 +1,216 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `akm migrate` auto-generating the 0.9 target config when no `--config` is
+ * given (see `scripts/akm-migrate/config-migrate.ts`'s `describeGeneratedConfig`
+ * / `writeGeneratedTargetConfig`, and `scripts/akm-migrate/migrate/legacy/
+ * config-generate.ts`).
+ *
+ * Covers: the mechanical part (bundles/defaultBundle) is derived without
+ * asking; the ambiguous part (profiles/defaults.llm/agent/improve) is dropped
+ * and named, never guessed; the live 0.8 config.json is never touched until
+ * `publishConfigLast`'s normal atomic install; `status`/`apply --dry-run`
+ * never write anything; an explicit `--config` always wins and is never
+ * second-guessed against an auto-generated file.
+ */
+
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { getLegacyWorkflowDbPath } from "../../scripts/akm-migrate/migrate/legacy/legacy-paths";
+import { getMigrationBackupRoot, getMigrationGeneratedConfigPath } from "../../scripts/akm-migrate/migration-backup";
+import { getConfigPath, getStateDbPathInDataDir } from "../../src/core/paths";
+import { openStateDbAtCeiling, PRE_CUTOVER_STATE_CEILING } from "../_fixtures/migration/seed-rows";
+import { runCliCapture } from "../_helpers/cli";
+import { openLegacyWorkflowDb } from "../_helpers/legacy-workflow-db";
+import { withIsolatedAkmStorage } from "../_helpers/sandbox";
+
+function seedLegacyInstall(storage: ReturnType<typeof withIsolatedAkmStorage>, extra: Record<string, unknown> = {}) {
+  fs.writeFileSync(getConfigPath(), `${JSON.stringify({ stashDir: storage.stashDir, sources: [], ...extra })}\n`, {
+    mode: 0o600,
+  });
+  openStateDbAtCeiling(getStateDbPathInDataDir(), PRE_CUTOVER_STATE_CEILING).close();
+  openLegacyWorkflowDb(getLegacyWorkflowDbPath()).close();
+}
+
+test("migrate status previews generation without writing anything", async () => {
+  const storage = withIsolatedAkmStorage();
+  try {
+    seedLegacyInstall(storage);
+    const configBefore = fs.readFileSync(getConfigPath());
+    const generatedPath = getMigrationGeneratedConfigPath();
+
+    const status = await runCliCapture(["migrate", "status"]);
+    expect(status.code).not.toBe(0); // still blocked — nothing generated yet
+    const plan = JSON.parse(status.stdout) as {
+      status: string;
+      blockers: string[];
+      generatedConfig?: { path: string; status: string; droppedKeys: string[] };
+    };
+    expect(plan.status).toBe("blocked");
+    expect(plan.generatedConfig).toEqual({ path: generatedPath, status: "pending", droppedKeys: [] });
+    expect(plan.blockers.some((b) => b.includes("akm migrate apply"))).toBe(true);
+
+    expect(fs.existsSync(generatedPath)).toBe(false);
+    expect(fs.readFileSync(getConfigPath())).toEqual(configBefore);
+
+    // `apply --dry-run` performs the identical read-only checks.
+    const dryRun = await runCliCapture(["migrate", "apply", "--dry-run"]);
+    expect(dryRun.code).not.toBe(0);
+    expect(JSON.parse(dryRun.stdout)).toEqual(plan);
+    expect(fs.existsSync(generatedPath)).toBe(false);
+  } finally {
+    storage.cleanup();
+  }
+});
+
+test("migrate apply with no --config writes a starter config and stops without mutating the live install", async () => {
+  const storage = withIsolatedAkmStorage();
+  try {
+    seedLegacyInstall(storage);
+    const configBefore = fs.readFileSync(getConfigPath());
+    const stateBefore = fs.readFileSync(getStateDbPathInDataDir());
+    const generatedPath = getMigrationGeneratedConfigPath();
+
+    const applied = await runCliCapture(["migrate", "apply"]);
+    expect(applied.code, applied.stderr).toBe(0);
+    const plan = JSON.parse(applied.stdout) as {
+      status: string;
+      message?: string;
+      generatedConfig?: { path: string; status: string; droppedKeys: string[] };
+      backupPath?: string;
+    };
+    expect(plan.status).toBe("ready");
+    expect(plan.generatedConfig).toEqual({ path: generatedPath, status: "written", droppedKeys: [] });
+    expect(plan.message).toContain(generatedPath);
+    expect(plan.message).toContain("re-run");
+    expect(plan.backupPath).toBeUndefined();
+
+    // The live 0.8 config.json and databases are byte-for-byte untouched.
+    expect(fs.readFileSync(getConfigPath())).toEqual(configBefore);
+    expect(fs.readFileSync(getStateDbPathInDataDir())).toEqual(stateBefore);
+
+    // The generated file is a schema-shaped 0.9 config deriving bundles from
+    // the 0.8 stashDir.
+    expect(fs.existsSync(generatedPath)).toBe(true);
+    const generated = JSON.parse(fs.readFileSync(generatedPath, "utf8")) as Record<string, unknown>;
+    expect(generated.configVersion).toBe("0.9.0");
+    expect(generated.stashDir).toBeUndefined();
+    expect(generated.sources).toBeUndefined();
+    const bundles = generated.bundles as Record<string, { path: string; writable?: boolean }>;
+    expect(Object.keys(bundles)).toHaveLength(1);
+    const [bundleId, bundle] = Object.entries(bundles)[0] as [string, { path: string; writable?: boolean }];
+    expect(path.resolve(bundle.path)).toBe(path.resolve(storage.stashDir));
+    expect(generated.defaultBundle).toBe(bundleId);
+
+    // No backup run was created — nothing actually mutated yet. (The
+    // migration-operation directory itself now exists — it holds the
+    // generated config file — but no backup RUN subdirectory does.)
+    const backupRuns = fs.existsSync(getMigrationBackupRoot())
+      ? fs
+          .readdirSync(getMigrationBackupRoot(), { withFileTypes: true })
+          .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
+      : [];
+    expect(backupRuns).toHaveLength(0);
+  } finally {
+    storage.cleanup();
+  }
+});
+
+test("a second no-config apply picks up the generated file and completes the migration", async () => {
+  const storage = withIsolatedAkmStorage();
+  try {
+    seedLegacyInstall(storage);
+
+    const first = await runCliCapture(["migrate", "apply"]);
+    expect(first.code, first.stderr).toBe(0);
+    expect(JSON.parse(first.stdout)).toMatchObject({ status: "ready" });
+
+    const second = await runCliCapture(["migrate", "apply"]);
+    expect(second.code, second.stderr).toBe(0);
+    const result = JSON.parse(second.stdout) as { status: string; backupPath?: string };
+    expect(result.status).toBe("current");
+    expect(result.backupPath).toBeDefined();
+
+    const config = JSON.parse(fs.readFileSync(getConfigPath(), "utf8")) as Record<string, unknown>;
+    expect(config.configVersion).toBe("0.9.0");
+    expect(config.bundles).toBeDefined();
+    expect(config.stashDir).toBeUndefined();
+
+    const status = await runCliCapture(["migrate", "status"]);
+    expect(status.code, status.stderr).toBe(0);
+    expect(JSON.parse(status.stdout)).toMatchObject({ status: "current" });
+  } finally {
+    storage.cleanup();
+  }
+});
+
+test("ambiguous profiles/defaults keys are dropped and named, never guessed, and apply still completes", async () => {
+  const storage = withIsolatedAkmStorage();
+  try {
+    seedLegacyInstall(storage, {
+      profiles: { agent: { fast: { platform: "opencode" } }, llm: { primary: { model: "x" } } },
+      defaults: { agent: "fast", llm: "primary" },
+    });
+
+    const status = await runCliCapture(["migrate", "status"]);
+    const plan = JSON.parse(status.stdout) as { generatedConfig?: { droppedKeys: string[] } };
+    expect(new Set(plan.generatedConfig?.droppedKeys)).toEqual(
+      new Set(["profiles.agent.fast", "profiles.llm.primary", "defaults.agent", "defaults.llm"]),
+    );
+
+    const first = await runCliCapture(["migrate", "apply"]);
+    expect(first.code, first.stderr).toBe(0);
+    const firstPlan = JSON.parse(first.stdout) as {
+      generatedConfig?: { droppedKeys: string[] };
+      message?: string;
+    };
+    expect(new Set(firstPlan.generatedConfig?.droppedKeys)).toEqual(
+      new Set(["profiles.agent.fast", "profiles.llm.primary", "defaults.agent", "defaults.llm"]),
+    );
+    expect(firstPlan.message).toContain("profiles.agent.fast");
+    expect(firstPlan.message).toContain("defaults.llm");
+
+    const generated = JSON.parse(fs.readFileSync(getMigrationGeneratedConfigPath(), "utf8")) as Record<string, unknown>;
+    expect(generated.profiles).toBeUndefined();
+    expect(generated.defaults).toBeUndefined();
+
+    // The engine-less generated config is still enough to complete the cutover.
+    const second = await runCliCapture(["migrate", "apply"]);
+    expect(second.code, second.stderr).toBe(0);
+    expect(JSON.parse(second.stdout)).toMatchObject({ status: "current" });
+  } finally {
+    storage.cleanup();
+  }
+});
+
+test("an explicit --config always wins and is never second-guessed against a generated file", async () => {
+  const storage = withIsolatedAkmStorage();
+  try {
+    seedLegacyInstall(storage);
+    const prepared = path.join(storage.root, "prepared.json");
+    fs.writeFileSync(
+      prepared,
+      `${JSON.stringify({ configVersion: "0.9.0", stashDir: storage.stashDir, sources: [] })}\n`,
+      { mode: 0o600 },
+    );
+    const generatedPath = getMigrationGeneratedConfigPath();
+
+    const status = await runCliCapture(["migrate", "status", "--config", prepared]);
+    expect(status.code, status.stderr).toBe(0);
+    const plan = JSON.parse(status.stdout) as { targetConfig: { source: string }; generatedConfig?: unknown };
+    expect(plan.targetConfig.source).toBe("prepared");
+    expect(plan.generatedConfig).toBeUndefined();
+    expect(fs.existsSync(generatedPath)).toBe(false);
+
+    const applied = await runCliCapture(["migrate", "apply", "--config", prepared]);
+    expect(applied.code, applied.stderr).toBe(0);
+    expect(JSON.parse(applied.stdout)).toMatchObject({ status: "current" });
+    // Generation never fired — --config drove the whole cutover on its own.
+    expect(fs.existsSync(generatedPath)).toBe(false);
+  } finally {
+    storage.cleanup();
+  }
+});

--- a/tests/integration/migration-lifecycle-regression.test.ts
+++ b/tests/integration/migration-lifecycle-regression.test.ts
@@ -60,6 +60,36 @@ function seedPreCutover(): string {
   return prepared;
 }
 
+/**
+ * R-089: a config.json written by 0.8.x's own `akm setup`/`akm init` can carry
+ * the pre-cutover source shape (`stashDir`/`sources`) with NO `configVersion`
+ * key at all — 0.8 only stamps `configVersion` when a 0.7-era migration did
+ * substantive work (`if (changed)`), so a config with nothing to carry forward
+ * (a fresh 0.8 install) is never stamped. Model this exactly like
+ * {@link seedPreCutover} but drop `configVersion` from the ACTIVE config only —
+ * the prepared 0.9 config an operator hands to `--config` still declares
+ * `configVersion: "0.9.0"` (required by `parseAndValidateConfigText`).
+ */
+function seedPreCutoverUnversioned(): string {
+  fs.writeFileSync(getConfigPath(), `${JSON.stringify({ stashDir: storage.stashDir, sources: [] })}\n`, {
+    mode: 0o600,
+  });
+  openStateDbAtCeiling(getStateDbPathInDataDir(), PRE_CUTOVER_STATE_CEILING).close();
+  openLegacyWorkflowDb(getLegacyWorkflowDbPath()).close();
+  const prepared = path.join(storage.root, "prepared-unversioned.json");
+  fs.writeFileSync(
+    prepared,
+    `${JSON.stringify({
+      configVersion: "0.9.0",
+      stashDir: storage.stashDir,
+      sources: [],
+      semanticSearchMode: "off",
+    })}\n`,
+    { mode: 0o600 },
+  );
+  return prepared;
+}
+
 function backupRuns(): string[] {
   if (!fs.existsSync(getMigrationBackupRoot())) return [];
   return fs
@@ -164,4 +194,146 @@ test("canonical writable state opens reject an old ledger without applying it", 
   openStateDbAtCeiling(getStateDbPathInDataDir(), PRE_CUTOVER_STATE_CEILING).close();
   expect(() => openStateDatabase()).toThrow(/obsolete writable schema|migrate apply/i);
   expect(inspectMigrationState().state.status).toBe("old");
+});
+
+test("a fresh-0.8 config with no configVersion key is classified old (not inconsistent) and migrates cleanly", async () => {
+  const prepared = seedPreCutoverUnversioned();
+
+  // Before the fix this artifact was `inconsistent`, an unconditional
+  // blocker, so `status` was permanently "blocked" no matter what the
+  // operator passed via `--config`.
+  const status = await runCliCapture(["migrate", "status", "--config", prepared]);
+  expect(status.code, status.stderr).toBe(0);
+  expect(JSON.parse(status.stdout)).toMatchObject({
+    status: "ready",
+    artifacts: { config: { status: "old" }, state: { status: "old" }, workflow: { status: "current" } },
+  });
+
+  const applied = await runCliCapture(["migrate", "apply", "--config", prepared]);
+  expect(applied.code, applied.stderr).toBe(0);
+  const result = JSON.parse(applied.stdout) as { status: string };
+  expect(result.status).toBe("current");
+  expect(JSON.parse(fs.readFileSync(getConfigPath(), "utf8"))).toMatchObject(currentConfig());
+  expect(inspectMigrationState()).toMatchObject({
+    config: { status: "current" },
+    state: { status: "current" },
+    workflow: { status: "missing" },
+  });
+
+  // Idempotent re-run: the (now current) active config.json is a valid
+  // target on its own, no `--config` needed.
+  const rerun = await runCliCapture(["migrate", "apply"]);
+  expect(rerun.code, rerun.stderr).toBe(0);
+  expect(JSON.parse(rerun.stdout)).toMatchObject({ status: "current" });
+});
+
+test("a machine with no akm state at all reports not-applicable, not blocked", async () => {
+  expect(fs.existsSync(getConfigPath())).toBe(false);
+  expect(fs.existsSync(getStateDbPathInDataDir())).toBe(false);
+  expect(fs.existsSync(getLegacyWorkflowDbPath())).toBe(false);
+
+  const plan = inspectMigrationPlan();
+  expect(plan).toMatchObject({
+    status: "not-applicable",
+    blockers: [],
+    message: "No akm installation found; nothing to migrate.",
+    artifacts: {
+      config: { status: "missing" },
+      state: { status: "missing" },
+      workflow: { status: "missing" },
+      index: { status: "missing" },
+    },
+  });
+
+  const status = await runCliCapture(["migrate", "status"]);
+  expect(status.code, status.stderr).toBe(0);
+  expect(JSON.parse(status.stdout)).toMatchObject({ status: "not-applicable" });
+
+  const applied = await runCliCapture(["migrate", "apply"]);
+  expect(applied.code, applied.stderr).toBe(0);
+  expect(JSON.parse(applied.stdout)).toMatchObject({ status: "not-applicable" });
+  expect(fs.existsSync(getConfigPath())).toBe(false);
+  expect(backupRuns()).toEqual([]);
+});
+
+test("a config.json with a present-but-garbage configVersion stays inconsistent/blocked", async () => {
+  fs.writeFileSync(
+    getConfigPath(),
+    `${JSON.stringify({ configVersion: "garbage", stashDir: storage.stashDir, sources: [] })}\n`,
+    { mode: 0o600 },
+  );
+  const before = fs.readFileSync(getConfigPath());
+
+  expect(inspectMigrationState().config).toMatchObject({
+    status: "inconsistent",
+    detail: "configVersion is missing or invalid",
+  });
+
+  const status = await runCliCapture(["migrate", "status"]);
+  expect(status.code).not.toBe(0);
+  const plan = JSON.parse(status.stdout) as { status: string; blockers: string[] };
+  expect(plan.status).toBe("blocked");
+  expect(plan.blockers.some((blocker) => blocker.includes("config.json is inconsistent"))).toBe(true);
+
+  const applied = await runCliCapture(["migrate", "apply"]);
+  expect(applied.code).not.toBe(0);
+  expect(fs.readFileSync(getConfigPath())).toEqual(before);
+  expect(backupRuns()).toEqual([]);
+});
+
+/**
+ * R-091: 0.8's own `akm workflow create` produced heading-based workflow
+ * definitions with no frontmatter `steps:` list. 0.9 requires `steps:` and
+ * does NOT auto-translate the old format (documented, intentionally not
+ * built here) — so after a migration this asset fails 0.9 structural
+ * validation and is invisible to `akm search --type workflow`, yet its
+ * `active` run row survives the cutover (only the run-key spelling is
+ * rewritten, `workflow:<n>` → `workflows/<n>`). Migrate apply must still
+ * SUCCEED, and must name the run and the fix in a non-fatal warning.
+ */
+test("migrate apply warns (non-fatally) about an active run whose workflow asset fails 0.9 structural validation", async () => {
+  const prepared = seedPreCutover();
+  fs.mkdirSync(path.join(storage.stashDir, "workflows"), { recursive: true });
+  fs.writeFileSync(
+    path.join(storage.stashDir, "workflows", "ship.md"),
+    `---
+name: ship
+type: workflow
+description: Ship it
+---
+
+## Step 1
+
+Do the thing.
+`,
+  );
+  const legacyWorkflowDb = openLegacyWorkflowDb(getLegacyWorkflowDbPath());
+  legacyWorkflowDb
+    .prepare(
+      `INSERT INTO workflow_runs (id, workflow_ref, workflow_title, status, params_json, created_at, updated_at)
+       VALUES ('run-orphan', 'workflow:ship', 'Ship it', 'active', '{}', '2026-01-01T00:00:00Z', '2026-01-02T00:00:00Z')`,
+    )
+    .run();
+  legacyWorkflowDb.close();
+
+  const applied = await runCliCapture(["migrate", "apply", "--config", prepared]);
+  expect(applied.code, applied.stderr).toBe(0);
+  expect(JSON.parse(applied.stdout)).toMatchObject({ status: "current" });
+
+  // The migrator must not silently delete or abandon the run — that decision
+  // belongs to the operator.
+  const migratedState = new Database(getStateDbPathInDataDir(), { readonly: true });
+  try {
+    expect(migratedState.query("SELECT status, workflow_ref FROM workflow_runs WHERE id = 'run-orphan'").get()).toEqual(
+      { status: "active", workflow_ref: "workflows/ship" },
+    );
+  } finally {
+    migratedState.close();
+  }
+
+  // The non-fatal warning names the run, the asset, and both remedies —
+  // forwarded from the akm-migrate subprocess's stderr through to the CLI's.
+  expect(applied.stderr).toContain("run-orphan");
+  expect(applied.stderr).toContain("workflows/ship");
+  expect(applied.stderr).toContain("akm workflow abandon run-orphan");
 });

--- a/tests/integration/okf-conformance.test.ts
+++ b/tests/integration/okf-conformance.test.ts
@@ -177,9 +177,24 @@ describe("OKF first-class conformance", () => {
     expect(fragment.content).not.toContain("Overview body.");
     expect(fragment.ref).toBe("adversarial//unknown");
 
-    const lint = akmLint({ dir: okfRoot });
+    const lint = await akmLint({ dir: okfRoot });
     expect(lint.ok).toBe(true);
-    expect(lint.flagged).toEqual([]);
+    // akm 0.9.0 lint/adapter-dispatch wiring — GAP CLOSURE: `unknown.md`'s
+    // `[Dangling](/missing.md)` link (seeded above) was ALWAYS a broken OKF
+    // link, but the pre-dispatch `akm lint` ran a CLI-only `missing-type`-only
+    // re-implementation for OKF bundles that never checked links at all —
+    // `okfAdapter.validate()`'s own `missing-ref` check (`okf-adapter.ts`) was
+    // unreachable dead code. `akm lint` now runs the real adapter, so this
+    // finding — genuinely present in the fixture the whole time — is reported
+    // (non-blocking, per §5's OKF leniency: consumers tolerate broken links).
+    expect(lint.flagged).toEqual([
+      {
+        file: "unknown.md",
+        issue: "missing-ref",
+        detail: "warning: OKF link target not found: missing (non-blocking, consumers tolerate broken links)",
+        fixed: false,
+      },
+    ]);
 
     await expect(
       writeMarkdownAsset({
@@ -539,58 +554,67 @@ describe("OKF first-class conformance", () => {
     }
   });
 
-  test("OKF lint uses its own diagnostic and keeps findings non-fatal by default", () => {
+  test("OKF lint dispatches to the real okf adapter validate() and keeps findings non-fatal by default", async () => {
     write(okfRoot, "missing-type.md", "---\ntitle: Missing Type\n---\n\nBody.\n");
     write(okfRoot, "uppercase-missing-type.MD", "---\ntitle: Uppercase Missing Type\n---\n\nBody.\n");
     write(okfRoot, "INDEX.MD", "# Reserved structural file\n");
 
-    const result = akmLint({ dir: okfRoot });
+    const result = await akmLint({ dir: okfRoot });
 
     expect(result.ok).toBe(true);
+    // akm 0.9.0 lint/adapter-dispatch wiring: `akm lint` now runs the OKF
+    // bundle through the real `okfAdapter.validate()` (spec §5) instead of a
+    // CLI-only re-implementation — the detail text below is the adapter's own
+    // (`okf-adapter.ts`'s `missing-type` message), not a re-recorded
+    // duplicate of it. This is the same fix that makes `missing-ref` reachable
+    // at all for OKF bundles (see the dedicated gap-closure test below).
     expect(result.flagged).toContainEqual({
       file: "missing-type.md",
       issue: "missing-type",
-      detail: "OKF concepts require parseable mapping frontmatter with a non-empty type.",
+      detail: "info: no frontmatter `type`; defaults to `knowledge` (OKF leniency, non-blocking)",
       fixed: false,
     });
     expect(result.flagged).toContainEqual({
       file: "uppercase-missing-type.MD",
       issue: "missing-type",
-      detail: "OKF concepts require parseable mapping frontmatter with a non-empty type.",
+      detail: "info: no frontmatter `type`; defaults to `knowledge` (OKF leniency, non-blocking)",
       fixed: false,
     });
     expect(result.flagged.some((issue) => issue.file === "INDEX.MD")).toBe(false);
     expect(result.flagged.some((issue) => issue.issue === "missing-name-or-type")).toBe(false);
 
-    const filtered = akmLint({ dir: okfRoot, typeFilter: "memories", fix: true });
+    // `typeFilter`/`fix` are akm-sweep-only options; a non-akm adapter dispatch
+    // (like the old `lintOkfBundle` it replaces) always validates the whole
+    // bundle and never writes.
+    const filtered = await akmLint({ dir: okfRoot, typeFilter: "memories", fix: true });
     expect(filtered.flagged).toContainEqual({
       file: "missing-type.md",
       issue: "missing-type",
-      detail: "OKF concepts require parseable mapping frontmatter with a non-empty type.",
+      detail: "info: no frontmatter `type`; defaults to `knowledge` (OKF leniency, non-blocking)",
       fixed: false,
     });
     expect(fs.existsSync(path.join(okfRoot, "missing-type.md"))).toBe(true);
   });
 
-  test("configured adapter ownership wins over filesystem probing during lint", () => {
+  test("configured adapter ownership wins over filesystem probing during lint", async () => {
     write(okfRoot, "knowledge/native.md", concept("knowledge", "Native", "Native body."));
     configure("akm");
     resetConfigCache();
 
-    const result = akmLint({ dir: okfRoot });
+    const result = await akmLint({ dir: okfRoot });
 
     expect(result.flagged.some((issue) => issue.issue === "missing-updated")).toBe(true);
     expect(result.flagged.some((issue) => issue.issue === "missing-type")).toBe(false);
   });
 
-  test("native lint --fix does not delete an uppercase Markdown memory", () => {
+  test("native lint --fix does not delete an uppercase Markdown memory", async () => {
     const basePath = path.join(okfRoot, "memories", "case-sensitive.MD");
     write(okfRoot, "memories/case-sensitive.MD", "---\ninferenceProcessed: true\nupdated: 2026-07-25\n---\nshort\n");
     write(okfRoot, "memories/case-sensitive.derived.md", concept("memory", "Derived", "Derived body."));
     configure("akm");
     resetConfigCache();
 
-    akmLint({ dir: okfRoot, fix: true });
+    await akmLint({ dir: okfRoot, fix: true });
 
     expect(fs.existsSync(basePath)).toBe(true);
   });
@@ -1005,7 +1029,7 @@ describe("OKF first-class conformance", () => {
       await akmIndex({ stashDir: componentRoot, full: true });
       const shown = await showLocal({ ref: "nested//memories/nested-root" });
       expect(shown.content).toContain("Nested component body.");
-      expect(akmLint().flagged).toEqual([]);
+      expect((await akmLint()).flagged).toEqual([]);
     });
   });
 });

--- a/tests/integration/three-db-cutover.test.ts
+++ b/tests/integration/three-db-cutover.test.ts
@@ -184,9 +184,27 @@ function ledgerIds(db: Database): string[] {
   return (db.query("SELECT id FROM schema_migrations ORDER BY rowid").all() as Array<{ id: string }>).map((r) => r.id);
 }
 
+/**
+ * `akm migrate apply`'s final result line is now rendered through the normal
+ * `--format` pipeline (pretty-printed JSON by default, D7), so it can span
+ * multiple lines — unlike the raw child's single compact line before that
+ * change. Any earlier progress-event lines (content migration, proposal-ref
+ * repair) stay single-line JSON and print ahead of it, so the result is
+ * always the trailing block starting at the last line beginning with `{`.
+ */
 function backupRunIdFromApply(stdout: string): string {
-  const line = stdout.trim().split("\n").at(-1);
-  const runId = line ? (JSON.parse(line) as { backupRunId?: unknown }).backupRunId : undefined;
+  const lines = stdout.trim().split("\n");
+  let resultStart = -1;
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    if (lines[i]?.startsWith("{")) {
+      resultStart = i;
+      break;
+    }
+  }
+  const runId =
+    resultStart >= 0
+      ? (JSON.parse(lines.slice(resultStart).join("\n")) as { backupRunId?: unknown }).backupRunId
+      : undefined;
   if (typeof runId !== "string") throw new Error("Migration apply did not report its backup run ID.");
   return runId;
 }
@@ -1438,7 +1456,7 @@ describe("already-current proposal ref repair", () => {
 
     const status = await runCliCapture(["migrate", "status"]);
     expect(status.code).not.toBe(0);
-    expect(status.stdout).toContain('"status":"blocked"');
+    expect(JSON.parse(status.stdout)).toMatchObject({ status: "blocked" });
     expect(status.stdout).toMatch(/pending proposal.*unmappable legacy ref/i);
   });
 
@@ -1454,7 +1472,7 @@ describe("already-current proposal ref repair", () => {
 
     const status = await runCliCapture(["migrate", "status"]);
     expect(status.code, status.stderr).toBe(0);
-    expect(status.stdout).toContain('"status":"ready"');
+    expect(JSON.parse(status.stdout)).toMatchObject({ status: "ready" });
     const applied = await runCliCapture(["migrate", "apply"]);
     expect(applied.code, applied.stderr).toBe(0);
     expect(applied.stdout).toContain('"event":"proposal-ref-repair"');

--- a/tests/integration/vault-dangerous-key-lint.test.ts
+++ b/tests/integration/vault-dangerous-key-lint.test.ts
@@ -280,11 +280,11 @@ describe("checkVaultForDangerousKeys", () => {
 // ── akmLint integration ───────────────────────────────────────────────────────
 
 describe("akmLint dangerous-vault-key integration", () => {
-  test("flags a vault file containing LD_PRELOAD", () => {
+  test("flags a vault file containing LD_PRELOAD", async () => {
     const stashDir = makeTempStash();
     writeVault(stashDir, ".env", "LD_PRELOAD=/evil/lib.so\nSAFE_KEY=ok\n");
 
-    const result = akmLint({ dir: stashDir });
+    const result = await akmLint({ dir: stashDir });
 
     const dangerous = result.flagged.filter((i) => i.issue === "dangerous-env-key");
     expect(dangerous).toHaveLength(1);
@@ -297,7 +297,7 @@ describe("akmLint dangerous-vault-key integration", () => {
     expect(result.summary.flagged).toBeGreaterThan(0);
   });
 
-  test("flags each dangerous key in a vault file separately", () => {
+  test("flags each dangerous key in a vault file separately", async () => {
     const stashDir = makeTempStash();
     writeVault(
       stashDir,
@@ -305,40 +305,40 @@ describe("akmLint dangerous-vault-key integration", () => {
       ["DYLD_INSERT_LIBRARIES=/evil.dylib", "NODE_OPTIONS=--require evil", "SAFE_KEY=fine"].join("\n"),
     );
 
-    const result = akmLint({ dir: stashDir });
+    const result = await akmLint({ dir: stashDir });
 
     const dangerous = result.flagged.filter((i) => i.issue === "dangerous-env-key");
     expect(dangerous).toHaveLength(2);
   });
 
-  test("does not flag a vault file with only safe keys", () => {
+  test("does not flag a vault file with only safe keys", async () => {
     const stashDir = makeTempStash();
     writeVault(stashDir, "clean.env", "API_TOKEN=abc\nDB_URL=postgres://localhost/db\n");
 
-    const result = akmLint({ dir: stashDir });
+    const result = await akmLint({ dir: stashDir });
 
     const dangerous = result.flagged.filter((i) => i.issue === "dangerous-env-key");
     expect(dangerous).toHaveLength(0);
   });
 
-  test("scans multiple vault files in the same stash", () => {
+  test("scans multiple vault files in the same stash", async () => {
     const stashDir = makeTempStash();
     writeVault(stashDir, "prod.env", "LD_PRELOAD=/evil.so\n");
     writeVault(stashDir, "dev.env", "SAFE=ok\n");
     writeVault(stashDir, "staging.env", "PATH=/evil:/usr/bin\n");
 
-    const result = akmLint({ dir: stashDir });
+    const result = await akmLint({ dir: stashDir });
 
     const dangerous = result.flagged.filter((i) => i.issue === "dangerous-env-key");
     // One finding from prod.env (LD_PRELOAD) + one from staging.env (PATH)
     expect(dangerous).toHaveLength(2);
   });
 
-  test("does not produce dangerous-vault-key findings when vaults/ dir is absent", () => {
+  test("does not produce dangerous-vault-key findings when vaults/ dir is absent", async () => {
     const stashDir = makeTempStash();
     // No vaults/ dir at all
 
-    const result = akmLint({ dir: stashDir });
+    const result = await akmLint({ dir: stashDir });
 
     const dangerous = result.flagged.filter((i) => i.issue === "dangerous-env-key");
     expect(dangerous).toHaveLength(0);
@@ -353,13 +353,13 @@ describe("akmLint dangerous-vault-key integration", () => {
     // dot (`secrets/creds.env`) is captured whole rather than truncated.
     const refOf = (detail: string): string | undefined => detail.match(/Ref: (\S+)\.\s/)?.[1];
 
-    test("env asset refs are `env/<name>`, with `.env` mapping to env/default", () => {
+    test("env asset refs are `env/<name>`, with `.env` mapping to env/default", async () => {
       const stashDir = makeTempStash();
       writeVault(stashDir, "prod.env", "LD_PRELOAD=/evil.so\n");
       writeVault(stashDir, ".env", "LD_PRELOAD=/evil.so\n");
 
-      const refs = akmLint({ dir: stashDir })
-        .flagged.filter((i) => i.issue === "dangerous-env-key")
+      const refs = (await akmLint({ dir: stashDir })).flagged
+        .filter((i) => i.issue === "dangerous-env-key")
         .map((i) => refOf(i.detail));
 
       expect(refs).toContain("env/prod");
@@ -367,20 +367,20 @@ describe("akmLint dangerous-vault-key integration", () => {
       for (const ref of refs) expect(ref).not.toContain(":");
     });
 
-    test("secret asset refs are `secrets/<filename>` (extension preserved)", () => {
+    test("secret asset refs are `secrets/<filename>` (extension preserved)", async () => {
       const stashDir = makeTempStash();
       const secretsDir = path.join(stashDir, "secrets");
       fs.mkdirSync(secretsDir, { recursive: true });
       fs.writeFileSync(path.join(secretsDir, "creds.env"), "BASH_ENV=/tmp/x\n", { mode: 0o600 });
 
-      const refs = akmLint({ dir: stashDir })
-        .flagged.filter((i) => i.issue === "dangerous-env-key")
+      const refs = (await akmLint({ dir: stashDir })).flagged
+        .filter((i) => i.issue === "dangerous-env-key")
         .map((i) => refOf(i.detail));
 
       expect(refs).toContain("secrets/creds.env");
     });
 
-    test("refs from non-default bundles include their bundle id", () => {
+    test("refs from non-default bundles include their bundle id", async () => {
       const primary = makeTempStash("akm-lint-primary-");
       const secondary = makeTempStash("akm-lint-secondary-");
       writeVault(primary, "prod.env", "LD_PRELOAD=/primary.so\n");
@@ -391,22 +391,22 @@ describe("akmLint dangerous-vault-key integration", () => {
         bundles: { primary: { path: primary }, team: { path: secondary } },
       };
 
-      const refs = akmLint({ config })
-        .flagged.filter((i) => i.issue === "dangerous-env-key")
+      const refs = (await akmLint({ config })).flagged
+        .filter((i) => i.issue === "dangerous-env-key")
         .map((i) => refOf(i.detail));
 
       expect(refs).toContain("env/prod");
       expect(refs).toContain("team//env/prod");
     });
 
-    test("every emitted ref resolves to a real type through the ref grammar", () => {
+    test("every emitted ref resolves to a real type through the ref grammar", async () => {
       const stashDir = makeTempStash();
       writeVault(stashDir, "prod.env", "LD_PRELOAD=/evil.so\n");
       const secretsDir = path.join(stashDir, "secrets");
       fs.mkdirSync(secretsDir, { recursive: true });
       fs.writeFileSync(path.join(secretsDir, "creds.env"), "BASH_ENV=/tmp/x\n", { mode: 0o600 });
 
-      const findings = akmLint({ dir: stashDir }).flagged.filter((i) => i.issue === "dangerous-env-key");
+      const findings = (await akmLint({ dir: stashDir })).flagged.filter((i) => i.issue === "dangerous-env-key");
       expect(findings.length).toBeGreaterThan(0);
       for (const finding of findings) {
         const ref = refOf(finding.detail);


### PR DESCRIPTION
## Summary

A verified review of 0.9.0-rc.15 and the fixes it turned up. Findings were reproduced against the **real published `akm-cli@0.8.14`** installed from npm into an isolated `HOME` with genuine 0.8 state (memories, imported knowledge, a workflow asset, an active workflow run, populated `state.db` + `workflow.db` + `index.db`), then driving the documented upgrade — not read out of the docs.

### Release blocker: fresh 0.8 installs could not migrate

A fresh `akm-cli@0.8.x` install writes `config.json` with **no `configVersion` key at all** — 0.8 stamps it only when a 0.7-era migration did substantive work (`if (changed)`), and a config 0.8 wrote itself has no legacy keys to trigger that. `inspectConfig` read the absent key as `inconsistent`, an unconditional blocker, so `migrate status` reported `blocked` and `migrate apply` refused with exit 78. **Every user who installed 0.8 fresh was unable to upgrade.**

An *absent* `configVersion` on a positively pre-cutover-shaped config is now classified `old`; a present-but-unparseable one still stays `inconsistent`. The transform path needed no change — only the classification was wrong.

Every migration fixture hand-wrote `configVersion: "0.8.0"`, which is why the integration suite never caught it. Added coverage for the shape 0.8 actually produces, plus a negative case.

### `akm-migrate` now derives the 0.9 config

Upgrading required hand-authoring a complete 0.9 config before `apply` would do anything. `bundles`/`defaultBundle` are a pure function of the 0.8 keys, so they are now derived by reusing `migrateConfigSourcesToBundles`. Engine settings are **not** guessed: `profiles.*` / `defaults.llm|agent|improve` are stripped and reported individually in `droppedKeys` by exact dotted path.

Generation is confirm-then-apply. The first `apply` with no `--config` writes a validated starter config and **stops** — no backup run, no sentinel, and `config.json`/`state.db`/`workflow.db` byte-for-byte unchanged. A second `apply` performs the cutover. An explicit `--config` always wins.

### `validate()` is now load-bearing

`validate()` is a REQUIRED interface member implemented by all 11 adapters, and nothing called it. Reproduced consequences:

- **OKF's `missing-ref` never ran.** A bundle with a dangling link reported nothing.
- **The one check the CLI did re-implement had already drifted** — the adapter treats `missing-type` as non-blocking INFO; the CLI copy presented it as a flagged issue with different wording. Divergent behavior, not just risk of it.
- **llm-wiki's four checks were unreachable dead code.**

Adds the single core `ValidateContext` overlay the interface contract calls for and routes lint through each bundle's own adapter. The akm sweep is extracted unchanged — every akm lint test needed only an `await`, **no assertion changes**.

The proposal pre-commit path also runs `validate()`, **advisory only**: it warns and does not reject the write, because the new `resolveRef`'s direct-path fallback disagrees with the legacy resolver on foreign-typed cross-bundle refs. Blocking without reconciling the two resolvers would risk false-positive rejections in a live write path. Documented as such.

`placeNew()` is deferred to 0.10 (D12) — 36 `stashDirFor` call sites across 19 files on the write path, no user-visible benefit today.

### Other fixes

- `akm help migrate 0.9.0` — the command the release notes tell you to run — **failed with exit 78 on a 0.8 config**. `help`/`hints`/bare `akm` now bypass the startup config load.
- `akm setup` dead-ended on an old config. It now refuses cleanly, leaves the file byte-for-byte untouched, and names `akm migrate status`.
- `akm migrate` was `hidden: true` and absent from `--help` entirely.
- `migrate status` on a machine with nothing to migrate reported `blocked`/exit 1; now `not-applicable`/exit 0.
- Post-migration warning when an active run targets a workflow asset that fails 0.9 validation (0.8 heading-format workflows aren't auto-translated).
- Retired hints for `vault`, `task show`, and the retired *flags* (`--background`, `--detect-only`, `--reset-recommended`, `--watch`, `--debounce-ms`).
- `--format text` for `health`/`lint`/`info` dumped raw JSON arrays as single lines (and `info` silently dropped most fields). Now readable, worst-status-first; `json`/`jsonl`/`yaml` unchanged.
- `--format` now works on `akm migrate` instead of warning and printing JSON anyway.

### Docs honesty

Scoped the adapter-refactor claim to what ships — recognition, indexing, presentation and validation are adapter-driven; **placement is not**, and llm-wiki is read-only like OKF. Documented that `logs.db` sits outside backup/restore, that `index.db` is only `quick_check`'d, and that `backup`/`restore`/`storage` live on the separate `akm-migrate` binary. Dropped brittle exact test counts. Inlined a minimal working 0.9 config and an 0.8→0.9 key mapping table.

## Test plan

Counts below are point-in-time at `a9a2109`; run `bun run check` for current figures.

| Gate | Before (rc.15) | After |
| --- | --- | --- |
| unit | 3226 | **3262 / 0 fail** |
| integration | 4838 | **4865 / 0 fail** |
| tsc / lint / build | clean | clean |
| 0.8→0.9 upgrade harness (24 checks) | **3/24** | **24/24** |

End-to-end upgrade verified from a pristine snapshot of a real `akm-cli@0.8.14` install, **with no hand-editing of the config**: config converted to `bundles`/`defaultBundle`, all 21 state migrations applied, `workflow.db` folded away, `index.db` quarantined, refs re-keyed fully-qualified, active workflow run preserved and re-keyed, verified backup written. Both the `--config` and no-`--config` paths confirmed.

Gap closure verified against fixtures captured *before* the change:

```
OKF   before: flagged=1  (missing-type only, CLI wording; dangling link invisible)
      after:  flagged=2  (missing-ref now reported; missing-type now carries the adapter's own INFO wording)
llm-wiki before: 0 findings (all four checks dead)
         after:  uncited-raw, broken-xref, broken-source, missing-description all fire
```

The one changed golden (`okf-conformance`) is legitimate: its fixture always contained a dangling link, and the old `flagged === []` assertion only passed because the check was dead code.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Lint passes (`bun run lint`)
- [x] Docs updated (if applicable)

## Note for reviewers

`akm migrate` JSON is now **pretty-printed** rather than compact single-line. Semantically identical and JSON parsers are unaffected, but anything grepping `'"status":"blocked"'` will break. STABILITY.md and `docs/reference/cli.md` updated.

The companion onboarding bundle is refreshed in **itlackey/akm-stash#6** — the README quick start currently sends new users to a bundle that is entirely 0.8-era (125 retired command occurrences, ~108 legacy `type:name` refs, and an onboarding workflow that cannot run). Worth landing alongside this.

Copilot's review round (4 comments, all valid) is addressed in `a9a2109` — see [the reply](https://github.com/itlackey/akm/pull/745#issuecomment-5183354115) for what each turned out to be, including one framing I corrected.