### PR TITLE
fix(lint,security): close five 0.9.1 milestone gaps (#760, #761, #762, #774, #756)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,57 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`akm lint` no longer reports a clean scan for a task file that cannot run.**
+  A `tasks/*.yml` whose YAML does not parse (bad indentation, an unterminated
+  quote, tab characters) produced `flagged: 0`: every task reader collapsed a
+  parse failure onto an empty mapping, and every task rule short-circuits on
+  one — so a CI gate on `--fail-on-flagged` passed a task that would die at
+  schedule time. The parse failure is now its own `invalid-task-yaml` finding.
+  A `tasks/*.yaml` file — a spelling akm never indexes and never schedules —
+  used to be skipped by the directory walk entirely; it is now collected and
+  flagged for the extension, with the rename in the message. Fixed on all three
+  task-lint surfaces (the CLI sweep, the `akm` adapter's `validate`, and the
+  `akm-task` format adapter) from one shared parse, so they cannot disagree.
+
+- **`akm lint --fix` refuses a bundle configured `writable: false`.** Every
+  other mutating command checks the flag before touching disk; `--fix` wrote
+  directly and never consulted it, so it rewrote frontmatter in a bundle
+  explicitly marked read-only. It is now a usage error raised before any file
+  is modified.
+
+- **A `--fix` write failure no longer aborts the run and hides the fixes that
+  already landed.** One unwritable file (read-only file, full disk) threw
+  straight out of `akm lint`, so the caller got an exception instead of a
+  result — with no way to tell which earlier files in the same sweep had
+  already been rewritten. A failed fix is now reported in-band on its own file
+  as `fixed: "failed"`, and the sweep continues through the rest of the bundle.
+
+- **`akm lint --type` says so when it does nothing.** For a non-akm bundle the
+  adapter validates the whole bundle regardless of `--type`, so scoping a run
+  silently had no effect. It now warns, naming the flag and the adapter.
+  Findings are unchanged (full-bundle validation was already a superset), and
+  it is deliberately a warning, not an error, so scripts passing one `--type`
+  across mixed-adapter bundle sets keep working.
+
+- **`missing-skill-md` fires again for an `agent-skills` package with no
+  manifest.** The check iterated pending CHANGES, and a change is always a
+  file — so a package directory holding resources but no `SKILL.md`
+  contributed nothing it could see, and a skills pack with a broken package
+  linted clean. It is now a real directory pass over the bundle root. Related:
+  under opencode's supported singular `skill/` alias the same package went
+  unflagged while an identical one under `skills/` was caught; both spellings
+  are now checked.
+
+- **`state.db`, `index.db`, `logs.db` and per-run task logs are created
+  owner-only.** They were created at whatever the process umask left them at
+  (typically `0644`), unlike the env/secret files akm writes, so on a shared
+  host any local user could read task history, captured command output, and
+  indexed content straight off disk. Databases and their `-wal`/`-shm`
+  sidecars are now `0600` in a `0700` data directory, and task logs are written
+  `0600` into a `0700` directory (POSIX only). `akm health`'s
+  `secret-file-perms` advisory now scans those paths too — and every configured
+  bundle's `env/`/`secrets/`, not just the default one.
+
 - **`timeout: none` on an exec unit is genuinely unbounded again.** The
   stream-drain safety net — a one-hour bound on a pipe still being read after
   the child is gone — was armed when capture STARTED, so a command that ran

--- a/docs/architecture/adapters.md
+++ b/docs/architecture/adapters.md
@@ -174,17 +174,20 @@ happens to expose a `placeNew()` implementation.
 A few adapter-specific behaviors are easy to assume differently from how
 they actually work:
 
-- **`agent-skills` recognition/validation are decoupled.** `validate()`
-  only inspects changes that resolve to an actual `SKILL.md`, so a package
-  directory with no manifest at all is never flagged by `missing-skill-md`
-  — an invalid skill is still indexed as `skill` (with its raw, invalid
-  name projected), and the violation only surfaces for files that exist.
+- **`agent-skills` recognition/validation are decoupled.** The per-change
+  half of `validate()` only inspects changes that resolve to an actual
+  `SKILL.md`, so an invalid skill is still indexed as `skill` (with its raw,
+  invalid name projected) and its field violations surface only for files
+  that exist. `missing-skill-md` is the exception and runs as a separate
+  directory pass over `ValidateContext.list`: a **top-level** directory that
+  holds files but no `SKILL.md` anywhere within three levels is flagged. A
+  package's own resource dirs (`pdf-processing/reference/`) are part of the
+  item, not candidate packages, and are never considered.
 - **`claude`/`opencode` share one codec** (`tool-dir-shared.ts`) and differ
   only in instruction filename, accepted subdirectory spellings, and
-  adapter/component ids. `opencode`'s `missing-skill-md` check matches the
-  literal `skills/` segment, so a skill package under the singular `skill/`
-  alias is never checked for a missing manifest, while the same package
-  under `skills/` is.
+  adapter/component ids. `missing-skill-md` is gated on each layout's own
+  accepted spellings, so opencode's singular `skill/` alias is checked
+  exactly like `skills/`.
 - **`dotenv` redaction is a hard, adapter-level contract.** No frontmatter
   `type:` override can bypass it: `env` entries surface only key names,
   `secret` entries surface only the file name, never content. A `.env`
@@ -193,7 +196,12 @@ they actually work:
 - **`akm-task`'s validation is stricter than the native `akm` adapter's.**
   Standalone `akm-task` bundles require `version: 2`, a `schedule`, and
   *exactly one* target; the native `akm` adapter's task check only requires
-  "at least one" target.
+  "at least one" target. Both report `invalid-task-yaml` when the YAML does
+  not parse at all — a parse failure is distinguished from an empty document,
+  which the field rules legitimately pass over. `.yaml` is listed in
+  `akm-task`'s `extensions` as a **collection hint only**: `recognize` still
+  gates on `.yml`, so a `.yaml` file is never indexed or scheduled — listing it
+  is what lets `validate` report the near-miss spelling instead of skipping it.
 - **`llm-wiki`, `akm`, and `okf` all reserve `index.md`/`log.md`** as
   structural files — never indexed as concepts, never valid write targets —
   at any depth.

--- a/docs/architecture/testing/manual-testing-checklist.md
+++ b/docs/architecture/testing/manual-testing-checklist.md
@@ -3241,19 +3241,31 @@ remaining gaps carry approved waivers with the expiries recorded below.
   - Covered: exact-value redaction for prompt-target and workflow-target task
     logs (`tests/integration/tasks-runner.test.ts` "redacts echoed agent
     credentials before task logs are persisted", webhook-URL case).
-  - Open: command-target task logs (secret echoed by a scheduled command is
-    persisted verbatim when not pattern-shaped), 0600 enforcement for
-    state.db / index.db / logs.db and per-run log files (created with umask
-    default, typically 0644), multi-bundle secret coverage (untested).
-  - Tracking: [#755](https://github.com/itlackey/akm/issues/755) (command-target log redaction),
-    [#756](https://github.com/itlackey/akm/issues/756) (0600 DB/log permissions, incl. multi-bundle coverage).
-  - issue: permission hardening + one redaction lane. impact: multi-user
-    hosts can read task history/telemetry; single-user machines unaffected.
-    owner: itlackey. verification test: per-item notes (stat-mode asserts
-    mirroring the existing secret-file-perms pattern). temporary mitigation:
-    data dir lives under the user's `$XDG_DATA_HOME`; env/secret files
-    themselves already carry 0600 enforcement. waiver approver: itlackey —
-    approved 2026-08-06 (0.9.0 release triage). waiver expiry: 0.9.1.
+  - **Fixed for 0.9.1** ([#756](https://github.com/itlackey/akm/issues/756)):
+    `openManagedDatabase` — the single home for the open recipe — now chmods
+    each database and its `-wal`/`-shm` sidecars to `0600` and its directory to
+    `0700`, so `state.db` / `index.db` / `logs.db` pick it up without per-call
+    changes; per-run task logs are written through `writeFileAtomic` (mode
+    `0600`) into a `0700` directory. `akm health`'s `secret-file-perms`
+    advisory now scans the data dir (databases + WAL/SHM), `<cache>/tasks/logs`,
+    and **every configured bundle's** `env/`/`secrets/`, not just the default
+    one. Pinned by `tests/integration/db-file-permissions.test.ts`
+    (stat-mode asserts under a deliberately widened `0o022` umask) and the new
+    cases in `tests/integration/commands/health/surfaces.test.ts`. POSIX only,
+    matching the advisory's existing `win32` early return.
+  - Open: command-target task logs (a secret echoed by a scheduled command is
+    persisted verbatim when it is not pattern-shaped).
+  - Tracking: [#755](https://github.com/itlackey/akm/issues/755) (command-target log redaction).
+  - issue: one redaction lane. impact: a multi-user host could read a
+    non-pattern-shaped secret out of a command task's history; single-user
+    machines unaffected, and the log/DB files are now `0600` regardless.
+    owner: itlackey. verification test: an exact-value redaction test for the
+    command arm mirroring the existing prompt-arm test in
+    `tests/integration/tasks-runner.test.ts`. temporary mitigation:
+    pattern-based redaction already catches the common credential shapes for
+    every task kind; the data dir lives under the user's `$XDG_DATA_HOME` and
+    is now `0700`. waiver approver: itlackey — approved 2026-08-06 (0.9.0
+    release triage). waiver expiry: 0.9.1.
 - [ ] **Package/release:** exact package-manager upgrade version verification,
       native installer/scheduler coverage, action/dependency provenance hardening,
       and post-publication artifact parity.
@@ -3291,20 +3303,32 @@ remaining gaps carry approved waivers with the expiries recorded below.
     errors instead of a false-clean `ok:true, flagged:0`
     (`src/commands/lint/index.ts`; pinned by
     `tests/integration/lint-fail-closed.test.ts`).
-  - Partial: adapter type scoping (adapter dispatch tested; `--type` is
-    silently ignored by non-akm adapter validation with no diagnostic).
-  - Open: malformed task YAML (and the `.yaml` misspelling) produces zero
-    findings; `--fix` against a read-only bundle or mid-sweep write failure
-    is neither transactional nor explicitly reported.
-  - Tracking: [#760](https://github.com/itlackey/akm/issues/760) (malformed task YAML),
-    [#761](https://github.com/itlackey/akm/issues/761) (--fix writable/transactional),
-    [#762](https://github.com/itlackey/akm/issues/762) (--type ignored on non-akm bundles).
-  - issue: lint trustworthiness at the edges. impact: a hand-edited task file
-    with broken YAML can pass lint silently. owner: itlackey. verification
-    test: per-item notes (§20 checklist lines). temporary mitigation:
-    interactive use surfaces empty summaries visibly; `--fix` remains
-    opt-in. waiver approver: itlackey — approved 2026-08-06 (0.9.0 release
-    triage). waiver expiry: 0.9.1.
+  - **Fixed for 0.9.1** (waiver discharged): all three tracked rows landed.
+    - [#760](https://github.com/itlackey/akm/issues/760) malformed task YAML —
+      the parse failure is now its own `invalid-task-yaml` finding instead of
+      collapsing onto `{}` (which every task rule short-circuits on), and a
+      `tasks/*.yaml` near miss is collected and flagged for the extension
+      rather than skipped by the walk. Fixed on all three task-lint surfaces
+      (the CLI sweep, the `akm` adapter's `validate`, and `akm-task`) from one
+      shared parse in `src/tasks/schema.ts`; pinned by
+      `tests/integration/lint-task-yaml.test.ts`.
+    - [#761](https://github.com/itlackey/akm/issues/761) `--fix` safety —
+      `--fix` against a bundle configured `writable: false` is now a usage
+      error raised before any file is touched, and a per-file fix-write
+      failure is reported in-band as `fixed: "failed"` (plus a `lint-failed`
+      finding if the per-file dispatch throws) instead of aborting the sweep
+      with an uncaught error that hid the fixes already on disk. Pinned by
+      `tests/integration/lint-fix-safety.test.ts`.
+    - [#762](https://github.com/itlackey/akm/issues/762) adapter type scoping —
+      a `--type` passed to a non-akm bundle now emits a warning naming the
+      flag and the adapter; findings are unchanged (validation was already a
+      superset). Pinned in `tests/integration/lint-adapter-dispatch.test.ts`.
+  - Also closed alongside these: [#774](https://github.com/itlackey/akm/issues/774)
+    — `missing-skill-md` is reachable again for `agent-skills` (a real
+    directory pass over `ValidateContext.list`, replacing the dangling
+    `{@link directorySkillDiagnostics}` reference), and opencode's singular
+    `skill/` alias is checked identically to `skills/`. Pinned by
+    `tests/integration/lint-missing-skill-md.test.ts`.
 
 For each unchecked row record:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1852,14 +1852,24 @@ akm lint --fail-on-flagged      # CI-friendly: exit non-zero when summary.flagge
 
 | Flag | Description |
 | --- | --- |
-| `--fix` (alias `--auto-fix`) | Apply auto-fixes in place |
+| `--fix` (alias `--auto-fix`) | Apply auto-fixes in place. Refused with a usage error when the target bundle is configured `writable: false`. |
 | `--dir` | Override the bundle root directory (default: from config) |
-| `--type` | Only lint assets of this type (e.g. `workflows`, `tasks`, `memories`) |
+| `--type` | Only lint assets of this type (e.g. `workflows`, `tasks`, `memories`). **akm bundles only** — every other adapter validates the whole bundle and warns on stderr that the flag had no effect. |
 | `--fail-on-flagged` | Exit non-zero when `summary.flagged > 0`. Default: exit 0 regardless of findings. |
 
 Returns `fixed[]` and `flagged[]` arrays plus a `summary: { fixed, flagged }`
 count. Each entry carries `file`, `issue`, `detail`, and whether it was
 `fixed`.
+
+Task files are checked for more than their fields: a `tasks/*.yml` whose YAML
+does not parse is reported as `invalid-task-yaml` (it used to fall through as an
+empty mapping and lint clean), and a `tasks/*.yaml` file — a spelling akm never
+indexes or schedules — is flagged for the extension rather than skipped.
+
+`--fix` is transactional per file: a fix that cannot be written (read-only file,
+full disk) is reported as `fixed: "failed"` on that file and the sweep continues,
+so a mid-run write failure can no longer abort the command and hide the fixes
+that already landed.
 
 ### improve
 

--- a/docs/reference/data-and-telemetry.md
+++ b/docs/reference/data-and-telemetry.md
@@ -46,6 +46,12 @@ Override: set `AKM_CONFIG_DIR` or `XDG_CONFIG_HOME`.
 
 Override: set `AKM_DATA_DIR` or `XDG_DATA_HOME`.
 
+On POSIX hosts the data directory is created `0700`, and `index.db`, `state.db`,
+`logs.db` and their `-wal`/`-shm` sidecars are created `0600` — regardless of
+your umask. They hold task history, captured command output, and indexed
+content, so on a shared machine they should not be world-readable. `akm health`
+warns (`secret-file-perms`) if any of these are group/other-readable.
+
 ### Cache Directory (`$XDG_CACHE_HOME/akm` or `~/.cache/akm/`)
 
 Everything in the cache is regenerable. It is safe to delete the entire cache directory; AKM will recreate what it needs on next use.
@@ -58,7 +64,7 @@ Everything in the cache is regenerable. It is safe to delete the entire cache di
 | `registry-index/` | Legacy per-URL JSON cache (v0.7 artifact) | Yes — fully replaced by `index.db` in 0.8.0 |
 | `semantic-status.json` | Semantic index build status marker | Yes |
 | `bin/` | Downloaded AKM binary cache (used by `akm upgrade`) | Yes |
-| `tasks/logs/` | Scheduled task log files | Yes — ephemeral logs |
+| `tasks/logs/` | Scheduled task log files (owner-only — file `0600`, dir `0700`, since they hold captured command/agent output) | Yes — ephemeral logs |
 | `tasks/history/` | Legacy task history JSONL (v0.7 migration artifact) | Yes |
 
 Override: set `AKM_CACHE_DIR` or `XDG_CACHE_HOME`.

--- a/src/commands/agent/contribute-cli.ts
+++ b/src/commands/agent/contribute-cli.ts
@@ -201,7 +201,8 @@ export const lintCommand = defineCommand({
     },
     type: {
       type: "string",
-      description: "Only lint assets of this type (e.g. workflows, tasks, memories)",
+      description:
+        "Only lint assets of this type (e.g. workflows, tasks, memories). akm bundles only — every other adapter validates the whole bundle and warns that the flag had no effect.",
       default: undefined,
     },
   },

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -13,6 +13,7 @@ import { openLogsDatabase } from "../core/logs-db";
 import { getCacheDir, getConfigPath, getDataDir, getStateDbPathInDataDir } from "../core/paths";
 import { listExistingTableNames, openStateDatabase } from "../core/state-db";
 import { DURATION_UNITS, parseDuration, parseSinceToIso } from "../core/time";
+import { resolveSourceEntries } from "../indexer/search/search-source";
 import { readSemanticStatus } from "../indexer/search/semantic-status";
 import type { SessionLogEntry } from "../integrations/session-logs";
 import { getExecutionLogCandidates } from "../integrations/session-logs";
@@ -370,6 +371,22 @@ function gatherImproveSummaryPhase(
  * probe/filesystem failure in either try/catch must not abort the health
  * report — each group degrades to "no advisory" independently.
  */
+/**
+ * Configured bundle roots other than `primary`, for the permission sweep.
+ * Best-effort: a config that cannot be resolved yields none rather than
+ * aborting the (already best-effort) advisory group.
+ */
+function secondaryStashDirs(primary: string): string[] {
+  try {
+    const primaryResolved = path.resolve(primary);
+    return resolveSourceEntries()
+      .map((source) => path.resolve(source.path))
+      .filter((dir) => dir !== primaryResolved && fs.existsSync(dir));
+  } catch {
+    return [];
+  }
+}
+
 function gatherAncillaryAdvisories(
   db: Database,
   stateDbPath: string,
@@ -402,10 +419,15 @@ function gatherAncillaryAdvisories(
   // binary-config-skew, egress-endpoints). Best-effort — a
   // filesystem probe failure must not abort the health report.
   try {
+    const primaryStashDir = options.stashDir ?? resolveStashDir();
     advisories.push(
       ...collectSurfacesAdvisories({
-        stashDir: options.stashDir ?? resolveStashDir(),
+        stashDir: primaryStashDir,
+        // Secondary bundles hold env/secret assets too (issue #756) — the
+        // advisory used to stop at the primary stash.
+        extraStashDirs: secondaryStashDirs(primaryStashDir),
         cacheDir: getCacheDir(),
+        dataDir: getDataDir(),
         configPath: getConfigPath(),
         config: egressConfigView,
       }),

--- a/src/commands/health/surfaces.ts
+++ b/src/commands/health/surfaces.ts
@@ -35,54 +35,92 @@ function modeOctal(mode: number): string {
 }
 
 /**
- * `secret-file-perms` (08-F4): flag env/secret/backup files that are not 0600
- * and their directories when not 0700. Scans `<stash>/env`, `<stash>/secrets`
- * and `<cache>/config-backups`; anything readable by group/other is an
- * offender. Silent when every path is tight (or none of the dirs exist).
+ * The managed SQLite databases, plus the WAL sidecars that carry the same page
+ * content. Checked individually rather than by sweeping the whole data dir:
+ * `$DATA` also holds registry caches and materialized bundle content, which is
+ * not sensitive and would bury the real offenders in the evidence list.
+ */
+const DATA_DB_BASENAMES = ["state.db", "index.db", "logs.db", "workflow.db"] as const;
+const DB_SIDECAR_SUFFIXES = ["", "-wal", "-shm"] as const;
+
+interface PermOffenderScan {
+  /** Directories walked recursively; every entry within is checked. */
+  roots: string[];
+  /** Individual files checked on their own, without walking their parent. */
+  files: string[];
+  /** Directories checked for their own mode only (not walked). */
+  dirs: string[];
+}
+
+function checkPathMode(abs: string, offenders: string[], expectDirectory?: boolean): fs.Stats | undefined {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(abs);
+  } catch {
+    return undefined; // absent → nothing to protect
+  }
+  if ((stat.mode & GROUP_OTHER_BITS) === 0) return stat;
+  const isDir = expectDirectory ?? stat.isDirectory();
+  offenders.push(isDir ? `${abs}/ (${modeOctal(stat.mode)}, want 700)` : `${abs} (${modeOctal(stat.mode)}, want 600)`);
+  return stat;
+}
+
+/**
+ * `secret-file-perms` (08-F4): flag files that are not 0600 and directories
+ * that are not 0700, anywhere akm stores credentials or captured content.
+ *
+ * Scans `<stash>/env`, `<stash>/secrets`, `<cache>/config-backups`, the
+ * per-run task logs under `<cache>/tasks/logs`, and the managed databases in
+ * `<data>` (`state.db` / `index.db` / `logs.db` / `workflow.db` plus their
+ * `-wal`/`-shm` sidecars). The database and task-log surfaces were the gap this
+ * advisory was always documented to cover but never actually scanned
+ * (issue #756) — those files hold task history and captured command output, and
+ * they are created by the umask, so on a shared host they were the easiest
+ * thing to read off disk. Silent when every path is tight (or absent).
  */
 export function collectSecretPermsAdvisory(
-  input: { stashDir: string; cacheDir: string },
+  input: { stashDir: string; extraStashDirs?: readonly string[]; cacheDir: string; dataDir?: string },
   platform: PlatformLike = process.platform,
 ): HealthCheckResult | undefined {
   if (platform === "win32") return undefined;
 
-  const roots = [
-    path.join(input.stashDir, "env"),
-    path.join(input.stashDir, "secrets"),
-    path.join(input.cacheDir, "config-backups"),
-  ];
+  // Every CONFIGURED bundle, not only the primary one: a secondary bundle's
+  // `env/`/`secrets/` hold exactly the same material, and an operator running
+  // `akm health` has no reason to expect the check stops at the default stash.
+  const stashDirs = [input.stashDir, ...(input.extraStashDirs ?? [])];
+  const scan: PermOffenderScan = {
+    roots: [
+      ...stashDirs.flatMap((dir) => [path.join(dir, "env"), path.join(dir, "secrets")]),
+      path.join(input.cacheDir, "config-backups"),
+      // Per-run task logs: raw command/agent stdout+stderr, one file per run.
+      path.join(input.cacheDir, "tasks", "logs"),
+    ],
+    files: [],
+    dirs: [],
+  };
+  if (input.dataDir) {
+    scan.dirs.push(input.dataDir);
+    for (const basename of DATA_DB_BASENAMES) {
+      for (const suffix of DB_SIDECAR_SUFFIXES) {
+        scan.files.push(path.join(input.dataDir, `${basename}${suffix}`));
+      }
+    }
+  }
+
   const offenders: string[] = [];
 
-  for (const root of roots) {
-    let stat: fs.Stats;
-    try {
-      stat = fs.statSync(root);
-    } catch {
-      continue; // absent → nothing to protect
-    }
-    if ((stat.mode & GROUP_OTHER_BITS) !== 0) offenders.push(`${root}/ (${modeOctal(stat.mode)}, want 700)`);
+  for (const root of scan.roots) {
+    if (checkPathMode(root, offenders, true) === undefined) continue;
     let entries: string[];
     try {
       entries = fs.readdirSync(root, { recursive: true }) as string[];
     } catch {
       continue;
     }
-    for (const entry of entries) {
-      const abs = path.join(root, entry);
-      let entryStat: fs.Stats;
-      try {
-        entryStat = fs.statSync(abs);
-      } catch {
-        continue;
-      }
-      if ((entryStat.mode & GROUP_OTHER_BITS) === 0) continue;
-      offenders.push(
-        entryStat.isDirectory()
-          ? `${abs}/ (${modeOctal(entryStat.mode)}, want 700)`
-          : `${abs} (${modeOctal(entryStat.mode)}, want 600)`,
-      );
-    }
+    for (const entry of entries) checkPathMode(path.join(root, entry), offenders);
   }
+  for (const dir of scan.dirs) checkPathMode(dir, offenders, true);
+  for (const file of scan.files) checkPathMode(file, offenders, false);
 
   if (offenders.length === 0) return undefined;
   const preview = offenders.slice(0, 5).join("; ") + (offenders.length > 5 ? `; +${offenders.length - 5} more` : "");
@@ -92,8 +130,9 @@ export function collectSecretPermsAdvisory(
     status: "warn",
     confidence: "high",
     message:
-      `${offenders.length} env/secret/backup path(s) are readable by group/other: ${preview}. ` +
-      "Tighten with chmod 600 (files) / chmod 700 (dirs) — these hold tokens, keys, and config snapshots.",
+      `${offenders.length} secret/backup/database/task-log path(s) are readable by group/other: ${preview}. ` +
+      "Tighten with chmod 600 (files) / chmod 700 (dirs) — these hold tokens, keys, config snapshots, " +
+      "task history, and captured command output.",
     evidence: { offenders: offenders.slice(0, OFFENDER_EVIDENCE_CAP) },
   };
 }
@@ -194,14 +233,23 @@ export function collectEgressAdvisory(config: EgressConfigView | undefined): Hea
  */
 export function collectSurfacesAdvisories(input: {
   stashDir: string;
+  /** Secondary configured bundle roots, scanned for `env/`/`secrets/` alongside the primary. */
+  extraStashDirs?: readonly string[];
   cacheDir: string;
+  /** `$DATA` — the managed databases' home. Omitted by callers that have none resolved. */
+  dataDir?: string;
   configPath: string;
   config: EgressConfigView | undefined;
   platform?: PlatformLike;
 }): HealthCheckResult[] {
   const results = [
     collectSecretPermsAdvisory(
-      { stashDir: input.stashDir, cacheDir: input.cacheDir },
+      {
+        stashDir: input.stashDir,
+        ...(input.extraStashDirs ? { extraStashDirs: input.extraStashDirs } : {}),
+        cacheDir: input.cacheDir,
+        ...(input.dataDir ? { dataDir: input.dataDir } : {}),
+      },
       input.platform ?? process.platform,
     ),
     collectConfigSkewAdvisory(input.configPath),

--- a/src/commands/lint/base-linter.ts
+++ b/src/commands/lint/base-linter.ts
@@ -462,11 +462,17 @@ function parseInnerFrontmatterBlock(body: string): Record<string, unknown> | nul
  * File mutations triggered by the fixable base checks (`unquoted-colon`,
  * `missing-updated`) are flushed to disk here when `ctx.fix` is set, and
  * `ctx.raw` is updated in place so a caller can re-parse the post-fix content.
+ * A failed flush (read-only file, full disk) DOWNGRADES the optimistic
+ * `fixed: true` findings this call made to `fixed: "failed"` rather than
+ * throwing — an uncaught throw here used to kill the whole sweep and hide
+ * which earlier files had already been rewritten (issue #761).
  */
 export function runBaseChecks(ctx: LintContext): LintIssue[] {
   const issues: LintIssue[] = [];
   let currentRaw = ctx.raw;
   let modified = false;
+  /** Findings whose `fixed: true` is only true once the flush below succeeds. */
+  const pendingFixes: LintIssue[] = [];
 
   // M8: Parse lint_skip from frontmatter for per-file rule suppression.
   // Accept both an array (`lint_skip: [missing-ref, stale-path]`) and a
@@ -485,12 +491,14 @@ export function runBaseChecks(ctx: LintContext): LintIssue[] {
       if (ctx.fix) {
         currentRaw = fixUnquotedColon(currentRaw);
         modified = true;
-        issues.push({
+        const issue: LintIssue = {
           file: ctx.relPath,
           issue: "unquoted-colon",
           detail: unquotedColonDetail,
           fixed: true,
-        });
+        };
+        issues.push(issue);
+        pendingFixes.push(issue);
       } else {
         issues.push({
           file: ctx.relPath,
@@ -513,12 +521,14 @@ export function runBaseChecks(ctx: LintContext): LintIssue[] {
       }
       currentRaw = fixMissingUpdated(currentRaw, mtime);
       modified = true;
-      issues.push({
+      const issue: LintIssue = {
         file: ctx.relPath,
         issue: "missing-updated",
         detail: `stamped updated: ${localDateStamp(mtime)}`,
         fixed: true,
-      });
+      };
+      issues.push(issue);
+      pendingFixes.push(issue);
     } else {
       issues.push({
         file: ctx.relPath,
@@ -530,9 +540,22 @@ export function runBaseChecks(ctx: LintContext): LintIssue[] {
   }
 
   if (modified) {
-    fs.writeFileSync(ctx.filePath, currentRaw, "utf8");
-    // Propagate the mutated raw back so subclasses can re-parse if needed
-    ctx.raw = currentRaw;
+    // Mirrors the two stub-delete call sites in `commands/lint/index.ts`
+    // (`appendMemoryStubIssue`/`appendWorkflowStubIssue`), which already report
+    // a failed mutation as `fixed: "failed"` instead of throwing. Without this
+    // the sweep aborted mid-run on the first unwritable file and the caller got
+    // an exception instead of a result naming the fixes that HAD landed.
+    try {
+      fs.writeFileSync(ctx.filePath, currentRaw, "utf8");
+      // Propagate the mutated raw back so subclasses can re-parse if needed
+      ctx.raw = currentRaw;
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      for (const issue of pendingFixes) {
+        issue.fixed = "failed";
+        issue.detail = `${issue.detail} — could not write fix: ${reason}`;
+      }
+    }
   }
 
   // ── 3. stale-path ──────────────────────────────────────────────────────

--- a/src/commands/lint/index.ts
+++ b/src/commands/lint/index.ts
@@ -4,7 +4,6 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { parse as parseYaml } from "yaml";
 import {
   factDiagnostics,
   matchWorkflowPlaceholder,
@@ -27,7 +26,15 @@ import type { AkmConfig } from "../../core/config/config";
 import { loadConfig, primaryBundlePath } from "../../core/config/config";
 import { UsageError } from "../../core/errors";
 import type { FileChange } from "../../core/file-change";
+import { warn } from "../../core/warn";
 import { resolveSourceEntries, type SearchSource } from "../../indexer/search/search-source";
+import {
+  parseTaskYaml,
+  TASK_EXTENSION,
+  TASK_NEAR_MISS_EXTENSION,
+  taskExtensionDetail,
+  taskYamlParseDetail,
+} from "../../tasks/schema";
 import { runBaseChecks } from "./base-linter";
 import { checkEnvForDangerousKeys } from "./env-key-rules";
 import { isAdvisoryLintIssue, type LintContext, type LintIssue, type LintIssueType } from "./types";
@@ -72,18 +79,33 @@ const STASH_SUBDIRS = [
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function collectYamlFiles(dir: string): string[] {
+/**
+ * Every task-shaped file under `tasks/`: the recognized `.yml` spelling AND the
+ * `.yaml` near-miss. A `.yaml` file is not a runnable task — it is invisible to
+ * the indexer's `tasks` matcher — but collecting it here is what lets the sweep
+ * SAY so (`invalid-task-yaml`, see {@link taskExtensionDetail}) instead of
+ * walking past it and reporting a clean scan (issue #760).
+ */
+function collectTaskFiles(dir: string): string[] {
   if (!fs.existsSync(dir)) return [];
   const results: string[] = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      results.push(...collectYamlFiles(full));
-    } else if (entry.isFile() && entry.name.endsWith(".yml")) {
+      results.push(...collectTaskFiles(full));
+    } else if (entry.isFile() && (isTaskFileName(entry.name) || isNearMissTaskFileName(entry.name))) {
       results.push(full);
     }
   }
   return results;
+}
+
+function isTaskFileName(fileName: string): boolean {
+  return fileName.toLowerCase().endsWith(TASK_EXTENSION);
+}
+
+function isNearMissTaskFileName(fileName: string): boolean {
+  return fileName.toLowerCase().endsWith(TASK_NEAR_MISS_EXTENSION);
 }
 
 function collectMarkdownFiles(dir: string, caseInsensitive = false): string[] {
@@ -177,6 +199,10 @@ const KNOWN_ADAPTER_ISSUE_TYPES: ReadonlySet<string> = new Set<LintIssueType>([
   "missing-type",
   "missing-name-or-type",
   "missing-skill-md",
+  // The `akm-task` adapter's own code. Now reachable from `akm lint` for a
+  // malformed or misnamed task file (issue #760); without it here, a genuine
+  // task finding would arrive folded onto `adapter-diagnostic`.
+  "invalid-task-yaml",
   "dangerous-env-key",
   "uncited-raw",
   "missing-description",
@@ -223,6 +249,20 @@ async function lintViaAdapter(
   // falls back to the akm-shaped sweep, the same default `akm lint` has
   // always applied to a bundle it can't otherwise place.
   if (!adapter) return lintAkmSweep(stashRoot, extraStashRoots, cfg, sources, options);
+
+  // `--type` names an AKM stash subdir; every other adapter has its own type
+  // vocabulary and `validate()` sees the whole bundle regardless. That is not a
+  // correctness problem (full-bundle validation is a superset of the requested
+  // scope), but a user narrowing a run deserves to hear the flag did nothing
+  // rather than infer it from identical output (issue #762). Warn, don't throw:
+  // a hard error would break scripts passing one `--type` across mixed-adapter
+  // bundle sets.
+  if (options.typeFilter) {
+    warn(
+      `Warning: lint --type "${options.typeFilter}" is not supported for the "${adapterId}" adapter — ` +
+        "type scoping applies to akm bundles only; the whole bundle was validated.",
+    );
+  }
 
   const files = collectAdapterFiles(stashRoot, adapter.extensions);
   const changes: FileChange[] = files.map((filePath) => ({
@@ -334,6 +374,32 @@ function runEnvDangerousKeyPass(
     }
   }
   return flagged;
+}
+
+/**
+ * Refuse `--fix` against a bundle the config marks `writable: false`, BEFORE
+ * the sweep touches a single file (issue #761).
+ *
+ * Every other mutating command routes through `core/write-source.ts`'s
+ * `ensureWritable`/`resolveWritable` pair; `akm lint --fix` writes and deletes
+ * directly and never consulted the flag, so it happily rewrote frontmatter in a
+ * bundle explicitly configured read-only. `SearchSource.writable` is already the
+ * EFFECTIVE policy (`resolveWritable` applied — see `resolveSourceEntries`), so
+ * this reads the same answer the write path would, without a second resolver.
+ *
+ * A root that is not a configured source at all (an ad-hoc `--dir`) carries no
+ * policy and stays fixable, exactly as today.
+ */
+function assertFixTargetWritable(stashRoot: string, sources: SearchSource[]): void {
+  const target = sources.find((source) => path.resolve(source.path) === path.resolve(stashRoot));
+  if (target?.writable !== false) return;
+  // Same error kind and code `write-source.ts#ensureWritable` raises for the
+  // identical refusal, so a scripted caller classifies both the same way.
+  throw new UsageError(
+    `lint --fix: bundle "${stashRoot}" is configured \`writable: false\`; refusing to modify it. ` +
+      "Run `akm lint` without --fix to report findings, or set `writable: true` on the bundle.",
+    "INVALID_FLAG_VALUE",
+  );
 }
 
 /** True when the issue represents a file deletion that was successfully applied. */
@@ -478,6 +544,7 @@ function lintAkmSweep(
   options: AkmLintOptions,
 ): AkmLintResult {
   const fix = options.fix === true;
+  if (fix) assertFixTargetWritable(stashRoot, sources);
   const fixed: LintIssue[] = [];
   const flagged: LintIssue[] = [];
   const warnings: LintIssue[] = [];
@@ -488,7 +555,7 @@ function lintAkmSweep(
     const dirPath = path.join(stashRoot, subdir);
     // Tasks are .yml files; everything else (including workflows, one
     // markdown format now) is .md
-    const files = subdir === "tasks" ? collectYamlFiles(dirPath) : collectMarkdownFiles(dirPath, true);
+    const files = subdir === "tasks" ? collectTaskFiles(dirPath) : collectMarkdownFiles(dirPath, true);
     const assetFiles =
       subdir === "workflows" ? files.filter((file) => path.basename(file).toLowerCase() !== "readme.md") : files;
 
@@ -524,15 +591,33 @@ function lintAkmSweep(
       let data: Record<string, unknown>;
       let body: string;
       let frontmatter: string | null;
+      // File-identity findings the per-type rules cannot produce: they describe
+      // the FILE (its extension, whether it parsed at all), not its fields.
+      const fileIssues: LintIssue[] = [];
 
       if (subdir === "tasks") {
         // Task files are pure YAML — parseFrontmatter returns empty data for them.
-        try {
-          const parsed = parseYaml(raw);
-          data =
-            parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
-        } catch {
-          data = {};
+        const parsed = parseTaskYaml(raw);
+        data = parsed.data;
+        if (!parsed.ok) {
+          // A parse failure used to fall through as `data = {}`, and every task
+          // rule short-circuits on an empty mapping — so an unparseable task
+          // file reported a CLEAN scan. Report the parse failure itself
+          // (issue #760).
+          fileIssues.push({
+            file: relPath,
+            issue: "invalid-task-yaml",
+            detail: taskYamlParseDetail(parsed.error),
+            fixed: false,
+          });
+        }
+        if (isNearMissTaskFileName(relPath)) {
+          fileIssues.push({
+            file: relPath,
+            issue: "invalid-task-yaml",
+            detail: taskExtensionDetail(relPath),
+            fixed: false,
+          });
         }
         body = raw;
         frontmatter = null;
@@ -540,10 +625,29 @@ function lintAkmSweep(
         ({ data, content: body, frontmatter } = parseFrontmatter(raw));
       }
 
-      const issues = lintAssetFile(
-        { filePath, relPath, raw, data, body, frontmatter, fix, stashRoot, extraStashRoots },
-        subdir,
-      );
+      // One file's checks — including its `--fix` mutations — must never abort
+      // the sweep: an uncaught throw here left the caller with an exception and
+      // no record of which earlier files had ALREADY been rewritten on disk
+      // (issue #761). A failure is reported per-file, in-band, and the sweep
+      // continues so the rest of the bundle is still linted.
+      let issues: LintIssue[];
+      try {
+        issues = [
+          ...fileIssues,
+          ...lintAssetFile(
+            { filePath, relPath, raw, data, body, frontmatter, fix, stashRoot, extraStashRoots },
+            subdir,
+          ),
+        ];
+      } catch (e) {
+        flagged.push(...fileIssues, {
+          file: relPath,
+          issue: "lint-failed",
+          detail: `lint ${fix ? "--fix " : ""}failed for this file: ${e instanceof Error ? e.message : String(e)}`,
+          fixed: fix ? "failed" : false,
+        });
+        continue;
+      }
 
       let fileDeleted = false;
       for (const issue of issues) {

--- a/src/commands/lint/types.ts
+++ b/src/commands/lint/types.ts
@@ -16,6 +16,15 @@ export type LintIssueType =
   | "dangerous-env-key"
   | "invalid-workflow-structure"
   | "missing-category"
+  /**
+   * A file the sweep reached but could not finish checking — the per-file
+   * dispatch threw (unreadable mid-run, a `--fix` write that failed in a way
+   * the fixer could not absorb). Reported in-band so a partial sweep is
+   * VISIBLE: before this code existed the throw escaped `akmLint()` entirely
+   * and the caller learned neither which file failed nor which fixes had
+   * already landed on disk (issue #761).
+   */
+  | "lint-failed"
   // ── non-akm adapter `validate()` codes (akm 0.9.0 lint/adapter-dispatch wiring) ──
   //
   // These four are `llm-wiki`'s native structural checks

--- a/src/core/adapter/adapters/agent-skills-adapter.ts
+++ b/src/core/adapter/adapters/agent-skills-adapter.ts
@@ -28,10 +28,13 @@
  *   - `skill-description-too-long` — description must be 1-1024 chars.
  *   - `missing-skill-md` — a package dir with no SKILL.md (edge case; git cannot
  *     commit an empty dir, so it is covered by a directory-level check, not a
- *     fixture).
+ *     fixture). Implemented by {@link missingManifestDiagnostics}, which scans
+ *     the component root through `ValidateContext.list` — the change-set loop
+ *     cannot reach it, because a change is always a file and a manifest-less
+ *     package contributes no SKILL.md change (issue #774).
  *
- * Only `missing-skill-md` is coded elsewhere today; the two field codes are
- * APPROVED-BUT-NOT-YET-CODED and are implemented here. Base checks are NOT run:
+ * The two field codes are APPROVED-BUT-NOT-YET-CODED elsewhere and are
+ * implemented here. Base checks are NOT run:
  * a SKILL.md carries no `updated` field, so `missing-updated` would fire on
  * every conformant skill and contradict the lint golden.
  *
@@ -141,6 +144,64 @@ function skillFieldDiagnostics(relPath: string, dirName: string, data: Record<st
   return diagnostics;
 }
 
+/**
+ * How deep below a candidate package directory the manifest probe looks. Agent
+ * Skills packages sit at the component root (`<name>/SKILL.md`), occasionally
+ * one group level down (`<group>/<name>/SKILL.md`) — this bound keeps a deep
+ * resource tree (a package's `reference/`, `assets/`, …) from turning the lint
+ * sweep into a full recursive walk.
+ */
+const MAX_PACKAGE_PROBE_DEPTH = 3;
+
+/** True when `SKILL.md` exists at `dir` or anywhere within {@link MAX_PACKAGE_PROBE_DEPTH} below it. */
+async function subtreeHasManifest(
+  dir: string,
+  entries: readonly string[],
+  ctx: ValidateContext,
+  depth: number,
+): Promise<boolean> {
+  if (entries.includes(SKILL_MANIFEST)) return true;
+  if (depth >= MAX_PACKAGE_PROBE_DEPTH) return false;
+  for (const entry of entries) {
+    const child = `${dir}/${entry}`;
+    // `list` on a FILE yields `[]` (the read throws and is swallowed), so an
+    // empty listing is the "not a directory worth descending" signal — no
+    // separate stat is available on ValidateContext, and none is needed.
+    const childEntries = await ctx.list(child);
+    if (childEntries.length === 0) continue;
+    if (await subtreeHasManifest(child, childEntries, ctx, depth + 1)) return true;
+  }
+  return false;
+}
+
+/**
+ * The directory-level `missing-skill-md` check (issue #774).
+ *
+ * `validate` walks CHANGES, and a change is always a file — so a package
+ * directory carrying resources but no manifest contributes nothing the
+ * change-loop can see, and the check the spec (§4.5) and the lint golden's
+ * `missingSkillMd` edge case both name was unreachable. This scans the
+ * component root through {@link ValidateContext.list} instead, so the case is
+ * actually reported.
+ *
+ * Deliberately TOP-LEVEL only: a package's own resource dirs
+ * (`pdf-processing/reference/`) are part of the item, not candidate packages,
+ * and flagging them would turn every conformant bundle red. A top-level dir
+ * that holds a manifest ANYWHERE beneath it is a grouping dir, not a broken
+ * package, so it is left alone too.
+ */
+async function missingManifestDiagnostics(ctx: ValidateContext): Promise<Diagnostic[]> {
+  const diagnostics: Diagnostic[] = [];
+  for (const name of await ctx.list(".")) {
+    if (name.startsWith(".")) continue; // .git, .github, … are not skill packages
+    const entries = await ctx.list(name);
+    if (entries.length === 0) continue; // a root file (README.md), or an untrackable empty dir
+    if (await subtreeHasManifest(name, entries, ctx, 1)) continue;
+    diagnostics.push({ file: name, issue: "missing-skill-md", detail: `no SKILL.md in ${name}/`, fixed: false });
+  }
+  return diagnostics;
+}
+
 async function validate(_c: BundleComponent, changes: FileChange[], ctx: ValidateContext): Promise<Diagnostic[]> {
   const diagnostics: Diagnostic[] = [];
   const seenDirs = new Set<string>();
@@ -154,10 +215,12 @@ async function validate(_c: BundleComponent, changes: FileChange[], ctx: Validat
     if (seenDirs.has(pkg.conceptId)) continue;
     seenDirs.add(pkg.conceptId);
 
-    // missing-skill-md is unreachable here (the change IS a SKILL.md); the empty-dir
-    // case is served by {@link directorySkillDiagnostics} for callers that scan dirs.
+    // `missing-skill-md` cannot fire here — the change IS a SKILL.md. The
+    // manifest-less package case is served by {@link missingManifestDiagnostics}
+    // below, which scans directories rather than changes.
     diagnostics.push(...skillFieldDiagnostics(toPosix(change.path), pkg.dirName, parseFrontmatter(raw).data));
   }
+  diagnostics.push(...(await missingManifestDiagnostics(ctx)));
   return diagnostics;
 }
 

--- a/src/core/adapter/adapters/akm-adapter.ts
+++ b/src/core/adapter/adapters/akm-adapter.ts
@@ -82,13 +82,13 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { parse as parseYaml } from "yaml";
 import {
   applyPostContributorFields,
   applyPreContributorFields,
   extractPackageMetadata,
 } from "../../../indexer/passes/metadata";
 import type { FileContext } from "../../../indexer/walk/file-context";
+import { parseTaskYaml, taskYamlParseDetail } from "../../../tasks/schema";
 import {
   assetPathForName,
   deriveCanonicalAssetNameFromStashRoot,
@@ -402,14 +402,19 @@ async function validate(c: BundleComponent, changes: FileChange[], ctx: Validate
     // everything else → `parseFrontmatter`.
     let parsed: ParsedForValidate;
     if (type === "task") {
-      let data: Record<string, unknown> = {};
-      try {
-        const doc = parseYaml(raw);
-        if (doc && typeof doc === "object" && !Array.isArray(doc)) data = doc as Record<string, unknown>;
-      } catch {
-        data = {};
+      const task = parseTaskYaml(raw);
+      // A parse failure is its OWN finding: every task rule short-circuits on
+      // an empty mapping, so collapsing "unparseable" onto `{}` made a broken
+      // task file validate clean (issue #760). Mirrors the CLI sweep.
+      if (!task.ok) {
+        diagnostics.push({
+          file: change.path,
+          issue: "invalid-task-yaml",
+          detail: taskYamlParseDetail(task.error),
+          fixed: false,
+        });
       }
-      parsed = { data, content: raw, frontmatter: null };
+      parsed = { data: task.data, content: raw, frontmatter: null };
     } else {
       const p = parseFrontmatter(raw);
       parsed = { data: p.data, content: p.content, frontmatter: p.frontmatter };

--- a/src/core/adapter/adapters/akm-lint.ts
+++ b/src/core/adapter/adapters/akm-lint.ts
@@ -199,23 +199,34 @@ export function dangerousEnvKeyDiagnostics(type: string | undefined, relPath: st
 
 // ── skill directory check (SkillLinter.lintDirectory) ────────────────────────
 
+/** The akm-native skill placement dir — the default gate for {@link skillDirectoryDiagnostics}. */
+const AKM_SKILL_DIRS: ReadonlySet<string> = new Set(["skills"]);
+
 /**
  * Reproduce `SkillLinter.lintDirectory` (`skill-linter.ts:31-45`) in the
- * change-set model: for a change under `skills/<name>/…`, emit `missing-skill-md`
- * when `skills/<name>/SKILL.md` is absent from the overlay. `seen` dedups so a
- * dir with multiple changed files reports once (matching the per-subdir call).
- * `file`/`detail` mirror the live check exactly (relDir + `no SKILL.md in <relDir>/`).
+ * change-set model: for a change under `<skillDir>/<name>/…`, emit
+ * `missing-skill-md` when `<skillDir>/<name>/SKILL.md` is absent from the
+ * overlay. `seen` dedups so a dir with multiple changed files reports once
+ * (matching the per-subdir call). `file`/`detail` mirror the live check exactly
+ * (relDir + `no SKILL.md in <relDir>/`).
+ *
+ * `skillDirs` defaults to the akm-native `skills/` placement dir. The tool-dir
+ * adapters pass their OWN accepted spellings, because opencode also accepts the
+ * singular `skill/` alias on read (`opencode-adapter.ts` LAYOUT) — with the
+ * gate hardcoded to `"skills"`, an identical manifest-less package went flagged
+ * under `skills/` and unflagged under `skill/` (issue #774).
  */
 export async function skillDirectoryDiagnostics(
   relPath: string,
   seen: Set<string>,
   ctx: ValidateContext,
+  skillDirs: ReadonlySet<string> = AKM_SKILL_DIRS,
 ): Promise<Diagnostic[]> {
   const segments = relPath
     .replace(/\\/g, "/")
     .split("/")
     .filter((s) => s.length > 0);
-  if (segments.length < 3 || segments[0] !== "skills") return []; // must be skills/<name>/<file…>
+  if (segments.length < 3 || !skillDirs.has(segments[0]!)) return []; // must be <skillDir>/<name>/<file…>
   const skillDir = `${segments[0]}/${segments[1]}`;
   if (seen.has(skillDir)) return [];
   seen.add(skillDir);

--- a/src/core/adapter/adapters/akm-task-adapter.ts
+++ b/src/core/adapter/adapters/akm-task-adapter.ts
@@ -11,6 +11,10 @@
  * invalid task (e.g. two targets) is still RECOGNIZED; the `invalid-task-yaml`
  * violation surfaces only in `validate`.
  *
+ * `.yaml` is the one extension `validate` inspects but `recognize` refuses: it
+ * is not a task spelling (nothing indexes or schedules it), so it is reported
+ * as `invalid-task-yaml` rather than silently skipped (issue #760).
+ *
  * ── validate (spec §6 task validation column) ──
  *
  * A task must declare `version: 2`, a `schedule`, and EXACTLY ONE target
@@ -28,9 +32,15 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { parse as parseYaml } from "yaml";
 import type { FileContext } from "../../../indexer/walk/file-context";
-import { taskFieldProblems } from "../../../tasks/schema";
+import {
+  parseTaskYaml,
+  TASK_EXTENSION,
+  TASK_NEAR_MISS_EXTENSION,
+  taskExtensionDetail,
+  taskFieldProblems,
+  taskYamlParseDetail,
+} from "../../../tasks/schema";
 import type { FileChange } from "../../file-change";
 import type { BundleAdapter } from "../bundle-adapter";
 import type { BundleComponent, Diagnostic, IndexDocument, ValidateContext } from "../types";
@@ -39,7 +49,7 @@ import { hashContent } from "./shared";
 /** A native task bundle is single-component; its one component is `main`. */
 const COMPONENT_ID = "main";
 /** The task YAML extension (spec §6 task row). */
-const TASK_EXT = ".yml";
+const TASK_EXT = TASK_EXTENSION;
 /** The mutually-exclusive task target keys (exactly one required). */
 const TARGET_KEYS = ["prompt", "workflow", "command"] as const;
 /** Upper bound on the bounded `content` FTS field (mirrors okf-adapter). */
@@ -69,17 +79,6 @@ function recognize(c: BundleComponent, file: FileContext): IndexDocument | null 
   };
 }
 
-/** Parse a task YAML into a plain record (tolerant: malformed / non-mapping → {}). */
-function parseTaskYaml(raw: string): Record<string, unknown> {
-  try {
-    const doc = parseYaml(raw);
-    if (doc && typeof doc === "object" && !Array.isArray(doc)) return doc as Record<string, unknown>;
-  } catch {
-    // malformed YAML
-  }
-  return {};
-}
-
 /**
  * The native `invalid-task-yaml` check: the shared field rules
  * ({@link taskFieldProblems} — see its doc for the lint-vs-parser
@@ -103,8 +102,34 @@ async function validate(_c: BundleComponent, changes: FileChange[], ctx: Validat
     if (change.op === "delete") continue;
     const raw = change.after ?? (await ctx.readFile(change.path));
     if (typeof raw !== "string") continue;
-    if (path.extname(change.path).toLowerCase() !== TASK_EXT) continue;
-    diagnostics.push(...taskDiagnostics(toPosix(change.path), parseTaskYaml(raw)));
+    const ext = path.extname(change.path).toLowerCase();
+    // `.yaml` is NOT a task extension — the file never indexes and never runs.
+    // It is validated here purely so the near miss is REPORTED rather than
+    // skipped the way every other extension is (issue #760).
+    if (ext !== TASK_EXT && ext !== TASK_NEAR_MISS_EXTENSION) continue;
+    const relPath = toPosix(change.path);
+    if (ext === TASK_NEAR_MISS_EXTENSION) {
+      diagnostics.push({
+        file: relPath,
+        issue: "invalid-task-yaml",
+        detail: taskExtensionDetail(relPath),
+        fixed: false,
+      });
+    }
+    const parsed = parseTaskYaml(raw);
+    if (!parsed.ok) {
+      // Distinguish "unparseable" from "empty": `taskDiagnostics` returns []
+      // for an empty mapping, so collapsing a parse failure onto `{}` made a
+      // broken task file lint clean.
+      diagnostics.push({
+        file: relPath,
+        issue: "invalid-task-yaml",
+        detail: taskYamlParseDetail(parsed.error),
+        fixed: false,
+      });
+      continue;
+    }
+    diagnostics.push(...taskDiagnostics(relPath, parsed.data));
   }
   return diagnostics;
 }
@@ -112,7 +137,11 @@ async function validate(_c: BundleComponent, changes: FileChange[], ctx: Validat
 export const akmTaskAdapter: BundleAdapter = {
   id: "akm-task",
   version: "0.9.0",
-  extensions: [TASK_EXT],
+  // `.yaml` is listed as a COLLECTION hint only — `recognize` still gates on
+  // `.yml`, so a `.yaml` file is never indexed as a task. Listing it is what
+  // routes the near-miss file into `validate`, where it is reported instead of
+  // silently skipped (issue #760).
+  extensions: [TASK_EXT, TASK_NEAR_MISS_EXTENSION],
 
   recognize,
   validate,
@@ -148,7 +177,7 @@ export const akmTaskAdapter: BundleAdapter = {
       } catch {
         continue;
       }
-      const data = parseTaskYaml(raw);
+      const { data } = parseTaskYaml(raw);
       if (typeof data.schedule === "string" && data.schedule.trim() !== "") return true;
     }
     return false;

--- a/src/core/adapter/adapters/tool-dir-shared.ts
+++ b/src/core/adapter/adapters/tool-dir-shared.ts
@@ -231,9 +231,11 @@ export async function validateToolDir(
 
     const relPath = toPosix(change.path);
     // The one coded skill check (missing-skill-md) fires on ANY change under a
-    // `skills/<name>/…` package (self-gated + deduped), even a bundled resource —
-    // mirrors the akm adapter's per-change SkillLinter.lintDirectory pass.
-    diagnostics.push(...(await skillDirectoryDiagnostics(relPath, seenSkillDirs, ctx)));
+    // `<skillDir>/<name>/…` package (self-gated + deduped), even a bundled
+    // resource — mirrors the akm adapter's per-change SkillLinter.lintDirectory
+    // pass. `layout.skillDirs` is passed so opencode's singular `skill/` alias
+    // is checked identically to `skills/` (issue #774).
+    diagnostics.push(...(await skillDirectoryDiagnostics(relPath, seenSkillDirs, ctx, layout.skillDirs)));
 
     const cls = classify(change.path, layout);
     if (cls === null) continue;

--- a/src/storage/managed-db.ts
+++ b/src/storage/managed-db.ts
@@ -40,19 +40,65 @@ export interface ManagedDbSpec {
   create?: boolean;
 }
 
+/** Owner-only file mode for the databases and owner-only mode for their directory. */
+const DB_FILE_MODE = 0o600;
+const DB_DIR_MODE = 0o700;
+
+/**
+ * The WAL sidecars SQLite creates next to a database in `journal_mode=WAL`.
+ * They carry the same page content as the database itself, so leaving them at
+ * the umask default would defeat tightening only the main file.
+ */
+const WAL_SIDECAR_SUFFIXES = ["-wal", "-shm"] as const;
+
+/**
+ * Tighten a managed database and its directory to owner-only (issue #756).
+ *
+ * `state.db` / `index.db` / `logs.db` hold task history, captured command
+ * output, and indexed content, but were created at whatever the process umask
+ * left them at (typically `0644`), unlike every env/secret file akm writes —
+ * those pin `0600` through {@link import("../core/common").writeFileAtomic}'s
+ * default mode. On a shared host any local user could read them straight off
+ * disk without going through akm.
+ *
+ * Best-effort by design: POSIX modes are meaningless on Windows, and a chmod
+ * can legitimately fail on a mounted/foreign filesystem or a file owned by
+ * another user. Neither is a reason to fail an otherwise healthy open — and
+ * `akm health`'s `secret-file-perms` advisory now scans these same paths, so a
+ * chmod that could not be applied is surfaced rather than lost.
+ */
+function tightenDatabasePermissions(dbPath: string, dir: string): void {
+  if (process.platform === "win32") return;
+  const chmod = (target: string, mode: number): void => {
+    try {
+      fs.chmodSync(target, mode);
+    } catch {
+      // Not our file / not a POSIX-mode filesystem — `akm health` reports it.
+    }
+  };
+  chmod(dir, DB_DIR_MODE);
+  chmod(dbPath, DB_FILE_MODE);
+  for (const suffix of WAL_SIDECAR_SUFFIXES) chmod(`${dbPath}${suffix}`, DB_FILE_MODE);
+}
+
 /**
  * Open a managed SQLite database: ensure the parent dir exists, open the handle,
  * apply standard pragmas, then run the schema initializer. The single home for
- * the open→pragmas→migrate recipe.
+ * the open→pragmas→migrate recipe — and therefore the single home for the
+ * owner-only permission enforcement every one of these databases needs
+ * ({@link tightenDatabasePermissions}).
  */
 export function openManagedDatabase(spec: ManagedDbSpec): Database {
   const dir = path.dirname(spec.path);
   if (spec.create !== false && !fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
+    fs.mkdirSync(dir, { recursive: true, mode: DB_DIR_MODE });
   }
   const db = spec.create === false ? openDatabase(spec.path, { create: false }) : openDatabase(spec.path);
   applyStandardPragmas(db, spec.pragmas ?? { dataDir: dir });
   spec.init?.(db);
+  // AFTER pragmas + init: `journal_mode=WAL` and the first DDL write are what
+  // materialize the `-wal`/`-shm` sidecars, so chmodding earlier would miss them.
+  tightenDatabasePermissions(spec.path, dir);
   return db;
 }
 

--- a/src/tasks/runner.ts
+++ b/src/tasks/runner.ts
@@ -38,6 +38,7 @@ import { shouldSkipUnactivatedTask } from "../core/activation-policy";
 import { assertNever } from "../core/assert";
 import { placementSpecFor } from "../core/asset/asset-placement";
 import { parseRefInput } from "../core/asset/resolve-ref";
+import { writeFileAtomic } from "../core/common";
 import { loadConfig } from "../core/config/config";
 import { AkmError, NotFoundError, rethrowIfTestIsolationError } from "../core/errors";
 import {
@@ -806,8 +807,12 @@ function persistRunLog(input: {
   const dbLines = input.dbLines.map((entry) => ({ ...entry, line: redactCredentialPatterns(entry.line) }));
   if (input.logPath) {
     try {
-      fs.mkdirSync(path.dirname(input.logPath), { recursive: true });
-      fs.writeFileSync(input.logPath, fileText);
+      // 0600/0700, not the umask default (issue #756): a run log holds captured
+      // command/agent output, which is exactly the material the redaction
+      // passes above are trying to keep out of other users' hands.
+      // `writeFileAtomic` pins mode 0600 by default.
+      fs.mkdirSync(path.dirname(input.logPath), { recursive: true, mode: 0o700 });
+      writeFileAtomic(input.logPath, fileText);
     } catch (error) {
       rethrowIfTestIsolationError(error);
       // Transitional file logging is fully best-effort.

--- a/src/tasks/schema.ts
+++ b/src/tasks/schema.ts
@@ -14,9 +14,22 @@
  * inline prompts use a YAML block scalar (`prompt: |`).
  */
 
+import { parse as parseYaml } from "yaml";
 import { WORKFLOW_MAX_TIMEOUT_MS } from "../workflows/resource-limits";
 
 export const TASK_SCHEMA_VERSION = 2;
+
+/** The ONE recognized on-disk task extension (spec §6 task row). */
+export const TASK_EXTENSION = ".yml";
+
+/**
+ * The near-miss spelling. `.yaml` is NOT a task extension: the indexer's
+ * `tasks` matcher (`indexer/walk/matchers.ts`) gates on `.yml`, so a
+ * `tasks/<id>.yaml` file is never indexed, never scheduled, and never runs.
+ * It is recognized HERE only so lint can say so out loud instead of walking
+ * past it (issue #760).
+ */
+export const TASK_NEAR_MISS_EXTENSION = ".yaml";
 
 /**
  * Largest expressible `timeoutMs` — `setTimeout`'s 32-bit signed ceiling
@@ -47,6 +60,60 @@ export function taskFieldProblems(data: Record<string, unknown>): string[] {
   if (typeof data.schedule !== "string" || data.schedule.trim() === "") problems.push("schedule");
   if ("enabled" in data && typeof data.enabled !== "boolean") problems.push("enabled (must be a boolean when present)");
   return problems;
+}
+
+/**
+ * The outcome of parsing a task YAML file, keeping "this file is broken" and
+ * "this file has nothing in it" DISTINGUISHABLE.
+ *
+ * Every task reader used to collapse both onto `{}` and every task linter
+ * short-circuits on an empty mapping, so a `tasks/*.yml` that could not be
+ * parsed at all (bad indentation, unterminated quote, tab characters) reported
+ * ZERO findings — a clean `akm lint` for a task that cannot run (issue #760).
+ */
+export type ParsedTaskYaml =
+  | { ok: true; data: Record<string, unknown> }
+  | { ok: false; data: Record<string, unknown>; error: string };
+
+/**
+ * Parse a task YAML document into a plain mapping. Non-mapping documents (a
+ * scalar, a sequence, an empty file) are NOT a parse failure — they parse fine
+ * and simply carry no fields, which the field rules above already describe.
+ *
+ * The ONE parse used by all three task-lint surfaces (`commands/lint/index.ts`'s
+ * akm sweep, the `akm` adapter's `validate`, and the `akm-task` adapter) so a
+ * malformed file cannot be a finding on one surface and silence on another.
+ */
+export function parseTaskYaml(raw: string): ParsedTaskYaml {
+  try {
+    const doc = parseYaml(raw);
+    if (doc && typeof doc === "object" && !Array.isArray(doc))
+      return { ok: true, data: doc as Record<string, unknown> };
+    return { ok: true, data: {} };
+  } catch (e) {
+    // yaml's errors carry a multi-line source excerpt; keep the first line so
+    // the diagnostic stays one readable finding.
+    const message = (e instanceof Error ? e.message : String(e)).split("\n")[0]?.trim() ?? "unknown parse error";
+    return { ok: false, data: {}, error: message };
+  }
+}
+
+/** The `invalid-task-yaml` detail for a file whose YAML could not be parsed. */
+export function taskYamlParseDetail(error: string): string {
+  return `task YAML does not parse: ${error}`;
+}
+
+/**
+ * The `invalid-task-yaml` detail for a task file using the `.yaml` near-miss
+ * spelling. See {@link TASK_NEAR_MISS_EXTENSION} for why this is an error and
+ * not a style nit.
+ */
+export function taskExtensionDetail(relPath: string): string {
+  const base = relPath.replace(/\.yaml$/i, "");
+  return (
+    `task file uses the ${TASK_NEAR_MISS_EXTENSION} extension; akm recognizes tasks only as ` +
+    `${TASK_EXTENSION}, so this file is never indexed or scheduled — rename it to ${base}${TASK_EXTENSION}.`
+  );
 }
 
 export interface TaskWorkflowTarget {

--- a/tests/core/adapter/akm-task-adapter.test.ts
+++ b/tests/core/adapter/akm-task-adapter.test.ts
@@ -52,11 +52,22 @@ describe("akm-task adapter — metadata", () => {
   test("id / version / extensions", () => {
     expect(akmTaskAdapter.id).toBe("akm-task");
     expect(akmTaskAdapter.version).toBe("0.9.0");
-    expect(akmTaskAdapter.extensions).toEqual([".yml"]);
+    // `.yaml` is a COLLECTION hint only (issue #760) so `akm lint` routes the
+    // near-miss spelling into `validate` instead of walking past it.
+    expect(akmTaskAdapter.extensions).toEqual([".yml", ".yaml"]);
   });
 
   test("a README markdown abstains (tasks are YAML)", () => {
     expect(recognizeRel("README.md")).toBeNull();
+  });
+
+  test("recognition still gates on .yml — a .yaml file is never indexed as a task", () => {
+    const doc = akmTaskAdapter.recognize(component(), {
+      ...buildFileContext(FIXTURE_ROOT, path.join(FIXTURE_ROOT, "nightly-index.yml")),
+      relPath: "misnamed.yaml",
+      ext: ".yaml",
+    });
+    expect(doc).toBeNull();
   });
 });
 

--- a/tests/integration/commands/health/surfaces.test.ts
+++ b/tests/integration/commands/health/surfaces.test.ts
@@ -56,6 +56,58 @@ describe("collectSecretPermsAdvisory (08-F4)", () => {
     fs.mkdirSync(path.join(stashDir, "env"), { mode: 0o755 });
     expect(collectSecretPermsAdvisory({ stashDir, cacheDir: stashDir }, "win32")).toBeUndefined();
   });
+
+  // ── issue #756: the DB + task-log surfaces the advisory always claimed ──
+  //
+  // `docs/architecture/testing/manual-testing-checklist.md` describes health as
+  // scanning "every bundle plus config, DB/WAL/SHM, backup, and task-log
+  // surfaces", but the collector's roots were only env/secrets/config-backups —
+  // so the two paths that hold task history and captured command output were
+  // never checked.
+
+  test("warns on a group/other-readable state.db, its WAL sidecar, and the data dir", () => {
+    const stashDir = makeTempDir("akm-surfaces-perms-");
+    const cacheDir = makeTempDir("akm-surfaces-cache-");
+    const dataDir = makeTempDir("akm-surfaces-data-");
+    fs.chmodSync(dataDir, 0o755);
+    fs.writeFileSync(path.join(dataDir, "state.db"), "sqlite", { mode: 0o644 });
+    fs.writeFileSync(path.join(dataDir, "state.db-wal"), "wal", { mode: 0o644 });
+
+    const adv = collectSecretPermsAdvisory({ stashDir, cacheDir, dataDir }, "linux");
+    const offenders = (adv?.evidence?.offenders as string[]) ?? [];
+    expect(offenders.some((o) => o.endsWith(`${dataDir}/ (755, want 700)`))).toBe(true);
+    expect(offenders.some((o) => o.includes("state.db (644, want 600)"))).toBe(true);
+    expect(offenders.some((o) => o.includes("state.db-wal (644, want 600)"))).toBe(true);
+  });
+
+  test("warns on a group/other-readable per-run task log", () => {
+    const stashDir = makeTempDir("akm-surfaces-perms-");
+    const cacheDir = makeTempDir("akm-surfaces-cache-");
+    const runDir = path.join(cacheDir, "tasks", "logs", "nightly");
+    fs.mkdirSync(runDir, { recursive: true, mode: 0o755 });
+    fs.writeFileSync(path.join(runDir, "2026-01-01T00-00-00-000Z.log"), "output", { mode: 0o644 });
+
+    const adv = collectSecretPermsAdvisory({ stashDir, cacheDir }, "linux");
+    const offenders = (adv?.evidence?.offenders as string[]) ?? [];
+    expect(offenders.some((o) => o.includes(".log (644, want 600)"))).toBe(true);
+  });
+
+  test("silent when the databases and task logs are 0600 under 0700 dirs", () => {
+    const stashDir = makeTempDir("akm-surfaces-perms-");
+    const cacheDir = makeTempDir("akm-surfaces-cache-");
+    const dataDir = makeTempDir("akm-surfaces-data-");
+    fs.chmodSync(dataDir, 0o700);
+    for (const name of ["state.db", "index.db", "logs.db"]) {
+      fs.writeFileSync(path.join(dataDir, name), "sqlite", { mode: 0o600 });
+    }
+    const runDir = path.join(cacheDir, "tasks", "logs", "nightly");
+    fs.mkdirSync(runDir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(runDir, "run.log"), "output", { mode: 0o600 });
+    fs.chmodSync(path.join(cacheDir, "tasks", "logs"), 0o700);
+    fs.chmodSync(path.join(cacheDir, "tasks"), 0o700);
+
+    expect(collectSecretPermsAdvisory({ stashDir, cacheDir, dataDir }, "linux")).toBeUndefined();
+  });
 });
 
 describe("collectConfigSkewAdvisory (08-F3)", () => {

--- a/tests/integration/db-file-permissions.test.ts
+++ b/tests/integration/db-file-permissions.test.ts
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Owner-only permissions on the managed databases and per-run task logs
+ * (issue #756).
+ *
+ * `state.db`, `index.db`, `logs.db`, and `<cache>/tasks/logs/<id>/<ts>.log`
+ * were created at whatever the process umask left them at (typically `0644`),
+ * unlike every env/secret file akm writes — those pin `0600` through
+ * `writeFileAtomic`'s default mode. On a shared host any local user could read
+ * task history, captured command output, and indexed content straight off disk.
+ *
+ * The umask is deliberately widened to `0o022` inside these tests: pinning the
+ * mode only under a restrictive ambient umask would prove nothing.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { openLogsDatabase } from "../../src/core/logs-db";
+import { openStateDatabase } from "../../src/core/state-db";
+import { openIndexDatabase } from "../../src/storage/repositories/index-connection";
+import { runTask } from "../../src/tasks/runner";
+import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../_helpers/sandbox";
+
+/** POSIX modes are not enforced on Windows — the production code skips there too. */
+const isPosix = process.platform !== "win32";
+
+function modeOf(target: string): number {
+  return fs.statSync(target).mode & 0o777;
+}
+
+describe("managed databases are created 0600 in a 0700 dir (issue #756)", () => {
+  let storage: IsolatedAkmStorage;
+  let previousUmask: number | undefined;
+
+  beforeEach(() => {
+    storage = withIsolatedAkmStorage();
+    // The permissive default: without the fix these files land at 0644.
+    previousUmask = process.umask(0o022);
+  });
+  afterEach(() => {
+    if (previousUmask !== undefined) process.umask(previousUmask);
+    storage?.cleanup();
+  });
+
+  test.skipIf(!isPosix)("state.db, index.db and logs.db are owner-only", () => {
+    const dataDir = path.join(storage.dataDir, "akm");
+
+    for (const open of [openStateDatabase, openIndexDatabase, openLogsDatabase]) {
+      const db = open();
+      db.close();
+    }
+
+    for (const name of ["state.db", "index.db", "logs.db"]) {
+      const dbPath = path.join(dataDir, name);
+      expect(fs.existsSync(dbPath), `${name} should exist`).toBe(true);
+      expect(modeOf(dbPath), `${name} mode`).toBe(0o600);
+      // The WAL sidecars carry the same page content, so they get the same mode.
+      for (const suffix of ["-wal", "-shm"]) {
+        const sidecar = `${dbPath}${suffix}`;
+        if (fs.existsSync(sidecar)) expect(modeOf(sidecar), `${name}${suffix} mode`).toBe(0o600);
+      }
+    }
+
+    expect(modeOf(dataDir), "data dir mode").toBe(0o700);
+  });
+});
+
+describe("per-run task logs are written 0600 in a 0700 dir (issue #756)", () => {
+  let storage: IsolatedAkmStorage;
+  let previousUmask: number | undefined;
+
+  beforeEach(() => {
+    storage = withIsolatedAkmStorage();
+    previousUmask = process.umask(0o022);
+  });
+  afterEach(() => {
+    if (previousUmask !== undefined) process.umask(previousUmask);
+    storage?.cleanup();
+  });
+
+  test.skipIf(!isPosix)("a command task's log file and its directory are owner-only", async () => {
+    const logDir = path.join(storage.cacheDir, "tasks", "logs");
+    const taskPath = path.join(storage.stashDir, "tasks", "echoer.yml");
+    fs.mkdirSync(path.dirname(taskPath), { recursive: true });
+    fs.writeFileSync(
+      taskPath,
+      [
+        "version: 2",
+        'schedule: "@daily"',
+        `command: ${JSON.stringify([process.execPath, "-e", "console.log('hello from the task')"])}`,
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = await runTask("echoer", { stashDir: storage.stashDir, logDir });
+
+    expect(result.status).toBe("completed");
+    expect(fs.readFileSync(result.log, "utf8")).toContain("hello from the task");
+    expect(modeOf(result.log), "task log mode").toBe(0o600);
+    expect(modeOf(path.dirname(result.log)), "task log dir mode").toBe(0o700);
+  });
+});

--- a/tests/integration/lint-adapter-dispatch.test.ts
+++ b/tests/integration/lint-adapter-dispatch.test.ts
@@ -28,7 +28,9 @@ import fs from "node:fs";
 import path from "node:path";
 import { akmLint } from "../../src/commands/lint/index";
 import { detectAdapterId } from "../../src/core/adapter/detect-adapter";
+import { _setWarnSinkForTests } from "../../src/core/warn";
 import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../_helpers/sandbox";
+import { overrideSeam } from "../_helpers/seams";
 
 function write(root: string, relPath: string, content: string): void {
   const full = path.join(root, relPath);
@@ -98,5 +100,58 @@ describe("akm lint dispatches an llm-wiki bundle through llmWikiAdapter.validate
     expect(result.ok).toBe(true);
     expect(result.flagged).toEqual([]);
     expect(result.fixed).toEqual([]);
+  });
+});
+
+/**
+ * `--type` names an AKM stash subdir. For a non-akm bundle the adapter's
+ * `validate()` sees the whole bundle no matter what, so the flag is a silent
+ * no-op — a user scoping a run got full-bundle output with nothing saying the
+ * flag had not applied (issue #762). The refusal is deliberately a WARNING and
+ * not an error: full-bundle validation is a superset of the requested scope, so
+ * nothing goes unreported, and a hard error would break scripts passing one
+ * `--type` across mixed-adapter bundle sets.
+ */
+describe("akm lint warns that --type is a no-op for a non-akm adapter (issue #762)", () => {
+  let storage: IsolatedAkmStorage;
+  afterEach(() => storage?.cleanup());
+
+  function wikiBundle(root: string): void {
+    write(root, "schema.md", "# Wiki schema\n");
+    write(root, "pages/topic.md", "---\ndescription: A well-formed page\n---\n\nBody.\n");
+  }
+
+  function captureWarnings(): string[] {
+    const lines: string[] = [];
+    overrideSeam(_setWarnSinkForTests, (_level, args) => {
+      lines.push(args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" "));
+    });
+    return lines;
+  }
+
+  test("the warning names the flag and the adapter, and the findings are unchanged", async () => {
+    storage = withIsolatedAkmStorage();
+    const wikiRoot = path.join(storage.root, "typed-wiki");
+    wikiBundle(wikiRoot);
+
+    const warnings = captureWarnings();
+    const scoped = await akmLint({ dir: wikiRoot, typeFilter: "memories" });
+
+    expect(warnings.some((line) => /--type "memories"/.test(line) && /llm-wiki/.test(line))).toBe(true);
+    // The content contract from the issue: scoping changes nothing, it only
+    // gains a signal. Compare against an unscoped run of the same bundle.
+    const unscoped = await akmLint({ dir: wikiRoot });
+    expect(scoped.flagged).toEqual(unscoped.flagged);
+  });
+
+  test("no warning is emitted when --type is absent", async () => {
+    storage = withIsolatedAkmStorage();
+    const wikiRoot = path.join(storage.root, "untyped-wiki");
+    wikiBundle(wikiRoot);
+
+    const warnings = captureWarnings();
+    await akmLint({ dir: wikiRoot });
+
+    expect(warnings.filter((line) => /--type/.test(line))).toEqual([]);
   });
 });

--- a/tests/integration/lint-fix-safety.test.ts
+++ b/tests/integration/lint-fix-safety.test.ts
@@ -1,0 +1,172 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `akm lint --fix` mutation safety (issue #761).
+ *
+ * Two gaps, both about a write nobody could see:
+ *
+ *   1. NO WRITABLE CHECK. Every other mutating command routes through
+ *      `core/write-source.ts`'s `ensureWritable`; `--fix` wrote directly and
+ *      never consulted the flag, so it happily rewrote frontmatter in a bundle
+ *      configured `writable: false`.
+ *   2. NO TRANSACTIONAL CONTRACT. A single file's fix-write throwing
+ *      (`base-linter.ts`'s `fs.writeFileSync`) escaped `akmLint()` entirely.
+ *      The caller got an exception instead of a result — and files fixed
+ *      EARLIER in the same sweep stayed mutated on disk with nothing reporting
+ *      that they had.
+ *
+ * Both are pinned here against the real `akmLint()` entry point.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { runBaseChecks } from "../../src/commands/lint/base-linter";
+import { akmLint } from "../../src/commands/lint/index";
+import type { AkmConfig } from "../../src/core/config/config";
+import { UsageError } from "../../src/core/errors";
+import { makeConfig } from "../_helpers/factories";
+import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../_helpers/sandbox";
+
+/**
+ * Permission bits are not enforced for uid 0, so the chmod-based sweep test
+ * below cannot make a write fail when the suite runs as root (containers do).
+ * The uid-independent half of the contract is pinned by the `runBaseChecks`
+ * test at the bottom, which forces a real ENOENT that root cannot bypass.
+ */
+const runningAsRoot = typeof process.getuid === "function" && process.getuid() === 0;
+
+/** A memory with no `updated:` — the `missing-updated` base check's fixable case. */
+const FIXABLE_MEMORY = "---\nname: note\ntype: memory\n---\n\nSome content.\n";
+
+function writeMemory(stashDir: string, name: string): string {
+  const full = path.join(stashDir, "memories", `${name}.md`);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, FIXABLE_MEMORY, "utf8");
+  return full;
+}
+
+function readOnlyConfig(stashDir: string): AkmConfig {
+  const config = makeConfig(stashDir);
+  return { ...config, bundles: { stash: { path: stashDir, writable: false } } as AkmConfig["bundles"] };
+}
+
+describe("akm lint --fix refuses a bundle configured writable: false (issue #761)", () => {
+  let storage: IsolatedAkmStorage;
+  afterEach(() => storage?.cleanup());
+
+  test("throws a UsageError and leaves every file byte-identical", async () => {
+    storage = withIsolatedAkmStorage();
+    const notePath = writeMemory(storage.stashDir, "note");
+    const before = fs.readFileSync(notePath, "utf8");
+
+    const attempt = akmLint({ fix: true, config: readOnlyConfig(storage.stashDir) });
+    await expect(attempt).rejects.toBeInstanceOf(UsageError);
+    await expect(attempt).rejects.toThrow(/writable: false/);
+
+    expect(fs.readFileSync(notePath, "utf8")).toBe(before);
+  });
+
+  test("a read-only bundle still LINTS — only the mutation is refused", async () => {
+    storage = withIsolatedAkmStorage();
+    writeMemory(storage.stashDir, "note");
+
+    const result = await akmLint({ config: readOnlyConfig(storage.stashDir) });
+
+    expect(result.ok).toBe(true);
+    expect(result.flagged.some((issue) => issue.issue === "missing-updated")).toBe(true);
+  });
+
+  test("naming the read-only bundle explicitly with --dir is refused too", async () => {
+    storage = withIsolatedAkmStorage();
+    const notePath = writeMemory(storage.stashDir, "note");
+    const before = fs.readFileSync(notePath, "utf8");
+
+    // The likelier real invocation: the user points at the bundle by path
+    // rather than relying on `defaultBundle`. The policy still applies.
+    const attempt = akmLint({ fix: true, dir: storage.stashDir, config: readOnlyConfig(storage.stashDir) });
+    await expect(attempt).rejects.toBeInstanceOf(UsageError);
+
+    expect(fs.readFileSync(notePath, "utf8")).toBe(before);
+  });
+
+  test("an ad-hoc --dir that is not a configured bundle carries no policy and stays fixable", async () => {
+    storage = withIsolatedAkmStorage();
+    const adhoc = path.join(storage.root, "adhoc-bundle");
+    fs.mkdirSync(path.join(adhoc, "memories"), { recursive: true });
+    const notePath = writeMemory(adhoc, "note");
+
+    const result = await akmLint({ fix: true, dir: adhoc, config: readOnlyConfig(storage.stashDir) });
+
+    expect(result.fixed.some((issue) => issue.issue === "missing-updated")).toBe(true);
+    expect(fs.readFileSync(notePath, "utf8")).toMatch(/updated:/);
+  });
+});
+
+describe("akm lint --fix is transactional per file (issue #761)", () => {
+  let storage: IsolatedAkmStorage;
+  afterEach(() => storage?.cleanup());
+
+  test.skipIf(runningAsRoot)(
+    "one unwritable file is reported as fixed:'failed' and the sweep still fixes the rest",
+    async () => {
+      storage = withIsolatedAkmStorage();
+      const names = ["a", "b", "c", "d", "e", "f"];
+      const paths = new Map(names.map((name) => [name, writeMemory(storage.stashDir, name)]));
+      const lockedPath = paths.get("c") as string;
+      fs.chmodSync(lockedPath, 0o444);
+
+      let result: Awaited<ReturnType<typeof akmLint>>;
+      try {
+        // The whole point: this used to throw EACCES out of akmLint().
+        result = await akmLint({ fix: true, config: makeConfig(storage.stashDir) });
+      } finally {
+        fs.chmodSync(lockedPath, 0o644);
+      }
+
+      expect(result.ok).toBe(true);
+
+      // The locked file is reported, in-band, as a fix that did NOT land.
+      const lockedFindings = result.flagged.filter((issue) => issue.file.endsWith("c.md"));
+      expect(lockedFindings.length).toBeGreaterThan(0);
+      expect(lockedFindings.every((issue) => issue.fixed === "failed")).toBe(true);
+      expect(lockedFindings.some((issue) => /could not write fix/.test(issue.detail))).toBe(true);
+
+      // Every OTHER file was still fixed — the sweep did not abort at the failure.
+      for (const name of names.filter((n) => n !== "c")) {
+        const contents = fs.readFileSync(paths.get(name) as string, "utf8");
+        expect(contents, `${name}.md should have been stamped`).toMatch(/updated:/);
+      }
+      expect(result.fixed.filter((issue) => issue.issue === "missing-updated").length).toBe(names.length - 1);
+
+      // And the file that could not be written is genuinely unchanged on disk.
+      expect(fs.readFileSync(lockedPath, "utf8")).toBe(FIXABLE_MEMORY);
+    },
+  );
+
+  test("runBaseChecks downgrades its optimistic fixed:true to fixed:'failed' when the flush throws", () => {
+    storage = withIsolatedAkmStorage();
+    // A path under a directory that does not exist: `writeFileSync` raises
+    // ENOENT for EVERY uid, so this half of the contract is pinned even where
+    // permission bits are unenforced.
+    const unwritable = path.join(storage.root, "no-such-dir", "note.md");
+
+    const issues = runBaseChecks({
+      filePath: unwritable,
+      relPath: "memories/note.md",
+      raw: FIXABLE_MEMORY,
+      data: { name: "note", type: "memory" },
+      body: "\nSome content.\n",
+      frontmatter: "name: note\ntype: memory",
+      fix: true,
+      stashRoot: storage.stashDir,
+    });
+
+    const updated = issues.filter((issue) => issue.issue === "missing-updated");
+    expect(updated.length).toBe(1);
+    expect(updated[0]?.fixed).toBe("failed");
+    expect(updated[0]?.detail).toMatch(/could not write fix/);
+  });
+});

--- a/tests/integration/lint-missing-skill-md.test.ts
+++ b/tests/integration/lint-missing-skill-md.test.ts
@@ -1,0 +1,151 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `missing-skill-md` is reachable again (issue #774).
+ *
+ * Two halves of the same gap:
+ *
+ *   1. `agent-skills` `validate()` iterated CHANGES, and a change is always a
+ *      FILE — so a package directory carrying resources but no `SKILL.md`
+ *      contributed nothing the loop could see. The code's own comment deferred
+ *      the case to `directorySkillDiagnostics`, a symbol that did not exist.
+ *      The check is now a real directory pass over `ValidateContext.list`.
+ *   2. The shared tool-dir check gated on the literal `skills/` segment, so
+ *      under opencode's supported singular `skill/` alias an identical
+ *      manifest-less package went unflagged while the `skills/` one was caught.
+ *      The gate now uses each layout's own accepted spellings.
+ *
+ * Both are driven through the real `akm lint` entry point, plus a direct
+ * `validate()` call for the containment rules the CLI cannot express.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { akmLint } from "../../src/commands/lint/index";
+import { agentSkillsAdapter } from "../../src/core/adapter/adapters/agent-skills-adapter";
+import { detectAdapterId } from "../../src/core/adapter/detect-adapter";
+import { createValidateContext } from "../../src/core/adapter/validate-context";
+import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../_helpers/sandbox";
+
+function write(root: string, relPath: string, content: string): void {
+  const full = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, "utf8");
+}
+
+function skillManifest(name: string): string {
+  return `---\nname: ${name}\ndescription: A conformant skill used as the clean control.\n---\n\nBody.\n`;
+}
+
+describe("agent-skills: a package directory with no SKILL.md is flagged (issue #774)", () => {
+  let storage: IsolatedAkmStorage;
+  afterEach(() => storage?.cleanup());
+
+  test("akm lint reports missing-skill-md for the manifest-less package only", async () => {
+    storage = withIsolatedAkmStorage();
+    const root = path.join(storage.root, "skills-pack");
+
+    // A conformant package (also what makes the root detect as agent-skills),
+    // with a bundled resource dir that must NOT be treated as its own package.
+    write(root, "pdf-processing/SKILL.md", skillManifest("pdf-processing"));
+    write(root, "pdf-processing/reference/FORMS.md", "# Forms\n");
+    // The broken one: resources, no manifest.
+    write(root, "half-built/reference/NOTES.md", "# Notes\n");
+    // A root-level file is not a package directory.
+    write(root, "README.md", "# Skills pack\n");
+
+    expect(detectAdapterId(root)).toBe("agent-skills");
+
+    const result = await akmLint({ dir: root });
+    const missing = result.flagged.filter((issue) => issue.issue === "missing-skill-md");
+
+    expect(missing.map((issue) => issue.file)).toEqual(["half-built"]);
+    expect(missing[0]?.detail).toBe("no SKILL.md in half-built/");
+    expect(missing[0]?.fixed).toBe(false);
+  });
+
+  test("a fully conformant pack stays clean — resource dirs are not candidate packages", async () => {
+    storage = withIsolatedAkmStorage();
+    const root = path.join(storage.root, "clean-pack");
+
+    write(root, "pdf-processing/SKILL.md", skillManifest("pdf-processing"));
+    write(root, "pdf-processing/reference/FORMS.md", "# Forms\n");
+    write(root, "pdf-processing/assets/template.txt", "template\n");
+    write(root, "README.md", "# Skills pack\n");
+
+    const result = await akmLint({ dir: root });
+
+    expect(result.flagged.filter((issue) => issue.issue === "missing-skill-md")).toEqual([]);
+  });
+
+  test("a grouping directory whose children carry manifests is not a broken package", async () => {
+    storage = withIsolatedAkmStorage();
+    const root = path.join(storage.root, "grouped-pack");
+
+    // `<group>/<name>/SKILL.md` — `skillPackage` accepts the nested shape, so
+    // the group dir itself must not be reported for having no manifest of its own.
+    write(root, "team/pdf-processing/SKILL.md", skillManifest("pdf-processing"));
+
+    const diagnostics = await agentSkillsAdapter.validate(
+      { id: "grouped", adapter: "agent-skills", root, writable: true },
+      [{ path: "team/pdf-processing/SKILL.md", op: "update" }],
+      createValidateContext({ root }),
+    );
+
+    expect(diagnostics.filter((d) => d.issue === "missing-skill-md")).toEqual([]);
+  });
+
+  test("dot-directories (.git, .github) are never candidate packages", async () => {
+    storage = withIsolatedAkmStorage();
+    const root = path.join(storage.root, "dotted-pack");
+
+    write(root, "pdf-processing/SKILL.md", skillManifest("pdf-processing"));
+    write(root, ".github/workflows/ci.yml", "name: ci\n");
+
+    const diagnostics = await agentSkillsAdapter.validate(
+      { id: "dotted", adapter: "agent-skills", root, writable: true },
+      [{ path: "pdf-processing/SKILL.md", op: "update" }],
+      createValidateContext({ root }),
+    );
+
+    expect(diagnostics.filter((d) => d.issue === "missing-skill-md")).toEqual([]);
+  });
+});
+
+describe("opencode: the singular skill/ alias is checked like skills/ (issue #774)", () => {
+  let storage: IsolatedAkmStorage;
+  afterEach(() => storage?.cleanup());
+
+  /** An `.opencode` root, with the skill package under the caller's chosen spelling. */
+  function opencodeBundle(root: string, skillDir: string): void {
+    write(root, "AGENTS.md", "# Agents\n");
+    write(root, "opencode.json", "{}\n");
+    // A package with a bundled resource but NO manifest.
+    write(root, `${skillDir}/half-built/reference/NOTES.md`, "# Notes\n");
+  }
+
+  test("skill/ and skills/ produce the same missing-skill-md finding", async () => {
+    storage = withIsolatedAkmStorage();
+    const plural = path.join(storage.root, "oc-plural");
+    const singular = path.join(storage.root, "oc-singular");
+    opencodeBundle(plural, "skills");
+    opencodeBundle(singular, "skill");
+
+    expect(detectAdapterId(plural)).toBe("opencode");
+    expect(detectAdapterId(singular)).toBe("opencode");
+
+    const pluralResult = await akmLint({ dir: plural });
+    const singularResult = await akmLint({ dir: singular });
+
+    expect(pluralResult.flagged.filter((i) => i.issue === "missing-skill-md").map((i) => i.file)).toEqual([
+      "skills/half-built",
+    ]);
+    // This is the half that used to be silently clean.
+    expect(singularResult.flagged.filter((i) => i.issue === "missing-skill-md").map((i) => i.file)).toEqual([
+      "skill/half-built",
+    ]);
+  });
+});

--- a/tests/integration/lint-task-yaml.test.ts
+++ b/tests/integration/lint-task-yaml.test.ts
@@ -1,0 +1,177 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `akm lint` no longer reports a clean scan for a task file that cannot run
+ * (issue #760).
+ *
+ * Two blind spots, one root cause — every task reader collapsed a YAML parse
+ * failure onto `{}`, and every task rule short-circuits on an empty mapping:
+ *
+ *   1. A `tasks/*.yml` whose YAML does not parse (bad indentation, an
+ *      unterminated quote, tab characters) produced `flagged: 0`.
+ *   2. A `tasks/*.yaml` file — the near-miss spelling akm never indexes and
+ *      never schedules — was not even collected by the directory walk, so it
+ *      was invisible rather than flagged.
+ *
+ * All THREE task-lint surfaces are pinned here, because the bug was present in
+ * each and they must agree: the CLI sweep (`commands/lint/index.ts`), the
+ * `akm` adapter's `validate` (the proposal-preflight surface), and the
+ * dedicated `akm-task` format adapter.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { akmLint } from "../../src/commands/lint/index";
+import { akmAdapter } from "../../src/core/adapter/adapters/akm-adapter";
+import { akmTaskAdapter } from "../../src/core/adapter/adapters/akm-task-adapter";
+import type { BundleComponent } from "../../src/core/adapter/types";
+import { createValidateContext } from "../../src/core/adapter/validate-context";
+import { makeConfig } from "../_helpers/factories";
+import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../_helpers/sandbox";
+
+/**
+ * Genuinely unparseable YAML: an unterminated single quote plus a tab-indented
+ * continuation. `yaml`'s parser throws on this — it is not merely a document
+ * that parses to a non-mapping.
+ */
+const MALFORMED_TASK = 'version: 2\nschedule: \'@daily\n\tcommand: ["echo", "hi"]\n';
+
+const VALID_TASK = 'version: 2\nschedule: "@daily"\ncommand: ["echo", "hi"]\n';
+
+function writeTask(stashDir: string, relPath: string, content: string): string {
+  const full = path.join(stashDir, "tasks", relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, "utf8");
+  return full;
+}
+
+function component(root: string, adapter: string): BundleComponent {
+  return { id: "fixture", adapter, root, writable: true };
+}
+
+describe("akm lint — malformed task YAML (issue #760)", () => {
+  let storage: IsolatedAkmStorage;
+  afterEach(() => storage?.cleanup());
+
+  test("a tasks/*.yml that does not parse is flagged, not reported clean", async () => {
+    storage = withIsolatedAkmStorage();
+    writeTask(storage.stashDir, "broken.yml", MALFORMED_TASK);
+
+    const result = await akmLint({ dir: storage.stashDir, config: makeConfig(storage.stashDir) });
+
+    expect(result.summary.flagged).toBeGreaterThan(0);
+    const parseFindings = result.flagged.filter(
+      (issue) => issue.issue === "invalid-task-yaml" && issue.file.endsWith("broken.yml"),
+    );
+    expect(parseFindings.length).toBe(1);
+    expect(parseFindings[0]?.detail).toMatch(/does not parse/);
+  });
+
+  test("a well-formed task still lints clean — the new check is not a blanket flag", async () => {
+    storage = withIsolatedAkmStorage();
+    writeTask(storage.stashDir, "nightly.yml", VALID_TASK);
+
+    const result = await akmLint({ dir: storage.stashDir, config: makeConfig(storage.stashDir) });
+
+    expect(result.flagged.filter((issue) => issue.issue === "invalid-task-yaml")).toEqual([]);
+  });
+
+  test("a tasks/*.yaml file is flagged for its extension instead of being skipped", async () => {
+    storage = withIsolatedAkmStorage();
+    // Content is VALID — the finding must come from the extension alone, so the
+    // near-miss cannot hide behind "well, it was broken anyway".
+    writeTask(storage.stashDir, "misnamed.yaml", VALID_TASK);
+
+    const result = await akmLint({ dir: storage.stashDir, config: makeConfig(storage.stashDir) });
+
+    const findings = result.flagged.filter((issue) => issue.file.endsWith("misnamed.yaml"));
+    expect(findings.map((issue) => issue.issue)).toEqual(["invalid-task-yaml"]);
+    expect(findings[0]?.detail).toMatch(/\.yaml/);
+    expect(findings[0]?.detail).toMatch(/never indexed or scheduled/);
+  });
+
+  test("a malformed tasks/*.yaml reports BOTH the extension and the parse failure", async () => {
+    storage = withIsolatedAkmStorage();
+    writeTask(storage.stashDir, "double-trouble.yaml", MALFORMED_TASK);
+
+    const result = await akmLint({ dir: storage.stashDir, config: makeConfig(storage.stashDir) });
+
+    const details = result.flagged
+      .filter((issue) => issue.file.endsWith("double-trouble.yaml"))
+      .map((issue) => issue.detail);
+    expect(details.some((d) => /does not parse/.test(d))).toBe(true);
+    expect(details.some((d) => /\.yaml extension/.test(d))).toBe(true);
+  });
+});
+
+describe("akm adapter validate() — malformed task YAML (issue #760)", () => {
+  let storage: IsolatedAkmStorage;
+  afterEach(() => storage?.cleanup());
+
+  test("reports the parse failure the CLI sweep reports, so the two surfaces agree", async () => {
+    storage = withIsolatedAkmStorage();
+    writeTask(storage.stashDir, "broken.yml", MALFORMED_TASK);
+
+    const diagnostics = await akmAdapter.validate(
+      component(storage.stashDir, "akm"),
+      [{ path: "tasks/broken.yml", op: "update" }],
+      createValidateContext({ root: storage.stashDir }),
+    );
+
+    expect(diagnostics.filter((d) => d.issue === "invalid-task-yaml").length).toBeGreaterThan(0);
+  });
+});
+
+describe("akm-task adapter validate() — malformed task YAML (issue #760)", () => {
+  let storage: IsolatedAkmStorage;
+  afterEach(() => storage?.cleanup());
+
+  test("a malformed .yml is invalid-task-yaml, not silence", async () => {
+    storage = withIsolatedAkmStorage();
+    const root = path.join(storage.root, "task-bundle");
+    fs.mkdirSync(root, { recursive: true });
+    fs.writeFileSync(path.join(root, "broken.yml"), MALFORMED_TASK, "utf8");
+
+    const diagnostics = await akmTaskAdapter.validate(
+      component(root, "akm-task"),
+      [{ path: "broken.yml", op: "update" }],
+      createValidateContext({ root }),
+    );
+
+    expect(diagnostics.map((d) => d.issue)).toEqual(["invalid-task-yaml"]);
+    expect(diagnostics[0]?.detail).toMatch(/does not parse/);
+  });
+
+  test("a .yaml task file reaches validate() and is flagged for the extension", async () => {
+    storage = withIsolatedAkmStorage();
+    const root = path.join(storage.root, "task-bundle");
+    fs.mkdirSync(root, { recursive: true });
+    fs.writeFileSync(path.join(root, "misnamed.yaml"), VALID_TASK, "utf8");
+
+    const diagnostics = await akmTaskAdapter.validate(
+      component(root, "akm-task"),
+      [{ path: "misnamed.yaml", op: "update" }],
+      createValidateContext({ root }),
+    );
+
+    expect(diagnostics.map((d) => d.issue)).toEqual(["invalid-task-yaml"]);
+    expect(diagnostics[0]?.detail).toMatch(/\.yaml/);
+  });
+
+  test("`akm lint` on an akm-task bundle collects the .yaml near miss end to end", async () => {
+    storage = withIsolatedAkmStorage();
+    const root = path.join(storage.root, "task-bundle");
+    fs.mkdirSync(root, { recursive: true });
+    // A conformant `.yml` task makes the root detect as `akm-task`.
+    fs.writeFileSync(path.join(root, "nightly.yml"), VALID_TASK, "utf8");
+    fs.writeFileSync(path.join(root, "misnamed.yaml"), VALID_TASK, "utf8");
+
+    const result = await akmLint({ dir: root, config: makeConfig(storage.stashDir) });
+
+    const findings = result.flagged.filter((issue) => issue.file.endsWith("misnamed.yaml"));
+    expect(findings.map((issue) => issue.issue)).toEqual(["invalid-task-yaml"]);
+  });
+});


### PR DESCRIPTION
## Summary

Five 0.9.1 milestone issues, picked for value-per-unit-of-risk. Four of the five are the same failure mode: **akm reported something reassuring that was not true** — a clean lint on a task that cannot run, a check that could never fire, a flag that silently did nothing. The fifth is a straightforward permissions gap. All five are contained, and each ships with a regression test that fails against the old behavior.

Closes #760, closes #761, closes #762, closes #774, closes #756.

### #760 — `akm lint` reported a clean scan for a task that cannot run

Every task reader collapsed a YAML parse failure onto `{}`, and every task rule short-circuits on an empty mapping — so a `tasks/*.yml` with an unterminated quote or tab indentation produced `flagged: 0`. A CI gate on `--fail-on-flagged` passed a task that would die at schedule time. A `tasks/*.yaml` file (a spelling the indexer's `tasks` matcher never accepts, so it is never indexed or scheduled) was not even collected by the directory walk.

One shared `parseTaskYaml` in `src/tasks/schema.ts` now keeps *broken* and *empty* distinguishable, and all three task-lint surfaces report both cases identically — the CLI sweep, the `akm` adapter's `validate` (the proposal-preflight surface, which had the same swallow), and the dedicated `akm-task` adapter. `.yaml` is added to `akm-task`'s `extensions` as a **collection hint only**: `recognize` still gates on `.yml`, so nothing new is indexed — it just routes the near miss into `validate` where it is reported with the rename in the message.

### #761 — `lint --fix` mutation safety

Two gaps, both about a write nobody could see:

- **No writable check.** Every other mutating command routes through `write-source.ts#ensureWritable`; `--fix` wrote directly and never consulted the flag, so it rewrote frontmatter in a bundle configured `writable: false`. It is now refused with the same `UsageError`/code, raised before any file is touched. `SearchSource.writable` is already the *effective* policy (`resolveWritable` applied), so this reads the same answer the write path would — no second resolver.
- **No transactional contract.** A single file's fix-write throwing escaped `akmLint()` entirely: the caller got an exception instead of a result, with no way to tell which earlier files in the same sweep had already been rewritten. `runBaseChecks` now downgrades its optimistic `fixed: true` to `fixed: "failed"` when the flush throws, and the sweep's per-file dispatch is wrapped so a throw becomes a `lint-failed` finding instead of aborting the run — mirroring the two stub-delete sites that already behaved this way.

An ad-hoc `--dir` that is not a configured bundle carries no policy and stays fixable, exactly as before.

### #762 — `--type` says so when it does nothing

For a non-akm bundle the adapter validates the whole bundle regardless of `--type`, so scoping a run was a silent no-op. It now warns, naming the flag and the adapter. Deliberately a warning and not an error: full-bundle validation is a superset of the requested scope so nothing goes unreported, and a hard error would break scripts passing one `--type` across mixed-adapter bundle sets. The `--type` help text and `docs/reference/cli.md` now state the akm-only scoping.

### #774 — `missing-skill-md` is reachable again

The `agent-skills` check iterated pending **changes**, and a change is always a file — so a package directory holding resources but no `SKILL.md` contributed nothing the loop could see, and a skills pack with a broken package linted clean. The code's own comment deferred the case to `directorySkillDiagnostics`, a symbol that does not exist anywhere in the repo.

Implemented as option 1 from the issue (`ValidateContext.list` is available and overlay-aware, as the issue asked us to confirm): a real **top-level** directory pass. A package's own resource dirs (`pdf-processing/reference/`) are part of the item, not candidate packages; a top-level dir holding a manifest anywhere beneath it is a grouping dir, not a broken package. Both are excluded, bounded by a probe depth of 3.

Related, same root cause: the shared tool-dir check hardcoded the literal `skills/` segment, so under opencode's supported singular `skill/` alias an identical manifest-less package went unflagged. The gate now takes each layout's own accepted spellings; the akm adapter's behavior is unchanged (it passes the default).

### #756 — owner-only databases and task logs

`state.db`, `index.db`, `logs.db` and per-run task logs were created at whatever the process umask left them at (typically `0644`), unlike every env/secret file akm writes — which pin `0600` via `writeFileAtomic`'s default mode. On a shared host any local user could read task history, captured command output, and indexed content straight off disk.

- `openManagedDatabase` — the single home for the open recipe, so all three databases pick it up without per-call-site changes — now chmods the database and its `-wal`/`-shm` sidecars to `0600` and the data dir to `0700`. Applied *after* pragmas and init, because `journal_mode=WAL` and the first DDL write are what materialize the sidecars. Best-effort and POSIX-only: a chmod can legitimately fail on a foreign filesystem, and that is not a reason to fail an otherwise healthy open — `akm health` now reports what could not be applied.
- `persistRunLog` writes through `writeFileAtomic` (mode `0600`) into a `0700` directory.
- `akm health`'s `secret-file-perms` advisory scans the data dir (databases + WAL/SHM) and `<cache>/tasks/logs` — the surfaces `manual-testing-checklist.md` §20.5 always claimed it covered — and now **every configured bundle's** `env/`/`secrets/`, not just the default one.

### Deliberately not in this PR

**#755** (exact-value redaction for command-target task logs) is the sibling of #756 under the same §24.2 waiver row, and I left it open on purpose. Its proposed fix — treat every `process.env` value not on `isEnvPassthroughValueSafeToExpose`'s 22-name allowlist as a secret — would redact `SHLVL=1`, `TERM=xterm`, `NODE_ENV` and so on, i.e. replace every `1` in a task log with `[REDACTED]`. Getting it right needs a design call on what counts as a "configured secret" for a command that inherits the ambient environment, which is more than a low-effort fix. The §24.2 row is updated to narrow the remaining gap to exactly this, and to record that the log/DB files are `0600` regardless now.

## Test plan

Four new suites plus additions to two existing ones. Each was checked to fail against the pre-change behavior.

- `tests/integration/lint-task-yaml.test.ts` — malformed `.yml` flagged (not `flagged: 0`); a valid task still clean; `.yaml` flagged for the extension; a malformed `.yaml` reports both; the same parse failure from the `akm` adapter and from `akm-task`; end-to-end `akm lint` on an `akm-task` bundle collecting the near miss.
- `tests/integration/lint-fix-safety.test.ts` — `--fix` on a `writable: false` bundle throws `UsageError` with every file byte-identical (both via `defaultBundle` and via an explicit `--dir`); a read-only bundle still lints; an ad-hoc `--dir` stays fixable; one unwritable file reported `fixed: "failed"` while the other five are still fixed. That last one is `skipIf(root)` since permission bits are unenforced for uid 0, so a uid-independent `runBaseChecks` case forces a real ENOENT alongside it.
- `tests/integration/lint-missing-skill-md.test.ts` — the manifest-less package is flagged and the resource dir is not; a conformant pack stays clean; grouping dirs and dot-dirs excluded; `skill/` and `skills/` produce the same finding.
- `tests/integration/db-file-permissions.test.ts` — stat-mode asserts on all three databases, their sidecars, the data dir, and a real command task's log file + dir, under a deliberately widened `0o022` umask (pinning modes under a restrictive ambient umask would prove nothing).
- `tests/integration/commands/health/surfaces.test.ts` — new cases for the DB/WAL/data-dir and task-log offenders, and the silent-when-tight control.
- `tests/integration/lint-adapter-dispatch.test.ts` — the `--type` warning names flag and adapter; findings are byte-identical to an unscoped run; no warning without the flag.

Full verification on this branch:

```
bun run lint         # OK (biome + all 14 repo lint gates)
bunx tsc --noEmit    # clean
bun run test:unit    # 3568 pass / 0 fail (256 files)
bun run test:integration  # 5096 pass / 0 fail (397 files)
```

The frozen `tests/fixtures/goldens/lint/all-types.json` and the authored format-family goldens are untouched and still pass. The one golden-adjacent test change is `akmTaskAdapter.extensions` in `tests/core/adapter/akm-task-adapter.test.ts` (`[".yml"]` → `[".yml", ".yaml"]`), with a new case pinning that `recognize` still refuses `.yaml` so the recognition golden's meaning is preserved.

## Checklist

- [x] Tests pass (`bun run test:unit` + `bun run test:integration`)
- [x] Lint passes (`bun run lint`)
- [x] Docs updated — `CHANGELOG.md`, `docs/reference/cli.md`, `docs/reference/data-and-telemetry.md`, `docs/architecture/adapters.md` (the two now-stale "never flagged" caveats), and `docs/architecture/testing/manual-testing-checklist.md` §24.2 (the Lint waiver discharged; the Secrets/permissions row narrowed to #755)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLQzxy3jXCFxHcuZ8N8etQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLQzxy3jXCFxHcuZ8N8etQ)_