### PR TITLE
Fix review findings in the 0.9.1 workflow engine, exec units, and lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,17 +42,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     diagnostic channel only. A schema miss is *not* re-prompted — a fixed argv
     cannot answer feedback, but re-running it could deploy twice.
   - **Exit codes:** non-zero → `non_zero_exit`, wall-clock expiry → `timeout`,
-    cancellation → `aborted`, failure to start (or a capture that never
-    completed) → `spawn_failed`. All are pre-existing `retry.on` reasons — the
-    failure taxonomy is unchanged. With the default `on_error: fail`, a non-zero
-    exit fails the step and the run, which is what makes a `test` step a gate.
+    cancellation → `aborted`, failure to start → `spawn_failed`. Those are
+    pre-existing `retry.on` reasons. With the default `on_error: fail`, a
+    non-zero exit fails the step and the run, which is what makes a `test` step
+    a gate.
   - **A partial capture is never promoted as the artifact.** Exiting 0 does not
     prove stdout was read to the end: a pipe can error, and a background
     descendant holding the stdout handle open after the command leader exits
     keeps the pipe alive past the drain deadline. Both leave a *prefix* of the
-    real output, so the unit fails `spawn_failed` — the same treatment, via the
-    same shared classifier, that the agent-dispatch path already gave the
-    identical condition.
+    real output, so the unit fails — with its own reason,
+    `exec_capture_incomplete`, which is deliberately **not** a `retry.on` value.
+    The command already ran; re-dispatching identical argv to fix a capture
+    problem would run its side effects a second time.
   - **Everything the command can spend is bounded — without inventing failures.**
     Alongside the wall-clock timeout, akm bounds the memory it spends on the
     command's behalf and the environment it can hand the command. Both bounds are
@@ -148,9 +149,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **The workflow JSON Schema subset now enforces `allOf`/`anyOf`/`oneOf`/`not`.**
   A step `output:` or `params:` schema may use the combinators, and the runtime
-  evaluates them instead of rejecting them at parse time. Evaluation stays
+  now evaluates them. Previously it ignored them: a schema using one was
+  accepted and simply constrained less than it appeared to. Evaluation stays
   bounded — nesting is capped at 64 levels and one validation at 100 000 checks,
   and exhausting either is reported as an error rather than a truncated pass.
+
+  **This one reaches runs already in flight.** The combinators live in the
+  frozen plan, which the decoder still accepts unchanged, so a run frozen before
+  the upgrade is resumed against the *new* evaluation: an artifact that passed
+  when the combinators were ignored can fail validation now. There is no
+  `irVersion` bump to gate it, because the plan bytes did not change — only what
+  they mean. Runs whose schemas use no combinators are unaffected, as is every
+  step already completed.
 
   `pattern` is **not** part of the subset. It is a recognized-but-unsupported
   keyword like `format` or `const`: using one is a loud, line-anchored authoring
@@ -163,6 +173,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `minLength`/`maxLength` bound the size, and a step's `### gate` rubric can
   check a shape and explain a mismatch. The `format` hint now points at `enum`
   rather than at `pattern`.
+
+  **Existing workflows that use one of these keywords must be edited before
+  they load again.** They previously parsed — the keyword was silently
+  non-constraining — so a workflow carrying `format: date-time` or `pattern:`
+  ran fine and now fails to parse for every caller: `workflow run`, `workflow
+  show`, `workflow create`, and `akm lint`. The quietest surface is `akm index`,
+  which skips an asset it cannot parse with a scan warning, so the workflow
+  simply stops appearing in the stash index. A run already frozen from such an
+  asset still resumes — the frozen-plan decoder does not re-screen keywords —
+  so resuming works while re-creating the same workflow errors until it is
+  edited.
+
+- **A document-level `defaults.llm` is now rejected at freeze when any step
+  resolves onto an agent engine**, naming the step and the engine. The guard
+  existed before but was unreachable: overrides were computed only for `llm`
+  engines, so `defaults.llm` on a document with an agent step was silently
+  DROPPED for that step — the run proceeded with the author's sampling settings
+  quietly discarded. Failing loudly is the point, but it means a document that
+  mixes `defaults.llm` with any agent-engine step no longer freezes.
+
+  There is no per-step opt-out: `llm: {}` is a no-op, `llm: null` is a parse
+  error, and the layer merge is additive. Move the `llm:` block from
+  `defaults:` onto the `unit:` of each LLM step that wants it.
+
+- **A scheduled workflow task now gets a 6-hour whole-run timeout by default.**
+  This applies to task files that declare no `timeoutMs:` — which is every task
+  file written before this release, since the key was previously rejected on
+  workflow targets. An unattended run that legitimately takes longer will be
+  aborted and the attempt reported failed on every firing until the task is
+  edited. `timeoutMs: null` opts out entirely, and any number overrides the
+  default. The abort itself is graceful: it lands at a step boundary, the
+  journal and lease are kept, and the run stays resumable with
+  `akm workflow resume <id>` — which the failure message names.
 
 - **Workflow `map` steps now fan out in parallel by default.** A `map` step
   that declares no `concurrency:` freezes a width of **4** instead of 1, and an
@@ -193,6 +236,53 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   current host's CPU cap.
 
 ### Fixed
+
+- **`timeout: none` on an exec unit is genuinely unbounded again.** The
+  stream-drain safety net — a one-hour bound on a pipe still being read after
+  the child is gone — was armed when capture STARTED, so a command that ran
+  past an hour had its output reader cancelled mid-run and was then failed for
+  an incomplete capture even though it exited 0. It is now armed from the
+  child's exit, which is the only window it was ever meant to bound. A unit with
+  a declared timeout is unaffected.
+
+- **A step artifact larger than 1 MiB no longer breaks the next step of the run
+  that produced it.** Step evidence is clipped to bound one SQLite row, and the
+  engine rebuilt each downstream `steps.<id>.output` scope by re-reading those
+  rows — so a large artifact (an exec unit's stdout retains up to 8 MiB) reached
+  the very next step as a truncation marker: a path reference failed with a
+  missing-property error that never mentioned truncation, and a whole-value
+  reference silently handed the marker to the unit as its input. The run now
+  carries its own complete values forward; the row stays clipped for resume,
+  where a reference into a clipped artifact fails by name.
+
+- **A workflow task whose run completed is no longer reported as a failed
+  timeout.** The deadline is observed between steps, so one landing during a
+  run's final bookkeeping set the timed-out flag on a run that then finished —
+  and the attempt was recorded as failed, with a hint to resume a run that had
+  nothing left to resume.
+
+- On Windows, an agent CLI, gate judge, or prompt task was spawned into an
+  environment the loader cannot start from: the shared passthrough allowlist
+  named no `SystemRoot`/`SystemDrive`/`WINDIR`, and without `PATHEXT` a
+  `bin: "bun"` profile was unresolvable — while an exec unit on the same host
+  worked, because its own allowlist names them. Those variables are now added
+  when any allowlisted child environment is built.
+
+- Scheduler PATH repair skipped itself in the environments it exists for. It
+  decided a PATH was "interactive" by testing whether any entry began with the
+  user's home directory as a *string*, so a home of `/` — system crontab,
+  launchd, service accounts — matched every absolute entry, and a sibling home
+  (`/home/alice/bin` against `/home/al`) matched too.
+
+- A directory whose name merely begins with two dots (`..data`) was treated as
+  a path escape. For a workflow exec `cwd` that meant the parser and the frozen
+  plan accepted a spelling the executor then failed as tampering, with a reason
+  no retry can clear.
+
+- `appendEvent` resolved the state.db path outside its own error handling, and
+  did so even when the caller supplied an open connection — so a caller holding
+  a perfectly good handle could take a configuration error from a function whose
+  contract is that it never propagates one.
 
 - Workflow freeze attributed per-step `engine`/`model`/`timeout`/`llm` overrides
   by matching the compiled draft step list against the source document

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   frozen `workflow.maxConcurrency`, the selected engine's concurrency, and the
   current host's CPU cap.
 
+- **`--max-steps` now counts steps, not engine-loop iterations.** The budget is
+  spent by the DISTINCT spine steps that finished — completed, failed, or
+  gate-rejected with the loop budget spent. It was previously spent by entries
+  in the `executed` report,
+  which gains one per gate-loop iteration and one per route-skip, so
+  `--max-steps 3` against a step with `gate.max_loops: 3` could stop after a
+  single step had finished, and an unselected branch target consumed budget for
+  work that was never dispatched. Three steps now means three steps, which is
+  what the flag has always said (`Stop after executing this many steps`). A step
+  the invocation left unfinished — an abort, a judge outage — still consumes
+  nothing, because the work is still owed. The same accounting is what a
+  `--max-retries` reopen subtracts, so loops and skips no longer shrink a
+  retry's remaining budget either, and `maxSteps:` in a workflow task file is
+  the same knob and moves with it. The count is now reported: `akm workflow run`
+  carries a `stepsProcessed` field alongside `executed`, so the number the
+  budget is spent on is visible rather than inferred from a list that counts
+  something else.
+
+  **This loosens the dispatch exposure of one invocation, and the loosening is
+  cumulative across steps.** A step's whole bounded gate loop now costs one step
+  instead of one per iteration, so the rounds a single `akm workflow run` can
+  dispatch go from roughly `N + max_loops` to `N × max_loops`.
+
+  What did **not** change is what the flag bounds within one step. `--max-steps`
+  was never a cap on total dispatch rounds on either version: the budget is
+  tested only BETWEEN steps, so a single step's gate loop could always run out
+  its full `gate.max_loops` no matter how little budget was left. The per-step
+  ceiling is `gate.max_loops` (1–100); the whole-run ceilings are
+  `budget.max_units` and `budget.max_tokens`, which are seeded from the unit
+  journal and hold across resumes.
+
 ### Fixed
 
 - **`timeout: none` on an exec unit is genuinely unbounded again.** The
@@ -242,8 +273,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the child is gone — was armed when capture STARTED, so a command that ran
   past an hour had its output reader cancelled mid-run and was then failed for
   an incomplete capture even though it exited 0. It is now armed from the
-  child's exit, which is the only window it was ever meant to bound. A unit with
-  a declared timeout is unaffected.
+  child's exit, which is the only window it was ever meant to bound.
+
+- **A bounded exec unit no longer waits out its whole `timeout` after the
+  command has already exited.** The drain deadline for a unit WITH a wall budget
+  ran from the moment capture started — budget plus a 2 s grace — so a command
+  that exited in milliseconds while a background descendant held a pipe open
+  kept the unit, and with it a fan-out slot, occupied for the entire declared
+  timeout before reporting. It now runs from the moment nothing living owns the
+  pipe: the child's exit, or (for a child that outlived its own kill ladder) the
+  budget's expiry, plus the same 2 s grace. A command that really does spend its
+  whole budget sees the identical ceiling it saw before; only the case that used
+  to stall stopped stalling.
+
+- **A stderr drain that never finished no longer fails an exec unit whose
+  command succeeded.** `exec_capture_incomplete` was raised when EITHER pipe
+  failed to drain, so a command that exited 0 with its stdout captured whole was
+  failed — and a valid artifact thrown away — because a background descendant
+  was still holding STDERR open. stderr is a diagnostic channel that never
+  contributes to the artifact, so only an incomplete STDOUT capture fails the
+  unit now; an incomplete stderr drain is reported on the warn stream instead,
+  naming the unit and warning that any stderr shown for it may be missing its
+  tail.
 
 - **A step artifact larger than 1 MiB no longer breaks the next step of the run
   that produced it.** Step evidence is clipped to bound one SQLite row, and the
@@ -255,11 +306,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   carries its own complete values forward; the row stays clipped for resume,
   where a reference into a clipped artifact fails by name.
 
-- **A workflow task whose run completed is no longer reported as a failed
-  timeout.** The deadline is observed between steps, so one landing during a
-  run's final bookkeeping set the timed-out flag on a run that then finished —
-  and the attempt was recorded as failed, with a hint to resume a run that had
-  nothing left to resume.
+- **A workflow run that completed is no longer reported as timed out.** The
+  deadline is observed between steps, so one landing during a run's final
+  bookkeeping set the timed-out flag on a run that then finished. On a scheduled
+  workflow task that recorded the attempt as failed, with a hint to resume a run
+  that had nothing left to resume; under `akm workflow run --timeout` it
+  rendered a `timedOut` marker on a `completed` run and exited nonzero. Both
+  surfaces now drop the marker once the run reached `completed` — a deadline
+  that lands with nothing left to abort has nothing to report.
+
+- **A rejected gate on an `exec` step no longer re-runs the command.** A gate
+  loop earns its re-dispatch by handing the judge's feedback to a unit that can
+  answer it. An exec unit cannot: its argv is frozen and never interpolated, and
+  the exec context environment carries no feedback variable — so the loop could
+  only re-run the byte-identical command, performing a deploy, a publish, or a
+  migration a second time for a verdict that could not change. The gate still
+  EVALUATES on an exec step and can still fail it: a rejection is final on the
+  first evaluation, carrying the judge's missing criteria and feedback exactly
+  as in the one-shot case. What an author sees is
+  that `gate.max_loops` is capped at 1 on a step whose unit is `exec:` — not an
+  authoring error, and no change at all to an engine step, where a declared
+  `max_loops` is still honored in full. This is the same reasoning that already
+  makes an exec unit's `output:` schema miss fail without a corrective
+  re-dispatch.
+
+- **The stale-worktree sweep no longer collects a worktree that is still in
+  use.** The opportunistic age-based GC of leftover `isolation: worktree` trees
+  judged staleness from the worktree root's mtime, which a unit writing only
+  inside subdirectories never touches — so another akm process minting a
+  worktree could delete the tree a long-running unit was working in. Every live
+  worktree now carries a liveness marker (pid, host, resolved path) in git's own
+  administrative directory for it, and the sweep skips a candidate whose holder
+  is still running here. A marker from a dead pid, from another host, or for a
+  different path is not liveness: crashed runs and retained dirty trees stay
+  collectible, which is what the sweep exists for.
 
 - On Windows, an agent CLI, gate judge, or prompt task was spawned into an
   environment the loader cannot start from: the shared passthrough allowlist

--- a/docs/architecture/testing/manual-testing-checklist.md
+++ b/docs/architecture/testing/manual-testing-checklist.md
@@ -1486,7 +1486,30 @@ Adapters may add named diagnostics; unknown adapter codes map to
       boundaries and either behaves transactionally or reports partial mutation
       explicitly. Silent direct edits/deletes are a failure.
 
-### 12.4 Output parity and automated coverage
+### 12.4 Advisory channel
+
+Non-fatal workflow compile advisories (a step with no `output:` schema, a
+reference to an undeclared param) travel in their own channel so a hint cannot
+fail a build.
+
+```sh
+akm lint --type workflows --format json > "$AKM_SANDBOX/lint-advisory.json"
+jq -e '.warnings | length > 0' "$AKM_SANDBOX/lint-advisory.json"
+jq -e '[.flagged[].issue] | index("workflow-warning") == null' "$AKM_SANDBOX/lint-advisory.json"
+akm lint --type workflows --fail-on-flagged; echo "exit=$?"
+```
+
+- [ ] **[CORE]** A compile advisory appears in `warnings` with issue code
+      `workflow-warning`, never in `flagged`, and `summary.warnings` counts it.
+- [ ] **[CORE]** `--fail-on-flagged` exits `0` for a bundle whose only findings
+      are advisories, and non-zero once a real error is present.
+- [ ] **[LOCAL]** Both lint paths agree: the akm sweep and a bundle linted
+      through its own adapter classify the same code the same way.
+- [ ] **[LOCAL]** A workflow file is parsed and compiled **once** per sweep, not
+      once per output channel — check with a large workflow and compare sweep
+      time against a bundle with the same file count and no workflows.
+
+### 12.5 Output parity and automated coverage
 
 - [ ] **[CORE]** JSON/JSONL/YAML/text/Markdown/HTML preserve the same finding
       set and summary. Text renders flagged before fixed.
@@ -1591,6 +1614,20 @@ akm lint --type workflows --fail-on-flagged
 - [ ] **LOCAL** Flat name plus safe path creates hierarchy; slash/traversal/duplicate step/missing section/unknown route/invalid params fail before write.
 - [ ] **LOCAL** Existing workflow requires force plus from/reset; force alone fails.
 - [ ] **LOCAL** Lint catches structure without rewriting valid prose.
+- [ ] **CORE** A schema keyword outside the enforced subset (`format`, `pattern`,
+      `$ref`, `const`, `uniqueItems`, `patternProperties`, …) in `output:` or
+      `params:` is a **line-anchored parse error naming the keyword**, not a
+      silently non-constraining schema. Confirm the same document fails
+      `workflow run`, `workflow show`, `workflow create`, and `akm lint`.
+- [ ] **LOCAL** `akm index` skips such a workflow with a scan warning rather
+      than indexing it — the quietest surface, so check it deliberately.
+- [ ] **LOCAL** `allOf`/`anyOf`/`oneOf`/`not` are accepted and **enforced** at
+      runtime; a bounded-evaluation overrun is reported as an error, never as a
+      truncated pass.
+- [ ] **LOCAL** A document-level `defaults.llm` combined with any step on an
+      agent engine fails at freeze, naming the step and the engine. Moving the
+      `llm:` block onto the LLM step's `unit:` is the documented remedy; `llm: {}`
+      is a no-op and `llm: null` is a parse error.
 
 ### 14.2 Typed params and partial run without an engine call
 
@@ -1619,6 +1656,10 @@ jq -e '
 - [ ] **LOCAL** Unknown param, underscore-hyphen alias, invalid JSON/enum/range, missing required, duplicate scalar, flags before target, and retired params bag fail exit `2`.
 - [ ] **LOCAL** Params supplied to active run fail because creation-only.
 - [ ] **LOCAL** Invalid max-steps values fail; bounded partial exits `0`, remains active.
+- [ ] **LOCAL** `--max-steps` counts **finished spine steps**: a step's whole
+      bounded gate loop counts as one, and a route-skipped step consumes none.
+      It does not bound the dispatches inside a single step's gate loop — pair
+      it with `budget.max_units` when that is what you need capped.
 
 ### 14.3 Status, list, abandon, resume, and scope
 
@@ -1657,10 +1698,158 @@ run freezes its own judge selection.
 - [ ] **AI** Gate journal distinguishes running/error/pass/reject and survives resume.
 - [ ] **AI** Config changes after start do not replace frozen execution/judge engine/model/timeout.
 
-### 14.5 Failure, interruption, concurrency, and events
+### 14.5 Exec (shell) units
+
+An exec unit spawns a command instead of dispatching to an engine, so run this
+whole subsection with **no engine configured** — that is the first assertion,
+not a setup shortcut. Author the fixtures first:
+
+```sh
+cat > "$AKM_BUNDLE_DIR/workflows/exec-basic.md" <<'EOF'
+---
+type: workflow
+description: Exec unit smoke
+steps:
+  - id: emit
+    unit:
+      exec:
+        command: ["printf", "hello\n\n"]
+---
+
+# Exec Basic
+
+## emit
+
+Print a greeting. Stdout is the promoted artifact; this prose never reaches the
+command.
+EOF
+
+cat > "$AKM_BUNDLE_DIR/workflows/exec-json.md" <<'EOF'
+---
+type: workflow
+description: Exec unit with a typed artifact
+steps:
+  - id: emit
+    unit:
+      exec:
+        command: ["echo", '{"verdict":"pass"}']
+      output: { type: object, required: [verdict], properties: { verdict: { type: string } } }
+---
+
+# Exec JSON
+
+## emit
+
+Emit exactly one JSON value.
+EOF
+
+akm index
+akm lint --type workflows --fail-on-flagged
+akm workflow run workflows/exec-basic --format json > "$AKM_SANDBOX/exec-basic.json"
+jq -e '.run.status == "completed"' "$AKM_SANDBOX/exec-basic.json"
+akm workflow status "$(jq -r .run.id "$AKM_SANDBOX/exec-basic.json")" --units
+```
+
+Authoring and dispatch:
+
+- [ ] **CORE** A workflow of only exec steps freezes and completes with **no
+      engine configured at all**; the run spends no tokens.
+- [ ] **CORE** Without `output:`, the artifact is stdout with trailing newlines
+      stripped (`hello`, not `hello\n\n`); empty stdout is *no output*.
+- [ ] **CORE** With `output:`, stdout must be exactly one JSON value — leading
+      and trailing whitespace tolerated, any other trailing text fails the unit
+      — and the value is validated against the schema.
+- [ ] **CORE** `engine`, `model`, or `llm` alongside `exec:` fails at parse,
+      naming the conflict.
+- [ ] **LOCAL** `command` is argv, never a shell string: an argument containing
+      `;`, `|`, `&&`, `$(…)`, backticks, `>`, or `*` reaches the child as those
+      literal bytes. `["bash", "-lc", "…"]` is the supported way to get a shell.
+- [ ] **LOCAL** Argv bounds hold: 1–64 entries, each non-empty and at most 4096
+      bytes; violations fail at parse and at frozen-plan decode.
+- [ ] **LOCAL** A step body is still required and is **not** passed to the
+      command.
+- [ ] **LOCAL** stderr is a diagnostic channel only — it never becomes the
+      artifact, and a passing command that writes to stderr still succeeds.
+
+Failure taxonomy — each reason, and whether `retry.on` may name it:
+
+- [ ] **CORE** Non-zero exit is `non_zero_exit` and, under the default
+      `on_error: fail`, fails the step and the run (this is what makes a `test`
+      step a gate). `on_error: continue` records it in evidence instead.
+- [ ] **LOCAL** Wall-clock expiry is `timeout`; run cancellation is `aborted`; a
+      missing binary or unusable working directory is `spawn_failed`. All three
+      are retryable via `retry.on`.
+- [ ] **LOCAL** `exec_output_limit`, `exec_context_too_large`, `exec_cwd_escape`
+      and `exec_capture_incomplete` are **rejected** in a `retry.on` list —
+      each is deterministic, an authoring problem, or work that already ran.
+- [ ] **LOCAL** On timeout or cancellation the child's whole **process group**
+      takes the SIGTERM→SIGKILL ladder; no orphaned grandchildren survive.
+
+Capture and retention:
+
+- [ ] **LOCAL** Past the 8 MiB per-stream retention cap akm keeps draining the
+      pipe, so the command never blocks: with no `output:` schema the unit
+      **succeeds** with the artifact marked truncated; with a schema it fails
+      `exec_output_limit`.
+- [ ] **LOCAL** A command that backgrounds a descendant inheriting **stderr**
+      (`sh -c 'daemon 2>&1 & echo ok'` shapes) and exits 0 **succeeds** with its
+      complete stdout artifact, and warns that the stderr tail may be missing.
+      Only an incomplete **stdout** capture fails the unit.
+- [ ] **LOCAL** That same unit settles promptly after its leader exits — it does
+      **not** sit until its declared timeout expires.
+- [ ] **LOCAL** `timeout: none` is genuinely unbounded: a command that runs well
+      past an hour still completes and promotes its artifact.
+
+Environment scope and context:
+
+- [ ] **LOCAL** The child gets the default allowlist only: credentials and cloud
+      or CI variables present in akm's own environment are **absent** unless
+      named. `pass_env:` widens it by name; `inherit_env: true` hands over the
+      whole environment verbatim.
+- [ ] **LOCAL** `env:` bindings inject resolved values, and the `AKM_*` context
+      is applied *after* them, so a binding cannot shadow it.
+- [ ] **LOCAL** `AKM_RUN_ID`, `AKM_STEP_ID`, `AKM_UNIT_ID`, `AKM_PARAMS`,
+      `AKM_INPUTS`, and (in a `map`) `AKM_ITEM` / `AKM_ITEM_INDEX` reach the
+      command with the documented shapes.
+- [ ] **LOCAL** An oversized `AKM_*` context fails `exec_context_too_large`
+      **before** the spawn, naming the variable, rather than surfacing a raw
+      `E2BIG`.
+
+`cwd` and isolation:
+
+- [ ] **LOCAL** `cwd` is relative and contained: absolute paths, drive letters,
+      `~`, and `..` **segments** are rejected by the parser *and* the
+      frozen-plan decoder, and containment is re-checked against the resolved
+      base (symlinks included) immediately before the spawn.
+- [ ] **LOCAL** A directory whose *name* merely begins with dots (`..data`) is a
+      legal contained `cwd` and must **not** fail `exec_cwd_escape`.
+- [ ] **LOCAL** Under `isolation: worktree` each unit gets a fresh detached
+      worktree; a clean one is gone once the step resolves, a dirty one is
+      retained and its path logged.
+- [ ] **LOCAL** When a dirty leftover is moved aside and the worktree then fails
+      to mint, the failure still reports **where the preserved work went**.
+- [ ] **DESTRUCTIVE** The stale-worktree sweep removes abandoned trees after
+      seven days but leaves a tree that is still in use by a live run.
+
+Gates, retry, and reuse:
+
+- [ ] **LOCAL** A `### gate` rubric on an exec step **evaluates** — a rejection
+      still fails the step — but never loops: the command runs exactly **once**
+      regardless of `gate.max_loops`, because a frozen argv cannot answer
+      feedback. Verify with a command that appends to a file.
+- [ ] **LOCAL** A declared `retry:` re-runs the command only for reasons it
+      names; a schema miss is never re-prompted (re-running could deploy twice).
+- [ ] **LOCAL** A completed exec unit is reused on resume, never re-executed —
+      confirm with a command whose side effect is observable.
+- [ ] **LOCAL** `map` fan-out over exec units respects the frozen concurrency
+      width, and each unit sees its own `AKM_ITEM`.
+
+### 14.6 Failure, interruption, concurrency, and events
 
 - [ ] **LOCAL** Execution nonzero returns workflow stdout result, exit `1`.
 - [ ] **LOCAL** Whole-run timeout leaves current step resumable and records evidence.
+- [ ] **LOCAL** A run that **completes** after its `--timeout` deadline landed is
+      reported as completed, not as timed out.
 - [ ] **LOCAL** SIGINT/SIGTERM map to `130`/`143`, release claims, leave recoverable run.
 - [ ] **LOCAL** Concurrent same-ref/scope starts create one active run; second driver loses lease safely.
 - [ ] **LOCAL** Map fan-out respects workflow and frozen engine concurrency caps.
@@ -1668,7 +1857,21 @@ run freezes its own judge selection.
 - [ ] **DESTRUCTIVE** Kill before unit, after unit, after judge; resume reclaims only unfinished work, no duplicate unit.
 - [ ] **DESTRUCTIVE** Run focused lease/crash/contention/publication suites.
 
-### 14.6 Retired surfaces and fallback
+### 14.7 Step artifacts, bounds, and evidence
+
+A step's promoted artifact is bounded for *persistence* only. The distinction
+between what the running invocation sees and what the row keeps is the point.
+
+- [ ] **LOCAL** A step promoting an artifact larger than the 1 MiB persistence
+      cap still hands the **complete** value to the next step of the same run —
+      both a whole-value `inputs:` reference and a path reference into it.
+- [ ] **LOCAL** The persisted row for that step carries a truncation marker, and
+      **resuming** into the truncated artifact fails loudly, naming truncation
+      as the cause rather than reporting a missing property.
+- [ ] **LOCAL** Over-cap evidence sacrifices the byte-largest values first, and
+      the persisted row is never left over cap.
+
+### 14.8 Retired surfaces and fallback
 
 - [ ] **CORE** Start/next/complete/brief/report fail `UNKNOWN_COMMAND` with run/status guidance.
 - [ ] **LOCAL** No template/validate/watch; replacements are create-print/lint/log.
@@ -1715,6 +1918,15 @@ akm task history --id manual-failure --limit 1
 - [ ] **LOCAL** Command child `78` maps CLI `78`; other failed status maps `1`.
 - [ ] **LOCAL** Missing/malformed task, invalid id, prompt/workflow failure, timeout, and signal record bounded history.
 - [ ] **LOCAL** Flat log and logs DB agree and redact credentials.
+- [ ] **LOCAL** A **workflow** task that declares no `timeoutMs:` gets the
+      6-hour unattended default: the log records `timed_out=true` with the
+      applied `timeout_ms`, the attempt is `failed` so the scheduler sees a
+      non-zero exit, and the aborted run is left **resumable** with the error
+      naming `akm workflow resume <id>`.
+- [ ] **LOCAL** `timeoutMs: null` opts a workflow task out entirely and arms no
+      timer; an explicit number overrides the default.
+- [ ] **LOCAL** A workflow task whose run **completes** as the deadline lands is
+      recorded `completed` with no timeout error and no resume hint.
 
 ### 15.3 Scheduler binding and native lifecycle
 
@@ -2865,6 +3077,8 @@ and not a substitute for the full check.
 | Sources/registry/write-source | provider/write/publication suites, controlled service; LIVE git/npm/HTTPS when lifecycle changed |
 | Storage/migration/transactions | crash/concurrency/property/published-upgrade gates, section 19, destructive rehearsal for cutover changes |
 | Workflow | workflow unit/integration, gate fake agents, slow expansion, crash/contention when scheduler changed |
+| Workflow exec units / subprocess capture | section 14.5 end to end on an engine-less install, plus the worktree isolation and stale-sweep gates; any capture, timeout, or process-group change also runs the agent spawn suites, which share that subprocess layer |
+| Workflow child environment / allowlist | section 14.5 environment gates plus section 11; a change to the shared floor is native Windows, not Linux emulation |
 | Task/scheduler | task suites, Linux standalone; native macOS/Windows for backend/quoting/binding; published upgrade for schema changes |
 | Env/secret/security path/archive/network | env/secret plus traversal/SSRF/archive/redaction/dangerous-key suites, section 20 |
 | Agent/LLM/improve/proposal | family suites and fake-service AI pass; live bounded provider only for changed external dispatch |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -609,15 +609,34 @@ The old `--params <json>` bag is removed.
 
 | Flag | Description |
 | --- | --- |
-| `--max-steps <n>` | Stop after executing at most this many steps, leaving a partial run active. Must be at least 1. |
+| `--max-steps <n>` | Stop once this many steps have finished, leaving a partial run active. Must be at least 1. |
 | `--max-retries <n>` | When a step fails, reopen the same run and retry the failed step up to this many additional times. Range: 0 through 100; default 0. Gate rejection and interruption are not retried. |
 | `--timeout <duration>` | Abort the whole invocation after `N`, `Nms`, `Ns`, or `Nm`; bare `N` is milliseconds. The active step remains resumable. |
 
-The result includes the current `run`, an `executed` step report list, and
-optional `done`, `gateRejection`, `aborted`, or `timedOut` markers. A failed
-run, rejected verification gate, timeout, or interrupt exits nonzero. `SIGINT`
-and `SIGTERM` map to 130 and 143; a timeout maps to exit 1. Reaching
-`--max-steps` with an active resumable run is successful.
+The result includes the current `run`, an `executed` step report list, a
+`stepsProcessed` count of the steps that finished, and optional `done`,
+`gateRejection`, `aborted`, or `timedOut` markers. A failed run, rejected
+verification gate, timeout, or interrupt exits nonzero. `SIGINT` and `SIGTERM`
+map to 130 and 143; a timeout maps to exit 1. Reaching `--max-steps` with an
+active resumable run is successful. A `--timeout` that lands during the run's
+final bookkeeping is not reported as a timeout: a run that reached `completed`
+has nothing left to abort and nothing left to resume.
+
+**What `--max-steps` counts.** The budget is spent by the **steps that
+finish** — completed, failed, or gate-rejected with the loop budget spent — not
+by entries in the `executed` report, which gains one per gate-loop iteration
+and one per route-skip. So a step's whole bounded `gate.max_loops` loop costs
+one, a route-skipped step costs nothing (no work was dispatched for it), and a
+step the invocation left unfinished — an abort, a verification-judge outage —
+costs nothing either, because the next invocation still owes that work.
+`--max-retries` subtracts the same way: a reopened run's remaining budget is
+not shrunk by loops or skips.
+
+The budget is checked **between** steps, so it does not bound what any single
+step dispatches — a step's gate loop runs to its own limit no matter how little
+budget is left. `gate.max_loops` (1–100) is the per-step ceiling;
+`budget.max_units` and `budget.max_tokens` are the whole-run ceilings, seeded
+from the unit journal so they hold across resumes.
 
 `run` is Stable and does not consult `experimental.workflowEngine`. Every
 non-empty `### gate` requires `workflow.judgeEngine` to name a configured LLM

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -32,7 +32,13 @@ families) plus the orchestration keys:
 - `params` — name → `{ type, description }` (JSON-Schema-typed, unlike a bare
   description string).
 - `defaults` — run-level dispatch defaults (`engine`, `model`, `llm`,
-  `timeout`, `on_error`), overridable per unit.
+  `timeout`, `on_error`), overridable per unit. `defaults.llm` is the
+  exception: `llm:` tuning applies only to engines of kind `llm`, and a
+  document-level `llm:` reaches EVERY step, so a document that also has a step
+  on an agent engine fails to freeze — naming the step and the engine — rather
+  than dropping the settings for that step. There is no per-step opt-out (`llm:
+  {}` is a no-op and `llm: null` is a parse error), so in a mixed document put
+  `llm:` on the `unit:` of each LLM step instead of in `defaults:`.
 - `budget` — run-lifetime ceilings (`max_units`, `max_tokens`; see
   [Budget ceilings](#budget-ceilings) below).
 - `steps` — an ordered list. Each step has an `id`
@@ -458,9 +464,11 @@ cannot step outside the tree its isolation promised.
   background descendant that keeps the stdout handle open after the command
   leader exits will hold the pipe past the drain deadline. Either way the
   captured text is a *prefix* of the real output, so the unit fails
-  `spawn_failed` (the same reason the agent-dispatch path reports for the same
-  condition) rather than promoting the prefix. If you hit this, have the command
-  wait for its children or redirect their output.
+  `exec_capture_incomplete` rather than promoting the prefix. That reason is
+  deliberately outside `retry.on`: the command already RAN, and re-dispatching
+  identical argv to fix a capture problem would run its side effects again. If
+  you hit this, have the command wait for its children or redirect their
+  output.
 
 Note that a schema failure is **not** retried by the corrective-feedback loop
 that model units use. Re-prompting is meaningless to a fixed argv — the same
@@ -477,7 +485,7 @@ failure reason.
 | exceeded `timeout` | `timeout` | yes |
 | run cancelled (`Ctrl-C`, `--timeout`, budget) | `aborted` | yes |
 | binary missing / working directory unusable | `spawn_failed` | yes |
-| output capture never completed | `spawn_failed` | yes |
+| output capture never completed | `exec_capture_incomplete` | **no** (the command already ran) |
 | stdout past the retention limit, **and** the unit declares `output:` | `exec_output_limit` | **no** (deterministic) |
 | stdout past the retention limit, no `output:` schema | — (unit succeeds; artifact marked truncated) | — |
 | `AKM_*` context too large for **this platform** to spawn | `exec_context_too_large` | **no** (an authoring/data problem) |

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -459,8 +459,8 @@ cannot step outside the tree its isolation promised.
   [Output limits](#output-limits) — the artifact is then explicitly marked
   truncated, never silently shortened, and only a unit with a declared `output:`
   schema fails for it.
-- **An incomplete capture is a failure, not a partial artifact.** Exiting 0 is
-  not on its own proof that stdout was fully read: a pipe can error, and a
+- **An incomplete STDOUT capture is a failure, not a partial artifact.** Exiting
+  0 is not on its own proof that stdout was fully read: a pipe can error, and a
   background descendant that keeps the stdout handle open after the command
   leader exits will hold the pipe past the drain deadline. Either way the
   captured text is a *prefix* of the real output, so the unit fails
@@ -469,6 +469,18 @@ cannot step outside the tree its isolation promised.
   identical argv to fix a capture problem would run its side effects again. If
   you hit this, have the command wait for its children or redirect their
   output.
+
+  Only **stdout** is fatal here. stderr never contributes to the artifact, so a
+  stderr drain that did not finish leaves the unit's actual result — a completed
+  command, a fully captured stdout — intact and the unit succeeds; failing it
+  would discard a valid artifact over a lost log tail. akm warns when that
+  happens, naming the unit, so stderr shown for it is never mistaken for the
+  whole of it.
+
+  The drain deadline itself starts when nothing living owns the pipe any more —
+  the command's exit, or for a unit with a declared `timeout` the earlier of
+  that and the budget expiring — plus a short grace. A unit does not sit until
+  its whole `timeout` because a descendant outlived the command.
 
 Note that a schema failure is **not** retried by the corrective-feedback loop
 that model units use. Re-prompting is meaningless to a fixed argv — the same
@@ -485,7 +497,8 @@ failure reason.
 | exceeded `timeout` | `timeout` | yes |
 | run cancelled (`Ctrl-C`, `--timeout`, budget) | `aborted` | yes |
 | binary missing / working directory unusable | `spawn_failed` | yes |
-| output capture never completed | `exec_capture_incomplete` | **no** (the command already ran) |
+| **stdout** capture never completed | `exec_capture_incomplete` | **no** (the command already ran) |
+| **stderr** capture never completed | — (unit succeeds; a warning says the stderr tail may be missing) | — |
 | stdout past the retention limit, **and** the unit declares `output:` | `exec_output_limit` | **no** (deterministic) |
 | stdout past the retention limit, no `output:` schema | — (unit succeeds; artifact marked truncated) | — |
 | `AKM_*` context too large for **this platform** to spawn | `exec_context_too_large` | **no** (an authoring/data problem) |
@@ -932,6 +945,19 @@ with the gate feedback and the missing-criteria list appended as attached
 context. The feedback changes each unit's inputs, so the re-run naturally
 dispatches fresh units instead of replaying journaled results. When the loop
 budget is spent, the rejection stands exactly as in the one-shot case.
+
+**An [exec step](#exec-shell-units) is judged, but never looped.** A gate loop
+earns its re-dispatch by handing the judge's feedback to a unit that can answer
+it, and an exec unit cannot: its argv is frozen and never interpolated, and the
+`AKM_*` context carries no feedback variable. A second loop would re-run the
+byte-identical command — deploying, publishing, or migrating twice — for a
+verdict that cannot change. So a step whose unit is `exec:` still has its
+artifact judged and can still be failed by the verdict; a rejection simply lands
+on the first evaluation, carrying the same missing criteria and feedback the
+one-shot case does. `gate.max_loops` on such a step is capped at 1 rather than
+rejected, and an engine step's declared `max_loops` is untouched. This is the
+same reasoning that makes an exec unit's `output:` schema miss fail without a
+corrective re-dispatch.
 
 **Fail-closed verification.** With no non-empty `### gate` rubric, no
 verification runs. When a rubric is present, the workflow requires

--- a/src/commands/lint/index.ts
+++ b/src/commands/lint/index.ts
@@ -31,7 +31,7 @@ import type { FileChange } from "../../core/file-change";
 import { resolveSourceEntries, type SearchSource } from "../../indexer/search/search-source";
 import { runBaseChecks } from "./base-linter";
 import { checkEnvForDangerousKeys } from "./env-key-rules";
-import type { LintContext, LintIssue, LintIssueType } from "./types";
+import { isAdvisoryLintIssue, type LintContext, type LintIssue, type LintIssueType } from "./types";
 
 // ── Public API types (re-exported for consumers) ──────────────────────────────
 
@@ -243,9 +243,11 @@ async function lintViaAdapter(
 
   const mapped = diagnostics.map(diagnosticToLintIssue);
   // Advisory diagnostics travel in their own channel — never `flagged`, so a
-  // `--fail-on-flagged` gate is not tripped by a non-fatal warning.
-  const warnings = mapped.filter((issue) => issue.issue === "workflow-warning");
-  const flagged = mapped.filter((issue) => issue.issue !== "workflow-warning");
+  // `--fail-on-flagged` gate is not tripped by a non-fatal warning. Classified
+  // by the shared `ADVISORY_LINT_ISSUES` set rather than a code spelled out
+  // here, so this and the sweep below can never disagree about a code.
+  const warnings = mapped.filter(isAdvisoryLintIssue);
+  const flagged = mapped.filter((issue) => !isAdvisoryLintIssue(issue));
   // The cross-bundle env dangerous-key sweep (see `runEnvDangerousKeyPass`'s
   // doc comment) ran for every non-akm adapter via the STASH_SUBDIRS
   // fallthrough this dispatch replaces — EXCEPT `okf`, which the old code
@@ -543,6 +545,12 @@ function lintAkmSweep(
         if (isFileDeletion(issue)) {
           fileDeleted = true;
           fixed.push(issue);
+        } else if (isAdvisoryLintIssue(issue)) {
+          // `lintAssetFile` returns errors only today, so this branch is
+          // reached by no current producer — it is here so that an advisory
+          // added to a per-type check later cannot silently become a
+          // `--fail-on-flagged` failure, the way the unclassified default does.
+          warnings.push(issue);
         } else if (issue.fixed === true) {
           fixed.push(issue);
         } else {

--- a/src/commands/lint/index.ts
+++ b/src/commands/lint/index.ts
@@ -12,8 +12,7 @@ import {
   nameOrTypeDiagnostics,
   ORPHANED_STUB_DETAIL,
   taskDiagnostics,
-  workflowCompileWarnings,
-  workflowStructureDiagnostics,
+  workflowFrontendDiagnostics,
 } from "../../core/adapter/adapters/akm-lint";
 import { detectAdapterId } from "../../core/adapter/detect-adapter";
 import { adapterForId } from "../../core/adapter/registry";
@@ -386,39 +385,41 @@ function appendMemoryStubIssue(ctx: LintContext, issues: LintIssue[]): void {
   issues.push({ file: ctx.relPath, issue: "orphaned-stub", detail: ORPHANED_STUB_DETAIL, fixed: false });
 }
 
-/** WorkflowLinter's `placeholder-stub` (WITH `--fix` delete) + `invalid-workflow-structure` (workflow-linter.ts:22-79). */
-function appendWorkflowIssues(ctx: LintContext, issues: LintIssue[]): void {
+/**
+ * WorkflowLinter's `placeholder-stub` check WITH its `--fix` delete
+ * (workflow-linter.ts:22-79). Its sibling `invalid-workflow-structure` check is
+ * deliberately NOT here: parse+compile is a single pass shared with the
+ * advisory channel, so {@link lintAkmSweep} runs it once per file and routes
+ * both halves.
+ */
+function appendWorkflowStubIssue(ctx: LintContext, issues: LintIssue[]): void {
   const placeholder = matchWorkflowPlaceholder(ctx.body);
-  if (placeholder) {
-    if (ctx.fix) {
-      try {
-        fs.unlinkSync(ctx.filePath);
-        issues.push({
-          file: ctx.relPath,
-          issue: "placeholder-stub",
-          detail: `deleted: found "${placeholder}"`,
-          fixed: true,
-        });
-      } catch (e) {
-        issues.push({
-          file: ctx.relPath,
-          issue: "placeholder-stub",
-          detail: `could not delete: ${e instanceof Error ? e.message : String(e)}`,
-          fixed: "failed",
-        });
-      }
-      return; // WorkflowLinter returns before the structure check once a stub is fixed.
+  if (!placeholder) return;
+  if (ctx.fix) {
+    try {
+      fs.unlinkSync(ctx.filePath);
+      issues.push({
+        file: ctx.relPath,
+        issue: "placeholder-stub",
+        detail: `deleted: found "${placeholder}"`,
+        fixed: true,
+      });
+    } catch (e) {
+      issues.push({
+        file: ctx.relPath,
+        issue: "placeholder-stub",
+        detail: `could not delete: ${e instanceof Error ? e.message : String(e)}`,
+        fixed: "failed",
+      });
     }
-    issues.push({
-      file: ctx.relPath,
-      issue: "placeholder-stub",
-      detail: `placeholder text: "${placeholder}"`,
-      fixed: false,
-    });
+    return;
   }
-  // NB: the CLI passes the ABSOLUTE filePath to parseWorkflow (matching the old
-  // WorkflowLinter), whereas the adapter passes the change relPath.
-  issues.push(...(workflowStructureDiagnostics(ctx.relPath, ctx.raw, ctx.filePath) as LintIssue[]));
+  issues.push({
+    file: ctx.relPath,
+    issue: "placeholder-stub",
+    detail: `placeholder text: "${placeholder}"`,
+    fixed: false,
+  });
 }
 
 /**
@@ -426,6 +427,10 @@ function appendWorkflowIssues(ctx: LintContext, issues: LintIssue[]): void {
  * per-`type` extra rules. Replaces `getLinterForType(subdir).lint(ctx)`.
  * `--fix` mutations (frontmatter rewrites inside `runBaseChecks`; stub deletes
  * here) are applied when `ctx.fix` is set.
+ *
+ * The workflow parse/compile frontend is NOT one of these rules — it is one
+ * pass feeding two channels, so {@link lintAkmSweep} owns it (see
+ * {@link appendWorkflowStubIssue}).
  */
 export function lintAssetFile(ctx: LintContext, subdir: string): LintIssue[] {
   const issues = runBaseChecks(ctx);
@@ -446,7 +451,7 @@ export function lintAssetFile(ctx: LintContext, subdir: string): LintIssue[] {
       appendMemoryStubIssue(ctx, issues);
       break;
     case "workflows":
-      appendWorkflowIssues(ctx, issues);
+      appendWorkflowStubIssue(ctx, issues);
       break;
     // knowledge / lessons / skills: base checks only (skill directory-level
     // `missing-skill-md` runs separately, per-subdir, in the sweep loop).
@@ -561,11 +566,24 @@ function lintAkmSweep(
 
       if (fileDeleted) continue; // file is gone — skip any remaining checks
 
-      // Workflow compile warnings are non-fatal advisories (`compileWorkflowPlan`'s
-      // `warnings`): surfaced in the result's separate `warnings` channel so
-      // they reach human + JSON lint output without tripping `--fail-on-flagged`.
+      // The workflow frontend is ONE parse+compile whose output feeds BOTH
+      // channels, so it runs here — once per file — rather than inside
+      // `lintAssetFile`, which is an errors-only surface (pinned by the lint
+      // golden). Which channel a finding lands in is decided by
+      // `ADVISORY_LINT_ISSUES`, never by which half of the pass produced it, so
+      // a future compile-warning kind carrying a fatal code cannot slip past
+      // `--fail-on-flagged`.
+      // NB: the CLI passes the ABSOLUTE filePath to parseWorkflow (matching the
+      // old WorkflowLinter), whereas the adapter passes the change relPath.
       if (subdir === "workflows") {
-        warnings.push(...(workflowCompileWarnings(relPath, raw, filePath) as LintIssue[]));
+        const frontend = workflowFrontendDiagnostics(relPath, raw, filePath);
+        for (const finding of [...frontend.errors, ...frontend.warnings]) {
+          if (isAdvisoryLintIssue(finding)) {
+            warnings.push(finding);
+          } else {
+            flagged.push(finding);
+          }
+        }
       }
     }
   }

--- a/src/commands/lint/types.ts
+++ b/src/commands/lint/types.ts
@@ -48,6 +48,29 @@ export type LintIssueType =
    */
   | "adapter-diagnostic";
 
+/**
+ * The issue codes that are ADVISORY: surfaced in lint output but never routed
+ * into `flagged`, so `--fail-on-flagged` cannot fail a run over one.
+ *
+ * ONE home for that decision. Both routing points consult it — the adapter
+ * path (`lint/index.ts#lintViaAdapter`) and the sweep's per-file loop — so a
+ * new advisory code cannot be classified correctly in one place and land in
+ * `flagged` (exit 1) in the other. A future advisory belongs in BOTH this set
+ * and {@link LintIssueType}: an unrecognized code is folded onto
+ * `adapter-diagnostic` at the adapter boundary, which is deliberately NOT
+ * advisory, so a code missing from the union cannot be routed by this set.
+ *
+ * Advisory-ness is deliberately NOT a field on {@link LintIssue}: issues are
+ * serialized verbatim by `--format json`, and a new key on every advisory
+ * would change every consumer's output to restate what `issue` already says.
+ */
+export const ADVISORY_LINT_ISSUES: ReadonlySet<string> = new Set<LintIssueType>(["workflow-warning"]);
+
+/** True when `issue` belongs to the advisory channel — see {@link ADVISORY_LINT_ISSUES}. */
+export function isAdvisoryLintIssue(issue: { issue: string }): boolean {
+  return ADVISORY_LINT_ISSUES.has(issue.issue);
+}
+
 export interface LintIssue {
   file: string;
   issue: LintIssueType;

--- a/src/commands/lint/types.ts
+++ b/src/commands/lint/types.ts
@@ -32,7 +32,7 @@ export type LintIssueType =
    * e.g. a step with no `output:` schema, or a `params.<name>` reference to an
    * undeclared param). Routed into `AkmLintResult.warnings`, never `flagged`,
    * so `--fail-on-flagged` ignores it (see
-   * `core/adapter/adapters/akm-lint.ts#workflowCompileWarnings`).
+   * `core/adapter/adapters/akm-lint.ts#workflowFrontendDiagnostics`).
    */
   | "workflow-warning"
   /**
@@ -52,11 +52,12 @@ export type LintIssueType =
  * The issue codes that are ADVISORY: surfaced in lint output but never routed
  * into `flagged`, so `--fail-on-flagged` cannot fail a run over one.
  *
- * ONE home for that decision. Both routing points consult it — the adapter
- * path (`lint/index.ts#lintViaAdapter`) and the sweep's per-file loop — so a
- * new advisory code cannot be classified correctly in one place and land in
- * `flagged` (exit 1) in the other. A future advisory belongs in BOTH this set
- * and {@link LintIssueType}: an unrecognized code is folded onto
+ * ONE home for that decision. EVERY routing point consults it — the adapter
+ * path (`lint/index.ts#lintViaAdapter`), the sweep's per-file loop, and the
+ * sweep's workflow-frontend pass — so a new advisory code cannot be classified
+ * correctly in one place and land in `flagged` (exit 1) in another; a finding
+ * is never filed by which producer emitted it. A future advisory belongs in
+ * BOTH this set and {@link LintIssueType}: an unrecognized code is folded onto
  * `adapter-diagnostic` at the adapter boundary, which is deliberately NOT
  * advisory, so a code missing from the union cannot be routed by this set.
  *

--- a/src/commands/workflow-cli.ts
+++ b/src/commands/workflow-cli.ts
@@ -11,6 +11,7 @@
 
 import { getStringArg } from "../cli/parse-args";
 import { defineGroupCommand, defineJsonCommand, EXIT_CODES, output } from "../cli/shared";
+import { armAbortDeadline } from "../core/abort-deadline";
 import { assertFlatAssetName, combineCreatePath, normalizeCreateSubPath } from "../core/asset/asset-create";
 import { NotFoundError, UsageError } from "../core/errors";
 import { akmIndex } from "../indexer/indexer";
@@ -171,7 +172,6 @@ const workflowRunCommand = defineJsonCommand({
     const maxRetries = parseIntegerFlag(getStringArg(args, "max-retries"), "--max-retries", 0, WORKFLOW_MAX_RETRIES);
     const timeoutMs = parseWorkflowTimeout(getStringArg(args, "timeout"));
     const controller = new AbortController();
-    let timedOut = false;
     let signalExitCode: number | undefined;
     const interrupt = (signal: "SIGINT" | "SIGTERM") => {
       signalExitCode = signal === "SIGINT" ? 130 : 143;
@@ -181,14 +181,12 @@ const workflowRunCommand = defineJsonCommand({
     const onSigterm = () => interrupt("SIGTERM");
     process.once("SIGINT", onSigint);
     process.once("SIGTERM", onSigterm);
-    const timer =
-      timeoutMs === undefined
-        ? undefined
-        : setTimeout(() => {
-            timedOut = true;
-            controller.abort(new Error(`Workflow run timed out after ${timeoutMs}ms.`));
-          }, timeoutMs);
-    timer?.unref?.();
+    // The same deadline a scheduled workflow task arms (`tasks/runner.ts`),
+    // sharing this controller with the signal handlers above.
+    const deadline = armAbortDeadline(controller, {
+      timeoutMs,
+      reason: `Workflow run timed out after ${timeoutMs}ms.`,
+    });
     try {
       const result = await runWorkflowSteps({
         target: args.target,
@@ -197,7 +195,7 @@ const workflowRunCommand = defineJsonCommand({
         ...(maxRetries !== undefined ? { maxRetries } : {}),
         signal: controller.signal,
       });
-      const rendered = { ...result, ...(timedOut ? { timedOut: true as const } : {}) };
+      const rendered = { ...result, ...(deadline.timedOut() ? { timedOut: true as const } : {}) };
       output("workflow-run", rendered);
       // `blocked` is a stopped, unverified run — a verification-judge failure
       // leaves it there for `akm workflow resume` — so it must not exit 0 and
@@ -206,7 +204,7 @@ const workflowRunCommand = defineJsonCommand({
         process.exitCode = signalExitCode ?? EXIT_CODES.GENERAL;
       }
     } finally {
-      if (timer) clearTimeout(timer);
+      deadline.disarm();
       process.off("SIGINT", onSigint);
       process.off("SIGTERM", onSigterm);
     }

--- a/src/commands/workflow-cli.ts
+++ b/src/commands/workflow-cli.ts
@@ -195,7 +195,12 @@ const workflowRunCommand = defineJsonCommand({
         ...(maxRetries !== undefined ? { maxRetries } : {}),
         signal: controller.signal,
       });
-      const rendered = { ...result, ...(deadline.timedOut() ? { timedOut: true as const } : {}) };
+      // The abort is observed between steps, so a deadline landing in the run's
+      // final bookkeeping fires on a run that then finishes. Reporting that as
+      // timed out would send an operator to resume a run with nothing left to
+      // resume — `tasks/runner.ts` suppresses the same case.
+      const timedOut = deadline.timedOut() && result.run.status !== "completed";
+      const rendered = { ...result, ...(timedOut ? { timedOut: true as const } : {}) };
       output("workflow-run", rendered);
       // `blocked` is a stopped, unverified run — a verification-judge failure
       // leaves it there for `akm workflow resume` — so it must not exit 0 and

--- a/src/core/abort-deadline.ts
+++ b/src/core/abort-deadline.ts
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * A wall-clock deadline that aborts a caller's {@link AbortController}.
+ *
+ * Both surfaces that bound a whole workflow run — `akm workflow run --timeout`
+ * (`commands/workflow-cli.ts`) and a scheduled workflow task (`tasks/runner.ts`)
+ * — need the same four things: a timer, an abort carrying a reason, a flag
+ * saying the deadline is why the run stopped, and an `unref` so a pending timer
+ * cannot hold the process open. Written out per call site, the two copies had
+ * already drifted apart in exactly the places that are easy to miss.
+ *
+ * The deadline arms a controller the CALLER owns rather than creating one,
+ * because each caller composes it with something different: the CLI merges
+ * SIGINT/SIGTERM into the same controller (and maps them to their own exit
+ * codes), while a task has only the deadline. For the same reason this is not
+ * an option on `runWorkflowSteps`: the engine already accepts a `signal`, so a
+ * timer there would be a SECOND way to stop a run rather than one way, and the
+ * CLI would still need its controller for signals.
+ *
+ * @module core/abort-deadline
+ */
+
+export interface AbortDeadlineOptions {
+  /** Milliseconds until the abort. `null`/`undefined` arms nothing at all. */
+  timeoutMs: number | null | undefined;
+  /** Abort reason, surfaced to whatever inspects the signal. */
+  reason: string;
+  /** Timer seams for tests; default to the globals. */
+  setTimeoutFn?: typeof setTimeout;
+  clearTimeoutFn?: typeof clearTimeout;
+}
+
+export interface AbortDeadline {
+  /** Cancel the timer. Safe to call when nothing was armed, and idempotent. */
+  disarm(): void;
+  /** True once the deadline fired — i.e. the deadline is why the run stopped. */
+  timedOut(): boolean;
+}
+
+export function armAbortDeadline(controller: AbortController, options: AbortDeadlineOptions): AbortDeadline {
+  const { timeoutMs, reason } = options;
+  if (timeoutMs === null || timeoutMs === undefined) {
+    return { disarm: () => {}, timedOut: () => false };
+  }
+  const setTimeoutImpl = options.setTimeoutFn ?? setTimeout;
+  const clearTimeoutImpl = options.clearTimeoutFn ?? clearTimeout;
+  let fired = false;
+  let timer: ReturnType<typeof setTimeoutImpl> | undefined = setTimeoutImpl(() => {
+    timer = undefined;
+    fired = true;
+    controller.abort(new Error(reason));
+  }, timeoutMs);
+  // A pending deadline must never be the reason the process stays alive.
+  (timer as unknown as { unref?: () => void } | undefined)?.unref?.();
+  return {
+    disarm: () => {
+      if (timer !== undefined) {
+        clearTimeoutImpl(timer);
+        timer = undefined;
+      }
+    },
+    timedOut: () => fired,
+  };
+}

--- a/src/core/adapter/adapters/akm-lint.ts
+++ b/src/core/adapter/adapters/akm-lint.ts
@@ -333,28 +333,18 @@ export function matchWorkflowPlaceholder(body: string): string | null {
 
 /**
  * WorkflowLinter's `invalid-workflow-structure` check (`workflow-linter.ts:48-77`):
- * parse and compile through the unified workflow frontend, surfacing every
- * structural or semantic error and skipping the read-only `/.cache/`+`/registry/`
- * cached copies. Shared with the live linter;
- * `parsePath` is the path handed to `parseWorkflow` (the adapter passes the
- * change relPath, the CLI passes the absolute filePath — matching each caller's
- * legacy behavior). NEVER writes.
+ * the ERROR half of {@link workflowFrontendDiagnostics}, for callers that only
+ * ever surface fatal findings — the read-only adapter `validate` path and
+ * `akm migrate`'s stale-workflow probe. A caller that ALSO surfaces the
+ * advisories must call {@link workflowFrontendDiagnostics} once instead of
+ * pairing this with a second view. NEVER writes.
  */
-export function workflowStructureDiagnostics(relPath: string, raw: string, parsePath: string): Diagnostic[] {
+export function workflowStructureDiagnostics(
+  relPath: string,
+  raw: string,
+  parsePath: string,
+): WorkflowFrontendDiagnostic[] {
   return workflowFrontendDiagnostics(relPath, raw, parsePath).errors;
-}
-
-/**
- * Non-fatal compile WARNINGS for a workflow (`compileWorkflowPlan`'s
- * `warnings` — e.g. a step with no `output:` schema, or a reference to an
- * undeclared param). Emitted as `workflow-warning` Diagnostics so `akm lint`
- * can surface them in its human and JSON output WITHOUT failing anything:
- * the lint sweep (`commands/lint/index.ts`) routes this issue code into its
- * separate `warnings` channel, never `flagged`, so `--fail-on-flagged` and
- * the adapter `validate()` error surface are unaffected.
- */
-export function workflowCompileWarnings(relPath: string, raw: string, parsePath: string): Diagnostic[] {
-  return workflowFrontendDiagnostics(relPath, raw, parsePath).warnings;
 }
 
 /**
@@ -369,45 +359,46 @@ function lineOf(err: { line?: number }): { line?: number } {
   return typeof err.line === "number" && Number.isFinite(err.line) && err.line > 0 ? { line: err.line } : {};
 }
 
-interface WorkflowFrontendDiagnostics {
-  errors: Diagnostic[];
-  warnings: Diagnostic[];
+/**
+ * One workflow frontend finding. The issue code is narrowed to the only two
+ * codes this pass emits, so a caller can route the result onto its own closed
+ * issue union (`commands/lint/types.ts`'s `LintIssueType`) without a cast.
+ */
+export type WorkflowFrontendDiagnostic = Diagnostic & {
+  issue: "invalid-workflow-structure" | "workflow-warning";
+};
+
+/** Both halves of one parse+compile — see {@link workflowFrontendDiagnostics}. */
+export interface WorkflowFrontendDiagnostics {
+  errors: WorkflowFrontendDiagnostic[];
+  warnings: WorkflowFrontendDiagnostic[];
 }
 
 /**
- * The last frontend pass, keyed by its exact inputs.
+ * ONE parse+compile of a workflow through the unified frontend, returning both
+ * halves of what it produces: fatal `invalid-workflow-structure` findings, and
+ * `compileWorkflowPlan`'s non-fatal `workflow-warning` advisories (a step with
+ * no `output:` schema, a reference to an undeclared param). The read-only
+ * `/.cache/` + `/registry/` cached copies are skipped, and nothing is written.
  *
- * {@link workflowStructureDiagnostics} and {@link workflowCompileWarnings} are
- * two VIEWS of ONE parse+compile, and the lint sweep asks for both, per file,
- * back to back — so without this the whole frontend ran twice for every
- * workflow in the stash (a full `parseWorkflow` + `compileWorkflowPlan` over
- * instruction bodies that may reach `WORKFLOW_MAX_INSTRUCTION_BYTES`) to throw
- * half the result away each time. One entry is all that buys: the second
- * caller always asks about the file the first just asked about.
+ * `parsePath` is the path handed to `parseWorkflow` (the adapter passes the
+ * change relPath, the CLI passes the absolute filePath — matching each
+ * caller's legacy behavior).
  *
- * Keyed on the full `raw` text, so a rewritten file (`--fix`) can never be
- * served a stale answer — the key stops matching the moment the bytes change.
+ * A caller that surfaces BOTH halves must call this once and route the result
+ * itself. The frontend is expensive — instruction bodies reach
+ * `WORKFLOW_MAX_INSTRUCTION_BYTES` — so asking for each half through its own
+ * view parses and compiles every workflow in the stash twice.
  */
-let lastFrontendPass: { key: string; result: WorkflowFrontendDiagnostics } | undefined;
-
-/** Shared parse+compile pass behind {@link workflowStructureDiagnostics} / {@link workflowCompileWarnings}. */
-function workflowFrontendDiagnostics(relPath: string, raw: string, parsePath: string): WorkflowFrontendDiagnostics {
-  const key = `${relPath} ${parsePath} ${raw}`;
-  if (lastFrontendPass?.key === key) return lastFrontendPass.result;
-  const result = computeWorkflowFrontendDiagnostics(relPath, raw, parsePath);
-  lastFrontendPass = { key, result };
-  return result;
-}
-
-function computeWorkflowFrontendDiagnostics(
+export function workflowFrontendDiagnostics(
   relPath: string,
   raw: string,
   parsePath: string,
 ): WorkflowFrontendDiagnostics {
-  const none = { errors: [], warnings: [] };
+  const none: WorkflowFrontendDiagnostics = { errors: [], warnings: [] };
   if (parsePath.includes("/.cache/") || parsePath.includes("/registry/")) return none;
-  const errors: Diagnostic[] = [];
-  const warnings: Diagnostic[] = [];
+  const errors: WorkflowFrontendDiagnostic[] = [];
+  const warnings: WorkflowFrontendDiagnostic[] = [];
   try {
     const result = parseWorkflow(raw, { path: parsePath });
     if (!result.ok) {

--- a/src/core/adapter/adapters/akm-lint.ts
+++ b/src/core/adapter/adapters/akm-lint.ts
@@ -369,12 +369,41 @@ function lineOf(err: { line?: number }): { line?: number } {
   return typeof err.line === "number" && Number.isFinite(err.line) && err.line > 0 ? { line: err.line } : {};
 }
 
+interface WorkflowFrontendDiagnostics {
+  errors: Diagnostic[];
+  warnings: Diagnostic[];
+}
+
+/**
+ * The last frontend pass, keyed by its exact inputs.
+ *
+ * {@link workflowStructureDiagnostics} and {@link workflowCompileWarnings} are
+ * two VIEWS of ONE parse+compile, and the lint sweep asks for both, per file,
+ * back to back — so without this the whole frontend ran twice for every
+ * workflow in the stash (a full `parseWorkflow` + `compileWorkflowPlan` over
+ * instruction bodies that may reach `WORKFLOW_MAX_INSTRUCTION_BYTES`) to throw
+ * half the result away each time. One entry is all that buys: the second
+ * caller always asks about the file the first just asked about.
+ *
+ * Keyed on the full `raw` text, so a rewritten file (`--fix`) can never be
+ * served a stale answer — the key stops matching the moment the bytes change.
+ */
+let lastFrontendPass: { key: string; result: WorkflowFrontendDiagnostics } | undefined;
+
 /** Shared parse+compile pass behind {@link workflowStructureDiagnostics} / {@link workflowCompileWarnings}. */
-function workflowFrontendDiagnostics(
+function workflowFrontendDiagnostics(relPath: string, raw: string, parsePath: string): WorkflowFrontendDiagnostics {
+  const key = `${relPath} ${parsePath} ${raw}`;
+  if (lastFrontendPass?.key === key) return lastFrontendPass.result;
+  const result = computeWorkflowFrontendDiagnostics(relPath, raw, parsePath);
+  lastFrontendPass = { key, result };
+  return result;
+}
+
+function computeWorkflowFrontendDiagnostics(
   relPath: string,
   raw: string,
   parsePath: string,
-): { errors: Diagnostic[]; warnings: Diagnostic[] } {
+): WorkflowFrontendDiagnostics {
   const none = { errors: [], warnings: [] };
   if (parsePath.includes("/.cache/") || parsePath.includes("/registry/")) return none;
   const errors: Diagnostic[] = [];

--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -344,7 +344,13 @@ function isContainedResolvedPath(resolvedCandidate: string, resolvedRoot: string
     normalizeFsPathForComparison(resolvedRoot),
     normalizeFsPathForComparison(resolvedCandidate),
   );
-  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+  if (rel === "") return true;
+  if (path.isAbsolute(rel)) return false;
+  // Compare the first SEGMENT, not a string prefix: `..data` and `...v2` are
+  // legal directory names, and only a leading `..` segment means the candidate
+  // climbed out of the root. Both separators, because `path.relative` answers
+  // in the host's spelling while callers may hold either.
+  return rel.split(/[/\\]+/)[0] !== "..";
 }
 
 /**

--- a/src/core/concurrent.ts
+++ b/src/core/concurrent.ts
@@ -3,21 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 /**
- * Maps over items concurrently with a pool size limit.
- * Uses Promise.allSettled semantics — one failure does not cancel others.
- *
- * Cooperative cancellation (P0.5 seam for the workflow scheduler): when
- * `opts.signal` aborts, workers stop CLAIMING new items — in-flight `fn`
- * calls run to completion (pass the same signal into `fn`'s own work to
- * preempt those too). Unclaimed items stay `undefined` in the result,
- * indistinguishable from individual failures by design: callers already
- * treat `undefined` as "no result".
- *
- * A thrown `fn` is SWALLOWED (its slot stays `undefined`) — a caller that
- * must report failure detail, or distinguish "threw" from "never claimed",
- * catches inside `fn` and returns an explicit outcome value instead.
- */
-/**
  * Serialize `fn` behind every task previously enqueued under `key`: an
  * in-process keyed promise chain (Bun is single-threaded, so this is a
  * sufficient — and free — admission control for per-key mutual exclusion).
@@ -50,6 +35,23 @@ export function serializeByKey<T>(
   return run;
 }
 
+/**
+ * Maps over items concurrently with a pool size limit.
+ * Uses Promise.allSettled semantics — one failure does not cancel others.
+ *
+ * Cooperative cancellation (P0.5 seam for the workflow scheduler): when
+ * `opts.signal` aborts, workers stop CLAIMING new items — in-flight `fn`
+ * calls run to completion (pass the same signal into `fn`'s own work to
+ * preempt those too). Unclaimed items stay `undefined` in the result,
+ * indistinguishable from individual failures by design: callers already
+ * treat `undefined` as "no result".
+ *
+ * A thrown `fn` is SWALLOWED (its slot stays `undefined`) — a caller that
+ * must report failure detail, or distinguish "threw" from "never claimed",
+ * catches inside `fn` and returns an explicit outcome value instead. This is
+ * the OPPOSITE of {@link serializeByKey} above, whose failures reject their
+ * own caller.
+ */
 export async function concurrentMap<T, R>(
   items: T[],
   fn: (item: T, index: number) => Promise<R>,

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -233,16 +233,24 @@ function resolveNow(ctx?: EventsContext): () => number {
 export function appendEvent(input: AppendEventInput, ctx?: EventsContext): void {
   const now = resolveNow(ctx);
   const ts = new Date(now()).toISOString();
-  const dbPath = resolveDbPath(ctx);
   const row = { eventType: input.eventType, ts, ref: input.ref, metadata: input.metadata };
 
-  // One try covers BOTH paths — including the ambient scope's lazy open — so
-  // the best-effort contract ("a write failure never propagates") holds no
-  // matter which handle this event lands on.
+  // One try covers EVERY path — including resolving the state.db path, which
+  // reads the environment and throws where no data dir can be derived — so the
+  // best-effort contract ("a write failure never propagates") holds no matter
+  // which handle this event lands on.
   try {
-    // Fast path: an explicitly supplied long-lived connection, or the ambient
-    // scoped one — either way the handle is borrowed and never closed here.
-    const borrowed = ctx?.db ?? borrowScopedStateDb(dbPath);
+    // Fast path: an explicitly supplied long-lived connection. Resolution is
+    // skipped outright, which is what "`dbPath` is ignored when `db` is
+    // provided" has to mean for a caller that already holds an open handle.
+    if (ctx?.db) {
+      insertEvent(ctx.db, row);
+      return;
+    }
+    const dbPath = resolveDbPath(ctx);
+    // The ambient scoped handle for this path, when a scope is open — borrowed
+    // exactly like the explicit one, and never closed here.
+    const borrowed = borrowScopedStateDb(dbPath);
     if (borrowed) {
       insertEvent(borrowed, row);
       return;

--- a/src/core/spawn-env.ts
+++ b/src/core/spawn-env.ts
@@ -72,8 +72,14 @@ export const COMMON_SPAWN_ENV_PASSTHROUGH = [
  * Config and install roots (`APPDATA`, `LOCALAPPDATA`, `ProgramFiles`, …) are
  * deliberately NOT here: a child can be created and can resolve its command
  * without them, so which allowlist wants them stays a per-caller decision.
+ *
+ * THE definition of the floor. The workflow exec allowlist
+ * (`EXEC_DEFAULT_ENV_PASSTHROUGH`) spreads this constant rather than
+ * re-spelling it, because that list is also consumed on POSIX — where
+ * {@link spawnEnvNamesFor} appends nothing — and the names still have to be
+ * requestable there for a win32 run of the same workflow.
  */
-const WIN32_SPAWN_ENV_FLOOR = [
+export const WIN32_SPAWN_ENV_FLOOR = [
   "SystemRoot",
   "SystemDrive",
   "WINDIR",
@@ -95,11 +101,16 @@ const WIN32_SPAWN_ENV_FLOOR = [
 export function spawnEnvNamesFor(names: Iterable<string>, platform: string = process.platform): string[] {
   const effective = [...names];
   if (platform !== "win32") return effective;
-  // Windows env names are case-insensitive; dedupe that way so a caller
-  // spelling `SYSTEMROOT` does not also receive `SystemRoot`.
-  const present = new Set(effective.map((name) => name.toUpperCase()));
+  // Deduped by EXACT spelling, never case-folded: {@link collectAllowlistedEnv}
+  // looks each surviving name up with exactly this case, and a `source` that is
+  // a plain object — the agent spawn's `envSource` seam — does not case-fold.
+  // Suppressing `SystemRoot` because the caller happened to write `SYSTEMROOT`
+  // would therefore drop the loader-critical variable the floor exists to
+  // guarantee. Keeping both spellings is harmless: the win32 environment is
+  // itself case-insensitive, so they resolve to the same value.
+  const present = new Set(effective);
   for (const name of WIN32_SPAWN_ENV_FLOOR) {
-    if (!present.has(name.toUpperCase())) effective.push(name);
+    if (!present.has(name)) effective.push(name);
   }
   return effective;
 }
@@ -133,6 +144,27 @@ export function collectAllowlistedEnv(
 }
 
 /**
+ * Answers already computed by {@link supplementPathForSchedulerContext}, keyed
+ * by the input PATH and the home directory it was computed against.
+ *
+ * Correctness envelope: the answer is a pure function of those two, the
+ * platform, and which candidate directories exist on disk. The platform cannot
+ * change under a running process, and the other two are in the key — so the one
+ * thing the memo assumes is that a candidate directory does not APPEAR while
+ * akm runs. Answering the rest of a run the way its start was answered is what
+ * a shell's own command-path caching already does, and the cost of not
+ * memoizing is paid on every child-env build: two PATH splits and up to seven
+ * SYNCHRONOUS `existsSync` probes, on the event loop a 10 000-unit fan-out
+ * shares with the run's lease heartbeat.
+ *
+ * Bounded so a caller that somehow varies its PATH cannot grow it without
+ * limit; a spawn path only ever sees a handful of distinct PATH strings, so
+ * the reset is effectively unreachable in practice.
+ */
+const supplementedPaths = new Map<string, string>();
+const SUPPLEMENTED_PATH_MEMO_MAX = 64;
+
+/**
  * Supplement `existingPath` with well-known user binary directories when
  * running in a scheduler context (cron/launchd) where PATH is stripped.
  *
@@ -143,9 +175,24 @@ export function collectAllowlistedEnv(
  * Only directories that actually exist on disk are prepended, and only if
  * they are not already present, so interactive-shell PATH ordering is never
  * disturbed.
+ *
+ * Memoized per input PATH — see {@link supplementedPaths} for what that
+ * assumes.
  */
 export function supplementPathForSchedulerContext(existingPath: string): string {
   const home = os.homedir();
+  // NUL-joined so no pair of (home, PATH) can collide onto one key: no path
+  // component can contain a NUL.
+  const key = `${home}\u0000${existingPath}`;
+  const memoized = supplementedPaths.get(key);
+  if (memoized !== undefined) return memoized;
+  const supplemented = computeSupplementedPath(existingPath, home);
+  if (supplementedPaths.size >= SUPPLEMENTED_PATH_MEMO_MAX) supplementedPaths.clear();
+  supplementedPaths.set(key, supplemented);
+  return supplemented;
+}
+
+function computeSupplementedPath(existingPath: string, home: string): string {
   // A home of `/` (system crontab, launchd, service accounts) or of `""`
   // prefixes EVERY entry, so a prefix test would read the most stripped
   // environments there are as interactive and skip the repair they exist for.

--- a/src/core/spawn-env.ts
+++ b/src/core/spawn-env.ts
@@ -5,13 +5,19 @@
 /**
  * The ONE allowlist-based child-environment primitive.
  *
- * Every akm code path that spawns a child from an explicit list of environment
+ * Two akm code paths spawn a child from an explicit list of environment
  * variable NAMES — the agent-CLI spawn wrapper
  * (`integrations/agent/spawn.ts`, `profile.envPassthrough`) and the workflow
- * `exec` unit runner (`workflows/exec/exec-unit.ts`) — starts from an EMPTY
- * environment and copies through named entries with {@link collectAllowlistedEnv}.
- * Keeping that in one leaf module is what makes "allowlist" a single reviewable
- * mechanism instead of two implementations that drift apart.
+ * `exec` unit runner (`workflows/exec/exec-unit.ts`) — and both start from an
+ * EMPTY environment and copy through named entries with
+ * {@link collectAllowlistedEnv}. Keeping that in one leaf module is what makes
+ * "allowlist" a single reviewable mechanism instead of two implementations
+ * that drift apart.
+ *
+ * NOT covered: the opencode-sdk server spawn
+ * (`integrations/harnesses/opencode-sdk/sdk-runner.ts`) keeps its own
+ * hard-coded name list and does not route through here, so it gets neither the
+ * platform floor below nor PATH supplementation.
  *
  * A LEAF: node built-ins only, so both the integrations layer and the workflow
  * engine can import it without opening a cycle.
@@ -48,6 +54,57 @@ export const COMMON_SPAWN_ENV_PASSTHROUGH = [
 ] as const;
 
 /**
+ * The names Windows itself requires of ANY child, whatever the caller's
+ * allowlist says. Applied at build time rather than added to
+ * {@link COMMON_SPAWN_ENV_PASSTHROUGH} because profile `envPassthrough` is
+ * frozen into workflow engine snapshots: growing the shared list would change
+ * the bytes — and so the hashes — of every plan already on disk, to express
+ * something that is not a policy choice at all.
+ *
+ * `SystemRoot`, `SystemDrive` and `WINDIR` are what PROCESS CREATION reads;
+ * without them the loader cannot find system DLLs and the spawn fails before
+ * the command runs. Without `PATHEXT` Windows never tries `bun.exe`/`bun.cmd`,
+ * so a `bin: "bun"` profile is unresolvable, and `COMSPEC` is how `.bat`/`.cmd`
+ * targets resolve at all. The rest are the win32 analogues of baseline names
+ * the POSIX side already grants — `HOME` (`USERPROFILE`, `HOMEDRIVE`,
+ * `HOMEPATH`) and `TMPDIR` (`TEMP`, `TMP`). None is a secret.
+ *
+ * Config and install roots (`APPDATA`, `LOCALAPPDATA`, `ProgramFiles`, …) are
+ * deliberately NOT here: a child can be created and can resolve its command
+ * without them, so which allowlist wants them stays a per-caller decision.
+ */
+const WIN32_SPAWN_ENV_FLOOR = [
+  "SystemRoot",
+  "SystemDrive",
+  "WINDIR",
+  "COMSPEC",
+  "PATHEXT",
+  "USERPROFILE",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "TEMP",
+  "TMP",
+] as const;
+
+/**
+ * The effective allowlist for `platform`: the caller's names, plus any floor
+ * the operating system requires of every child regardless of allowlist.
+ * Exported for tests, which must be able to ask for a platform they are not
+ * running on.
+ */
+export function spawnEnvNamesFor(names: Iterable<string>, platform: string = process.platform): string[] {
+  const effective = [...names];
+  if (platform !== "win32") return effective;
+  // Windows env names are case-insensitive; dedupe that way so a caller
+  // spelling `SYSTEMROOT` does not also receive `SystemRoot`.
+  const present = new Set(effective.map((name) => name.toUpperCase()));
+  for (const name of WIN32_SPAWN_ENV_FLOOR) {
+    if (!present.has(name.toUpperCase())) effective.push(name);
+  }
+  return effective;
+}
+
+/**
  * Build a child environment from an allowlist: start EMPTY and copy through
  * exactly the named variables that exist in `source`. Names absent from the
  * source are simply absent from the child (never an empty string, which many
@@ -56,14 +113,16 @@ export const COMMON_SPAWN_ENV_PASSTHROUGH = [
  * `PATH`, when it comes through, is supplemented for scheduler contexts — see
  * {@link supplementPathForSchedulerContext}. That happens here rather than in
  * each caller so a child spawned from cron/launchd/Task Scheduler can find the
- * user's toolchain no matter which spawn path reached it.
+ * user's toolchain no matter which spawn path reached it. On win32 the names
+ * in {@link WIN32_SPAWN_ENV_FLOOR} come through too, for the same reason: the
+ * spawn cannot succeed without them, whichever caller built the list.
  */
 export function collectAllowlistedEnv(
   names: Iterable<string>,
   source: Record<string, string | undefined> = process.env,
 ): Record<string, string> {
   const env: Record<string, string> = {};
-  for (const name of names) {
+  for (const name of spawnEnvNamesFor(names)) {
     const value = source[name];
     if (value !== undefined) env[name] = value;
   }
@@ -87,9 +146,16 @@ export function collectAllowlistedEnv(
  */
 export function supplementPathForSchedulerContext(existingPath: string): string {
   const home = os.homedir();
+  // A home of `/` (system crontab, launchd, service accounts) or of `""`
+  // prefixes EVERY entry, so a prefix test would read the most stripped
+  // environments there are as interactive and skip the repair they exist for.
+  const comparableHome = home === "" || home === path.sep ? undefined : home;
   // If PATH already contains the home directory, we are in an interactive
-  // shell — skip supplementation entirely.
-  if (existingPath.split(path.delimiter).some((d) => d.startsWith(home))) {
+  // shell — skip supplementation entirely. Compared on a path boundary: a
+  // sibling home (`/home/alice` next to `/home/al`) is not this user's.
+  const isUnderHome = (dir: string): boolean =>
+    comparableHome !== undefined && (dir === comparableHome || dir.startsWith(comparableHome + path.sep));
+  if (existingPath.split(path.delimiter).some(isUnderHome)) {
     return existingPath;
   }
   const candidates = pathCandidatesForCurrentPlatform(home);

--- a/src/core/subprocess.ts
+++ b/src/core/subprocess.ts
@@ -203,6 +203,17 @@ export async function readStream(
      * matters.)
      */
     maxBytes?: number;
+    /**
+     * Keep `timeoutMs` UNARMED until this settles (either way). Omitted, the
+     * deadline starts with the drain.
+     *
+     * For a caller whose child has no wall budget of its own, arming at the
+     * drain's start would cap the RUN: a healthy process still writing when the
+     * deadline expires loses its reader mid-stream. Passing the child's exit
+     * here bounds only what a pipe does AFTER the process that owned it is
+     * gone, which is the leak this timeout exists for.
+     */
+    armTimeoutAfter?: Promise<unknown>;
   },
 ): Promise<StreamReadResult> {
   if (!stream) return { text: "", timedOut: false, overflowed: false, bytesRead: 0, retainedBytes: 0 };
@@ -261,13 +272,22 @@ export async function readStream(
   }
   const setTimeoutImpl = opts.setTimeoutFn ?? setTimeout;
   const clearTimeoutImpl = opts.clearTimeoutFn ?? clearTimeout;
+  const timeoutMs = opts.timeoutMs;
   let timer: ReturnType<typeof setTimeoutImpl> | undefined;
+  let drained = false;
   const timeoutPromise = new Promise<typeof STREAM_READ_TIMEOUT>((resolve) => {
-    timer = setTimeoutImpl(() => {
-      timer = undefined;
-      resolve(STREAM_READ_TIMEOUT);
-    }, opts.timeoutMs);
-    if (typeof timer !== "number") timer.unref?.();
+    const arm = () => {
+      // The drain already finished while the deadline was still waiting to be
+      // armed; a timer started now would belong to nobody.
+      if (drained) return;
+      timer = setTimeoutImpl(() => {
+        timer = undefined;
+        resolve(STREAM_READ_TIMEOUT);
+      }, timeoutMs);
+      if (typeof timer !== "number") timer.unref?.();
+    };
+    if (opts.armTimeoutAfter) void opts.armTimeoutAfter.then(arm, arm);
+    else arm();
   });
   try {
     while (true) {
@@ -284,6 +304,7 @@ export async function readStream(
   } catch (error) {
     return { text, timedOut: false, error, overflowed, bytesRead, retainedBytes };
   } finally {
+    drained = true;
     if (timer !== undefined) {
       clearTimeoutImpl(timer);
     }
@@ -355,6 +376,12 @@ const EMPTY_READ: StreamReadResult = {
   bytesRead: 0,
   retainedBytes: 0,
 };
+/**
+ * Drain deadline for a run with no wall budget, counted from the child's EXIT
+ * (never from capture — see {@link runManagedSubprocess}). It bounds only the
+ * window in which a descendant can keep an inherited pipe open after the leader
+ * is gone, so it can be generous without ever capping the run itself.
+ */
 const UNBOUNDED_STREAM_READ_SAFETY_MS = 60 * 60 * 1000;
 
 function toError(err: unknown): Error {
@@ -454,14 +481,24 @@ export async function runManagedSubprocess(
   }
 
   // Stream-drain timeout: the wall budget plus a 2 s grace, or a one-hour
-  // safety bound when execution itself is unbounded. This timer starts with
-  // capture, so the null-timeout path must not impose a short hidden deadline
-  // on an otherwise healthy long-running process.
+  // safety bound when execution itself is unbounded.
+  //
+  // WHEN it starts differs, and that difference is the whole contract of a null
+  // timeout. Bounded, the deadline runs from capture: the child is killed at
+  // its budget anyway, so a drain outliving budget + 2 s is a pipe nobody owns.
+  // Unbounded, the caller asked for NO cap on the run, so the same net is armed
+  // only once the child has exited — up to then every byte is a live process's,
+  // and cancelling the reader would discard the output of work that is still
+  // going. After the exit it is a background descendant holding the fd, which
+  // is exactly what the safety bound is for.
   const streamDrainTimeoutMs = timeoutMs !== null ? timeoutMs + 2_000 : UNBOUNDED_STREAM_READ_SAFETY_MS;
+  // Settles on a rejected `proc.exited` too: either way the child is gone.
+  const childSettled = capture && timeoutMs === null ? proc.exited.catch(() => undefined) : undefined;
   const readOpts = {
     timeoutMs: streamDrainTimeoutMs,
     setTimeoutFn: setTimeoutImpl,
     clearTimeoutFn: clearTimeoutImpl,
+    ...(childSettled ? { armTimeoutAfter: childSettled } : {}),
     ...(opts.maxOutputBytes !== undefined ? { maxBytes: opts.maxOutputBytes } : {}),
   };
   const stdoutPromise = capture ? readStream(proc.stdout ?? null, readOpts) : Promise.resolve(EMPTY_READ);

--- a/src/core/subprocess.ts
+++ b/src/core/subprocess.ts
@@ -207,11 +207,12 @@ export async function readStream(
      * Keep `timeoutMs` UNARMED until this settles (either way). Omitted, the
      * deadline starts with the drain.
      *
-     * For a caller whose child has no wall budget of its own, arming at the
-     * drain's start would cap the RUN: a healthy process still writing when the
-     * deadline expires loses its reader mid-stream. Passing the child's exit
-     * here bounds only what a pipe does AFTER the process that owned it is
-     * gone, which is the leak this timeout exists for.
+     * Arming at the drain's start would cap the RUN: a healthy process still
+     * writing when the deadline expires loses its reader mid-stream. Passing
+     * the moment the pipe stops belonging to a live process — the child's exit,
+     * or for a bounded run the earlier of that and the wall budget — bounds only
+     * what a pipe does AFTER the process that owned it is gone, which is the
+     * leak this timeout exists for.
      */
     armTimeoutAfter?: Promise<unknown>;
   },
@@ -383,6 +384,15 @@ const EMPTY_READ: StreamReadResult = {
  * is gone, so it can be generous without ever capping the run itself.
  */
 const UNBOUNDED_STREAM_READ_SAFETY_MS = 60 * 60 * 1000;
+/**
+ * Drain deadline for a run WITH a wall budget, counted from the moment the
+ * pipe's owner left — the child exited, or (a child that survived its own kill
+ * ladder) the budget expired. Anything still holding the fd open then is a
+ * background descendant, not the command, so this is the same 2 s the old
+ * capture-anchored deadline allowed past the budget; only its starting point
+ * moved earlier.
+ */
+const POST_EXIT_STREAM_DRAIN_GRACE_MS = 2_000;
 
 function toError(err: unknown): Error {
   return err instanceof Error ? err : new Error(String(err));
@@ -448,8 +458,19 @@ export async function runManagedSubprocess(
   // Skipped entirely when timeoutMs is null.
   let timedOut = false;
   let timer: ReturnType<typeof setTimeoutImpl> | undefined;
+  // Settles when a bounded run's wall budget expires — the second way (after
+  // the child's own exit) a captured pipe can stop belonging to a live command.
+  // See the drain-deadline note below.
+  let onBudgetExpiry: (() => void) | undefined;
+  const budgetExpired =
+    capture && timeoutMs !== null
+      ? new Promise<void>((resolve) => {
+          onBudgetExpiry = resolve;
+        })
+      : undefined;
   if (timeoutMs !== null) {
     timer = setTimeoutImpl(() => {
+      onBudgetExpiry?.();
       scheduleKillLadder(proc, {
         onKill: () => {
           timedOut = true;
@@ -480,25 +501,29 @@ export async function runManagedSubprocess(
     else abortSignal.addEventListener("abort", onAbort, { once: true });
   }
 
-  // Stream-drain timeout: the wall budget plus a 2 s grace, or a one-hour
-  // safety bound when execution itself is unbounded.
+  // Stream-drain timeout: a short grace once nothing living owns the pipe any
+  // more, or a one-hour safety bound when execution itself is unbounded.
   //
-  // WHEN it starts differs, and that difference is the whole contract of a null
-  // timeout. Bounded, the deadline runs from capture: the child is killed at
-  // its budget anyway, so a drain outliving budget + 2 s is a pipe nobody owns.
-  // Unbounded, the caller asked for NO cap on the run, so the same net is armed
-  // only once the child has exited — up to then every byte is a live process's,
-  // and cancelling the reader would discard the output of work that is still
-  // going. After the exit it is a background descendant holding the fd, which
-  // is exactly what the safety bound is for.
-  const streamDrainTimeoutMs = timeoutMs !== null ? timeoutMs + 2_000 : UNBOUNDED_STREAM_READ_SAFETY_MS;
+  // Neither is armed while the command is still running: every byte up to then
+  // is a live process's, and cancelling the reader would discard the output of
+  // work that is still going. What ends that ownership is where the two cases
+  // differ. Unbounded, the caller asked for NO cap on the run, so only the
+  // child's own exit can end it. Bounded, the wall budget ends it too — a child
+  // that outlived its own kill ladder is not something akm can keep waiting on
+  // — which leaves the SAME budget + grace ceiling as before for a command that
+  // really did spend its whole budget, and cuts the common case that used to
+  // stall: a leader exiting in milliseconds no longer holds the drain (and with
+  // it the unit, and with it a fan-out slot) open for a budget it never came
+  // close to spending.
+  const streamDrainTimeoutMs = timeoutMs !== null ? POST_EXIT_STREAM_DRAIN_GRACE_MS : UNBOUNDED_STREAM_READ_SAFETY_MS;
   // Settles on a rejected `proc.exited` too: either way the child is gone.
-  const childSettled = capture && timeoutMs === null ? proc.exited.catch(() => undefined) : undefined;
+  const childSettled = capture ? proc.exited.catch(() => undefined) : undefined;
+  const pipeOwnerGone = childSettled && budgetExpired ? Promise.race([childSettled, budgetExpired]) : childSettled;
   const readOpts = {
     timeoutMs: streamDrainTimeoutMs,
     setTimeoutFn: setTimeoutImpl,
     clearTimeoutFn: clearTimeoutImpl,
-    ...(childSettled ? { armTimeoutAfter: childSettled } : {}),
+    ...(pipeOwnerGone ? { armTimeoutAfter: pipeOwnerGone } : {}),
     ...(opts.maxOutputBytes !== undefined ? { maxBytes: opts.maxOutputBytes } : {}),
   };
   const stdoutPromise = capture ? readStream(proc.stdout ?? null, readOpts) : Promise.resolve(EMPTY_READ);

--- a/src/integrations/agent/engine-resolution.ts
+++ b/src/integrations/agent/engine-resolution.ts
@@ -140,6 +140,29 @@ function resolveCredential(
     : { names: [specific], required: false };
 }
 
+/**
+ * Read a credential descriptor's value out of `process.env`: the FIRST
+ * non-empty trimmed value across `names`, in declared order. A `required`
+ * descriptor that resolves to nothing is a config error naming its PRIMARY
+ * variable — the one an operator is told to set.
+ *
+ * The ONE env-credential seam. The live-config dispatch boundary
+ * ({@link materializeLlmConnection}) and the FROZEN workflow dispatch boundary
+ * (`materializeFrozenLlm` in `workflows/exec/unit-dispatch.ts`, whose frozen
+ * snapshots carry a structurally identical descriptor) both read through it, so
+ * lookup order and the failure message cannot drift between them.
+ */
+export function resolveCredentialFromEnv(credential: CredentialDescriptor | undefined): string | undefined {
+  for (const name of credential?.names ?? []) {
+    const candidate = process.env[name]?.trim();
+    if (candidate) return candidate;
+  }
+  if (credential?.required) {
+    throw new ConfigError(`Required engine credential ${credential.names[0]} is not set.`, "INVALID_CONFIG_FILE");
+  }
+  return undefined;
+}
+
 /** Collect materialized engine credentials for output and persistence redaction. */
 export function collectEngineCredentialValues(
   config: EngineResolutionConfig,
@@ -231,20 +254,7 @@ export function materializeLlmConnection(resolved: ResolvedLlmUse): LlmConnectio
       );
     }
   }
-  let apiKey: string | undefined;
-  for (const name of resolved.credential?.names ?? []) {
-    const candidate = process.env[name]?.trim();
-    if (candidate) {
-      apiKey = candidate;
-      break;
-    }
-  }
-  if (resolved.credential?.required && !apiKey) {
-    throw new ConfigError(
-      `Required engine credential ${resolved.credential.names[0]} is not set.`,
-      "INVALID_CONFIG_FILE",
-    );
-  }
+  const apiKey = resolveCredentialFromEnv(resolved.credential);
   return {
     ...resolved.connection,
     ...(apiKey ? { apiKey } : {}),

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import type { InstalledBundle, InstallKind } from "../registry/types";
+import type { ProgramExecCore } from "../workflows/program/schema";
 
 export type AkmSearchType = string;
 export type SearchSource = "local" | "registry" | "all";
@@ -124,8 +125,12 @@ export interface WorkflowStepOrchestrationSummary {
    * words that will actually be spawned, never shell-parsed and never clipped,
    * so what `show` prints is what runs. `passEnv`/`inheritEnv` describe the
    * child's environment SCOPE by variable name; no value is ever projected.
+   *
+   * The SHARED projection shape (`workflows/program/schema.ts`), not a mirror
+   * of it: a field added there must not be able to reach the frozen plan while
+   * silently missing from what `show` describes.
    */
-  exec?: { command: string[]; cwd?: string; passEnv?: string[]; inheritEnv?: true };
+  exec?: ProgramExecCore;
   fanOut?: { over: string; concurrency?: number; reducer?: string };
   hasSchema?: boolean;
   env?: string[];

--- a/src/tasks/runner.ts
+++ b/src/tasks/runner.ts
@@ -471,12 +471,18 @@ async function runWorkflowTask(input: {
             (detail?.id ? ` — resume it with \`akm workflow resume ${detail.id}\`.` : "."),
         );
 
+  // One failure value for the three sinks below (status, log line, history
+  // detail): a thrown error outranks a gate rejection, which outranks the
+  // deadline. Re-laddering per sink is how a log line ends up naming a
+  // different cause than the history row it was written beside.
+  const failure = error ?? (gateError ? new Error(gateError) : timeoutError);
+
   const finishedAt = finishAttempt(startedAt, now());
-  const status: TaskRunStatus = error || gateError || timeoutError ? "failed" : mapWorkflowStatus(detail?.status);
+  const status: TaskRunStatus = failure ? "failed" : mapWorkflowStatus(detail?.status);
   const log = renderWorkflowLog({
     task,
     detail,
-    error: error ?? (gateError ? new Error(gateError) : timeoutError),
+    error: failure,
     warnings: runWarnings,
     ...(timedOutAfterMs !== undefined ? { timedOutAfterMs } : {}),
   });
@@ -499,13 +505,7 @@ async function runWorkflowTask(input: {
     target: { kind: "workflow", ref: task.target.ref },
     detail: {
       runId: detail?.id,
-      ...(error
-        ? { error: error.message }
-        : gateError
-          ? { error: gateError }
-          : timeoutError
-            ? { error: timeoutError.message }
-            : {}),
+      ...(failure ? { error: failure.message } : {}),
     },
   };
   appendHistory(result, historyReserved);

--- a/src/tasks/runner.ts
+++ b/src/tasks/runner.ts
@@ -33,6 +33,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { armAbortDeadline } from "../core/abort-deadline";
 import { shouldSkipUnactivatedTask } from "../core/activation-policy";
 import { assertNever } from "../core/assert";
 import { placementSpecFor } from "../core/asset/asset-placement";
@@ -411,23 +412,19 @@ async function runWorkflowTask(input: {
   // Unset → the unattended default; `null` → the explicit no-timeout opt-out.
   const timeoutMs =
     workflowTarget.timeoutMs === undefined ? DEFAULT_WORKFLOW_TASK_TIMEOUT_MS : workflowTarget.timeoutMs;
-  const setTimeoutImpl = input.setTimeoutFn ?? setTimeout;
-  const clearTimeoutImpl = input.clearTimeoutFn ?? clearTimeout;
-  // Same wiring `akm workflow run --timeout` uses (commands/workflow-cli.ts):
-  // one AbortController for the run's lifetime, aborted by a timer. The engine
-  // reads `options.signal` at every step boundary and breaks GRACEFULLY —
-  // in-flight units are cancelled, the journal and the run lease are retained,
-  // and the run is left `active`, i.e. resumable with `akm workflow resume`.
+  // The shared deadline `akm workflow run --timeout` also arms
+  // ({@link armAbortDeadline}): one AbortController for the run's lifetime,
+  // aborted by a timer. The engine reads `options.signal` at every step
+  // boundary and breaks GRACEFULLY — in-flight units are cancelled, the journal
+  // and the run lease are retained, and the run is left `active`, i.e.
+  // resumable with `akm workflow resume`.
   const controller = new AbortController();
-  let timedOut = false;
-  const timer =
-    timeoutMs === null
-      ? undefined
-      : setTimeoutImpl(() => {
-          timedOut = true;
-          controller.abort(new Error(`Workflow task "${task.id}" timed out after ${timeoutMs}ms.`));
-        }, timeoutMs);
-  (timer as unknown as { unref?: () => void } | undefined)?.unref?.();
+  const deadline = armAbortDeadline(controller, {
+    timeoutMs,
+    reason: `Workflow task "${task.id}" timed out after ${timeoutMs}ms.`,
+    ...(input.setTimeoutFn ? { setTimeoutFn: input.setTimeoutFn } : {}),
+    ...(input.clearTimeoutFn ? { clearTimeoutFn: input.clearTimeoutFn } : {}),
+  });
 
   let detail: WorkflowRunSummary | undefined;
   let gateError: string | undefined;
@@ -452,14 +449,20 @@ async function runWorkflowTask(input: {
     if (e instanceof AkmError && e.kind === "config") throw e;
     error = e instanceof Error ? e : new Error(String(e));
   } finally {
-    if (timer !== undefined) clearTimeoutImpl(timer);
+    deadline.disarm();
   }
 
   // A timeout is a failed ATTEMPT even though the engine stopped cleanly: the
   // aborted run comes back `active` (resumable), which on its own would map to
   // task status "active" and a 0 exit code, telling the OS scheduler nothing
   // went wrong. Surface it like the command target's `timed_out=true` instead.
-  const timedOutAfterMs = timedOut && timeoutMs !== null ? timeoutMs : undefined;
+  //
+  // Unless the run COMPLETED anyway. The abort is observed between steps, so a
+  // deadline landing in the run's final bookkeeping can set the flag on a run
+  // that then finishes — and reporting that as a failure would tell an operator
+  // to resume a run with nothing left to resume.
+  const ranToCompletion = detail?.status === "completed";
+  const timedOutAfterMs = deadline.timedOut() && timeoutMs !== null && !ranToCompletion ? timeoutMs : undefined;
   const timeoutError =
     timedOutAfterMs === undefined
       ? undefined

--- a/src/workflows/exec/dispatch-redaction.ts
+++ b/src/workflows/exec/dispatch-redaction.ts
@@ -16,7 +16,12 @@
  * @module workflows/exec/dispatch-redaction
  */
 
-import { collectSensitiveValues, isEnvPassthroughValueSafeToExpose, redactSensitiveValue } from "../../core/redaction";
+import {
+  collectSensitiveValues,
+  isEnvPassthroughValueSafeToExpose,
+  redactSensitiveText,
+  redactSensitiveValue,
+} from "../../core/redaction";
 import type { FrozenEngineSnapshot } from "../ir/schema";
 import type { UnitDispatcher } from "./unit-dispatch";
 
@@ -35,6 +40,12 @@ export interface DispatchEngines {
  * Shared by the unit path and the gate-judge path. There is deliberately ONE
  * collector: a second, parallel implementation is exactly how a dispatch path
  * silently loses the scrub.
+ *
+ * The credential values are read from `process.env` AT CALL TIME, so a caller
+ * must collect no earlier than the dispatch whose outcome it scrubs. A snapshot
+ * taken when the dispatch was merely *planned* can predate a credential the
+ * dispatch then resolves live, leaving the exact value it must remove out of
+ * the set.
  */
 export function collectWorkflowDispatchSensitiveValues(
   dispatch: DispatchEngines,
@@ -86,13 +97,37 @@ export function redactUnitOutcome<T extends { failureReason?: string }>(
 }
 
 /**
- * Wrap a dispatcher so every result it returns is scrubbed with the request's
- * own `sensitiveValues` — a caller holding the wrapped dispatcher cannot
- * observe (or journal) an unredacted outcome. Used at seams whose results head
- * STRAIGHT for durable state (the gate judge); the unit path instead scrubs
- * once at its own journal boundary (`dispatchJournaledAttempt`), AFTER the
- * structured-output parse loop has seen the raw text.
+ * Scrub a value THROWN out of a dispatch. A rejection is as durable as a
+ * resolved failure — the message becomes the blocked step's notes — so it goes
+ * through the same value set. Re-wrapped ONLY when redaction actually changed
+ * the message, so an untouched throw keeps its original object (and its type,
+ * which callers branch on) byte-identical.
+ */
+function redactDispatchError(err: unknown, sensitiveValues: readonly string[]): unknown {
+  if (sensitiveValues.length === 0 || !(err instanceof Error)) return err;
+  const redacted = redactSensitiveText(err.message, sensitiveValues);
+  if (redacted === err.message) return err;
+  const replacement = new Error(redacted);
+  replacement.name = err.name;
+  return replacement;
+}
+
+/**
+ * Wrap a dispatcher so BOTH its exits are scrubbed with the request's own
+ * `sensitiveValues` — the outcome it resolves to and the error it throws — so a
+ * caller holding the wrapped dispatcher cannot observe (or journal) either one
+ * unredacted. Used at seams whose results head STRAIGHT for durable state (the
+ * gate judge, on both its agent and its llm branch); the unit path instead
+ * scrubs once at its own journal boundary (`dispatchJournaledAttempt`), AFTER
+ * the structured-output parse loop has seen the raw text.
  */
 export function withDispatchRedaction(inner: UnitDispatcher): UnitDispatcher {
-  return async (request, feedback) => redactUnitOutcome(await inner(request, feedback), request.sensitiveValues ?? []);
+  return async (request, feedback) => {
+    const sensitiveValues = request.sensitiveValues ?? [];
+    try {
+      return redactUnitOutcome(await inner(request, feedback), sensitiveValues);
+    } catch (err) {
+      throw redactDispatchError(err, sensitiveValues);
+    }
+  };
 }

--- a/src/workflows/exec/exec-unit.ts
+++ b/src/workflows/exec/exec-unit.ts
@@ -204,12 +204,12 @@ export interface RunExecUnitInput {
 /**
  * Run one exec unit and map its process outcome onto the dispatch vocabulary:
  * non-zero exit → `non_zero_exit`, wall-clock expiry → `timeout`, cancellation
- * → `aborted`, a child that never started or a capture that never completed →
- * `spawn_failed`. All four are pre-existing `AgentFailureReason` members, so
- * `retry.on` keeps working unchanged. The out-of-taxonomy `exec_cwd_escape`,
- * `exec_output_limit` and `exec_context_too_large` are deliberate: each is
- * tampering, a runaway, or an authoring bug — never a transient — so no
- * `retry.on` value can ever re-dispatch one.
+ * → `aborted`, a child that never started → `spawn_failed`. All four are
+ * pre-existing `AgentFailureReason` members, so `retry.on` keeps working
+ * unchanged. The out-of-taxonomy `exec_cwd_escape`, `exec_output_limit`,
+ * `exec_context_too_large` and `exec_capture_incomplete` are deliberate: each is
+ * tampering, a runaway, an authoring bug, or work that ALREADY RAN — never a
+ * transient — so no `retry.on` value can ever re-dispatch one.
  *
  * ## An INCOMPLETE capture is a failure, never a partial artifact
  *
@@ -220,6 +220,13 @@ export interface RunExecUnitInput {
  * judge and `steps.<id>.output` a silently truncated artifact. So the unit fails
  * instead, through the same shared classifier (`streamCaptureFailure`) the agent
  * spawn path uses.
+ *
+ * Its reason is `exec_capture_incomplete`, deliberately OUTSIDE the `retry.on`
+ * taxonomy, for the same reason `journal_write_failed` is: the command RAN TO
+ * COMPLETION and exited 0 — what failed is akm's record of it. A retryable
+ * reason here would let `retry.on: [spawn_failed]` re-dispatch byte-identical
+ * argv for a command that already deployed, already published, already migrated.
+ * `spawn_failed` keeps its documented meaning — the child never started.
  *
  * ## Output OVERFLOW does not fail a command that passed
  *
@@ -312,12 +319,13 @@ export async function runExecUnit(input: RunExecUnitInput): Promise<UnitDispatch
     return {
       ok: false,
       text: "",
-      failureReason: "spawn_failed",
+      failureReason: "exec_capture_incomplete",
       error:
-        `exec unit "${input.unitId}" ran ${display} and it exited 0, but its output capture did not complete ` +
-        `(${captureFailure}), so the stdout artifact would be incomplete. A background descendant still holding ` +
-        `stdout open is the usual cause — have the command wait for its children, or redirect their output` +
-        `${stderrTail(result.stderr)}`,
+        `exec unit "${input.unitId}" ran ${display} and the command COMPLETED (it exited 0), but its output could ` +
+        `not be fully captured (${captureFailure}), so the stdout artifact would be incomplete. The unit is NOT ` +
+        `retried: the command already ran, and re-dispatching identical argv to fix a capture problem would run its ` +
+        `side effects a second time. A background descendant still holding stdout open is the usual cause — have ` +
+        `the command wait for its children, or redirect their output${stderrTail(result.stderr)}`,
     };
   }
   // The command exited 0 and the pipes drained to their end. The ONE thing an
@@ -421,34 +429,12 @@ function outputLimitFailure(
  * authored values a human wrote and sized; this is the surface where the SIZE
  * is data-dependent and therefore surprising.
  */
-/**
- * Byte sizes of large context payloads, keyed by the payload string itself.
- * `AKM_PARAMS` / `AKM_INPUTS` are serialized ONCE per step
- * (`computeStepWorkList`) and every fan-out unit shares the same string, so a
- * 10 000-unit map step measures each payload once here instead of re-scanning
- * up to ~96 KiB per unit. Small values skip the cache (measuring is cheaper
- * than caching), and the map is cleared before it can outgrow a handful of
- * steps' worth of distinct payloads.
- */
-const largeContextSizeCache = new Map<string, number>();
-
-function cachedUtf8Bytes(value: string): number {
-  if (value.length < 1024) return utf8Bytes(value);
-  let bytes = largeContextSizeCache.get(value);
-  if (bytes === undefined) {
-    bytes = utf8Bytes(value);
-    if (largeContextSizeCache.size >= 64) largeContextSizeCache.clear();
-    largeContextSizeCache.set(value, bytes);
-  }
-  return bytes;
-}
-
 function checkExecContextSize(input: RunExecUnitInput): UnitDispatchResult | undefined {
   const limits = execContextLimits(input.platform ?? process.platform);
   const entries = Object.entries(input.context ?? {});
   let total = 0;
   for (const [name, value] of entries) {
-    const bytes = cachedUtf8Bytes(value);
+    const bytes = utf8Bytes(value);
     total += bytes + utf8Bytes(name) + 1;
     if (bytes > limits.perVarBytes) {
       return contextTooLarge(

--- a/src/workflows/exec/exec-unit.ts
+++ b/src/workflows/exec/exec-unit.ts
@@ -40,9 +40,9 @@
  * `redactUnitOutcome` BEFORE anything is journaled, which is why this module may
  * return raw stdout/stderr diagnostics without knowing anything about redaction.
  *
- * Layering: a LEAF. Node built-ins, `core/spawn-env`, `core/subprocess` and the
- * import-free `workflows/resource-limits` (plus erased types) only, so the
- * executor can consume it without opening an import cycle.
+ * Layering: a LEAF. Node built-ins, `core/spawn-env`, `core/subprocess`,
+ * `core/warn` and the import-free `workflows/resource-limits` (plus erased
+ * types) only, so the executor can consume it without opening an import cycle.
  *
  * @module workflows/exec/exec-unit
  */
@@ -54,6 +54,7 @@ import {
   COMMON_SPAWN_ENV_PASSTHROUGH,
   collectAllowlistedEnv,
   supplementPathForSchedulerContext,
+  WIN32_SPAWN_ENV_FLOOR,
 } from "../../core/spawn-env";
 import {
   type ManagedSubprocessResult,
@@ -62,6 +63,7 @@ import {
   type StreamReadResult,
   streamCaptureFailure,
 } from "../../core/subprocess";
+import { warn } from "../../core/warn";
 import type { IrExecSpec } from "../ir/schema";
 import {
   type ExecContextLimits,
@@ -88,8 +90,10 @@ const EXEC_STDERR_DIAGNOSTIC_CLIP = WORKFLOW_UNIT_DIAGNOSTIC_CLIP - 500;
 
 /**
  * The DEFAULT environment allowlist for an exec unit's child — the single
- * definition, mirrored nowhere else (the docs describe it, the tests assert
- * against it, and `exec.passEnv` extends it per unit).
+ * definition of the EXEC list (the docs describe it, the tests assert against
+ * it, and `exec.passEnv` extends it per unit). The win32 process-creation
+ * names are not re-spelled here: they are spread from
+ * {@link WIN32_SPAWN_ENV_FLOOR}, which owns them.
  *
  * The child starts from an EMPTY environment and receives only these names,
  * matching how an agent harness child is already built
@@ -117,19 +121,17 @@ const EXEC_STDERR_DIAGNOSTIC_CLIP = WORKFLOW_UNIT_DIAGNOSTIC_CLIP - 500;
  *                     switch to the host default.
  *   - `TMPDIR`      — POSIX scratch space; absent, tools write to `/tmp` or
  *                     fail on read-only hosts.
- *   - `SystemRoot`, `SystemDrive`, `WINDIR` — Windows PROCESS CREATION itself
- *                     needs these: with an empty environment the loader cannot
- *                     find system DLLs and the spawn fails before the command
- *                     runs. Not optional on win32.
- *   - `COMSPEC`     — Windows resolves `.bat`/`.cmd` targets through cmd.exe.
- *   - `PATHEXT`     — Windows only treats these extensions as executable; an
- *                     absent PATHEXT makes `command: ["bun", …]` unresolvable
- *                     because `bun.exe`/`bun.cmd` are never tried.
- *   - `USERPROFILE`, `HOMEDRIVE`, `HOMEPATH` — the Windows `HOME` analogues.
+ *   - {@link WIN32_SPAWN_ENV_FLOOR} — what Windows itself requires of any
+ *                     child (process creation, command resolution, and the
+ *                     win32 analogues of `HOME`/`TMPDIR`). Spread in rather
+ *                     than re-spelled: `spawnEnvNamesFor` appends the same
+ *                     names on win32, and two hand-written copies of one OS
+ *                     requirement is exactly how a floor drifts.
  *   - `APPDATA`, `LOCALAPPDATA` — Windows config/cache roots (npm, bun, git).
- *   - `TEMP`, `TMP` — the Windows `TMPDIR` analogues.
  *   - `ProgramData`, `ProgramFiles` — machine-wide install roots that Windows
- *                     toolchain shims resolve against.
+ *                     toolchain shims resolve against. These four are NOT on
+ *                     the floor (a child is creatable without them), so an
+ *                     arbitrary shell command asks for them here.
  *   - `AKM_EVENT_SOURCE` — provenance, never a secret: an exec unit that calls
  *                     `akm` must record machine traffic rather than user
  *                     demand, exactly as the agent passthrough list does
@@ -149,19 +151,13 @@ export const EXEC_DEFAULT_ENV_PASSTHROUGH: readonly string[] = [
   "SHELL",
   "LC_CTYPE",
   "TZ",
-  // Windows process creation, command resolution, and toolchain roots
-  "SystemRoot",
-  "SystemDrive",
-  "WINDIR",
-  "COMSPEC",
-  "PATHEXT",
-  "USERPROFILE",
-  "HOMEDRIVE",
-  "HOMEPATH",
+  // SystemRoot, SystemDrive, WINDIR, COMSPEC, PATHEXT, USERPROFILE, HOMEDRIVE,
+  // HOMEPATH, TEMP, TMP. Named here as well as appended by `spawnEnvNamesFor`
+  // because this list is consumed on POSIX too, where nothing is appended.
+  ...WIN32_SPAWN_ENV_FLOOR,
+  // Windows toolchain roots, deliberately not part of the floor
   "APPDATA",
   "LOCALAPPDATA",
-  "TEMP",
-  "TMP",
   "ProgramData",
   "ProgramFiles",
 ];
@@ -211,7 +207,7 @@ export interface RunExecUnitInput {
  * tampering, a runaway, an authoring bug, or work that ALREADY RAN — never a
  * transient — so no `retry.on` value can ever re-dispatch one.
  *
- * ## An INCOMPLETE capture is a failure, never a partial artifact
+ * ## An INCOMPLETE STDOUT capture is a failure, never a partial artifact
  *
  * `exitCode === 0` is not on its own proof that stdout was fully read: a pipe
  * can error, and the stream-drain timeout can fire while the command LEADER has
@@ -221,12 +217,21 @@ export interface RunExecUnitInput {
  * instead, through the same shared classifier (`streamCaptureFailure`) the agent
  * spawn path uses.
  *
- * Its reason is `exec_capture_incomplete`, deliberately OUTSIDE the `retry.on`
- * taxonomy, for the same reason `journal_write_failed` is: the command RAN TO
- * COMPLETION and exited 0 — what failed is akm's record of it. A retryable
- * reason here would let `retry.on: [spawn_failed]` re-dispatch byte-identical
- * argv for a command that already deployed, already published, already migrated.
- * `spawn_failed` keeps its documented meaning — the child never started.
+ * Only STDOUT is fatal here. stderr is a diagnostic channel that never
+ * contributes to the artifact, so a stderr drain that did not finish leaves the
+ * unit's actual result — a completed command, a fully captured stdout — intact;
+ * failing it would throw away a valid artifact over a lost log tail. The agent
+ * path classifies both pipes because there stderr genuinely feeds its
+ * diagnostics; the difference lives in the CALLERS, not in the shared
+ * classifier.
+ *
+ * The stdout reason is `exec_capture_incomplete`, deliberately OUTSIDE the
+ * `retry.on` taxonomy, for the same reason `journal_write_failed` is: the
+ * command RAN TO COMPLETION and exited 0 — what failed is akm's record of it. A
+ * retryable reason here would let `retry.on: [spawn_failed]` re-dispatch
+ * byte-identical argv for a command that already deployed, already published,
+ * already migrated. `spawn_failed` keeps its documented meaning — the child
+ * never started.
  *
  * ## Output OVERFLOW does not fail a command that passed
  *
@@ -314,20 +319,21 @@ export async function runExecUnit(input: RunExecUnitInput): Promise<UnitDispatch
   // An exit code of 0 does NOT prove the output was fully captured — see the
   // module note above. Checked before the artifact is promoted, so a partial
   // stdout can never become `steps.<id>.output`.
-  const captureFailure = streamCaptureFailure(result.stdoutRead, result.stderrRead);
+  const captureFailure = streamCaptureFailure(result.stdoutRead, DRAINED_CLEAN);
   if (captureFailure) {
     return {
       ok: false,
       text: "",
       failureReason: "exec_capture_incomplete",
       error:
-        `exec unit "${input.unitId}" ran ${display} and the command COMPLETED (it exited 0), but its output could ` +
+        `exec unit "${input.unitId}" ran ${display} and the command COMPLETED (it exited 0), but its stdout could ` +
         `not be fully captured (${captureFailure}), so the stdout artifact would be incomplete. The unit is NOT ` +
         `retried: the command already ran, and re-dispatching identical argv to fix a capture problem would run its ` +
         `side effects a second time. A background descendant still holding stdout open is the usual cause — have ` +
         `the command wait for its children, or redirect their output${stderrTail(result.stderr)}`,
     };
   }
+  reportStderrCaptureFailure(input, display, result);
   // The command exited 0 and the pipes drained to their end. The ONE thing an
   // overflow can still ruin is a TYPED artifact: a truncated prefix is not one
   // JSON value, so there is nothing to validate and nothing safe to promote.
@@ -341,6 +347,40 @@ export async function runExecUnit(input: RunExecUnitInput): Promise<UnitDispatch
   // overflowed, `stdout` already carries the truncation marker (which is
   // deliberately the LAST thing in the artifact, so it survives the strip).
   return { ok: true, text: stripTrailingNewlines(stdout) };
+}
+
+/**
+ * A drain report with nothing wrong in it, passed as the OTHER pipe so
+ * {@link streamCaptureFailure} classifies exactly one of them.
+ *
+ * The classifier stays shared with the agent path — what a failed drain means
+ * must not drift — while each caller decides which pipes are fatal for IT.
+ */
+const DRAINED_CLEAN: StreamReadResult = {
+  text: "",
+  timedOut: false,
+  overflowed: false,
+  bytesRead: 0,
+  retainedBytes: 0,
+};
+
+/**
+ * Report a stderr drain that did not finish on an otherwise successful unit.
+ *
+ * Warn-only by construction: the artifact is stdout, which was captured whole,
+ * so there is nothing wrong with the unit's RESULT — only with how much of its
+ * log tail akm holds. A dispatch result has no channel for a non-fatal note, so
+ * the operator surface is the warn stream.
+ */
+function reportStderrCaptureFailure(input: RunExecUnitInput, display: string, result: ManagedSubprocessResult): void {
+  const stderrFailure = streamCaptureFailure(DRAINED_CLEAN, result.stderrRead);
+  if (!stderrFailure) return;
+  warn(
+    `exec unit "${input.unitId}" ran ${display} and it exited 0 with its stdout fully captured, but ` +
+      `${stderrFailure}. stderr is a diagnostic channel and never contributes to the artifact, so the unit stands; ` +
+      `any stderr shown for it may be missing its tail. A background descendant still holding stderr open is the ` +
+      `usual cause.`,
+  );
 }
 
 /** The sentence naming what the retention cap discarded, shared by both reports below. */

--- a/src/workflows/exec/frozen-judge.ts
+++ b/src/workflows/exec/frozen-judge.ts
@@ -14,7 +14,10 @@
  *     notes. So the judge outcome goes through the SAME scrub every unit outcome
  *     goes through: {@link collectWorkflowDispatchSensitiveValues} +
  *     {@link withDispatchRedaction} (exec/dispatch-redaction.ts). Nothing about
- *     a judge call reaches durable state before that scrub.
+ *     a judge call reaches durable state before that scrub. BOTH branches below
+ *     state it that way — the agent branch wrapping the injected dispatcher, the
+ *     llm branch wrapping its own chatCompletion call — so a change to that one
+ *     contract cannot reach only one of the two judge paths.
  *
  *  2. **Identity.** The dispatch request carries the REAL run/step and the gate's
  *     real node/unit ids — the same ids `journalGateEvaluationStart/Finish` write
@@ -33,7 +36,6 @@
  */
 
 import { ConfigError } from "../../core/errors";
-import { redactSensitiveText } from "../../core/redaction";
 import type { IrInvocation, WorkflowPlanGraph } from "../ir/schema";
 import type { JudgeCallIdentity, SummaryJudge } from "../validate-summary";
 import { collectWorkflowDispatchSensitiveValues, withDispatchRedaction } from "./dispatch-redaction";
@@ -87,21 +89,24 @@ export function frozenSummaryJudge(
     }
     const fallbackEngine = engine.fallbackLlmEngine ? plan.execution.engines[engine.fallbackLlmEngine] : undefined;
     const fallback = fallbackEngine?.kind === "llm" ? fallbackEngine : undefined;
-    // The engine pair is fixed when the judge is BUILT, so the sensitive-value
-    // set is too — collected once here, not per gate evaluation. Same collector
-    // the unit path uses; see the module doc on why `env` is absent here but
-    // the credential/passthrough values are still collected.
-    const sensitiveValues = collectWorkflowDispatchSensitiveValues(
-      { engine, ...(fallback ? { fallbackEngine: fallback } : {}) },
-      undefined,
-    );
-    // Scrub at the seam: every outcome this judge's dispatcher returns is
-    // redacted BEFORE the verdict (or the failure message) can reach the gate
-    // row / the blocked step's notes. Identical contract to the unit path,
-    // including the failureReason downgrade when redaction altered it.
+    // Scrub at the seam: every outcome this judge's dispatcher returns — and
+    // every error it throws — is redacted BEFORE the verdict (or the failure
+    // message) can reach the gate row / the blocked step's notes. Identical
+    // contract to the llm branch below and to the unit path, including the
+    // failureReason downgrade when redaction altered it.
     const dispatch = withDispatchRedaction(dispatcher);
     return async ({ system, user }, identity) => {
       const id = dispatchIdentity(owner, identity);
+      // Collected per dispatch, not once per judge: the engine PAIR is fixed at
+      // build time but its secrets are not — they are read from `process.env`,
+      // which the dispatch itself re-reads, so a build-time set would miss a
+      // credential set or rotated between the two reads. Same collector the unit
+      // path uses; see the module doc on why `env` is absent here but the
+      // credential/passthrough values are still collected.
+      const sensitiveValues = collectWorkflowDispatchSensitiveValues(
+        { engine, ...(fallback ? { fallbackEngine: fallback } : {}) },
+        undefined,
+      );
       const outcome = await dispatch({
         runId: id.runId,
         stepId: id.stepId,
@@ -122,45 +127,52 @@ export function frozenSummaryJudge(
       return outcome.text ?? "";
     };
   }
-  // An llm judge's only secret is its own credential (materializeFrozenLlm
-  // reads it out of process.env); collected once at build time through the
-  // SHARED collector so the llm and agent judge paths cannot drift.
-  const sensitiveValues = collectWorkflowDispatchSensitiveValues({ engine }, undefined);
-  return async ({ system, user }) => {
-    // Inline chatCompletion rather than the unit dispatcher ON PURPOSE: the
-    // manual completion path (`runtime/runs.ts`) builds an llm judge with no
-    // dispatcher, and a static runs → native-executor edge would close an
-    // import cycle. The materialization itself is the shared
-    // {@link materializeFrozenLlm}, so the two llm dispatch paths cannot drift.
+  // The llm judge's ONE call, shaped as a {@link UnitDispatcher} so this branch
+  // states its redaction through the SAME {@link withDispatchRedaction} contract
+  // the agent branch above uses — including the throw, which a transport error
+  // takes and which becomes the blocked step's notes (`judgeFailure` in
+  // step-work.ts).
+  //
+  // Inline chatCompletion rather than the injected unit dispatcher ON PURPOSE:
+  // the manual completion path (`runtime/runs.ts`) builds an llm judge with no
+  // dispatcher, and a static runs → native-executor edge would close an import
+  // cycle. The materialization itself is the shared {@link materializeFrozenLlm},
+  // so the two llm dispatch paths cannot drift.
+  const dispatch = withDispatchRedaction(async (request) => {
     const { chatCompletion } = await import("../../llm/client");
-    try {
-      const text = await chatCompletion(
-        materializeFrozenLlm(engine, invocation),
-        [
-          { role: "system", content: system },
-          { role: "user", content: user },
-        ],
-        {
-          timeoutMs: invocation.timeoutMs,
-          ...(signal ? { signal } : {}),
-        },
-      );
-      return redactSensitiveText(text, sensitiveValues);
-    } catch (err) {
-      // A transport error's message becomes the blocked step's notes (see
-      // `judgeFailure` in step-work.ts) — a durable surface. Re-wrap ONLY
-      // when redaction actually changed the message, so the untouched path keeps
-      // the original error object (and its type) byte-identical.
-      throw redactJudgeError(err, sensitiveValues);
-    }
+    const text = await chatCompletion(
+      materializeFrozenLlm(engine, invocation),
+      [
+        { role: "system", content: request.systemPrompt ?? "" },
+        { role: "user", content: request.prompt },
+      ],
+      {
+        timeoutMs: request.timeoutMs,
+        ...(signal ? { signal } : {}),
+      },
+    );
+    return { ok: true, text };
+  });
+  return async ({ system, user }, identity) => {
+    const id = dispatchIdentity(owner, identity);
+    // An llm judge's only secret is its own credential, which
+    // `materializeFrozenLlm` resolves out of `process.env` inside the dispatch
+    // below — so the set is collected here, per dispatch, and cannot predate the
+    // value the call actually authenticates with.
+    const sensitiveValues = collectWorkflowDispatchSensitiveValues({ engine }, undefined);
+    const outcome = await dispatch({
+      runId: id.runId,
+      stepId: id.stepId,
+      unitId: id.unitId,
+      nodeId: gateNodeId(id.stepId),
+      prompt: user,
+      systemPrompt: system,
+      engine,
+      invocation,
+      timeoutMs: invocation.timeoutMs,
+      ...(sensitiveValues.length > 0 ? { sensitiveValues } : {}),
+      ...(signal ? { signal } : {}),
+    });
+    return outcome.text;
   };
-}
-
-function redactJudgeError(err: unknown, sensitiveValues: readonly string[]): unknown {
-  if (sensitiveValues.length === 0 || !(err instanceof Error)) return err;
-  const redacted = redactSensitiveText(err.message, sensitiveValues);
-  if (redacted === err.message) return err;
-  const replacement = new Error(redacted);
-  replacement.name = err.name;
-  return replacement;
 }

--- a/src/workflows/exec/native-executor.ts
+++ b/src/workflows/exec/native-executor.ts
@@ -396,11 +396,10 @@ function classifyUnitReuse(
 
 /**
  * The step's COMPLETED journal rows grouped by base journal id (`~r<N>`
- * stripped), built ONCE per step so classifyUnitReuse — which runs per unit,
- * twice (preflight gate + runUnit) — is a map probe over that unit's own
- * attempt rows instead of an O(rows) scan of the whole step journal per call
- * (a 10 000-unit fan-out resume would otherwise re-walk the full journal
- * 20 000 times).
+ * stripped), built ONCE per step so classifyUnitReuse is a map probe over that
+ * unit's own attempt rows instead of an O(rows) scan of the whole step journal
+ * (a 10 000-unit fan-out resume would otherwise re-walk the full journal once
+ * per unit).
  */
 type CompletedRowIndex = Map<string, WorkflowRunUnitRow[]>;
 
@@ -414,16 +413,6 @@ function indexCompletedRows(rows: Iterable<WorkflowRunUnitRow>): CompletedRowInd
     else index.set(base, [row]);
   }
   return index;
-}
-
-/**
- * Does the step have at least one unit that will ACTUALLY dispatch? Env
- * resolution and worktree preflight are dispatch prerequisites, so a step whose
- * units are all reused / diverged must skip them (reviewer finding
- * #2). Mirrors runUnit's reuse decision exactly (shared {@link classifyUnitReuse}).
- */
-function stepWillDispatch(workUnits: StepWorkUnit[], completedRows: CompletedRowIndex, gateLoop: number): boolean {
-  return workUnits.some((u) => classifyUnitReuse(u, completedRows, gateLoop).kind === "dispatch");
 }
 
 /**
@@ -543,7 +532,12 @@ async function executeStepPlanInConnection(plan: IrStepPlan, ctx: StepExecutionC
   // to hand back a cached result. The predicate mirrors runUnit's reuse
   // decision exactly (shared classifyUnitReuse).
   const gateLoop = ctx.gateLoop ?? 1;
-  const willDispatch = stepWillDispatch(workUnits, completedRows, gateLoop);
+  // Classify every unit ONCE. The gate below and each unit's own dispatch then
+  // read the SAME decision rather than recomputing it from inputs that must be
+  // identical — the agreement the gate depends on is structural, not a property
+  // two call sites have to keep re-establishing.
+  const reuseDecisions = workUnits.map((unit) => classifyUnitReuse(unit, completedRows, gateLoop));
+  const willDispatch = reuseDecisions.some((decision) => decision.kind === "dispatch");
 
   // Env bindings resolve once per step, before any dispatch; a binding error
   // fails the whole step cleanly rather than N units racing into it. Skipped
@@ -583,12 +577,25 @@ async function executeStepPlanInConnection(plan: IrStepPlan, ctx: StepExecutionC
     worktreeBase = base;
   }
 
+  // The values that must never survive into the journal. Collected once per
+  // step, not once per unit: the frozen engine and its SDK fallback are
+  // resolved from the step template and handed unchanged to every unit, and
+  // `env` is step-wide, so a fan-out was re-scanning process.env — and
+  // re-inspecting every passthrough value — once per unit, including for units
+  // that go on to reuse a journaled row and dispatch nothing at all.
+  const sensitiveValues = willDispatch && workUnits[0] ? collectWorkflowDispatchSensitiveValues(workUnits[0], env) : [];
+
   // Budget ceilings + lifetime-cap accounting, and the budget-chained abort
   // signal they trip. Extracted verbatim (behavior-identical) — see
   // {@link openDispatchBudget}.
   const { signal, budget, unchainSignal } = openDispatchBudget(ctx, dispatched);
 
   let outcomes: Array<UnitOutcome | undefined>;
+  // Worktree removals started by finished units and awaited below, before this
+  // step reports anything. Cleanup is best-effort, but "the step resolved" must
+  // still mean "its clean worktrees are gone" — only the WAIT moves off the
+  // unit's scheduler slot, not the guarantee.
+  const pendingWorktreeCleanups: Array<Promise<void>> = [];
   const selectedEngine = template.invocation ? ctx.engines?.[template.invocation.engine] : undefined;
   const selectedLlmEngine =
     selectedEngine?.kind === "llm"
@@ -599,7 +606,7 @@ async function executeStepPlanInConnection(plan: IrStepPlan, ctx: StepExecutionC
   try {
     outcomes = await scheduleUnits(
       workUnits,
-      (workUnit) =>
+      (workUnit, index) =>
         runUnit({
           plan,
           workUnit,
@@ -608,7 +615,9 @@ async function executeStepPlanInConnection(plan: IrStepPlan, ctx: StepExecutionC
           ctx,
           signal,
           dispatcher,
-          completedRows,
+          reuse: reuseDecisions[index]!,
+          sensitiveValues,
+          pendingWorktreeCleanups,
           budget,
         }),
       {
@@ -620,6 +629,9 @@ async function executeStepPlanInConnection(plan: IrStepPlan, ctx: StepExecutionC
     );
   } finally {
     unchainSignal?.();
+    // The barrier. `allSettled` because each task already swallowed its own
+    // failure into a warn — nothing here can fail the step.
+    await Promise.allSettled(pendingWorktreeCleanups);
   }
 
   // Declared budget ceilings and the lifetime cap are hard backstops: a step
@@ -706,8 +718,18 @@ interface RunUnitInput {
    */
   signal?: AbortSignal;
   dispatcher: UnitDispatcher;
-  /** The step's completed rows indexed by base id, for durable-row reuse. */
-  completedRows?: CompletedRowIndex;
+  /**
+   * This unit's durable-row decision, classified once per step alongside the
+   * gate that consumes the same array — never re-derived here.
+   */
+  reuse: UnitReuseDecision;
+  /**
+   * The step's sensitive values, collected once (step-constant — see the
+   * collection site in {@link executeStepPlanInConnection}).
+   */
+  sensitiveValues: string[];
+  /** The step's worktree-removal barrier — see {@link JournaledAttemptInput}. */
+  pendingWorktreeCleanups: Array<Promise<void>>;
   /** Shared lifetime-cap budget; consumed once per actual dispatch attempt. */
   budget: DispatchBudget;
 }
@@ -731,7 +753,7 @@ async function runUnit(input: RunUnitInput): Promise<UnitOutcome> {
   // unit id by computeStepWorkList: a retry re-dispatches the SAME input, the
   // `~r<n>` suffix is journal bookkeeping only.
   const { prompt, inputHash } = workUnit.resolved;
-  const sensitiveValues = collectWorkflowDispatchSensitiveValues(workUnit, env);
+  const sensitiveValues = input.sensitiveValues;
 
   const request: UnitDispatchRequest = {
     runId: ctx.runId,
@@ -764,13 +786,12 @@ async function runUnit(input: RunUnitInput): Promise<UnitOutcome> {
   // `retry.on`.
   const retry = workUnit.retry;
   const maxAttempts = 1 + Math.max(0, retry?.max ?? 0);
-  const gateLoop = ctx.gateLoop ?? 1;
   const journalBaseId = workUnit.journalBaseId;
   const attemptIdFor = (attempt: number): string => (attempt === 0 ? journalBaseId : `${journalBaseId}~r${attempt}`);
 
-  // Durable-row reuse (shared classifyUnitReuse — the SAME decision
-  // executeStepPlan's preflight gate uses, so the gate can never disagree with
-  // what happens here). A completed row with the matching input hash IS the
+  // Durable-row reuse — literally the decision executeStepPlan's preflight gate
+  // counted, handed down rather than recomputed, so the gate cannot disagree
+  // with what happens here. A completed row with the matching input hash IS the
   // result: return it without touching rows, dispatching, or re-emitting events
   // (a crash-resume must never double-issue work). A completed loop-1 row with
   // a DIFFERENT hash is replay divergence (under a frozen plan the same
@@ -778,7 +799,7 @@ async function runUnit(input: RunUnitInput): Promise<UnitOutcome> {
   // tampered with; executeStepPlan promotes this to a hard step failure
   // regardless of on_error). Stale gate-loop rows, failed/running/missing rows,
   // and pre-release R1 positional ids all fall through and dispatch live.
-  const reuse = classifyUnitReuse(workUnit, input.completedRows, gateLoop);
+  const reuse = input.reuse;
   if (reuse.kind === "reuse") {
     // Identity in the durable step evidence is the CONTENT-derived base id, not
     // the `~r<n>` attempt row it was reused from — the work list only ever knows
@@ -833,6 +854,7 @@ async function runUnit(input: RunUnitInput): Promise<UnitOutcome> {
       attemptId,
       inputHash,
       ...(input.worktreeBase !== undefined ? { worktreeBase: input.worktreeBase } : {}),
+      pendingWorktreeCleanups: input.pendingWorktreeCleanups,
     });
     // The journal ROW keeps the `~r<n>`/`~l<loop>` attempt id (dispatchJournaledAttempt
     // wrote it), but the returned outcome's identity in the DURABLE step evidence is
@@ -865,6 +887,12 @@ interface JournaledAttemptInput {
   inputHash: string;
   /** Git repo to mint this attempt's isolation worktree from (`isolation: worktree`). */
   worktreeBase?: string;
+  /**
+   * Where this attempt parks its worktree removal for the step to await. See
+   * the barrier in {@link executeStepPlanInConnection} for why it is not
+   * awaited here.
+   */
+  pendingWorktreeCleanups: Array<Promise<void>>;
 }
 
 /**
@@ -1067,19 +1095,32 @@ async function dispatchJournaledAttempt(input: JournaledAttemptInput): Promise<U
     journalError = err;
   }
 
-  // Worktree lifecycle epilogue: a CLEAN worktree (`git status --porcelain`
-  // empty) is removed; a DIRTY one is retained and logged — the unit left
-  // uncollected work, and its journaled worktree_path says where. Cleanup is
-  // best-effort observability, never a unit failure.
+  // Worktree lifecycle epilogue: a CLEAN worktree is removed; a DIRTY one is
+  // retained and logged — the unit left uncollected work, and its journaled
+  // worktree_path says where. Cleanup is best-effort observability, never a
+  // unit failure, so it is STARTED here and awaited at the step barrier: the
+  // removal serializes on the same per-repo chain as every sibling's
+  // `git worktree add`, and awaiting it in this unit's scheduler slot made a
+  // finished unit wait out other units' full checkouts before its worker could
+  // claim the next item.
   if (worktreePath !== undefined && input.worktreeBase !== undefined) {
-    const cleanup = await cleanupUnitWorktree(input.worktreeBase, worktreePath);
-    if (cleanup.dirty) {
-      warn(
-        `Workflow unit ${attemptId} left uncommitted changes in its isolation worktree; retained at ${worktreePath}`,
-      );
-    } else if (!cleanup.removed) {
-      warn(`Workflow unit ${attemptId}: could not clean up isolation worktree ${worktreePath}: ${cleanup.error}`);
-    }
+    const worktreeBase = input.worktreeBase;
+    input.pendingWorktreeCleanups.push(
+      (async () => {
+        try {
+          const cleanup = await cleanupUnitWorktree(worktreeBase, worktreePath);
+          if (cleanup.dirty) {
+            warn(
+              `Workflow unit ${attemptId} left uncommitted changes in its isolation worktree; retained at ${worktreePath}`,
+            );
+          } else if (!cleanup.removed) {
+            warn(`Workflow unit ${attemptId}: could not clean up isolation worktree ${worktreePath}: ${cleanup.error}`);
+          }
+        } catch (err) {
+          warn(`Workflow unit ${attemptId}: could not clean up isolation worktree ${worktreePath}: ${message(err)}`);
+        }
+      })(),
+    );
   }
 
   // A journal-write failure AFTER a successful dispatch is its own loud

--- a/src/workflows/exec/native-executor.ts
+++ b/src/workflows/exec/native-executor.ts
@@ -144,7 +144,8 @@ import {
 import type { FrozenEngineSnapshot, IrBudget, IrInvocation, IrStepPlan } from "../ir/schema";
 import { WORKFLOW_UNIT_DIAGNOSTIC_CLIP } from "../resource-limits";
 // The ONE dispatch redaction contract, shared with the gate-judge path
-// (exec/frozen-judge.ts). Re-exported for existing importers of this module.
+// (exec/frozen-judge.ts). Consumers import the leaf directly — this module is
+// not a second front door onto the seam.
 import { collectWorkflowDispatchSensitiveValues, redactUnitOutcome } from "./dispatch-redaction";
 // The exec (shell) unit runner — a leaf that owns argv spawning, containment,
 // and the process-outcome → failure-reason mapping.
@@ -171,7 +172,6 @@ import {
   type UnitDispatchResult,
 } from "./unit-dispatch";
 
-export { collectWorkflowDispatchSensitiveValues, redactUnitOutcome } from "./dispatch-redaction";
 export type { UnitDispatcher, UnitDispatchRequest, UnitDispatchResult } from "./unit-dispatch";
 
 import { enqueueUnitWrite } from "./unit-writer";
@@ -372,7 +372,7 @@ function classifyUnitReuse(
   completedRows: CompletedRowIndex | undefined,
   gateLoop: number,
 ): UnitReuseDecision {
-  const inputHash = workUnit.resolved.inputHash;
+  const inputHash = workUnit.inputHash;
   // Scan EVERY journaled attempt row of this unit (`<base>` / `<base>~r<N>`
   // for ANY N), not just the attempts the CURRENT retry policy allows:
   // retry/onError are deliberately excluded from the input hash (step-work.ts)
@@ -738,21 +738,18 @@ async function runUnit(input: RunUnitInput): Promise<UnitOutcome> {
   const { plan, workUnit, env, ctx, dispatcher } = input;
   const unitId = workUnit.unitId;
 
-  // An `exec` unit legitimately carries neither — it spawns a child process
-  // instead of calling an engine. Every OTHER kind must have both.
-  if (!workUnit.exec && (!workUnit.engine || !workUnit.invocation)) {
-    return {
-      unitId,
-      ok: false,
-      failureReason: "dispatch_error",
-      error: `unit "${unitId}" has no frozen engine snapshot and cannot be dispatched`,
-    };
-  }
+  // Engine/exec presence is a WHOLE-LIST invariant, never a per-unit condition:
+  // computeStepWorkList fails the entire step before it builds any unit when a
+  // template carries neither an `exec` spec nor an `invocation`, and when an
+  // `invocation` names an engine absent from the frozen catalog — and
+  // executeStepPlanInConnection returns on `!workList.ok` without reaching here.
+  // So every unit below carries either `exec` (a child process, naming no
+  // engine) or `engine` + `invocation`.
 
   // The prompt (and therefore the input hash) was built once with the BASE
   // unit id by computeStepWorkList: a retry re-dispatches the SAME input, the
   // `~r<n>` suffix is journal bookkeeping only.
-  const { prompt, inputHash } = workUnit.resolved;
+  const { prompt, inputHash } = workUnit;
   const sensitiveValues = input.sensitiveValues;
 
   const request: UnitDispatchRequest = {
@@ -951,9 +948,9 @@ async function dispatchJournaledAttempt(input: JournaledAttemptInput): Promise<U
   let worktreePath: string | undefined;
   if (input.worktreeBase !== undefined) {
     const created = await createUnitWorktree(input.worktreeBase, ctx.runId, attemptId);
-    if (!created.ok) {
-      return { unitId: request.unitId, ok: false, failureReason: "worktree_failed", error: created.error };
-    }
+    // Reported BEFORE the failure check: when the worktree could not be minted,
+    // the leftover moved aside is the only copy of the prior attempt's
+    // uncollected work, so that is exactly when its path must not be swallowed.
     if (created.preservedLeftover !== undefined) {
       // Never destroy a dirty (or unverifiable) leftover from a prior
       // invocation of the same attempt — it was moved aside instead.
@@ -961,6 +958,9 @@ async function dispatchJournaledAttempt(input: JournaledAttemptInput): Promise<U
         `Workflow unit ${attemptId}: a previous attempt left uncollected work in its isolation worktree; ` +
           `preserved at ${created.preservedLeftover}`,
       );
+    }
+    if (!created.ok) {
+      return { unitId: request.unitId, ok: false, failureReason: "worktree_failed", error: created.error };
     }
     worktreePath = created.path;
     request = { ...request, cwd: worktreePath };

--- a/src/workflows/exec/run-workflow.ts
+++ b/src/workflows/exec/run-workflow.ts
@@ -32,6 +32,9 @@
  * the one-shot case. A typed-artifact schema mismatch feeds the same loop
  * (the validation errors are the feedback; no judge ran, so no gate unit is
  * journaled for that attempt) — only the FINAL loop's mismatch fails the run.
+ * A step whose subgraph is an `exec` unit is judged but NEVER looped
+ * (`effectiveGateMaxLoops`): its argv cannot read the feedback, so a second
+ * loop would only re-run the identical side effect.
  *
  * Frozen plan (redesign addendum, R1): the plan graph is read from the run
  * row (`plan_json`, persisted by `startWorkflowRun` under migration 006) with
@@ -87,12 +90,14 @@ import {
 // fresh-execution and resume paths cannot drift from each other.
 import {
   activeGateLoop,
+  blockStepForJudgeFailure,
   cascadeSkippedRouter,
+  effectiveGateMaxLoops,
   finalizeExecutedStep,
   type GateFeedback,
-  judgeFailureNotes,
   type RouteSkipInfo,
   recoverGateFeedback,
+  referencedStepIds,
   seedJournaledRouteDecisions,
 } from "./step-work";
 
@@ -660,12 +665,15 @@ interface StepDriveContext {
   /** Every prior step's evidence, keyed by step id (live values preferred over rows). */
   evidence: Record<string, Record<string, unknown> | undefined>;
   /**
-   * The COMPLETE in-memory evidence of every step THIS call completed, keyed by
-   * step id — written here as each step advances and preferred over the re-read
-   * row when {@link driveRun} rebuilds the downstream scope. See `driveRun`'s
-   * parameter docs for why the row alone is not enough.
+   * The COMPLETE in-memory evidence of every step THIS call completed AND some
+   * later step can still read, keyed by step id — written here as each step
+   * advances and preferred over the re-read row when {@link driveRun} rebuilds
+   * the downstream scope. See `driveRun`'s parameter docs for why the row alone
+   * is not enough.
    */
   liveEvidence: Map<string, Record<string, unknown>>;
+  /** Step ids some other step's `inputs[]` / `map.over` / `route.input` names. */
+  liveEvidenceConsumers: ReadonlySet<string>;
   /** The run-wide report list — appended in place, one entry per loop iteration. */
   executed: ExecutedStepReport[];
   routeSelected: Set<string>;
@@ -677,25 +685,30 @@ interface StepDriveContext {
   dispatchSignal: AbortSignal | undefined;
 }
 
-/** Loop-control + accounting outcome of one step's bounded gate loop. */
+/**
+ * Loop-control + accounting outcome of one step's bounded gate loop. `kind` is
+ * the SINGLE discriminator every consumer derives from — whether the engine
+ * keeps walking the spine (only `"advanced"` does) and whether the step consumed
+ * its one `maxSteps` allowance ({@link STEP_FINISHED_KINDS}). A new exit point
+ * must name its kind, so it cannot silently skew the remaining-steps accounting
+ * the way a forgotten boolean could.
+ */
 interface StepGateLoopOutcome {
-  /** The step completed and the spine may move on. */
-  advanced: boolean;
-  /** Failure, judge failure, final rejection, or abort — this invocation is done. */
-  stopEngine: boolean;
-  /**
-   * True once this step finished processing (completed / failed /
-   * gate-exhausted) — the ONE maxSteps consumption for its whole gate loop.
-   * Aborts and judge failures leave the step unfinished and consume nothing.
-   */
-  stepFinished: boolean;
-  aborted: boolean;
+  kind: "advanced" | "failed" | "gate-exhausted" | "judge-failed" | "aborted";
   gateRejection?: RunWorkflowResult["gateRejection"];
   judgeFailure?: RunWorkflowResult["judgeFailure"];
   /** Running per-run dispatch/token totals, threaded back into the engine loop. */
   unitsDispatched: number;
   tokensUsed: number;
 }
+
+/**
+ * The kinds that FINISHED the step (completed / failed / gate-exhausted) — the
+ * ONE `maxSteps` consumption for its whole gate loop. An abort and a judge
+ * outage leave the step unfinished and consume nothing: the next invocation
+ * still owes the work.
+ */
+const STEP_FINISHED_KINDS: ReadonlySet<StepGateLoopOutcome["kind"]> = new Set(["advanced", "failed", "gate-exhausted"]);
 
 /**
  * One attempt at a step's work. Route-only steps (YAML `route:` — no execution
@@ -763,13 +776,14 @@ async function runStepGateLoop(
   const { summaryJudge, leaseHolder, heartbeat } = ctx;
   const { startLoop, maxLoops } = gate;
   let { unitsDispatched, tokensUsed } = totals;
-  let gateRejection: RunWorkflowResult["gateRejection"];
-  let judgeFailure: RunWorkflowResult["judgeFailure"];
-  let aborted = false;
   let gateFeedback: GateFeedback | undefined = gate.seededFeedback;
-  let advanced = false;
-  let stopEngine = false;
-  let stepFinished = false;
+  // Every exit carries the running totals back to the engine loop; naming the
+  // kind is the whole decision an exit point has to make.
+  const outcome = (rest: Omit<StepGateLoopOutcome, "unitsDispatched" | "tokensUsed">): StepGateLoopOutcome => ({
+    ...rest,
+    unitsDispatched,
+    tokensUsed,
+  });
 
   for (let gateLoop = startLoop; gateLoop <= maxLoops; gateLoop++) {
     // A loop re-execution dispatches a fresh round of units — renew the
@@ -783,11 +797,7 @@ async function runStepGateLoop(
     heartbeat?.assertAlive();
     unitsDispatched = result.unitsDispatched;
     if (result.tokensUsed !== undefined) tokensUsed = result.tokensUsed;
-    if (options.signal?.aborted) {
-      aborted = true;
-      stopEngine = true;
-      break;
-    }
+    if (options.signal?.aborted) return outcome({ kind: "aborted" });
 
     executed.push({
       stepId: step.id,
@@ -821,15 +831,15 @@ async function runStepGateLoop(
         summaryJudge,
         ...(ctx.plan.execution ? { engines: ctx.plan.execution.engines } : {}),
         signal: options.signal,
+        // The judge runs under the DISPATCH signal, so the completion path must
+        // see it too: an abort delivered there (a lost lease, a caller Ctrl-C)
+        // is an interruption, not a verifier outage.
+        ...(ctx.dispatchSignal ? { dispatchSignal: ctx.dispatchSignal } : {}),
         leaseHolder,
       });
     } catch (error) {
       heartbeat?.assertAlive();
-      if (options.signal?.aborted) {
-        aborted = true;
-        stopEngine = true;
-        break;
-      }
+      if (options.signal?.aborted) return outcome({ kind: "aborted" });
       throw error;
     }
     heartbeat?.assertAlive();
@@ -842,19 +852,19 @@ async function runStepGateLoop(
       continue;
     }
     if (finalize.kind === "advanced") {
-      // Hand the rest of this invocation the COMPLETE artifact. `finalize` has
-      // already journaled the step (and stamped any route decision onto
-      // `result.evidence`), and the persisted row may carry a truncation
-      // envelope in place of an over-cap value — the row bound must not change
-      // what the very next step reads.
-      ctx.liveEvidence.set(step.id, result.evidence);
+      // Hand the rest of this invocation the COMPLETE artifact — but only when
+      // some LATER step's frozen references can actually read it (set-time
+      // retention, see `referencedStepIds`). `finalize` has already journaled
+      // the step (and stamped any route decision onto `result.evidence`), and
+      // the persisted row may carry a truncation envelope in place of an
+      // over-cap value — the row bound must not change what the very next step
+      // reads.
+      if (ctx.liveEvidenceConsumers.has(step.id)) ctx.liveEvidence.set(step.id, result.evidence);
       // A route-only step's summary IS its decision (finalize surfaces it).
       if (finalize.summaryOverride !== undefined) {
         executed[executed.length - 1] = { ...executed[executed.length - 1]!, summary: finalize.summaryOverride };
       }
-      advanced = true;
-      stepFinished = true;
-      break;
+      return outcome({ kind: "advanced" });
     }
     if (finalize.kind === "judge-failed") {
       // Verifier infrastructure failure (thrown judge / malformed verdict /
@@ -862,9 +872,7 @@ async function runStepGateLoop(
       // consumed, and the step does not count against maxSteps. Surface the
       // resume instruction in the step report so every output mode shows it.
       executed[executed.length - 1] = { ...executed[executed.length - 1]!, summary: finalize.summary };
-      judgeFailure = { stepId: step.id, message: finalize.summary };
-      stopEngine = true;
-      break;
+      return outcome({ kind: "judge-failed", judgeFailure: { stepId: step.id, message: finalize.summary } });
     }
     if (finalize.kind === "failed") {
       // A route-failure was pushed as ok:true (the units succeeded); reflect
@@ -872,26 +880,19 @@ async function runStepGateLoop(
       if (finalize.routeFailure) {
         executed[executed.length - 1] = { ...executed[executed.length - 1]!, ok: false, summary: finalize.summary };
       }
-      stepFinished = true;
-      stopEngine = true;
-      break;
+      return outcome({ kind: "failed" });
     }
     // gate-exhausted: rejected with no loop budget left — stop with feedback.
-    gateRejection = finalize.gateRejection;
-    stepFinished = true;
-    stopEngine = true;
+    return outcome({ kind: "gate-exhausted", gateRejection: finalize.gateRejection });
   }
 
-  return {
-    advanced,
-    stopEngine,
-    stepFinished,
-    aborted,
-    unitsDispatched,
-    tokensUsed,
-    ...(gateRejection ? { gateRejection } : {}),
-    ...(judgeFailure ? { judgeFailure } : {}),
-  };
+  // Unreachable: `retry` is the ONLY path that continues the loop, and
+  // `finalizeExecutedStep` returns it exclusively while `gateLoop < maxLoops`,
+  // so the final iteration always exits through a terminal kind. Falling out
+  // here would mean those two bounds disagree — a bug, not a run outcome.
+  throw new Error(
+    `Workflow run ${next.run.id} step "${step.id}" left its gate loop with no terminal outcome (loop bounds disagree).`,
+  );
 }
 
 /** The engine loop proper — runs under the lease held by `runWorkflowSteps`. */
@@ -911,6 +912,11 @@ async function driveRun(
    * invisible to the run that produced it. A LATER `akm workflow run` starts
    * with an empty map and reads the rows, where a reference into a truncated
    * artifact fails loudly by name (`isTruncatedEvidence`).
+   *
+   * Only steps some OTHER step's references NAME are stored (`referencedStepIds`
+   * — the set-time filter): a step nothing downstream reads has no consumer to
+   * keep it complete for, so retaining it would buy nothing and cost its bytes
+   * for the rest of the invocation.
    */
   liveEvidence: Map<string, Record<string, unknown>>,
 ): Promise<RunWorkflowResult> {
@@ -934,6 +940,13 @@ async function driveRun(
   let { unitsDispatched, tokensUsed } = await seedRunAccountingFromJournal(next.run.id);
 
   const plan = await loadAuthoritativeRunPlan(options, next);
+
+  // Live-evidence retention is decided at SET time, from the frozen plan alone:
+  // a completed step's complete artifact is held only while some other step's
+  // references can still read it. An exec unit's promoted stdout can be 8 MiB,
+  // and holding every step's for the whole invocation is pure ballast when
+  // nothing downstream names it.
+  const liveEvidenceConsumers = referencedStepIds(plan);
 
   // Route bookkeeping: targets a completed router did NOT select are skipped
   // when the spine reaches them; a target ANY router selected is protected
@@ -996,10 +1009,10 @@ async function driveRun(
 
     // Bounded gate loop (addendum R2, `gate.max_loops`): loop 1 is the normal
     // execution; a gate rejection with attempts left re-executes the subgraph
-    // with the judge's feedback threaded into unit prompts. `advanced` = the
-    // step completed and the spine may move on; `stopEngine` = failure or
-    // final rejection — this invocation is done.
-    const maxLoops = Math.max(1, stepPlan.gate.maxLoops ?? 1);
+    // with the judge's feedback threaded into unit prompts. The bound comes
+    // from the shared derivation, which holds an exec step to a single
+    // execution — its argv cannot answer feedback (see effectiveGateMaxLoops).
+    const maxLoops = effectiveGateMaxLoops(stepPlan);
 
     const { startLoop, seededFeedback } = await recoverGateLoopState(next.run.id, stepPlan);
 
@@ -1031,12 +1044,15 @@ async function driveRun(
       });
     } catch (error) {
       const detail = error instanceof Error && error.message ? ` (${error.message})` : "";
-      const notes = judgeFailureNotes(
-        next.run.id,
-        step.id,
-        `the verification judge could not be resolved from the frozen plan${detail}`,
-      );
-      await completeWorkflowStep({ runId: next.run.id, stepId: step.id, status: "blocked", notes, leaseHolder });
+      // Nothing was dispatched, so there is no evidence to preserve — the same
+      // blocked write the post-execution path uses, minus the results it does
+      // not have.
+      const notes = await blockStepForJudgeFailure({
+        runId: next.run.id,
+        stepId: step.id,
+        cause: `the verification judge could not be resolved from the frozen plan${detail}`,
+        leaseHolder,
+      });
       executed.push({ stepId: step.id, ok: false, unitCount: 0, failedUnits: 0, summary: notes });
       judgeFailure = { stepId: step.id, message: notes };
       break;
@@ -1051,6 +1067,7 @@ async function driveRun(
         step,
         evidence,
         liveEvidence,
+        liveEvidenceConsumers,
         executed,
         routeSelected,
         routeUnselected,
@@ -1064,12 +1081,14 @@ async function driveRun(
     );
     unitsDispatched = outcome.unitsDispatched;
     tokensUsed = outcome.tokensUsed;
-    if (outcome.aborted) aborted = true;
+    if (outcome.kind === "aborted") aborted = true;
     if (outcome.gateRejection) gateRejection = outcome.gateRejection;
     if (outcome.judgeFailure) judgeFailure = outcome.judgeFailure;
 
-    if (outcome.stepFinished) stepsProcessed += 1;
-    if (outcome.stopEngine || !outcome.advanced) break;
+    if (STEP_FINISHED_KINDS.has(outcome.kind)) stepsProcessed += 1;
+    // Only an advance leaves the spine walkable; every other kind ends this
+    // invocation (failure, exhausted gate, judge outage, abort).
+    if (outcome.kind !== "advanced") break;
 
     next = await getNextWorkflowStep(next.run.id);
   }

--- a/src/workflows/exec/run-workflow.ts
+++ b/src/workflows/exec/run-workflow.ts
@@ -197,15 +197,23 @@ export async function runWorkflowSteps(options: RunWorkflowOptions): Promise<Run
   let remainingSteps = options.maxSteps;
   const executed: ExecutedStepReport[] = [];
   let stepsProcessed = 0;
+  // Spans the retry loop: a retry re-opens only the ONE failed step, so every
+  // step this call already completed keeps handing its complete artifact
+  // downstream instead of falling back to the (possibly clipped) row. See the
+  // {@link driveRun} declaration.
+  const liveEvidence = new Map<string, Record<string, unknown>>();
 
   for (;;) {
-    const result = await runWorkflowAttempt({
-      ...options,
-      target,
-      ...(params !== undefined ? { params } : { params: undefined }),
-      ...(parameterFlags !== undefined ? { parameterFlags } : { parameterFlags: undefined }),
-      ...(remainingSteps !== undefined ? { maxSteps: remainingSteps } : { maxSteps: undefined }),
-    });
+    const result = await runWorkflowAttempt(
+      {
+        ...options,
+        target,
+        ...(params !== undefined ? { params } : { params: undefined }),
+        ...(parameterFlags !== undefined ? { parameterFlags } : { parameterFlags: undefined }),
+        ...(remainingSteps !== undefined ? { maxSteps: remainingSteps } : { maxSteps: undefined }),
+      },
+      liveEvidence,
+    );
     executed.push(...result.executed);
     stepsProcessed += result.stepsProcessed;
     const aggregate = { ...result, executed, stepsProcessed };
@@ -227,7 +235,10 @@ export async function runWorkflowSteps(options: RunWorkflowOptions): Promise<Run
   }
 }
 
-async function runWorkflowAttempt(options: RunWorkflowOptions): Promise<RunWorkflowResult> {
+async function runWorkflowAttempt(
+  options: RunWorkflowOptions,
+  liveEvidence: Map<string, Record<string, unknown>>,
+): Promise<RunWorkflowResult> {
   const next: WorkflowNextResult = await getNextWorkflowStep(options.target, options.params, {
     parameterFlags: options.parameterFlags,
   });
@@ -289,7 +300,9 @@ async function runWorkflowAttempt(options: RunWorkflowOptions): Promise<RunWorkf
     // handle and does not close it, and this scope's own `finally` closes on
     // every exit path (return, throw, abort), after which escaped async work
     // transparently falls back to opening its own connection.
-    const result = await withWorkflowRunsConnection(() => driveRun(options, next, leaseHolder, heartbeat));
+    const result = await withWorkflowRunsConnection(() =>
+      driveRun(options, next, leaseHolder, heartbeat, liveEvidence),
+    );
     // Creation-time notices reach the caller only here: the run row has no
     // warnings column, and a later invocation of the same run must stay silent
     // about a decision it did not make. `driveRun` never sets `warnings`.
@@ -613,12 +626,26 @@ async function skipUnselectedRouteTarget(input: {
  * replay and making the resumed run diverge from the interrupted one. The rows
  * are re-read per step (NOT the once-at-start budget seed) so a step reached
  * later within THIS same invocation still starts fresh at loop 1.
+ *
+ * Only the STEP's rows are read (index-backed on `(run_id, step_id)`): both
+ * helpers already discard every row carrying a different `step_id`, and gate
+ * rows are journaled under the step's own id, so the narrow query returns a
+ * superset of what they read. Re-reading the whole run journal here would
+ * re-materialize every earlier step's `result_json` — synchronously, blocking
+ * the event loop the lease heartbeat and abort handling share — once per step.
  */
 async function recoverGateLoopState(
   runId: string,
-  stepId: string,
+  stepPlan: IrStepPlan,
 ): Promise<{ startLoop: number; seededFeedback: GateFeedback | undefined }> {
-  const stepJournal = await withWorkflowRunsRepo((repo) => repo.getUnitsForRun(runId));
+  // A step with no effective completion criteria never reaches a judge
+  // (`validateStepSummary` short-circuits before the gate-journaling wrapper),
+  // so it can have no gate rows and needs no query at all.
+  if (!stepPlan.gate.criteria.some((criterion) => criterion.trim().length > 0)) {
+    return { startLoop: 1, seededFeedback: undefined };
+  }
+  const stepId = stepPlan.stepId;
+  const stepJournal = await withWorkflowRunsRepo((repo) => repo.getUnitsForStep(runId, stepId));
   const startLoop = activeGateLoop(stepJournal, stepId);
   return { startLoop, seededFeedback: recoverGateFeedback(stepJournal, stepId, startLoop) };
 }
@@ -630,8 +657,15 @@ interface StepDriveContext {
   plan: WorkflowPlanGraph;
   stepPlan: IrStepPlan;
   step: WorkflowRunStepState;
-  /** Every prior step's journaled evidence, keyed by step id. */
+  /** Every prior step's evidence, keyed by step id (live values preferred over rows). */
   evidence: Record<string, Record<string, unknown> | undefined>;
+  /**
+   * The COMPLETE in-memory evidence of every step THIS call completed, keyed by
+   * step id — written here as each step advances and preferred over the re-read
+   * row when {@link driveRun} rebuilds the downstream scope. See `driveRun`'s
+   * parameter docs for why the row alone is not enough.
+   */
+  liveEvidence: Map<string, Record<string, unknown>>;
   /** The run-wide report list — appended in place, one entry per loop iteration. */
   executed: ExecutedStepReport[];
   routeSelected: Set<string>;
@@ -808,6 +842,12 @@ async function runStepGateLoop(
       continue;
     }
     if (finalize.kind === "advanced") {
+      // Hand the rest of this invocation the COMPLETE artifact. `finalize` has
+      // already journaled the step (and stamped any route decision onto
+      // `result.evidence`), and the persisted row may carry a truncation
+      // envelope in place of an over-cap value — the row bound must not change
+      // what the very next step reads.
+      ctx.liveEvidence.set(step.id, result.evidence);
       // A route-only step's summary IS its decision (finalize surfaces it).
       if (finalize.summaryOverride !== undefined) {
         executed[executed.length - 1] = { ...executed[executed.length - 1]!, summary: finalize.summaryOverride };
@@ -860,6 +900,19 @@ async function driveRun(
   initial: WorkflowNextResult,
   leaseHolder: string,
   heartbeat: LeaseHeartbeat | undefined,
+  /**
+   * The COMPLETE in-memory evidence of every step THIS call has completed,
+   * keyed by step id, preferred over the re-read row when the downstream scope
+   * is rebuilt below. The spine rows are re-read between steps, and
+   * `clipStepEvidenceForPersistence` (runtime/runs.ts) may have replaced an
+   * over-cap artifact with a truncation envelope on the way in — a bound on ONE
+   * SQLite row, not on what a run may promote (the exec per-pipe cap alone
+   * retains 8 MiB). Preferring the live value keeps the persistence bound
+   * invisible to the run that produced it. A LATER `akm workflow run` starts
+   * with an empty map and reads the rows, where a reference into a truncated
+   * artifact fails loudly by name (`isTruncatedEvidence`).
+   */
+  liveEvidence: Map<string, Record<string, unknown>>,
 ): Promise<RunWorkflowResult> {
   let next = initial;
   if (initial.done) return completedRunResult(initial.run.id);
@@ -939,7 +992,7 @@ async function driveRun(
     }
 
     const evidence: Record<string, Record<string, unknown> | undefined> = {};
-    for (const s of next.workflow.steps) evidence[s.id] = s.evidence;
+    for (const s of next.workflow.steps) evidence[s.id] = liveEvidence.get(s.id) ?? s.evidence;
 
     // Bounded gate loop (addendum R2, `gate.max_loops`): loop 1 is the normal
     // execution; a gate rejection with attempts left re-executes the subgraph
@@ -948,7 +1001,7 @@ async function driveRun(
     // final rejection — this invocation is done.
     const maxLoops = Math.max(1, stepPlan.gate.maxLoops ?? 1);
 
-    const { startLoop, seededFeedback } = await recoverGateLoopState(next.run.id, step.id);
+    const { startLoop, seededFeedback } = await recoverGateLoopState(next.run.id, stepPlan);
 
     // Resume AFTER the FINAL rejection (`startLoop` past the loop bound): the
     // gate was already exhausted before the crash, so there is NO fresh loop to
@@ -997,6 +1050,7 @@ async function driveRun(
         stepPlan,
         step,
         evidence,
+        liveEvidence,
         executed,
         routeSelected,
         routeUnselected,

--- a/src/workflows/exec/step-work.ts
+++ b/src/workflows/exec/step-work.ts
@@ -61,6 +61,7 @@ import type {
   IrUnitNode,
   WorkflowPlanGraph,
 } from "../ir/schema";
+import { engineRuntimeKind } from "../ir/schema";
 import {
   type ExpressionScope,
   parseReference,
@@ -372,7 +373,8 @@ export function computeStepWorkList(plan: IrStepPlan, input: WorkListInput): Com
   if (frozenInvocation && !frozenEngine) {
     return { ok: false, error: `Step "${plan.stepId}" references missing frozen engine "${frozenInvocation.engine}".` };
   }
-  const runner: IrRuntimeKind = frozenEngine ? (frozenEngine.kind === "llm" ? "llm" : frozenEngine.runnerKind) : "exec";
+  // No frozen engine at all means an exec unit: it carries argv, not an invocation.
+  const runner: IrRuntimeKind = frozenEngine ? engineRuntimeKind(frozenEngine) : "exec";
   // Taken VERBATIM from the frozen plan — there is no engine-side backstop, by
   // design. The whole timeout decision happens once at freeze time
   // (`ir/freeze.ts` `effectiveTimeout`: unit `timeout:` → document
@@ -875,15 +877,6 @@ export interface ExecutedStepOutcome {
 }
 
 /**
- * Reduce a step's terminal unit outcomes into the promoted artifact + step
- * verdict — the shared semantics between native dispatch and the report path.
- * Applies the `on_error` policy (`fail` vs `continue`), the reducer (via
- * {@link buildEvidence}), the vote-tie failure, and the typed-artifact schema
- * validation (fail-fast, errors in the summary, `artifactSchemaFailure` marker).
- * Callers own dispatch-specific concerns (replay-divergence, budget) BEFORE
- * calling this; those never occur on the report path (units are journaled).
- */
-/**
  * The FIRST failed unit's diagnostic, appended to the step summary.
  *
  * A failure reason alone is not a diagnosis. `non_zero_exit` says a command
@@ -905,6 +898,15 @@ function firstFailureDiagnostic(failed: UnitOutcome[]): string {
   return ` First failure diagnostic (${first.unitId}): ${clip(diagnostic, WORKFLOW_UNIT_DIAGNOSTIC_CLIP)}`;
 }
 
+/**
+ * Reduce a step's terminal unit outcomes into the promoted artifact + step
+ * verdict — the shared semantics between native dispatch and the report path.
+ * Applies the `on_error` policy (`fail` vs `continue`), the reducer (via
+ * {@link buildEvidence}), the vote-tie failure, and the typed-artifact schema
+ * validation (fail-fast, errors in the summary, `artifactSchemaFailure` marker).
+ * Callers own dispatch-specific concerns (replay-divergence, budget) BEFORE
+ * calling this; those never occur on the report path (units are journaled).
+ */
 export function reduceStepOutcomes(
   plan: IrStepPlan,
   reducer: IrMapReducer,
@@ -1629,7 +1631,8 @@ export async function finalizeExecutedStep(input: FinalizeStepInput): Promise<Fi
             stepId,
             loop: gateLoop,
             invocation: gateInvocation,
-            runner: gateEngine?.kind === "agent" ? gateEngine.runnerKind : ("llm" as const),
+            // No engine snapshot means the built-in llm judge.
+            runner: gateEngine ? engineRuntimeKind(gateEngine) : ("llm" as const),
             inputHash: createHash("sha256")
               .update(
                 canonicalJsonString({

--- a/src/workflows/exec/step-work.ts
+++ b/src/workflows/exec/step-work.ts
@@ -61,9 +61,20 @@ import type {
   IrUnitNode,
   WorkflowPlanGraph,
 } from "../ir/schema";
-import { type ExpressionScope, resolveReferenceString } from "../program/expressions";
+import {
+  type ExpressionScope,
+  parseReference,
+  type ResolveReferenceResult,
+  resolveReferenceString,
+} from "../program/expressions";
 import { WORKFLOW_MAX_MAP_EXPANSION, WORKFLOW_UNIT_DIAGNOSTIC_CLIP } from "../resource-limits";
-import { completeWorkflowStep, type SummaryValidationFailure, type WorkflowNextResult } from "../runtime/runs";
+import {
+  completeWorkflowStep,
+  isTruncatedEvidence,
+  type SummaryValidationFailure,
+  type TruncatedEvidenceValue,
+  type WorkflowNextResult,
+} from "../runtime/runs";
 import { GATE_EVALUATION_PHASE } from "../runtime/unit-phases";
 import { type JudgeCallIdentity, parseJudgeVerdict, type SummaryJudge } from "../validate-summary";
 import { gateNodeId } from "./frozen-judge";
@@ -234,6 +245,56 @@ function validateFanOutItems(stepId: string, items: unknown[]): string | undefin
   return undefined;
 }
 
+/**
+ * Resolve one whole-value reference, refusing a value a persisted TRUNCATION
+ * ENVELOPE stands in for (`clipStepEvidenceForPersistence`, runtime/runs.ts).
+ *
+ * The engine threads each step's complete in-memory evidence to the rest of its
+ * own invocation, so only a RESUMED run can meet an envelope here. Left to the
+ * raw resolver, a path reference into one reports a generic missing property
+ * and a whole-value reference at one succeeds — handing the envelope to a unit
+ * as if it were the artifact. Both are silent corruption; name the cause
+ * instead. Every whole-value position (`inputs[]`, `map.over`, `route.input`)
+ * goes through here.
+ */
+function resolveStepReference(reference: string, scope: ExpressionScope): ResolveReferenceResult {
+  const resolved = resolveReferenceString(reference, scope);
+  const truncated = truncatedReferenceTarget(reference, scope, resolved);
+  if (!truncated) return resolved;
+  return {
+    ok: false,
+    error: {
+      reference,
+      message:
+        `${reference} reads a step artifact that was NOT persisted (${truncated.originalBytes} bytes exceeded the ` +
+        `${truncated.limitBytes}-byte evidence_json cap, so the row stores a truncation marker). This run was ` +
+        `resumed from rows that no longer hold the value — it cannot be recovered. Start a new run, or have the ` +
+        `producing step emit a reference (path, id) instead of inline bulk data.`,
+    },
+  };
+}
+
+/** The envelope a reference lands on or walks through, if any. */
+function truncatedReferenceTarget(
+  reference: string,
+  scope: ExpressionScope,
+  resolved: ResolveReferenceResult,
+): TruncatedEvidenceValue | undefined {
+  if (resolved.ok) return isTruncatedEvidence(resolved.value) ? resolved.value : undefined;
+  // A FAILED resolution is re-walked: the envelope is an object with none of
+  // the original's keys, so the raw failure is whatever property went missing
+  // along the way, several segments past the truncation.
+  const parsed = parseReference(reference);
+  if (!parsed.ok || parsed.expr.kind !== "stepOutput") return undefined;
+  let current: unknown = scope.stepOutputs[parsed.expr.stepId];
+  for (const segment of parsed.expr.path) {
+    if (isTruncatedEvidence(current)) return current;
+    if (typeof current !== "object" || current === null) return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return isTruncatedEvidence(current) ? current : undefined;
+}
+
 export function computeStepWorkList(plan: IrStepPlan, input: WorkListInput): ComputeWorkListResult {
   const root = plan.root;
   // Route-only steps (YAML `route:`) carry no execution subgraph.
@@ -259,7 +320,7 @@ export function computeStepWorkList(plan: IrStepPlan, input: WorkListInput): Com
   // attached to every dispatched unit as structured context.
   const resolvedInputs: Array<{ reference: string; value: unknown }> = [];
   for (const reference of template.inputs ?? []) {
-    const resolved = resolveReferenceString(reference, scope);
+    const resolved = resolveStepReference(reference, scope);
     if (!resolved.ok) {
       return {
         ok: false,
@@ -273,7 +334,7 @@ export function computeStepWorkList(plan: IrStepPlan, input: WorkListInput): Com
   // its producer explicitly — no ambient key search.
   let items: unknown[];
   if (root.kind === "map") {
-    const source = resolveReferenceString(root.over, scope);
+    const source = resolveStepReference(root.over, scope);
     if (!source.ok) {
       return {
         ok: false,
@@ -1194,7 +1255,7 @@ export type RouteSkipInfo = { router: string; selected: string | null };
  * string equality against the declared `when:` matches.
  */
 export function evaluateRoute(route: IrRouteSpec, scope: ExpressionScope): RouteDecision {
-  const resolved = resolveReferenceString(route.input, scope);
+  const resolved = resolveStepReference(route.input, scope);
   if (!resolved.ok) {
     return { ok: false, error: `route input ${route.input} failed to resolve: ${resolved.error.message}` };
   }

--- a/src/workflows/exec/step-work.ts
+++ b/src/workflows/exec/step-work.ts
@@ -68,7 +68,7 @@ import {
   type ResolveReferenceResult,
   resolveReferenceString,
 } from "../program/expressions";
-import { WORKFLOW_MAX_MAP_EXPANSION, WORKFLOW_UNIT_DIAGNOSTIC_CLIP } from "../resource-limits";
+import { clip, WORKFLOW_MAX_MAP_EXPANSION, WORKFLOW_UNIT_DIAGNOSTIC_CLIP } from "../resource-limits";
 import {
   completeWorkflowStep,
   isTruncatedEvidence,
@@ -175,7 +175,10 @@ export interface StepWorkUnit {
   retry?: IrRetry;
   onError: IrOnError;
   isolation?: IrIsolation;
-  resolved: { prompt: string; inputHash: string };
+  /** The unit's rendered instructions, built once by the work-list builder. */
+  prompt: string;
+  /** Canonical hash of this unit's frozen inputs — the durable-reuse identity. */
+  inputHash: string;
 }
 
 export interface StepWorkList {
@@ -487,7 +490,6 @@ function buildStepWorkUnit(ctx: StepWorkUnitContext, unitId: string, item: unkno
         instructions: template.instructions,
       });
   const inputHash = computeUnitInputHash(ctx, item);
-  const resolved: StepWorkUnit["resolved"] = { prompt, inputHash };
 
   return {
     unitId,
@@ -518,7 +520,8 @@ function buildStepWorkUnit(ctx: StepWorkUnitContext, unitId: string, item: unkno
     ...(template.retry ? { retry: template.retry } : {}),
     onError: template.onError,
     ...(template.isolation ? { isolation: template.isolation } : {}),
-    resolved,
+    prompt,
+    inputHash,
   };
 }
 
@@ -755,6 +758,40 @@ export function stepOutputsFromEvidence(
     if (stepEvidence !== undefined) outputs[stepId] = projectStepOutput(stepEvidence);
   }
   return outputs;
+}
+
+/** The step's dispatch template — the map template for a fan-out, else the root unit. */
+function stepTemplate(stepPlan: IrStepPlan): IrUnitNode | undefined {
+  const root = stepPlan.root;
+  if (!root) return undefined;
+  return root.kind === "map" ? root.template : root;
+}
+
+/**
+ * The step ids that ANOTHER step of the frozen plan can still read: the
+ * producers named by an `inputs[]` entry, a `map.over`, or a `route.input`.
+ * Those three fields are the WHOLE reference surface — instructions are never
+ * scanned (workflow-format-unification, spec §2.3) — so a step outside this set
+ * has no in-plan consumer and nothing needs to hold its artifact in memory once
+ * it is journaled.
+ *
+ * Derived from the plan alone: O(plan), independent of run state, and stable
+ * across the retry and gate loops (a retry re-opens one failed step, and a
+ * looping step has not advanced, so neither can turn an unreferenced producer
+ * into a referenced one mid-invocation).
+ */
+export function referencedStepIds(plan: WorkflowPlanGraph): Set<string> {
+  const referenced = new Set<string>();
+  const note = (reference: string): void => {
+    const parsed = parseReference(reference);
+    if (parsed.ok && parsed.expr.kind === "stepOutput") referenced.add(parsed.expr.stepId);
+  };
+  for (const step of plan.steps) {
+    if (step.root?.kind === "map") note(step.root.over);
+    for (const reference of stepTemplate(step)?.inputs ?? []) note(reference);
+    if (step.route) note(step.route.input);
+  }
+  return referenced;
 }
 
 /**
@@ -1045,6 +1082,30 @@ function sortKeys(value: unknown): unknown {
 /** The unit id of a step's gate-evaluation row for a given 1-based loop. */
 export function gateUnitId(stepId: string, loop: number): string {
   return `${stepId}.gate:l${loop}`;
+}
+
+/**
+ * How many times a step's subgraph may run under its completion gate — the
+ * bound the engine loop walks and the one `loopsRemaining` is derived from.
+ *
+ * A gate loop only earns its re-dispatch when the subgraph can ANSWER the
+ * judge: an engine unit reads the rejection feedback in its prompt and produces
+ * different work. An `exec` unit cannot. Its argv is frozen and never
+ * interpolated, {@link buildExecContextEnv} exposes no feedback variable, and
+ * the default dispatcher drops feedback for exec — so a second loop re-runs the
+ * BYTE-IDENTICAL command for a verdict that cannot change, which for a deploy /
+ * publish / migrate command means performing the side effect twice. The same
+ * reasoning already pins exec structured output to a single attempt and makes
+ * `exec_capture_incomplete` non-retryable (`native-executor.ts`).
+ *
+ * So an exec step's gate still EVALUATES — the verdict can still fail the step
+ * — but it never loops: a rejection lands on the gate-exhausted terminal
+ * instead of re-dispatching. An authored `gate.max_loops` on an engine step is
+ * untouched.
+ */
+export function effectiveGateMaxLoops(stepPlan: IrStepPlan): number {
+  const declared = Math.max(1, stepPlan.gate.maxLoops ?? 1);
+  return stepTemplate(stepPlan)?.exec ? 1 : declared;
 }
 
 /**
@@ -1470,6 +1531,16 @@ export interface FinalizeStepInput {
   engines?: Record<string, FrozenEngineSnapshot>;
   /** Cooperative run cancellation checked before completion is committed. */
   signal?: AbortSignal;
+  /**
+   * The EFFECTIVE dispatch signal the judge call runs under — the engine's
+   * heartbeat-chained controller, which aborts on a LOST LEASE as well as on a
+   * caller abort. It must reach the completion path, because the interruption
+   * guard there is what tells an aborted judge apart from a failed one: seeing
+   * only {@link signal}, a lost-lease abort mid-judge reads as a thrown judge
+   * call and durably blocks the step blaming verifier infrastructure, moments
+   * before the real lost-lease error is raised. Defaults to {@link signal}.
+   */
+  dispatchSignal?: AbortSignal;
   /** Engine run-lease holder (engine path only); absent on the manual/report path. */
   leaseHolder?: string;
 }
@@ -1494,7 +1565,7 @@ export type FinalizeStepResult =
  * missing judge, unresolvable frozen judge, thrown judge call, malformed
  * verdict — so the resume instruction is worded once.
  */
-export function judgeFailureNotes(runId: string, stepId: string, cause: string): string {
+function judgeFailureNotes(runId: string, stepId: string, cause: string): string {
   return (
     `Step "${stepId}" could not be verified: ${cause}. ` +
     `This is a verification-judge failure, not a verdict — no gate loop was consumed and the step's ` +
@@ -1504,18 +1575,53 @@ export function judgeFailureNotes(runId: string, stepId: string, cause: string):
   );
 }
 
-/** Complete the step `blocked` for a judge-infrastructure failure and surface it. */
-async function blockStepForJudgeFailure(input: FinalizeStepInput, cause: string): Promise<FinalizeStepResult> {
-  const notes = judgeFailureNotes(input.runId, input.stepId, cause);
+export interface JudgeFailureBlock {
+  runId: string;
+  stepId: string;
+  /** What went wrong, spliced into the shared notes. */
+  cause: string;
+  /**
+   * The executed step's evidence, when the judge failed AFTER its units ran.
+   * Persisting it is what makes the documented recovery real: `akm workflow
+   * resume` re-evaluates the gate against these results instead of
+   * re-dispatching them. The PRE-DISPATCH failure (an unresolvable frozen
+   * judge, caught before a single unit runs) has no results to preserve and
+   * omits it — the difference is what the step produced, not a policy split.
+   */
+  evidence?: Record<string, unknown>;
+  leaseHolder?: string;
+}
+
+/**
+ * Complete a step `blocked` for a verifier-INFRASTRUCTURE failure and return
+ * the notes written. The ONE implementation for both judge-failure paths — the
+ * engine's pre-dispatch judge resolution (`run-workflow.ts`) and this module's
+ * post-execution gate — so the wording, the blocked status, and the evidence
+ * decision cannot drift between them.
+ */
+export async function blockStepForJudgeFailure(input: JudgeFailureBlock): Promise<string> {
+  const notes = judgeFailureNotes(input.runId, input.stepId, input.cause);
   await completeWorkflowStep({
     runId: input.runId,
     stepId: input.stepId,
     status: "blocked",
     notes,
+    ...(input.evidence !== undefined ? { evidence: input.evidence } : {}),
+    ...(input.leaseHolder !== undefined ? { leaseHolder: input.leaseHolder } : {}),
+  });
+  return notes;
+}
+
+/** The finalize path's blocked write: the executed units' evidence is preserved. */
+async function blockFinalizedStep(input: FinalizeStepInput, cause: string): Promise<FinalizeStepResult> {
+  const summary = await blockStepForJudgeFailure({
+    runId: input.runId,
+    stepId: input.stepId,
+    cause,
     evidence: input.result.evidence,
     ...(input.leaseHolder !== undefined ? { leaseHolder: input.leaseHolder } : {}),
   });
-  return { kind: "judge-failed", summary: notes };
+  return { kind: "judge-failed", summary };
 }
 
 /**
@@ -1572,7 +1678,7 @@ export async function finalizeExecutedStep(input: FinalizeStepInput): Promise<Fi
   // verifier infrastructure failure, never a silent bypass and never an honest
   // rejection: block for resume without invoking the gate (no loop consumed).
   if (completionCriteria.some((c) => c.trim().length > 0) && !innerJudge) {
-    return blockStepForJudgeFailure(
+    return blockFinalizedStep(
       input,
       "this step declares completion criteria but no verification judge is available " +
         "(the frozen plan resolves no judge — set workflow.judgeEngine, or restore the judge configuration)",
@@ -1676,7 +1782,15 @@ export async function finalizeExecutedStep(input: FinalizeStepInput): Promise<Fi
   // lease, a concurrent state change, a DB error — which would otherwise skip the
   // finish and strand the gate row in `running`. Finish it as an errored row (the
   // observed outcome: the completion did not succeed), then re-propagate.
+  //
+  // The signal handed down is the DISPATCH signal (the judge call runs under
+  // it), not just the caller's: the interruption guard inside the completion
+  // path rethrows an abort instead of classifying it as a judge outage, and a
+  // lost lease aborting mid-judge is an interruption — recording it as a
+  // verifier failure would blame infrastructure and durably block a step whose
+  // gate simply never finished evaluating.
   let completion: Awaited<ReturnType<typeof completeWorkflowStep>>;
+  const completionSignal = input.dispatchSignal ?? input.signal;
   try {
     completion = await completeWorkflowStep({
       runId,
@@ -1685,7 +1799,7 @@ export async function finalizeExecutedStep(input: FinalizeStepInput): Promise<Fi
       summary,
       evidence: result.evidence,
       summaryJudge,
-      ...(input.signal ? { signal: input.signal } : {}),
+      ...(completionSignal ? { signal: completionSignal } : {}),
       ...lease,
     });
   } catch (err) {
@@ -1707,7 +1821,7 @@ export async function finalizeExecutedStep(input: FinalizeStepInput): Promise<Fi
   // verdict. Consume NO gate loop; block the step (and therefore the run) so
   // `akm workflow resume` retries the gate over the journaled units.
   if (rejection && judgeFailed) {
-    return blockStepForJudgeFailure(input, judgeFailure ?? "the verification judge failed");
+    return blockFinalizedStep(input, judgeFailure ?? "the verification judge failed");
   }
 
   if (!rejection) {
@@ -1732,7 +1846,8 @@ function safeJson(value: unknown): string {
   }
 }
 
-/** Truncate to `max` chars with an ellipsis marker. */
-export function clip(text: string, max: number): string {
-  return text.length > max ? `${text.slice(0, max)}…` : text;
-}
+// `clip` lives with the bounds it applies (`workflows/resource-limits.ts`) so
+// the write side here and the read side in `runtime/runs.ts` — which cannot
+// import this module — truncate through one implementation. Re-exported
+// because this module is where the dispatch path already reaches for it.
+export { clip } from "../resource-limits";

--- a/src/workflows/exec/unit-dispatch.ts
+++ b/src/workflows/exec/unit-dispatch.ts
@@ -4,7 +4,7 @@
 
 import type { LlmConnectionConfig } from "../../core/config/config";
 import { deepMergeConfig } from "../../core/config/deep-merge";
-import { ConfigError } from "../../core/errors";
+import { resolveCredentialFromEnv } from "../../integrations/agent/engine-resolution";
 import type { AgentTokenUsage } from "../../integrations/agent/spawn";
 import type { FrozenEngineSnapshot, IrExecSpec, IrInvocation } from "../ir/schema";
 
@@ -74,24 +74,18 @@ export type UnitDispatcher = (request: UnitDispatchRequest, feedback?: string) =
  * overrides. The ONE definition — the default dispatcher's llm runner and the
  * frozen gate judge both dispatch through it, so credential resolution and
  * connection-field mapping cannot drift between the two llm dispatch paths.
+ *
+ * The credential read itself is {@link resolveCredentialFromEnv}, shared with
+ * the live-config dispatch boundary (`materializeLlmConnection`): a frozen
+ * snapshot's `credential` and a resolved engine's `CredentialDescriptor` are the
+ * same descriptor, so lookup order and the "required … is not set" failure are
+ * one implementation, not two that happen to agree.
  */
 export function materializeFrozenLlm(
   snapshot: Extract<FrozenEngineSnapshot, { kind: "llm" }>,
   invocation: IrInvocation | undefined,
 ): LlmConnectionConfig {
-  let apiKey: string | undefined;
-  for (const name of snapshot.credential?.names ?? []) {
-    const candidate = process.env[name]?.trim();
-    if (candidate) {
-      apiKey = candidate;
-      break;
-    }
-  }
-  if (snapshot.credential?.required && !apiKey)
-    throw new ConfigError(
-      `Required engine credential ${snapshot.credential.names[0]} is not set.`,
-      "INVALID_CONFIG_FILE",
-    );
+  const apiKey = resolveCredentialFromEnv(snapshot.credential);
   const base = {
     provider: snapshot.provider,
     endpoint: snapshot.endpoint,

--- a/src/workflows/exec/unit-writer.ts
+++ b/src/workflows/exec/unit-writer.ts
@@ -55,15 +55,13 @@ import { getStateDbPath } from "../../core/state-db";
  */
 const chains = new Map<string, Promise<unknown>>();
 
-export interface EnqueueUnitWriteOptions {
-  /**
-   * Serialization key. Defaults to the current state.db path — the file whose
-   * single write lock the chain is protecting. Callers should only override it
-   * when they are writing to a DIFFERENT database file.
-   */
-  key?: string;
-}
-
-export function enqueueUnitWrite<T>(fn: () => Promise<T>, opts?: EnqueueUnitWriteOptions): Promise<T> {
-  return serializeByKey(chains, opts?.key ?? getStateDbPath(), fn);
+/**
+ * Enqueue a `workflow_run_units` write behind every write already queued for
+ * the same state.db. The key is the current state.db path — the file whose one
+ * write lock this exists to protect — and is not a caller's choice: a caller
+ * writing somewhere else is not on this queue at all, and wants
+ * {@link serializeByKey} with its own chain map.
+ */
+export function enqueueUnitWrite<T>(fn: () => Promise<T>): Promise<T> {
+  return serializeByKey(chains, getStateDbPath(), fn);
 }

--- a/src/workflows/exec/worktree.ts
+++ b/src/workflows/exec/worktree.ts
@@ -21,6 +21,10 @@
  *      is never destroyed.
  *   4. {@link sweepStaleWorktrees} — opportunistic, at most once per process:
  *      an age-based GC of run roots and retained trees that outlived their run.
+ *      Age alone cannot see a unit that is still running in ANOTHER process, so
+ *      every live worktree carries a liveness lease (pid + host + path) in
+ *      git's own administrative directory for it, and the sweep skips a tree
+ *      whose lease holder is still running.
  *
  * What "uncollected work" means (the honest contract): the clean probe is
  * `git status --porcelain` WITHOUT `--ignored`, so it counts tracked-file
@@ -174,11 +178,13 @@ export function assertGitWorkTree(dir: string): string | undefined {
 const repoOperationTails = new Map<string, Promise<unknown>>();
 
 /**
- * Base repos already pruned in this process, keyed `<repo>\0<runId>`. A run's
- * keys are dropped when its drained worktree root is removed
- * ({@link removeRunRootIfEmpty}), so the set never outgrows the live runs.
+ * Base repos already pruned in this process, per run id. Granularity is
+ * per-(repo, run), not per-repo: a run resuming against a repo another run
+ * already pruned must still reap ITS own orphaned registrations. A run's whole
+ * entry is dropped when its drained worktree root is removed
+ * ({@link removeRunRootIfEmpty}), so the map never outgrows the live runs.
  */
-const prunedRuns = new Set<string>();
+const prunedRuns = new Map<string, Set<string>>();
 
 /**
  * Serialize `fn` against every other repo-mutating worktree operation on the
@@ -201,7 +207,16 @@ export type WorktreeCreateResult =
        */
       preservedLeftover?: string;
     }
-  | { ok: false; error: string };
+  | {
+      ok: false;
+      error: string;
+      /**
+       * Same field on the failure path: when the leftover was moved aside and
+       * the re-creation then failed, that copy is the ONLY one left of the
+       * previous attempt's work, so the caller must still be told where it is.
+       */
+      preservedLeftover?: string;
+    };
 
 /** Journal-safe directory name for a unit attempt id (ids carry `:` / `~`). */
 function sanitizeAttemptId(attemptId: string): string {
@@ -256,6 +271,10 @@ async function pathExists(p: string): Promise<boolean> {
  * the prune and the add form ONE critical section against the base repo's
  * administrative state, so a concurrent unit's prune can never land between
  * another unit's prune and its add.
+ *
+ * A successful add takes a liveness lease ({@link acquireWorktreeLease}) so the
+ * GC sweep — in this process or another one — never collects the tree while the
+ * unit is still running in it.
  */
 export async function createUnitWorktree(
   baseDir: string,
@@ -285,7 +304,11 @@ export async function createUnitWorktree(
       }
       await fsp.mkdir(path.dirname(dest), { recursive: true });
     } catch (err) {
-      return { ok: false, error: `could not prepare worktree directory ${dest}: ${message(err)}` };
+      return {
+        ok: false,
+        error: `could not prepare worktree directory ${dest}: ${message(err)}`,
+        ...(preservedLeftover !== undefined ? { preservedLeftover } : {}),
+      };
     }
     // Prune only drops administrative entries whose worktree directory is
     // already gone; it never touches a live worktree. Two triggers, both
@@ -295,15 +318,21 @@ export async function createUnitWorktree(
     //     before re-adding at the same path;
     //   • first worktree of this (repo, run) — reaps registrations orphaned by
     //     earlier runs whose roots were GC'd or deleted out from under git.
-    const pruneKey = `${repoKey}\u0000${runId}`;
-    if (leftoverHandled || !prunedRuns.has(pruneKey)) {
-      prunedRuns.add(pruneKey);
+    const prunedRepos = prunedRuns.get(runId);
+    if (leftoverHandled || !prunedRepos?.has(repoKey)) {
+      if (prunedRepos) prunedRepos.add(repoKey);
+      else prunedRuns.set(runId, new Set([repoKey]));
       await git(baseDir, ["worktree", "prune"]);
     }
     const added = await git(baseDir, ["worktree", "add", "--detach", dest]);
     if (!added.ok) {
-      return { ok: false, error: `could not create isolation worktree at ${dest}: ${added.error}` };
+      return {
+        ok: false,
+        error: `could not create isolation worktree at ${dest}: ${added.error}`,
+        ...(preservedLeftover !== undefined ? { preservedLeftover } : {}),
+      };
     }
+    await acquireWorktreeLease(dest);
     return { ok: true, path: dest, ...(preservedLeftover !== undefined ? { preservedLeftover } : {}) };
   });
 }
@@ -349,7 +378,11 @@ export async function cleanupUnitWorktree(baseDir: string, worktreePath: string)
     await removeRunRootIfEmpty(worktreePath);
     return { removed: true, dirty: false };
   }
-  // It refused. Ask the probe WHY rather than parsing git's message, whose
+  // It refused, so the tree stays on disk — drop its lease, since no unit is
+  // using it any more and the sweep must be free to collect it once it is
+  // stale. (A successful removal took the whole admin directory, lease with it.)
+  await releaseWorktreeLease(worktreePath);
+  // Ask the probe WHY it refused rather than parsing git's message, whose
   // wording varies with version and locale — and which the caller's warn text
   // has never been written against.
   const status = await git(worktreePath, ["status", "--porcelain"]);
@@ -360,6 +393,112 @@ export async function cleanupUnitWorktree(baseDir: string, worktreePath: string)
     return { removed: false, dirty: true };
   }
   return { removed: false, dirty: false, error: removed.error };
+}
+
+// ── Liveness leases ─────────────────────────────────────────────────────────
+
+/** Marker file, inside a worktree's git admin dir, naming the process using it. */
+const LEASE_FILE_NAME = "akm-lease";
+
+interface WorktreeLease {
+  pid: number;
+  host: string;
+  /**
+   * Resolved path the lease was taken for. Git reuses an admin directory name
+   * once the previous registration is pruned, so a moved-aside
+   * `.retained-<ts>` copy still points at what is now a DIFFERENT worktree's
+   * admin dir; without this check it would inherit that worktree's liveness.
+   */
+  path: string;
+}
+
+/**
+ * Path of `p`'s git administrative directory (`<repo>/.git/worktrees/<name>`),
+ * read from the `.git` FILE every linked worktree carries. Undefined when `p`
+ * is not a readable linked worktree.
+ */
+async function worktreeAdminDir(p: string): Promise<string | undefined> {
+  let contents: string;
+  try {
+    contents = await fsp.readFile(path.join(p, ".git"), "utf8");
+  } catch {
+    return undefined;
+  }
+  const gitdir = /^gitdir:[ \t]*(\S.*)$/m.exec(contents)?.[1];
+  return gitdir?.trim();
+}
+
+/**
+ * Record this process as the user of `worktreePath`, so {@link
+ * sweepStaleWorktrees} can tell a live worktree from an abandoned one.
+ *
+ * The marker lives in git's administrative directory for the worktree, never in
+ * the checkout: an untracked file inside the tree would make it probe DIRTY (and
+ * be retained forever), while git's own `worktree remove`/`prune` delete the
+ * admin dir — lease included — with no extra bookkeeping here. Best effort: a
+ * lease that cannot be written only leaves the tree collectible once stale,
+ * which is the pre-lease behaviour.
+ */
+async function acquireWorktreeLease(worktreePath: string): Promise<void> {
+  const adminDir = await worktreeAdminDir(worktreePath);
+  if (adminDir === undefined) return;
+  const lease: WorktreeLease = {
+    pid: process.pid,
+    host: os.hostname(),
+    path: await safeRealpathAsync(worktreePath),
+  };
+  try {
+    await fsp.writeFile(path.join(adminDir, LEASE_FILE_NAME), JSON.stringify(lease));
+  } catch {
+    /* best effort — see above */
+  }
+}
+
+/** Drop the lease of a worktree this process is done with but is not removing. */
+async function releaseWorktreeLease(worktreePath: string): Promise<void> {
+  const adminDir = await worktreeAdminDir(worktreePath);
+  if (adminDir === undefined) return;
+  try {
+    await fsp.rm(path.join(adminDir, LEASE_FILE_NAME), { force: true });
+  } catch {
+    /* best effort — a stale lease only delays the sweep by one run of it */
+  }
+}
+
+/**
+ * True when a still-running process holds `candidate`'s lease — the guard age
+ * cannot provide. A unit that runs longer than the sweep threshold while
+ * writing only inside subdirectories leaves the worktree ROOT's mtime at
+ * creation time, so another akm process minting a worktree would otherwise
+ * delete a tree that is still in use.
+ *
+ * A lease from a dead pid, from another host (where the pid means nothing), or
+ * for a different path is NOT liveness: crashed runs and retained dirty trees
+ * stay collectible, which is the whole point of the sweep.
+ */
+async function isWorktreeLeaseLive(candidate: string): Promise<boolean> {
+  const adminDir = await worktreeAdminDir(candidate);
+  if (adminDir === undefined) return false;
+  let lease: Partial<WorktreeLease>;
+  try {
+    lease = JSON.parse(await fsp.readFile(path.join(adminDir, LEASE_FILE_NAME), "utf8")) as Partial<WorktreeLease>;
+  } catch {
+    return false;
+  }
+  if (lease.host !== os.hostname()) return false;
+  if (lease.path !== (await safeRealpathAsync(candidate))) return false;
+  return isProcessAlive(lease.pid);
+}
+
+/** `kill(pid, 0)` liveness probe. EPERM proves the process exists but is not ours. */
+function isProcessAlive(pid: unknown): boolean {
+  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
 }
 
 // ── Garbage collection ──────────────────────────────────────────────────────
@@ -386,10 +525,7 @@ async function removeRunRootIfEmpty(worktreePath: string): Promise<void> {
   // `prunedRuns` never outgrows the live runs. (A later worktree of the same
   // run simply prunes once more; the guard is an optimization, not a
   // correctness gate.)
-  const suffix = `\u0000${path.basename(runRoot)}`;
-  for (const key of prunedRuns) {
-    if (key.endsWith(suffix)) prunedRuns.delete(key);
-  }
+  prunedRuns.delete(path.basename(runRoot));
 }
 
 /** Options for {@link sweepStaleWorktrees}. `root`/`now` are test seams. */
@@ -417,8 +553,11 @@ export interface SweepStaleWorktreesOptions {
  *
  * Safety invariants: it only ever descends two levels from `root`; entries
  * that are not real directories (symlinks included — `Dirent.isDirectory()`
- * reflects `lstat`) are skipped, never followed; and every candidate is
- * re-verified with {@link isWithin} against the resolved root before removal.
+ * reflects `lstat`) are skipped, never followed; a stale-looking candidate
+ * whose {@link isWorktreeLeaseLive} lease holder is still running is skipped
+ * (age alone cannot see a unit in flight in another process); and every
+ * candidate is re-verified with {@link isWithin} against the resolved root
+ * before removal.
  * Deleting a directory leaves its registration in whatever base repo minted
  * it; the next run's `git worktree prune` on that repo reaps it.
  *
@@ -453,6 +592,7 @@ export async function sweepStaleWorktrees(opts: SweepStaleWorktreesOptions = {})
       const candidate = path.join(runRoot, entry.name);
       if (!(await isWithinAsync(candidate, root))) continue;
       if (now - (await lastActivityMs(candidate, entry.name)) < maxAgeMs) continue;
+      if (await isWorktreeLeaseLive(candidate)) continue;
       try {
         await fsp.rm(candidate, { recursive: true, force: true });
         removed.push(candidate);

--- a/src/workflows/exec/worktree.ts
+++ b/src/workflows/exec/worktree.ts
@@ -330,11 +330,28 @@ export interface WorktreeCleanupResult {
  * blow up disk. "Uncollected work" the caller preserves is therefore
  * tracked-or-untracked-unignored changes only (module doc).
  *
- * Only `git worktree remove` takes the base repo's lock, so the status probe
- * stays OFF {@link withRepoWorktreeLock} — parallel units probe concurrently
- * and serialize only on the mutation.
+ * Only `git worktree remove` takes the base repo's lock; the status probe stays
+ * OFF {@link withRepoWorktreeLock}. Since the probe now runs only when a
+ * removal was refused, a dirty worktree costs one failed removal inside the
+ * lock that it used to avoid — the trade that makes every CLEAN cleanup a
+ * single git process.
  */
 export async function cleanupUnitWorktree(baseDir: string, worktreePath: string): Promise<WorktreeCleanupResult> {
+  // Try the removal FIRST and let it be the cleanliness check: `git worktree
+  // remove` without `--force` already refuses a worktree carrying changes, on
+  // the same terms as the probe (ignored files excluded either way). The clean
+  // case — the overwhelmingly common one — is then ONE git process per unit
+  // instead of two, which a wide fan-out pays per unit.
+  const removed = await withRepoWorktreeLock(await safeRealpathAsync(baseDir), () =>
+    git(baseDir, ["worktree", "remove", worktreePath]),
+  );
+  if (removed.ok) {
+    await removeRunRootIfEmpty(worktreePath);
+    return { removed: true, dirty: false };
+  }
+  // It refused. Ask the probe WHY rather than parsing git's message, whose
+  // wording varies with version and locale — and which the caller's warn text
+  // has never been written against.
   const status = await git(worktreePath, ["status", "--porcelain"]);
   if (!status.ok) {
     return { removed: false, dirty: false, error: status.error };
@@ -342,14 +359,7 @@ export async function cleanupUnitWorktree(baseDir: string, worktreePath: string)
   if (status.stdout.trim() !== "") {
     return { removed: false, dirty: true };
   }
-  const removed = await withRepoWorktreeLock(await safeRealpathAsync(baseDir), () =>
-    git(baseDir, ["worktree", "remove", worktreePath]),
-  );
-  if (!removed.ok) {
-    return { removed: false, dirty: false, error: removed.error };
-  }
-  await removeRunRootIfEmpty(worktreePath);
-  return { removed: true, dirty: false };
+  return { removed: false, dirty: false, error: removed.error };
 }
 
 // ── Garbage collection ──────────────────────────────────────────────────────

--- a/src/workflows/ir/compile.ts
+++ b/src/workflows/ir/compile.ts
@@ -320,12 +320,30 @@ function checkInputReference(text: string, index: number, check: ReferenceCheck)
  *      block — a likely typo. Prose can no longer carry param references at
  *      all (it is never scanned), so this warning's surface shrinks to the
  *      two whole-value fields that can legally contain one.
+ *   C. `gate.max_loops` above 1 on an `exec` step. The engine judges such a
+ *      step but never loops it (`exec/step-work.ts#effectiveGateMaxLoops`):
+ *      a frozen argv cannot read the judge's feedback, so a second loop would
+ *      only re-run the identical command — and its side effects. The declared
+ *      budget is not silently different from what runs; say so.
  */
 export function collectWorkflowWarnings(document: WorkflowDocument): WorkflowError[] {
   const warnings: WorkflowError[] = [];
   const declaredParams = document.params ? new Set(Object.keys(document.params)) : undefined;
 
   for (const step of document.steps) {
+    const maxLoops = step.gate?.maxLoops ?? 1;
+    const execUnit = step.map ? step.map.unit?.exec : step.unit?.exec;
+    if (maxLoops > 1 && execUnit && step.gateRubric?.text.trim()) {
+      warnings.push({
+        line: step.source.start,
+        message:
+          `Step "${step.id}" declares \`gate.max_loops: ${maxLoops}\` on an \`exec\` step — it runs its command ` +
+          `ONCE. A gate loop re-executes the step so it can address the judge's feedback, and a frozen argv cannot ` +
+          `read that feedback; looping would only repeat the command's side effects. The gate still evaluates and ` +
+          `can still fail the step.`,
+      });
+    }
+
     if ((step.map || step.route === undefined) && step.output === undefined) {
       warnings.push({
         line: step.source.start,

--- a/src/workflows/ir/compile.ts
+++ b/src/workflows/ir/compile.ts
@@ -29,7 +29,7 @@
  */
 
 import { formatReference, parseReference } from "../program/expressions";
-import type { ProgramDefaults, ProgramExec, ProgramUnit } from "../program/schema";
+import { type ProgramDefaults, type ProgramExec, type ProgramUnit, projectExecCore } from "../program/schema";
 import type { WorkflowDocument, WorkflowError } from "../schema";
 import type { IrIsolation, IrMapReducer, IrOnError, IrRetry, IrRouteSpec } from "./schema";
 
@@ -232,20 +232,11 @@ function compileUnit(
     instructions,
     templating: "verbatim",
     ...(inputs && inputs.length > 0 ? { inputs: [...inputs] } : {}),
-    ...(unit?.exec
-      ? {
-          exec: {
-            command: [...unit.exec.command],
-            ...(unit.exec.cwd ? { cwd: unit.exec.cwd } : {}),
-            // Both env-scope keys are carried CONDITIONALLY (and `inheritEnv`
-            // only when true), so an exec unit that says nothing about its
-            // environment freezes — and therefore hashes — byte-identically to
-            // one authored before these keys existed.
-            ...(unit.exec.passEnv && unit.exec.passEnv.length > 0 ? { passEnv: [...unit.exec.passEnv] } : {}),
-            ...(unit.exec.inheritEnv ? { inheritEnv: true as const } : {}),
-          },
-        }
-      : {}),
+    // Shared projection: both env-scope keys are carried CONDITIONALLY (and
+    // `inheritEnv` only when true), so an exec unit that says nothing about its
+    // environment freezes — and therefore hashes — byte-identically to one
+    // authored before these keys existed.
+    ...(unit?.exec ? { exec: projectExecCore(unit.exec) } : {}),
     ...(unit?.output !== undefined ? { schema: unit.output } : {}),
     ...(unit?.retry ? { retry: { max: unit.retry.max, on: [...unit.retry.on] } } : {}),
     onError: unit?.onError ?? defaults?.onError ?? "fail",

--- a/src/workflows/ir/freeze.ts
+++ b/src/workflows/ir/freeze.ts
@@ -22,7 +22,7 @@ import { resolveLlmModel, resolveModel } from "../../integrations/agent/model-al
 import { getBuiltinAgentProfile } from "../../integrations/agent/profiles";
 import { HARNESS_BY_ID } from "../../integrations/harnesses";
 import { defaultLlmEngineConcurrency, defaultMapConcurrency, workflowMaxConcurrency } from "../concurrency-policy";
-import type { ProgramUnit } from "../program/schema";
+import { type ProgramUnit, projectExecCore } from "../program/schema";
 import { DEFAULT_EXEC_TIMEOUT_MS } from "../resource-limits";
 import type { WorkflowAsset } from "../runtime/workflow-asset-loader";
 import { compileWorkflowPlan, type WorkflowPlanDraft, type WorkflowUnitDraft } from "./compile";
@@ -137,15 +137,14 @@ export function compileResolveFreezeWorkflow(
     const layers: EngineUseConfig[] = [...(documentDefaults ? [documentDefaults] : []), ...(unit ? [unit] : [])];
     const declared = layeredTimeout(layers);
     const timeoutMs = declared === undefined ? DEFAULT_EXEC_TIMEOUT_MS : declared;
+    // The shared structural projection, plus the one thing freezing adds: the
+    // RESOLVED timeout. The default allowlist stays the ABSENCE of both env
+    // keys — one encoding per state, which is what keeps the canonical hash
+    // preimage stable. `command` is non-empty by parser construction.
+    const core = projectExecCore(exec);
     return {
-      command: [...exec.command] as [string, ...string[]],
-      ...(exec.cwd ? { cwd: exec.cwd } : {}),
-      // Env-scope keys are frozen structurally (the draft already dropped an
-      // empty `passEnv` and a false `inheritEnv`), so the default allowlist
-      // stays the ABSENCE of both keys — one encoding per state, which is what
-      // keeps the canonical hash preimage stable.
-      ...(exec.passEnv && exec.passEnv.length > 0 ? { passEnv: [...exec.passEnv] } : {}),
-      ...(exec.inheritEnv ? { inheritEnv: true as const } : {}),
+      ...core,
+      command: core.command as [string, ...string[]],
       timeoutMs,
     };
   };

--- a/src/workflows/ir/schema.ts
+++ b/src/workflows/ir/schema.ts
@@ -54,6 +54,21 @@ export type IrInstructionTemplating = "verbatim";
 export type IrRuntimeKind = "llm" | "agent" | "sdk" | "exec";
 
 /**
+ * The {@link IrRuntimeKind} a frozen engine dispatches as — the value journaled
+ * in `workflow_run_units.runner` and read back by `status --units`.
+ *
+ * Lives here, beside the union, because the mapping is a property OF the union:
+ * spelled at each call site instead, a kind added to `FrozenEngineSnapshot`
+ * would type-check against whichever site happens to end with a default and be
+ * silently mis-journaled. Callers supply their own answer for the ABSENCE of an
+ * engine, which genuinely differs — a unit without one is an `exec` unit, while
+ * a gate without one is an llm judge.
+ */
+export function engineRuntimeKind(engine: FrozenEngineSnapshot): IrRuntimeKind {
+  return engine.kind === "llm" ? "llm" : engine.runnerKind;
+}
+
+/**
  * A frozen exec (shell) unit: the argv the engine spawns, where it spawns it,
  * and the wall-clock budget it gets.
  *

--- a/src/workflows/program/schema.ts
+++ b/src/workflows/program/schema.ts
@@ -140,6 +140,43 @@ export interface ProgramExec {
 }
 
 /**
+ * An exec spec projected into its canonical structural form: argv copied, the
+ * env-scope keys present ONLY in their meaningful state. `inheritEnv` narrows
+ * to `true` because `false` is spelled as absence.
+ */
+export interface ProgramExecCore {
+  command: string[];
+  cwd?: string;
+  passEnv?: string[];
+  inheritEnv?: true;
+}
+
+/**
+ * The ONE structural projection of an exec spec — ONE encoding per state.
+ *
+ * Every layer that carries an exec forward derives from this: the compiled
+ * draft, the frozen plan (which layers `timeoutMs` on top), and the summary
+ * `akm workflow show` prints. Written out per layer instead, a field added to
+ * {@link ProgramExec} reaches whichever copies were remembered and silently
+ * vanishes from the rest — and nothing catches it, because every key here is
+ * optional, so an omitted spread is not a type error. What it would cost:
+ * either the frozen plan loses a field the author wrote (and the canonical
+ * hash preimage stops matching the authored intent), or `show` describes
+ * something other than what runs.
+ *
+ * The ABSENCE of both env keys is the default allowlist. The parser rejects an
+ * empty `pass_env` outright, so no layer has to distinguish absent from empty.
+ */
+export function projectExecCore(exec: ProgramExec): ProgramExecCore {
+  return {
+    command: [...exec.command],
+    ...(exec.cwd ? { cwd: exec.cwd } : {}),
+    ...(exec.passEnv && exec.passEnv.length > 0 ? { passEnv: [...exec.passEnv] } : {}),
+    ...(exec.inheritEnv ? { inheritEnv: true as const } : {}),
+  };
+}
+
+/**
  * The optional dispatch-override bag for a unit/map step. Absent entirely
  * (bare `{ id: validate }`) means the step still IS a unit step — it just
  * carries the run's engine/model/timeout defaults verbatim.

--- a/src/workflows/renderer.ts
+++ b/src/workflows/renderer.ts
@@ -21,7 +21,7 @@ import type {
   WorkflowStepOrchestrationSummary,
 } from "../sources/types";
 import { parseWorkflow } from "./parser";
-import type { ProgramDefaults } from "./program/schema";
+import { type ProgramDefaults, projectExecCore } from "./program/schema";
 import type { WorkflowDocument, WorkflowStep } from "./schema";
 
 function shellQuote(value: string): string {
@@ -116,16 +116,9 @@ function summarizeStepOrchestration(
     ...(engine !== undefined ? { engine } : {}),
     ...(model !== undefined ? { model } : {}),
     ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-    ...(exec
-      ? {
-          exec: {
-            command: [...exec.command],
-            ...(exec.cwd !== undefined ? { cwd: exec.cwd } : {}),
-            ...(exec.passEnv !== undefined ? { passEnv: [...exec.passEnv] } : {}),
-            ...(exec.inheritEnv === true ? { inheritEnv: true as const } : {}),
-          },
-        }
-      : {}),
+    // Same projection the draft and the frozen plan use, so what `show` prints
+    // cannot drift from what runs.
+    ...(exec ? { exec: projectExecCore(exec) } : {}),
     ...(step.map
       ? {
           fanOut: {

--- a/src/workflows/resource-limits.ts
+++ b/src/workflows/resource-limits.ts
@@ -194,6 +194,18 @@ export function execContextLimits(platform: string = process.platform): ExecCont
  */
 export const WORKFLOW_UNIT_DIAGNOSTIC_CLIP = 2_000;
 
+/**
+ * Truncate to `max` chars with an ellipsis marker.
+ *
+ * Lives with the bounds rather than with either caller: the write side
+ * (`exec/step-work.ts`) and the read side (`runtime/runs.ts`) clip against the
+ * same constants, and `runtime/runs.ts` cannot take the helper from
+ * `exec/step-work.ts` — that module imports `runtime/runs.ts`.
+ */
+export function clip(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
 // ── Persistence bounds ───────────────────────────────────────────────────────
 
 /**

--- a/src/workflows/runtime/runs.ts
+++ b/src/workflows/runtime/runs.ts
@@ -627,6 +627,25 @@ function truncatedEvidenceValue(
 }
 
 /**
+ * True when `value` is the {@link TruncatedEvidenceValue} envelope persisted in
+ * place of an over-cap evidence entry.
+ *
+ * A LIVE invocation never sees one: the engine threads each step's complete
+ * in-memory evidence to the rest of its own run. A RESUMED invocation rebuilds
+ * the downstream scope from these rows, so `exec/step-work.ts` tests every
+ * whole-value reference with this predicate — otherwise a reference INTO the
+ * envelope reports a generic missing property and a reference AT it silently
+ * hands the envelope to a unit as if it were the artifact.
+ */
+export function isTruncatedEvidence(value: unknown): value is TruncatedEvidenceValue {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Record<string, unknown>)[WORKFLOW_EVIDENCE_TRUNCATED_MARKER] === true
+  );
+}
+
+/**
  * Bound what a step's evidence costs in ONE SQLite row.
  *
  * `buildEvidence` (exec/step-work.ts) promotes `evidence.output` UNCLIPPED by
@@ -637,13 +656,14 @@ function truncatedEvidenceValue(
  * megabytes. This is the write boundary, so the bound lives here rather than in
  * the shared step-semantics module.
  *
- * Over-cap values are REPLACED (largest top-level entry first, until the row
- * fits) with a {@link TruncatedEvidenceValue} envelope. Nothing is silently
- * shortened: a consumer either sees the real value or sees an object whose
- * marker key says the data is gone. `preview` is intentionally not shaped like
- * the original, so an expression reaching INTO a truncated artifact
- * (`steps.x.output.files`) fails loudly at resolution instead of quietly
- * resolving against a half-array.
+ * Over-cap values are REPLACED (largest top-level entry BY UTF-8 BYTES first —
+ * the unit the cap is measured in — until the row fits) with a
+ * {@link TruncatedEvidenceValue} envelope. Nothing is silently shortened: a
+ * consumer either sees the real value or sees an object whose marker key says
+ * the data is gone. `preview` is intentionally not shaped like the original, so
+ * an expression reaching INTO a truncated artifact (`steps.x.output.files`)
+ * cannot quietly resolve against a half-array; a resumed run's reference is
+ * rejected by name through {@link isTruncatedEvidence}.
  *
  * Returns the JSON to persist plus the keys that were replaced (empty in the
  * overwhelmingly common case, where nothing is copied or re-serialized twice).
@@ -662,9 +682,16 @@ export function clipStepEvidenceForPersistence(
 
   const clipped: Record<string, unknown> = { ...evidence };
   const truncatedKeys: string[] = [];
+  // Ordered by UTF-8 BYTES, the unit the cap itself is measured in: ordering by
+  // `json.length` (UTF-16 code units) sacrifices the char-largest key rather
+  // than the byte-largest one, so multibyte-heavy evidence loses extra keys the
+  // cap never required.
   const bySizeDesc = Object.keys(evidence)
-    .map((key) => ({ key, json: JSON.stringify(evidence[key]) ?? "null" }))
-    .sort((a, b) => b.json.length - a.json.length);
+    .map((key) => {
+      const json = JSON.stringify(evidence[key]) ?? "null";
+      return { key, json, bytes: utf8Bytes(json) };
+    })
+    .sort((a, b) => b.bytes - a.bytes);
   for (const entry of bySizeDesc) {
     clipped[entry.key] = truncatedEvidenceValue(entry.json, `Step evidence "${entry.key}"`, limitBytes, true);
     truncatedKeys.push(entry.key);
@@ -797,9 +824,11 @@ export async function completeWorkflowStep(
       const completedAt = new Date().toISOString();
       // Bound the single-row cost of the promoted artifact (issue C). The
       // caller's in-memory evidence object is never mutated — a clipped COPY is
-      // serialized — so the live step result, the gate's artifact judging, and
-      // this invocation's downstream `steps.<id>.output` scope all keep the
-      // complete value.
+      // serialized — so the live step result and the gate's artifact judging
+      // keep the complete value. The DOWNSTREAM scope keeps it only because the
+      // engine threads this same in-memory evidence forward (`driveRun` prefers
+      // it over the re-read row): what the clip actually costs is a LATER
+      // invocation, which has nothing but these rows to rebuild the scope from.
       const persistedEvidence = clipStepEvidenceForPersistence(input.evidence);
       if (persistedEvidence.truncatedKeys.length > 0) {
         warn(
@@ -807,7 +836,8 @@ export async function completeWorkflowStep(
             `${WORKFLOW_MAX_EVIDENCE_JSON_BYTES}-byte persistence cap; ` +
             `${persistedEvidence.truncatedKeys.map((k) => `"${k}"`).join(", ")} ` +
             `${persistedEvidence.truncatedKeys.length === 1 ? "was" : "were"} stored as a truncation marker. ` +
-            `Steps that reference this step's output on resume will fail loudly rather than read partial data.`,
+            `The rest of THIS invocation still reads the complete value, but a run resumed from these rows will ` +
+            `fail loudly when a later step references this step's output rather than read partial data.`,
         );
       }
       repo.updateStepCompletion({

--- a/src/workflows/runtime/runs.ts
+++ b/src/workflows/runtime/runs.ts
@@ -32,6 +32,7 @@ import { materializeWorkflowParameterFlags, validateWorkflowParams, type Workflo
 import { canonicalPlanJson, computePlanHash } from "../ir/plan-hash";
 import { decodeWorkflowPlanV3, type FrozenEngineSnapshot, type IrRuntimeKind, WORKFLOW_IR_VERSION } from "../ir/schema";
 import {
+  clip,
   utf8Bytes,
   WORKFLOW_EVIDENCE_TRUNCATION_PREVIEW_CHARS,
   WORKFLOW_MAX_EVIDENCE_JSON_BYTES,
@@ -166,8 +167,7 @@ function toUnitDiagnostic(
     } catch {
       /* leave the raw journaled text */
     }
-    diagnostic =
-      text.length > WORKFLOW_UNIT_DIAGNOSTIC_CLIP ? `${text.slice(0, WORKFLOW_UNIT_DIAGNOSTIC_CLIP)}…` : text;
+    diagnostic = clip(text, WORKFLOW_UNIT_DIAGNOSTIC_CLIP);
   }
   return {
     unitId: row.unit_id,
@@ -678,7 +678,8 @@ export function clipStepEvidenceForPersistence(
   // subtree of a value already proven serializable here.
   let json = JSON.stringify(evidence);
   if (json === undefined) return { json: null, truncatedKeys: [] };
-  if (utf8Bytes(json) <= limitBytes) return { json, truncatedKeys: [] };
+  let bytes = utf8Bytes(json);
+  if (bytes <= limitBytes) return { json, truncatedKeys: [] };
 
   const clipped: Record<string, unknown> = { ...evidence };
   const truncatedKeys: string[] = [];
@@ -692,11 +693,23 @@ export function clipStepEvidenceForPersistence(
       return { key, json, bytes: utf8Bytes(json) };
     })
     .sort((a, b) => b.bytes - a.bytes);
-  for (const entry of bySizeDesc) {
-    clipped[entry.key] = truncatedEvidenceValue(entry.json, `Step evidence "${entry.key}"`, limitBytes, true);
+  for (const [index, entry] of bySizeDesc.entries()) {
+    const envelope = truncatedEvidenceValue(entry.json, `Step evidence "${entry.key}"`, limitBytes, true);
+    clipped[entry.key] = envelope;
     truncatedKeys.push(entry.key);
+    // Track the row size arithmetically from the per-key sizes already computed
+    // for the sort, so a run of replacements costs ONE whole-object
+    // serialization rather than one per replaced key. The total is an ESTIMATE
+    // — a key whose value is `undefined` is charged the `"null"` the sort used
+    // but is OMITTED from the serialized row — so it decides only WHEN to
+    // measure. Whether the row FITS is settled by an exact serialization every
+    // time, the last key included, so an exhausted loop falls through to the
+    // whole-object marker on measurement rather than on drift.
+    bytes += utf8Bytes(JSON.stringify(envelope)) - entry.bytes;
+    if (bytes > limitBytes && index < bySizeDesc.length - 1) continue;
     json = JSON.stringify(clipped);
-    if (utf8Bytes(json) <= limitBytes) return { json, truncatedKeys };
+    bytes = utf8Bytes(json);
+    if (bytes <= limitBytes) return { json, truncatedKeys };
   }
   // Pathological shape (so many keys that even the envelopes overflow): persist
   // ONE whole-object marker. Still unambiguous, still bounded.

--- a/tests/_helpers/git.ts
+++ b/tests/_helpers/git.ts
@@ -26,15 +26,25 @@ export interface MakeGitRepoOptions {
   prefix?: string;
   /** Called with the new repo dir so the suite can schedule its removal. */
   register?: (dir: string) => void;
+  /**
+   * Init here instead of a fresh mkdtemp dir (created if absent). For a suite
+   * whose repo has to live at a path it already owns — an isolated storage
+   * sandbox it cleans up wholesale.
+   */
+  dir?: string;
 }
 
 /** Init a temp git repo with one committed file (`README.md`). */
 export function makeGitRepo(options: MakeGitRepoOptions = {}): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), options.prefix ?? "akm-git-repo-"));
+  const dir = options.dir ?? fs.mkdtempSync(path.join(os.tmpdir(), options.prefix ?? "akm-git-repo-"));
+  fs.mkdirSync(dir, { recursive: true });
   options.register?.(dir);
   git(dir, ["init", "-q"]);
   git(dir, ["config", "user.email", "test@akm.invalid"]);
   git(dir, ["config", "user.name", "akm-test"]);
+  // A developer or CI runner with `commit.gpgsign = true` in their own git
+  // config would otherwise fail every fixture commit here.
+  git(dir, ["config", "commit.gpgsign", "false"]);
   fs.writeFileSync(path.join(dir, "README.md"), "# fixture\n");
   git(dir, ["add", "README.md"]);
   git(dir, ["commit", "-q", "-m", "fixture"]);

--- a/tests/agent/agent-spawn.test.ts
+++ b/tests/agent/agent-spawn.test.ts
@@ -417,11 +417,14 @@ describe("runAgent — cooperative abort (RunAgentOptions.signal, P0.5)", () => 
       clearTimeoutFn,
     });
 
-    expect(timers.length).toBe(3);
-    // First timer is the main timeout. Fire it so the timeout branch schedules the SIGKILL grace timer.
+    // One timer at capture: the kill deadline. The two stream-drain deadlines
+    // are armed when the child exits or its budget expires, not up front, so a
+    // command whose leader exits early cannot wait out its whole budget.
+    expect(timers.length).toBe(1);
+    // That first timer is the main timeout. Fire it so the timeout branch schedules the SIGKILL grace timer.
     timers[0]?.cb();
-    expect(timers.length).toBe(4);
-    expect(timers[3]?.unrefCalled).toBe(true);
+    expect(timers.length).toBe(2);
+    expect(timers[1]?.unrefCalled).toBe(true);
 
     const result = await promise;
     expect(result.ok).toBe(false);

--- a/tests/agent/agent-spawn.test.ts
+++ b/tests/agent/agent-spawn.test.ts
@@ -458,10 +458,13 @@ describe("runAgent — cooperative abort (RunAgentOptions.signal, P0.5)", () => 
       signal: controller.signal,
     });
 
-    expect(timers.length).toBe(2);
+    // Counted as a DELTA: with no wall budget the drain deadlines are armed by
+    // the child's exit, so what is already scheduled here is not this test's
+    // subject — the ONE timer the abort adds is.
+    const before = timers.length;
     controller.abort();
-    expect(timers.length).toBe(3);
-    expect(timers[2]?.unrefCalled).toBe(true);
+    expect(timers.length).toBe(before + 1);
+    expect(timers[before]?.unrefCalled).toBe(true);
 
     const result = await promise;
     expect(result.ok).toBe(false);

--- a/tests/agent/spawn-path-supplement.test.ts
+++ b/tests/agent/spawn-path-supplement.test.ts
@@ -9,13 +9,14 @@
  *   • Empty PATH receives only candidates that exist.
  */
 
-import { describe, expect, test } from "bun:test";
-import { existsSync } from "node:fs";
+import { describe, expect, spyOn, test } from "bun:test";
+import fs, { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
 import {
   COMMON_SPAWN_ENV_PASSTHROUGH,
+  collectAllowlistedEnv,
   spawnEnvNamesFor,
   supplementPathForSchedulerContext,
 } from "../../src/core/spawn-env";
@@ -91,6 +92,26 @@ describe("supplementPathForSchedulerContext", () => {
     }
   });
 
+  test("the same PATH is probed once, not once per spawned child", () => {
+    // Every allowlisted child-env build calls this. A fan-out of 10 000 exec
+    // units must not mean 10 000 rounds of synchronous stat probes on the event
+    // loop the run's lease heartbeat shares.
+    const stripped = `/opt/akm-memo-probe-${process.pid}:/usr/bin`;
+    const probes = spyOn(fs, "existsSync");
+    try {
+      const first = supplementPathForSchedulerContext(stripped);
+      const afterFirst = probes.mock.calls.length;
+      expect(afterFirst).toBeGreaterThan(0);
+
+      for (let i = 0; i < 50; i++) {
+        expect(supplementPathForSchedulerContext(stripped)).toBe(first);
+      }
+      expect(probes.mock.calls.length).toBe(afterFirst);
+    } finally {
+      probes.mockRestore();
+    }
+  });
+
   test("a sibling dir that merely string-prefixes home does not read as interactive", () => {
     // `/home/al` must not be satisfied by `/home/alice/...`: the home check is
     // a path-boundary comparison, so this PATH is as stripped as one naming no
@@ -129,10 +150,25 @@ describe("spawnEnvNamesFor", () => {
     }
   });
 
-  test("does not re-add a floor name the caller already spells, in any case", () => {
+  test("does not re-add a floor name the caller already spells exactly", () => {
+    const names = spawnEnvNamesFor(["PATH", "SystemRoot"], "win32");
+    expect(names.filter((name) => name === "SystemRoot")).toEqual(["SystemRoot"]);
+  });
+
+  test("REGRESSION: a caller's non-canonical spelling does not suppress the canonical floor name", () => {
+    // Dropping `SystemRoot` because the caller happened to write `SYSTEMROOT`
+    // would silence exactly the process-creation failure the floor exists to
+    // prevent — the surviving name is looked up with EXACT case against a
+    // source that need not case-fold (the agent spawn's plain-object
+    // `envSource`), so a folded dedupe loses the variable entirely.
     const names = spawnEnvNamesFor(["PATH", "SYSTEMROOT"], "win32");
-    const systemRootSpellings = names.filter((name) => name.toUpperCase() === "SYSTEMROOT");
-    expect(systemRootSpellings).toEqual(["SYSTEMROOT"]);
+    expect(names).toContain("SystemRoot");
+    expect(names).toContain("SYSTEMROOT");
+
+    // Why the canonical spelling has to survive: this is the lookup.
+    const source = { SystemRoot: "C:\\Windows" };
+    expect(collectAllowlistedEnv(["SYSTEMROOT"], source).SYSTEMROOT).toBeUndefined();
+    expect(collectAllowlistedEnv(["SystemRoot"], source).SystemRoot).toBe("C:\\Windows");
   });
 
   test("leaves config and install roots to the caller", () => {

--- a/tests/agent/spawn-path-supplement.test.ts
+++ b/tests/agent/spawn-path-supplement.test.ts
@@ -14,7 +14,11 @@ import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { supplementPathForSchedulerContext } from "../../src/core/spawn-env";
+import {
+  COMMON_SPAWN_ENV_PASSTHROUGH,
+  spawnEnvNamesFor,
+  supplementPathForSchedulerContext,
+} from "../../src/core/spawn-env";
 
 const home = os.homedir();
 
@@ -85,5 +89,56 @@ describe("supplementPathForSchedulerContext", () => {
     for (const seg of segments) {
       expect(existsSync(seg)).toBe(true);
     }
+  });
+
+  test("a sibling dir that merely string-prefixes home does not read as interactive", () => {
+    // `/home/al` must not be satisfied by `/home/alice/...`: the home check is
+    // a path-boundary comparison, so this PATH is as stripped as one naming no
+    // home at all and must be supplemented identically.
+    const stripped = ["/usr/bin", "/bin"].join(path.delimiter);
+    const sibling = [`${home}kit`, "/usr/bin", "/bin"].join(path.delimiter);
+    const prefixOf = (result: string, original: string): string => result.slice(0, result.length - original.length);
+
+    const supplementedResult = supplementPathForSchedulerContext(stripped);
+    const siblingResult = supplementPathForSchedulerContext(sibling);
+
+    expect(siblingResult.endsWith(sibling)).toBe(true);
+    expect(prefixOf(siblingResult, sibling)).toBe(prefixOf(supplementedResult, stripped));
+    // Non-vacuous wherever any candidate dir exists: the sibling PATH gets the
+    // same repair the stripped one does, rather than being skipped.
+    expect(siblingResult === sibling).toBe(supplementedResult === stripped);
+  });
+});
+
+describe("spawnEnvNamesFor", () => {
+  test("passes the caller's allowlist through unchanged off win32", () => {
+    expect(spawnEnvNamesFor(["PATH", "HOME"], "linux")).toEqual(["PATH", "HOME"]);
+    expect(spawnEnvNamesFor(["PATH", "HOME"], "darwin")).toEqual(["PATH", "HOME"]);
+  });
+
+  test("adds the win32 process-creation floor to any allowlist", () => {
+    // The agent-CLI baseline carries none of these, yet a Windows child cannot
+    // be created (SystemRoot) or resolve its command (PATHEXT) without them.
+    const names = spawnEnvNamesFor(COMMON_SPAWN_ENV_PASSTHROUGH, "win32");
+    for (const required of ["SystemRoot", "SystemDrive", "WINDIR", "COMSPEC", "PATHEXT"]) {
+      expect(names).toContain(required);
+    }
+    // The caller's own names survive.
+    for (const name of COMMON_SPAWN_ENV_PASSTHROUGH) {
+      expect(names).toContain(name);
+    }
+  });
+
+  test("does not re-add a floor name the caller already spells, in any case", () => {
+    const names = spawnEnvNamesFor(["PATH", "SYSTEMROOT"], "win32");
+    const systemRootSpellings = names.filter((name) => name.toUpperCase() === "SYSTEMROOT");
+    expect(systemRootSpellings).toEqual(["SYSTEMROOT"]);
+  });
+
+  test("leaves config and install roots to the caller", () => {
+    // Deliberately not a floor: a child is creatable without them.
+    const names = spawnEnvNamesFor(["PATH"], "win32");
+    expect(names).not.toContain("APPDATA");
+    expect(names).not.toContain("ProgramFiles");
   });
 });

--- a/tests/architecture/agent-spawn-seam.test.ts
+++ b/tests/architecture/agent-spawn-seam.test.ts
@@ -216,8 +216,9 @@ describe("`runAgent` seam (v1 spec §9.7, §12.2)", () => {
       setTimeoutFn,
       clearTimeoutFn,
     });
-    // Drive the timer synchronously.
-    expect(fakeTimers.length).toBe(3);
+    // Drive the timer synchronously. Only the kill deadline exists at capture —
+    // the stream-drain deadlines are armed off the child's exit or its budget.
+    expect(fakeTimers.length).toBe(1);
     fakeTimers.find((t) => t.ms === 10)?.cb();
     const result = await promise;
     expect(result.ok).toBe(false);

--- a/tests/core/append-event-db-handle.test.ts
+++ b/tests/core/append-event-db-handle.test.ts
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `appendEvent`'s best-effort contract, for the caller that brings its own
+ * connection (`ctx.db` — the `akmImprove` shape).
+ *
+ * Two properties are pinned here, both invisible to the callers that let
+ * `appendEvent` open state.db for them:
+ *   • `dbPath` is IGNORED when `db` is provided — resolution never runs, so an
+ *     environment that cannot name a data dir is not an error for a caller
+ *     already holding an open handle.
+ *   • the event still lands on that handle.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { appendEvent } from "../../src/core/events";
+import { openStateDatabase } from "../../src/core/state-db";
+import { withEnvSync, withIsolatedAkmStorage } from "../_helpers/sandbox";
+
+describe("appendEvent with a caller-supplied connection", () => {
+  test("writes without resolving the data dir", () => {
+    const storage = withIsolatedAkmStorage();
+    try {
+      const db = openStateDatabase();
+      try {
+        // Both data-dir env vars unset: any resolution attempt throws the
+        // bun-test isolation guard, which `appendEvent` deliberately rethrows
+        // even from inside its catch. Reaching the handle is the only way
+        // through.
+        withEnvSync({ AKM_DATA_DIR: undefined, XDG_DATA_HOME: undefined }, () => {
+          appendEvent({ eventType: "add", ref: "memories/alpha" }, { db });
+        });
+
+        const rows = db.prepare("SELECT event_type, ref FROM events").all() as Array<{
+          event_type: string;
+          ref: string | null;
+        }>;
+        expect(rows).toEqual([{ event_type: "add", ref: "memories/alpha" }]);
+      } finally {
+        db.close();
+      }
+    } finally {
+      storage.cleanup();
+    }
+  });
+});

--- a/tests/core/subprocess.test.ts
+++ b/tests/core/subprocess.test.ts
@@ -15,8 +15,9 @@
  *     `proc.kill()` directly (the negative-pid `process.kill` path is skipped).
  *   • Abort: aborting mid-run runs the same ladder and flags `aborted`.
  *   • Synchronous spawn failure surfaces as `spawnError`, never a throw.
- *   • Drain deadlines: WHEN the stream-drain timeout is armed — with capture
- *     for a bounded run, only on the child's exit for an unbounded one.
+ *   • Drain deadlines: WHEN the stream-drain timeout is armed — never while a
+ *     live command still owns the pipe, so on the child's exit, or for a
+ *     bounded run the earlier of that and the wall budget.
  */
 import { describe, expect, test } from "bun:test";
 import { runManagedSubprocess, type SpawnedSubprocess, type SpawnFn } from "../../src/core/subprocess";
@@ -243,6 +244,8 @@ describe("runManagedSubprocess — abort", () => {
 
 describe("runManagedSubprocess — when the stream-drain deadline is armed", () => {
   const SAFETY_MS = 60 * 60 * 1000;
+  /** The post-exit grace a bounded run's pipes get once nothing owns them. */
+  const GRACE_MS = 2_000;
 
   test("a null timeout schedules NOTHING against a still-running child", async () => {
     const { timers, setTimeoutFn, clearTimeoutFn } = fakeTimers();
@@ -307,7 +310,7 @@ describe("runManagedSubprocess — when the stream-drain deadline is armed", () 
     expect(result.stdout).toBe("prefix");
   });
 
-  test("a bounded run still arms both drain deadlines with capture (budget + 2 s)", async () => {
+  test("a bounded run arms its drain deadline when the CHILD EXITS, not at capture", async () => {
     const { timers, setTimeoutFn, clearTimeoutFn } = fakeTimers();
     const child = controllableSpawn();
 
@@ -319,19 +322,60 @@ describe("runManagedSubprocess — when the stream-drain deadline is armed", () 
       clearTimeoutFn,
     });
 
+    child.writeStdout("prefix");
     await tick();
-    // The kill timer at the budget, plus one drain deadline per pipe: a bounded
-    // child is killed at its budget anyway, so a drain outliving budget + 2 s is
-    // a pipe nobody owns.
+    // The kill timer at the budget and nothing else: while the command runs,
+    // its pipes are a live process's.
     expect(timers.filter((timer) => timer.ms === 30_000)).toHaveLength(1);
-    expect(timers.filter((timer) => timer.ms === 32_000)).toHaveLength(2);
+    expect(timers.filter((timer) => timer.ms === GRACE_MS)).toHaveLength(0);
     expect(timers.some((timer) => timer.ms === SAFETY_MS)).toBe(false);
 
-    child.writeStdout("ok");
-    child.closeStdout();
+    // The leader exits 0 in milliseconds but stdout stays open — a background
+    // descendant holds the fd. The deadline is armed HERE, so the run cannot
+    // stall for a 30 s budget it never came close to spending.
     child.exit(0);
+    await tick();
+    const drain = timers.filter((timer) => timer.ms === GRACE_MS);
+    expect(drain).toHaveLength(1); // stderr drained before the exit; a finished drain arms nothing.
+    drain[0]?.cb();
+
     const result = await promise;
-    expect(result.stdout).toBe("ok");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdoutRead.timedOut).toBe(true);
+    expect(result.stdout).toBe("prefix");
+  });
+
+  test("a bounded child that outlives its kill ladder still has its drain cut at budget + grace", async () => {
+    const { timers, setTimeoutFn, clearTimeoutFn } = fakeTimers();
+    const child = controllableSpawn();
+
+    const promise = runManagedSubprocess(["wedged"], {
+      capture: true,
+      timeoutMs: 30_000,
+      spawnFn: child.spawn,
+      setTimeoutFn,
+      clearTimeoutFn,
+    });
+
+    child.writeStdout("prefix");
+    await tick();
+    expect(timers.filter((timer) => timer.ms === GRACE_MS)).toHaveLength(0);
+
+    // The budget expires with the child still running (this fake ignores its
+    // signals). Waiting on an exit that may never come would leave the drain
+    // unarmed forever, so the budget arms it too — landing on the same absolute
+    // moment this path always had: budget + grace.
+    timers.find((timer) => timer.ms === 30_000)?.cb();
+    await tick();
+    const drain = timers.filter((timer) => timer.ms === GRACE_MS);
+    expect(drain).toHaveLength(1);
+    drain[0]?.cb();
+
+    child.exit(137);
+    const result = await promise;
+    expect(result.timedOut).toBe(true);
+    expect(result.stdoutRead.timedOut).toBe(true);
+    expect(result.stdout).toBe("prefix");
   });
 });
 

--- a/tests/core/subprocess.test.ts
+++ b/tests/core/subprocess.test.ts
@@ -15,6 +15,8 @@
  *     `proc.kill()` directly (the negative-pid `process.kill` path is skipped).
  *   • Abort: aborting mid-run runs the same ladder and flags `aborted`.
  *   • Synchronous spawn failure surfaces as `spawnError`, never a throw.
+ *   • Drain deadlines: WHEN the stream-drain timeout is armed — with capture
+ *     for a bounded run, only on the child's exit for an unbounded one.
  */
 import { describe, expect, test } from "bun:test";
 import { runManagedSubprocess, type SpawnedSubprocess, type SpawnFn } from "../../src/core/subprocess";
@@ -87,6 +89,50 @@ function killTrackingSpawn(config: { pid?: number; ignoreSigterm?: boolean; exit
     return proc;
   };
   return { spawn, signals };
+}
+
+/**
+ * A fake child whose stdout the test writes by hand and whose exit it resolves
+ * by hand — the two things a drain-deadline test has to drive. stderr is a
+ * closed empty pipe, so it drains immediately.
+ */
+function controllableSpawn(): {
+  spawn: SpawnFn;
+  writeStdout: (text: string) => void;
+  closeStdout: () => void;
+  exit: (code: number) => void;
+} {
+  let stdoutController!: ReadableStreamDefaultController<Uint8Array>;
+  let resolveExit!: (code: number) => void;
+  const exited = new Promise<number>((resolve) => {
+    resolveExit = resolve;
+  });
+  const proc: SpawnedSubprocess = {
+    exitCode: null,
+    exited,
+    stdout: new ReadableStream<Uint8Array>({
+      start(controller) {
+        stdoutController = controller;
+      },
+    }),
+    stderr: asReadableStream(""),
+    stdin: null,
+    kill() {},
+  };
+  return {
+    spawn: () => proc,
+    writeStdout: (text) => stdoutController.enqueue(new TextEncoder().encode(text)),
+    closeStdout: () => stdoutController.close(),
+    exit: (code) => {
+      proc.exitCode = code;
+      resolveExit(code);
+    },
+  };
+}
+
+/** Flush pending microtasks (fake timers never fire on their own). */
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 5));
 }
 
 describe("runManagedSubprocess — timeout escalation (SIGKILL ladder)", () => {
@@ -195,31 +241,101 @@ describe("runManagedSubprocess — abort", () => {
   });
 });
 
-describe("runManagedSubprocess — capture and failure surfacing", () => {
-  test("does not impose a short stream deadline when the process timeout is disabled", async () => {
-    const { timers, setTimeoutFn, clearTimeoutFn } = fakeTimers();
-    const spawn: SpawnFn = () => ({
-      exitCode: 0,
-      exited: Promise.resolve(0),
-      stdout: asReadableStream("out\n"),
-      stderr: asReadableStream(""),
-      stdin: null,
-      kill() {},
-    });
+describe("runManagedSubprocess — when the stream-drain deadline is armed", () => {
+  const SAFETY_MS = 60 * 60 * 1000;
 
-    const result = await runManagedSubprocess(["echo"], {
+  test("a null timeout schedules NOTHING against a still-running child", async () => {
+    const { timers, setTimeoutFn, clearTimeoutFn } = fakeTimers();
+    const child = controllableSpawn();
+
+    const promise = runManagedSubprocess(["long-job"], {
       capture: true,
       timeoutMs: null,
-      spawnFn: spawn,
+      spawnFn: child.spawn,
       setTimeoutFn,
       clearTimeoutFn,
     });
 
+    child.writeStdout("before\n");
+    await tick();
+    // No kill timer (the caller asked for no budget) and no drain deadline: an
+    // unbounded run must have no timer that could cancel a live child's reader,
+    // which is the slot the old arm-at-capture safety bound occupied.
+    expect(timers).toHaveLength(0);
+
+    // So output written arbitrarily far past that old deadline still lands, and
+    // the exit-0 verdict stands on the WHOLE artifact.
+    child.writeStdout("after\n");
+    child.closeStdout();
+    child.exit(0);
+
+    const result = await promise;
     expect(result.exitCode).toBe(0);
-    expect(timers.filter((timer) => timer.ms === 60 * 60 * 1000)).toHaveLength(2);
-    expect(timers.some((timer) => timer.ms === 30_000)).toBe(false);
+    expect(result.stdout).toBe("before\nafter\n");
+    expect(result.stdoutRead.timedOut).toBe(false);
   });
 
+  test("the safety bound is armed by the child's EXIT, so a descendant cannot hold the drain open forever", async () => {
+    const { timers, setTimeoutFn, clearTimeoutFn } = fakeTimers();
+    const child = controllableSpawn();
+
+    const promise = runManagedSubprocess(["leader"], {
+      capture: true,
+      timeoutMs: null,
+      spawnFn: child.spawn,
+      setTimeoutFn,
+      clearTimeoutFn,
+    });
+
+    child.writeStdout("prefix");
+    await tick();
+    expect(timers).toHaveLength(0);
+
+    // The leader exits 0 but stdout stays open — a background descendant still
+    // holds the fd. THAT is what the safety bound exists to cut.
+    child.exit(0);
+    await tick();
+    // One, not two: stderr drained before the exit, and a finished drain arms
+    // no timer at all.
+    const safety = timers.filter((timer) => timer.ms === SAFETY_MS);
+    expect(safety).toHaveLength(1);
+    safety[0]?.cb();
+
+    const result = await promise;
+    expect(result.exitCode).toBe(0);
+    expect(result.stdoutRead.timedOut).toBe(true);
+    expect(result.stdout).toBe("prefix");
+  });
+
+  test("a bounded run still arms both drain deadlines with capture (budget + 2 s)", async () => {
+    const { timers, setTimeoutFn, clearTimeoutFn } = fakeTimers();
+    const child = controllableSpawn();
+
+    const promise = runManagedSubprocess(["job"], {
+      capture: true,
+      timeoutMs: 30_000,
+      spawnFn: child.spawn,
+      setTimeoutFn,
+      clearTimeoutFn,
+    });
+
+    await tick();
+    // The kill timer at the budget, plus one drain deadline per pipe: a bounded
+    // child is killed at its budget anyway, so a drain outliving budget + 2 s is
+    // a pipe nobody owns.
+    expect(timers.filter((timer) => timer.ms === 30_000)).toHaveLength(1);
+    expect(timers.filter((timer) => timer.ms === 32_000)).toHaveLength(2);
+    expect(timers.some((timer) => timer.ms === SAFETY_MS)).toBe(false);
+
+    child.writeStdout("ok");
+    child.closeStdout();
+    child.exit(0);
+    const result = await promise;
+    expect(result.stdout).toBe("ok");
+  });
+});
+
+describe("runManagedSubprocess — capture and failure surfacing", () => {
   test("captures stdout/stderr on a clean exit", async () => {
     const spawn: SpawnFn = () => ({
       exitCode: 0,

--- a/tests/integration/common.test.ts
+++ b/tests/integration/common.test.ts
@@ -243,6 +243,16 @@ describe("isWithin", () => {
   test("returns false for sibling directory with similar prefix", () => {
     expect(isWithin("/root-other/file.txt", "/root")).toBe(false);
   });
+
+  test("returns true for a contained directory whose NAME begins with two dots", () => {
+    // `..data` is a legal directory name; only a leading `..` SEGMENT escapes.
+    expect(isWithin("/root/..data/file.txt", "/root")).toBe(true);
+    expect(isWithin("/root/...v2", "/root")).toBe(true);
+  });
+
+  test("still returns false when a real traversal lands on a dot-prefixed name", () => {
+    expect(isWithin("/root/../..data", "/root")).toBe(false);
+  });
 });
 
 // ── readBodyWithByteCap / jsonWithByteCap ────────────────────────────────────

--- a/tests/integration/lint-advisory-channel.test.ts
+++ b/tests/integration/lint-advisory-channel.test.ts
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * The lint advisory channel and the workflow frontend pass behind it.
+ *
+ * Two properties, both about routing a NON-FATAL finding correctly:
+ *   • `ADVISORY_LINT_ISSUES` is the single home for "never `flagged`", so the
+ *     adapter path and the sweep cannot disagree about a code and let a
+ *     non-fatal hint fail `--fail-on-flagged` (exit 1) on one path only.
+ *   • `workflowStructureDiagnostics` / `workflowCompileWarnings` are two views
+ *     of ONE parse+compile, so asking for both must not re-run the frontend —
+ *     and must never serve an answer computed for different bytes.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ADVISORY_LINT_ISSUES, isAdvisoryLintIssue } from "../../src/commands/lint/types";
+import { workflowCompileWarnings, workflowStructureDiagnostics } from "../../src/core/adapter/adapters/akm-lint";
+import { workflowDoc } from "../_helpers/workflow";
+
+const REL = "workflows/advisory.md";
+const PARSE_PATH = "/stash/workflows/advisory.md";
+
+/** Compiles cleanly, but the step declares no `output:` schema — one advisory. */
+const WARNS = workflowDoc([]);
+/** Fails the schema-definition check — errors, and therefore no advisories. */
+const ERRORS = workflowDoc(["    output:", "      type: strig"]);
+
+describe("advisory issue classification", () => {
+  test("workflow-warning is advisory and ordinary findings are not", () => {
+    expect(isAdvisoryLintIssue({ issue: "workflow-warning" })).toBe(true);
+    for (const issue of ["invalid-workflow-structure", "placeholder-stub", "adapter-diagnostic", "broken-xref"]) {
+      expect(isAdvisoryLintIssue({ issue })).toBe(false);
+    }
+  });
+
+  test("every advisory code the frontend emits is registered", () => {
+    const emitted = workflowCompileWarnings(REL, WARNS, PARSE_PATH);
+    expect(emitted.length).toBeGreaterThan(0);
+    for (const diagnostic of emitted) {
+      expect(ADVISORY_LINT_ISSUES.has(diagnostic.issue)).toBe(true);
+    }
+  });
+});
+
+describe("workflow frontend pass", () => {
+  test("both views agree, and a compile warning never rides the error channel", () => {
+    expect(workflowStructureDiagnostics(REL, WARNS, PARSE_PATH)).toEqual([]);
+    expect(workflowCompileWarnings(REL, WARNS, PARSE_PATH).map((d) => d.issue)).toEqual(["workflow-warning"]);
+  });
+
+  test("a document that fails to compile reports errors and no advisories", () => {
+    expect(workflowStructureDiagnostics(REL, ERRORS, PARSE_PATH).length).toBeGreaterThan(0);
+    expect(workflowCompileWarnings(REL, ERRORS, PARSE_PATH)).toEqual([]);
+  });
+
+  test("changed bytes are never served a previous file's answer", () => {
+    // Same relPath and parsePath, different content, interleaved — the shape a
+    // `--fix` rewrite produces. Each answer must describe the bytes passed in.
+    expect(workflowCompileWarnings(REL, WARNS, PARSE_PATH).length).toBe(1);
+    expect(workflowCompileWarnings(REL, ERRORS, PARSE_PATH).length).toBe(0);
+    expect(workflowStructureDiagnostics(REL, ERRORS, PARSE_PATH).length).toBeGreaterThan(0);
+    expect(workflowStructureDiagnostics(REL, WARNS, PARSE_PATH)).toEqual([]);
+    expect(workflowCompileWarnings(REL, WARNS, PARSE_PATH).length).toBe(1);
+  });
+});

--- a/tests/integration/lint-advisory-channel.test.ts
+++ b/tests/integration/lint-advisory-channel.test.ts
@@ -5,18 +5,26 @@
 /**
  * The lint advisory channel and the workflow frontend pass behind it.
  *
- * Two properties, both about routing a NON-FATAL finding correctly:
- *   • `ADVISORY_LINT_ISSUES` is the single home for "never `flagged`", so the
- *     adapter path and the sweep cannot disagree about a code and let a
- *     non-fatal hint fail `--fail-on-flagged` (exit 1) on one path only.
- *   • `workflowStructureDiagnostics` / `workflowCompileWarnings` are two views
- *     of ONE parse+compile, so asking for both must not re-run the frontend —
- *     and must never serve an answer computed for different bytes.
+ * Three properties, all about routing a NON-FATAL finding correctly:
+ *   • `ADVISORY_LINT_ISSUES` is the single home for "never `flagged`", so no
+ *     two routing points can disagree about a code and let a non-fatal hint
+ *     fail `--fail-on-flagged` (exit 1) on one path only.
+ *   • `workflowFrontendDiagnostics` is ONE parse+compile carrying both halves,
+ *     so the sweep runs the frontend exactly once per workflow file — the
+ *     property a pair of single-view helpers could only hold by accident, when
+ *     their two call sites happened to sit next to each other.
+ *   • the sweep files each finding by the classifier, never by which half of
+ *     the pass produced it.
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { akmLint } from "../../src/commands/lint/index";
 import { ADVISORY_LINT_ISSUES, isAdvisoryLintIssue } from "../../src/commands/lint/types";
-import { workflowCompileWarnings, workflowStructureDiagnostics } from "../../src/core/adapter/adapters/akm-lint";
+import { workflowFrontendDiagnostics, workflowStructureDiagnostics } from "../../src/core/adapter/adapters/akm-lint";
+import * as workflowParser from "../../src/workflows/parser";
+import { makeSandboxDir } from "../_helpers/sandbox";
 import { workflowDoc } from "../_helpers/workflow";
 
 const REL = "workflows/advisory.md";
@@ -27,6 +35,24 @@ const WARNS = workflowDoc([]);
 /** Fails the schema-definition check — errors, and therefore no advisories. */
 const ERRORS = workflowDoc(["    output:", "      type: strig"]);
 
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0)) cleanup();
+});
+
+/** A temp stash holding `files` under `workflows/`. */
+function makeWorkflowStash(files: Record<string, string>): string {
+  const { dir, cleanup } = makeSandboxDir("akm-lint-advisory");
+  cleanups.push(cleanup);
+  const workflowsDir = path.join(dir, "workflows");
+  fs.mkdirSync(workflowsDir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(workflowsDir, name), content, "utf8");
+  }
+  return dir;
+}
+
 describe("advisory issue classification", () => {
   test("workflow-warning is advisory and ordinary findings are not", () => {
     expect(isAdvisoryLintIssue({ issue: "workflow-warning" })).toBe(true);
@@ -36,7 +62,7 @@ describe("advisory issue classification", () => {
   });
 
   test("every advisory code the frontend emits is registered", () => {
-    const emitted = workflowCompileWarnings(REL, WARNS, PARSE_PATH);
+    const emitted = workflowFrontendDiagnostics(REL, WARNS, PARSE_PATH).warnings;
     expect(emitted.length).toBeGreaterThan(0);
     for (const diagnostic of emitted) {
       expect(ADVISORY_LINT_ISSUES.has(diagnostic.issue)).toBe(true);
@@ -45,23 +71,68 @@ describe("advisory issue classification", () => {
 });
 
 describe("workflow frontend pass", () => {
-  test("both views agree, and a compile warning never rides the error channel", () => {
-    expect(workflowStructureDiagnostics(REL, WARNS, PARSE_PATH)).toEqual([]);
-    expect(workflowCompileWarnings(REL, WARNS, PARSE_PATH).map((d) => d.issue)).toEqual(["workflow-warning"]);
+  test("one pass carries both halves, and a compile warning never rides the error channel", () => {
+    const pass = workflowFrontendDiagnostics(REL, WARNS, PARSE_PATH);
+    expect(pass.errors).toEqual([]);
+    expect(pass.warnings.map((d) => d.issue)).toEqual(["workflow-warning"]);
   });
 
   test("a document that fails to compile reports errors and no advisories", () => {
-    expect(workflowStructureDiagnostics(REL, ERRORS, PARSE_PATH).length).toBeGreaterThan(0);
-    expect(workflowCompileWarnings(REL, ERRORS, PARSE_PATH)).toEqual([]);
+    const pass = workflowFrontendDiagnostics(REL, ERRORS, PARSE_PATH);
+    expect(pass.errors.length).toBeGreaterThan(0);
+    expect(pass.warnings).toEqual([]);
   });
 
-  test("changed bytes are never served a previous file's answer", () => {
-    // Same relPath and parsePath, different content, interleaved — the shape a
-    // `--fix` rewrite produces. Each answer must describe the bytes passed in.
-    expect(workflowCompileWarnings(REL, WARNS, PARSE_PATH).length).toBe(1);
-    expect(workflowCompileWarnings(REL, ERRORS, PARSE_PATH).length).toBe(0);
-    expect(workflowStructureDiagnostics(REL, ERRORS, PARSE_PATH).length).toBeGreaterThan(0);
+  test("workflowStructureDiagnostics is the error half of the same pass", () => {
+    expect(workflowStructureDiagnostics(REL, ERRORS, PARSE_PATH)).toEqual(
+      workflowFrontendDiagnostics(REL, ERRORS, PARSE_PATH).errors,
+    );
     expect(workflowStructureDiagnostics(REL, WARNS, PARSE_PATH)).toEqual([]);
-    expect(workflowCompileWarnings(REL, WARNS, PARSE_PATH).length).toBe(1);
+  });
+
+  test("each call answers for the arguments it was given", () => {
+    // Two files whose findings must not be confused with each other, then the
+    // same paths re-asked with different bytes (the shape a `--fix` rewrite
+    // produces) — no answer may outlive the call it was computed for.
+    expect(workflowFrontendDiagnostics("workflows/a.md", WARNS, "/stash/workflows/a.md").warnings[0]?.file).toBe(
+      "workflows/a.md",
+    );
+    expect(workflowFrontendDiagnostics("workflows/a b.md", WARNS, "/stash/c.md").warnings[0]?.file).toBe(
+      "workflows/a b.md",
+    );
+    expect(workflowFrontendDiagnostics(REL, ERRORS, PARSE_PATH).warnings).toEqual([]);
+    expect(workflowFrontendDiagnostics(REL, WARNS, PARSE_PATH).warnings).toHaveLength(1);
+  });
+});
+
+describe("akm lint sweep routing", () => {
+  test("the workflow frontend runs exactly once per workflow file", async () => {
+    const stashDir = makeWorkflowStash({
+      "clean.md": WARNS,
+      "broken.md": ERRORS,
+      "also-clean.md": workflowDoc(["    output: { type: string }"]),
+    });
+    const parseSpy = spyOn(workflowParser, "parseWorkflow");
+
+    await akmLint({ dir: stashDir, typeFilter: "workflows" });
+
+    expect(parseSpy.mock.calls).toHaveLength(3);
+    parseSpy.mockRestore();
+  });
+
+  test("every finding lands in the channel the classifier names", async () => {
+    const stashDir = makeWorkflowStash({ "clean.md": WARNS, "broken.md": ERRORS });
+
+    const result = await akmLint({ dir: stashDir, typeFilter: "workflows" });
+
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.flagged.length).toBeGreaterThan(0);
+    for (const issue of result.warnings) expect(isAdvisoryLintIssue(issue)).toBe(true);
+    for (const issue of result.flagged) expect(isAdvisoryLintIssue(issue)).toBe(false);
+    expect(result.summary).toEqual({
+      fixed: 0,
+      flagged: result.flagged.length,
+      warnings: result.warnings.length,
+    });
   });
 });

--- a/tests/integration/tasks-runner.test.ts
+++ b/tests/integration/tasks-runner.test.ts
@@ -346,6 +346,26 @@ describe("runTask — workflow target", () => {
     };
   }
 
+  /**
+   * An orchestrator stopped by a verification gate whose deadline ALSO fired,
+   * so two of the runner's three failure channels are live in one attempt.
+   */
+  function gateRejectedRunner(captured: CapturedRunOptions[]) {
+    return async (options: CapturedRunOptions) => {
+      captured.push(options);
+      await new Promise<void>((resolve) => {
+        if (options.signal?.aborted) return resolve();
+        options.signal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      return {
+        run: runSummary("run-gated", options.target, "active"),
+        executed: [],
+        stepsProcessed: 1,
+        gateRejection: { stepId: "verify", missing: ["evidence"], feedback: "no evidence for the claim" },
+      };
+    };
+  }
+
   /** An orchestrator that completes immediately, so only the wiring is observed. */
   function instantWorkflowRunner(captured: CapturedRunOptions[]) {
     return async (options: CapturedRunOptions) => {
@@ -416,6 +436,39 @@ describe("runTask — workflow target", () => {
     const log = fs.readFileSync(result.log, "utf8");
     expect(log).not.toContain("timed_out=true");
     expect(log).toContain("run_id=run-finished status=completed");
+  });
+
+  test("a gate rejection outranks the deadline in the status, the log and the history row alike", async () => {
+    writeTask(
+      "wf-gated",
+      ["version: 2", 'schedule: "@daily"', "workflow: workflows/noop", "timeoutMs: 100", ""].join("\n"),
+    );
+    const { timers, setTimeoutFn, clearTimeoutFn } = collectTimers();
+    const captured: CapturedRunOptions[] = [];
+
+    const promise = runTask("wf-gated", {
+      stashDir,
+      logDir,
+      runWorkflowStepsImpl: gateRejectedRunner(captured) as never,
+      setTimeoutFn,
+      clearTimeoutFn,
+    });
+    await fireWhenRegistered(timers, 100);
+    const result = await promise;
+
+    // Two failure channels are live at once (gate rejection + fired deadline).
+    // Whichever one wins must win everywhere: a log naming one cause beside a
+    // history row naming the other is unreadable after the fact.
+    expect(captured[0]!.signal?.aborted).toBe(true);
+    expect(result.status).toBe("failed");
+    const gateMessage = 'Verification rejected step "verify": no evidence for the claim';
+    expect(result.detail?.error).toBe(gateMessage);
+    const log = fs.readFileSync(result.log, "utf8");
+    expect(log).toContain(`error=${gateMessage}`);
+    expect(log).not.toContain("timed out after");
+    // The deadline is still recorded as a fact about the attempt.
+    expect(log).toContain("timed_out=true timeout_ms=100");
+    expect(readTaskHistory({ id: "wf-gated" })[0]?.detail?.error).toBe(gateMessage);
   });
 
   test("an explicit timeout overrides the unattended default", async () => {

--- a/tests/integration/tasks-runner.test.ts
+++ b/tests/integration/tasks-runner.test.ts
@@ -325,6 +325,27 @@ describe("runTask — workflow target", () => {
     };
   }
 
+  /**
+   * An orchestrator whose run COMPLETES even though the deadline fired — the
+   * narrow window where the timer lands during the run's final bookkeeping,
+   * after the last step boundary the abort could have stopped it at.
+   */
+  function completesDespiteAbortRunner(captured: CapturedRunOptions[]) {
+    return async (options: CapturedRunOptions) => {
+      captured.push(options);
+      await new Promise<void>((resolve) => {
+        if (options.signal?.aborted) return resolve();
+        options.signal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      return {
+        run: runSummary("run-finished", options.target, "completed"),
+        executed: [],
+        stepsProcessed: 1,
+        done: true,
+      };
+    };
+  }
+
   /** An orchestrator that completes immediately, so only the wiring is observed. */
   function instantWorkflowRunner(captured: CapturedRunOptions[]) {
     return async (options: CapturedRunOptions) => {
@@ -366,6 +387,35 @@ describe("runTask — workflow target", () => {
     expect(log).toContain("timed_out=true timeout_ms=100");
     expect(log).toContain("run_id=run-wedged status=active");
     expect(readRunLogRows("wf-timeout").some((row) => row.line.includes("timed_out=true timeout_ms=100"))).toBe(true);
+  });
+
+  test("a run that completes anyway is not reported as a timeout", async () => {
+    writeTask(
+      "wf-raced",
+      ["version: 2", 'schedule: "@daily"', "workflow: workflows/noop", "timeoutMs: 100", ""].join("\n"),
+    );
+    const { timers, setTimeoutFn, clearTimeoutFn } = collectTimers();
+    const captured: CapturedRunOptions[] = [];
+
+    const promise = runTask("wf-raced", {
+      stashDir,
+      logDir,
+      runWorkflowStepsImpl: completesDespiteAbortRunner(captured) as never,
+      setTimeoutFn,
+      clearTimeoutFn,
+    });
+    await fireWhenRegistered(timers, 100);
+    const result = await promise;
+
+    // The deadline fired — but the run finished, so there is nothing to resume
+    // and nothing failed.
+    expect(captured[0]!.signal?.aborted).toBe(true);
+    expect(result.status).toBe("completed");
+    expect(exitCodeForStatus(result.status)).toBe(0);
+    expect(result.detail?.error).toBeUndefined();
+    const log = fs.readFileSync(result.log, "utf8");
+    expect(log).not.toContain("timed_out=true");
+    expect(log).toContain("run_id=run-finished status=completed");
   });
 
   test("an explicit timeout overrides the unattended default", async () => {

--- a/tests/integration/workflow-cli.test.ts
+++ b/tests/integration/workflow-cli.test.ts
@@ -71,6 +71,26 @@ steps:
 Finish the workflow.
 `;
 
+/** A one-step workflow whose unit is a shell command — no engine required. */
+function execWorkflow(command: string[]): string {
+  return [
+    "---",
+    "type: workflow",
+    "description: Exec workflow",
+    "steps:",
+    "  - id: work",
+    "    unit:",
+    "      exec:",
+    `        command: ${JSON.stringify(command)}`,
+    "---",
+    "",
+    "## work",
+    "",
+    "Do it.",
+    "",
+  ].join("\n");
+}
+
 describe("workflow CLI", () => {
   test("runtime accepts only canonical conceptId refs", () => {
     expect(parseWorkflowRefInput("workflows/release")).toEqual({
@@ -153,6 +173,33 @@ describe("workflow CLI", () => {
     expect((JSON.parse(listed.stdout) as { runs: Array<{ id: string }> }).runs.map((item) => item.id)).toEqual([
       run.run.id,
     ]);
+  });
+
+  test("--timeout tags an unfinished run, and never a run that reached completed", async () => {
+    // An exec unit needs no engine, so both runs below execute for real.
+    await createWorkflow("wedged", execWorkflow(["bun", "-e", "await Bun.sleep(30000)"]));
+    const wedged = await runCliCapture(["workflow", "run", "workflows/wedged", "--timeout=150ms"]);
+    expect(wedged.code).toBe(1);
+    expect(JSON.parse(wedged.stdout)).toMatchObject({
+      run: { status: "active" },
+      aborted: true,
+      timedOut: true,
+    });
+
+    await createWorkflow("quick", execWorkflow(["bun", "-e", "process.stdout.write('ok')"]));
+    const completed = await runCliCapture(["workflow", "run", "workflows/quick"]);
+    expect(completed.code).toBe(0);
+    const finished = (JSON.parse(completed.stdout) as { run: { id: string; status: string } }).run;
+    expect(finished.status).toBe("completed");
+
+    // Re-running a completed run is a no-op that returns `done`; a deadline
+    // that fires around it describes nothing an operator could resume.
+    const rerun = await runCliCapture(["workflow", "run", finished.id, "--timeout=1ms"]);
+    expect(rerun.code).toBe(0);
+    const rendered = JSON.parse(rerun.stdout) as { run: { status: string }; done?: true; timedOut?: true };
+    expect(rendered.run.status).toBe("completed");
+    expect(rendered.done).toBe(true);
+    expect(rendered.timedOut).toBeUndefined();
   });
 
   test("run rejects aliases, retired JSON params, and params on an active run", async () => {

--- a/tests/integration/workflow-worktree-leftovers.test.ts
+++ b/tests/integration/workflow-worktree-leftovers.test.ts
@@ -124,6 +124,29 @@ describe.skipIf(!GIT)("createUnitWorktree — leftover handling (never destroy d
     expect(fs.existsSync(path.join(created.path, "README.md"))).toBe(true);
   });
 
+  test("a preserved leftover is reported even when the re-creation then FAILS", async () => {
+    const repo = makeGitRepo();
+
+    const first = await mustCreate(repo, "work:solo");
+    fs.writeFileSync(path.join(first.path, "uncollected-work.txt"), "important\n");
+
+    // The base repo is gone by the time the attempt is retried: the leftover
+    // can no longer be verified (so it is moved aside) and the `git worktree
+    // add` that follows fails. The moved-aside copy is now the ONLY one of the
+    // previous attempt's work, so the failure result must still carry it —
+    // otherwise the operator is told worktree_failed and nothing else.
+    fs.rmSync(path.join(repo, ".git"), { recursive: true, force: true });
+
+    const failed = await createUnitWorktree(repo, RUN_ID, "work:solo");
+    expect(failed.ok).toBe(false);
+    if (failed.ok) return;
+    expect(failed.error).toContain("could not create isolation worktree");
+    const preserved = failed.preservedLeftover as string;
+    expect(preserved).toBeDefined();
+    expect(preserved.startsWith(`${first.path}.retained-`)).toBe(true);
+    expect(fs.readFileSync(path.join(preserved, "uncollected-work.txt"), "utf8")).toBe("important\n");
+  });
+
   test("successive dirty leftovers get DISTINCT retained paths (no overwrite)", async () => {
     const repo = makeGitRepo();
 

--- a/tests/integration/workflows/chaos.test.ts
+++ b/tests/integration/workflows/chaos.test.ts
@@ -101,7 +101,7 @@ function workListFor(
   // two helpers cannot drift when `WorkListInput` grows a field.
   return fullWorkList(plan, stepIndex, runId, params, stepOutputs).units.map((u) => ({
     unitId: u.journalBaseId,
-    inputHash: u.resolved.inputHash,
+    inputHash: u.inputHash,
   }));
 }
 

--- a/tests/integration/workflows/exec-unit.test.ts
+++ b/tests/integration/workflows/exec-unit.test.ts
@@ -38,7 +38,13 @@ import {
 import { requireExecutableWorkflowPlan } from "../../../src/workflows/runtime/plan-classifier";
 import { getWorkflowStatus } from "../../../src/workflows/runtime/runs";
 import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../../_helpers/sandbox";
-import { freezeWorkflow, parseErrors, seedWorkflowRun, storeFrozenWorkflowPlan } from "../../_helpers/workflow";
+import {
+  freezeWorkflow,
+  parseErrors,
+  seedWorkflowRun,
+  storeFrozenWorkflowPlan,
+  workflowDoc,
+} from "../../_helpers/workflow";
 
 let storage: IsolatedAkmStorage;
 /** Scratch root for fixtures the workflow itself touches (never akm storage). */
@@ -78,23 +84,8 @@ function storePlan(plan: WorkflowPlanGraph): void {
 }
 
 /** Freeze a one-step exec workflow whose `unit:` block is spelled by the caller. */
-function execPlan(unitLines: string[], opts: { stepId?: string; body?: string; extra?: string[] } = {}) {
-  const stepId = opts.stepId ?? "work";
-  const markdown = [
-    "---",
-    "type: workflow",
-    ...(opts.extra ?? []),
-    "steps:",
-    `  - id: ${stepId}`,
-    ...unitLines,
-    "---",
-    "",
-    `## ${stepId}`,
-    "",
-    opts.body ?? "Run the command.",
-    "",
-  ].join("\n");
-  return freezeWorkflow(markdown);
+function execPlan(unitLines: string[], opts: { extra?: string[] } = {}) {
+  return freezeWorkflow(workflowDoc(unitLines, "## work\n\nRun the command.\n", opts.extra ?? []));
 }
 
 function run(plan: WorkflowPlanGraph, ctx: Partial<StepExecutionContext> = {}): Promise<StepExecutionResult> {

--- a/tests/integration/workflows/exec-unit.test.ts
+++ b/tests/integration/workflows/exec-unit.test.ts
@@ -38,7 +38,7 @@ import {
 import { requireExecutableWorkflowPlan } from "../../../src/workflows/runtime/plan-classifier";
 import { getWorkflowStatus } from "../../../src/workflows/runtime/runs";
 import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../../_helpers/sandbox";
-import { freezeWorkflow, seedWorkflowRun, storeFrozenWorkflowPlan } from "../../_helpers/workflow";
+import { freezeWorkflow, parseErrors, seedWorkflowRun, storeFrozenWorkflowPlan } from "../../_helpers/workflow";
 
 let storage: IsolatedAkmStorage;
 /** Scratch root for fixtures the workflow itself touches (never akm storage). */
@@ -1116,23 +1116,31 @@ describe("exec unit — retained output is BOUNDED, but a passing command is nev
 });
 
 describe("exec unit — an INCOMPLETE capture is never a success (finding 2)", () => {
-  test("leader exits 0 while a descendant holds stdout open → `spawn_failed`, not a partial artifact", async () => {
-    seedRun(["work"]);
-    // The command LEADER writes a prefix of its output and exits 0 immediately,
-    // but leaves a detached descendant holding the stdout fd open far past the
-    // stream-drain deadline (the unit's wall budget + 2s). `exitCode` is 0 and
-    // `stdout` holds only the leader's prefix — promoting it would hand every
-    // downstream reference a silently truncated artifact.
+  /**
+   * A command whose LEADER writes a prefix of its output and exits 0
+   * immediately, leaving a detached descendant holding the stdout fd open far
+   * past the stream-drain deadline (the unit's wall budget + 2s). `exitCode` is
+   * 0 and `stdout` holds only the leader's prefix — promoting it would hand
+   * every downstream reference a silently truncated artifact. `log`, when
+   * given, records one line per REAL execution.
+   */
+  function fdHolderArgv(log?: string): string[] {
     const holder = "setTimeout(() => {}, 30000)";
-    const code =
-      `const cp=require('node:child_process'); ` +
-      `const child=cp.spawn(${JSON.stringify(BUN)}, ['-e', ${JSON.stringify(holder)}], ` +
-      `{ stdio: ['ignore', 'inherit', 'ignore'] }); child.unref(); ` +
-      `process.stdout.write('partial-artifact');`;
+    return bunArgv(
+      (log ? `require('node:fs').appendFileSync(${JSON.stringify(log)}, 'x'); ` : "") +
+        `const cp=require('node:child_process'); ` +
+        `const child=cp.spawn(${JSON.stringify(BUN)}, ['-e', ${JSON.stringify(holder)}], ` +
+        `{ stdio: ['ignore', 'inherit', 'ignore'] }); child.unref(); ` +
+        `process.stdout.write('partial-artifact');`,
+    );
+  }
+
+  test("leader exits 0 while a descendant holds stdout open → `exec_capture_incomplete`, not a partial artifact", async () => {
+    seedRun(["work"]);
     const plan = execPlan([
       "    unit:",
       "      exec:",
-      `        command: ${JSON.stringify(bunArgv(code))}`,
+      `        command: ${JSON.stringify(fdHolderArgv())}`,
       '      timeout: "2s"',
     ]);
     storePlan(plan);
@@ -1140,14 +1148,74 @@ describe("exec unit — an INCOMPLETE capture is never a success (finding 2)", (
     const result = await run(plan);
 
     expect(result.ok).toBe(false);
-    // The SAME reason the agent spawn path reports for the same condition.
-    expect(result.units[0]!.failureReason).toBe("spawn_failed");
-    expect(result.units[0]!.error).toContain("output capture did not complete");
-    expect(result.units[0]!.error).toContain("drain timed out");
+    // NOT `spawn_failed`: the child started and finished. What failed is akm's
+    // record of its output, which is a different thing and a different reason.
+    expect(result.units[0]!.failureReason).toBe("exec_capture_incomplete");
+    const error = result.units[0]!.error ?? "";
+    expect(error).toContain("the command COMPLETED");
+    expect(error).toContain("could not be fully captured");
+    expect(error).toContain("drain timed out");
     // The prefix never became the step artifact.
     expect(result.evidence.output).toBeNull();
     expect(JSON.stringify(result.evidence)).not.toContain("partial-artifact");
+
+    const rows = await unitRows();
+    expect(rows[0]!.status).toBe("failed");
+    expect(rows[0]!.failure_reason).toBe("exec_capture_incomplete");
   }, 90_000);
+
+  test("`retry: { on: [spawn_failed] }` does NOT re-run a command that already completed", async () => {
+    seedRun(["work"]);
+    // The whole point of the separate reason: a unit that declares the widest
+    // plausible retry policy for a start-up failure must not re-dispatch
+    // byte-identical argv for a command that ALREADY ran its side effects.
+    const log = path.join(tmpDir, "executions.log");
+    const plan = execPlan([
+      "    unit:",
+      "      exec:",
+      `        command: ${JSON.stringify(fdHolderArgv(log))}`,
+      '      timeout: "2s"',
+      "      retry: { max: 2, on: [spawn_failed] }",
+    ]);
+    storePlan(plan);
+
+    const result = await run(plan);
+
+    expect(result.ok).toBe(false);
+    expect(result.units[0]!.failureReason).toBe("exec_capture_incomplete");
+    // ONE execution — not the 1 + 2 retries the declared policy would have run.
+    expect(fs.readFileSync(log, "utf8")).toBe("x");
+    // …and one journal row: no `~r1`/`~r2` attempt ids were ever minted.
+    const rows = await unitRows();
+    expect(rows.map((r) => r.unit_id)).toEqual(["work:solo"]);
+  }, 90_000);
+
+  test("`exec_capture_incomplete` cannot be opted into from retry.on either", () => {
+    // Out of the taxonomy at the AUTHORING surface too, exactly like the other
+    // exec-only reasons: there is no spelling of `retry:` that re-dispatches a
+    // command that already ran.
+    const errors = parseErrors(
+      [
+        "---",
+        "type: workflow",
+        "steps:",
+        "  - id: work",
+        "    unit:",
+        "      exec:",
+        '        command: ["true"]',
+        "      retry: { max: 2, on: [exec_capture_incomplete] }",
+        "---",
+        "",
+        "## work",
+        "",
+        "Run the command.",
+        "",
+      ].join("\n"),
+    );
+    expect(errors.map((error) => error.message).join(" ")).toContain(
+      'unknown failure reason "exec_capture_incomplete"',
+    );
+  });
 });
 
 describe("exec unit — a stderr-only diagnosis survives to the journal (finding 3)", () => {

--- a/tests/integration/workflows/exec-unit.test.ts
+++ b/tests/integration/workflows/exec-unit.test.ts
@@ -19,7 +19,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
 import { openStateDatabase } from "../../../src/core/state-db";
-import { readStream, runManagedSubprocess } from "../../../src/core/subprocess";
+import { readStream } from "../../../src/core/subprocess";
+import { _setWarnSinkForTests } from "../../../src/core/warn";
 import { withWorkflowRunsRepo } from "../../../src/storage/repositories/workflow-runs-repository";
 import { EXEC_DEFAULT_ENV_PASSTHROUGH, runExecUnit } from "../../../src/workflows/exec/exec-unit";
 import {
@@ -29,6 +30,7 @@ import {
   type StepExecutionResult,
 } from "../../../src/workflows/exec/native-executor";
 import { cpuDerivedUnitConcurrency } from "../../../src/workflows/exec/scheduler";
+import type { UnitDispatchResult } from "../../../src/workflows/exec/unit-dispatch";
 import type { IrStepPlan, WorkflowPlanGraph } from "../../../src/workflows/ir/schema";
 import {
   execContextLimits,
@@ -37,6 +39,7 @@ import {
 } from "../../../src/workflows/resource-limits";
 import { requireExecutableWorkflowPlan } from "../../../src/workflows/runtime/plan-classifier";
 import { getWorkflowStatus } from "../../../src/workflows/runtime/runs";
+import { makeGitRepo } from "../../_helpers/git";
 import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../../_helpers/sandbox";
 import {
   freezeWorkflow,
@@ -757,24 +760,10 @@ describe("exec unit — map fan-out", () => {
 });
 
 describe("exec unit — worktree isolation", () => {
-  async function initRepo(dir: string): Promise<void> {
-    fs.mkdirSync(dir, { recursive: true });
-    for (const args of [
-      ["init", "-q"],
-      ["config", "user.email", "t@example.com"],
-      ["config", "user.name", "Test"],
-      ["config", "commit.gpgsign", "false"],
-    ]) {
-      await runManagedSubprocess(["git", "-C", dir, ...args], { capture: true, timeoutMs: 30_000 });
-    }
-    fs.writeFileSync(path.join(dir, "README.md"), "base\n");
-    await runManagedSubprocess(["git", "-C", dir, "add", "."], { capture: true, timeoutMs: 30_000 });
-    await runManagedSubprocess(["git", "-C", dir, "commit", "-qm", "base"], { capture: true, timeoutMs: 30_000 });
-  }
-
   test("the command runs in a fresh detached worktree, not in the base repo", async () => {
-    const repo = path.join(tmpDir, "repo");
-    await initRepo(repo);
+    // The shared fixture, inside this suite's own sandbox root so `afterEach`
+    // takes the repo with it.
+    const repo = makeGitRepo({ dir: path.join(tmpDir, "repo") });
     seedRun(["work"]);
     // Print the cwd and mutate a tracked file — the base repo must stay clean.
     const code =
@@ -798,7 +787,7 @@ describe("exec unit — worktree isolation", () => {
     expect(cwd).toContain(RUN_ID);
 
     // The base checkout was never touched.
-    expect(fs.readFileSync(path.join(repo, "README.md"), "utf8")).toBe("base\n");
+    expect(fs.readFileSync(path.join(repo, "README.md"), "utf8")).toBe("# fixture\n");
     // The dirty worktree is RETAINED (uncollected work is never destroyed) and
     // its path is journaled on the unit row.
     const rows = (await withWorkflowRunsRepo((repo_) => repo_.getUnitsForStep(RUN_ID, "work"))) as Array<{
@@ -1110,10 +1099,10 @@ describe("exec unit — an INCOMPLETE capture is never a success (finding 2)", (
   /**
    * A command whose LEADER writes a prefix of its output and exits 0
    * immediately, leaving a detached descendant holding the stdout fd open far
-   * past the stream-drain deadline (the unit's wall budget + 2s). `exitCode` is
-   * 0 and `stdout` holds only the leader's prefix — promoting it would hand
-   * every downstream reference a silently truncated artifact. `log`, when
-   * given, records one line per REAL execution.
+   * past the stream-drain deadline (the leader's exit plus the post-exit
+   * grace). `exitCode` is 0 and `stdout` holds only the leader's prefix —
+   * promoting it would hand every downstream reference a silently truncated
+   * artifact. `log`, when given, records one line per REAL execution.
    */
   function fdHolderArgv(log?: string): string[] {
     const holder = "setTimeout(() => {}, 30000)";
@@ -1207,6 +1196,60 @@ describe("exec unit — an INCOMPLETE capture is never a success (finding 2)", (
       'unknown failure reason "exec_capture_incomplete"',
     );
   });
+});
+
+describe("exec unit — a STDERR-only drain failure never discards a valid artifact", () => {
+  /**
+   * The mirror image of `fdHolderArgv`: the leader writes its WHOLE stdout
+   * artifact and exits 0, leaving a detached descendant holding only the STDERR
+   * fd open. stdout drained completely, the command exited 0 — the only thing
+   * stuck is the diagnostic channel, which never contributes to the artifact.
+   */
+  function stderrHolderArgv(): string[] {
+    const holder = "setTimeout(() => {}, 30000)";
+    return bunArgv(
+      `const cp=require('node:child_process'); ` +
+        `const child=cp.spawn(${JSON.stringify(BUN)}, ['-e', ${JSON.stringify(holder)}], ` +
+        `{ stdio: ['ignore', 'ignore', 'inherit'] }); child.unref(); ` +
+        `process.stdout.write('complete-artifact');`,
+    );
+  }
+
+  test("the unit SUCCEEDS with its full stdout artifact, and settles nowhere near its wall budget", async () => {
+    // A two-MINUTE budget under a 30-second test timeout: the SETTLE is the
+    // evidence, exactly as in the kill-ladder tests above. A drain deadline
+    // armed from capture instead of from the leader's exit would hold this unit
+    // for the whole 120 s, and the test would fail on its own timeout rather
+    // than pass slowly.
+    const BUDGET_MS = 120_000;
+    const warnings: string[] = [];
+    _setWarnSinkForTests((level, args) => {
+      if (level === "warn") warnings.push(args.map(String).join(" "));
+    });
+
+    let result: UnitDispatchResult;
+    try {
+      result = await runExecUnit({
+        unitId: "work:solo",
+        exec: { command: stderrHolderArgv() as [string, ...string[]], timeoutMs: BUDGET_MS },
+        baseDir: workDir,
+        timeoutMs: BUDGET_MS,
+      });
+    } finally {
+      _setWarnSinkForTests(undefined);
+    }
+
+    // A completed command with a complete stdout is a SUCCESS. Failing it
+    // `exec_capture_incomplete` would throw away a valid artifact — and that
+    // reason is non-retryable, so the work could never be recovered either.
+    expect(result.failureReason).toBeUndefined();
+    expect(result.ok).toBe(true);
+    expect(result.text).toBe("complete-artifact");
+
+    // The lost log tail is still SAID somewhere — a success that quietly
+    // dropped part of its diagnostics would be its own kind of dishonest.
+    expect(warnings.join("\n")).toContain("stderr drain timed out");
+  }, 30_000);
 });
 
 describe("exec unit — a stderr-only diagnosis survives to the journal (finding 3)", () => {

--- a/tests/integration/workflows/gate-artifacts.test.ts
+++ b/tests/integration/workflows/gate-artifacts.test.ts
@@ -599,6 +599,119 @@ every file reviewed thoroughly
   });
 });
 
+// ── exec steps: the gate judges, but never loops ─────────────────────────────
+//
+// An exec unit's argv is frozen and never interpolated, its context env carries
+// no feedback variable, and the dispatcher drops feedback for exec — so a gate
+// loop could only re-run the BYTE-IDENTICAL command, performing its side effect
+// again for a verdict that cannot change. The gate still evaluates and can
+// still fail the step; it just never re-dispatches (`effectiveGateMaxLoops`).
+
+const EXEC_UNIT_LINES = `    unit:
+      exec:
+        command: ["bin/deploy", "--prod"]
+`;
+
+const EXEC_GATED_WF = `---
+type: workflow
+steps:
+  - id: deploy
+${EXEC_UNIT_LINES}    gate: { max_loops: 3 }
+---
+
+## deploy
+
+Deploy the service.
+
+### gate
+
+the deployment is verified
+`;
+
+const EXEC_GATED_STEPS = [{ id: "deploy", criteria: ["the deployment is verified"] }];
+
+const REJECTION = '{"complete": false, "missing": ["the deployment is verified"], "feedback": "No health check."}';
+
+describe("exec steps under a completion gate — judged once, never looped", () => {
+  test("a rejected gate exhausts immediately: the command is dispatched exactly once", async () => {
+    seedRun({ steps: EXEC_GATED_STEPS });
+    let execDispatches = 0;
+    let judgeCalls = 0;
+    const result = await runWorkflowSteps({
+      target: RUN_ID,
+      dispatcher: async (req: UnitDispatchRequest): Promise<UnitDispatchResult> => {
+        if (req.exec) execDispatches++;
+        return { ok: true, text: "deployed" };
+      },
+      loadPlan: usePlan(EXEC_GATED_WF),
+      summaryJudge: async () => {
+        judgeCalls++;
+        return REJECTION;
+      },
+    });
+
+    // The invariant: one dispatch of a side-effecting command, even though the
+    // plan declares max_loops 3.
+    expect(execDispatches).toBe(1);
+    expect(judgeCalls).toBe(1);
+    // Exhaustion, not a bypass — the verdict still stopped the run.
+    expect(result.done).toBeUndefined();
+    expect(result.judgeFailure).toBeUndefined();
+    expect(result.gateRejection).toEqual({
+      stepId: "deploy",
+      missing: ["the deployment is verified"],
+      feedback: "No health check.",
+    });
+    expect(result.stepsProcessed).toBe(1);
+    await withWorkflowRunsRepo((repo) => {
+      const ids = repo
+        .getUnitsForStep(RUN_ID, "deploy")
+        .map((r) => r.unit_id)
+        .sort();
+      // No `~l2` re-dispatch and no second gate evaluation.
+      expect(ids).toEqual(["deploy.gate:l1", "deploy:solo"]);
+    });
+    // A gate rejection leaves the step pending and the run active, as ever.
+    const status = await getWorkflowStatus(RUN_ID);
+    expect(status.run.status).toBe("active");
+    expect(status.workflow.steps[0]!.status).toBe("pending");
+  });
+
+  test("a passing gate advances the exec step normally — evaluation is not skipped", async () => {
+    seedRun({ steps: EXEC_GATED_STEPS });
+    let judgeCalls = 0;
+    const result = await runWorkflowSteps({
+      target: RUN_ID,
+      dispatcher: async () => ({ ok: true, text: "deployed" }),
+      loadPlan: usePlan(EXEC_GATED_WF),
+      summaryJudge: async () => {
+        judgeCalls++;
+        return '{"complete": true, "missing": []}';
+      },
+    });
+    expect(judgeCalls).toBe(1);
+    expect(result.done).toBe(true);
+    expect((await getWorkflowStatus(RUN_ID)).workflow.steps[0]!.status).toBe("completed");
+  });
+
+  test("the same document with an ENGINE unit still loops — the bound is exec-specific", async () => {
+    const ENGINE_GATED_WF = EXEC_GATED_WF.replace(EXEC_UNIT_LINES, "");
+    seedRun({ steps: EXEC_GATED_STEPS });
+    let dispatches = 0;
+    const result = await runWorkflowSteps({
+      target: RUN_ID,
+      dispatcher: async () => {
+        dispatches++;
+        return { ok: true, text: "deployed" };
+      },
+      loadPlan: usePlan(ENGINE_GATED_WF),
+      summaryJudge: async () => REJECTION,
+    });
+    expect(dispatches).toBe(3); // the declared max_loops, honored in full
+    expect(result.gateRejection?.stepId).toBe("deploy");
+  });
+});
+
 // ── Crash-resume seeds the gate loop from the journal (Codex round-3 P1) ──────
 //
 // The engine loop must SEED its per-step gate state from the journal exactly as
@@ -678,7 +791,7 @@ function loop1Hash(p: WorkflowPlanGraph): string {
     engines: p.execution?.engines,
   });
   if (!c.ok) throw new Error(c.error);
-  return c.list.units[0]!.resolved.inputHash;
+  return c.list.units[0]!.inputHash;
 }
 
 /** The loop-2 solo unit id + hash brief/report would compute for the recovered feedback. */
@@ -693,7 +806,7 @@ function loop2Unit(p: WorkflowPlanGraph, gateFeedback: GateFeedback): { unitId: 
   });
   if (!c.ok) throw new Error(c.error);
   const u = c.list.units[0]!;
-  return { unitId: u.journalBaseId, inputHash: u.resolved.inputHash };
+  return { unitId: u.journalBaseId, inputHash: u.inputHash };
 }
 
 describe("gate max_loops — crash-resume seeds the loop from the journal", () => {

--- a/tests/integration/workflows/gate-judge-dispatch.test.ts
+++ b/tests/integration/workflows/gate-judge-dispatch.test.ts
@@ -300,7 +300,7 @@ describe("gate judge redaction is replay-deterministic — the recovered feedbac
     const unit = replayed.list.units[0]!;
     const journaled = rows.find((r) => r.unit_id === unit.journalBaseId);
     expect(unit.journalBaseId).toBe("work:solo~l2");
-    expect(journaled?.input_hash).toBe(unit.resolved.inputHash);
+    expect(journaled?.input_hash).toBe(unit.inputHash);
     // …and loop 2's hash still differs from loop 1's, so the loop really did
     // re-dispatch rather than reuse the rejected attempt's row.
     expect(journaled?.input_hash).not.toBe(rows.find((r) => r.unit_id === "work:solo")?.input_hash);

--- a/tests/integration/workflows/native-executor.test.ts
+++ b/tests/integration/workflows/native-executor.test.ts
@@ -2387,7 +2387,7 @@ Build the assigned item.
           runner: u.runner,
           engine: u.engine?.name ?? null,
           model: u.invocation?.model ?? null,
-          inputHash: u.resolved.inputHash,
+          inputHash: u.inputHash,
           startedAt: now,
         });
         repo.finishUnit({

--- a/tests/integration/workflows/persistence-write-path.test.ts
+++ b/tests/integration/workflows/persistence-write-path.test.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { serializeByKey } from "../../../src/core/concurrent";
 import { getStateDbPath, openStateDatabase } from "../../../src/core/state-db";
 import { borrowScopedStateDb, openScopedStateDbCount } from "../../../src/core/state-db-scope";
 import {
@@ -161,25 +162,24 @@ describe("state.db connection scope", () => {
 
 describe("unit writer queue", () => {
   test("chains are keyed per database path — unrelated databases do not queue behind each other", async () => {
+    // The per-key separation belongs to `serializeByKey`, which is what
+    // `enqueueUnitWrite` calls with the live state.db path; exercise it on its
+    // own chain map rather than asking the wrapper to write somewhere it never
+    // writes in production.
+    const chains = new Map<string, Promise<unknown>>();
     const order: string[] = [];
     let release!: () => void;
     const gate = new Promise<void>((resolve) => {
       release = resolve;
     });
 
-    const blocked = enqueueUnitWrite(
-      async () => {
-        await gate;
-        order.push("a");
-      },
-      { key: "/tmp/does-not-exist/a.db" },
-    );
-    const independent = enqueueUnitWrite(
-      async () => {
-        order.push("b");
-      },
-      { key: "/tmp/does-not-exist/b.db" },
-    );
+    const blocked = serializeByKey(chains, "/tmp/does-not-exist/a.db", async () => {
+      await gate;
+      order.push("a");
+    });
+    const independent = serializeByKey(chains, "/tmp/does-not-exist/b.db", async () => {
+      order.push("b");
+    });
 
     await independent;
     // "b" drained while "a" is still parked ⇒ the chains are genuinely separate.
@@ -190,16 +190,15 @@ describe("unit writer queue", () => {
   });
 
   test("writes sharing one database path stay strictly ordered", async () => {
+    // Every call keys on the live state.db path — the isolated one this suite
+    // installs — so all 12 share a chain, which is the production shape.
     const order: number[] = [];
     await Promise.all(
       Array.from({ length: 12 }, (_, i) =>
-        enqueueUnitWrite(
-          async () => {
-            await new Promise((resolve) => setTimeout(resolve, (12 - i) % 4));
-            order.push(i);
-          },
-          { key: "/tmp/does-not-exist/shared.db" },
-        ),
+        enqueueUnitWrite(async () => {
+          await new Promise((resolve) => setTimeout(resolve, (12 - i) % 4));
+          order.push(i);
+        }),
       ),
     );
     expect(order).toEqual(Array.from({ length: 12 }, (_, i) => i));

--- a/tests/integration/workflows/persistence-write-path.test.ts
+++ b/tests/integration/workflows/persistence-write-path.test.ts
@@ -10,6 +10,7 @@ import {
   withWorkflowRunsConnection,
   withWorkflowRunsRepo,
 } from "../../../src/storage/repositories/workflow-runs-repository";
+import { runWorkflowSteps } from "../../../src/workflows/exec/run-workflow";
 import { enqueueUnitWrite } from "../../../src/workflows/exec/unit-writer";
 import { WORKFLOW_MAX_EVIDENCE_JSON_BYTES } from "../../../src/workflows/resource-limits";
 import {
@@ -35,6 +36,10 @@ import { freezeWorkflow, seedWorkflowRun, storeFrozenWorkflowPlan } from "../../
  *      {@link WORKFLOW_MAX_EVIDENCE_JSON_BYTES} and an over-cap value is stored
  *      as an unmistakably-marked truncation envelope, never as a silently
  *      shortened value that reads like complete data.
+ *   D. …and that bound is a PERSISTENCE bound only: the invocation that
+ *      produced an over-cap artifact still feeds the complete value to its own
+ *      later steps, while a run resumed from the truncated row refuses to
+ *      dispatch against it and says truncation is why.
  */
 
 let storage: IsolatedAkmStorage;
@@ -318,6 +323,24 @@ describe("evidence_json persistence bound", () => {
     }
   });
 
+  test("replacement order follows UTF-8 bytes, not UTF-16 length", () => {
+    // `ascii` is the LONGER string in code units but the SMALLER one in bytes;
+    // `cjk` is 3 bytes per char. Ordering by `.length` would sacrifice `ascii`
+    // first, leave the row still over cap, and then destroy `cjk` too —
+    // replacing only `cjk` is enough.
+    const evidence = { ascii: "a".repeat(400_000), cjk: "漢".repeat(350_000) };
+    expect(evidence.ascii.length).toBeGreaterThan(evidence.cjk.length);
+    expect(Buffer.byteLength(JSON.stringify(evidence.cjk), "utf8")).toBeGreaterThan(
+      Buffer.byteLength(JSON.stringify(evidence.ascii), "utf8"),
+    );
+
+    const clipped = clipStepEvidenceForPersistence(evidence);
+    expect(clipped.truncatedKeys).toEqual(["cjk"]);
+    expect(Buffer.byteLength(clipped.json as string, "utf8")).toBeLessThanOrEqual(WORKFLOW_MAX_EVIDENCE_JSON_BYTES);
+    const parsed = JSON.parse(clipped.json as string) as Record<string, unknown>;
+    expect(parsed.ascii).toBe(evidence.ascii);
+  });
+
   test("a tiny cap still yields a single whole-object marker rather than an oversized row", () => {
     const clipped = clipStepEvidenceForPersistence({ output: bigOutput(4), units: [] }, 64);
     const parsed = JSON.parse(clipped.json as string) as Record<string, unknown>;
@@ -351,4 +374,132 @@ describe("evidence_json persistence bound", () => {
     expect(Array.isArray(readBack?.output)).toBe(false);
     expect(readBack?.units).toEqual(evidence.units as never);
   });
+});
+
+// ── D. the row bound never reaches the LIVE run ──────────────────────────────
+
+const FLOW_RUN_ID = "55555555-5555-4555-8555-555555555555";
+
+/** Wide + long enough that `produce`'s promoted array alone blows the 1 MiB row cap. */
+const CHUNK_COUNT = 20;
+const CHUNK_CHARS = 60_000;
+
+/** Distinct per index — content-derived unit identity rejects duplicate items. */
+function chunkText(index: number): string {
+  return `${"c".repeat(CHUNK_CHARS - 4)}#${String(index).padStart(3, "0")}`;
+}
+
+const FLOW_PLAN = freezeWorkflow(`---
+type: workflow
+params:
+  chunks: { type: array }
+steps:
+  - id: produce
+    map:
+      over: params.chunks
+  - id: consume
+    map:
+      over: steps.produce.output
+---
+
+## produce
+
+Emit the chunk.
+
+## consume
+
+Handle the chunk.
+`);
+
+function seedFlowRun(): void {
+  const db = openStateDatabase(getStateDbPath());
+  try {
+    seedWorkflowRun(db, {
+      runId: FLOW_RUN_ID,
+      params: { chunks: Array.from({ length: CHUNK_COUNT }, (_, i) => `seed-${i}`) },
+      steps: [{ stepId: "produce" }, { stepId: "consume" }],
+      checkinArmedAt: new Date().toISOString(),
+    });
+    storeFrozenWorkflowPlan(db, FLOW_RUN_ID, FLOW_PLAN);
+  } finally {
+    db.close();
+  }
+}
+
+describe("evidence_json bound vs. the live run", () => {
+  test("a step promoting more than the cap still feeds the NEXT step the complete value", async () => {
+    seedFlowRun();
+    const consumePrompts: string[] = [];
+    const result = await runWorkflowSteps({
+      target: FLOW_RUN_ID,
+      dispatcher: async (request) => {
+        if (request.stepId === "consume") {
+          consumePrompts.push(request.prompt);
+          return { ok: true, text: "handled" };
+        }
+        // Each `produce` unit emits the chunk for its own fan-out index.
+        const index = /^## Item \(index (\d+)\)$/m.exec(request.prompt)?.[1];
+        return { ok: true, text: chunkText(Number(index)) };
+      },
+      summaryJudge: null,
+    });
+
+    expect(result.done).toBe(true);
+    // The whole promoted array reached `consume` — every unit got its own
+    // complete 60k-char item, not a truncation envelope (which is not even an
+    // array, so the fan-out would have failed to resolve at all).
+    expect(consumePrompts).toHaveLength(CHUNK_COUNT);
+    for (let i = 0; i < CHUNK_COUNT; i++) {
+      expect(consumePrompts.some((prompt) => prompt.includes(chunkText(i)))).toBe(true);
+    }
+
+    // …and the row is STILL bounded: the cap did its job on persistence only.
+    const stored = await withWorkflowRunsRepo((repo) => repo.getStep(FLOW_RUN_ID, "produce"));
+    expect(Buffer.byteLength(stored?.evidence_json as string, "utf8")).toBeLessThanOrEqual(
+      WORKFLOW_MAX_EVIDENCE_JSON_BYTES,
+    );
+    const persisted = JSON.parse(stored?.evidence_json as string) as Record<string, Record<string, unknown>>;
+    expect(persisted.output?.[WORKFLOW_EVIDENCE_TRUNCATED_MARKER]).toBe(true);
+  }, 60_000);
+
+  test("a run resumed from a truncated row fails the referencing step by NAMING truncation", async () => {
+    seedFlowRun();
+    // The rows a previous invocation would have left behind: `produce`
+    // completed, its promoted artifact replaced by the truncation envelope.
+    const truncated = clipStepEvidenceForPersistence({
+      units: [],
+      itemCount: CHUNK_COUNT,
+      output: Array.from({ length: CHUNK_COUNT }, (_, i) => chunkText(i)),
+    });
+    expect(truncated.truncatedKeys).toContain("output");
+    const db = openStateDatabase(getStateDbPath());
+    try {
+      db.prepare(
+        `UPDATE workflow_run_steps SET status = 'completed', summary = 'produced', evidence_json = ?, completed_at = ?
+           WHERE run_id = ? AND step_id = 'produce'`,
+      ).run(truncated.json, new Date().toISOString(), FLOW_RUN_ID);
+      db.prepare("UPDATE workflow_runs SET current_step_id = 'consume' WHERE id = ?").run(FLOW_RUN_ID);
+    } finally {
+      db.close();
+    }
+
+    let dispatches = 0;
+    const result = await runWorkflowSteps({
+      target: FLOW_RUN_ID,
+      dispatcher: async () => {
+        dispatches++;
+        return { ok: true, text: "handled" };
+      },
+      summaryJudge: null,
+    });
+
+    // Nothing ran on destroyed data, and the failure says WHY.
+    expect(dispatches).toBe(0);
+    expect(result.executed[0]?.ok).toBe(false);
+    expect(result.executed[0]?.summary).toContain("steps.produce.output");
+    expect(result.executed[0]?.summary).toContain("was NOT persisted");
+    expect(result.executed[0]?.summary).toContain("truncation marker");
+    const status = await getWorkflowStatus(FLOW_RUN_ID);
+    expect(status.workflow.steps[1]?.status).toBe("failed");
+  }, 30_000);
 });

--- a/tests/integration/workflows/persistence-write-path.test.ts
+++ b/tests/integration/workflows/persistence-write-path.test.ts
@@ -340,6 +340,35 @@ describe("evidence_json persistence bound", () => {
     expect(parsed.ascii).toBe(evidence.ascii);
   });
 
+  test("the row is under cap at every cap, whatever the running size bookkeeping predicts", () => {
+    // The loop tracks the row size arithmetically to avoid re-serializing the
+    // whole object once per replaced key, but that total is only an estimate —
+    // `ghost` is charged the "null" the sort used while `JSON.stringify` OMITS
+    // it, so replacing `ghost` adds bytes the estimate never counted. Whatever
+    // the bookkeeping predicts, the row that comes back must fit the cap.
+    const evidence: Record<string, unknown> = {
+      ascii: "a".repeat(9_000),
+      cjk: "漢".repeat(4_000),
+      nested: { rows: Array.from({ length: 300 }, (_, i) => ({ i, text: "λ".repeat(20) })) },
+      ghost: undefined,
+      tiny: "t",
+    };
+    const rawBytes = Buffer.byteLength(JSON.stringify(evidence), "utf8");
+    for (let cap = 1_200; cap < rawBytes; cap += 149) {
+      const clipped = clipStepEvidenceForPersistence(evidence, cap);
+      const parsed = JSON.parse(clipped.json as string) as Record<string, unknown>;
+      // The whole-object marker is the bounded last resort — it is a fixed size
+      // and so is exempt from the cap it could not meet.
+      if (parsed[WORKFLOW_EVIDENCE_TRUNCATED_MARKER] === true) continue;
+      expect(Buffer.byteLength(clipped.json as string, "utf8")).toBeLessThanOrEqual(cap);
+      // Every replaced key really is an envelope, and no other key was touched.
+      for (const key of clipped.truncatedKeys) {
+        expect((parsed[key] as Record<string, unknown>)[WORKFLOW_EVIDENCE_TRUNCATED_MARKER]).toBe(true);
+      }
+      expect(clipped.truncatedKeys.length).toBeGreaterThan(0);
+    }
+  });
+
   test("a tiny cap still yields a single whole-object marker rather than an oversized row", () => {
     const clipped = clipStepEvidenceForPersistence({ output: bigOutput(4), units: [] }, 64);
     const parsed = JSON.parse(clipped.json as string) as Record<string, unknown>;
@@ -459,6 +488,79 @@ describe("evidence_json bound vs. the live run", () => {
     );
     const persisted = JSON.parse(stored?.evidence_json as string) as Record<string, Record<string, unknown>>;
     expect(persisted.output?.[WORKFLOW_EVIDENCE_TRUNCATED_MARKER]).toBe(true);
+  }, 60_000);
+
+  test("an UNREFERENCED bulk step alongside a referenced one does not disturb the live value", async () => {
+    // The live-evidence map is filtered at SET time by the frozen plan's
+    // reference surface: `noise` is named by nobody and is not retained, while
+    // `produce` is named by `consume` and must still arrive COMPLETE. Both
+    // steps blow the row cap, so only the in-memory value can carry it.
+    const MIXED_PLAN = freezeWorkflow(`---
+type: workflow
+params:
+  chunks: { type: array }
+steps:
+  - id: noise
+  - id: produce
+    map:
+      over: params.chunks
+  - id: consume
+    map:
+      over: steps.produce.output
+---
+
+## noise
+
+Emit bulk nobody reads.
+
+## produce
+
+Emit the chunk.
+
+## consume
+
+Handle the chunk.
+`);
+    const db = openStateDatabase(getStateDbPath());
+    try {
+      seedWorkflowRun(db, {
+        runId: FLOW_RUN_ID,
+        params: { chunks: Array.from({ length: CHUNK_COUNT }, (_, i) => `seed-${i}`) },
+        steps: [{ stepId: "noise" }, { stepId: "produce" }, { stepId: "consume" }],
+        checkinArmedAt: new Date().toISOString(),
+      });
+      storeFrozenWorkflowPlan(db, FLOW_RUN_ID, MIXED_PLAN);
+    } finally {
+      db.close();
+    }
+
+    const consumePrompts: string[] = [];
+    const result = await runWorkflowSteps({
+      target: FLOW_RUN_ID,
+      dispatcher: async (request) => {
+        if (request.stepId === "noise") return { ok: true, text: "n".repeat(WORKFLOW_MAX_EVIDENCE_JSON_BYTES + 1) };
+        if (request.stepId === "consume") {
+          consumePrompts.push(request.prompt);
+          return { ok: true, text: "handled" };
+        }
+        const index = /^## Item \(index (\d+)\)$/m.exec(request.prompt)?.[1];
+        return { ok: true, text: chunkText(Number(index)) };
+      },
+      summaryJudge: null,
+    });
+
+    expect(result.done).toBe(true);
+    expect(consumePrompts).toHaveLength(CHUNK_COUNT);
+    for (let i = 0; i < CHUNK_COUNT; i++) {
+      expect(consumePrompts.some((prompt) => prompt.includes(chunkText(i)))).toBe(true);
+    }
+    // Both rows are bounded — the unreferenced step completed exactly as before.
+    for (const stepId of ["noise", "produce"]) {
+      const stored = await withWorkflowRunsRepo((repo) => repo.getStep(FLOW_RUN_ID, stepId));
+      expect(stored?.status).toBe("completed");
+      const persisted = JSON.parse(stored?.evidence_json as string) as Record<string, Record<string, unknown>>;
+      expect(persisted.output?.[WORKFLOW_EVIDENCE_TRUNCATED_MARKER]).toBe(true);
+    }
   }, 60_000);
 
   test("a run resumed from a truncated row fails the referencing step by NAMING truncation", async () => {

--- a/tests/integration/workflows/step-work.test.ts
+++ b/tests/integration/workflows/step-work.test.ts
@@ -26,6 +26,7 @@ import {
   finalizeExecutedStep,
   type RouteSkipInfo,
   recoverGateFeedback,
+  referencedStepIds,
   seedJournaledRouteDecisions,
   type UnitOutcome,
   unitOutcomeFromRow,
@@ -172,7 +173,7 @@ describe("computeStepWorkList — dispatch-input hash envelope (reviewer finding
     };
     const wl = computeStepWorkList(step, { ...input, engines });
     if (!wl.ok) throw new Error(wl.error);
-    return wl.list.units[0]!.resolved.inputHash;
+    return wl.list.units[0]!.inputHash;
   }
 
   const baseline = hashOf({});
@@ -272,12 +273,12 @@ describe("computeStepWorkList — purity + content-derived identity", () => {
     const u = a.list.units[0]!;
     expect(u.unitId).toBe("s1:solo");
     // Instructions reach the unit byte-exact.
-    expect(u.resolved.prompt).toContain("Do the assigned work.");
+    expect(u.prompt).toContain("Do the assigned work.");
     // Params attach as structured JSON context (never interpolated into text).
-    expect(u.resolved.prompt).toContain('"x":"alpha"');
-    expect(u.resolved.prompt).toContain('"y":"beta"');
+    expect(u.prompt).toContain('"x":"alpha"');
+    expect(u.prompt).toContain('"y":"beta"');
     // 64-hex sha256.
-    expect(u.resolved.inputHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(u.inputHash).toMatch(/^[0-9a-f]{64}$/);
   });
 
   test("fan-out identity is content-derived — independent of item order", () => {
@@ -306,7 +307,7 @@ describe("computeStepWorkList — purity + content-derived identity", () => {
     expect(fwdA?.unitId).toMatch(/^review:[0-9a-f]{12}$/);
     // The item reaches the unit as ATTACHED CONTEXT (never resolved/spliced) —
     // the "## Item (index N)" block `buildUnitPrompt` emits.
-    expect(fwdA?.resolved.prompt).toContain("## Item (index 0)\nYou were given this item");
+    expect(fwdA?.prompt).toContain("## Item (index 0)\nYou were given this item");
   });
 
   test("duplicate fan-out items are a whole-list failure naming the collision", () => {
@@ -366,7 +367,7 @@ describe("computeStepWorkList — purity + content-derived identity", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const u = result.list.units[0]!;
-    expect(u.resolved.prompt).toContain("Literal ${{ not.parsed }} and steps.prior.output here.");
+    expect(u.prompt).toContain("Literal ${{ not.parsed }} and steps.prior.output here.");
   });
 
   test("gate feedback changes the prompt AND the input hash", () => {
@@ -390,10 +391,10 @@ describe("computeStepWorkList — purity + content-derived identity", () => {
     const u2 = loop2.list.units[0]!;
     expect(u1.journalBaseId).toBe("s1:solo");
     expect(u2.journalBaseId).toBe("s1:solo~l2");
-    expect(u2.resolved.prompt).toContain("Add analysis.");
-    expect(u2.resolved.prompt).toContain("- thoroughness");
-    expect(u1.resolved.prompt).not.toContain("Add analysis.");
-    expect(u2.resolved.inputHash).not.toBe(u1.resolved.inputHash);
+    expect(u2.prompt).toContain("Add analysis.");
+    expect(u2.prompt).toContain("- thoroughness");
+    expect(u1.prompt).not.toContain("Add analysis.");
+    expect(u2.inputHash).not.toBe(u1.inputHash);
   });
 });
 
@@ -724,9 +725,9 @@ describe("anti-drift — recomputing loop 2 from the journal reproduces the engi
     if (!list.ok) return;
     const u = list.list.units[0]!;
     expect(u.journalBaseId).toBe("work:solo~l2");
-    expect(u.resolved.prompt).toBe(workPrompts[1]!);
+    expect(u.prompt).toBe(workPrompts[1]!);
     const journaled = rows.find((r) => r.unit_id === "work:solo~l2");
-    expect(journaled?.input_hash).toBe(u.resolved.inputHash);
+    expect(journaled?.input_hash).toBe(u.inputHash);
   });
 });
 
@@ -802,6 +803,85 @@ describe("buildEvidence — surface-independent unit projection (R4 anti-drift)"
     const reportEvidence = buildEvidence([reportOutcome], "collect", false);
     expect(canonicalJson(engineEvidence.units)).toBe(canonicalJson(reportEvidence.units));
     expect(engineEvidence.units).toEqual([{ unitId: "s1:solo", ok: true, text: "did the work" }]);
+  });
+});
+
+// ── Live-evidence retention set (referencedStepIds) ──────────────────────────
+//
+// The engine holds a completed step's COMPLETE artifact in memory only while
+// some other step can still read it. The retention set is derived from the
+// frozen plan's whole reference surface — `inputs[]`, `map.over`,
+// `route.input` — and nothing else, since instructions are never scanned.
+
+const REFERENCE_SURFACE_WF = `---
+type: workflow
+params:
+  seeds: { type: array }
+steps:
+  - id: bulk
+  - id: listing
+  - id: flagging
+    unit:
+      output: { type: object, properties: { verdict: { type: string } }, required: [verdict] }
+  - id: fanned
+    map:
+      over: steps.listing.output
+  - id: summarize
+    inputs: [steps.flagging.output.verdict]
+  - id: triage
+    route:
+      input: steps.flagging.output.verdict
+      when: [{ match: pass, step: ship }]
+      default: rework
+  - id: ship
+  - id: rework
+---
+
+## bulk
+
+Emit a lot.
+
+## listing
+
+List things.
+
+## flagging
+
+Flag it.
+
+## fanned
+
+Handle one.
+
+## summarize
+
+Summarize.
+
+## triage
+
+Route.
+
+## ship
+
+Ship.
+
+## rework
+
+Rework.
+`;
+
+describe("referencedStepIds — what the live-evidence map is allowed to hold", () => {
+  test("collects producers named by inputs[], map.over and route.input, and nothing else", () => {
+    const referenced = referencedStepIds(plan(REFERENCE_SURFACE_WF));
+    expect([...referenced].sort()).toEqual(["flagging", "listing"]);
+    // `bulk` produces an artifact no step names — nothing can read it, so
+    // nothing needs to keep it complete for the rest of the invocation.
+    expect(referenced.has("bulk")).toBe(false);
+    // Consumers are not producers: naming a reference does not make a step's
+    // own artifact live.
+    expect(referenced.has("fanned")).toBe(false);
+    expect(referenced.has("summarize")).toBe(false);
+    expect(referenced.has("triage")).toBe(false);
   });
 });
 
@@ -1079,6 +1159,35 @@ describe("fail-closed validation gates", () => {
     const gate = rows.find((r) => r.unit_id === "work.gate:l1");
     expect(gate?.status).toBe("failed");
     expect(gate?.result_json).toBeNull();
+  });
+
+  test("an abort on the DISPATCH signal mid-judge rethrows — it is never recorded as a verifier failure", async () => {
+    // The judge dispatches under the heartbeat-chained signal, not the caller's,
+    // so a lost lease aborts THERE. Seeing only `signal`, the completion path's
+    // interruption guard classified the aborted judge as an outage and durably
+    // blocked the step blaming verifier infrastructure — misattribution plus a
+    // spurious blocked run, moments before the real lost-lease error surfaced.
+    seedRun([{ id: "work", criteria: ["the work is thorough"] }], plan(GATED_WF));
+    const dispatch = new AbortController();
+    const judge: SummaryJudge = async () => {
+      dispatch.abort(new Error("Workflow run lost its run lease mid-dispatch"));
+      throw dispatch.signal.reason;
+    };
+    await expect(
+      finalizeExecutedStep(finalizeArgs({ summaryJudge: judge, dispatchSignal: dispatch.signal })),
+    ).rejects.toThrow(/lost its run lease mid-dispatch/);
+
+    // No blocked write: the step is untouched and the run stays active, so the
+    // next invocation re-evaluates the gate over the journaled units.
+    const status = await getWorkflowStatus(RUN_ID);
+    expect(status.run.status).toBe("active");
+    const step = status.workflow.steps.find((s) => s.id === "work");
+    expect(step?.status).toBe("pending");
+    expect(step?.notes ?? "").not.toContain("could not be verified");
+    // The gate row is still finished (errored, no verdict) — an interruption
+    // must not strand it `running` either.
+    const rows = await withWorkflowRunsRepo((repo) => repo.getUnitsForStep(RUN_ID, "work"));
+    expect(rows.find((r) => r.unit_id === "work.gate:l1")?.status).toBe("failed");
   });
 
   test("the engine also refuses to bypass validation when no judge is configured — run blocked, resumable", async () => {

--- a/tests/integration/workflows/worktree-concurrency.test.ts
+++ b/tests/integration/workflows/worktree-concurrency.test.ts
@@ -14,7 +14,8 @@
  *   - a run's worktree root is removed once its last unit worktree is gone,
  *     but survives while a dirty worktree is retained;
  *   - the age-based sweep removes stale retained/orphaned entries and leaves
- *     fresh ones alone;
+ *     fresh ones alone — but never a worktree whose unit is still running,
+ *     however old its root's mtime looks;
  *   - the sweep never escapes the `akm-worktrees` root (refuses a foreign
  *     root, never follows a symlink out).
  *
@@ -38,6 +39,7 @@ import {
   worktreesRoot,
 } from "../../../src/workflows/exec/worktree";
 import { git, makeGitRepo as makeTempGitRepo } from "../../_helpers/git";
+import { makeSandboxDir, withEnv } from "../../_helpers/sandbox";
 
 const GIT = isGitAvailable();
 
@@ -309,6 +311,53 @@ describe("sweepStaleWorktrees — age-based GC", () => {
     const parent = fs.mkdtempSync(path.join(os.tmpdir(), "akm-wt-sweep-none-"));
     roots.push(parent);
     expect(await sweepStaleWorktrees({ root: path.join(parent, WORKTREES_DIR_NAME) })).toEqual([]);
+  });
+});
+
+// ── Liveness: the sweep must never collect a worktree still in use ──────────
+
+describe.skipIf(!GIT)("sweepStaleWorktrees — liveness guard", () => {
+  const sandboxes: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const cleanup of sandboxes.splice(0)) cleanup();
+  });
+
+  function age(dir: string, ms: number): void {
+    const when = new Date(Date.now() - ms);
+    fs.utimesSync(dir, when, when);
+  }
+
+  test("a worktree whose owning process is still alive survives, however old the root looks", async () => {
+    const sandbox = makeSandboxDir("akm-wt-live");
+    sandboxes.push(sandbox.cleanup);
+    // TMPDIR moves `worktreesRoot()` into the sandbox, so both the mint and the
+    // default-root sweep stay inside it — the shared real root (and whatever
+    // other suites are minting under it right now) is never touched.
+    await withEnv({ TMPDIR: sandbox.dir }, async () => {
+      expect(worktreesRoot().startsWith(sandbox.dir)).toBe(true);
+      const repo = makeTempGitRepo({ dir: path.join(sandbox.dir, "repo") });
+      const live = await createUnitWorktree(repo, RUN_ID, "live:0");
+      expect(live.ok).toBe(true);
+      if (!live.ok) return;
+
+      // A long-running unit that writes only inside subdirectories leaves the
+      // worktree root's mtime at creation time — age alone reads it as stale.
+      fs.mkdirSync(path.join(live.path, "nested"), { recursive: true });
+      fs.writeFileSync(path.join(live.path, "nested", "in-progress.txt"), "working\n");
+      age(live.path, STALE_WORKTREE_MAX_AGE_MS * 2);
+
+      expect(await sweepStaleWorktrees()).toEqual([]);
+      expect(fs.readFileSync(path.join(live.path, "nested", "in-progress.txt"), "utf8")).toBe("working\n");
+
+      // Once the unit is finished with it, the same aged tree is collectible
+      // again — retaining forensic state for 7 days is the sweep's whole job.
+      const retained = await cleanupUnitWorktree(repo, live.path);
+      expect(retained.dirty).toBe(true);
+      age(live.path, STALE_WORKTREE_MAX_AGE_MS * 2);
+      expect(await sweepStaleWorktrees()).toContain(live.path);
+      expect(fs.existsSync(live.path)).toBe(false);
+    });
   });
 });
 

--- a/tests/workflows/exec-unit-authoring.test.ts
+++ b/tests/workflows/exec-unit-authoring.test.ts
@@ -13,8 +13,10 @@
 
 import { describe, expect, test } from "bun:test";
 import { computeStepWorkList } from "../../src/workflows/exec/step-work";
+import { collectWorkflowWarnings } from "../../src/workflows/ir/compile";
 import type { IrUnitNode, WorkflowPlanGraph } from "../../src/workflows/ir/schema";
 import { decodeWorkflowPlanV3 } from "../../src/workflows/ir/schema";
+import { parseWorkflow } from "../../src/workflows/parser";
 import {
   DEFAULT_EXEC_TIMEOUT_MS,
   execContextLimits,
@@ -366,7 +368,7 @@ describe("exec unit — replay identity / input hashing", () => {
       engines: plan.execution.engines,
     });
     if (!list.ok) throw new Error(list.error);
-    return list.list.units[0]!.resolved.inputHash;
+    return list.list.units[0]!.inputHash;
   }
 
   test("ADDITIVE: an existing llm unit's input hash is byte-identical to the pre-exec engine", () => {
@@ -489,5 +491,35 @@ describe("exec unit — the AKM_* context ceilings are PER-PLATFORM", () => {
     // is the tripwire removal.
     expect(posix.perVarBytes).toBeGreaterThan(win32.perVarBytes);
     expect(posix.totalBytes).toBeGreaterThan(win32.totalBytes);
+  });
+});
+
+describe("exec unit — the completion gate judges once, never loops", () => {
+  const GATED_BODY = "## work\n\nDo it.\n\n### gate\n\nthe deployment is verified\n";
+
+  function warningsFor(markdown: string): string[] {
+    const parsed = parseWorkflow(markdown, { path: "workflows/demo.md" });
+    if (!parsed.ok) throw new Error(parsed.errors.map((error) => error.message).join(" | "));
+    return collectWorkflowWarnings(parsed.document).map((warning) => warning.message);
+  }
+
+  test("`gate.max_loops` above 1 on an exec step warns that the command still runs once", () => {
+    const messages = warningsFor(doc([...EXEC_STEP, "    gate: { max_loops: 3 }"], GATED_BODY));
+    const warning = messages.find((message) => message.includes("runs its command ONCE"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain("max_loops: 3");
+    expect(warning).toContain("cannot read that feedback");
+  });
+
+  test("an ENGINE step with the same max_loops is not warned about — the bound is exec-specific", () => {
+    const messages = warningsFor(doc(["    gate: { max_loops: 3 }"], GATED_BODY));
+    expect(messages.some((message) => message.includes("runs its command ONCE"))).toBe(false);
+  });
+
+  test("an exec step that never asked for a loop is not warned about", () => {
+    expect(warningsFor(doc(EXEC_STEP, GATED_BODY)).some((m) => m.includes("runs its command ONCE"))).toBe(false);
+    // Nor is one with loops declared but no rubric — there is no gate to loop.
+    const noRubric = warningsFor(doc([...EXEC_STEP, "    gate: { max_loops: 3 }"]));
+    expect(noRubric.some((m) => m.includes("runs its command ONCE"))).toBe(false);
   });
 });

--- a/tests/workflows/freeze-llm-guard.test.ts
+++ b/tests/workflows/freeze-llm-guard.test.ts
@@ -14,30 +14,16 @@
 import { describe, expect, test } from "bun:test";
 import { ConfigError } from "../../src/core/errors";
 import type { IrUnitNode } from "../../src/workflows/ir/schema";
-import { freezeWorkflow } from "../_helpers/workflow";
+import { freezeWorkflow, workflowDoc } from "../_helpers/workflow";
 
 // WORKFLOW_TEST_CONFIG's default engine is `test-agent` (opencode-sdk, an
 // agent engine with the `test-llm` fallback) — exactly the shape whose llm
 // overrides used to vanish.
 
-function workflow(frontmatter: string[]): string {
-  return [
-    "---",
-    "type: workflow",
-    ...frontmatter,
-    "steps:",
-    "  - id: review",
-    "---",
-    "",
-    "## review",
-    "",
-    "Review.",
-    "",
-  ].join("\n");
-}
-
 describe("bug 7 — llm overrides on a non-llm engine throw at freeze", () => {
   test("unit-level llm overrides on the (agent) default engine throw a ConfigError naming step and engine", () => {
+    // Spelled out rather than built from `workflowDoc`: this is the one case
+    // that asserts the step NAME, and the shared scaffold hard-codes it.
     const markdown = [
       "---",
       "type: workflow",
@@ -66,26 +52,13 @@ describe("bug 7 — llm overrides on a non-llm engine throw at freeze", () => {
   });
 
   test("document defaults.llm with an agent engine anywhere in the stack also throws", () => {
-    const markdown = workflow(["defaults: { llm: { temperature: 0.2 } }"]);
+    const markdown = workflowDoc([], undefined, ["defaults: { llm: { temperature: 0.2 } }"]);
     expect(() => freezeWorkflow(markdown)).toThrow(ConfigError);
     expect(() => freezeWorkflow(markdown)).toThrow(/agent engine and cannot receive llm/);
   });
 
   test("llm overrides on an actual LLM engine freeze into the invocation (no false positive)", () => {
-    const markdown = [
-      "---",
-      "type: workflow",
-      "steps:",
-      "  - id: review",
-      "    unit: { engine: test-llm, llm: { temperature: 0 } }",
-      "---",
-      "",
-      "## review",
-      "",
-      "Review.",
-      "",
-    ].join("\n");
-    const plan = freezeWorkflow(markdown);
+    const plan = freezeWorkflow(workflowDoc(["    unit: { engine: test-llm, llm: { temperature: 0 } }"]));
     const root = plan.steps[0]!.root as IrUnitNode;
     expect(root.invocation!.engine).toBe("test-llm");
     expect(root.invocation!.llm).toEqual({ temperature: 0 });
@@ -96,7 +69,7 @@ describe("bug 7 — llm overrides on a non-llm engine throw at freeze", () => {
     // fallback resolves a model through a separate mechanism (`llmEngine`),
     // never through the invocation-override layers, so the live guard must
     // not fire on it.
-    const plan = freezeWorkflow(workflow([]));
+    const plan = freezeWorkflow(workflowDoc([]));
     const root = plan.steps[0]!.root as IrUnitNode;
     expect(root.invocation!.engine).toBe("test-agent");
     expect(root.invocation!.llm).toBeUndefined();

--- a/tests/workflows/frozen-judge.test.ts
+++ b/tests/workflows/frozen-judge.test.ts
@@ -3,6 +3,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import { describe, expect, test } from "bun:test";
+import { ConfigError } from "../../src/core/errors";
+import { _setChatCompletionForTests, type ChatCompletionConfig, type ChatMessage } from "../../src/llm/client";
 import { frozenSummaryJudge } from "../../src/workflows/exec/frozen-judge";
 import type { UnitDispatchRequest } from "../../src/workflows/exec/native-executor";
 import type { WorkflowPlanGraph } from "../../src/workflows/ir/schema";
@@ -32,6 +34,52 @@ function agentPlan(overrides?: Partial<{ envPassthrough: string[] }>): WorkflowP
     },
     steps: [],
   } satisfies WorkflowPlanGraph;
+}
+
+function llmPlan(credentialNames: [string, ...string[]]): WorkflowPlanGraph {
+  return {
+    irVersion: 3,
+    title: "judge",
+    execution: {
+      maxConcurrency: 1,
+      engines: {
+        grader: {
+          name: "grader",
+          kind: "llm",
+          endpoint: "http://localhost:1/v1/chat/completions",
+          model: "test-model",
+          concurrency: 1,
+          credential: { names: credentialNames, required: false },
+        },
+      },
+    },
+    steps: [],
+  } satisfies WorkflowPlanGraph;
+}
+
+/** Swap the llm transport for the duration of `fn`, then restore it. */
+async function withChatCompletion(
+  fake: (config: ChatCompletionConfig, messages: ChatMessage[]) => Promise<string>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  _setChatCompletionForTests(async (config, messages) => fake(config, messages));
+  try {
+    await fn();
+  } finally {
+    _setChatCompletionForTests(undefined);
+  }
+}
+
+/** Set an env var for the duration of `fn`, restoring whatever was there. */
+async function withEnv(name: string, value: string, fn: () => Promise<void>): Promise<void> {
+  const previous = process.env[name];
+  process.env[name] = value;
+  try {
+    await fn();
+  } finally {
+    if (previous === undefined) delete process.env[name];
+    else process.env[name] = previous;
+  }
 }
 
 describe("frozen workflow judge", () => {
@@ -208,5 +256,145 @@ describe("frozen workflow judge", () => {
     );
     await judge?.({ system: "s", user: "u" });
     expect(request?.env).toBeUndefined();
+  });
+
+  test("a THROWN agent dispatch is redacted too, not just a returned failure", async () => {
+    const name = "WORKFLOW_JUDGE_TEST_TOKEN";
+    const secret = "s3cr3t-judge-token-value";
+    await withEnv(name, secret, async () => {
+      const judge = frozenSummaryJudge(
+        agentPlan({ envPassthrough: [name] }),
+        { engine: "reviewer", model: null, timeoutMs: null },
+        undefined,
+        async () => {
+          throw new Error(`spawn failed with ${secret}`);
+        },
+        OWNER,
+      );
+      await expect(judge?.({ system: "system", user: "user" })).rejects.toThrow(/spawn failed with \[REDACTED\]/);
+    });
+  });
+});
+
+describe("frozen judge sensitive values are collected at DISPATCH time, not at build time", () => {
+  test("an agent judge scrubs a passthrough secret exported AFTER the judge was built", async () => {
+    const name = "WORKFLOW_JUDGE_LATE_TOKEN";
+    const secret = "s3cr3t-exported-after-the-judge-existed";
+    let request: UnitDispatchRequest | undefined;
+    // Built while the name is UNSET, so a build-time snapshot would be empty.
+    const judge = frozenSummaryJudge(
+      agentPlan({ envPassthrough: [name] }),
+      { engine: "reviewer", model: null, timeoutMs: null },
+      undefined,
+      async (input) => {
+        request = input;
+        return { ok: true, text: `{"complete":true,"missing":[],"feedback":"the child used ${secret}"}` };
+      },
+      OWNER,
+    );
+
+    await withEnv(name, secret, async () => {
+      const raw = await judge?.({ system: "s", user: "u" });
+      expect(raw).not.toContain(secret);
+      expect(raw).toContain("[REDACTED]");
+      expect(request?.sensitiveValues).toContain(secret);
+    });
+  });
+
+  test("an llm judge scrubs a credential exported AFTER the judge was built", async () => {
+    const name = "WORKFLOW_JUDGE_LATE_LLM_KEY";
+    const secret = "sk-live-rotated-after-the-judge-existed";
+    const judge = frozenSummaryJudge(
+      llmPlan([name]),
+      { engine: "grader", model: null, timeoutMs: null },
+      undefined,
+      undefined,
+      OWNER,
+    );
+
+    await withEnv(name, secret, async () => {
+      let usedKey: string | undefined;
+      await withChatCompletion(
+        async (config) => {
+          usedKey = config.apiKey;
+          return `{"complete":true,"missing":[],"feedback":"authenticated with ${secret}"}`;
+        },
+        async () => {
+          const raw = await judge?.({ system: "s", user: "u" });
+          // The call really did authenticate with the late credential…
+          expect(usedKey).toBe(secret);
+          // …so the value it can echo is exactly the value that gets scrubbed.
+          expect(raw).not.toContain(secret);
+          expect(raw).toContain("[REDACTED]");
+        },
+      );
+    });
+  });
+});
+
+describe("frozen llm judge redaction states the same contract as the agent branch", () => {
+  const invocation = { engine: "grader", model: null, timeoutMs: null };
+
+  test("a transport error is redacted before it can become the blocked step's notes", async () => {
+    const name = "WORKFLOW_JUDGE_LLM_KEY";
+    const secret = "sk-live-transport-error-must-not-leak";
+    const judge = frozenSummaryJudge(llmPlan([name]), invocation, undefined, undefined, OWNER);
+    await withEnv(name, secret, async () => {
+      await withChatCompletion(
+        async () => {
+          throw new Error(`connect ECONNREFUSED using ${secret}`);
+        },
+        async () => {
+          await expect(judge?.({ system: "s", user: "u" })).rejects.toThrow(/connect ECONNREFUSED using \[REDACTED\]/);
+        },
+      );
+    });
+  });
+
+  test("an error carrying no secret is rethrown as ITSELF, so callers keep branching on its type", async () => {
+    const name = "WORKFLOW_JUDGE_LLM_KEY";
+    const judge = frozenSummaryJudge(llmPlan([name]), invocation, undefined, undefined, OWNER);
+    const thrown = new ConfigError("engine 'grader' is unavailable", "INVALID_CONFIG_FILE");
+    await withEnv(name, "sk-live-unrelated-to-the-error", async () => {
+      await withChatCompletion(
+        async () => {
+          throw thrown;
+        },
+        async () => {
+          const caught = await judge?.({ system: "s", user: "u" }).then(
+            () => undefined,
+            (err: unknown) => err,
+          );
+          expect(caught).toBe(thrown);
+        },
+      );
+    });
+  });
+
+  test("the prompts stay separated and the invocation's exact model is dispatched", async () => {
+    const judge = frozenSummaryJudge(
+      llmPlan(["WORKFLOW_JUDGE_UNSET_LLM_KEY"]),
+      { engine: "grader", model: "exact-model", timeoutMs: 4321 },
+      undefined,
+      undefined,
+      OWNER,
+    );
+    let messages: ChatMessage[] | undefined;
+    let model: string | undefined;
+    await withChatCompletion(
+      async (config, sent) => {
+        messages = sent;
+        model = config.model;
+        return '{"complete":true,"missing":[]}';
+      },
+      async () => {
+        expect(await judge?.({ system: "judge system", user: "judge user" })).toContain('"complete":true');
+        expect(messages).toEqual([
+          { role: "system", content: "judge system" },
+          { role: "user", content: "judge user" },
+        ]);
+        expect(model).toBe("exact-model");
+      },
+    );
   });
 });

--- a/tests/workflows/parser-bounds.test.ts
+++ b/tests/workflows/parser-bounds.test.ts
@@ -95,20 +95,7 @@ describe("bug 9 — parser enforces the decoder's bounds with line anchors", () 
     expect(unitCase[0]!.message).toContain(`invalid engine name "My_Engine"`);
     expect(unitCase[0]!.message).toContain("lowercase");
 
-    const markdown = [
-      "---",
-      "type: workflow",
-      "defaults:",
-      "  engine: UPPER",
-      "steps:",
-      "  - id: work",
-      "---",
-      "",
-      "## work",
-      "",
-      "Do it.",
-      "",
-    ].join("\n");
+    const markdown = workflowWith([], undefined, ["defaults:", "  engine: UPPER"]);
     const defaultsCase = parseErrors(markdown);
     expect(defaultsCase).toHaveLength(1);
     expect(defaultsCase[0]!.line).toBe(4);

--- a/tests/workflows/schema-definition.test.ts
+++ b/tests/workflows/schema-definition.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { checkJsonSchemaDefinition } from "../../src/core/json-schema";
-import { parseErrors } from "../_helpers/workflow";
+import { parseErrors, workflowDoc } from "../_helpers/workflow";
 
 describe("checkJsonSchemaDefinition (core/json-schema.ts)", () => {
   test("a valid subset schema produces no issues", () => {
@@ -145,20 +145,7 @@ describe("checkJsonSchemaDefinition (core/json-schema.ts)", () => {
 
 describe("bug 10 — workflow parser rejects malformed / unsupported schemas", () => {
   test('`type: "strig"` in a step output schema is a line-anchored parser error', () => {
-    const markdown = [
-      "---",
-      "type: workflow",
-      "steps:",
-      "  - id: work",
-      "    output:",
-      "      type: strig",
-      "---",
-      "",
-      "## work",
-      "",
-      "Do it.",
-      "",
-    ].join("\n");
+    const markdown = workflowDoc(["    output:", "      type: strig"]);
     const errors = parseErrors(markdown);
     expect(errors).toHaveLength(1);
     expect(errors[0]!.line).toBe(6); // the `type: strig` line
@@ -167,21 +154,7 @@ describe("bug 10 — workflow parser rejects malformed / unsupported schemas", (
   });
 
   test("`format:` in an output schema is a parser error naming the unsupported keyword and the supported subset", () => {
-    const markdown = [
-      "---",
-      "type: workflow",
-      "steps:",
-      "  - id: work",
-      "    output:",
-      "      type: string",
-      "      format: email",
-      "---",
-      "",
-      "## work",
-      "",
-      "Do it.",
-      "",
-    ].join("\n");
+    const markdown = workflowDoc(["    output:", "      type: string", "      format: email"]);
     const errors = parseErrors(markdown);
     expect(errors).toHaveLength(1);
     expect(errors[0]!.line).toBe(7); // the `format:` line
@@ -194,41 +167,17 @@ describe("bug 10 — workflow parser rejects malformed / unsupported schemas", (
   });
 
   test("`oneOf:` in an output schema parses cleanly (the combinators are enforced)", () => {
-    const markdown = [
-      "---",
-      "type: workflow",
-      "steps:",
-      "  - id: work",
+    const markdown = workflowDoc([
       "    output:",
       "      type: object",
       "      properties:",
       "        result: { oneOf: [{ type: string }, { type: integer }] }",
-      "---",
-      "",
-      "## work",
-      "",
-      "Do it.",
-      "",
-    ].join("\n");
+    ]);
     expect(parseErrors(markdown)).toHaveLength(0);
   });
 
   test("`pattern:` in an output schema is a line-anchored authoring error naming the keyword", () => {
-    const markdown = [
-      "---",
-      "type: workflow",
-      "steps:",
-      "  - id: work",
-      "    output:",
-      "      type: string",
-      "      pattern: '^\\d+\\.\\d+\\.\\d+$'",
-      "---",
-      "",
-      "## work",
-      "",
-      "Do it.",
-      "",
-    ].join("\n");
+    const markdown = workflowDoc(["    output:", "      type: string", "      pattern: '^\\d+\\.\\d+\\.\\d+$'"]);
     const errors = parseErrors(markdown);
     expect(errors).toHaveLength(1);
     expect(errors[0]!.line).toBe(7); // the `pattern:` line
@@ -241,21 +190,11 @@ describe("bug 10 — workflow parser rejects malformed / unsupported schemas", (
     // to reason about the regex itself. There is no such analysis now: this is
     // the same "not enforced" message `format` or `const` gets, with no claim
     // about the pattern's own shape.
-    const markdown = [
-      "---",
-      "type: workflow",
-      "steps:",
-      "  - id: work",
+    const markdown = workflowDoc([
       "    output:",
       "      type: string",
       "      pattern: '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$'",
-      "---",
-      "",
-      "## work",
-      "",
-      "Do it.",
-      "",
-    ].join("\n");
+    ]);
     const errors = parseErrors(markdown);
     expect(errors).toHaveLength(1);
     expect(errors[0]!.line).toBe(7);
@@ -266,20 +205,7 @@ describe("bug 10 — workflow parser rejects malformed / unsupported schemas", (
   });
 
   test("a params schema gets the same definition checking", () => {
-    const markdown = [
-      "---",
-      "type: workflow",
-      "params:",
-      "  files: { type: aray }",
-      "steps:",
-      "  - id: work",
-      "---",
-      "",
-      "## work",
-      "",
-      "Do it.",
-      "",
-    ].join("\n");
+    const markdown = workflowDoc([], undefined, ["params:", "  files: { type: aray }"]);
     const errors = parseErrors(markdown);
     expect(errors).toHaveLength(1);
     expect(errors[0]!.line).toBe(4);
@@ -288,43 +214,25 @@ describe("bug 10 — workflow parser rejects malformed / unsupported schemas", (
   });
 
   test("a valid subset schema (with annotations) still parses cleanly", () => {
-    const markdown = [
-      "---",
-      "type: workflow",
-      "params:",
-      "  files: { type: array, description: The files to review, items: { type: string } }",
-      "steps:",
-      "  - id: work",
-      "    output:",
-      "      type: object",
-      "      required: [verdict]",
-      "      properties:",
-      "        verdict: { type: string, enum: [pass, fail] }",
-      "---",
-      "",
-      "## work",
-      "",
-      "Do it.",
-      "",
-    ].join("\n");
+    const markdown = workflowDoc(
+      [
+        "    output:",
+        "      type: object",
+        "      required: [verdict]",
+        "      properties:",
+        "        verdict: { type: string, enum: [pass, fail] }",
+      ],
+      undefined,
+      ["params:", "  files: { type: array, description: The files to review, items: { type: string } }"],
+    );
     expect(parseErrors(markdown)).toHaveLength(0);
   });
 
   test("a unit-level output schema is checked too", () => {
-    const markdown = [
-      "---",
-      "type: workflow",
-      "steps:",
-      "  - id: work",
+    const markdown = workflowDoc([
       "    unit:",
       "      output: { type: object, patternProperties: { '^x': { type: string } } }",
-      "---",
-      "",
-      "## work",
-      "",
-      "Do it.",
-      "",
-    ].join("\n");
+    ]);
     const errors = parseErrors(markdown);
     expect(errors).toHaveLength(1);
     expect(errors[0]!.message).toContain('keyword "patternProperties" is not enforced');

--- a/tests/workflows/unit-dispatch.test.ts
+++ b/tests/workflows/unit-dispatch.test.ts
@@ -1,0 +1,116 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * The env-credential seam both dispatch boundaries read through.
+ *
+ * `materializeFrozenLlm` (frozen workflow dispatch) and
+ * `materializeLlmConnection` (live-config dispatch) resolve the SAME credential
+ * descriptor, so lookup order and the required-credential failure must be one
+ * behavior, not two that happen to agree. These tests pin it from both sides.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ConfigError } from "../../src/core/errors";
+import { materializeLlmConnection } from "../../src/integrations/agent/engine-resolution";
+import { materializeFrozenLlm } from "../../src/workflows/exec/unit-dispatch";
+import type { FrozenEngineSnapshot } from "../../src/workflows/ir/schema";
+
+const PRIMARY = "FROZEN_CRED_PRIMARY";
+const FALLBACK = "FROZEN_CRED_FALLBACK";
+
+/**
+ * ISOLATION-01/02: these names carry none of the `AKM_*` / `XDG_*` / `HOME`
+ * prefixes `tests/_preload.ts` snapshots, so an unrestored set would leak into
+ * every later test in the shard. Restore explicitly, even when the body throws.
+ */
+function withEnv<T>(vars: Record<string, string | undefined>, body: () => T): T {
+  const original = Object.keys(vars).map((key): [string, string | undefined] => [key, process.env[key]]);
+  const apply = (entries: Iterable<[string, string | undefined]>): void => {
+    for (const [key, value] of entries) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  };
+  apply(Object.entries(vars));
+  try {
+    return body();
+  } finally {
+    apply(original);
+  }
+}
+
+function llmSnapshot(credential?: {
+  names: [string, ...string[]];
+  required: boolean;
+}): Extract<FrozenEngineSnapshot, { kind: "llm" }> {
+  return {
+    name: "fast",
+    kind: "llm",
+    endpoint: "https://example.test/v1/chat/completions",
+    model: "base-model",
+    concurrency: 1,
+    ...(credential ? { credential } : {}),
+  };
+}
+
+describe("frozen llm credential materialization", () => {
+  test("takes the first non-empty trimmed name, skipping a blank earlier one", () => {
+    const connection = withEnv({ [PRIMARY]: "   ", [FALLBACK]: "  fallback-secret  " }, () =>
+      materializeFrozenLlm(llmSnapshot({ names: [PRIMARY, FALLBACK], required: true }), undefined),
+    );
+
+    expect(connection.apiKey).toBe("fallback-secret");
+    expect(connection.model).toBe("base-model");
+    expect(connection.endpoint).toBe("https://example.test/v1/chat/completions");
+  });
+
+  test("an unset required credential fails identically at the frozen and the live boundary", () => {
+    const [frozenError, liveError] = withEnv({ [PRIMARY]: undefined, [FALLBACK]: undefined }, () => {
+      const capture = (run: () => unknown): unknown => {
+        try {
+          run();
+        } catch (err) {
+          return err;
+        }
+        return undefined;
+      };
+      return [
+        capture(() => materializeFrozenLlm(llmSnapshot({ names: [PRIMARY, FALLBACK], required: true }), undefined)),
+        capture(() =>
+          materializeLlmConnection({
+            engine: "fast",
+            connection: { endpoint: "https://example.test/v1/chat/completions", model: "base-model" },
+            credential: { names: [PRIMARY, FALLBACK], required: true },
+            timeoutMs: null,
+          }),
+        ),
+      ];
+    });
+
+    expect(frozenError).toBeInstanceOf(ConfigError);
+    expect(liveError).toBeInstanceOf(ConfigError);
+    expect((frozenError as ConfigError).message).toBe(`Required engine credential ${PRIMARY} is not set.`);
+    expect((liveError as ConfigError).message).toBe((frozenError as ConfigError).message);
+    expect((frozenError as ConfigError).code).toBe("INVALID_CONFIG_FILE");
+    expect((liveError as ConfigError).code).toBe((frozenError as ConfigError).code);
+  });
+
+  test("an unset optional credential materializes no apiKey key at all", () => {
+    const connection = withEnv({ [PRIMARY]: undefined }, () =>
+      materializeFrozenLlm(llmSnapshot({ names: [PRIMARY], required: false }), undefined),
+    );
+
+    expect(Object.hasOwn(connection, "apiKey")).toBe(false);
+  });
+
+  test("a snapshot with no credential descriptor resolves without touching the environment", () => {
+    const connection = withEnv({ [PRIMARY]: "unused-secret" }, () =>
+      materializeFrozenLlm(llmSnapshot(), { engine: "fast", model: "override-model", timeoutMs: null }),
+    );
+
+    expect(Object.hasOwn(connection, "apiKey")).toBe(false);
+    expect(connection.model).toBe("override-model");
+  });
+});


### PR DESCRIPTION
## Summary

Two rounds of review over the 0.9.1 workflow work, and the fixes for everything that survived verification. Base is `release/0.9.1` rather than `main` because this branch forked from that line — content-wise it is `release/0.9.1` plus these 14 commits, and a merge-tree dry run reports no conflicts.

**Two high-severity bugs are in `release/0.9.1` today.** Both are in the exec-unit feature, and both were reproduced empirically before being fixed:

- **A stderr-only capture failure discarded a valid artifact.** `sh -c "daemon >/dev/null & echo ok"` exits 0 with stdout fully drained, but the backgrounded child holds stderr — so the unit stalled its *entire* 10-minute budget and then failed non-retryably, with a diagnostic that blamed stdout. Measured at the tip: a 1500 ms unit returned at 3509 ms, empty-texted. Only stdout can make a capture incomplete now; an unfinished stderr drain is a warning on a successful unit. Separately, the drain deadline was anchored at capture rather than at child exit, which is what produced the full-budget stall — it now runs from `min(child exit, budget) + grace`, leaving the upper bound unchanged.
- **A gate rubric on an exec step re-ran the command once per loop.** A `### gate` with `max_loops: 3` ran `./deploy.sh` three times while the judge's feedback never reached it. An exec step's gate still *evaluates* and can still fail the step, but it no longer loops: a frozen argv cannot answer feedback, so a rejection goes straight to gate-exhausted.

The rest: `--max-steps` quietly changed what it counts (recorded in the CHANGELOG, not reverted — it is deliberate and test-pinned); `defaults.llm` with an agent step now fails at freeze; unsupported JSON-Schema keywords became parse errors that make previously-running assets unloadable; combinator enforcement reaches runs frozen before the upgrade. Those four were compatibility changes with no CHANGELOG entry — they have one now, including the quiet `akm index` path that drops an unparseable workflow with only a scan warning.

Also fixed: the win32 process-creation env floor was missing from the agent spawn allowlist; path containment rejected directories merely *named* `..data`; `appendEvent` could propagate from a function contracted never to; a lost-lease abort mid-judge was durably recorded as a verifier outage; the live-evidence map retained artifacts no later step could reference; `akm workflow run --timeout` reported completed runs as timed out; and the stale-worktree sweep could remove a tree still in use.

**Method.** Ten finder angles, then adversarial verifiers instructed to refute rather than confirm. Across both rounds that killed 16 candidates outright — including four that would have caused real damage if acted on: frozen-plan decoder "regressions" that git archaeology showed no emitted plan ever carried, a `started_at` clobber the run-lease TTL makes unreachable, and a `git worktree remove` claim that is backwards (it *succeeds* on a registered-but-missing tree). Several verifiers also corrected the diagnosis behind a real bug — the gate re-run is not caused by the input hash, and the lint single-pass had to be consumed at the sweep level because a golden pins `lintAssetFile` to errors only.

Two findings were deliberately left partial and are called out rather than buried: the discriminated-union refactor of `StepWorkUnit`/`UnitDispatchRequest` is follow-up-sized (it touches both dispatchers and the frozen-plan decode boundary), so only the provably-dead guard was removed; and the 7-day worktree sweep's liveness check was implemented differently from the review's suggestion, because a registration check would have exempted exactly the abandoned trees the sweep exists to collect.

## Test plan

- `bunx tsc --noEmit` — clean.
- `bun run lint` — exit 0, including every convention lint (isolation, license headers, runtime boundary, repository SQL, goldens, doc examples, terminology).
- `bun run test:unit` — 3567 pass / 0 fail.
- `bun run test:integration` — 5071 pass / 0 fail.
- New regression tests cover each high-severity fix: a bounded-timeout unit whose leader exits while a descendant holds stderr succeeds with its complete artifact and settles promptly; an exec step under a rejecting gate runs its command exactly once.
- Lint goldens are unchanged — they are the behavior oracle for the advisory-channel and single-pass work, so byte-identical output was the acceptance bar.
- The two fixture workflows added to the manual runbook were parsed through `parseWorkflow` to confirm they are copy-pasteable and produce the argv their assertions describe.

Verification ran on Linux. The win32 env-floor fix is reasoned and unit-tested but **not** exercised on a native Windows runner — worth a platform pass before release.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Lint passes (`bun run lint`)
- [x] Docs updated (if applicable)

CHANGELOG entries for every user-visible change, a `defaults.llm` caveat in the workflow schema reference, corrected exec failure-reason tables, and a new manual-testing section for exec units (run deliberately on an engine-less install, since that is the feature's first claim).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLTCEF92QXsE6FuzWUjNac)_