### PR TITLE
Refactor unit resolution and dispatch redaction; extract loopback classifier

### DIFF
--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -325,11 +325,25 @@ export function isContainedRelativePath(value: string): boolean {
 }
 
 export function isWithin(candidate: string, root: string): boolean {
-  const resolvedRoot = safeRealpath(root);
-  const resolvedCandidate = safeRealpath(candidate);
-  const normalizedRoot = normalizeFsPathForComparison(resolvedRoot);
-  const normalizedCandidate = normalizeFsPathForComparison(resolvedCandidate);
-  const rel = path.relative(normalizedRoot, normalizedCandidate);
+  return isContainedResolvedPath(safeRealpath(candidate), safeRealpath(root));
+}
+
+/**
+ * {@link isWithin} for callers that must not block the event loop (e.g. the
+ * workflow exec dispatch path, which runs once per fan-out unit). Same
+ * comparison, same normalization, same nearest-existing-ancestor fallback —
+ * only the realpath syscalls are awaited.
+ */
+export async function isWithinAsync(candidate: string, root: string): Promise<boolean> {
+  return isContainedResolvedPath(await safeRealpathAsync(candidate), await safeRealpathAsync(root));
+}
+
+/** The containment comparison shared by {@link isWithin} and {@link isWithinAsync}. */
+function isContainedResolvedPath(resolvedCandidate: string, resolvedRoot: string): boolean {
+  const rel = path.relative(
+    normalizeFsPathForComparison(resolvedRoot),
+    normalizeFsPathForComparison(resolvedCandidate),
+  );
   return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
 }
 
@@ -360,6 +374,28 @@ export function safeRealpath(p: string): string {
       try {
         const realParent = fs.realpathSync(current);
         return path.join(realParent, ...suffix);
+      } catch {
+        // parent also doesn't exist; keep walking up
+      }
+    }
+  }
+}
+
+/** {@link safeRealpath}'s async twin — awaited syscalls, identical walk-up. */
+export async function safeRealpathAsync(p: string): Promise<string> {
+  const resolved = path.resolve(p);
+  try {
+    return await fs.promises.realpath(resolved);
+  } catch {
+    const suffix: string[] = [];
+    let current = resolved;
+    for (;;) {
+      const parent = path.dirname(current);
+      if (parent === current) return resolved;
+      suffix.unshift(path.basename(current));
+      current = parent;
+      try {
+        return path.join(await fs.promises.realpath(current), ...suffix);
       } catch {
         // parent also doesn't exist; keep walking up
       }

--- a/src/core/concurrent.ts
+++ b/src/core/concurrent.ts
@@ -17,6 +17,39 @@
  * must report failure detail, or distinguish "threw" from "never claimed",
  * catches inside `fn` and returns an explicit outcome value instead.
  */
+/**
+ * Serialize `fn` behind every task previously enqueued under `key`: an
+ * in-process keyed promise chain (Bun is single-threaded, so this is a
+ * sufficient — and free — admission control for per-key mutual exclusion).
+ *
+ * `chains` is the caller's own module-state map, so independent subsystems
+ * (the unit-writer's per-database write queue, the worktree module's per-repo
+ * git lock) never share chains. A failed task rejects its OWN caller but
+ * never wedges the chain, and a drained tail deletes its map entry so a
+ * long-lived process does not retain one settled promise per key it ever
+ * touched.
+ */
+export function serializeByKey<T>(
+  chains: Map<string, Promise<unknown>>,
+  key: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const tail = chains.get(key) ?? Promise.resolve();
+  const run = tail.then(() => fn());
+  // Keep the chain alive regardless of individual outcomes.
+  const settled = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  chains.set(key, settled);
+  // If another task was enqueued in the meantime the map now holds ITS tail,
+  // and this check leaves it alone.
+  void settled.then(() => {
+    if (chains.get(key) === settled) chains.delete(key);
+  });
+  return run;
+}
+
 export async function concurrentMap<T, R>(
   items: T[],
   fn: (item: T, index: number) => Promise<R>,

--- a/src/core/loopback.ts
+++ b/src/core/loopback.ts
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Loopback classification for LLM endpoints: does this endpoint name a model
+ * server running on THIS machine? A host is loopback when it is `localhost` or
+ * a `*.localhost` name (RFC 6761 §6.3), anywhere in `127.0.0.0/8`, an
+ * unspecified address (`0.0.0.0` / `::` — a client connecting there reaches
+ * local loopback), IPv6 `::1`, or the dotted IPv4-mapped spelling of a
+ * `127.0.0.0/8` address (`::ffff:127.0.0.1`). Address shapes are validated by
+ * `node:net`'s `isIP`, so a near-miss NAME like `127.0.0.1.evil.com` is remote.
+ *
+ * The check is purely syntactic — no DNS, no interface list — so the same
+ * config classifies the same on a laptop, on CI, and on a machine with no
+ * network. Ambiguity resolves toward LOOPBACK: misclassifying a local server
+ * as remote widens a concurrency pool onto a single-threaded local model
+ * (one loaded model, reload thrash, HTTP 500 — a hard failure); the reverse
+ * only costs throughput. The remedy in either direction is one line of config:
+ * `engines.<name>.concurrency`.
+ *
+ * The ONE local-vs-remote answer for concurrency defaults — the workflow
+ * engine's frozen engine concurrency (`workflows/concurrency-policy.ts`) and
+ * the indexer's LLM pool (`indexer/indexer.ts` `getDefaultLlmConcurrency`)
+ * both classify through here. NOT shared with the website snapshot fetcher's
+ * SSRF policy (`sources/snapshot-fetchers/host-guard.ts`), which deliberately
+ * draws different lines for a different threat model.
+ *
+ * @module core/loopback
+ */
+
+import { isIP } from "node:net";
+
+/**
+ * The IPv4-mapped IPv6 spellings of `127.0.0.0/8`: the dotted form, whose
+ * capture is validated by `isIP`, and the hex form `::ffff:7fxx:xxxx`. Both are
+ * needed because WHATWG `URL` re-serializes `[::ffff:127.0.0.1]` to the hex
+ * form, so an endpoint written the dotted way arrives here as hex.
+ */
+const IPV4_MAPPED_IPV6 = /^::ffff:(?:([\d.]+)|7f[\da-f]{2}:[\da-f]{1,4})$/;
+/** IPv6 groups before the last one, all of which must be zero (or elided). */
+const ZERO_GROUP = /^0+$/;
+/** The last IPv6 group of `::` / `::1`, in any zero-padding. */
+const LOOPBACK_LAST_GROUP = /^0*[01]?$/;
+
+/**
+ * True when `host` — a URL host component, with or without IPv6 brackets —
+ * names this machine WITHOUT resolving anything.
+ *
+ * Not recognized: the IPv4-compatible form (`::127.0.0.1`), and any NAME that
+ * merely resolves to loopback.
+ *
+ * Exported for the boundary-case table in
+ * `tests/workflows/concurrency-defaults.test.ts`, which has to reach the host
+ * predicate directly: several of its cases (a bare `""`, a malformed literal
+ * like `1::2::3`) cannot round-trip through a URL without changing meaning.
+ */
+export function isLoopbackHost(host: string): boolean {
+  // Strip IPv6 brackets (`URL.hostname` keeps them) and the DNS root label. An
+  // empty host (`new URL("localhost:1234")` parses as scheme `localhost:` with
+  // no host) has nothing to judge, so it fails safe like an unparseable one.
+  const name = host.trim().toLowerCase().replace(/^\[/, "").replace(/\]$/, "").replace(/\.$/, "");
+  if (name === "" || name === "localhost" || name.endsWith(".localhost")) return true;
+  const mapped = IPV4_MAPPED_IPV6.exec(name);
+  if (mapped) {
+    const quad = mapped[1];
+    // The hex branch already matched 127.x in the pattern; the dotted one still
+    // needs `isIP` so `::ffff:127.0.0.256` stays remote.
+    return quad === undefined || (isIP(quad) === 4 && quad.startsWith("127."));
+  }
+  const version = isIP(name);
+  if (version === 4) return name.startsWith("127.") || name === "0.0.0.0";
+  if (version !== 6) return false;
+  const groups = name.split(":");
+  const last = groups.pop() ?? "";
+  return groups.every((group) => group === "" || ZERO_GROUP.test(group)) && LOOPBACK_LAST_GROUP.test(last);
+}
+
+/** True when `endpoint` points at this machine (see {@link isLoopbackHost}). */
+export function isLoopbackEndpoint(endpoint: string | undefined): boolean {
+  if (!endpoint) return true;
+  try {
+    return isLoopbackHost(new URL(endpoint).hostname);
+  } catch {
+    // An unparseable endpoint is treated as local: guessing "remote" here would
+    // widen the pool on exactly the configs we understand least.
+    return true;
+  }
+}

--- a/src/core/spawn-env.ts
+++ b/src/core/spawn-env.ts
@@ -24,6 +24,30 @@ import os from "node:os";
 import path from "node:path";
 
 /**
+ * The baseline env names every allowlisted akm child receives regardless of
+ * what it runs: process identity (`HOME`, `USER`), tool resolution (`PATH`),
+ * locale (`LANG`, `LC_ALL`), terminal (`TERM`), scratch space (`TMPDIR`), and
+ * akm's own event provenance (`AKM_EVENT_SOURCE` — machine traffic, never a
+ * secret). BOTH allowlists extend it — the agent-CLI profiles'
+ * `COMMON_PASSTHROUGH` (`integrations/agent/profiles.ts`) and the workflow
+ * exec unit's `EXEC_DEFAULT_ENV_PASSTHROUGH` (`workflows/exec/exec-unit.ts`)
+ * — so a baseline name cannot drift into one child-spawn path but not the
+ * other. NOTE: profile `envPassthrough` is frozen into workflow engine
+ * snapshots, so growing this list changes frozen-plan content — extend
+ * deliberately.
+ */
+export const COMMON_SPAWN_ENV_PASSTHROUGH = [
+  "HOME",
+  "PATH",
+  "USER",
+  "LANG",
+  "LC_ALL",
+  "TERM",
+  "TMPDIR",
+  "AKM_EVENT_SOURCE",
+] as const;
+
+/**
  * Build a child environment from an allowlist: start EMPTY and copy through
  * exactly the named variables that exist in `source`. Names absent from the
  * source are simply absent from the child (never an empty string, which many

--- a/src/core/state-db-scope.ts
+++ b/src/core/state-db-scope.ts
@@ -76,14 +76,11 @@ function installExitBackstop(): void {
 /**
  * Close every scope-owned handle. Idempotent and safe to call at any time: a
  * closed scope stops lending, so in-flight borrowers fall back to their own
- * connections instead of using a dead handle.
- *
- * This is the disposal hook the engine can wire next to
- * `disposeDispatchResources` if it ever wants deterministic teardown at the end
- * of a run; until then the per-scope `finally` plus the process-exit backstop
- * above are what guarantee no handle leak.
+ * connections instead of using a dead handle. Module-private: the per-scope
+ * `finally` plus the process-exit backstop above are what guarantee no handle
+ * leak — export this the day a caller actually wires deterministic teardown.
  */
-export function closeAllStateDbScopes(): void {
+function closeAllStateDbScopes(): void {
   for (const scope of [...liveScopes]) closeScope(scope);
 }
 

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -11,6 +11,7 @@ import type { BundleComponent } from "../core/adapter/types";
 import { isHttpUrl, toErrorMessage } from "../core/common";
 import { concurrentMap } from "../core/concurrent";
 import type { AkmConfig, LlmConnectionConfig } from "../core/config/config";
+import { isLoopbackEndpoint } from "../core/loopback";
 import { getDbPath } from "../core/paths";
 import { SCRIPT_EXTENSIONS } from "../core/recognition-util";
 import { withStateDb } from "../core/state-db";
@@ -223,20 +224,14 @@ function throwIfAborted(signal?: AbortSignal): void {
 
 export function getDefaultLlmConcurrency(llmConfig?: LlmConnectionConfig): number {
   if (typeof llmConfig?.concurrency === "number") return llmConfig.concurrency;
-  if (!llmConfig?.endpoint) return 1;
-  try {
-    const url = new URL(llmConfig.endpoint);
-    // URL.hostname keeps IPv6 brackets ("[::1]") — strip them so the loopback
-    // comparison actually matches.
-    const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
-    if (host === "localhost" || host === "127.0.0.1" || host === "::1" || host.endsWith(".localhost")) return 1;
-  } catch {
-    return 1;
-  }
+  // Local model servers stay at 1 (single loaded model; parallel requests
+  // trigger reload thrash); an absent or unparseable endpoint fails safe as
+  // local. ONE classifier decides what "local" means (`core/loopback.ts`,
+  // shared with the workflow engine's frozen concurrency default).
+  if (isLoopbackEndpoint(llmConfig?.endpoint)) return 1;
   // Remote endpoints default to a modest 2-wide pool (owner ruling 2026-07-21):
   // enough to overlap request latency without hammering rate-limited APIs.
-  // Local model servers stay at 1 (single loaded model; parallel requests
-  // trigger reload thrash). The explicit-override branch above only fires for
+  // The explicit-override branch above only fires for
   // callers that put `concurrency` on the connection themselves —
   // `engines.<name>.concurrency` is a valid schema field but `resolveLlmEngineUse`
   // does NOT copy it into the resolved connection, so on the enrichment path the

--- a/src/integrations/agent/profiles.ts
+++ b/src/integrations/agent/profiles.ts
@@ -9,6 +9,8 @@
  * coding-agent CLI. Named engines lower canonical harness metadata into this
  * intentionally small internal shape. The wrapper is in `./spawn.ts`.
  */
+import { COMMON_SPAWN_ENV_PASSTHROUGH } from "../../core/spawn-env";
+
 export type AgentStdioMode = "captured" | "interactive";
 export type AgentParseMode = "text" | "json";
 
@@ -65,7 +67,7 @@ export interface AgentProfile {
 // the stamp at the agent boundary — e.g. `akm wiki ingest` spawns an agent whose
 // `akm curate/show/search` tool-calls then log source='user', silently inflating
 // every lane's read-back (GRR). It is a provenance tag, never a secret.
-const COMMON_PASSTHROUGH = ["HOME", "PATH", "USER", "LANG", "LC_ALL", "TERM", "TMPDIR", "AKM_EVENT_SOURCE"] as const;
+const COMMON_PASSTHROUGH = COMMON_SPAWN_ENV_PASSTHROUGH;
 
 /**
  * Built-in profiles for the agent CLIs akm knows out of the box: the five the

--- a/src/tasks/schema.ts
+++ b/src/tasks/schema.ts
@@ -14,15 +14,19 @@
  * inline prompts use a YAML block scalar (`prompt: |`).
  */
 
+import { WORKFLOW_MAX_TIMEOUT_MS } from "../workflows/resource-limits";
+
 export const TASK_SCHEMA_VERSION = 2;
 
 /**
  * Largest expressible `timeoutMs` — `setTimeout`'s 32-bit signed ceiling
  * (2^31-1, ~24.8 days). A larger delay overflows and fires almost immediately,
  * which would silently abort a run seconds after it started instead of hours
- * later. Mirrored as `maximum` on `timeoutMs` in `schemas/akm-task.json`.
+ * later. One definition with the workflow bound (`WORKFLOW_MAX_TIMEOUT_MS`) —
+ * it is a platform fact, not a per-surface policy. Mirrored as `maximum` on
+ * `timeoutMs` in `schemas/akm-task.json`.
  */
-export const TASK_MAX_TIMEOUT_MS = 2 ** 31 - 1;
+export const TASK_MAX_TIMEOUT_MS = WORKFLOW_MAX_TIMEOUT_MS;
 
 /**
  * Lint-level shape problems for a parsed task YAML mapping: the field rules

--- a/src/workflows/concurrency-policy.ts
+++ b/src/workflows/concurrency-policy.ts
@@ -2,8 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { isIP } from "node:net";
 import os from "node:os";
+import { isLoopbackEndpoint } from "../core/loopback";
 import { WORKFLOW_MAX_CONCURRENCY } from "./resource-limits";
 
 /**
@@ -88,77 +88,14 @@ export const DEFAULT_REMOTE_LLM_ENGINE_CONCURRENCY = 4;
 // ── Loopback classification ──────────────────────────────────────────────────
 //
 // Everything above turns on ONE question: does this endpoint name a model
-// server running on THIS machine? A host is loopback when it is `localhost` or
-// a `*.localhost` name (RFC 6761 §6.3), anywhere in `127.0.0.0/8`, an
-// unspecified address (`0.0.0.0` / `::` — a client connecting there reaches
-// local loopback), IPv6 `::1`, or the dotted IPv4-mapped spelling of a
-// `127.0.0.0/8` address (`::ffff:127.0.0.1`). Address shapes are validated by
-// `node:net`'s `isIP`, so a near-miss NAME like `127.0.0.1.evil.com` is remote.
-//
-// The check is purely syntactic — no DNS, no interface list — so freeze
-// produces the same plan on a laptop, on CI, and on a machine with no network.
-// Ambiguity resolves toward LOOPBACK: misclassifying a local server as remote
-// freezes width 4 and causes the hard failure this policy exists to prevent
-// (one loaded model, reload thrash, HTTP 500); the reverse only costs
-// throughput. The remedy in either direction is one line of config:
-// `engines.<name>.concurrency`.
+// server running on THIS machine? The classifier lives in `core/loopback.ts`
+// (shared with the indexer's LLM pool default); the re-export keeps this
+// module the policy surface workflow callers and the boundary-case table in
+// `tests/workflows/concurrency-defaults.test.ts` import from. The check is
+// purely syntactic — no DNS, no interface list — so freeze produces the same
+// plan on a laptop, on CI, and on a machine with no network.
 
-/**
- * The IPv4-mapped IPv6 spellings of `127.0.0.0/8`: the dotted form, whose
- * capture is validated by `isIP`, and the hex form `::ffff:7fxx:xxxx`. Both are
- * needed because WHATWG `URL` re-serializes `[::ffff:127.0.0.1]` to the hex
- * form, so an endpoint written the dotted way arrives here as hex.
- */
-const IPV4_MAPPED_IPV6 = /^::ffff:(?:([\d.]+)|7f[\da-f]{2}:[\da-f]{1,4})$/;
-/** IPv6 groups before the last one, all of which must be zero (or elided). */
-const ZERO_GROUP = /^0+$/;
-/** The last IPv6 group of `::` / `::1`, in any zero-padding. */
-const LOOPBACK_LAST_GROUP = /^0*[01]?$/;
-
-/**
- * True when `host` — a URL host component, with or without IPv6 brackets —
- * names this machine WITHOUT resolving anything.
- *
- * Not recognized: the IPv4-compatible form (`::127.0.0.1`), and any NAME that
- * merely resolves to loopback.
- *
- * Exported for the boundary-case table in
- * `tests/workflows/concurrency-defaults.test.ts`, which has to reach the host
- * predicate directly: several of its cases (a bare `""`, a malformed literal
- * like `1::2::3`) cannot round-trip through a URL without changing meaning.
- */
-export function isLoopbackHost(host: string): boolean {
-  // Strip IPv6 brackets (`URL.hostname` keeps them) and the DNS root label. An
-  // empty host (`new URL("localhost:1234")` parses as scheme `localhost:` with
-  // no host) has nothing to judge, so it fails safe like an unparseable one.
-  const name = host.trim().toLowerCase().replace(/^\[/, "").replace(/\]$/, "").replace(/\.$/, "");
-  if (name === "" || name === "localhost" || name.endsWith(".localhost")) return true;
-  const mapped = IPV4_MAPPED_IPV6.exec(name);
-  if (mapped) {
-    const quad = mapped[1];
-    // The hex branch already matched 127.x in the pattern; the dotted one still
-    // needs `isIP` so `::ffff:127.0.0.256` stays remote.
-    return quad === undefined || (isIP(quad) === 4 && quad.startsWith("127."));
-  }
-  const version = isIP(name);
-  if (version === 4) return name.startsWith("127.") || name === "0.0.0.0";
-  if (version !== 6) return false;
-  const groups = name.split(":");
-  const last = groups.pop() ?? "";
-  return groups.every((group) => group === "" || ZERO_GROUP.test(group)) && LOOPBACK_LAST_GROUP.test(last);
-}
-
-/** True when `endpoint` points at this machine (see {@link isLoopbackHost}). */
-export function isLoopbackEndpoint(endpoint: string | undefined): boolean {
-  if (!endpoint) return true;
-  try {
-    return isLoopbackHost(new URL(endpoint).hostname);
-  } catch {
-    // An unparseable endpoint is treated as local: guessing "remote" here would
-    // widen the pool on exactly the configs we understand least.
-    return true;
-  }
-}
+export { isLoopbackEndpoint, isLoopbackHost } from "../core/loopback";
 
 /**
  * Concurrency to freeze for an LLM engine. An explicit

--- a/src/workflows/exec/dispatch-redaction.ts
+++ b/src/workflows/exec/dispatch-redaction.ts
@@ -18,6 +18,7 @@
 
 import { collectSensitiveValues, isEnvPassthroughValueSafeToExpose, redactSensitiveValue } from "../../core/redaction";
 import type { FrozenEngineSnapshot } from "../ir/schema";
+import type { UnitDispatcher } from "./unit-dispatch";
 
 /** The engine pair a dispatch may draw credentials from. `StepWorkUnit` satisfies it structurally. */
 export interface DispatchEngines {
@@ -82,4 +83,16 @@ export function redactUnitOutcome<T extends { failureReason?: string }>(
     redacted.failureReason = "reported_failure";
   }
   return redacted;
+}
+
+/**
+ * Wrap a dispatcher so every result it returns is scrubbed with the request's
+ * own `sensitiveValues` — a caller holding the wrapped dispatcher cannot
+ * observe (or journal) an unredacted outcome. Used at seams whose results head
+ * STRAIGHT for durable state (the gate judge); the unit path instead scrubs
+ * once at its own journal boundary (`dispatchJournaledAttempt`), AFTER the
+ * structured-output parse loop has seen the raw text.
+ */
+export function withDispatchRedaction(inner: UnitDispatcher): UnitDispatcher {
+  return async (request, feedback) => redactUnitOutcome(await inner(request, feedback), request.sensitiveValues ?? []);
 }

--- a/src/workflows/exec/exec-unit.ts
+++ b/src/workflows/exec/exec-unit.ts
@@ -49,7 +49,12 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { collectAllowlistedEnv, supplementPathForSchedulerContext } from "../../core/spawn-env";
+import { isWithinAsync } from "../../core/common";
+import {
+  COMMON_SPAWN_ENV_PASSTHROUGH,
+  collectAllowlistedEnv,
+  supplementPathForSchedulerContext,
+} from "../../core/spawn-env";
 import {
   type ManagedSubprocessResult,
   runManagedSubprocess,
@@ -88,9 +93,11 @@ const EXEC_STDERR_DIAGNOSTIC_CLIP = WORKFLOW_UNIT_DIAGNOSTIC_CLIP - 500;
  *
  * The child starts from an EMPTY environment and receives only these names,
  * matching how an agent harness child is already built
- * (`profile.envPassthrough` → `collectAllowlistedEnv`). Every entry earns its
- * place by being load-bearing for ordinary commands on some supported
- * platform:
+ * (`profile.envPassthrough` → `collectAllowlistedEnv`) — and literally
+ * extending the same {@link COMMON_SPAWN_ENV_PASSTHROUGH} baseline those
+ * profiles start from, so the two child-spawn allowlists share one floor.
+ * Every entry earns its place by being load-bearing for ordinary commands on
+ * some supported platform:
  *
  *   - `PATH`        — command resolution. Without it only an absolute `argv[0]`
  *                     can ever be spawned.
@@ -135,17 +142,14 @@ const EXEC_STDERR_DIAGNOSTIC_CLIP = WORKFLOW_UNIT_DIAGNOSTIC_CLIP - 500;
  * values as credential-bearing.
  */
 export const EXEC_DEFAULT_ENV_PASSTHROUGH: readonly string[] = [
-  "PATH",
-  "HOME",
-  "USER",
+  // PATH, HOME, USER, LANG, LC_ALL, TERM, TMPDIR, AKM_EVENT_SOURCE
+  ...COMMON_SPAWN_ENV_PASSTHROUGH,
+  // POSIX names a raw shell command needs beyond the agent baseline
   "LOGNAME",
   "SHELL",
-  "LANG",
-  "LC_ALL",
   "LC_CTYPE",
-  "TERM",
   "TZ",
-  "TMPDIR",
+  // Windows process creation, command resolution, and toolchain roots
   "SystemRoot",
   "SystemDrive",
   "WINDIR",
@@ -160,7 +164,6 @@ export const EXEC_DEFAULT_ENV_PASSTHROUGH: readonly string[] = [
   "TMP",
   "ProgramData",
   "ProgramFiles",
-  "AKM_EVENT_SOURCE",
 ];
 
 export interface RunExecUnitInput {
@@ -418,12 +421,34 @@ function outputLimitFailure(
  * authored values a human wrote and sized; this is the surface where the SIZE
  * is data-dependent and therefore surprising.
  */
+/**
+ * Byte sizes of large context payloads, keyed by the payload string itself.
+ * `AKM_PARAMS` / `AKM_INPUTS` are serialized ONCE per step
+ * (`computeStepWorkList`) and every fan-out unit shares the same string, so a
+ * 10 000-unit map step measures each payload once here instead of re-scanning
+ * up to ~96 KiB per unit. Small values skip the cache (measuring is cheaper
+ * than caching), and the map is cleared before it can outgrow a handful of
+ * steps' worth of distinct payloads.
+ */
+const largeContextSizeCache = new Map<string, number>();
+
+function cachedUtf8Bytes(value: string): number {
+  if (value.length < 1024) return utf8Bytes(value);
+  let bytes = largeContextSizeCache.get(value);
+  if (bytes === undefined) {
+    bytes = utf8Bytes(value);
+    if (largeContextSizeCache.size >= 64) largeContextSizeCache.clear();
+    largeContextSizeCache.set(value, bytes);
+  }
+  return bytes;
+}
+
 function checkExecContextSize(input: RunExecUnitInput): UnitDispatchResult | undefined {
   const limits = execContextLimits(input.platform ?? process.platform);
   const entries = Object.entries(input.context ?? {});
   let total = 0;
   for (const [name, value] of entries) {
-    const bytes = utf8Bytes(value);
+    const bytes = cachedUtf8Bytes(value);
     total += bytes + utf8Bytes(name) + 1;
     if (bytes > limits.perVarBytes) {
       return contextTooLarge(
@@ -502,50 +527,6 @@ async function isExistingDirectory(candidate: string): Promise<boolean> {
     return (await fs.promises.stat(candidate)).isDirectory();
   } catch {
     return false;
-  }
-}
-
-/**
- * `core/common`'s `isWithin`, without its two blocking `fs.realpathSync` calls.
- * Same comparison, same normalization, same nearest-existing-ancestor fallback —
- * only the syscalls are awaited instead of blocking the loop.
- */
-async function isWithinAsync(candidate: string, root: string): Promise<boolean> {
-  const rel = path.relative(
-    normalizeForComparison(await safeRealpathAsync(root)),
-    normalizeForComparison(await safeRealpathAsync(candidate)),
-  );
-  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
-}
-
-function normalizeForComparison(value: string): string {
-  return process.platform === "win32" ? value.toLowerCase() : value;
-}
-
-/**
- * Resolve symlinks on `p`, walking up to the closest existing ancestor when `p`
- * itself does not exist, so a comparison between an existing base and a
- * not-yet-created child stays consistent through symlinked hierarchies
- * (macOS `/tmp` → `/private/tmp`, a symlinked HOME).
- */
-async function safeRealpathAsync(p: string): Promise<string> {
-  const resolved = path.resolve(p);
-  try {
-    return await fs.promises.realpath(resolved);
-  } catch {
-    const suffix: string[] = [];
-    let current = resolved;
-    for (;;) {
-      const parent = path.dirname(current);
-      if (parent === current) return resolved;
-      suffix.unshift(path.basename(current));
-      current = parent;
-      try {
-        return path.join(await fs.promises.realpath(current), ...suffix);
-      } catch {
-        // parent also doesn't exist; keep walking up
-      }
-    }
   }
 }
 

--- a/src/workflows/exec/frozen-judge.ts
+++ b/src/workflows/exec/frozen-judge.ts
@@ -13,8 +13,8 @@
  *     `result_json`, and a judge failure's message becomes the blocked step's
  *     notes. So the judge outcome goes through the SAME scrub every unit outcome
  *     goes through: {@link collectWorkflowDispatchSensitiveValues} +
- *     {@link redactUnitOutcome} (exec/dispatch-redaction.ts). Nothing about a
- *     judge call reaches durable state before that scrub.
+ *     {@link withDispatchRedaction} (exec/dispatch-redaction.ts). Nothing about
+ *     a judge call reaches durable state before that scrub.
  *
  *  2. **Identity.** The dispatch request carries the REAL run/step and the gate's
  *     real node/unit ids — the same ids `journalGateEvaluationStart/Finish` write
@@ -32,14 +32,12 @@
  * @module workflows/exec/frozen-judge
  */
 
-import type { LlmConnectionConfig } from "../../core/config/config";
-import { deepMergeConfig } from "../../core/config/deep-merge";
 import { ConfigError } from "../../core/errors";
 import { redactSensitiveText } from "../../core/redaction";
-import type { FrozenLlmEngine, IrInvocation, WorkflowPlanGraph } from "../ir/schema";
+import type { IrInvocation, WorkflowPlanGraph } from "../ir/schema";
 import type { JudgeCallIdentity, SummaryJudge } from "../validate-summary";
-import { collectWorkflowDispatchSensitiveValues, redactUnitOutcome } from "./dispatch-redaction";
-import type { UnitDispatcher } from "./unit-dispatch";
+import { collectWorkflowDispatchSensitiveValues, withDispatchRedaction } from "./dispatch-redaction";
+import { materializeFrozenLlm, type UnitDispatcher } from "./unit-dispatch";
 
 /**
  * The run/step a judge belongs to, known when the judge is BUILT. Callers that
@@ -87,17 +85,24 @@ export function frozenSummaryJudge(
         "INVALID_CONFIG_FILE",
       );
     }
+    const fallbackEngine = engine.fallbackLlmEngine ? plan.execution.engines[engine.fallbackLlmEngine] : undefined;
+    const fallback = fallbackEngine?.kind === "llm" ? fallbackEngine : undefined;
+    // The engine pair is fixed when the judge is BUILT, so the sensitive-value
+    // set is too — collected once here, not per gate evaluation. Same collector
+    // the unit path uses; see the module doc on why `env` is absent here but
+    // the credential/passthrough values are still collected.
+    const sensitiveValues = collectWorkflowDispatchSensitiveValues(
+      { engine, ...(fallback ? { fallbackEngine: fallback } : {}) },
+      undefined,
+    );
+    // Scrub at the seam: every outcome this judge's dispatcher returns is
+    // redacted BEFORE the verdict (or the failure message) can reach the gate
+    // row / the blocked step's notes. Identical contract to the unit path,
+    // including the failureReason downgrade when redaction altered it.
+    const dispatch = withDispatchRedaction(dispatcher);
     return async ({ system, user }, identity) => {
-      const fallbackEngine = engine.fallbackLlmEngine ? plan.execution.engines[engine.fallbackLlmEngine] : undefined;
-      const fallback = fallbackEngine?.kind === "llm" ? fallbackEngine : undefined;
       const id = dispatchIdentity(owner, identity);
-      // Same collector the unit path uses — see the module doc on why `env` is
-      // absent here but the credential/passthrough values are still collected.
-      const sensitiveValues = collectWorkflowDispatchSensitiveValues(
-        { engine, ...(fallback ? { fallbackEngine: fallback } : {}) },
-        undefined,
-      );
-      const result = await dispatcher({
+      const outcome = await dispatch({
         runId: id.runId,
         stepId: id.stepId,
         unitId: id.unitId,
@@ -111,34 +116,26 @@ export function frozenSummaryJudge(
         ...(sensitiveValues.length > 0 ? { sensitiveValues } : {}),
         ...(signal ? { signal } : {}),
       });
-      // Scrub BEFORE the verdict (or the failure message) can reach the gate row
-      // / the blocked step's notes. Identical contract to the unit path,
-      // including the failureReason downgrade when redaction altered it.
-      const outcome = redactUnitOutcome(
-        {
-          unitId: id.unitId,
-          ok: result.ok,
-          ...(result.text !== undefined ? { text: result.text } : {}),
-          ...(result.failureReason !== undefined ? { failureReason: result.failureReason } : {}),
-          ...(result.error !== undefined ? { error: result.error } : {}),
-        },
-        sensitiveValues,
-      );
       if (!outcome.ok) {
         throw new Error(outcome.error || `Verification engine "${invocation.engine}" failed.`);
       }
       return outcome.text ?? "";
     };
   }
+  // An llm judge's only secret is its own credential (materializeFrozenLlm
+  // reads it out of process.env); collected once at build time through the
+  // SHARED collector so the llm and agent judge paths cannot drift.
+  const sensitiveValues = collectWorkflowDispatchSensitiveValues({ engine }, undefined);
   return async ({ system, user }) => {
+    // Inline chatCompletion rather than the unit dispatcher ON PURPOSE: the
+    // manual completion path (`runtime/runs.ts`) builds an llm judge with no
+    // dispatcher, and a static runs → native-executor edge would close an
+    // import cycle. The materialization itself is the shared
+    // {@link materializeFrozenLlm}, so the two llm dispatch paths cannot drift.
     const { chatCompletion } = await import("../../llm/client");
-    // An llm judge's only secret is its own credential (materialize reads it out
-    // of process.env); collect it through the SHARED collector so the llm and
-    // agent judge paths cannot drift.
-    const sensitiveValues = collectWorkflowDispatchSensitiveValues({ engine }, undefined);
     try {
       const text = await chatCompletion(
-        materialize(engine, invocation),
+        materializeFrozenLlm(engine, invocation),
         [
           { role: "system", content: system },
           { role: "user", content: user },
@@ -151,7 +148,7 @@ export function frozenSummaryJudge(
       return redactSensitiveText(text, sensitiveValues);
     } catch (err) {
       // A transport error's message becomes the blocked step's notes (see
-      // `judgeState.failure` in step-work.ts) — a durable surface. Re-wrap ONLY
+      // `judgeFailure` in step-work.ts) — a durable surface. Re-wrap ONLY
       // when redaction actually changed the message, so the untouched path keeps
       // the original error object (and its type) byte-identical.
       throw redactJudgeError(err, sensitiveValues);
@@ -166,35 +163,4 @@ function redactJudgeError(err: unknown, sensitiveValues: readonly string[]): unk
   const replacement = new Error(redacted);
   replacement.name = err.name;
   return replacement;
-}
-
-function materialize(engine: FrozenLlmEngine, invocation: IrInvocation): LlmConnectionConfig {
-  let apiKey: string | undefined;
-  for (const name of engine.credential?.names ?? []) {
-    const value = process.env[name]?.trim();
-    if (value) {
-      apiKey = value;
-      break;
-    }
-  }
-  if (engine.credential?.required && !apiKey)
-    throw new ConfigError(
-      `Required engine credential ${engine.credential.names[0]} is not set.`,
-      "INVALID_CONFIG_FILE",
-    );
-  const base = {
-    provider: engine.provider,
-    endpoint: engine.endpoint,
-    model: invocation.model ?? engine.model,
-    ...(engine.temperature !== undefined ? { temperature: engine.temperature } : {}),
-    ...(engine.maxTokens !== undefined ? { maxTokens: engine.maxTokens } : {}),
-    ...(engine.supportsJsonSchema !== undefined ? { supportsJsonSchema: engine.supportsJsonSchema } : {}),
-    ...(engine.extraParams ? { extraParams: engine.extraParams } : {}),
-    ...(engine.contextLength !== undefined ? { contextLength: engine.contextLength } : {}),
-    ...(engine.enableThinking !== undefined ? { enableThinking: engine.enableThinking } : {}),
-    ...(apiKey ? { apiKey } : {}),
-  };
-  return (
-    invocation.llm ? deepMergeConfig(base, invocation.llm as Record<string, unknown>) : base
-  ) as LlmConnectionConfig;
 }

--- a/src/workflows/exec/native-executor.ts
+++ b/src/workflows/exec/native-executor.ts
@@ -47,8 +47,8 @@
  *     null); a `collect` fan-out promotes `null` in that item's slot.
  *   - A downstream `steps.x.output` reference to an empty solo step therefore
  *     resolves against `null` and fails LOUDLY at reference resolution
- *     (`… resolved to null`) — a deterministic `expression_error` on BOTH
- *     surfaces, never a silent empty string.
+ *     (`… resolved to null`) — a deterministic whole-step failure, never a
+ *     silent empty string.
  *   - A SCHEMA unit is unaffected by this normalization: an empty response is
  *     not parseable JSON, so `runStructured` fails it (`parse_error`) — an
  *     empty output can never satisfy a declared schema as a silent `null`.
@@ -131,8 +131,6 @@
  *     engine loop's job (`run-workflow.ts`) via `completeWorkflowStep`.
  */
 
-import { deepMergeConfig } from "../../core/config/deep-merge";
-import { ConfigError } from "../../core/errors";
 import { appendEvent } from "../../core/events";
 import { validateJsonSchemaSubset } from "../../core/json-schema";
 import { runStructured } from "../../core/structured";
@@ -166,7 +164,12 @@ import {
   type UnitOutcome,
   unitOutcomeFromRow,
 } from "./step-work";
-import type { UnitDispatcher, UnitDispatchRequest, UnitDispatchResult } from "./unit-dispatch";
+import {
+  materializeFrozenLlm,
+  type UnitDispatcher,
+  type UnitDispatchRequest,
+  type UnitDispatchResult,
+} from "./unit-dispatch";
 
 export { collectWorkflowDispatchSensitiveValues, redactUnitOutcome } from "./dispatch-redaction";
 export type { UnitDispatcher, UnitDispatchRequest, UnitDispatchResult } from "./unit-dispatch";
@@ -358,8 +361,6 @@ class DispatchBudget {
  *                  env/worktree);
  *   - `dispatch` — no reusable row (or a stale gate-loop row that re-dispatches
  *                  live): this unit will actually issue work.
- * The caller guarantees `workUnit.resolved.ok` (an unresolved unit fails as an
- * `expression_error` before reaching here and never dispatches).
  */
 type UnitReuseDecision =
   | { kind: "reuse"; row: WorkflowRunUnitRow }
@@ -368,12 +369,10 @@ type UnitReuseDecision =
 
 function classifyUnitReuse(
   workUnit: StepWorkUnit,
-  existingUnits: Map<string, WorkflowRunUnitRow> | undefined,
+  completedRows: CompletedRowIndex | undefined,
   gateLoop: number,
 ): UnitReuseDecision {
-  if (!workUnit.resolved.ok) return { kind: "dispatch" };
   const inputHash = workUnit.resolved.inputHash;
-  const base = workUnit.journalBaseId;
   // Scan EVERY journaled attempt row of this unit (`<base>` / `<base>~r<N>`
   // for ANY N), not just the attempts the CURRENT retry policy allows:
   // retry/onError are deliberately excluded from the input hash (step-work.ts)
@@ -383,41 +382,48 @@ function classifyUnitReuse(
   // A completed hash-matching row anywhere wins (reuse); a completed loop-1
   // row with a DIFFERENT hash — and no matching sibling — is replay divergence.
   let divergedAttemptId: string | undefined;
-  if (existingUnits) {
-    for (const [attemptId, prior] of existingUnits) {
-      if (prior.status !== "completed" || !isAttemptRowOf(attemptId, base)) continue;
-      if (prior.input_hash === inputHash) return { kind: "reuse", row: prior };
-      // Gate-loop rows are NOT replay-deterministic (the prompt embeds a fresh
-      // judge output): a stale loop-N row with a different hash re-dispatches
-      // live. Divergence only guards loop-1 rows, whose inputs ARE a pure
-      // function of (frozen plan, params, journaled results).
-      if (gateLoop <= 1) divergedAttemptId ??= attemptId;
-    }
+  for (const prior of completedRows?.get(workUnit.journalBaseId) ?? []) {
+    if (prior.input_hash === inputHash) return { kind: "reuse", row: prior };
+    // Gate-loop rows are NOT replay-deterministic (the prompt embeds a fresh
+    // judge output): a stale loop-N row with a different hash re-dispatches
+    // live. Divergence only guards loop-1 rows, whose inputs ARE a pure
+    // function of (frozen plan, params, journaled results).
+    if (gateLoop <= 1) divergedAttemptId ??= prior.unit_id;
   }
   if (divergedAttemptId !== undefined) return { kind: "diverge", attemptId: divergedAttemptId };
   return { kind: "dispatch" };
 }
 
-/** True when `attemptId` journals an attempt of `base`: the base id itself or `<base>~r<N>`. */
-function isAttemptRowOf(attemptId: string, base: string): boolean {
-  if (attemptId === base) return true;
-  if (!attemptId.startsWith(`${base}~r`)) return false;
-  const suffix = attemptId.slice(base.length + 2);
-  return suffix.length > 0 && /^\d+$/.test(suffix);
+/**
+ * The step's COMPLETED journal rows grouped by base journal id (`~r<N>`
+ * stripped), built ONCE per step so classifyUnitReuse — which runs per unit,
+ * twice (preflight gate + runUnit) — is a map probe over that unit's own
+ * attempt rows instead of an O(rows) scan of the whole step journal per call
+ * (a 10 000-unit fan-out resume would otherwise re-walk the full journal
+ * 20 000 times).
+ */
+type CompletedRowIndex = Map<string, WorkflowRunUnitRow[]>;
+
+function indexCompletedRows(rows: Iterable<WorkflowRunUnitRow>): CompletedRowIndex {
+  const index: CompletedRowIndex = new Map();
+  for (const row of rows) {
+    if (row.status !== "completed") continue;
+    const base = row.unit_id.replace(/~r\d+$/, "");
+    const forBase = index.get(base);
+    if (forBase) forBase.push(row);
+    else index.set(base, [row]);
+  }
+  return index;
 }
 
 /**
  * Does the step have at least one unit that will ACTUALLY dispatch? Env
  * resolution and worktree preflight are dispatch prerequisites, so a step whose
- * units are all reused / unresolved / diverged must skip them (reviewer finding
+ * units are all reused / diverged must skip them (reviewer finding
  * #2). Mirrors runUnit's reuse decision exactly (shared {@link classifyUnitReuse}).
  */
-function stepWillDispatch(
-  workUnits: StepWorkUnit[],
-  existingUnits: Map<string, WorkflowRunUnitRow>,
-  gateLoop: number,
-): boolean {
-  return workUnits.some((u) => u.resolved.ok && classifyUnitReuse(u, existingUnits, gateLoop).kind === "dispatch");
+function stepWillDispatch(workUnits: StepWorkUnit[], completedRows: CompletedRowIndex, gateLoop: number): boolean {
+  return workUnits.some((u) => classifyUnitReuse(u, completedRows, gateLoop).kind === "dispatch");
 }
 
 /**
@@ -525,10 +531,9 @@ async function executeStepPlanInConnection(plan: IrStepPlan, ctx: StepExecutionC
   // is reused, not re-dispatched — a crash-resume must never double-issue
   // side-effecting work. Loading the rows up front is what lets us skip the
   // dispatch prerequisites below when nothing will actually dispatch.
-  const existingUnits = new Map<string, WorkflowRunUnitRow>();
-  for (const row of await withWorkflowRunsRepo((repo) => repo.getUnitsForStep(ctx.runId, plan.stepId))) {
-    existingUnits.set(row.unit_id, row);
-  }
+  const completedRows = indexCompletedRows(
+    await withWorkflowRunsRepo((repo) => repo.getUnitsForStep(ctx.runId, plan.stepId)),
+  );
 
   // Reviewer finding #2: env resolution and worktree preflight are DISPATCH
   // prerequisites, so they must run only when a unit will actually dispatch. A
@@ -538,7 +543,7 @@ async function executeStepPlanInConnection(plan: IrStepPlan, ctx: StepExecutionC
   // to hand back a cached result. The predicate mirrors runUnit's reuse
   // decision exactly (shared classifyUnitReuse).
   const gateLoop = ctx.gateLoop ?? 1;
-  const willDispatch = stepWillDispatch(workUnits, existingUnits, gateLoop);
+  const willDispatch = stepWillDispatch(workUnits, completedRows, gateLoop);
 
   // Env bindings resolve once per step, before any dispatch; a binding error
   // fails the whole step cleanly rather than N units racing into it. Skipped
@@ -603,7 +608,7 @@ async function executeStepPlanInConnection(plan: IrStepPlan, ctx: StepExecutionC
           ctx,
           signal,
           dispatcher,
-          existingUnits,
+          completedRows,
           budget,
         }),
       {
@@ -701,8 +706,8 @@ interface RunUnitInput {
    */
   signal?: AbortSignal;
   dispatcher: UnitDispatcher;
-  /** Prior unit rows for this step, for durable-row reuse. */
-  existingUnits?: Map<string, WorkflowRunUnitRow>;
+  /** The step's completed rows indexed by base id, for durable-row reuse. */
+  completedRows?: CompletedRowIndex;
   /** Shared lifetime-cap budget; consumed once per actual dispatch attempt. */
   budget: DispatchBudget;
 }
@@ -711,13 +716,6 @@ async function runUnit(input: RunUnitInput): Promise<UnitOutcome> {
   const { plan, workUnit, env, ctx, dispatcher } = input;
   const unitId = workUnit.unitId;
 
-  // A per-unit expression resolution failure (missing param, bad `item.<path>`)
-  // is deterministic authoring/data breakage computed by the shared work-list:
-  // the unit fails WITHOUT dispatching — and without journaling a row, since no
-  // resolved input exists to hash.
-  if (!workUnit.resolved.ok) {
-    return { unitId, ok: false, failureReason: "expression_error", error: workUnit.resolved.error };
-  }
   // An `exec` unit legitimately carries neither — it spawns a child process
   // instead of calling an engine. Every OTHER kind must have both.
   if (!workUnit.exec && (!workUnit.engine || !workUnit.invocation)) {
@@ -780,7 +778,7 @@ async function runUnit(input: RunUnitInput): Promise<UnitOutcome> {
   // tampered with; executeStepPlan promotes this to a hard step failure
   // regardless of on_error). Stale gate-loop rows, failed/running/missing rows,
   // and pre-release R1 positional ids all fall through and dispatch live.
-  const reuse = classifyUnitReuse(workUnit, input.existingUnits, gateLoop);
+  const reuse = classifyUnitReuse(workUnit, input.completedRows, gateLoop);
   if (reuse.kind === "reuse") {
     // Identity in the durable step evidence is the CONTENT-derived base id, not
     // the `~r<n>` attempt row it was reused from — the work list only ever knows
@@ -905,7 +903,7 @@ interface JournaledAttemptInput {
  * replacing it: a tool that fails after printing its real complaint on stdout
  * is common, and the reason lives on whichever stream that tool chose.
  */
-export function journaledUnitResultJson(outcome: UnitOutcome): string | null {
+function journaledUnitResultJson(outcome: UnitOutcome): string | null {
   if (outcome.result !== undefined) return JSON.stringify(outcome.result);
   if (outcome.ok) return outcome.text ? JSON.stringify(outcome.text) : null;
   const parts = [outcome.error, outcome.text].filter((part): part is string => Boolean(part && part.trim()));
@@ -1525,38 +1523,6 @@ function frozenUnitRunner(
   // SDK runner receives a frozen fallback copied into the request by its caller.
   const fallback = request.fallbackEngine ? materializeFrozenLlm(request.fallbackEngine, undefined) : undefined;
   return { kind: "sdk", profile, ...(fallback ? { fallbackConnection: fallback } : {}) };
-}
-
-function materializeFrozenLlm(
-  snapshot: Extract<FrozenEngineSnapshot, { kind: "llm" }>,
-  invocation: IrInvocation | undefined,
-): import("../../core/config/config").LlmConnectionConfig {
-  let apiKey: string | undefined;
-  for (const name of snapshot.credential?.names ?? []) {
-    const candidate = process.env[name]?.trim();
-    if (candidate) {
-      apiKey = candidate;
-      break;
-    }
-  }
-  if (snapshot.credential?.required && !apiKey)
-    throw new ConfigError(
-      `Required engine credential ${snapshot.credential.names[0]} is not set.`,
-      "INVALID_CONFIG_FILE",
-    );
-  const base = {
-    provider: snapshot.provider,
-    endpoint: snapshot.endpoint,
-    model: invocation?.model ?? snapshot.model,
-    ...(snapshot.temperature !== undefined ? { temperature: snapshot.temperature } : {}),
-    ...(snapshot.maxTokens !== undefined ? { maxTokens: snapshot.maxTokens } : {}),
-    ...(snapshot.supportsJsonSchema !== undefined ? { supportsJsonSchema: snapshot.supportsJsonSchema } : {}),
-    ...(snapshot.extraParams ? { extraParams: snapshot.extraParams } : {}),
-    ...(snapshot.contextLength !== undefined ? { contextLength: snapshot.contextLength } : {}),
-    ...(snapshot.enableThinking !== undefined ? { enableThinking: snapshot.enableThinking } : {}),
-    ...(apiKey ? { apiKey } : {}),
-  };
-  return invocation?.llm ? (deepMergeConfig(base, invocation.llm as Record<string, unknown>) as typeof base) : base;
 }
 
 // ── Small helpers ────────────────────────────────────────────────────────────

--- a/src/workflows/exec/run-workflow.ts
+++ b/src/workflows/exec/run-workflow.ts
@@ -785,6 +785,7 @@ async function runStepGateLoop(
         routeSelected,
         routeUnselected,
         summaryJudge,
+        ...(ctx.plan.execution ? { engines: ctx.plan.execution.engines } : {}),
         signal: options.signal,
         leaseHolder,
       });

--- a/src/workflows/exec/step-work.ts
+++ b/src/workflows/exec/step-work.ts
@@ -63,7 +63,6 @@ import type {
 } from "../ir/schema";
 import { type ExpressionScope, resolveReferenceString } from "../program/expressions";
 import { WORKFLOW_MAX_MAP_EXPANSION, WORKFLOW_UNIT_DIAGNOSTIC_CLIP } from "../resource-limits";
-import { requireExecutableWorkflowPlan } from "../runtime/plan-classifier";
 import { completeWorkflowStep, type SummaryValidationFailure, type WorkflowNextResult } from "../runtime/runs";
 import { GATE_EVALUATION_PHASE } from "../runtime/unit-phases";
 import { type JudgeCallIdentity, parseJudgeVerdict, type SummaryJudge } from "../validate-summary";
@@ -125,10 +124,11 @@ export interface WorkListInput {
 }
 
 /**
- * One unit's fully-resolved dispatch plan. `unitId`/`nodeId`/`item` are always
- * present (content-derived, independent of resolution); `resolved` carries the
- * assembled prompt + input hash, or a deterministic resolution error (a bad
- * `item.<path>` reference) that fails just this unit without dispatching.
+ * One unit's fully-resolved dispatch plan. `unitId`/`nodeId`/`item` are
+ * content-derived; `resolved` carries the assembled prompt + input hash.
+ * Resolution cannot fail per-unit: everything that CAN fail (map.over /
+ * route.input / inputs:) resolves once per step and fails the WHOLE list
+ * ({@link ComputeWorkListResult}).
  */
 export interface StepWorkUnit {
   /** Content-derived base id: `<node_id>:<hash12>` (fan-out) / `<node_id>:solo`. */
@@ -163,7 +163,7 @@ export interface StepWorkUnit {
   retry?: IrRetry;
   onError: IrOnError;
   isolation?: IrIsolation;
-  resolved: { ok: true; prompt: string; inputHash: string } | { ok: false; error: string };
+  resolved: { prompt: string; inputHash: string };
 }
 
 export interface StepWorkList {
@@ -189,14 +189,10 @@ export type ComputeWorkListResult = { ok: true; list: StepWorkList } | { ok: fal
  * units an earlier run already journaled.
  *
  * Whole-list failures (missing subgraph, unresolvable / non-array `over`,
- * null or duplicate fan-out items) return `{ ok: false }`. The per-unit
- * `resolved: { ok: false }` branch is STRUCTURALLY UNREACHABLE in the unified
- * format — prose is never scanned for references, and everything that CAN
- * fail (map.over / route.input / inputs:) resolves once per step, failing the
- * whole list above. The branch is retained because every consumer of the work
- * list shares the shape and defensively handles it; if a future unit kind
- * reintroduces per-unit resolution (e.g. an exec/shell unit with real
- * substitution), the failure plumbing is already in place.
+ * null or duplicate fan-out items) return `{ ok: false }`. Per-unit resolution
+ * cannot fail in the unified format — prose is never scanned for references,
+ * and everything that CAN fail (map.over / route.input / inputs:) resolves
+ * once per step, failing the whole list above.
  */
 /**
  * Validate a fan-out item list BEFORE any identity/dispatch work: expansion
@@ -428,7 +424,7 @@ function buildStepWorkUnit(ctx: StepWorkUnitContext, unitId: string, item: unkno
         instructions: template.instructions,
       });
   const inputHash = computeUnitInputHash(ctx, item);
-  const resolved: StepWorkUnit["resolved"] = { ok: true, prompt, inputHash };
+  const resolved: StepWorkUnit["resolved"] = { prompt, inputHash };
 
   return {
     unitId,
@@ -1402,6 +1398,13 @@ export interface FinalizeStepInput {
    * both mean no judge; live configuration is never consulted here.
    */
   summaryJudge: SummaryJudge | null | undefined;
+  /**
+   * Frozen engine catalog from the SAME decoded plan `stepPlan` came from —
+   * gate-row metadata (`stepPlan.gate.judge` names its engine here). The
+   * caller already holds the hash-verified plan, so it is never re-loaded or
+   * re-decoded down here.
+   */
+  engines?: Record<string, FrozenEngineSnapshot>;
   /** Cooperative run cancellation checked before completion is committed. */
   signal?: AbortSignal;
   /** Engine run-lease holder (engine path only); absent on the manual/report path. */
@@ -1547,25 +1550,17 @@ export async function finalizeExecutedStep(input: FinalizeStepInput): Promise<Fi
   // Journal engine-driven judge calls as unit rows. With no criteria there is
   // no judge invocation or row; a criteria-bearing plan without a judge is a
   // configuration error rather than a silent bypass.
-  const frozenGate = innerJudge
-    ? await withWorkflowRunsRepo((repo) => {
-        const row = repo.getRunById(runId);
-        if (!row) throw new UsageError(`Workflow run ${runId} was not found.`);
-        const plan = requireExecutableWorkflowPlan(row);
-        const invocation = plan.steps.find((step) => step.stepId === stepId)?.gate.judge ?? null;
-        return invocation ? { invocation, engine: plan.execution?.engines[invocation.engine] ?? null } : null;
-      })
-    : null;
-  const gateInvocation = frozenGate?.invocation ?? null;
+  const gateInvocation = innerJudge ? (stepPlan.gate.judge ?? null) : null;
+  const gateEngine = gateInvocation ? (input.engines?.[gateInvocation.engine] ?? null) : null;
   let gateUnit: GateUnitRef | undefined;
-  // `failure` classifies a verifier INFRASTRUCTURE failure observed during the
-  // judge call — a throw (transport/service error) or a response that is not a
-  // well-formed verdict (same parser as validateStepSummary, so the fail-closed
-  // rejection it synthesizes is recognizably NOT an honest verdict here).
-  const judgeState: { invoked: boolean; failure?: string } = { invoked: false };
+  // `judgeFailure` records a verifier INFRASTRUCTURE failure observed during
+  // the judge call — a throw (transport/service error) or a response that is
+  // not a well-formed verdict (same parser as validateStepSummary, so the
+  // fail-closed rejection it synthesizes is recognizably NOT an honest verdict
+  // here).
+  let judgeFailure: string | undefined;
   const summaryJudge: SummaryJudge | null = innerJudge
     ? async (prompt) => {
-        judgeState.invoked = true;
         if (gateInvocation) {
           gateUnit = {
             runId,
@@ -1573,12 +1568,12 @@ export async function finalizeExecutedStep(input: FinalizeStepInput): Promise<Fi
             stepId,
             loop: gateLoop,
             invocation: gateInvocation,
-            runner: frozenGate?.engine?.kind === "agent" ? frozenGate.engine.runnerKind : ("llm" as const),
+            runner: gateEngine?.kind === "agent" ? gateEngine.runnerKind : ("llm" as const),
             inputHash: createHash("sha256")
               .update(
                 canonicalJsonString({
                   hashVersion: 3,
-                  dispatch: frozenGate?.engine ?? null,
+                  dispatch: gateEngine,
                   invocation: gateInvocation,
                   prompt,
                 }),
@@ -1598,11 +1593,11 @@ export async function finalizeExecutedStep(input: FinalizeStepInput): Promise<Fi
           raw = await innerJudge(prompt, identity);
         } catch (err) {
           const detail = err instanceof Error && err.message ? ` (${err.message})` : "";
-          judgeState.failure = `the verification judge failed${detail}`;
+          judgeFailure = `the verification judge failed${detail}`;
           throw err;
         }
         if (parseJudgeVerdict(raw) === undefined) {
-          judgeState.failure =
+          judgeFailure =
             "the verification judge responded with a malformed verdict instead of the required JSON result";
         }
         return raw;
@@ -1612,7 +1607,7 @@ export async function finalizeExecutedStep(input: FinalizeStepInput): Promise<Fi
   // Reviewer #6: once the judge is invoked, its gate row is journaled `running`
   // (journalGateEvaluationStart) and MUST be finished on every exit. The
   // already-fixed window is the judge itself throwing (caught inside
-  // validateStepSummary — `judgeState.failure` records it). The remaining
+  // validateStepSummary — `judgeFailure` records it). The remaining
   // window is `completeWorkflowStep` throwing AFTER the judge ran — a stolen
   // lease, a concurrent state change, a DB error — which would otherwise skip the
   // finish and strand the gate row in `running`. Finish it as an errored row (the
@@ -1635,7 +1630,7 @@ export async function finalizeExecutedStep(input: FinalizeStepInput): Promise<Fi
   }
   const rejection =
     "ok" in completion && completion.ok === false ? (completion as SummaryValidationFailure) : undefined;
-  const judgeFailed = judgeState.failure !== undefined;
+  const judgeFailed = judgeFailure !== undefined;
 
   if (gateUnit) {
     // An infrastructure failure journals an ERRORED gate row (no verdict) —
@@ -1648,7 +1643,7 @@ export async function finalizeExecutedStep(input: FinalizeStepInput): Promise<Fi
   // verdict. Consume NO gate loop; block the step (and therefore the run) so
   // `akm workflow resume` retries the gate over the journaled units.
   if (rejection && judgeFailed) {
-    return blockStepForJudgeFailure(input, judgeState.failure ?? "the verification judge failed");
+    return blockStepForJudgeFailure(input, judgeFailure ?? "the verification judge failed");
   }
 
   if (!rejection) {

--- a/src/workflows/exec/unit-dispatch.ts
+++ b/src/workflows/exec/unit-dispatch.ts
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import type { LlmConnectionConfig } from "../../core/config/config";
+import { deepMergeConfig } from "../../core/config/deep-merge";
+import { ConfigError } from "../../core/errors";
 import type { AgentTokenUsage } from "../../integrations/agent/spawn";
 import type { FrozenEngineSnapshot, IrExecSpec, IrInvocation } from "../ir/schema";
 
@@ -64,3 +67,42 @@ export interface UnitDispatchResult {
 
 /** The one dispatch seam. `feedback` carries a structured-output retry prompt. */
 export type UnitDispatcher = (request: UnitDispatchRequest, feedback?: string) => Promise<UnitDispatchResult>;
+
+/**
+ * Materialize a frozen llm engine snapshot into a live connection: resolve the
+ * credential out of `process.env`, then apply the invocation's model/llm
+ * overrides. The ONE definition — the default dispatcher's llm runner and the
+ * frozen gate judge both dispatch through it, so credential resolution and
+ * connection-field mapping cannot drift between the two llm dispatch paths.
+ */
+export function materializeFrozenLlm(
+  snapshot: Extract<FrozenEngineSnapshot, { kind: "llm" }>,
+  invocation: IrInvocation | undefined,
+): LlmConnectionConfig {
+  let apiKey: string | undefined;
+  for (const name of snapshot.credential?.names ?? []) {
+    const candidate = process.env[name]?.trim();
+    if (candidate) {
+      apiKey = candidate;
+      break;
+    }
+  }
+  if (snapshot.credential?.required && !apiKey)
+    throw new ConfigError(
+      `Required engine credential ${snapshot.credential.names[0]} is not set.`,
+      "INVALID_CONFIG_FILE",
+    );
+  const base = {
+    provider: snapshot.provider,
+    endpoint: snapshot.endpoint,
+    model: invocation?.model ?? snapshot.model,
+    ...(snapshot.temperature !== undefined ? { temperature: snapshot.temperature } : {}),
+    ...(snapshot.maxTokens !== undefined ? { maxTokens: snapshot.maxTokens } : {}),
+    ...(snapshot.supportsJsonSchema !== undefined ? { supportsJsonSchema: snapshot.supportsJsonSchema } : {}),
+    ...(snapshot.extraParams ? { extraParams: snapshot.extraParams } : {}),
+    ...(snapshot.contextLength !== undefined ? { contextLength: snapshot.contextLength } : {}),
+    ...(snapshot.enableThinking !== undefined ? { enableThinking: snapshot.enableThinking } : {}),
+    ...(apiKey ? { apiKey } : {}),
+  };
+  return invocation?.llm ? (deepMergeConfig(base, invocation.llm as Record<string, unknown>) as typeof base) : base;
+}

--- a/src/workflows/exec/unit-writer.ts
+++ b/src/workflows/exec/unit-writer.ts
@@ -44,9 +44,15 @@
  * A failed write rejects its own caller but never wedges its chain.
  */
 
+import { serializeByKey } from "../../core/concurrent";
 import { getStateDbPath } from "../../core/state-db";
 
-/** One promise chain per database path. Entries are pruned when their chain drains. */
+/**
+ * One promise chain per database path ({@link serializeByKey}). Entries are
+ * pruned when their chain drains, so a long-lived process that touches many
+ * data dirs (the test harness swaps `AKM_DATA_DIR` per test) does not
+ * accumulate one resolved promise per path forever.
+ */
 const chains = new Map<string, Promise<unknown>>();
 
 export interface EnqueueUnitWriteOptions {
@@ -59,22 +65,5 @@ export interface EnqueueUnitWriteOptions {
 }
 
 export function enqueueUnitWrite<T>(fn: () => Promise<T>, opts?: EnqueueUnitWriteOptions): Promise<T> {
-  const key = opts?.key ?? getStateDbPath();
-  const tail = chains.get(key) ?? Promise.resolve();
-  const run = tail.then(() => fn());
-  // Keep the chain alive regardless of individual outcomes.
-  const settled = run.then(
-    () => undefined,
-    () => undefined,
-  );
-  chains.set(key, settled);
-  // Drop the entry once this task is the drained tail, so a long-lived process
-  // that touches many data dirs (the test harness swaps `AKM_DATA_DIR` per
-  // test) does not accumulate one resolved promise per path forever. If another
-  // write was enqueued in the meantime the map now holds ITS tail, and this
-  // check leaves it alone.
-  void settled.then(() => {
-    if (chains.get(key) === settled) chains.delete(key);
-  });
-  return run;
+  return serializeByKey(chains, opts?.key ?? getStateDbPath(), fn);
 }

--- a/src/workflows/exec/worktree.ts
+++ b/src/workflows/exec/worktree.ts
@@ -41,10 +41,10 @@
  * same repository. Two invariants close that:
  *
  *   • every repo-mutating operation runs inside {@link withRepoWorktreeLock},
- *     a promise chain keyed by the resolved base repo path (the
- *     `unit-writer.ts` idiom — Bun is single-threaded, so an in-process chain
- *     is sufficient), so at most one add/prune/remove per repository is ever
- *     in flight;
+ *     a promise chain keyed by the resolved base repo path (`serializeByKey`
+ *     in `core/concurrent.ts`, shared with `unit-writer.ts` — Bun is
+ *     single-threaded, so an in-process chain is sufficient), so at most one
+ *     add/prune/remove per repository is ever in flight;
  *   • those git calls are ASYNC ({@link runManagedSubprocess}) rather than
  *     `spawnSync`, so a unit waiting on a git lock parks a promise instead of
  *     wedging the whole event loop (and with it every other in-flight unit,
@@ -62,11 +62,12 @@
  */
 
 import { spawnSync } from "node:child_process";
-import fs, { type Dirent } from "node:fs";
+import type { Dirent } from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { isWithin, safeRealpath } from "../../core/common";
+import { isWithinAsync, safeRealpathAsync } from "../../core/common";
+import { serializeByKey } from "../../core/concurrent";
 import { runManagedSubprocess } from "../../core/subprocess";
 import { warn } from "../../core/warn";
 
@@ -172,29 +173,21 @@ export function assertGitWorkTree(dir: string): string | undefined {
 /** In-flight tail of each base repository's serialized git-worktree chain. */
 const repoOperationTails = new Map<string, Promise<unknown>>();
 
-/** Base repos already pruned in this process, keyed `<repo>\0<runId>`. */
+/**
+ * Base repos already pruned in this process, keyed `<repo>\0<runId>`. A run's
+ * keys are dropped when its drained worktree root is removed
+ * ({@link removeRunRootIfEmpty}), so the set never outgrows the live runs.
+ */
 const prunedRuns = new Set<string>();
 
 /**
  * Serialize `fn` against every other repo-mutating worktree operation on the
- * same base repository. Keyed by the RESOLVED repo path so two spellings of
- * one repo (symlinked tmpdir, relative cwd) share a chain. A failure rejects
- * its own caller but never wedges the chain (`unit-writer.ts` idiom).
+ * same base repository ({@link serializeByKey}). Keyed by the RESOLVED repo
+ * path so two spellings of one repo (symlinked tmpdir, relative cwd) share a
+ * chain. A failure rejects its own caller but never wedges the chain.
  */
 function withRepoWorktreeLock<T>(repoKey: string, fn: () => Promise<T>): Promise<T> {
-  const previous = repoOperationTails.get(repoKey) ?? Promise.resolve();
-  const run = previous.then(fn);
-  const tail = run.then(
-    () => undefined,
-    () => undefined,
-  );
-  repoOperationTails.set(repoKey, tail);
-  // Drop drained keys so a long-lived process does not retain one promise per
-  // repository it ever touched.
-  void tail.then(() => {
-    if (repoOperationTails.get(repoKey) === tail) repoOperationTails.delete(repoKey);
-  });
-  return run;
+  return serializeByKey(repoOperationTails, repoKey, fn);
 }
 
 export type WorktreeCreateResult =
@@ -230,12 +223,19 @@ export function runWorktreeRoot(runId: string): string {
  * (never overwriting an earlier retained copy). Throws on fs errors — the
  * caller maps them onto its result object.
  */
-function moveLeftoverAside(dest: string): string {
+async function moveLeftoverAside(dest: string): Promise<string> {
   const base = `${dest}.retained-${Date.now()}`;
   let aside = base;
-  for (let n = 1; fs.existsSync(aside); n++) aside = `${base}-${n}`;
-  fs.renameSync(dest, aside);
+  for (let n = 1; await pathExists(aside); n++) aside = `${base}-${n}`;
+  await fsp.rename(dest, aside);
   return aside;
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  return fsp.access(p).then(
+    () => true,
+    () => false,
+  );
 }
 
 /**
@@ -257,26 +257,33 @@ function moveLeftoverAside(dest: string): string {
  * administrative state, so a concurrent unit's prune can never land between
  * another unit's prune and its add.
  */
-export function createUnitWorktree(baseDir: string, runId: string, attemptId: string): Promise<WorktreeCreateResult> {
+export async function createUnitWorktree(
+  baseDir: string,
+  runId: string,
+  attemptId: string,
+): Promise<WorktreeCreateResult> {
   // Opportunistic, at most once per process, never awaited — GC must never sit
   // on the dispatch path.
   sweepStaleWorktreesOnce();
-  const repoKey = safeRealpath(baseDir);
+  const repoKey = await safeRealpathAsync(baseDir);
   const dest = path.join(runWorktreeRoot(runId), sanitizeAttemptId(attemptId));
   return withRepoWorktreeLock(repoKey, async () => {
     let preservedLeftover: string | undefined;
     let leftoverHandled = false;
     try {
-      if (fs.existsSync(dest)) {
+      if (await pathExists(dest)) {
         const status = await git(dest, ["status", "--porcelain"]);
         if (status.ok && status.stdout.trim() === "") {
-          fs.rmSync(dest, { recursive: true, force: true });
+          // Async on purpose: a recursive delete of a whole leftover checkout
+          // inside this critical section would otherwise block the event loop
+          // (every other in-flight unit, the lease heartbeat, abort handling).
+          await fsp.rm(dest, { recursive: true, force: true });
         } else {
-          preservedLeftover = moveLeftoverAside(dest);
+          preservedLeftover = await moveLeftoverAside(dest);
         }
         leftoverHandled = true;
       }
-      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      await fsp.mkdir(path.dirname(dest), { recursive: true });
     } catch (err) {
       return { ok: false, error: `could not prepare worktree directory ${dest}: ${message(err)}` };
     }
@@ -335,13 +342,13 @@ export async function cleanupUnitWorktree(baseDir: string, worktreePath: string)
   if (status.stdout.trim() !== "") {
     return { removed: false, dirty: true };
   }
-  const removed = await withRepoWorktreeLock(safeRealpath(baseDir), () =>
+  const removed = await withRepoWorktreeLock(await safeRealpathAsync(baseDir), () =>
     git(baseDir, ["worktree", "remove", worktreePath]),
   );
   if (!removed.ok) {
     return { removed: false, dirty: false, error: removed.error };
   }
-  removeRunRootIfEmpty(worktreePath);
+  await removeRunRootIfEmpty(worktreePath);
   return { removed: true, dirty: false };
 }
 
@@ -354,14 +361,24 @@ export async function cleanupUnitWorktree(baseDir: string, worktreePath: string)
  * fully drained root disappears. Never touches anything that is not a DIRECT
  * child of the worktrees root.
  */
-function removeRunRootIfEmpty(worktreePath: string): void {
+async function removeRunRootIfEmpty(worktreePath: string): Promise<void> {
   const root = worktreesRoot();
   const runRoot = path.dirname(path.resolve(worktreePath));
-  if (!isWithin(runRoot, root) || safeRealpath(path.dirname(runRoot)) !== safeRealpath(root)) return;
+  if (!(await isWithinAsync(runRoot, root))) return;
+  if ((await safeRealpathAsync(path.dirname(runRoot))) !== (await safeRealpathAsync(root))) return;
   try {
-    fs.rmdirSync(runRoot);
+    await fsp.rmdir(runRoot);
   } catch {
     // ENOTEMPTY (retained work) / ENOENT (already gone) — both fine.
+    return;
+  }
+  // The run's worktrees are fully drained — drop its prune bookkeeping so
+  // `prunedRuns` never outgrows the live runs. (A later worktree of the same
+  // run simply prunes once more; the guard is an optimization, not a
+  // correctness gate.)
+  const suffix = `\u0000${path.basename(runRoot)}`;
+  for (const key of prunedRuns) {
+    if (key.endsWith(suffix)) prunedRuns.delete(key);
   }
 }
 
@@ -413,7 +430,7 @@ export async function sweepStaleWorktrees(opts: SweepStaleWorktreesOptions = {})
   for (const runRootEntry of runRoots) {
     if (!runRootEntry.isDirectory()) continue;
     const runRoot = path.join(root, runRootEntry.name);
-    if (!isWithin(runRoot, root)) continue;
+    if (!(await isWithinAsync(runRoot, root))) continue;
     let entries: Dirent[];
     try {
       entries = await fsp.readdir(runRoot, { withFileTypes: true, encoding: "utf8" });
@@ -424,7 +441,7 @@ export async function sweepStaleWorktrees(opts: SweepStaleWorktreesOptions = {})
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
       const candidate = path.join(runRoot, entry.name);
-      if (!isWithin(candidate, root)) continue;
+      if (!(await isWithinAsync(candidate, root))) continue;
       if (now - (await lastActivityMs(candidate, entry.name)) < maxAgeMs) continue;
       try {
         await fsp.rm(candidate, { recursive: true, force: true });

--- a/src/workflows/ir/freeze.ts
+++ b/src/workflows/ir/freeze.ts
@@ -134,14 +134,9 @@ export function compileResolveFreezeWorkflow(
    * exactly like `effectiveTimeout`'s null.
    */
   const freezeExec = (exec: NonNullable<WorkflowUnitDraft["exec"]>, unit: ProgramUnit | undefined): IrExecSpec => {
-    const layers = [...(documentDefaults ? [documentDefaults] : []), ...(unit ? [unit] : [])];
-    let timeoutMs: number | null = DEFAULT_EXEC_TIMEOUT_MS;
-    for (let index = layers.length - 1; index >= 0; index--) {
-      if (Object.hasOwn(layers[index] ?? {}, "timeoutMs")) {
-        timeoutMs = layers[index]?.timeoutMs ?? null;
-        break;
-      }
-    }
+    const layers: EngineUseConfig[] = [...(documentDefaults ? [documentDefaults] : []), ...(unit ? [unit] : [])];
+    const declared = layeredTimeout(layers);
+    const timeoutMs = declared === undefined ? DEFAULT_EXEC_TIMEOUT_MS : declared;
     return {
       command: [...exec.command] as [string, ...string[]],
       ...(exec.cwd ? { cwd: exec.cwd } : {}),
@@ -280,10 +275,23 @@ function exactModel(
   return resolveModel(selected, engine.platform, engine.modelAliases, config.modelAliases);
 }
 
-function effectiveTimeout(config: AkmConfig, engine: EngineConfig, layers: readonly EngineUseConfig[]): number | null {
+/**
+ * Newest-layer-first scan for a declared `timeoutMs` across authoring layers
+ * (document `defaults`, then the unit). Returns `undefined` when no layer
+ * declares one; an explicit `timeoutMs: null` ("unbounded") wins over deeper
+ * layers — hence `hasOwn`, not a value test. The ONE definition of authoring
+ * timeout precedence, shared by engine and exec freezing.
+ */
+function layeredTimeout(layers: readonly EngineUseConfig[]): number | null | undefined {
   for (let index = layers.length - 1; index >= 0; index--) {
     if (Object.hasOwn(layers[index] ?? {}, "timeoutMs")) return layers[index]?.timeoutMs ?? null;
   }
+  return undefined;
+}
+
+function effectiveTimeout(config: AkmConfig, engine: EngineConfig, layers: readonly EngineUseConfig[]): number | null {
+  const declared = layeredTimeout(layers);
+  if (declared !== undefined) return declared;
   if (Object.hasOwn(engine, "timeoutMs")) return engine.timeoutMs ?? null;
   if (engine.kind === "llm") return DEFAULT_LLM_TIMEOUT_MS;
   if (engine.platform === "opencode-sdk") {

--- a/tests/_helpers/git.ts
+++ b/tests/_helpers/git.ts
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Temp git-repo fixtures for the worktree integration suites. Real `git` only
+ * — callers gate on `isGitAvailable()` and skip when it is absent.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/** Run a git command in `cwd`; throws on a non-zero exit, returns stdout. */
+export function git(cwd: string, args: string[]): string {
+  const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf8", timeout: 15_000 });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
+  }
+  return result.stdout ?? "";
+}
+
+export interface MakeGitRepoOptions {
+  /** mkdtemp prefix for the repo dir (helps attribute leftovers to a suite). */
+  prefix?: string;
+  /** Called with the new repo dir so the suite can schedule its removal. */
+  register?: (dir: string) => void;
+}
+
+/** Init a temp git repo with one committed file (`README.md`). */
+export function makeGitRepo(options: MakeGitRepoOptions = {}): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), options.prefix ?? "akm-git-repo-"));
+  options.register?.(dir);
+  git(dir, ["init", "-q"]);
+  git(dir, ["config", "user.email", "test@akm.invalid"]);
+  git(dir, ["config", "user.name", "akm-test"]);
+  fs.writeFileSync(path.join(dir, "README.md"), "# fixture\n");
+  git(dir, ["add", "README.md"]);
+  git(dir, ["commit", "-q", "-m", "fixture"]);
+  return dir;
+}

--- a/tests/_helpers/workflow.ts
+++ b/tests/_helpers/workflow.ts
@@ -1,9 +1,10 @@
 import type { AkmConfig } from "../../src/core/config/config";
-import { compileResolveFreezeWorkflow } from "../../src/workflows/ir/freeze";
+import { compileResolveFreezeWorkflow, type FreezeOptions } from "../../src/workflows/ir/freeze";
 import { canonicalPlanJson, computePlanHash } from "../../src/workflows/ir/plan-hash";
 import type { WorkflowPlanGraph } from "../../src/workflows/ir/schema";
 import { parseWorkflow } from "../../src/workflows/parser";
 import { frozenStepRows } from "../../src/workflows/runtime/plan-classifier";
+import type { WorkflowError } from "../../src/workflows/schema";
 
 export const WORKFLOW_TEST_CONFIG = {
   configVersion: "0.9.0",
@@ -25,8 +26,17 @@ export const WORKFLOW_TEST_CONFIG = {
  * format-unification). Replaces the pre-unification `freezeWorkflowProgram`
  * (YAML program) / `freezeMarkdownWorkflow` (classic linear markdown) split —
  * one frontend now.
+ *
+ * `config` defaults to {@link WORKFLOW_TEST_CONFIG}; suites with their own
+ * engine catalog pass it explicitly. `options` are threaded straight through
+ * to {@link compileResolveFreezeWorkflow} (e.g. the `compile` test seam).
  */
-export function freezeWorkflow(markdown: string, sourcePath = "workflows/demo.md"): WorkflowPlanGraph {
+export function freezeWorkflow(
+  markdown: string,
+  sourcePath = "workflows/demo.md",
+  config: AkmConfig = WORKFLOW_TEST_CONFIG,
+  options: FreezeOptions = {},
+): WorkflowPlanGraph {
   const parsed = parseWorkflow(markdown, { path: sourcePath });
   if (!parsed.ok) {
     throw new Error(parsed.errors.map((error) => `${error.line}: ${error.message}`).join(" | "));
@@ -41,8 +51,98 @@ export function freezeWorkflow(markdown: string, sourcePath = "workflows/demo.md
       steps: [],
       document: parsed.document,
     },
-    WORKFLOW_TEST_CONFIG,
+    config,
+    options,
   ).plan;
+}
+
+/** Parse a workflow document and return its parser errors (`[]` when it parses cleanly). */
+export function parseErrors(markdown: string, sourcePath = "workflows/test.md"): WorkflowError[] {
+  const result = parseWorkflow(markdown, { path: sourcePath });
+  return result.ok ? [] : result.errors;
+}
+
+/**
+ * Build a minimal one-step workflow document around a `work` step.
+ *
+ * `stepLines` are extra frontmatter lines under `  - id: work` (already
+ * indented by the caller), `body` is the markdown after the frontmatter, and
+ * `extra` lines land between `type: workflow` and `steps:` (e.g. `defaults:`
+ * or `params:` blocks).
+ */
+export function workflowDoc(stepLines: string[], body = "## work\n\nDo it.\n", extra: string[] = []): string {
+  return ["---", "type: workflow", ...extra, "steps:", "  - id: work", ...stepLines, "---", "", body].join("\n");
+}
+
+export interface SeedWorkflowRunStep {
+  stepId: string;
+  /** Defaults to `stepId`. */
+  stepTitle?: string;
+  /** Defaults to `"instructions"`. */
+  instructions?: string;
+  /** Defaults to `null`. */
+  completionJson?: string | null;
+}
+
+/**
+ * Seed the `workflow_runs` + `workflow_run_steps` rows an executable run
+ * starts from — the INSERT boilerplate every integration suite otherwise
+ * hand-rolls. Steps are inserted `pending` with contiguous sequence indexes;
+ * a bare string step is shorthand for `{ stepId }`.
+ */
+export function seedWorkflowRun(
+  db: { prepare(sql: string): { run(...params: unknown[]): unknown } },
+  options: {
+    runId: string;
+    steps: Array<string | SeedWorkflowRunStep>;
+    /** Defaults to `"workflows/demo"`. */
+    workflowRef?: string;
+    /** Defaults to `dir:v1:<workflowRef basename>`. */
+    scopeKey?: string;
+    /** Defaults to `"Demo"`. */
+    workflowTitle?: string;
+    /** Defaults to `{}`. */
+    params?: Record<string, unknown>;
+    /** Defaults to the first step's id. */
+    currentStepId?: string;
+    /** Defaults to `null` (check-in not armed). */
+    checkinArmedAt?: string | null;
+  },
+): void {
+  const now = new Date().toISOString();
+  const workflowRef = options.workflowRef ?? "workflows/demo";
+  const scopeKey = options.scopeKey ?? `dir:v1:${workflowRef.split("/").pop()}`;
+  const steps = options.steps.map((step) => (typeof step === "string" ? { stepId: step } : step));
+  db.prepare(
+    `INSERT INTO workflow_runs
+       (id, workflow_ref, scope_key, workflow_entry_id, workflow_title, status,
+        params_json, current_step_id, created_at, updated_at, checkin_armed_at)
+     VALUES (?, ?, ?, NULL, ?, 'active', ?, ?, ?, ?, ?)`,
+  ).run(
+    options.runId,
+    workflowRef,
+    scopeKey,
+    options.workflowTitle ?? "Demo",
+    JSON.stringify(options.params ?? {}),
+    options.currentStepId ?? steps[0]!.stepId,
+    now,
+    now,
+    options.checkinArmedAt ?? null,
+  );
+  steps.forEach((step, index) => {
+    db.prepare(
+      `INSERT INTO workflow_run_steps
+         (run_id, step_id, step_title, instructions, completion_json, sequence_index, status)
+       VALUES (?, ?, ?, ?, ?, ?, 'pending')`,
+    ).run(
+      options.runId,
+      step.stepId,
+      step.stepTitle ?? step.stepId,
+      step.instructions ?? "instructions",
+      step.completionJson ?? null,
+      index,
+    );
+  });
 }
 
 export function storeFrozenWorkflowPlan(

--- a/tests/integration/workflow-worktree-leftovers.test.ts
+++ b/tests/integration/workflow-worktree-leftovers.test.ts
@@ -20,9 +20,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import {
   cleanupUnitWorktree,
@@ -30,6 +28,7 @@ import {
   isGitAvailable,
   runWorktreeRoot,
 } from "../../src/workflows/exec/worktree";
+import { git, makeGitRepo as makeTempGitRepo } from "../_helpers/git";
 
 const GIT = isGitAvailable();
 
@@ -51,24 +50,9 @@ afterEach(() => {
   }
 });
 
-function git(cwd: string, args: string[]): void {
-  const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf8", timeout: 15_000 });
-  if (result.status !== 0) {
-    throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
-  }
-}
-
-/** Init a temp git repo with one committed file (`README.md`). */
+/** Init a temp git repo with one committed file (`README.md`), removed in afterEach. */
 function makeGitRepo(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-wt-unit-repo-"));
-  scratch.push(dir);
-  git(dir, ["init", "-q"]);
-  git(dir, ["config", "user.email", "test@akm.invalid"]);
-  git(dir, ["config", "user.name", "akm-test"]);
-  fs.writeFileSync(path.join(dir, "README.md"), "# fixture\n");
-  git(dir, ["add", "README.md"]);
-  git(dir, ["commit", "-q", "-m", "fixture"]);
-  return dir;
+  return makeTempGitRepo({ prefix: "akm-wt-unit-repo-", register: (dir) => scratch.push(dir) });
 }
 
 /** Init a temp git repo whose committed `.gitignore` ignores `build/` and `*.log`. */

--- a/tests/integration/workflows/chaos.test.ts
+++ b/tests/integration/workflows/chaos.test.ts
@@ -99,10 +99,10 @@ function workListFor(
 ): Array<{ unitId: string; inputHash: string }> {
   // Projection over `fullWorkList` — one place computes the work list, so the
   // two helpers cannot drift when `WorkListInput` grows a field.
-  return fullWorkList(plan, stepIndex, runId, params, stepOutputs).units.map((u) => {
-    if (!u.resolved.ok) throw new Error(`unit ${u.unitId} did not resolve: ${u.resolved.error}`);
-    return { unitId: u.journalBaseId, inputHash: u.resolved.inputHash };
-  });
+  return fullWorkList(plan, stepIndex, runId, params, stepOutputs).units.map((u) => ({
+    unitId: u.journalBaseId,
+    inputHash: u.resolved.inputHash,
+  }));
 }
 
 /**

--- a/tests/integration/workflows/exec-unit.test.ts
+++ b/tests/integration/workflows/exec-unit.test.ts
@@ -38,7 +38,7 @@ import {
 import { requireExecutableWorkflowPlan } from "../../../src/workflows/runtime/plan-classifier";
 import { getWorkflowStatus } from "../../../src/workflows/runtime/runs";
 import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../../_helpers/sandbox";
-import { freezeWorkflow, storeFrozenWorkflowPlan } from "../../_helpers/workflow";
+import { freezeWorkflow, seedWorkflowRun, storeFrozenWorkflowPlan } from "../../_helpers/workflow";
 
 let storage: IsolatedAkmStorage;
 /** Scratch root for fixtures the workflow itself touches (never akm storage). */
@@ -56,19 +56,12 @@ function bunArgv(code: string): string[] {
 function seedRun(steps: string[], params: Record<string, unknown> = {}): void {
   const db = openStateDatabase();
   try {
-    const now = new Date().toISOString();
-    db.prepare(
-      `INSERT INTO workflow_runs
-         (id, workflow_ref, scope_key, workflow_entry_id, workflow_title, status,
-          params_json, current_step_id, created_at, updated_at)
-       VALUES (?, 'workflows/exec-demo', 'dir:v1:exec-demo', NULL, 'Exec demo', 'active', ?, ?, ?, ?)`,
-    ).run(RUN_ID, JSON.stringify(params), steps[0]!, now, now);
-    steps.forEach((stepId, index) => {
-      db.prepare(
-        `INSERT INTO workflow_run_steps
-           (run_id, step_id, step_title, instructions, completion_json, sequence_index, status)
-         VALUES (?, ?, ?, 'instructions', NULL, ?, 'pending')`,
-      ).run(RUN_ID, stepId, stepId, index);
+    seedWorkflowRun(db, {
+      runId: RUN_ID,
+      workflowRef: "workflows/exec-demo",
+      workflowTitle: "Exec demo",
+      params,
+      steps,
     });
   } finally {
     db.close();

--- a/tests/integration/workflows/gate-artifacts.test.ts
+++ b/tests/integration/workflows/gate-artifacts.test.ts
@@ -678,9 +678,7 @@ function loop1Hash(p: WorkflowPlanGraph): string {
     engines: p.execution?.engines,
   });
   if (!c.ok) throw new Error(c.error);
-  const r = c.list.units[0]!.resolved;
-  if (!r.ok) throw new Error(r.error);
-  return r.inputHash;
+  return c.list.units[0]!.resolved.inputHash;
 }
 
 /** The loop-2 solo unit id + hash brief/report would compute for the recovered feedback. */
@@ -695,7 +693,6 @@ function loop2Unit(p: WorkflowPlanGraph, gateFeedback: GateFeedback): { unitId: 
   });
   if (!c.ok) throw new Error(c.error);
   const u = c.list.units[0]!;
-  if (!u.resolved.ok) throw new Error(u.resolved.error);
   return { unitId: u.journalBaseId, inputHash: u.resolved.inputHash };
 }
 

--- a/tests/integration/workflows/gate-judge-dispatch.test.ts
+++ b/tests/integration/workflows/gate-judge-dispatch.test.ts
@@ -10,12 +10,10 @@ import { withWorkflowRunsRepo } from "../../../src/storage/repositories/workflow
 import type { UnitDispatchRequest, UnitDispatchResult } from "../../../src/workflows/exec/native-executor";
 import { runWorkflowSteps } from "../../../src/workflows/exec/run-workflow";
 import { computeStepWorkList, recoverGateFeedback } from "../../../src/workflows/exec/step-work";
-import { compileResolveFreezeWorkflow } from "../../../src/workflows/ir/freeze";
 import type { WorkflowPlanGraph } from "../../../src/workflows/ir/schema";
-import { parseWorkflow } from "../../../src/workflows/parser";
 import { getWorkflowStatus, resumeWorkflowRun } from "../../../src/workflows/runtime/runs";
 import { sandboxEnvDir } from "../../_helpers/sandbox";
-import { storeFrozenWorkflowPlan } from "../../_helpers/workflow";
+import { freezeWorkflow, seedWorkflowRun, storeFrozenWorkflowPlan } from "../../_helpers/workflow";
 
 /**
  * The gate judge is a real dispatch, held to the same two contracts every unit
@@ -99,36 +97,16 @@ the work is thorough
 `;
 
 function freezeWithAgentJudge(markdown: string): WorkflowPlanGraph {
-  const parsed = parseWorkflow(markdown, { path: "workflows/demo.md" });
-  if (!parsed.ok) throw new Error(parsed.errors.map((e) => `${e.line}: ${e.message}`).join(" | "));
-  return compileResolveFreezeWorkflow(
-    {
-      ref: "workflows/demo",
-      path: "workflows/demo.md",
-      sourcePath: "/tmp",
-      title: "demo",
-      steps: [],
-      document: parsed.document,
-    },
-    JUDGE_CONFIG,
-  ).plan;
+  return freezeWorkflow(markdown, undefined, JUDGE_CONFIG);
 }
 
 function seedRun(): void {
   const db = openStateDatabase(path.join(tmpDir, "state.db"));
   try {
-    const now = new Date().toISOString();
-    db.prepare(
-      `INSERT INTO workflow_runs
-         (id, workflow_ref, scope_key, workflow_entry_id, workflow_title, status,
-          params_json, current_step_id, created_at, updated_at)
-       VALUES (?, 'workflows/demo', 'dir:v1:demo', NULL, 'Demo', 'active', '{}', 'work', ?, ?)`,
-    ).run(RUN_ID, now, now);
-    db.prepare(
-      `INSERT INTO workflow_run_steps
-         (run_id, step_id, step_title, instructions, completion_json, sequence_index, status)
-       VALUES (?, 'work', 'work', 'instructions', ?, 0, 'pending')`,
-    ).run(RUN_ID, JSON.stringify(["the work is thorough"]));
+    seedWorkflowRun(db, {
+      runId: RUN_ID,
+      steps: [{ stepId: "work", completionJson: JSON.stringify(["the work is thorough"]) }],
+    });
   } finally {
     db.close();
   }
@@ -320,7 +298,6 @@ describe("gate judge redaction is replay-deterministic — the recovered feedbac
     });
     if (!replayed.ok) throw new Error(replayed.error);
     const unit = replayed.list.units[0]!;
-    if (!unit.resolved.ok) throw new Error(unit.resolved.error);
     const journaled = rows.find((r) => r.unit_id === unit.journalBaseId);
     expect(unit.journalBaseId).toBe("work:solo~l2");
     expect(journaled?.input_hash).toBe(unit.resolved.inputHash);

--- a/tests/integration/workflows/native-executor.test.ts
+++ b/tests/integration/workflows/native-executor.test.ts
@@ -2377,7 +2377,6 @@ Build the assigned item.
       let seeded = 0;
       for (const u of wl.list.units) {
         if (seeded >= count) break;
-        if (!u.resolved.ok) continue;
         repo.insertUnit({
           runId: RUN_ID,
           unitId: u.unitId,

--- a/tests/integration/workflows/persistence-write-path.test.ts
+++ b/tests/integration/workflows/persistence-write-path.test.ts
@@ -19,7 +19,7 @@ import {
   WORKFLOW_EVIDENCE_TRUNCATED_MARKER,
 } from "../../../src/workflows/runtime/runs";
 import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../../_helpers/sandbox";
-import { freezeWorkflow, storeFrozenWorkflowPlan } from "../../_helpers/workflow";
+import { freezeWorkflow, seedWorkflowRun, storeFrozenWorkflowPlan } from "../../_helpers/workflow";
 
 /**
  * Persistence / write-path regressions for the workflow journal:
@@ -54,18 +54,11 @@ instructions
 function seedRun(dbPath: string): void {
   const db = openStateDatabase(dbPath);
   try {
-    const now = new Date().toISOString();
-    db.prepare(
-      `INSERT INTO workflow_runs
-         (id, workflow_ref, scope_key, workflow_entry_id, workflow_title, status,
-          params_json, current_step_id, created_at, updated_at, checkin_armed_at)
-       VALUES (?, 'workflows/demo', 'dir:v1:demo', NULL, 'Demo', 'active', '{}', 'step-1', ?, ?, ?)`,
-    ).run(RUN_ID, now, now, now);
-    db.prepare(
-      `INSERT INTO workflow_run_steps
-         (run_id, step_id, step_title, instructions, completion_json, sequence_index, status)
-       VALUES (?, 'step-1', 'Do the thing', 'instructions', NULL, 0, 'pending')`,
-    ).run(RUN_ID);
+    seedWorkflowRun(db, {
+      runId: RUN_ID,
+      steps: [{ stepId: "step-1", stepTitle: "Do the thing" }],
+      checkinArmedAt: new Date().toISOString(),
+    });
     storeFrozenWorkflowPlan(db, RUN_ID, PLAN);
   } finally {
     db.close();

--- a/tests/integration/workflows/step-work.test.ts
+++ b/tests/integration/workflows/step-work.test.ts
@@ -172,9 +172,7 @@ describe("computeStepWorkList — dispatch-input hash envelope (reviewer finding
     };
     const wl = computeStepWorkList(step, { ...input, engines });
     if (!wl.ok) throw new Error(wl.error);
-    const u = wl.list.units[0]!;
-    if (!u.resolved.ok) throw new Error(u.resolved.error);
-    return u.resolved.inputHash;
+    return wl.list.units[0]!.resolved.inputHash;
   }
 
   const baseline = hashOf({});
@@ -273,16 +271,13 @@ describe("computeStepWorkList — purity + content-derived identity", () => {
 
     const u = a.list.units[0]!;
     expect(u.unitId).toBe("s1:solo");
-    expect(u.resolved.ok).toBe(true);
-    if (u.resolved.ok) {
-      // Instructions reach the unit byte-exact.
-      expect(u.resolved.prompt).toContain("Do the assigned work.");
-      // Params attach as structured JSON context (never interpolated into text).
-      expect(u.resolved.prompt).toContain('"x":"alpha"');
-      expect(u.resolved.prompt).toContain('"y":"beta"');
-      // 64-hex sha256.
-      expect(u.resolved.inputHash).toMatch(/^[0-9a-f]{64}$/);
-    }
+    // Instructions reach the unit byte-exact.
+    expect(u.resolved.prompt).toContain("Do the assigned work.");
+    // Params attach as structured JSON context (never interpolated into text).
+    expect(u.resolved.prompt).toContain('"x":"alpha"');
+    expect(u.resolved.prompt).toContain('"y":"beta"');
+    // 64-hex sha256.
+    expect(u.resolved.inputHash).toMatch(/^[0-9a-f]{64}$/);
   });
 
   test("fan-out identity is content-derived — independent of item order", () => {
@@ -309,10 +304,9 @@ describe("computeStepWorkList — purity + content-derived identity", () => {
     // — the R2 identity guarantee that survives list reordering/regeneration.
     expect(fwdA?.unitId).toBe(revA?.unitId);
     expect(fwdA?.unitId).toMatch(/^review:[0-9a-f]{12}$/);
-    expect(fwdA?.resolved.ok).toBe(true);
     // The item reaches the unit as ATTACHED CONTEXT (never resolved/spliced) —
     // the "## Item (index N)" block `buildUnitPrompt` emits.
-    if (fwdA?.resolved.ok) expect(fwdA.resolved.prompt).toContain("## Item (index 0)\nYou were given this item");
+    expect(fwdA?.resolved.prompt).toContain("## Item (index 0)\nYou were given this item");
   });
 
   test("duplicate fan-out items are a whole-list failure naming the collision", () => {
@@ -345,20 +339,10 @@ describe("computeStepWorkList — purity + content-derived identity", () => {
   // reference (`${{ steps.prior.output.name }}` alongside `${{ item }}`).
   // Instructions are never parsed as references any more, and `inputs:` — the
   // one remaining per-step (not per-unit) reference position besides
-  // `map.over` — resolves ONCE for the whole step BEFORE fan-out. Reading
-  // `computeStepWorkList`'s unit-construction loop (`src/workflows/exec/
-  // step-work.ts`), every unit's `resolved` field is now unconditionally
-  // `{ ok: true, prompt, inputHash }` — there is no remaining code path that
-  // produces `{ ok: false }` on an individual `StepWorkUnit`. A per-unit
-  // "expression_error" outcome (asserted by `native-executor.test.ts`'s "null
-  // item" case, also ported below) is therefore currently UNREACHABLE via
-  // computeStepWorkList; the type still declares the union (for a future
-  // per-unit-resolved need — spec §2.3's non-agent/raw-exec unit-kind note),
-  // but no fixture in this port can construct it. REPORTED to the
-  // orchestrating agent as a behavior-surface change worth confirming
-  // intentional, not fixed here. The closest surviving equivalent — an
-  // unresolvable declared `inputs:` reference — IS still a real failure, just
-  // a WHOLE-LIST one now:
+  // `map.over` — resolves ONCE for the whole step BEFORE fan-out. Per-unit
+  // resolution cannot fail (`StepWorkUnit.resolved` carries no failure arm);
+  // the closest surviving equivalent — an unresolvable declared `inputs:`
+  // reference — IS still a real failure, just a WHOLE-LIST one:
   test("an unresolvable declared `inputs:` reference is a WHOLE-LIST failure (no more per-unit resolution)", () => {
     const step = mapStep("Review the assigned item.", "params.files", ["steps.prior.output.name"]);
     const result = computeStepWorkList(step, {
@@ -382,10 +366,7 @@ describe("computeStepWorkList — purity + content-derived identity", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const u = result.list.units[0]!;
-    expect(u.resolved.ok).toBe(true);
-    if (u.resolved.ok) {
-      expect(u.resolved.prompt).toContain("Literal ${{ not.parsed }} and steps.prior.output here.");
-    }
+    expect(u.resolved.prompt).toContain("Literal ${{ not.parsed }} and steps.prior.output here.");
   });
 
   test("gate feedback changes the prompt AND the input hash", () => {
@@ -409,13 +390,10 @@ describe("computeStepWorkList — purity + content-derived identity", () => {
     const u2 = loop2.list.units[0]!;
     expect(u1.journalBaseId).toBe("s1:solo");
     expect(u2.journalBaseId).toBe("s1:solo~l2");
-    expect(u1.resolved.ok && u2.resolved.ok).toBe(true);
-    if (u1.resolved.ok && u2.resolved.ok) {
-      expect(u2.resolved.prompt).toContain("Add analysis.");
-      expect(u2.resolved.prompt).toContain("- thoroughness");
-      expect(u1.resolved.prompt).not.toContain("Add analysis.");
-      expect(u2.resolved.inputHash).not.toBe(u1.resolved.inputHash);
-    }
+    expect(u2.resolved.prompt).toContain("Add analysis.");
+    expect(u2.resolved.prompt).toContain("- thoroughness");
+    expect(u1.resolved.prompt).not.toContain("Add analysis.");
+    expect(u2.resolved.inputHash).not.toBe(u1.resolved.inputHash);
   });
 });
 
@@ -746,12 +724,9 @@ describe("anti-drift — recomputing loop 2 from the journal reproduces the engi
     if (!list.ok) return;
     const u = list.list.units[0]!;
     expect(u.journalBaseId).toBe("work:solo~l2");
-    expect(u.resolved.ok).toBe(true);
-    if (u.resolved.ok) {
-      expect(u.resolved.prompt).toBe(workPrompts[1]!);
-      const journaled = rows.find((r) => r.unit_id === "work:solo~l2");
-      expect(journaled?.input_hash).toBe(u.resolved.inputHash);
-    }
+    expect(u.resolved.prompt).toBe(workPrompts[1]!);
+    const journaled = rows.find((r) => r.unit_id === "work:solo~l2");
+    expect(journaled?.input_hash).toBe(u.resolved.inputHash);
   });
 });
 
@@ -964,40 +939,21 @@ describe("reviewer #7 — a tampered route selection fails loudly on every surfa
 
 // ── Reviewer #6 — the gate row is finalized when completeWorkflowStep throws ───
 
-/** A solo executing step plan whose gate carries criteria (so the judge runs). */
-function gatedStep(): IrStepPlan {
-  return {
-    stepId: "work",
-    title: "Work",
-    sequenceIndex: 0,
-    root: {
-      kind: "unit",
-      id: "work",
-      instructions: "Do the work.",
-      templating: "verbatim",
-      invocation: SDK_INVOCATION,
-      onError: "fail",
-    },
-    gate: {
-      kind: "gate",
-      id: "work.gate",
-      stepId: "work",
-      criteria: ["the work is thorough"],
-    },
-  };
-}
-
 function passingResult(): ExecutedStepOutcome {
   const unit: UnitOutcome = { unitId: "work:solo", ok: true, text: "did the work" };
   return { ok: true, units: [unit], evidence: buildEvidence([unit], "collect", false), summary: "Executed 1 unit." };
 }
 
 function finalizeArgs(overrides: Record<string, unknown>) {
+  // The SAME frozen plan seedRun stores: finalizeExecutedStep reads the gate
+  // judge invocation and its engine snapshot from the caller-held plan, so the
+  // fixture must hand it the real frozen step, not a hand-built lookalike.
+  const frozen = plan(GATED_WF);
   return {
     runId: RUN_ID,
     workflowRef: "workflows/demo",
     stepId: "work",
-    stepPlan: gatedStep(),
+    stepPlan: frozen.steps[0]!,
     completionCriteria: ["the work is thorough"],
     gateLoop: 1,
     loopsRemaining: false,
@@ -1007,6 +963,7 @@ function finalizeArgs(overrides: Record<string, unknown>) {
     routeSelected: new Set<string>(),
     routeUnselected: new Map<string, RouteSkipInfo>(),
     summaryJudge: null as SummaryJudge | null,
+    engines: frozen.execution?.engines,
     ...overrides,
   };
 }

--- a/tests/integration/workflows/worktree-concurrency.test.ts
+++ b/tests/integration/workflows/worktree-concurrency.test.ts
@@ -24,7 +24,6 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -38,6 +37,7 @@ import {
   WORKTREES_DIR_NAME,
   worktreesRoot,
 } from "../../../src/workflows/exec/worktree";
+import { git, makeGitRepo as makeTempGitRepo } from "../../_helpers/git";
 
 const GIT = isGitAvailable();
 
@@ -60,25 +60,9 @@ afterEach(() => {
   }
 });
 
-function git(cwd: string, args: string[]): string {
-  const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf8", timeout: 15_000 });
-  if (result.status !== 0) {
-    throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
-  }
-  return result.stdout ?? "";
-}
-
-/** Init a temp git repo with one committed file (`README.md`). */
+/** Init a temp git repo with one committed file (`README.md`), removed in afterEach. */
 function makeGitRepo(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-wt-conc-repo-"));
-  scratch.push(dir);
-  git(dir, ["init", "-q"]);
-  git(dir, ["config", "user.email", "test@akm.invalid"]);
-  git(dir, ["config", "user.name", "akm-test"]);
-  fs.writeFileSync(path.join(dir, "README.md"), "# fixture\n");
-  git(dir, ["add", "README.md"]);
-  git(dir, ["commit", "-q", "-m", "fixture"]);
-  return dir;
+  return makeTempGitRepo({ prefix: "akm-wt-conc-repo-", register: (dir) => scratch.push(dir) });
 }
 
 /** Worktree paths git currently has REGISTERED for `repo` (excluding the repo itself). */

--- a/tests/integration/worktree-isolation.test.ts
+++ b/tests/integration/worktree-isolation.test.ts
@@ -20,7 +20,6 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -37,6 +36,7 @@ import { isGitAvailable, runWorktreeRoot } from "../../src/workflows/exec/worktr
 import { compileResolveFreezeWorkflow } from "../../src/workflows/ir/freeze";
 import type { FrozenAgentEngine, FrozenLlmEngine, WorkflowPlanGraph } from "../../src/workflows/ir/schema";
 import { parseWorkflow } from "../../src/workflows/parser";
+import { makeGitRepo as makeTempGitRepo } from "../_helpers/git";
 import { makeSandboxDir, withEnv, writeSandboxConfig } from "../_helpers/sandbox";
 
 const GIT = isGitAvailable();
@@ -67,24 +67,9 @@ afterEach(() => {
   }
 });
 
-function git(cwd: string, args: string[]): void {
-  const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf8", timeout: 15_000 });
-  if (result.status !== 0) {
-    throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
-  }
-}
-
-/** Init a temp git repo with one committed file (`README.md`). */
+/** Init a temp git repo with one committed file (`README.md`), removed in afterEach. */
 function makeGitRepo(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-wt-repo-"));
-  scratch.push(dir);
-  git(dir, ["init", "-q"]);
-  git(dir, ["config", "user.email", "test@akm.invalid"]);
-  git(dir, ["config", "user.name", "akm-test"]);
-  fs.writeFileSync(path.join(dir, "README.md"), "# fixture\n");
-  git(dir, ["add", "README.md"]);
-  git(dir, ["commit", "-q", "-m", "fixture"]);
-  return dir;
+  return makeTempGitRepo({ prefix: "akm-wt-repo-", register: (dir) => scratch.push(dir) });
 }
 
 function seedRun(steps: Array<{ id: string; title: string }>, params: Record<string, unknown> = {}): void {

--- a/tests/workflows/concurrency-defaults.test.ts
+++ b/tests/workflows/concurrency-defaults.test.ts
@@ -34,7 +34,7 @@ import {
 import { scheduleUnits } from "../../src/workflows/exec/scheduler";
 import { computeStepWorkList } from "../../src/workflows/exec/step-work";
 import { compileWorkflowPlan } from "../../src/workflows/ir/compile";
-import { compileResolveFreezeWorkflow, type FreezeOptions } from "../../src/workflows/ir/freeze";
+import type { FreezeOptions } from "../../src/workflows/ir/freeze";
 import {
   decodeWorkflowPlanV3,
   type FrozenLlmEngine,
@@ -42,8 +42,8 @@ import {
   type IrUnitNode,
   type WorkflowPlanGraph,
 } from "../../src/workflows/ir/schema";
-import { parseWorkflow } from "../../src/workflows/parser";
 import { WORKFLOW_MAX_CONCURRENCY } from "../../src/workflows/resource-limits";
+import { freezeWorkflow } from "../_helpers/workflow";
 
 // `remote` is deliberately NOT loopback and `local` deliberately is — the LLM
 // engine default is endpoint-derived, so both branches need a fixture.
@@ -75,21 +75,9 @@ const BASE_CONFIG = {
   workflow: { judgeEngine: "remote" },
 } as const satisfies AkmConfig;
 
+/** The shared freeze helper, with THIS suite's engine catalog as the default config. */
 function freeze(markdown: string, config: AkmConfig = BASE_CONFIG, options: FreezeOptions = {}): WorkflowPlanGraph {
-  const parsed = parseWorkflow(markdown, { path: "workflows/demo.md" });
-  if (!parsed.ok) throw new Error(parsed.errors.map((error) => `${error.line}: ${error.message}`).join(" | "));
-  return compileResolveFreezeWorkflow(
-    {
-      ref: "workflows/demo",
-      path: "workflows/demo.md",
-      sourcePath: "/tmp",
-      title: "demo",
-      steps: [],
-      document: parsed.document,
-    },
-    config,
-    options,
-  ).plan;
+  return freezeWorkflow(markdown, undefined, config, options);
 }
 
 /** A one-map-step document; `mapKeys` are extra lines inside the `map:` block. */

--- a/tests/workflows/exec-unit-authoring.test.ts
+++ b/tests/workflows/exec-unit-authoring.test.ts
@@ -15,23 +15,13 @@ import { describe, expect, test } from "bun:test";
 import { computeStepWorkList } from "../../src/workflows/exec/step-work";
 import type { IrUnitNode, WorkflowPlanGraph } from "../../src/workflows/ir/schema";
 import { decodeWorkflowPlanV3 } from "../../src/workflows/ir/schema";
-import { parseWorkflow } from "../../src/workflows/parser";
 import {
   DEFAULT_EXEC_TIMEOUT_MS,
   execContextLimits,
   WORKFLOW_MAX_EXEC_ARGV,
   WORKFLOW_MAX_EXEC_PASS_ENV,
 } from "../../src/workflows/resource-limits";
-import { freezeWorkflow } from "../_helpers/workflow";
-
-function doc(stepLines: string[], body = "## work\n\nDo it.\n", extra: string[] = []): string {
-  return ["---", "type: workflow", ...extra, "steps:", "  - id: work", ...stepLines, "---", "", body].join("\n");
-}
-
-function parseErrors(markdown: string): Array<{ line: number; message: string }> {
-  const result = parseWorkflow(markdown, { path: "workflows/exec.md" });
-  return result.ok ? [] : result.errors;
-}
+import { workflowDoc as doc, freezeWorkflow, parseErrors } from "../_helpers/workflow";
 
 function rootUnit(plan: WorkflowPlanGraph, index = 0): IrUnitNode {
   const root = plan.steps[index]!.root;
@@ -376,9 +366,7 @@ describe("exec unit — replay identity / input hashing", () => {
       engines: plan.execution.engines,
     });
     if (!list.ok) throw new Error(list.error);
-    const resolved = list.list.units[0]!.resolved;
-    if (!resolved.ok) throw new Error(resolved.error);
-    return resolved.inputHash;
+    return list.list.units[0]!.resolved.inputHash;
   }
 
   test("ADDITIVE: an existing llm unit's input hash is byte-identical to the pre-exec engine", () => {

--- a/tests/workflows/parser-bounds.test.ts
+++ b/tests/workflows/parser-bounds.test.ts
@@ -12,23 +12,13 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { parseWorkflow } from "../../src/workflows/parser";
 import {
   WORKFLOW_MAX_CONCURRENCY,
   WORKFLOW_MAX_GATE_LOOPS,
   WORKFLOW_MAX_RETRIES,
   WORKFLOW_MAX_TIMEOUT_MS,
 } from "../../src/workflows/resource-limits";
-
-function parseErrors(markdown: string): Array<{ line: number; message: string }> {
-  const result = parseWorkflow(markdown, { path: "workflows/bounds.md" });
-  if (result.ok) return [];
-  return result.errors;
-}
-
-function workflowWith(frontmatterStepLines: string[], body = "## work\n\nDo it.\n"): string {
-  return ["---", "type: workflow", "steps:", "  - id: work", ...frontmatterStepLines, "---", "", body].join("\n");
-}
+import { parseErrors, workflowDoc as workflowWith } from "../_helpers/workflow";
 
 describe("bug 9 — parser enforces the decoder's bounds with line anchors", () => {
   test("gate.max_loops above the shared bound is a line-anchored parser error", () => {

--- a/tests/workflows/schema-definition.test.ts
+++ b/tests/workflows/schema-definition.test.ts
@@ -12,13 +12,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { checkJsonSchemaDefinition } from "../../src/core/json-schema";
-import { parseWorkflow } from "../../src/workflows/parser";
-
-function parseErrors(markdown: string): Array<{ line: number; message: string }> {
-  const result = parseWorkflow(markdown, { path: "workflows/schemas.md" });
-  if (result.ok) return [];
-  return result.errors;
-}
+import { parseErrors } from "../_helpers/workflow";
 
 describe("checkJsonSchemaDefinition (core/json-schema.ts)", () => {
   test("a valid subset schema produces no issues", () => {


### PR DESCRIPTION
## Summary

This PR consolidates several improvements to the workflow execution path:

1. **Unit resolution simplification**: Removes the per-unit `resolved: { ok: false }` branch from `StepWorkUnit`. Resolution failures (bad references, null items, duplicates) now fail the entire work list rather than individual units, matching the unified format where prose is never scanned for references. This eliminates unreachable code paths and simplifies unit handling throughout the dispatch pipeline.

2. **Dispatch redaction refactoring**: Extracts `withDispatchRedaction` wrapper and `materializeFrozenLlm` helper to `unit-dispatch.ts`, making them reusable by both the default dispatcher and the frozen gate judge. Moves sensitive-value collection outside the per-evaluation loop in `frozenSummaryJudge` for efficiency.

3. **Loopback host classification**: Extracts the loopback detection logic from `concurrency-policy.ts` into a new `core/loopback.ts` module, shared with the indexer's LLM pool concurrency defaults. Adds `isLoopbackEndpoint` export for boundary-case testing.

4. **Async filesystem operations**: Adds `isWithinAsync` and `safeRealpathAsync` to `core/common.ts` for non-blocking path containment checks in the dispatch path (e.g., worktree isolation validation).

5. **Serialization utility**: Extracts `serializeByKey` to `core/concurrent.ts` for keyed promise-chain admission control, used by both the unit writer and worktree module.

6. **Test helpers**: Adds `seedWorkflowRun`, `parseErrors`, `workflowDoc` helpers and a new `tests/_helpers/git.ts` module for git fixture management, reducing boilerplate in integration suites.

7. **Environment baseline**: Defines `COMMON_SPAWN_ENV_PASSTHROUGH` in `core/spawn-env.ts` as the shared baseline for all child processes (agent and exec), ensuring the two allowlists cannot drift.

8. **Misc cleanup**: Removes unused imports, simplifies timeout resolution in `freeze.ts`, updates documentation to reflect the new structure.

## Test plan

Existing test suites pass, including:
- `step-work.test.ts`: Updated to remove checks for unreachable `resolved.ok` branches
- `native-executor.test.ts`: Simplified unit seeding
- `gate-judge-dispatch.test.ts`: Uses new `seedWorkflowRun` helper
- `exec-unit.test.ts`: Uses new `seedWorkflowRun` helper
- `concurrency-defaults.test.ts`: Imports loopback classifier from new module
- Worktree tests: Use new `git` helper from `tests/_helpers/git.ts`

All changes are internal refactors with no user-facing behavior changes.

https://claude.ai/code/session_01643JMhqeLJGtYM7HZKD1aL