### PR TITLE
fix(durability,improve): close #757, #759, #652 — plus a real website-refresh data bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`akm improve` auto-sync now commits exactly the files the run wrote.**
+  Every akm write path records the file it mutated into a run-scoped
+  write-provenance journal, and the end-of-run (and crash-path) commit stages
+  precisely those paths. A managed-directory file someone else edits while a
+  long run is in flight is left dirty for its author instead of being swept into
+  akm's commit, and a file that was already dirty when the run started and was
+  then rewritten by the run is now committed instead of being silently skipped.
+  Deletions are journaled like writes, so a path written and then reverted or
+  purged stages its final on-disk state — or produces no commit at all. The run
+  reports its journal as `writtenPaths` on the improve result, and the
+  `stash_synced` event gains `attributed` / `unattributed` counts. `akm sync` /
+  `akm push`, which supply no explicit path list, keep the managed-pathspec
+  fallback unchanged. (#652)
+
 - **`akm lint` no longer reports a clean scan for a task file that cannot run.**
   A `tasks/*.yml` whose YAML does not parse (bad indentation, an unterminated
   quote, tab characters) produced `flagged: 0`: every task reader collapsed a

--- a/docs/architecture/improvement.md
+++ b/docs/architecture/improvement.md
@@ -141,13 +141,25 @@ explicit promote surface independent of this gate.
 ### Auto-sync
 
 For git-backed bundles (detected by a `.git` directory), `akm improve`
-automatically commits all changes as a single batch at the end of the run —
+automatically commits its changes as a single batch at the end of the run —
 the same operation as `akm sync` — and pushes if the bundle is writable, per
 the active strategy's `sync` setting. The `reflect-distill` and
 `proactive-maintenance` strategies skip sync entirely, so an interrupted run
 does not leave an uncommitted backlog. `--no-sync` disables sync for a single
 run; `--no-push` commits without pushing. Strategy sync behavior is
 configured via the `sync` block under `improve.strategies.<name>`.
+
+The commit is scoped by **write provenance**, not by directory: every akm write
+path records the file it mutated into a run-scoped journal
+(`src/core/write-provenance.ts`), and the end-of-run sync stages exactly the
+journaled paths that Git still reports as changed. A file someone else edits
+under a managed directory while the run is in flight is therefore left dirty for
+its author, while a file that was already dirty when the run started and was
+then rewritten by the run IS committed. Deletions are journaled like writes, so
+the final on-disk state is what lands — a path written and then reverted or
+purged produces no commit at all. The run reports its journal as
+`writtenPaths` on the improve result. Callers that supply no explicit path list
+(`akm sync`, `akm push`) keep the managed-pathspec fallback in `saveGitStash`.
 
 ### Session extraction
 

--- a/docs/architecture/reviews/env-secret-access.md
+++ b/docs/architecture/reviews/env-secret-access.md
@@ -239,5 +239,81 @@ Each step is additive and green in isolation, so the cycle ratchet never goes re
 
 - **No new command surface / return path.** Do not add an `x-bearer-token path`-style command; the precedent (`secret path` / `secret remove` removal, R-027 / D-49) is that akm removes a surface rather than risk a resolver mismatch or accidental exposure.
 - **Do not rely on `--format` / `output()` exemption as the safety mechanism.** The new path must be structurally value-free on its own (same-frame header set, never returned upward), not depend on CLI-level formatting exemptions.
-- **Do not ship Proposal 3's independent enumerator now.** Deleting the `env-secret-ref → search-source` edge (P3) is the correct *eventual* structural cleanup, but only if `secretSourceRoots` **delegates to a shared lock-first helper** also used by `resolveEntryContentDir`; the as-written second-source-of-truth reintroduces the resolver-mismatch class that already cost `secret path` / `secret remove`. Track it as a separate, later refactor.
+- **Do not ship Proposal 3's independent enumerator now.** Deleting the `env-secret-ref → search-source` edge (P3) is the correct *eventual* structural cleanup, but only if `secretSourceRoots` **delegates to a shared lock-first helper** also used by `resolveEntryContentDir`; the as-written second-source-of-truth reintroduces the resolver-mismatch class that already cost `secret path` / `secret remove`. Track it as a separate, later refactor. **Update (issue #744): that condition was tested and cannot be met today — see §8 for the measurements and the single blocking edge.**
 - **Do not adopt Proposal 2's breaking field rename now.** The opaque `CredentialProvider` (void/boolean methods, strongest containment) is the principled long-term target if a breaking contract change ever becomes acceptable; today its lockstep churn is unjustified when P4 reaches the same consumers additively.
+
+---
+
+## 8. P3 feasibility re-assessment (issue #744, 2026-08-12) — BLOCKED on one edge
+
+§7 defers P3 with a condition: it may land "only if `secretSourceRoots` **delegates to a shared lock-first helper** also used by `resolveEntryContentDir`." That condition was tested directly. **It cannot be met today.** The blocker is a single import edge, named at the end of this section; P3 should stay deferred until that edge is severed.
+
+### 8.1 What was built and measured
+
+The strongest possible reading of the §7 condition was implemented as a probe: rather than write a *new* `secretSourceRoots` that "delegates to" a shared helper, `SearchSource`, `resolveSourceEntries` and `resolveEntryContentDir` were moved **verbatim** out of `indexer/search/search-source.ts` into a candidate leaf module, so the reader and the indexer would call the *same function object* — one resolver by construction, not two that agree by convention. That is strictly better than the proposal's sketch and removes any second-source-of-truth argument.
+
+It still fails, for a reason the original critique did not reach.
+
+### 8.2 Finding 1 — the "lock-first helper" is lock-first but **provider-second**, and the second half is load-bearing
+
+`lockContentRootFor` (`src/integrations/lockfile.ts:169-177`) answers **only** for `git`/`npm` bundles that carry a lock `localRoot`; its first line returns `undefined` for every other kind by construction:
+
+```ts
+if (!bundleId || (type !== "git" && type !== "npm")) return undefined;
+```
+
+So for a **filesystem** bundle (the primary bundle — where `secrets/` actually live), a **website** cache, and a **legacy/unlocked git** bundle, the content root comes exclusively from the second half of `resolveEntryContentDir`: `resolveSourceProviderFactory(entry.type)` → `factory(entry)` → `provider.path()`. Exactly the three cases the issue's acceptance criteria demand be pinned.
+
+And that second half is not an implementation detail to route around — it is the repo's *declared* single source of truth (`search-source.ts:161-166`): "each provider owns its own path… This replaces the old per-kind switch ladder (filesystem path / git cache / website cache) that lived here in 0.6.0." Any leaf resolver that derives those paths itself reintroduces the ladder 0.6.0 deleted.
+
+### 8.3 Finding 2 — a leaf cannot populate the provider registry, and a half-populated registry mis-resolves **silently**
+
+The registry is populated by one eager side-effect import, `search-source.ts:16` (`import "../../sources/providers/index"`). A leaf reader structurally cannot perform it: `providers/index → website.ts → website-ingest.ts → snapshot-fetchers/registry.ts → x.ts` is the fetcher subgraph, and pulling it in is the very coupling P3 exists to delete.
+
+Measured against a fixture config holding all five shapes (filesystem primary, lock-managed git, **legacy/unlocked git**, **website cache**, lock-managed npm), same config, two processes:
+
+| bundle | via `search-source` (registered) | via the leaf (not registered) |
+|---|---|---|
+| `primary` (filesystem) | `…/fixture/primary-stash` | `…/.akm/unresolved-sources/primary` ❌ |
+| `locked-git` | `…/installs/locked-git/content` | same ✅ (lock-first) |
+| `legacy-git` | `…/cache/registry-index/git-07aa…/repo` | same ✅ *(by accident — see below)* |
+| `site-cache` (website) | `…/cache/registry-index/website-de10…` | `…/.akm/unresolved-sources/site-cache` ❌ |
+| `locked-npm` | `…/installs/locked-npm` | same ✅ (lock-first) |
+
+End to end, with the secret genuinely present in the primary bundle:
+
+- `resolveSecretPath("secrets/x-bearer-token")` today → `…/fixture/primary-stash/secrets/x-bearer-token`
+- the same logic on the leaf enumerator → `…/.akm/unresolved-sources/primary/secrets/x-bearer-token`
+
+**A different file, no error, no warning** — `findEnvSource` falls back to `candidates[0]` when its `existsSync` probe finds nothing, and `resolveSecretFromStore` swallows every failure to `null`. This is precisely the resolver-mismatch class that cost `secret path` / `secret remove` (R-027 / D-49).
+
+Worse than a clean failure: registration is **partial and accidental**. In the leaf's import closure `git` *is* registered — not deliberately, but because `core/write-source.ts` happens to import `sources/providers/git.ts`. So the leaf resolves git correctly and filesystem/website incorrectly, and which kinds work depends on which unrelated modules got pulled in. A resolver whose correctness varies by transitive import order is the worst available property.
+
+### 8.4 Finding 3 — all three escapes are closed
+
+| Escape | Result |
+|---|---|
+| (a) Derive filesystem/website/git roots in the leaf | Reinstates the per-kind switch ladder deleted in 0.6.0 — the second source of truth §7 forbids. |
+| (b) Side-effect-import `providers/index` from the leaf | Measured: **7 cycle participants** (`env-secret-read`, `source-entries`, `providers/index`, `website`, `website-ingest`, `snapshot-fetchers/registry`, `x`) against an **absolute 0 baseline**. This is the subgraph coming back through another door. |
+| (c) Rely on ambient registration order | §4.1's rejected P1 flaw, with a worse failure mode: P1 degraded to env-var-only, this resolves a *different file*. Making it loud needs either a hardcoded four-kind list (new duplicated truth) or turning `resolveEntryContentDir`'s deliberately-soft `undefined` degradation — which the indexer relies on to keep running past a bad source — into a throw. |
+
+### 8.5 The one blocking edge, and the prerequisite
+
+The single edge that makes `providers/index` unimportable from a leaf is:
+
+```
+src/sources/providers/website.ts  ──▶  src/sources/snapshot-fetchers/website-ingest.ts
+```
+
+`website.ts` needs `getWebsiteCachePaths` / `validateWebsiteUrl` / `shouldAllowPrivateWebsiteUrlForTests` for `path()`, and `ensureWebsiteMirror` for `sync()`. The other three providers are already subgraph-free (`filesystem.ts`, `git.ts`, `npm.ts`).
+
+Re-running the P3 graph with **only that edge removed** yields **0 cycle participants**. So the prerequisite is exact and singular:
+
+1. Extract the pure path derivations (`getWebsiteCachePaths` + `normalizeSiteUrl`, `validateWebsiteUrl`, `shouldAllowPrivateWebsiteUrlForTests`) from `website-ingest.ts` into a leaf module both it and `website.ts` import. Necessary, **not sufficient** — `sync()` still reaches `ensureWebsiteMirror`.
+2. Stop `website.ts`'s `sync()` from statically importing `ensureWebsiteMirror` — inject the mirror as a capability on `SyncOptions`, bound from a composition root, exactly the P4 idiom applied to the mirror instead of the secret.
+
+With both done, `providers/index` becomes a leaf-importable registration point, the moved `resolveSourceEntries` is genuinely one shared resolver, and P3's acceptance criteria are reachable. Until then P3 cannot satisfy §7's condition and must not land.
+
+### 8.6 Correction to the issue's framing
+
+`CYCLE_PARTICIPANT_BASELINE` is **already empty** and the ratchet is absolute; `bun scripts/lint-import-cycles.ts` reports `0 cycle participant(s)`. There is no import cycle in `src/` today — `env-secret-ref → search-source` is a one-way DAG edge, and the cycle is only *latent* (it closes if a fetcher imports the reader). So #744's "the baseline shrinks" criterion is vacuous as written: the measurable win P3 offers is not a smaller baseline but the removal of the latent back-edge, which is what §8.5 gates.

--- a/docs/architecture/specs/0.9.0-open-items-register.md
+++ b/docs/architecture/specs/0.9.0-open-items-register.md
@@ -124,7 +124,12 @@ false rather than merely being incomplete:
 
 ### Not scanned
 
-`0.9.0-decisions.md`, `tests/TESTS_REVIEW.md`, and 38 "major" findings from the
-Phase-3 documentation review (`X-PHASE3-MAJORS`) were never worked through
-item by item. The Phase-3 blockers were fixed; its majors were not individually
-verified.
+`0.9.0-decisions.md` and 38 "major" findings from the Phase-3 documentation
+review (`X-PHASE3-MAJORS`) were never worked through item by item. The Phase-3
+blockers were fixed; its majors were not individually verified.
+
+`tests/TESTS_REVIEW.md` was also in this list. It has since been scanned:
+all 67 of its findings were dispositioned against the tree on 2026-08-12
+(issue #773) — 49 fixed, 14 still open, 4 superseded by decision — and the
+document was replaced with that disposition record. The still-open items are
+grouped into six themed clusters there.

--- a/docs/architecture/testing/manual-testing-checklist.md
+++ b/docs/architecture/testing/manual-testing-checklist.md
@@ -3187,27 +3187,53 @@ remaining gaps carry approved waivers with the expiries recorded below.
       registry stale fallback, and sync/write serialization.
   - Covered: strict lockfile (`tests/integration/lockfile.test.ts` corrupt-
     lockfile fail-closed + CAS cases).
-  - Partial: atomic index generations (single-transaction swap exists; no test
-    reads concurrently mid-rebuild), safe website/npm refresh (npm side
-    covered; website snapshot interrupted mid-write can strand a mixed dir),
-    sync serialization (git-source CAS race tested; `akm sync`'s own
-    `createExactPathCommit` race not directly).
   - **Fixed 2026-08-06** (fix-now directed at 0.9.0 triage): registry stale
     fallback — a failed registry fetch now serves the cached index even past
     its TTL, with a warning, instead of hard-failing
     (`src/storage/repositories/registry-cache.ts`; pinned by
     `tests/integration/registry-stale-fallback.test.ts`).
-  - Open: live-lock age (an alive-but-slow writer past `staleAfterMs` can be
-    reclaimed; no test pins reclaim behavior), full source lifecycle rollback
-    (no test walks add→blocked-install→rollback against a dangerous fixture).
-  - Tracking: [#757](https://github.com/itlackey/akm/issues/757) (live-lock reclaim),
-    [#758](https://github.com/itlackey/akm/issues/758) (blocked-install rollback),
-    [#759](https://github.com/itlackey/akm/issues/759) (concurrency/atomicity coverage).
-  - issue: recovery-path coverage gaps. impact: worst plausible outcome is a
-    mixed website snapshot after a crash; recovery via re-run. owner:
-    itlackey. verification test: per-item notes. temporary mitigation: all
-    paths recover via re-run (`akm bundle update`, `akm index --full`); locks
-    are per-purpose and 12h-stale thresholds make live reclaim unlikely.
+  - **Fixed for 0.9.1** ([#757](https://github.com/itlackey/akm/issues/757),
+    [#759](https://github.com/itlackey/akm/issues/759)): four of the five
+    partial/open items landed.
+    - Live-lock age — a lock whose holder PID is genuinely ALIVE but whose
+      mtime has aged past the threshold is now pinned in both directions, at
+      the production thresholds, for the index-writer lease and the improve
+      run lock (`tests/integration/index-writer-lock.test.ts`,
+      `tests/integration/commands/improve/improve-lock-invariants.test.ts`).
+      Each positive test fails when `probeLock`'s age branch is disabled; each
+      negative control fails when it is made unconditional.
+    - Atomic index generations — a second reader connection opened from inside
+      `insertTransaction` now proves it observes the complete previous
+      generation, never zero or partial rows
+      (`tests/integration/indexer/reindex-generation-atomicity.test.ts`).
+    - Sync serialization — `createExactPathCommit`'s own CAS is raced by a real
+      concurrent commit landing inside the `update-ref` window, mirroring the
+      `write-source.ts` pattern
+      (`tests/integration/sync-exact-commit-cas.test.ts`).
+    - Safe website refresh — this one was a REAL BUG, not just missing
+      coverage: the refresh deleted the whole mirror and then wrote pages in
+      place, so an interrupted run left a partial mirror that a later
+      non-forced run would serve (the freshness marker is only rewritten on
+      success, so the stale marker still looked fresh). Fixed with
+      staging-dir-then-rename plus an age-gated sweep of abandoned staging
+      dirs (`src/sources/snapshot-fetchers/website-ingest.ts`; pinned by
+      `tests/integration/website-refresh-interruption.test.ts`, all four cases
+      of which fail against the old in-place write). Residual, documented in
+      code: publication is two renames, so a kill in that one-syscall window
+      leaves the mirror absent — `requireStashDir` callers refresh immediately,
+      others recover on the next expiry or `--force`.
+  - Open: full source lifecycle rollback (no test walks
+    add→blocked-install→rollback against a dangerous fixture).
+  - Tracking: [#758](https://github.com/itlackey/akm/issues/758) (blocked-install rollback).
+  - issue: one recovery-path coverage gap (blocked-install rollback). impact:
+    the mixed-website-snapshot outcome this waiver was written for is now
+    fixed, not merely mitigated; what remains is untested rollback on a
+    blocked install, recoverable by re-running `akm bundle add`. owner:
+    itlackey. verification test: a test walking add→blocked-install→rollback
+    against a dangerous fixture, asserting config.json/akm.lock parity.
+    temporary mitigation: all paths recover via re-run (`akm bundle update`,
+    `akm index --full`); the dangerous-env audit already blocks the install
+    itself, so rollback fidelity is the only untested part.
     waiver approver: itlackey — approved 2026-08-06 (0.9.0 release triage).
     waiver expiry: 0.9.1.
 - [ ] **Security:** Git/direct-write symlink containment, authenticated OpenCode

--- a/docs/reference/data-and-telemetry.md
+++ b/docs/reference/data-and-telemetry.md
@@ -128,7 +128,7 @@ the set of types the code actually emits at HEAD (verified against every
 | `select` | `akm show` after a search returning the same ref | `ref`, `entryId` |
 | `feedback` | `akm feedback <ref>` | `signal` (positive/negative) |
 | `sync` | `akm sync` (renamed from `save` in 0.9.0; historical rows keep `save`, and `akm log --type save`/`--type sync` are synonyms on read) | `ref` |
-| `stash_synced` | `akm improve`'s internal auto-sync pass (the `sync.push` feature), **distinct from** the `akm sync` command above | `committed`, `pushed`, `skipped`, `reason` |
+| `stash_synced` | `akm improve`'s internal auto-sync pass (the `sync.push` feature), **distinct from** the `akm sync` command above | `committed`, `pushed`, `skipped`, `reason`, `attributed` (paths the run wrote and staged), `unattributed` (in-scope paths that went dirty during the run without the run writing them — left for their author) |
 | `env_access` | `akm env run <name> -- <command>` (audit trail: key **names** only, values never recorded) | `ref`, `keys` |
 | `secret_access` | `akm secret run <ref> <VAR> -- <command>` (audit trail: var **name** only, value never recorded) | `ref`, `var` |
 

--- a/src/commands/improve/distill/quality-gate.ts
+++ b/src/commands/improve/distill/quality-gate.ts
@@ -19,6 +19,7 @@ import { appendEvent, type EventsContext } from "../../../core/events";
 import type { AkmDistillResult, DistillOutcome } from "../../../core/improve-types";
 import { parseEmbeddedJsonResponse } from "../../../core/parse";
 import { withStateDb } from "../../../core/state-db";
+import { recordWrittenPath } from "../../../core/write-provenance";
 import { getDefaultLlmConfig } from "../../../integrations/agent/engine-resolution";
 import type { ChatCompletionOptions, ChatMessage } from "../../../llm/client";
 import type { LlmFeatureKey } from "../../../llm/feature-gate";
@@ -330,11 +331,15 @@ export function writeQualityRejection(
   const rejectDir = path.join(stash, ".akm", "distill-rejected");
   fs.mkdirSync(rejectDir, { recursive: true });
   const ts = timestampForFilename();
+  const rejectPath = path.join(rejectDir, `${ts}-${proposalRef.replace(/[:/\\]/g, "-")}.md`);
   fs.writeFileSync(
-    path.join(rejectDir, `${ts}-${proposalRef.replace(/[:/\\]/g, "-")}.md`),
+    rejectPath,
     `---\nscore: ${score}\nreason: ${reason}\noutcome: ${outcome}\n---\n\n${content}`,
     "utf8",
   );
+  // #652: the rejection envelope lands under the managed `.akm/` tree, which
+  // the pre-provenance sync swept up by pathspec — journal it explicitly.
+  recordWrittenPath(rejectPath);
   appendEvent(
     {
       eventType: "distill_invoked",

--- a/src/commands/improve/improve.ts
+++ b/src/commands/improve/improve.ts
@@ -24,7 +24,8 @@ import { resolveMutationTarget } from "../../core/mutation-target";
 import { getDbPath, getStateDbPathInDataDir } from "../../core/paths";
 import { redactSensitiveText } from "../../core/redaction";
 import { openStateDatabase } from "../../core/state-db";
-import { info, warn } from "../../core/warn";
+import { info, warn, warnVerbose } from "../../core/warn";
+import { beginWriteProvenance, relativeWrittenPath, type WriteProvenanceJournal } from "../../core/write-provenance";
 import { resolveWritable, resolveWriteTarget } from "../../core/write-source";
 import { ensureIndex } from "../../indexer/ensure-index";
 import { akmIndex } from "../../indexer/indexer";
@@ -175,6 +176,14 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
   } = setup;
   let clearBudgetTimer = (): void => {};
   let initialGitPaths = new Set<string>();
+  // #652: run-scoped write-provenance journal. Opened once the run owns its
+  // lock (so it spans every write the run can make) and closed on every exit
+  // path. While open, every akm write path records the file it mutated.
+  let writeJournal: WriteProvenanceJournal | undefined;
+  const closeWriteJournal = (): void => {
+    writeJournal?.end();
+    writeJournal = undefined;
+  };
 
   const preEnsureCleanupWarnings: string[] = [];
   // Assigned by runIndexAndCollect() (closure) so TS cannot prove definite
@@ -211,6 +220,7 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
   const commitStashBatch = makeCommitStashBatch({
     run: setup,
     getInitialGitPaths: () => initialGitPaths,
+    getWriteJournal: () => writeJournal,
     // Captured via getter: the live `eventsCtx` binding is reassigned after the
     // prepass, and the catch-path sync must write through the current context.
     getEventsCtx: () => eventsCtx,
@@ -237,6 +247,9 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
       process.on("exit", exitBackstop);
       initialGitPaths =
         syncRepoDir && isGitBackedStash(syncRepoDir) ? new Set(listGitChangedPaths(syncRepoDir)) : new Set<string>();
+      // #652: open AFTER the lock, so the journal covers exactly the window in
+      // which this run — and only this run — is allowed to write.
+      writeJournal = beginWriteProvenance();
 
       // Drain the standing proposal backlog before indexing so fresh proposal
       // generation sees promotions from this same serialized run.
@@ -269,6 +282,7 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
       exitBackstop = undefined;
     }
     releaseRunLock();
+    closeWriteJournal();
     throw err;
   }
 
@@ -323,6 +337,12 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
     // the only commit; for a multi-cycle run the earlier cycles were banked by
     // the inter-cycle calls and this records the last batch). `result` carries
     // the full `{accepted}`/`{refs}`/`{triage_*}` token data for the message.
+    //
+    // #652: surface the run's write provenance on the envelope BEFORE the sync
+    // (the sync itself writes no assets), so `result.writtenPaths` describes
+    // exactly the set the commit below was scoped to.
+    const writtenPaths = describeRunWrittenPaths(setup, writeJournal?.writtenPaths() ?? []);
+    if (writtenPaths.length > 0) result.writtenPaths = writtenPaths;
     result.sync = commitStashBatch(result);
 
     return result;
@@ -353,6 +373,10 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
       exitBackstop = undefined;
     }
     releaseRunLock();
+    // #652: close the write-provenance journal LAST among the write-facing
+    // teardown steps — the catch path's crash-safety commit above still needs
+    // it open to know what this run wrote.
+    closeWriteJournal();
     // I1: close the long-lived state.db connection opened at the top of the run.
     try {
       eventsDb?.close();
@@ -360,6 +384,23 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
       // ignore — DB may already be closed
     }
   }
+}
+
+/**
+ * Shape the run's journaled absolute paths for `result.writtenPaths` (#652):
+ * POSIX-relative to the run's primary stash dir (the repo root for a git-backed
+ * stash) when the write landed inside it, absolute otherwise — a run writing to
+ * a `--target` bundle outside the stash still reports what it wrote. Deduped and
+ * sorted so the field is stable across runs.
+ */
+function describeRunWrittenPaths(setup: ImproveRunSetup, writtenPaths: readonly string[]): string[] {
+  const root = setup.primaryStashDir ?? setup.syncRepoDir;
+  const described = new Set<string>();
+  for (const absolutePath of writtenPaths) {
+    const relative = root ? relativeWrittenPath(root, absolutePath) : undefined;
+    described.add(relative ?? absolutePath.replaceAll(path.sep, "/"));
+  }
+  return [...described].sort();
 }
 
 // ── akmImprove run-setup / stage-sequencing / run-teardown units ────────────
@@ -818,23 +859,83 @@ async function runTriagePrePass(run: ImproveRunSetup): Promise<DrainResult | und
   return triageDrain;
 }
 
+/** A path is never staged by auto-sync when it is (or looks like) a lock file. */
+function isSyncExcludedPath(relativePath: string): boolean {
+  return path.basename(relativePath).includes(".lock");
+}
+
+/**
+ * Resolve the EXACT repo-relative path set the auto-sync commit stages (#652).
+ *
+ * Precedence:
+ *
+ *   1. **Run-scoped write provenance** (`writtenPaths`, absolute) — the paths
+ *      this run actually wrote, created, or removed, intersected with the paths
+ *      Git currently reports as changed. The intersection is what makes the set
+ *      correct rather than merely plausible: it drops a journaled path whose
+ *      final bytes match HEAD (nothing to commit), a journaled path that was
+ *      created and then removed again (never existed for Git), and any journaled
+ *      path Git ignores (which `saveGitStash` would otherwise reject outright).
+ *      A journaled path that was ALREADY dirty when the run started stays IN —
+ *      this run rewrote it, so this run owns it.
+ *   2. **Dirty-path diff** (pre-#652 behaviour) — only when no journal was open,
+ *      which a live run never hits. Kept as the defensive fallback so a future
+ *      caller that commits outside the journal window degrades to the previous,
+ *      battle-tested heuristic instead of silently committing nothing.
+ *
+ * `unattributed` counts in-scope paths that became dirty DURING the run without
+ * this run writing them: concurrent human edits (correctly excluded) and, if the
+ * number is ever surprising, the fingerprint of a missing journal call site.
+ */
+export function resolveSyncPathSet(input: {
+  repoDir: string;
+  assetPrefix: string;
+  changedPaths: readonly string[];
+  initialPaths: ReadonlySet<string>;
+  writtenPaths: readonly string[];
+  provenance: boolean;
+}): { paths: string[]; unattributed: string[] } {
+  const { repoDir, assetPrefix, changedPaths, initialPaths, writtenPaths, provenance } = input;
+  const inScope = (relativePath: string): boolean =>
+    !isSyncExcludedPath(relativePath) &&
+    (!assetPrefix || relativePath === assetPrefix || relativePath.startsWith(`${assetPrefix}/`));
+
+  if (!provenance) {
+    return { paths: changedPaths.filter((p) => !initialPaths.has(p) && inScope(p)), unattributed: [] };
+  }
+
+  const changed = new Set(changedPaths);
+  const attributed = new Set<string>();
+  for (const absolutePath of writtenPaths) {
+    const relativePath = relativeWrittenPath(repoDir, absolutePath);
+    if (!relativePath || !changed.has(relativePath) || !inScope(relativePath)) continue;
+    attributed.add(relativePath);
+  }
+  return {
+    paths: [...attributed].sort(),
+    unattributed: changedPaths.filter((p) => !attributed.has(p) && !initialPaths.has(p) && inScope(p)).sort(),
+  };
+}
+
 /**
  * Crash-safe / incremental stash sync (#662) — see the factory-returned
  * closure's original doc block: the primary stash writes as a filesystem
  * source DURING the run; this commits them at end-of-run AND from the catch
- * path. Idempotent + NON-FATAL. `getEventsCtx`/`getInitialGitPaths` are
- * getters because both outer bindings are (re)assigned after this factory
- * runs — the returned closure must observe the live values.
+ * path. Idempotent + NON-FATAL. `getEventsCtx`/`getInitialGitPaths`/
+ * `getWriteJournal` are getters because those outer bindings are (re)assigned
+ * after this factory runs — the returned closure must observe the live values.
  */
 function makeCommitStashBatch(deps: {
   run: ImproveRunSetup;
   getInitialGitPaths: () => Set<string>;
+  getWriteJournal: () => WriteProvenanceJournal | undefined;
   getEventsCtx: () => EventsContext;
 }): (messageContext: Parameters<typeof renderSyncCommitMessage>[1]) => AkmImproveResult["sync"] | undefined {
   const { writeTarget, primaryStashDir, effectiveSync, options, _earlyConfig, improveProfile } = deps.run;
   return (messageContext) => {
     const eventsCtx = deps.getEventsCtx();
     const initialGitPaths = deps.getInitialGitPaths();
+    const writeJournal = deps.getWriteJournal();
     const repoDir = writeTarget?.source.repoPath ?? primaryStashDir;
     if (!primaryStashDir || !repoDir || effectiveSync.enabled === false || !isGitBackedStash(repoDir)) {
       return undefined;
@@ -850,11 +951,19 @@ function makeCommitStashBatch(deps: {
     try {
       const assetRoot = writeTarget?.source.path ?? primaryStashDir;
       const assetPrefix = assetRoot ? path.relative(repoDir, assetRoot).replaceAll(path.sep, "/") : "";
-      const paths = listGitChangedPaths(repoDir).filter((changedPath) => {
-        if (initialGitPaths.has(changedPath)) return false;
-        if (path.basename(changedPath).includes(".lock")) return false;
-        return !assetPrefix || changedPath === assetPrefix || changedPath.startsWith(`${assetPrefix}/`);
+      const { paths, unattributed } = resolveSyncPathSet({
+        repoDir,
+        assetPrefix,
+        changedPaths: listGitChangedPaths(repoDir),
+        initialPaths: initialGitPaths,
+        writtenPaths: writeJournal?.writtenPaths() ?? [],
+        provenance: writeJournal !== undefined,
       });
+      if (unattributed.length > 0) {
+        warnVerbose(
+          `[improve] auto-sync left ${unattributed.length} path(s) uncommitted — not written by this run: ${unattributed.join(", ")}`,
+        );
+      }
       const syncResult = saveGitStashFn(undefined, message, writableOverride, {
         push,
         repoDir,
@@ -868,6 +977,11 @@ function makeCommitStashBatch(deps: {
             pushed: syncResult.pushed,
             skipped: syncResult.skipped,
             reason: syncResult.reason ?? null,
+            // #652 provenance audit trail: how many paths this run staged, and
+            // how many in-scope paths went dirty during the run that it did NOT
+            // write (concurrent edits — deliberately left for their author).
+            attributed: paths.length,
+            unattributed: unattributed.length,
           },
         },
         eventsCtx,

--- a/src/commands/improve/improve.ts
+++ b/src/commands/improve/improve.ts
@@ -161,6 +161,36 @@ export function armBudgetWatchdog(
   };
 }
 
+/**
+ * The run's write-provenance journal lifecycle as one named unit (#652).
+ *
+ * The journal is opened once the run owns its lock — so it spans exactly the
+ * window in which this run, and only this run, is allowed to write — and closed
+ * on every exit path including the crash-safety commit. Keeping the mutable
+ * handle behind this factory rather than as a bare `let` in {@link akmImprove}
+ * is also what keeps that function under the R31 size gate
+ * (`tests/architecture/improve-fn-size-ratchet.test.ts`, absolute 220-line bar
+ * with an empty baseline): lifecycle state belongs in a named unit, not in the
+ * orchestrator's preamble.
+ */
+function createRunWriteJournal(): {
+  open(): void;
+  close(): void;
+  current(): WriteProvenanceJournal | undefined;
+} {
+  let journal: WriteProvenanceJournal | undefined;
+  return {
+    open: () => {
+      journal = beginWriteProvenance();
+    },
+    close: () => {
+      journal?.end();
+      journal = undefined;
+    },
+    current: () => journal,
+  };
+}
+
 export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmImproveResult> {
   const setup = resolveImproveRunSetup(options);
   options = setup.options;
@@ -176,14 +206,7 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
   } = setup;
   let clearBudgetTimer = (): void => {};
   let initialGitPaths = new Set<string>();
-  // #652: run-scoped write-provenance journal. Opened once the run owns its
-  // lock (so it spans every write the run can make) and closed on every exit
-  // path. While open, every akm write path records the file it mutated.
-  let writeJournal: WriteProvenanceJournal | undefined;
-  const closeWriteJournal = (): void => {
-    writeJournal?.end();
-    writeJournal = undefined;
-  };
+  const runJournal = createRunWriteJournal();
 
   const preEnsureCleanupWarnings: string[] = [];
   // Assigned by runIndexAndCollect() (closure) so TS cannot prove definite
@@ -220,7 +243,7 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
   const commitStashBatch = makeCommitStashBatch({
     run: setup,
     getInitialGitPaths: () => initialGitPaths,
-    getWriteJournal: () => writeJournal,
+    getWriteJournal: () => runJournal.current(),
     // Captured via getter: the live `eventsCtx` binding is reassigned after the
     // prepass, and the catch-path sync must write through the current context.
     getEventsCtx: () => eventsCtx,
@@ -249,7 +272,7 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
         syncRepoDir && isGitBackedStash(syncRepoDir) ? new Set(listGitChangedPaths(syncRepoDir)) : new Set<string>();
       // #652: open AFTER the lock, so the journal covers exactly the window in
       // which this run — and only this run — is allowed to write.
-      writeJournal = beginWriteProvenance();
+      runJournal.open();
 
       // Drain the standing proposal backlog before indexing so fresh proposal
       // generation sees promotions from this same serialized run.
@@ -282,7 +305,7 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
       exitBackstop = undefined;
     }
     releaseRunLock();
-    closeWriteJournal();
+    runJournal.close();
     throw err;
   }
 
@@ -341,7 +364,7 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
     // #652: surface the run's write provenance on the envelope BEFORE the sync
     // (the sync itself writes no assets), so `result.writtenPaths` describes
     // exactly the set the commit below was scoped to.
-    const writtenPaths = describeRunWrittenPaths(setup, writeJournal?.writtenPaths() ?? []);
+    const writtenPaths = describeRunWrittenPaths(setup, runJournal.current()?.writtenPaths() ?? []);
     if (writtenPaths.length > 0) result.writtenPaths = writtenPaths;
     result.sync = commitStashBatch(result);
 
@@ -376,7 +399,7 @@ export async function akmImprove(options: AkmImproveOptions = {}): Promise<AkmIm
     // #652: close the write-provenance journal LAST among the write-facing
     // teardown steps — the catch path's crash-safety commit above still needs
     // it open to know what this run wrote.
-    closeWriteJournal();
+    runJournal.close();
     // I1: close the long-lived state.db connection opened at the top of the run.
     try {
       eventsDb?.close();

--- a/src/commands/improve/memory/memory-improve.ts
+++ b/src/commands/improve/memory/memory-improve.ts
@@ -9,6 +9,7 @@ import { mutateFrontmatter, parseFrontmatter } from "../../../core/asset/frontma
 import { conceptIdFromTypeName } from "../../../core/asset/resolve-ref";
 import { asNonEmptyString, groupBy, stringArray } from "../../../core/common";
 import { DERIVED_SUFFIX } from "../../../core/recognition-util";
+import { recordWrittenPath } from "../../../core/write-provenance";
 import { isDerivedMemory, memoryIdentityRef, parseMemoryName, resolveParentRef } from "./derived-ref";
 
 export type MemoryPruneReason = "duplicate-derived" | "superseded-derived" | "obsolete-derived";
@@ -327,6 +328,8 @@ export function applyMemoryCleanup(stashDir: string, plan: MemoryCleanupPlan): M
       if (resolvedBody === (fm.content ?? "")) continue; // no change
       const newContent = assembleAsset(fm.data, resolvedBody);
       fs.writeFileSync(candidate.filePath, newContent, "utf8");
+      // #652: relative-date resolution rewrites the asset in place.
+      recordWrittenPath(candidate.filePath);
       relativeDatesResolved++;
     } catch (error) {
       warnings.push(formatApplyWarning("relative-date-resolve", candidate.ref, error));
@@ -609,6 +612,10 @@ function archiveCleanupCandidate(
   const archivedPath = path.join(archiveDir, originalPath);
   fs.mkdirSync(path.dirname(archivedPath), { recursive: true });
   fs.renameSync(filePath, archivedPath);
+  // #652: an archive is a delete + a create. BOTH ends are journaled so the
+  // sync stages the removal of the original alongside the archived copy.
+  recordWrittenPath(filePath);
+  recordWrittenPath(archivedPath);
 
   const archiveRef = path.relative(stashDir, archivedPath).replace(/\\/g, "/");
   const auditPath = path.join(archiveDir, "cleanup.md");
@@ -630,6 +637,7 @@ function archiveCleanupCandidate(
     "Archived derived memory for recoverable cleanup.\n",
   );
   fs.writeFileSync(auditPath, auditAsset, "utf8");
+  recordWrittenPath(auditPath);
 
   return {
     ref: candidate.ref,

--- a/src/commands/improve/run-context.ts
+++ b/src/commands/improve/run-context.ts
@@ -46,6 +46,7 @@ import { resolveStashDir } from "../../core/common";
 import type { AkmConfig } from "../../core/config/config";
 import type { LlmConnectionConfig } from "../../core/config/config-types";
 import type { EventsContext } from "../../core/events";
+import { recordWrittenPath } from "../../core/write-provenance";
 import { chatCompletion } from "../../llm/client";
 import type { ProposalsContext } from "../proposal/repository";
 
@@ -180,6 +181,10 @@ function buildRunContext(carriers: RunContextCarriers, memo: Map<string, string>
     },
     writeAsset(filePath: string, content: string): void {
       carriers.writeFile(filePath, content);
+      // #652: journal the write for the run's write-provenance set. Recorded
+      // here (not in the default `writeFile` carrier) so an injected IO seam is
+      // attributed identically to a real `fs` write.
+      recordWrittenPath(filePath);
       memo?.set(memoKey(filePath), content);
     },
     noteAssetWrite(filePath: string): void {

--- a/src/commands/improve/session-asset.ts
+++ b/src/commands/improve/session-asset.ts
@@ -28,6 +28,7 @@ import path from "node:path";
 import { stashDirFor } from "../../core/asset/asset-placement";
 import { assembleAsset } from "../../core/asset/asset-serialize";
 import { conceptIdFromTypeName } from "../../core/asset/resolve-ref";
+import { recordWrittenPath } from "../../core/write-provenance";
 import { normalizeHarnessId } from "../../integrations/harnesses";
 import type { SessionData, SessionEvent } from "../../integrations/session-logs/types";
 
@@ -301,6 +302,9 @@ export async function writeSessionAsset(
   const filePath = resolveSessionAssetPath(stashDir, harness, sessionId);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, content, "utf8");
+  // #652: extract's session asset is written outside the proposal queue —
+  // journal it so the run's auto-sync stages it as one of its own writes.
+  recordWrittenPath(filePath);
 
   return {
     written: true,

--- a/src/commands/proposal/repository.ts
+++ b/src/commands/proposal/repository.ts
@@ -73,6 +73,7 @@ import {
 import { canonicalBundleIdForTarget, resolveBundleWriteTarget } from "../../core/mutation-target";
 import { withImmediateTransaction, withStateDb } from "../../core/state-db";
 import { warn } from "../../core/warn";
+import { recordWrittenPath } from "../../core/write-provenance";
 import {
   assertAkmAssetWrite,
   assertWriteTargetPathsClean,
@@ -1322,6 +1323,9 @@ function rollbackPreparedProposalTransaction(txn: ProposalTxn): void {
     if (p.originalHash === null) {
       if (currentHash === p.publishedHash && sameProposalFile(p.assetPath, p.publishPath)) {
         fs.unlinkSync(p.assetPath);
+        // #652: un-publishing is a mutation of this run's own write — journal
+        // it so the sync stages the FINAL state of a written-then-reverted path.
+        recordWrittenPath(p.assetPath);
       } else if (currentHash !== null) {
         throw new Error(`Cannot roll back proposal transaction: target was created externally.`);
       }
@@ -1331,8 +1335,10 @@ function rollbackPreparedProposalTransaction(txn: ProposalTxn): void {
     cleanupProposalPublication(p);
     return;
   }
-  if (currentHash === p.publishedHash) fs.unlinkSync(p.assetPath);
-  else if (currentHash !== null && currentHash !== p.originalHash) {
+  if (currentHash === p.publishedHash) {
+    fs.unlinkSync(p.assetPath);
+    recordWrittenPath(p.assetPath);
+  } else if (currentHash !== null && currentHash !== p.originalHash) {
     throw new Error(`Cannot roll back proposal transaction: ${p.assetPath} diverged.`);
   }
   if (fs.existsSync(p.displacedPath)) {
@@ -1340,6 +1346,9 @@ function rollbackPreparedProposalTransaction(txn: ProposalTxn): void {
       throw new Error(`Cannot restore proposal backup: ${p.assetPath} is occupied.`);
     }
     fs.linkSync(p.displacedPath, p.assetPath);
+    // #652: restoring the displaced original still leaves the path in a state
+    // this run produced; journal it so the final on-disk bytes are staged.
+    recordWrittenPath(p.assetPath);
   }
   cleanupProposalPublication(p);
 }
@@ -1455,6 +1464,10 @@ async function finalizeProposalTransaction(
 ): Promise<Proposal> {
   const p = txn.journal.payload;
   validatePublishedProposal(p);
+  // #652: finalizing an `asset-published` transaction that a CRASHED earlier
+  // run left behind is this run adopting that write — journal the asset so the
+  // adopting run's auto-sync commits it instead of leaving it stranded.
+  recordWrittenPath(p.assetPath);
   cleanupProposalPublication(p);
   if (txn.journal.phase === "asset-published") {
     const commitRoot = target.source.repoPath ?? target.source.path;
@@ -1837,6 +1850,9 @@ function publishProposalAsset(txn: ProposalTxn, target: ResolvedWriteTarget): vo
       }
     }
     fs.linkSync(p.publishPath, p.assetPath);
+    // #652: the accepted-proposal (and revert) target is the run's headline
+    // write — journal it the instant the asset lands, before the txn advances.
+    recordWrittenPath(p.assetPath);
     fsyncTxnDir(path.dirname(p.assetPath));
     const snapshot = captureWriteTargetPathSnapshot(target, p.assetPath);
     if (snapshot) p.gitSnapshots = { [snapshot.path]: snapshot.state };

--- a/src/core/asset/frontmatter.ts
+++ b/src/core/asset/frontmatter.ts
@@ -12,6 +12,7 @@
 
 import fs from "node:fs";
 import { parse as yamlParse, stringify as yamlStringify } from "yaml";
+import { recordWrittenPath } from "../write-provenance";
 import { assembleAsset, serializeFrontmatter } from "./asset-serialize";
 
 /**
@@ -166,6 +167,9 @@ export function mutateFrontmatter(
       ? `---\n${serializeFrontmatter(nextFrontmatter)}\n---\n${parsed.content}`
       : assembleAsset(nextFrontmatter, parsed.content);
   fs.writeFileSync(filePath, next, "utf8");
+  // #652: in-place frontmatter stamps (belief state, contradiction markers,
+  // salience) are real asset mutations — journal them for the run's sync.
+  recordWrittenPath(filePath);
   return true;
 }
 

--- a/src/core/improve-result.ts
+++ b/src/core/improve-result.ts
@@ -50,6 +50,7 @@ const COMMON_FIELDS = [
   "cycleMetrics",
   "runId",
   "sync",
+  "writtenPaths",
   "terminated",
 ] as const;
 
@@ -93,8 +94,12 @@ function validateCommon(value: Record<string, unknown>): void {
     "extract",
     "coverageGaps",
     "deadUrls",
+    "writtenPaths",
   ] as const) {
     if (value[field] !== undefined && !Array.isArray(value[field])) fail(`${field} must be an array`);
+  }
+  if (Array.isArray(value.writtenPaths) && value.writtenPaths.some((entry) => typeof entry !== "string")) {
+    fail("writtenPaths must be an array of strings");
   }
   for (const field of [
     "cyclesRun",

--- a/src/core/improve-types.ts
+++ b/src/core/improve-types.ts
@@ -657,6 +657,18 @@ export interface AkmImproveResult {
    * (a sync failure is non-fatal and never fails the run).
    */
   sync?: { committed: boolean; pushed: boolean; skipped: boolean; reason?: string };
+  /**
+   * #652 — run-scoped write provenance: every path this run actually wrote,
+   * created, or removed, as recorded by the write-provenance journal (NOT
+   * inferred from a Git dirty-path diff). This is the exact set the end-of-run
+   * auto-sync scopes its commit to, minus paths whose final bytes match HEAD.
+   *
+   * Deduped and sorted. Entries are POSIX paths relative to the run's primary
+   * stash dir; a write that landed outside it (e.g. a `--target` bundle) is
+   * reported as an absolute path. Omitted entirely when the run wrote nothing —
+   * and always absent on a dry run, which writes nothing by construction.
+   */
+  writtenPaths?: string[];
   /** Present only when a started run was persisted after abnormal termination. */
   terminated?: { reason: string; at: string; errorMessage?: string };
 }

--- a/src/core/write-provenance.ts
+++ b/src/core/write-provenance.ts
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Run-scoped write provenance (#652).
+ *
+ * # Why this exists
+ *
+ * `akm improve`'s end-of-run auto-sync used to infer "what did this run write?"
+ * by diffing two Git dirty-path snapshots: everything dirty at end-of-run minus
+ * everything dirty when the run acquired its lock. That inference is wrong in
+ * both directions:
+ *
+ *   - an unrelated managed-dir edit made by a human DURING a long run appears in
+ *     the end-of-run diff and gets swept into akm's commit;
+ *   - a path that was ALREADY dirty when the run started and is then rewritten by
+ *     the run is subtracted out and never committed.
+ *
+ * The journal below replaces the inference with a record. Every akm write path
+ * that mutates a file on disk calls {@link recordWrittenPath}; a run opens a
+ * journal for its duration and reads back the exact set of paths it touched.
+ *
+ * # Contract
+ *
+ *   - A *write* and a *removal* are recorded identically — the journal records
+ *     "this run mutated this path", not what the mutation was. The final on-disk
+ *     state is what gets staged (`git add -A -- <path>` stages a deletion just as
+ *     happily as a modification), so a path written and then reverted, purged, or
+ *     rolled back needs no special handling: it is journaled once and the stager
+ *     sees whatever survived.
+ *   - Recording is a no-op when no journal is open, so non-improve command paths
+ *     pay nothing but a `Set.size` check.
+ *   - Journals nest: every open journal observes every recorded path. Concurrent
+ *     in-process runs (tests) therefore over-report rather than cross-attribute
+ *     writes to the wrong run, which is the safe direction — over-reporting stages
+ *     a path that has no diff, under-reporting loses a write.
+ *   - Nothing here throws. A provenance failure must never break a write.
+ */
+
+import path from "node:path";
+
+interface JournalState {
+  readonly touched: Set<string>;
+}
+
+const activeJournals = new Set<JournalState>();
+
+/** Handle for one open run-scoped journal. Obtain via {@link beginWriteProvenance}. */
+export interface WriteProvenanceJournal {
+  /** Absolute paths mutated while this journal was open (deduped, sorted). */
+  writtenPaths(): string[];
+  /**
+   * Close the journal and return its paths. Idempotent — a closed journal keeps
+   * answering {@link writtenPaths} but stops observing new writes.
+   */
+  end(): string[];
+}
+
+/** Open a journal. The caller MUST close it (`end()`) in a `finally`. */
+export function beginWriteProvenance(): WriteProvenanceJournal {
+  const state: JournalState = { touched: new Set<string>() };
+  activeJournals.add(state);
+  const snapshot = (): string[] => [...state.touched].sort();
+  return {
+    writtenPaths: snapshot,
+    end: () => {
+      activeJournals.delete(state);
+      return snapshot();
+    },
+  };
+}
+
+/** True while at least one journal is open. */
+export function isWriteProvenanceActive(): boolean {
+  return activeJournals.size > 0;
+}
+
+/**
+ * Record that the current run mutated `filePath` (write, create, rename, or
+ * delete). No-op when no journal is open. Never throws.
+ */
+export function recordWrittenPath(filePath: string | undefined | null): void {
+  if (activeJournals.size === 0 || !filePath) return;
+  let absolute: string;
+  try {
+    absolute = path.resolve(filePath);
+  } catch {
+    return;
+  }
+  for (const journal of activeJournals) journal.touched.add(absolute);
+}
+
+/**
+ * Normalize an absolute journaled path against `root`: POSIX-relative when the
+ * path is inside `root`, `undefined` otherwise (the caller decides whether an
+ * out-of-root write is reportable or, for staging, simply out of scope).
+ */
+export function relativeWrittenPath(root: string, absolutePath: string): string | undefined {
+  const relative = path.relative(root, absolutePath).replaceAll(path.sep, "/");
+  if (!relative || relative === ".." || relative.startsWith("../") || path.isAbsolute(relative)) return undefined;
+  return relative;
+}

--- a/src/core/write-source.ts
+++ b/src/core/write-source.ts
@@ -57,6 +57,7 @@ import { resolveConfiguredSources } from "./config/config";
 import { ConfigError, UsageError } from "./errors";
 import { sanitizeCommitMessage } from "./git-message";
 import { warn } from "./warn";
+import { recordWrittenPath } from "./write-provenance";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -428,6 +429,9 @@ export async function writeAssetToSource(
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(filePath, normalized, "utf8");
     recordWriteTargetPath(source, filePath);
+    // #652: run-scoped write provenance — the canonical asset write is the
+    // single largest contributor to an improve run's written-path set.
+    recordWrittenPath(filePath);
   } catch (error) {
     discardEmptyGitPreflight(preflight);
     throw error;
@@ -473,6 +477,9 @@ export async function deleteAssetFromSource(
   try {
     fs.unlinkSync(filePath);
     recordWriteTargetPath(source, filePath);
+    // #652: a removal is journaled exactly like a write — the stager stages the
+    // final on-disk state, so a deleted path lands as a staged deletion.
+    recordWrittenPath(filePath);
   } catch (error) {
     discardEmptyGitPreflight(preflight);
     throw error;

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -558,6 +558,39 @@ export async function akmIndex(options: IndexOptions): Promise<IndexResponse> {
 }
 
 /**
+ * Named observation points fired from INSIDE the reindex write transaction
+ * (see {@link persistDirRecords}). TEST-ONLY.
+ *
+ *  - `full-delete-applied` — every `DELETE` of the full-rebuild wipe has run,
+ *    but the re-insert has not started. This is the instant at which a
+ *    non-atomic implementation would expose an empty database.
+ *  - `records-persisted` — all rows are re-inserted, but the transaction has
+ *    not committed yet, so the new generation is still invisible outside.
+ */
+export type IndexTransactionPoint = "full-delete-applied" | "records-persisted";
+
+let indexTransactionHookForTests: ((point: IndexTransactionPoint) => void) | undefined;
+
+/**
+ * TEST-ONLY. Observe the in-flight reindex transaction; `undefined` restores.
+ *
+ * Exists because the delete-then-reinsert atomicity guarantee is, by
+ * construction, invisible from outside the transaction: by the time
+ * `akmIndex()` resolves, the commit has already collapsed both generations
+ * into one observable state. Concurrency tests install a hook that opens a
+ * SECOND connection at these points and asserts it still sees the previous
+ * complete generation. Inert in production (one `undefined?.()` per reindex).
+ */
+export function _setIndexTransactionHookForTests(hook?: (point: IndexTransactionPoint) => void): void {
+  indexTransactionHookForTests = hook;
+}
+
+/** Fire a named in-transaction observation point (no-op outside tests). */
+function indexTransactionHook(point: IndexTransactionPoint): void {
+  indexTransactionHookForTests?.(point);
+}
+
+/**
  * Detect an adapter for every resolvable source that does not declare one, and
  * persist each detection into `config.json`.
  *
@@ -1410,6 +1443,10 @@ function persistDirRecords(
       // (cross-DB) nulls entry_ids that no longer resolve to a rebuilt entry and
       // re-resolves the rest by entry_ref — subsuming the old detach.
       db.exec("DELETE FROM entries");
+      // Atomicity observation point: inside the transaction the tables are now
+      // empty, but no other connection may observe that. See
+      // tests/integration/indexer/reindex-generation-atomicity.test.ts.
+      indexTransactionHook("full-delete-applied");
     }
 
     for (const {
@@ -1560,6 +1597,9 @@ function persistDirRecords(
         }
       }
     }
+    // Atomicity observation point: the new generation is fully written but
+    // uncommitted, so it must still be invisible to other connections.
+    indexTransactionHook("records-persisted");
   });
 
   insertTransaction();

--- a/src/indexer/passes/memory-inference.ts
+++ b/src/indexer/passes/memory-inference.ts
@@ -46,6 +46,7 @@ import { todayIso } from "../../core/common";
 import { concurrentMap } from "../../core/concurrent";
 import type { SourceConfigEntry } from "../../core/config/config";
 import { warn } from "../../core/warn";
+import { recordWrittenPath } from "../../core/write-provenance";
 import { type WriteTargetSource, writeAssetToSource } from "../../core/write-source";
 import { isProcessEnabled } from "../../llm/feature-gate";
 import { resolveIndexPassLLM } from "../../llm/index-passes";
@@ -608,6 +609,9 @@ function markParentProcessed(parent: MemoryRecord): void {
   const next = assembleAsset(updatedFm, block.content);
   try {
     fs.writeFileSync(parent.filePath, next, "utf8");
+    // #652: the parent's `inference_processed` stamp is a real asset mutation
+    // (the documented writeAssetToSource exception above) — journal it.
+    recordWrittenPath(parent.filePath);
   } catch (err) {
     warn(
       `memory inference: failed to mark parent processed ${parent.filePath}: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/sources/providers/git-stash.ts
+++ b/src/sources/providers/git-stash.ts
@@ -89,6 +89,40 @@ export interface SaveGitStashOptions {
 const GIT_PUSH_TIMEOUT_MS = 120_000;
 const ZERO_OID = "0000000000000000000000000000000000000000";
 
+// ── Test seam: exact-path commit race window ─────────────────────────────────
+
+/**
+ * Named points inside {@link createExactPathCommit}'s publication sequence.
+ * TEST-ONLY.
+ *
+ *  - `before-update-ref` — the commit object exists, every pre-check has
+ *    passed, and the branch ref is about to be compare-and-swapped from
+ *    `baseHead` to it. A concurrent process that commits at exactly this
+ *    instant is the race the `update-ref <ref> <new> <old>` CAS defends
+ *    against, and it is the ONLY guard on the `akm sync` path (`akm sync`
+ *    passes no `expectedBaseHead`, so the earlier preflight check is inert
+ *    there).
+ */
+export type GitExactCommitPoint = "before-update-ref";
+
+let exactCommitHookForTests: ((point: GitExactCommitPoint) => void) | undefined;
+
+/**
+ * TEST-ONLY. Interleave work into the exact-path commit sequence; `undefined`
+ * restores. Exists because the CAS window is a few microseconds wide between
+ * two synchronous `git` invocations — a wall-clock race would be
+ * non-deterministic, and every earlier pre-check would swallow a commit that
+ * landed before the window opened. Inert in production.
+ */
+export function _setGitExactCommitHookForTests(hook?: (point: GitExactCommitPoint) => void): void {
+  exactCommitHookForTests = hook;
+}
+
+/** Fire a named exact-path-commit race point (no-op outside tests). */
+function gitExactCommitHook(point: GitExactCommitPoint): void {
+  exactCommitHookForTests?.(point);
+}
+
 /**
  * Resolve the writable flag for an end-of-run / `akm sync` commit from the
  * configured default bundle.
@@ -649,6 +683,10 @@ function createExactPathCommit(
       throw new Error(`Git target changed before its exact commit could be attached.`);
     }
     assertWorktreeMatchesExpected(repoDir, options.paths, expected);
+    // Race window: everything below this line is defended only by the
+    // update-ref compare-and-swap. See
+    // tests/integration/sync-exact-commit-cas.test.ts.
+    gitExactCommitHook("before-update-ref");
     const update = runGit(["-C", repoDir, "update-ref", branchRef, commitOid, options.baseHead ?? ZERO_OID]);
     if (update.status !== 0) {
       throw new Error(`Git target advanced before its exact commit could be attached.`);

--- a/src/sources/providers/git.ts
+++ b/src/sources/providers/git.ts
@@ -27,6 +27,8 @@ export {
   syncMirroredRepo,
 } from "./git-provider";
 export {
+  _setGitExactCommitHookForTests,
+  type GitExactCommitPoint,
   GitStashPushError,
   isGitBackedStash,
   listGitChangedPaths,

--- a/src/sources/snapshot-fetchers/website-ingest.ts
+++ b/src/sources/snapshot-fetchers/website-ingest.ts
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import {
@@ -322,27 +322,160 @@ async function fetchSnapshotViaRegistry(
   return dispatchSnapshotFetchers(parsed, context, stashDir);
 }
 
+// ── Snapshot staging (refresh atomicity, issue #759) ─────────────────────────
+
+/**
+ * TEST-ONLY crash-window event, fired after each page file of a refresh lands.
+ * See {@link _setWebsiteSnapshotWriteHookForTests}.
+ */
+export interface WebsiteSnapshotWriteEvent {
+  point: "page-written";
+  /** 1-based index of the page just written. */
+  index: number;
+  /** Total pages this refresh will write. */
+  total: number;
+  /** Stash-relative path of the page just written. */
+  relPath: string;
+}
+
+let snapshotWriteHookForTests: ((event: WebsiteSnapshotWriteEvent) => void) | undefined;
+
+/**
+ * TEST-ONLY. Interrupt a refresh partway through its page-write loop;
+ * `undefined` restores. Exists because "a process killed mid-refresh" cannot
+ * be staged from outside the module — the whole loop is a single synchronous
+ * burst between two awaits. Inert in production (one `undefined?.()` per page).
+ */
+export function _setWebsiteSnapshotWriteHookForTests(hook?: (event: WebsiteSnapshotWriteEvent) => void): void {
+  snapshotWriteHookForTests = hook;
+}
+
+function snapshotWriteHook(event: WebsiteSnapshotWriteEvent): void {
+  snapshotWriteHookForTests?.(event);
+}
+
+/**
+ * A refresh replaces the ENTIRE stash directory. Writing in place meant
+ * deleting the previous snapshot first and then materializing the new one file
+ * by file, so a process killed anywhere in that loop left the mirror empty or
+ * holding an arbitrary subset of the new pages with the old content already
+ * destroyed — and, because the freshness marker still looked recent, the next
+ * `sync()` could serve that wreckage instead of rebuilding it.
+ *
+ * The new snapshot is built in a sibling staging directory and swapped in with
+ * renames instead. An interrupted refresh leaves the PREVIOUS complete snapshot
+ * untouched; the abandoned staging directory is swept by the next refresh. The
+ * staging/retired names are dot-prefixed so the indexer's walk (which skips
+ * dot-directories) never sees a half-written snapshot even mid-flight.
+ */
+interface SnapshotStaging {
+  /** Directory the new snapshot is materialized into. */
+  readonly dir: string;
+  /** Final location the staging directory is renamed onto. */
+  readonly target: string;
+}
+
+function snapshotSiblingPrefix(stashDir: string, kind: "staging" | "retired"): string {
+  return `.${path.basename(stashDir)}.${kind}-`;
+}
+
+function snapshotSiblingPath(stashDir: string, kind: "staging" | "retired"): string {
+  const unique = `${process.pid}-${randomBytes(6).toString("hex")}`;
+  return path.join(path.dirname(stashDir), `${snapshotSiblingPrefix(stashDir, kind)}${unique}`);
+}
+
+/**
+ * Age gate for the staging sweep. Nothing enforces one refresh at a time for a
+ * given website source, so a sibling directory may belong to a refresh that is
+ * still running in another process; deleting it would break a healthy run
+ * instead of cleaning up after a dead one. Only clearly-abandoned directories
+ * (untouched for an hour — far longer than the 10-minute crawl wall-clock cap)
+ * are swept. Leftovers are inert until then: they are dot-prefixed, so the
+ * indexer's walk skips them.
+ */
+const SNAPSHOT_STAGING_SWEEP_AGE_MS = 60 * 60 * 1000;
+
+/** Remove staging/retired directories abandoned by an earlier interrupted run. */
+function sweepSnapshotStaging(stashDir: string): void {
+  const parent = path.dirname(stashDir);
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(parent);
+  } catch {
+    return;
+  }
+  const prefixes = [snapshotSiblingPrefix(stashDir, "staging"), snapshotSiblingPrefix(stashDir, "retired")];
+  const cutoff = Date.now() - SNAPSHOT_STAGING_SWEEP_AGE_MS;
+  for (const entry of entries) {
+    if (!prefixes.some((prefix) => entry.startsWith(prefix))) continue;
+    const abandoned = path.join(parent, entry);
+    try {
+      if (fs.statSync(abandoned).mtimeMs > cutoff) continue;
+    } catch {
+      continue;
+    }
+    fs.rmSync(abandoned, { recursive: true, force: true });
+  }
+}
+
+function beginSnapshotStaging(stashDir: string): SnapshotStaging {
+  fs.mkdirSync(path.dirname(stashDir), { recursive: true });
+  sweepSnapshotStaging(stashDir);
+  const dir = snapshotSiblingPath(stashDir, "staging");
+  fs.mkdirSync(dir, { recursive: true });
+  return { dir, target: stashDir };
+}
+
+/**
+ * Swap the staged snapshot in. POSIX cannot atomically exchange two non-empty
+ * directories, so the previous snapshot is renamed ASIDE first and deleted
+ * afterwards: the window in which the target does not exist is one syscall
+ * wide instead of an entire write loop.
+ */
+function publishSnapshotStaging(staging: SnapshotStaging): void {
+  let retired: string | undefined;
+  if (fs.existsSync(staging.target)) {
+    retired = snapshotSiblingPath(staging.target, "retired");
+    fs.renameSync(staging.target, retired);
+  }
+  fs.renameSync(staging.dir, staging.target);
+  if (retired) fs.rmSync(retired, { recursive: true, force: true });
+}
+
+/** Drop an unpublished staging directory (no-op once it has been renamed). */
+function discardSnapshotStaging(staging: SnapshotStaging): void {
+  fs.rmSync(staging.dir, { recursive: true, force: true });
+}
+
 /** Materialize a single fetcher snapshot as the source's whole stash. */
 function writeSnapshotToStash(stashDir: string, snapshot: WikiSnapshotResult): void {
   const preferredName = snapshot.preferredName ?? deriveImportPath(snapshot.url);
   const relPath = avoidReservedBasename(preferredName);
+  // Validate against the FINAL location so the guarantee (and the error text)
+  // is independent of where the file is staged.
   const knowledgeDir = path.join(stashDir, "knowledge");
-  const filePath = path.resolve(knowledgeDir, `${relPath}.md`);
-  if (!isWithin(filePath, knowledgeDir)) {
+  if (!isWithin(path.resolve(knowledgeDir, `${relPath}.md`), knowledgeDir)) {
     throw new UsageError(`Snapshot fetcher returned an unsafe preferred name: ${JSON.stringify(preferredName)}`);
   }
-  fs.rmSync(stashDir, { recursive: true, force: true });
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  const slug = relPath.split("/").pop() ?? "index";
-  fs.writeFileSync(
-    filePath,
-    buildMarkdownSnapshot(
-      { url: snapshot.url, title: snapshot.title, markdown: snapshot.markdown },
-      slug,
-      snapshot.tags,
-    ),
-    "utf8",
-  );
+  const staging = beginSnapshotStaging(stashDir);
+  try {
+    const filePath = path.resolve(path.join(staging.dir, "knowledge"), `${relPath}.md`);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const slug = relPath.split("/").pop() ?? "index";
+    fs.writeFileSync(
+      filePath,
+      buildMarkdownSnapshot(
+        { url: snapshot.url, title: snapshot.title, markdown: snapshot.markdown },
+        slug,
+        snapshot.tags,
+      ),
+      "utf8",
+    );
+    snapshotWriteHook({ point: "page-written", index: 1, total: 1, relPath: `knowledge/${relPath}.md` });
+    publishSnapshotStaging(staging);
+  } finally {
+    discardSnapshotStaging(staging);
+  }
 }
 
 async function scrapeWebsiteToStash(
@@ -381,19 +514,32 @@ async function scrapeWebsiteToStash(
     throw new Error(`No content could be scraped from ${startUrl}`);
   }
 
-  fs.rmSync(stashDir, { recursive: true, force: true });
-  const knowledgeDir = path.join(stashDir, "knowledge");
-  fs.mkdirSync(knowledgeDir, { recursive: true });
+  const staging = beginSnapshotStaging(stashDir);
+  try {
+    const knowledgeDir = path.join(staging.dir, "knowledge");
+    fs.mkdirSync(knowledgeDir, { recursive: true });
 
-  const usedPaths = new Set<string>();
-  for (const page of pages) {
-    const relPath = avoidReservedBasename(urlToRelativePath(page.url));
-    const uniquePath = uniqueSlug(relPath, usedPaths);
-    const filePath = path.join(knowledgeDir, `${uniquePath}.md`);
-    const dir = path.dirname(filePath);
-    if (dir !== knowledgeDir) fs.mkdirSync(dir, { recursive: true });
-    const slug = uniquePath.split("/").pop() ?? "index";
-    fs.writeFileSync(filePath, buildMarkdownSnapshot(page, slug), "utf8");
+    const usedPaths = new Set<string>();
+    let written = 0;
+    for (const page of pages) {
+      const relPath = avoidReservedBasename(urlToRelativePath(page.url));
+      const uniquePath = uniqueSlug(relPath, usedPaths);
+      const filePath = path.join(knowledgeDir, `${uniquePath}.md`);
+      const dir = path.dirname(filePath);
+      if (dir !== knowledgeDir) fs.mkdirSync(dir, { recursive: true });
+      const slug = uniquePath.split("/").pop() ?? "index";
+      fs.writeFileSync(filePath, buildMarkdownSnapshot(page, slug), "utf8");
+      written++;
+      snapshotWriteHook({
+        point: "page-written",
+        index: written,
+        total: pages.length,
+        relPath: `knowledge/${uniquePath}.md`,
+      });
+    }
+    publishSnapshotStaging(staging);
+  } finally {
+    discardSnapshotStaging(staging);
   }
 }
 

--- a/tests/TESTS_REVIEW.md
+++ b/tests/TESTS_REVIEW.md
@@ -1,671 +1,176 @@
-# Tests Directory Review
-
-Review date: 2026-07-26
-
-## Scope And Method
-
-This was a read-only review of the `tests/` tree, test runners, test helpers,
-fixtures, release scripts, CI configuration, and the relevant production code
-needed to validate test claims. Seven read-only explore agents were dispatched
-in parallel for organization, duplication, assertion value, runtime, isolation,
-runner/fixture design, and broad quality review. No tests were changed, and no
-test or source files were modified.
-
-Inventory from the tracked tree:
-
-- 596 tracked `*.test.ts` files.
-- 225 files are selected by the unit runner; 371 are selected by the integration runner.
-- 78 test files sit directly under `tests/`.
-- `tests/integration/` has 237 test files at its root and 134 below subdirectories.
-- `tests/integrations/` has 3 test files, but is not selected by the integration runner.
-- Fixture namespaces contain 5 executable test files: 4 under `tests/_fixtures/` and 1 under `tests/fixtures/`.
-
-Severity means:
-
-- **High**: can make a green test run materially misleading, or violates the documented default test contract.
-- **Medium**: creates meaningful flake, maintenance, classification, or coverage risk.
-- **Low**: mainly reduces discoverability or adds avoidable maintenance cost.
-
-## Executive Summary
-
-The main structural problem is that directory names and runner boundaries do not
-agree. The unit runner treats everything outside the singular
-`tests/integration/` directory as unit scope, while documentation says that
-`tests/commands/` and `tests/workflows/` are integration scope. This leaves a
-plural `tests/integrations/` directory, fixture directories containing runnable
-tests, real package installation work in the unit target, and a default unit
-suite containing tests documented as taking 8-9 minutes.
-
-There are no exact duplicate test files, but there are many high-confidence
-near-duplicates. The strongest candidates are repeated target-routing cases,
-repeated unknown-builder rejection cases, copied agent-output blocks, direct
-helper assertions repeated at integration level, and a second copy of the
-removed `akm vault` command check.
-
-Several tests are materially weaker than their names imply. The most serious
-examples are a min-score test that never observes the production default, a
-vector-search test that only calls FTS, and an `assembleInfo` test that only
-checks that a function exists. There are also key-only CLI goldens, conditional
-success/error assertions, and real subprocess/network calls that are not
-controlled by the test.
-
-## Organization And Discovery Findings
-
-### ORG-01: Documented suite boundaries do not match executable boundaries [High]
-
-`AGENTS.md:22-27` says integration covers `tests/integration/`,
-`tests/commands/`, and `tests/workflows/`. The actual scripts contradict that:
-
-- `scripts/test-unit.sh:40-43` selects every `*.test.ts` outside `tests/integration/`.
-- `scripts/test-integration.sh:34-35` selects only `tests/integration/**/*.test.ts`.
-
-Therefore `tests/commands/` and `tests/workflows/` run as unit tests, not
-integration tests. The documented `<60s` unit contract and the intended meaning
-of the two test targets are both unreliable. New tests can be placed according
-to the documentation and silently run in the other target.
-
-### ORG-02: The plural `tests/integrations/` directory is outside integration discovery [High]
-
-These files are in `tests/integrations/agent/`, not `tests/integration/agent/`:
-
-- `tests/integrations/agent/runner.test.ts`
-- `tests/integrations/agent/runner-dispatch.test.ts`
-- `tests/integrations/agent/prompts-confidence.test.ts`
-
-The integration runner never sees them. They run in the unit target despite the
-directory name. Their contents are mostly resolver, dispatch-seam, and prompt
-tests, so the intended destination is also unclear. The directory typo is a
-real discovery defect regardless of the eventual classification.
-
-### ORG-03: The root of `tests/` is an unclassified bucket [Medium]
-
-There are 78 root-level test files covering pure helpers, CLI behavior, setup,
-package installation, output contracts, and evaluation workflows. The
-directory does not communicate whether a file is unit, command-contract,
-acceptance, or integration coverage. `tests/package-install.test.ts` is a
-particularly clear mismatch: it performs package packing/install work but is
-selected by the unit runner. This makes the root location hide runtime and
-environment requirements from the target that executes it.
-
-### ORG-04: Executable tests are stored in fixture namespaces [Medium]
-
-The following files are tests, not fixture data or helper modules:
-
-- `tests/_fixtures/migration/cutover-rekey-property-gate.test.ts`
-- `tests/_fixtures/migration/cutover-rekey-property.test.ts`
-- `tests/_fixtures/migration/migration-fixtures.test.ts`
-- `tests/_fixtures/migration/rekey-merge-property.test.ts`
-- `tests/fixtures/stashes/load.test.ts`
-
-The runner includes them based on filename, while the directory names imply
-support data. The placement obscures ownership and makes it easy to miss these
-tests when reviewing a suite by feature. The migration gate is also an 8-9
-minute default unit test, which makes this placement operationally important.
-
-### ORG-05: Integration contains files that explicitly describe themselves as unit tests [Medium]
-
-Examples include:
-
-- `tests/integration/graph-extraction-queue.test.ts:9-12`
-- `tests/integration/graph-extraction-topn.test.ts:7-12`
-- `tests/integration/project-context.test.ts:1-7`
-- `tests/integration/graph-boost-cache-reset.test.ts:1-23`
-- `tests/integration/standards-prompt-injection.test.ts:5-26`
-- `tests/integration/commands/consolidate/consolidate-chunks.test.ts:1-12`
-- `tests/integration/commands/consolidate/consolidate-op-handlers.test.ts:28-31`
-- `tests/integration/commands/improve/outcome-loop.test.ts:5-20`
-- `tests/integration/commands/improve/salience.test.ts:5-15`
-
-Some of these have legitimate SQLite, filesystem, or HTTP boundaries, so this
-is not an automatic move recommendation. It is evidence that the repository
-does not have a stable unit/integration classification rule.
-
-### ORG-06: Command grouping is inconsistent [Medium]
-
-Some command tests are directly under `tests/commands/`, others are grouped by
-command below `tests/commands/<command>/`, and the same pattern is repeated
-below `tests/integration/commands/`. For example, improve and consolidate have
-deep subdirectories while other command suites remain at the command root.
-With 237 integration tests at the integration root and only 134 nested below
-it, the layout is primarily historical rather than discoverable by feature.
-
-### ORG-07: Benchmark and characterization naming has no separate execution boundary [Low]
-
-The tree uses both `.characterization.test.ts` and `-characterization.test.ts`.
-`tests/commands/distill/distill-promotion-policy.bench.test.ts` is the only
-benchmark-suffixed test and is still included in the normal unit target. The
-suffix therefore communicates a runtime/intent distinction that the runner does
-not enforce.
-
-### ORG-08: Fixture discovery has two incompatible systems [Low]
-
-`tests/fixtures/stashes/load.ts:37-50` uses MANIFEST-based fixture discovery and
-`load.test.ts:95-99` expects the manifest list. The
-`tests/fixtures/stashes/curate-golden/` corpus is copied manually by
-`tests/integration/curate-golden-eval.test.ts:36,54-61` and is not part of the
-same fixture namespace contract. A stash-like fixture can therefore exist in
-the fixture tree without being visible to `listFixtures()` or the shared
-loader.
-
-### ORG-09: Test documentation contains stale commands and ambiguous runner semantics [Low]
-
-`AGENTS.md:25` and `tests/integration/semantic-search-e2e.test.ts:9` document
-`tests/semantic-search-e2e.test.ts`, but the file is actually under
-`tests/integration/`. `package.json:61-63` defines `bun run test` as the unit
-runner, while `docs/architecture/testing/testing-workflow.md:27` presents bare
-`bun test` as the fast full-project command and `tests/release-check.sh:122`
-uses bare `bun test` for the full suite. The same command name therefore has
-different documented meanings in different files.
-
-### ORG-10: Duplicate test titles reduce failure discoverability [Low]
-
-`tests/config-cli.test.ts:224-230` contains two tests with the identical title
-`parseConfigValue rejects retired boolean semanticSearchMode values`. The
-inputs differ, but a failure report does not identify which value failed.
-
-## Duplicate And Redundant Coverage
-
-No exact duplicate `*.test.ts` file contents were found. The following are
-high-confidence duplicate or near-duplicate cases within the test behavior.
-
-### DUP-01: Import target scenarios are repeated in one file [High]
-
-`tests/integration/commands/import.test.ts:94-147` and
-`:149-224` repeat the same success, unknown-target, and read-only-target
-scenarios. Only fixture names and text differ. The second block adds no target
-resolution branch.
-
-### DUP-02: Remember target scenarios are repeated in one file [High]
-
-`tests/commands/remember.test.ts:69-123` and `:126-191` both cover writable
-target, unknown target, and read-only target behavior. The first block adds a
-default-target distinction, but the three target-error cases are duplicated
-with renamed fixtures.
-
-### DUP-03: `runAgent` result paths are tested in both unit and architecture suites [Medium]
-
-`tests/agent/agent-spawn.test.ts:102-165` and
-`tests/architecture/agent-spawn-seam.test.ts:113-177,179-225` both cover
-captured success, non-zero exit, spawn failure, parse failure, and timeout.
-The architecture suite has unique interactive-stdio and timer-clearing
-assertions, so only the common result-path cases are redundant.
-
-### DUP-04: Unknown command-builder rejection is asserted four times [High]
-
-`tests/agent/agent-builders.test.ts:284-287`, `:380-383`, and `:419-422`
-all call `getCommandBuilder("unknown-platform")` and assert the same error.
-`:578-581` repeats the same registry branch with a different unknown string.
-The custom-string distinction may be useful once; four copies are not.
-
-### DUP-05: Agent-shaped output assertions and fixtures are repeated [High]
-
-`tests/integration/agent-output.test.ts:64-152` and `:233-279` each create an
-architect/release stash and test agent-shaped search/show projections. The
-later WS2 block repeats the essential-field and allowed-key checks from the
-earlier block. The first block's additional negative-field and content tests
-are distinct; the repeated projection checks are not.
-
-### DUP-06: Truncation helper behavior is repeated at integration level [High]
-
-The shared helper is comprehensively tested in
-`tests/core/text-truncation.test.ts:15-59`. The integration file
-`tests/integration/commands/consolidate/consolidate-pipeline-fixes.test.ts:220-254`
-imports the same helper and repeats the complete-sentence, punctuation,
-ellipsis, and connector cases without exercising consolidate pipeline wiring.
-
-### DUP-07: Proactive cooldown cases are duplicated [Medium]
-
-`tests/commands/improve/proactive-maintenance.test.ts:32-58` tests never
-reflected and recently reflected selector behavior. The same cases appear in
-`tests/cooldown-select-fix.test.ts:175-200`, while the post-lock filter cases
-in `:57-168` are the distinct behavior. The selector regression block should
-not repeat the same selector cases unless it is intentionally a separate
-contract suite.
-
-### DUP-08: Process-runner resolution is duplicated [Medium]
-
-`tests/agent/agent-process-config.test.ts:19-49` and
-`tests/integrations/agent/runner.test.ts:58-99` both cover default-engine
-fallback, explicit process-engine selection, timeout behavior, and rejection of
-an agent engine for an LLM process. The plural integration file adds overlay
-coverage, but the common resolution cases remain duplicated and are also in
-the wrong target.
-
-### DUP-09: Removed `akm vault` command rejection is tested twice [High]
-
-`tests/integration/env.test.ts:563-573` and
-`tests/integration/env-path-run.test.ts:162-177` both only assert that the
-top-level `vault` verb exits non-zero. The `vault:` reference behavior in
-`env.test.ts:575-587` is distinct and valuable; the second top-level command
-check is not.
-
-### DUP-10: Unknown registry-provider warning is tested through two paths [Medium]
-
-`tests/integration/registry-search.test.ts:565-571` and `:770-777` both assert
-empty hits, one warning, and the provider name for an unknown provider. The
-environment-variable parsing path is meaningfully different, so this is a
-parameterization candidate rather than an outright deletion candidate.
-
-### DUP-11: Several secondary overlaps are weaker copies of existing contracts [Medium]
-
-- `tests/commands/consolidate/consolidate-wave2-d.test.ts:77-107` checks error class identity, while `tests/cli/exit-code-classification.test.ts:59-98` tests the actual exit envelope and code mapping.
-- `tests/commands/consolidate/consolidate-wave2-e.test.ts:60-102` overlaps the registry shape cases in `tests/output-shapes-unit.test.ts:134-174`.
-- `tests/commands/consolidate/consolidate-wave2-e.test.ts:107-139` overlaps the YAML/frontmatter cases in `tests/remember-unit.test.ts:36-97`.
-- `tests/commands/consolidate/consolidate-wave2-e.test.ts:148-155` overlaps the info integration test in `tests/integration/info-command.test.ts:171-184` while adding only a function-existence check.
-
-### DUP-12: CLI envelope setup is copied across many files [Low]
-
-Nearly identical `runCli`, sandbox, and JSON-envelope setup appears in:
-
-- `tests/commands/config-cli-envelope.test.ts:24-38`
-- `tests/commands/contribute-cli-envelope.test.ts:27-41`
-- `tests/commands/sources-cli-envelope.test.ts:30-44`
-- `tests/commands/observability-cli-envelope.test.ts:34-48`
-- `tests/integration/commands/env-cli-envelope.test.ts:25-41`
-
-This is not duplicate behavior by itself, but it creates a large maintenance
-hotspot where isolation or envelope changes must be repeated manually.
-
-### Intentional overlap that should not be removed without a contract decision
-
-- Golden proposal behavior is intentionally represented in both command and integration suites.
-- Golden crash recovery and durable-recovery suites repeat execution to pin separate recovery surfaces.
-- Adapter conformance files repeat the recognition/placement/render/lint matrix for each adapter.
-- `tests/core/asset-serialize.test.ts:147-261` repeats serialization checks at historical call sites by design.
-
-These are runtime and maintenance costs, but they are not accidental duplicates
-on the current evidence.
-
-## Tests With Little Or Misleading Value
-
-### VALUE-01: The min-score default test does not test the min-score default [High]
-
-`tests/commands/consolidate/consolidate-wave2-bc.test.ts:284-292` is named as a
-test of the `0.2` `db-search` default, but only asserts that
-`config.search?.minScore` is `undefined`. A production change from `0.2` to any
-other internal default would still pass. The test explicitly avoids the
-function where the default is applied.
-
-### VALUE-02: The vector-only test never invokes vector search [High]
-
-`tests/integration/parallel-search.test.ts:255-281` inserts an embedding and
-sets `hasEmbeddings`, but calls `searchFts()` and asserts only that FTS returns
-no rows. It never invokes `akmSearch`, `searchLocal`, `searchVec`, or the
-hybrid/vector path. A completely broken vector-only search implementation can
-pass this test.
-
-### VALUE-03: `assembleInfo` coverage is a function-existence smoke test [High]
-
-`tests/commands/consolidate/consolidate-wave2-e.test.ts:148-155` says it tests
-that `sourceProviders` is populated, then only asserts
-`typeof assembleInfo === "function"`. The integration counterpart,
-`tests/integration/info-command.test.ts:171-175`, only asserts that
-`sourceProviders` is an array. Missing provider entries or wrong provider
-fields can pass both tests.
-
-### VALUE-04: Output-shape fixtures are already compliant and include a tautology [Medium]
-
-`tests/commands/consolidate/consolidate-wave2-e.test.ts:17-103` supplies
-`path`, `editable`, `name`, `installRef`, and `score` in the input fixture, so a
-pass-through implementation satisfies most of the shape assertions. The
-`Object.keys(out).length > 0` assertion at `:91-94` adds no behavior because
-the fixture is non-empty. Missing-field and field-filtering inputs are needed
-to prove the shape helper does work.
-
-### VALUE-05: Ollama failure behavior is not asserted [Medium]
-
-`tests/integration/setup.test.ts:169-180` is named as an unavailable/failure
-case, but accepts either `available` value and checks only types. It also lets
-the production code fall through to a real `ollama list` command. The test can
-pass when the fallback succeeds, fails, or is unavailable.
-
-### VALUE-06: Observability coverage depends on ambient index state [Medium]
-
-`tests/commands/observability-cli-envelope.test.ts:60-80` accepts either the
-success envelope or an internal-error envelope based on whether an index exists
-from prior suite state. A regression in either branch can be hidden. The
-dedicated `tests/integration/lessons-coverage.test.ts:58-65,99-110` already
-demonstrates deterministic state setup.
-
-### VALUE-07: Migration-path test reimplements the production path calculation [Medium]
-
-`tests/integration/migration-help.test.ts:89-108` constructs a temp directory,
-calls `path.resolve`, and reads the expected file directly. It does not call
-the migration loader. The test can pass while the loader uses a different path
-or fails to load the file.
-
-### VALUE-08: Exit-code classification is tested as class naming, not classification [Medium]
-
-`tests/commands/consolidate/consolidate-wave2-d.test.ts:79-107` checks
-`name` and `instanceof`, despite its title promising exit-code classification.
-The actual mapping is covered by `tests/cli/exit-code-classification.test.ts:59-98`.
-The wave-2 tests are a weaker duplicate, not an independent exit-code contract.
-
-### VALUE-09: Ref-boundary test never supplies the claimed legacy spelling [High]
-
-`tests/integration/commands/ref-input-boundary.test.ts:6-19` claims to cover
-legacy `type:name`, short concept IDs, and qualified refs. Its actual
-`SPELLINGS` at `:43-44` are `"knowledge/guide"`, `"knowledge/guide"`, and
-`"catalog//knowledge/guide"`. The legacy spelling is absent, so all three
-commands at `:79-105` fail to exercise the claimed legacy boundary.
-
-### VALUE-10: CLI goldens pin keys, not values [Medium]
-
-`tests/commands/goldens-cli-output.test.ts:17-20` explicitly defines key-only
-baselines. Examples include `tests/fixtures/goldens/cli/a-search.json:1-6`
-and `a-list.json:1-4`. Wrong refs, names, paths, counts, or content can pass
-as long as the key set remains unchanged. This may be intentional for a
-migration baseline, but it provides weak regression protection and should not
-be treated as behavioral output coverage.
-
-### VALUE-11: CLI global error handlers have no direct behavior coverage [Medium]
-
-The handlers in `src/cli.ts:33-71` are explicitly skipped by
-`tests/commands/goldens-cli-output.test.ts:22-29`. The real-entrypoint coverage
-in `tests/integration/show-argv-entrypoint.test.ts:50-60` does not exercise an
-unhandled rejection or uncaught exception. The advertised JSON envelope for
-these paths can regress without a focused test.
-
-### VALUE-12: The LLM stateless seam cannot detect the private state it claims to guard [Medium]
-
-`tests/architecture/llm-stateless-seam.test.ts:36-100` checks exports and
-function arity. It cannot observe the private mutable
-`chatCompletionOverride` in `src/llm/client.ts:259-275`, even though the test
-claims to protect against hidden module state. The test proves module shape, not
-stateless behavior or reset behavior.
-
-### VALUE-13: Registry-index success is invoked twice for one assertion [Low]
-
-`tests/integration/registry-build-index.test.ts:280-300` first calls
-`buildRegistryIndex` only to assert `resolves.toBeDefined()`, then calls the
-same operation again to inspect the result. The first invocation adds runtime
-and network/server work without additional coverage.
-
-### VALUE-14: Benign workflow-parameter test does not inspect the returned brief [Low]
-
-`tests/integration/workflows/params-validation.test.ts:136-146` asserts only
-`resolves.toBeDefined()`. It does not verify that the edited parameters are
-accepted, that the brief contains the expected values, or that the integrity
-error is absent from the returned object.
-
-### VALUE-15: Special-character serialization test does not parse serialized data [Low]
-
-`tests/commands/consolidate/consolidate-wave2-e.test.ts:132-139` only checks
-that the output contains `description:`. It does not verify quoting, newline
-preservation, YAML parseability, or that a newline cannot inject another key.
-Those stronger checks already exist in `tests/remember-unit.test.ts:65-83`.
-
-### VALUE-16: Cache tests only prove that clearing does not throw [Low]
-
-`tests/integration/parallel-search.test.ts:183-194` has both a single-call and
-repeated-call test, and every assertion is `not.toThrow()`. The repeated call
-subsumes the single-call smoke test and neither proves that cached values were
-discarded or recomputed.
-
-### VALUE-17: Several status-only assertions do not lock the intended error contract [Low]
-
-Examples are `tests/config-cli-silent-layer.test.ts:129-133`,
-`tests/completions.test.ts:146-151`, and
-`tests/commands/remember.test.ts:111-123,178-190`. They assert only non-zero
-status or a broad error fragment where the surrounding contract distinguishes
-usage, config, and general failures. These tests can pass with the wrong exit
-classification or wrong error envelope.
-
-## Runtime, Flakiness, And Test Design Findings
-
-### RUNTIME-01: The 8-9 minute property gate runs in the default unit suite [High]
-
-`tests/_fixtures/migration/cutover-rekey-property-gate.test.ts:18-20` says the
-gate is slow-listed and requires `AKM_RUN_SLOW_TESTS=1`. The file defines
-`GATE_SEED_COUNT = 1000` at `:34`, uses a 20-minute timeout at `:75`, and has no
-environment guard. `scripts/test-unit.sh:40-43` deliberately includes every
-non-integration test. `AKM_RUN_SLOW_TESTS` is therefore dead documentation, and
-the default unit/check path pays the full property-gate cost.
-
-### RUNTIME-02: A 10,000-item map expansion is also in the default unit suite [High]
-
-`tests/workflows/engine-ir-v3.test.ts:670-697` constructs and validates 10,000
-items. The test documents roughly 8 seconds alone, roughly 18 seconds under
-shard contention, and up to 60 seconds on a loaded box, with a 180-second
-timeout. This directly contradicts the documented fast unit target and makes
-shard duration sensitive to host size.
-
-### RUNTIME-03: Package installation work is classified as unit work [Medium]
-
-`tests/package-install.test.ts:188-221` calls package packing, npm global
-installation, launcher verification, and uninstall flows. The implementation
-uses real npm commands in `scripts/package-install.ts:169-179,412-457`. This
-depends on host tooling and filesystem/process behavior while running in the
-unit target.
-
-### RUNTIME-04: A fixture helper hides a real CLI subprocess from the unit target [Medium]
-
-`tests/fixtures/stashes/load.ts:107-139` runs `Bun.spawnSync` for `akm index`.
-`tests/fixtures/stashes/load.test.ts:19,57` invokes it, so a unit test starts a
-real CLI process even though the test file itself contains no spawn call. The
-isolation linter scans test files in `scripts/lint-tests-isolation.ts:291-303`
-and does not inspect helper implementations for this rule. A stalled helper
-can block a shard beyond the JavaScript test timeout.
-
-### RUNTIME-05: A source test performs real website/DNS work [Medium]
-
-`tests/integration/source-source.test.ts:607-615` calls
-`ensureSourceCaches` with `https://example.invalid/docs` without mocking the
-website provider. The call reaches provider sync at
-`src/indexer/search/search-source.ts:382-388` and website fetch/retry logic at
-`src/sources/snapshot-fetchers/website-ingest.ts:353-374`. The test is expected
-to warn rather than throw, but DNS and retry behavior remain environment- and
-latency-dependent.
-
-### RUNTIME-06: Host Ollama detection can add a 10-second subprocess timeout [Medium]
-
-The failure case in `tests/integration/setup.test.ts:169-180` mocks fetch but
-not the CLI fallback. Production invokes `ollama list` with a 10-second timeout
-at `src/setup/detect.ts:84-103`. The result depends on the host's PATH and
-Ollama state, and the test can spend the full fallback timeout.
-
-### RUNTIME-07: Near-deadline and real-process timing assertions are scheduler-sensitive [Medium]
-
-Examples include:
-
-- `tests/integration/llm-client.test.ts:847-874`, which waits 460ms against a 500ms timeout.
-- `tests/integration/reflect-propose-http-timeout.test.ts:45-106`, which uses real localhost servers and 1ms timeouts.
-- `tests/integration/opencode-sdk-managed-server.test.ts:75-81,109-115`, which polls process state and asserts a 500ms close bound.
-- `tests/integration/commands/events.test.ts:169-174` and `tests/integration/proposals.test.ts:967-971,988-995,1046-1051`, which use narrow wall-clock windows.
-
-The runners intentionally create contention with parallel shards, increasing
-the chance that these tests fail or pass for scheduling reasons rather than
-behavior.
-
-### RUNTIME-08: Timeout tests leave delayed work running after the assertion [Low]
-
-`tests/llm-feature-gate.test.ts:181-193,213-230` uses promises that resolve
-200ms after the gate returns. Production has no cancellation path at
-`src/llm/feature-gate.ts:188-199`. The late work is harmless in the current
-cases but can keep handles alive, interleave logs, or become observable when a
-test later adds shared state.
-
-### RUNTIME-09: Backup-pruning coverage busy-spins to create unique timestamps [Low]
-
-`tests/integration/config.test.ts:366-375` performs ten saves and spins for
-10ms after each save. Production already adds sequence suffixes for timestamp
-collisions at `src/core/config/config-io.ts:121-133`, so the delay is both
-expensive and unnecessary for the behavior under test.
-
-### RUNTIME-10: Golden tests intentionally re-execute scenarios [Medium]
-
-The following suites rerun scenarios to capture independent golden fixtures:
-
-- `tests/commands/consolidate/goldens-consolidate-ops.test.ts:960-966`
-- `tests/commands/goldens-mv-txn.test.ts:481-487`
-- `tests/commands/proposal/goldens-proposal-txn.test.ts:620-624`
-
-This is defensible for fixture isolation, but it materially adds default-suite
-work and should be counted as a deliberate performance cost rather than normal
-unit coverage.
-
-### RUNTIME-11: Release sub-suites omit the required explicit Bun timeout [Medium]
-
-`bunfig.toml:9-14` documents that Bun 1.3.14 ignores the configured timeout and
-requires a CLI flag. `tests/release-check.sh:96,110,113,120` runs focused
-`bun test` commands without `--timeout`; only `:122` passes
-`--timeout=30000`. The same test can therefore have a 5-second default in one
-release step and a 30-second or 120-second timeout in another runner.
-
-### RUNTIME-12: Opt-in gates treat `=0` as enabled [Low]
-
-`tests/integration/semantic-search-e2e.test.ts:30` and
-`tests/integration/docker-install.test.ts:102` use `!!process.env...`. A user
-who sets `AKM_SEMANTIC_TESTS=0` or `AKM_DOCKER_TESTS=0` still enables the
-expensive suite, contrary to the documented `=1` convention.
-
-## Isolation And Shared-State Findings
-
-### ISOLATION-01: `FAST_API_KEY` is not restored [Medium]
-
-`tests/engine-resolution.test.ts:105-109` assigns `process.env.FAST_API_KEY`
-without restoring it. The preload harness does not include this arbitrary
-credential name in its managed set, and production reads credential names from
-the environment at `src/integrations/agent/engine-resolution.ts:234-244`.
-Later tests can inherit the synthetic `engine-secret` value.
-
-### ISOLATION-02: `USERPROFILE` is deleted without restoration [Medium]
-
-`tests/integration/setup.test.ts:98-115` deletes and sets `USERPROFILE` while
-testing Windows fallback behavior, then only deletes it. The standard sandbox
-helper manages `HOME` but not `USERPROFILE` (`tests/_helpers/sandbox.ts:187-192`),
-so a pre-existing value can be lost for later tests.
-
-### ISOLATION-03: `HF_HOME` is set and not restored [Medium]
-
-`tests/integration/semantic-search-e2e.test.ts:272-275` sets `HF_HOME` to a
-path under the sandbox HOME when absent. Its cleanup at `:314-317` restores the
-standard environment but not `HF_HOME`. The local embedder reads this variable
-at `src/llm/embedders/local.ts:229-233`. The leak is especially likely when
-the semantic gate is enabled in a shared process.
-
-### ISOLATION-04: Registry provider registrations are process-global [Low]
-
-`tests/provider-registry.test.ts:11-18` and
-`tests/integration/registry-search.test.ts:890-984` register custom providers.
-The registry map in `src/registry/factory.ts:23-33` has no unregister/reset
-operation. Current names are mostly unique, but the suite's behavior depends on
-global registrations persisting and creates order/collision risk for future
-tests.
-
-### ISOLATION-05: Graph ranking tests reuse and mutate one SQLite fixture [Low]
-
-`tests/integration/graph-boost-ranking.test.ts:86-121` builds one per-file
-database in `beforeAll`, and `:263-307` mutates the stored graph. The current
-`beforeEach` clears the graph cache but does not recreate the database. A new
-test that mutates the DB without reinstalling the graph can become order
-dependent.
-
-### ISOLATION-06: The isolation linter does not inspect helper-side process spawns [Medium]
-
-The runner's Rule 5 scans test files outside `tests/integration/` at
-`scripts/lint-tests-isolation.ts:420-444`, but the real spawn in
-`tests/fixtures/stashes/load.ts:126-139` is in a helper. This creates a gap
-between the stated unit no-real-spawn invariant and what the linter can detect.
-
-### ISOLATION-07: The isolation allowlist contains paths that no longer exist [Low]
-
-`scripts/lint-tests-isolation.ts:154-158,238-239` allowlists
-`tests/integration/ripgrep.test.ts` and
-`tests/integration/tasks-legacy-md-warning.test.ts`, but neither file exists in
-the tracked tree. `tests/lint-isolation-ratchet.test.ts:20-27` checks only the
-combined allowlist size, not that every allowlisted path exists. A future test
-recreated at either path would inherit a stale exemption silently.
-
-### ISOLATION-08: Lint coverage is narrower than the harnessed environment [Low]
-
-The isolation linter's `AKM_ENV_VARS` list is only
-`AKM_BUNDLE_DIR`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_CACHE_HOME`, and
-`HOME` (`scripts/lint-tests-isolation.ts:81-82`). The preload contract also
-manages state/config/data directories, verbosity, LLM keys, embedding keys,
-registry URLs, and npm registry values (`AGENTS.md:30-33`). The tripwire helps
-at runtime, but direct assignments to the additional variables are not caught
-by the static isolation rule.
-
-## Test Harness, Release, And CI Findings
-
-### INFRA-01: Docker smoke test uses the retired ref grammar [High]
-
-`tests/docker/smoke-test.sh:101-108,203-204` creates a script and calls
-`akm show script:deploy/deploy-app.sh`. The current ref grammar is
-`[bundle//]conceptId`; the old `type:name` grammar is migrator-only according
-to `src/core/asset/asset-ref.ts:31-36,139-180`. The Docker matrix is opt-in, so
-this broken assertion is normally invisible.
-
-### INFRA-02: Docker execution can pass with zero variants or masked failures [High]
-
-`tests/docker/run-docker-tests.sh:81-86,119-135` warns and skips missing
-Dockerfiles, then exits successfully when `FAILED=0`, including when no variant
-ran. In `tests/docker/smoke-test.sh:30-58`, output assertions suppress command
-failures with `|| true`, and `:214-217` explicitly converts a failed `akm list`
-into a pass. A typo, missing image variant, or failed command can therefore
-produce a green Docker gate.
-
-### INFRA-03: The Alpine binary fixture is tracked but omitted from both matrices [Medium]
-
-`tests/docker/Dockerfile.alpine-binary` is documented in
-`docs/architecture/testing/testing-workflow.md:296-305`, but is absent from
-`tests/docker/run-docker-tests.sh:16-24,30-35` and
-`tests/integration/docker-install.test.ts:90-92,127-156`. The tracked fixture
-has no default automated coverage, and the shell and Bun runners maintain
-separate variant lists that can drift.
-
-### INFRA-04: CI does not exercise gated semantic, Docker, native scheduler, or real-platform coverage [Medium]
-
-The main CI job runs only Ubuntu `bun run check` and build at
-`.github/workflows/ci.yml:29-42`. Docker and semantic suites are skipped unless
-their environment gates are set, and native scheduler tests require disposable
-macOS/Windows runners at `tests/integration/native-scheduler.test.ts:16-23`.
-Green CI does not establish coverage for real embeddings, container installs,
-or native schedulers.
-
-### INFRA-05: Release validation mutates the checkout and omits repository lint rules [Medium]
-
-`tests/release-check.sh:95-99` runs `bunx biome check --write src/ tests/`, so a
-validation command can modify source and test files. It also does not run the
-full `package.json:72` lint command, which includes isolation, license,
-runtime-boundary, SQL, golden, ref-literal, shipped-asset, and schema checks.
-The release script can pass while leaving a dirty tree and missing custom lint
-failures.
-
-### INFRA-06: Integration failure logs are deleted before the runner exits [Low]
-
-`scripts/test-integration.sh:43-47` says shard logs are kept for diagnosis, but
-`:82-92` prints a tail and `:87` deletes each log unconditionally, including on
-failure. The unit runner retains logs on failure at
-`scripts/test-unit.sh:97-102`. Integration flakes therefore lose the detailed
-artifact the runner advertises.
-
-### INFRA-07: Semantic test cache and command documentation are unreliable [Medium]
-
-The semantic test documentation points to the wrong path as noted in ORG-09.
-The test also derives `HF_HOME` from the sandboxed HOME at
-`tests/integration/semantic-search-e2e.test.ts:272-286`, while the preload
-creates and later removes that HOME. Unless a user supplies `HF_HOME`, model
-downloads are not retained between runs, and the test can unexpectedly pay the
-download cost again.
-
-### INFRA-08: Release and normal runners use materially different timeout policies [Medium]
-
-The normal shard scripts pass `--timeout=120000` at
-`scripts/test-unit.sh:65-68` and `scripts/test-integration.sh:57-60`, while
-focused release steps omit the flag and the Bun config value is known to be
-ignored (`bunfig.toml:9-14`). This makes timeout behavior depend on which entry
-point a developer or CI job chooses.
-
-## Prioritized Triage
-
-The findings with the highest risk to the credibility of a green run are:
-
-1. Align runner discovery and documentation, and remove the plural integration directory ambiguity (`ORG-01`, `ORG-02`).
-2. Gate or relocate the 1,000-case property test and the 10,000-item expansion (`RUNTIME-01`, `RUNTIME-02`).
-3. Replace the false min-score, vector-only, info, and legacy-ref tests with assertions that reach the claimed production paths (`VALUE-01`, `VALUE-02`, `VALUE-03`, `VALUE-09`).
-4. Stop Docker from passing with zero tests or swallowed failures, and update its retired ref grammar (`INFRA-01`, `INFRA-02`).
-5. Remove or isolate real network, host-tool, and package-install work from the default unit target (`RUNTIME-03`, `RUNTIME-04`, `RUNTIME-05`, `RUNTIME-06`).
-6. Restore unmanaged environment variables and make the static isolation rules cover helper-side process execution (`ISOLATION-01` through `ISOLATION-06`).
-7. Consolidate the repeated target, builder, output, truncation, cooldown, and removed-command cases (`DUP-01` through `DUP-10`).
+# Tests Directory Review — retired
+
+**Original review date:** 2026-07-26 (commit `821c8f47`)
+**Triaged item-by-item:** 2026-08-12, against the tree at commit `c0994ae`
+**Status:** closed as a document. This is a disposition record, not a problem list.
+
+The original 672-line review is preserved verbatim in git history:
+
+```sh
+git show 821c8f47:tests/TESTS_REVIEW.md
+```
+
+It is not reproduced here because it read as a live list of unresolved
+problems long after most of its findings had been fixed — the staleness that
+issue #773 was opened to correct. Every one of its 67 numbered findings now
+carries a disposition below.
+
+## Why the document went stale
+
+The review landed on 2026-07-26. A remediation program ("Phase 2") worked
+through most of it on **2026-07-27** across eleven commits — `3408159a`,
+`6c92d96a`, `a1262a68`, `e511ff6d`, `8cf96889`, `0f7790e8`, `7af9e8e3`,
+`d7594c6c`, `026cfb91`, `d37f6b5c`, `63aa59f5` — but never updated the review
+itself. Its only subsequent edit was one mechanical `AKM_STASH_DIR` →
+`AKM_BUNDLE_DIR` rename (`363dbe26`).
+
+## Disposition summary
+
+| | Count |
+| --- | --- |
+| Findings total | **67** |
+| Fixed | **49** |
+| Still open | **14** |
+| Superseded by decision | **4** |
+
+Disposition rules used:
+
+- **fixed** — every location the finding cites has been addressed at HEAD.
+- **still-open** — at least one cited location is unchanged and the defect
+  still holds. Several are *reduced*: part of the finding was fixed and the
+  remainder is named in the evidence column.
+- **superseded-by-decision** — the behavior is unchanged on purpose and the
+  decision is recorded in the tree.
+
+## Where the live items now live
+
+The still-open findings are grouped into six themed clusters — one per theme,
+not one per finding — so live work is visible in the tracker rather than
+buried here. Nothing below should be worked from this file.
+
+| Cluster | Findings | Theme |
+| --- | --- | --- |
+| ORG | ORG-03, ORG-04, ORG-05, ORG-06 | the test tree has no unit/integration classification rule |
+| DUP | DUP-03, DUP-07, DUP-10, DUP-12 | remaining near-duplicate coverage and copy-pasted CLI-envelope harnesses |
+| VALUE | VALUE-16, plus the VALUE-02 and VALUE-17 residuals below | assertions weaker than the test names promise |
+| RUNTIME | RUNTIME-07 (residual) | one remaining scheduler-sensitive suite |
+| ISOLATION | ISOLATION-04, ISOLATION-05 | process-global state with no reset seam |
+| INFRA | INFRA-04, INFRA-07 | gated coverage never runs in CI, and its model cache is not retained |
+
+Two derived items came out of the fixes themselves rather than the original
+findings, and belong with the clusters above:
+
+- The `ISOLATION-08` widening of `AKM_ENV_VARS` grandfathered **22**
+  pre-existing files into the isolation allowlist; draining them is recorded
+  as follow-up debt in `scripts/lint-tests-isolation.ts:327-339`.
+- Deleting the false vector-only test (`VALUE-02`) left **no ungated test
+  driving `akmSearch` on a vector-only match path** — recorded in `8cf96889`'s
+  own commit body as "NOT closed by this work".
+
+## Full disposition table
+
+### Organization and discovery
+
+| Finding | Disposition | Evidence at HEAD |
+| --- | --- | --- |
+| ORG-01 | fixed | `AGENTS.md:23` now states `tests/commands/`+`tests/workflows/` run under the unit target, matching `scripts/test-unit.sh:43`; `026cfb91` |
+| ORG-02 | fixed | `tests/integrations/` (plural) no longer exists; the three files moved to `tests/agent/`; `e511ff6d` |
+| ORG-03 | **still open** (reduced) | The cited mismatch is gone — the real `npm pack`/`install --global` test moved to `tests/integration/package-install.test.ts:5-17` (`6c92d96a`) — but the root bucket itself grew from 78 to **94** unclassified `tests/*.test.ts` files |
+| ORG-04 | **still open** (reduced) | Four migration tests moved out of `tests/_fixtures/` to `tests/migrate/legacy/` (`6c92d96a`); `tests/fixtures/stashes/load.test.ts` is still an executable test inside a fixture namespace |
+| ORG-05 | **still open** (reduced) | Three of nine addressed (`project-context.test.ts` moved to `tests/`; the two `graph-extraction-*` headers now justify their placement, `63aa59f5`). Still self-describing as unit tests: `tests/integration/graph-boost-cache-reset.test.ts:2`, `standards-prompt-injection.test.ts:6`, `commands/consolidate/consolidate-chunks.test.ts:11`, `commands/improve/salience.test.ts:6`, `commands/improve/outcome-loop.test.ts:6` |
+| ORG-06 | **still open** | Layout still mixes flat and per-command nesting; the root/nested split under `tests/integration/` widened from 237/134 to **256/131** |
+| ORG-07 | superseded | Naming unified on `.characterization.test.ts` (`63aa59f5`); the single `.bench.` file stays in the unit target by explicit decision recorded at `tests/commands/distill/distill-promotion-policy.bench.test.ts:2` |
+| ORG-08 | fixed | `tests/fixtures/stashes/curate-golden/MANIFEST.json` added, so `listFixtures()` reports all five; `tests/fixtures/stashes/load.test.ts:72` now pins the five-item list; `d37f6b5c` |
+| ORG-09 | fixed | `AGENTS.md:25` and `tests/integration/semantic-search-e2e.test.ts:9` name the real path; `docs/architecture/testing/testing-workflow.md:35-39` presents `bun run check`, not bare `bun test`; `026cfb91` |
+| ORG-10 | fixed | Titles disambiguated at `tests/config-cli.test.ts:253,258` (`… value 'true'` / `… value 'false'`); `a1262a68` |
+
+### Duplicate and redundant coverage
+
+| Finding | Disposition | Evidence at HEAD |
+| --- | --- | --- |
+| DUP-01 | fixed | `tests/integration/commands/import.test.ts:93-171` is one `--target` block of five distinct scenarios; the duplicate block is gone; `a1262a68` |
+| DUP-02 | fixed | `tests/commands/remember.test.ts:77-163` keeps three target cases plus the distinct default-bundle case; the renamed-fixture copies are gone; `a1262a68` |
+| DUP-03 | **still open** | `tests/agent/agent-spawn.test.ts:103-132,166,220` and `tests/architecture/agent-spawn-seam.test.ts:113,155,179` still both cover captured success, non-zero exit, spawn failure, parse failure, and timeout |
+| DUP-04 | fixed | Two of four copies deleted with in-place markers at `tests/agent/agent-builders.test.ts:412-414,450-451`; three distinct surviving variants kept deliberately (`:316`, `:334`, `:609`); `e511ff6d` |
+| DUP-05 | fixed | The WS2 block is deleted, with the reason recorded at `tests/integration/agent-output.test.ts:233-237`; `e511ff6d` |
+| DUP-06 | fixed | No `detectTruncatedDescription` reference remains in `tests/integration/commands/consolidate/consolidate-pipeline-fixes.test.ts`; the 12 helper cases live only in `tests/core/text-truncation.test.ts`; `8cf96889` |
+| DUP-07 | **still open** | `tests/cooldown-select-fix.test.ts:175-200` still repeats the selector cases from `tests/commands/improve/proactive-maintenance.test.ts:33,47`; the file is untouched since `76dcfffc` (2026-07-19), before the review |
+| DUP-08 | fixed | `tests/agent/agent-process-config.test.ts:19-40` retains only three tests (incl. the uniquely-covered `timeoutMs: null`); the runner file moved to `tests/agent/runner.test.ts`; `e511ff6d` |
+| DUP-09 | fixed | `tests/integration/env-path-run.test.ts` no longer mentions `vault`; the check lives only in `tests/integration/env.test.ts:543` |
+| DUP-10 | **still open** | `tests/integration/registry-search.test.ts:565-571` and `:770-777` still assert the same three things through two paths |
+| DUP-11 | fixed | Three of four overlaps deleted (`0f7790e8`): the wave2-d exit-code block, the frontmatter block, and the `assembleInfo` existence check. The fourth (`shapeSearchHit` registry brief, now `tests/commands/consolidate/consolidate-wave2-e.test.ts:62-98`) was kept deliberately as the only `installRef`/`title→name` coverage |
+| DUP-12 | **still open** (grown) | The identical `runCli` wrapper + `beforeEach`/`afterEach` block now appears in **11** `*-cli-envelope.test.ts` files (e.g. `tests/commands/config-cli-envelope.test.ts:29-42` and `tests/integration/commands/env-cli-envelope.test.ts:25-41`), up from the five cited |
+
+### Tests with little or misleading value
+
+| Finding | Disposition | Evidence at HEAD |
+| --- | --- | --- |
+| VALUE-01 | fixed | `tests/commands/consolidate/consolidate-wave2-bc.test.ts:296-312` replaces the config-shape check with a test that drives `searchLocal` at engineered scores 0.18/0.27 against the real 0.2 floor; `0f7790e8` |
+| VALUE-02 | fixed (residual) | The false test is deleted; `tests/integration/parallel-search.test.ts` no longer claims vector-only coverage. Residual: no ungated test drives `akmSearch` on a vector-only path — recorded in `8cf96889` |
+| VALUE-03 | fixed | The signature-only test is deleted; `tests/integration/info-command.test.ts:289-299` asserts `sourceProviders` empty with no bundle and exact contents with one; `0f7790e8` |
+| VALUE-04 | fixed | The `Object.keys(out).length > 0` tautology is deleted with a marker at `tests/commands/consolidate/consolidate-wave2-e.test.ts:93-96`; a missing-field input was added at `:82-90`; `0f7790e8` |
+| VALUE-05 | fixed | `tests/integration/setup.test.ts:205-211` now injects through `_setDetectForTests` and asserts the concrete result; `d7594c6c` |
+| VALUE-06 | fixed | The data dir is isolated at `tests/commands/observability-cli-envelope.test.ts:40-46` (`d7594c6c`); the conditional `lessons` test went away with the command family in the 0.9.0 CLI overhaul |
+| VALUE-07 | fixed | `tests/integration/migration-help.test.ts:92-131` extracts the traversal literal from production source and applies it at the real `dist/` depth; `8cf96889` |
+| VALUE-08 | fixed | The four class-identity tests are deleted; `tests/commands/consolidate/consolidate-wave2-d.test.ts` no longer has an exit-code block; mapping stays in `tests/cli/exit-code-classification.test.ts`; `0f7790e8` |
+| VALUE-09 | fixed | `tests/integration/commands/ref-input-boundary.test.ts:47` has two distinct spellings and the docstring at `:5-22` names `tests/resolve-ref.test.ts:271-274` as the colon-grammar rejection site; `8cf96889` |
+| VALUE-10 | superseded | Key-set goldens are the documented convention, not an oversight: `tests/commands/goldens-cli-output.test.ts:10-20` designates them `frozen-migration-input` capture-only oracles, policed by `tests/fixtures/goldens/DESIGNATIONS.json` |
+| VALUE-11 | fixed | `tests/integration/cli-global-error-handlers.test.ts` adds five spawn-based tests over both handlers, drilled by deleting the registrations; `63aa59f5` |
+| VALUE-12 | fixed | `tests/architecture/llm-stateless-seam.test.ts:29-36` now states what the suite cannot catch and names `chatCompletionOverride` as the counterexample; `63aa59f5` |
+| VALUE-13 | fixed | No `resolves.toBeDefined()` probe remains in `tests/integration/registry-build-index.test.ts`; each `buildRegistryIndex` call is asserted once; `8cf96889` |
+| VALUE-14 | fixed | `tests/integration/workflows/params-validation.test.ts:178-185` asserts the run id and the tampered params verbatim; `8cf96889` |
+| VALUE-15 | fixed | The weak block is deleted (marker at `tests/commands/consolidate/consolidate-wave2-e.test.ts:107-115`); `tests/remember-unit.test.ts:65,79,101` cover newline injection, metacharacters, and the empty description; `0f7790e8` |
+| VALUE-16 | **still open** (reduced) | The redundant single-call smoke test is gone, but the survivor at `tests/integration/parallel-search.test.ts:140-145` still only asserts `not.toThrow()` — it does not prove cached values were discarded or recomputed |
+| VALUE-17 | fixed (residual) | All three cited sites pinned: `tests/config-cli-silent-layer.test.ts:131-139` (exit 2 / `INVALID_FLAG_VALUE`), `tests/commands/remember.test.ts:127` (exit 78 / `INVALID_CONFIG_FILE`), and the weaker `completions.test.ts` unsupported-shell test deleted (`a1262a68`). Residual: ~48 `not.toBe(0)` status-only assertions remain tree-wide |
+
+### Runtime, flakiness, and test design
+
+| Finding | Disposition | Evidence at HEAD |
+| --- | --- | --- |
+| RUNTIME-01 | fixed | `tests/migrate/legacy/cutover-rekey-property-gate.test.ts:42,67` gates the 1000-seed gate behind `AKM_RUN_SLOW_TESTS === "1"`; run on every push by the `slow-gated-tests` job at `.github/workflows/ci.yml:53-64`; `6c92d96a` (unit target 312s → 18s) |
+| RUNTIME-02 | fixed | `tests/workflows/engine-ir-v3.test.ts:36,716` gates the 10k-item expansion behind the same flag; same CI job; `6c92d96a` |
+| RUNTIME-03 | fixed | The real `npm pack`/`install --global` test moved to `tests/integration/package-install.test.ts`; `tests/package-install.test.ts:5-12` records that everything remaining is injected-fake logic; `6c92d96a` |
+| RUNTIME-04 | fixed | The one call site of the spawning default path moved to `tests/integration/fixtures/stashes/load.test.ts`; the unit file at `tests/fixtures/stashes/load.test.ts:7-16` documents that it never spawns; `d37f6b5c` |
+| RUNTIME-05 | fixed | `tests/integration/source-source.test.ts:607-635` uses a mocked `ensureWebsiteMirror` and a `.test` host; the note at `:612-622` explains why `.invalid` never reached the path at all; `d7594c6c` |
+| RUNTIME-06 | fixed | Same change as VALUE-05 — no `ollama list` subprocess, no 10s fallback |
+| RUNTIME-07 | **still open** (reduced) | Four of five sites fixed: `llm-client.test.ts:864` uses `setSystemTime`; `opencode-sdk-managed-server.test.ts:113,143` asserts liveness via `pollUntil`; `proposals.test.ts:1028` records the removed sleeps; `commands/events.test.ts` was examined and the finding rejected as mis-described (`3408159a`). Still open: `tests/integration/reflect-propose-http-timeout.test.ts:19-56` still runs real localhost servers against 1ms timeouts, untouched since before the review |
+| RUNTIME-08 | fixed | `tests/llm-feature-gate.test.ts:182,226` clear the test-owned handle rather than leaving delayed work live; `3408159a` |
+| RUNTIME-09 | fixed | `tests/integration/config.test.ts:396-409` removes the busy-spin, with proof that `pruneOldBackups` is count-based; `6c92d96a` |
+| RUNTIME-10 | superseded | The review itself called this defensible. Two of three cited suites no longer exist (`goldens-consolidate-ops.test.ts` removed in `e82eec81`; `goldens-mv-txn.test.ts` with `akm mv` in `95a6c0a6`); `tests/commands/proposal/goldens-proposal-txn.test.ts` re-executes by design for fixture isolation |
+| RUNTIME-11 | fixed | Every `bun test` in `tests/release-check.sh` passes `--timeout=120000`; the unified policy is stated at `:95-102`; `026cfb91` |
+| RUNTIME-12 | fixed | Strict gates at `tests/integration/semantic-search-e2e.test.ts:30` and `tests/integration/docker-install.test.ts:113` (`=== "1"`); `026cfb91`, `7af9e8e3` |
+
+### Isolation and shared state
+
+| Finding | Disposition | Evidence at HEAD |
+| --- | --- | --- |
+| ISOLATION-01 | fixed | `tests/engine-resolution.test.ts:105-119` snapshots and restores `FAST_API_KEY` in `finally`; `d7594c6c` |
+| ISOLATION-02 | fixed | `tests/integration/setup.test.ts:100-118` restores `USERPROFILE` in `finally`; `d7594c6c` |
+| ISOLATION-03 | fixed | `tests/integration/semantic-search-e2e.test.ts:249-269` tracks `hfHomeMutated`/`savedHfHome` and `restoreEnv()` at `:257` restores exactly; `026cfb91` |
+| ISOLATION-04 | **still open** | `src/registry/create-provider-registry.ts:13-26` still exposes only `register`/`resolve`/`list`. Call sites now save-and-restore in `finally` (`tests/provider-registry.test.ts:15-29`, `tests/integration/registry-search.test.ts:881-891`), but they do so by re-registering `undefined` — a workaround for the missing seam, not the seam |
+| ISOLATION-05 | **still open** | `tests/integration/graph-boost-ranking.test.ts:86` still builds the database once in `beforeAll`; `beforeEach` at `:105-119` clears only the graph cache; `:304` and `:738` still mutate the stored graph |
+| ISOLATION-06 | fixed | The single helper-side spawn moved to integration scope and its allowlist entry retired with no replacement; `scripts/lint-tests-isolation.ts:131`, `d37f6b5c` |
+| ISOLATION-07 | fixed | `tests/lint-isolation-ratchet.test.ts:52` asserts every allowlisted path resolves to a real file; the two dead entries were removed; `d37f6b5c` |
+| ISOLATION-08 | fixed (residual) | `scripts/lint-tests-isolation.ts:94-110` widens `AKM_ENV_VARS` from 5 names to the full 15-name `HARNESSED` contract. Residual: 22 pre-existing files grandfathered in, recorded at `:327-339` |
+
+### Test harness, release, and CI
+
+| Finding | Disposition | Evidence at HEAD |
+| --- | --- | --- |
+| INFRA-01 | fixed | `tests/docker/smoke-test.sh:222-223` uses `akm show scripts/deploy/deploy-app.sh`; no `script:` grammar remains in the file; `7af9e8e3` |
+| INFRA-02 | fixed | `tests/docker/run-docker-tests.sh:134-147` exits 1 when zero variants ran; no `|| true` remains in `tests/docker/smoke-test.sh`; `7af9e8e3` |
+| INFRA-03 | superseded | `Dockerfile.alpine-binary` was deleted rather than wired in — the binary targets glibc and Alpine is musl. Recorded at `docs/architecture/testing/testing-workflow.md:179-183,283-285`; `7af9e8e3` |
+| INFRA-04 | **still open** (reduced) | The `slow-gated-tests` job at `.github/workflows/ci.yml:53-64` closes the property-gate half. CI is still `check` + `slow-gated-tests` + `node-smoke` only: no semantic (`AKM_SEMANTIC_TESTS`), no Docker (`AKM_DOCKER_TESTS`), and `tests/integration/native-scheduler.test.ts:16-23` still requires disposable macOS/Windows runners that no workflow provides |
+| INFRA-05 | fixed | `tests/release-check.sh:105-114` runs verify-only `bun run lint` (the same command CI gates on) instead of a mutating `biome check --write`; `026cfb91` |
+| INFRA-06 | fixed | `scripts/test-integration.sh:43-45` promises logs are kept on failure and `:90-92` now delivers — the unconditional in-loop delete is gone, matching the unit runner; `026cfb91` |
+| INFRA-07 | **still open** (reduced) | The doc-path half is fixed (see ORG-09) and `HF_HOME` is now restored (ISOLATION-03). Still open: `tests/integration/semantic-search-e2e.test.ts:291-295` derives `HF_HOME` from `process.env.HOME`, which `tests/_preload.ts:101` points at a per-process sandbox root under `os.tmpdir()` — so unless the caller supplies `HF_HOME`, downloaded models are still not retained between runs |
+| INFRA-08 | fixed | Same change as RUNTIME-11 — one 120s policy across `scripts/test-unit.sh:68`, `scripts/test-integration.sh:57`, and every `tests/release-check.sh` step |
+
+## Confidence
+
+Every row above was checked by reading the cited file at HEAD. Fixing commits
+are named where `git log -S` / `git log -- <path>` identified them; the full
+history is required to resolve them (a shallow clone will not).
+
+No finding was left undispositioned, and none was marked fixed on the strength
+of a commit message alone.

--- a/tests/core/write-provenance.test.ts
+++ b/tests/core/write-provenance.test.ts
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/** The run-scoped write-provenance journal (#652). */
+
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { mutateFrontmatter, parseFrontmatter } from "../../src/core/asset/frontmatter";
+import {
+  beginWriteProvenance,
+  isWriteProvenanceActive,
+  recordWrittenPath,
+  relativeWrittenPath,
+} from "../../src/core/write-provenance";
+
+test("records absolute, deduped, sorted paths while open — and nothing once closed", () => {
+  expect(isWriteProvenanceActive()).toBe(false);
+  const journal = beginWriteProvenance();
+  expect(isWriteProvenanceActive()).toBe(true);
+
+  recordWrittenPath("/stash/memories/b.md");
+  recordWrittenPath("/stash/memories/a.md");
+  // Duplicates and equivalent spellings collapse to one entry.
+  recordWrittenPath("/stash/memories/a.md");
+  recordWrittenPath("/stash/memories/../memories/a.md");
+  expect(journal.writtenPaths()).toEqual(["/stash/memories/a.md", "/stash/memories/b.md"]);
+
+  expect(journal.end()).toEqual(["/stash/memories/a.md", "/stash/memories/b.md"]);
+  expect(isWriteProvenanceActive()).toBe(false);
+  recordWrittenPath("/stash/memories/c.md");
+  expect(journal.writtenPaths()).toEqual(["/stash/memories/a.md", "/stash/memories/b.md"]);
+  // end() is idempotent — closing twice is not an error.
+  expect(journal.end()).toEqual(["/stash/memories/a.md", "/stash/memories/b.md"]);
+});
+
+test("recording outside a journal is a no-op, and empty paths are ignored", () => {
+  expect(() => recordWrittenPath("/stash/memories/a.md")).not.toThrow();
+  const journal = beginWriteProvenance();
+  try {
+    recordWrittenPath("");
+    recordWrittenPath(undefined);
+    recordWrittenPath(null);
+    expect(journal.writtenPaths()).toEqual([]);
+  } finally {
+    journal.end();
+  }
+});
+
+test("nested journals each observe every write", () => {
+  const outer = beginWriteProvenance();
+  recordWrittenPath("/stash/memories/outer.md");
+  const inner = beginWriteProvenance();
+  recordWrittenPath("/stash/memories/inner.md");
+  expect(inner.end()).toEqual(["/stash/memories/inner.md"]);
+  recordWrittenPath("/stash/memories/after.md");
+  expect(outer.end()).toEqual(["/stash/memories/after.md", "/stash/memories/inner.md", "/stash/memories/outer.md"]);
+});
+
+test("relativeWrittenPath returns POSIX-relative inside the root, undefined outside", () => {
+  expect(relativeWrittenPath("/repo", "/repo/memories/a.md")).toBe("memories/a.md");
+  expect(relativeWrittenPath("/repo", "/repo")).toBeUndefined();
+  expect(relativeWrittenPath("/repo", "/elsewhere/a.md")).toBeUndefined();
+  expect(relativeWrittenPath("/repo", "/repository/a.md")).toBeUndefined();
+});
+
+test("an in-place frontmatter stamp journals the asset it rewrote", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akm-provenance-"));
+  const filePath = path.join(dir, "note.md");
+  fs.writeFileSync(filePath, "---\ntype: memory\n---\n\nBody.\n", "utf8");
+  const journal = beginWriteProvenance();
+  try {
+    mutateFrontmatter(filePath, (parsed) => ({ ...parsed.data, beliefState: "deprecated" }));
+    expect(journal.writtenPaths()).toEqual([filePath]);
+    expect(parseFrontmatter(fs.readFileSync(filePath, "utf8")).data.beliefState).toBe("deprecated");
+  } finally {
+    journal.end();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/integration/commands/improve/improve-lock-invariants.test.ts
+++ b/tests/integration/commands/improve/improve-lock-invariants.test.ts
@@ -11,6 +11,10 @@
  *      returns to baseline (no accumulation across runs).
  *   3. A stale lock (dead holder pid) is recovered: the run proceeds and an
  *      `improve_lock_recovered` event is emitted.
+ *   4. A stale lock whose holder pid is still ALIVE but whose mtime has aged
+ *      past the run's derived `lockStaleAfterMs` is recovered too, with
+ *      `reason: "age_exceeded"` — and, as the negative control, a fresh lock
+ *      with the same live holder is NOT recovered.
  *
  * Driven entirely in-process through akmImprove.
  */
@@ -19,12 +23,42 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
 import { akmImprove } from "../../../../src/commands/improve/improve";
+import { MIN_IMPROVE_LOCK_STALE_MS } from "../../../../src/commands/improve/locks";
+import { isProcessAlive } from "../../../../src/core/common";
 import type { AkmConfig } from "../../../../src/core/config/config";
 import { saveConfig } from "../../../../src/core/config/config";
 import { readEvents } from "../../../../src/core/events";
 import { type Cleanup, withIsolatedAkmStorage } from "../../../_helpers/sandbox";
 
 const TIMEOUT_MS = 20_000;
+
+/**
+ * How far to backdate the planted lock for the age-reclaim test.
+ *
+ * The threshold under test is NOT passed in by the test — `akmImprove` derives
+ * it itself at `src/commands/improve/improve.ts:529` as
+ * `max(MIN_IMPROVE_LOCK_STALE_MS, budgetMs + 10min)`, and these runs use the
+ * default budget, so the 4h floor binds. Three times the real floor constant
+ * clears that comfortably while staying expressed in production terms.
+ */
+const AGE_EXCEEDED_LOCK_AGE_MS = MIN_IMPROVE_LOCK_STALE_MS * 3;
+
+/**
+ * Plant an improve lock owned by a real, foreign, genuinely LIVE pid (our parent
+ * process — alive for the whole run and never equal to `process.pid`), aged by
+ * `ageMs`. `probeLock` checks liveness before age
+ * (`src/core/file-lock.ts:205-210`), so this sentinel can only ever be
+ * classified stale through the age branch, never `pid_dead`.
+ */
+function plantLiveHolderImproveLock(lockDir: string, ageMs: number): { lockPath: string; holderPid: number } {
+  const lockPath = path.join(lockDir, ".akm", "improve.lock");
+  const holderPid = process.ppid;
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  const lockedAt = new Date(Date.now() - ageMs);
+  fs.writeFileSync(lockPath, JSON.stringify({ pid: holderPid, startedAt: lockedAt.toISOString() }), "utf8");
+  fs.utimesSync(lockPath, lockedAt, lockedAt);
+  return { lockPath, holderPid };
+}
 
 let cleanup: Cleanup = () => {};
 let stashDir = "";
@@ -113,6 +147,58 @@ describe("akm improve — whole-run lock invariants", () => {
       expect(recovered.length).toBeGreaterThanOrEqual(1);
       expect(recovered.at(-1)?.metadata?.lockName).toBe("improve");
       expect(lockFilesOnDisk()).toEqual([]);
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "an age-expired lock whose holder is still alive is recovered as age_exceeded",
+    async () => {
+      // Regression (#757): the companion to the pid_dead test above. Here the
+      // holder is genuinely alive — an improve run that overran its own budget
+      // — and only the lock's age makes it reclaimable. No staleAfterMs is
+      // supplied by the test: akmImprove derives the real budget-based
+      // threshold internally (improve.ts:529).
+      const { lockPath, holderPid } = plantLiveHolderImproveLock(stashDir, AGE_EXCEEDED_LOCK_AGE_MS);
+      expect(isProcessAlive(holderPid)).toBe(true);
+      expect(holderPid).not.toBe(process.pid);
+
+      const result = await akmImprove({ scope: "memory", stashDir, config: quietConfig() });
+      expect(result.ok).toBe(true);
+
+      const recovered = readEvents().events.filter((e) => e.eventType === "improve_lock_recovered");
+      expect(recovered.length).toBe(1);
+      const metadata = recovered[0]?.metadata ?? {};
+      expect(metadata.lockName).toBe("improve");
+      expect(metadata.reason).toBe("age_exceeded");
+      expect(metadata.stalePid).toBe(holderPid);
+      // The dispossessed holder was still running when its lock was taken —
+      // exactly the live-writer double-grant this regression pins.
+      expect(isProcessAlive(metadata.stalePid as number)).toBe(true);
+      expect(metadata.lockAgeMs as number).toBeGreaterThanOrEqual(MIN_IMPROVE_LOCK_STALE_MS);
+
+      // The planted sentinel was replaced, then released by the run that took it.
+      expect(fs.existsSync(lockPath)).toBe(false);
+      expect(lockFilesOnDisk()).toEqual([]);
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "a fresh lock whose holder is still alive is not recovered",
+    async () => {
+      // Negative control for the test above: identical live foreign holder,
+      // identical code path, only the age differs. Without this, an
+      // implementation that reclaimed every contended lock would still pass.
+      const { lockPath, holderPid } = plantLiveHolderImproveLock(stashDir, 0);
+
+      await expect(akmImprove({ scope: "memory", stashDir, config: quietConfig() })).rejects.toThrow(
+        /akm improve is already running/,
+      );
+
+      expect(readEvents().events.filter((e) => e.eventType === "improve_lock_recovered")).toEqual([]);
+      // The live holder's sentinel survives untouched.
+      expect(JSON.parse(fs.readFileSync(lockPath, "utf8")).pid).toBe(holderPid);
     },
     TIMEOUT_MS,
   );

--- a/tests/integration/improve-git-exact-paths.test.ts
+++ b/tests/integration/improve-git-exact-paths.test.ts
@@ -8,6 +8,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { akmImprove } from "../../src/commands/improve/improve";
 import type { AkmConfig } from "../../src/core/config/config";
+import { recordWrittenPath } from "../../src/core/write-provenance";
 import { type Cleanup, withIsolatedAkmStorage } from "../_helpers/sandbox";
 
 let cleanup: Cleanup = () => {};
@@ -69,7 +70,13 @@ test("improve auto-sync excludes pre-staged WIP from the same content directory"
       strategyFilteredRefs: [],
     })) as never,
     runImprovePreparationStageFn: (async (args: { plannedRefs: Array<{ ref: string }> }) => {
-      fs.writeFileSync(path.join(memoriesDir, "operation.md"), "operation\n", "utf8");
+      // Stand in for a real akm write: every production write path journals the
+      // file it mutated (#652), and only journaled paths are staged. A bare
+      // `fs.writeFileSync` here would be indistinguishable from a concurrent
+      // human edit — which is exactly the distinction this suite pins.
+      const operationPath = path.join(memoriesDir, "operation.md");
+      fs.writeFileSync(operationPath, "operation\n", "utf8");
+      recordWrittenPath(operationPath);
       return {
         actionableRefs: args.plannedRefs,
         loopRefs: args.plannedRefs,

--- a/tests/integration/improve-write-provenance.test.ts
+++ b/tests/integration/improve-write-provenance.test.ts
@@ -1,0 +1,350 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Run-scoped write provenance for the improve auto-sync commit (#652).
+ *
+ * These tests drive the REAL `saveGitStash` against a REAL git repo, so every
+ * assertion is about the commit that actually landed — not about the arguments
+ * a seam observed.
+ *
+ * The contract under test: the end-of-run commit contains exactly the paths the
+ * run itself wrote (as recorded by the write-provenance journal, through the
+ * production write paths), and nothing else:
+ *
+ *   - a managed-directory edit made by someone else DURING the run stays dirty,
+ *   - a path that was ALREADY dirty when the run started and is then rewritten
+ *     by the run IS committed (the pre-#652 dirty-diff subtracted it out),
+ *   - a deletion the run performed lands as a staged deletion,
+ *   - a path written and then removed again produces no commit at all,
+ *   - callers that pass NO explicit path list (`akm sync`, `akm push`) still get
+ *     the managed-pathspec fallback.
+ */
+
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { akmImprove, resolveSyncPathSet } from "../../src/commands/improve/improve";
+import { parseRefInput } from "../../src/core/asset/resolve-ref";
+import type { AkmConfig, SourceConfigEntry } from "../../src/core/config/config";
+import { deleteAssetFromSource, type WriteTargetSource, writeAssetToSource } from "../../src/core/write-source";
+import { saveGitStash } from "../../src/sources/providers/git";
+import { type Cleanup, withIsolatedAkmStorage } from "../_helpers/sandbox";
+
+let cleanup: Cleanup = () => {};
+let stashDir = "";
+
+beforeEach(() => {
+  const storage = withIsolatedAkmStorage();
+  cleanup = storage.cleanup;
+  stashDir = storage.stashDir;
+});
+
+afterEach(() => {
+  cleanup();
+  cleanup = () => {};
+  stashDir = "";
+});
+
+const config = {
+  semanticSearchMode: "off",
+  defaults: { improveStrategy: "provenance-test" },
+  improve: {
+    strategies: {
+      "provenance-test": {
+        processes: Object.fromEntries(
+          [
+            "reflect",
+            "distill",
+            "consolidate",
+            "memoryInference",
+            "graphExtraction",
+            "extract",
+            "validation",
+            "triage",
+            "proactiveMaintenance",
+            "recombine",
+            "procedural",
+          ].map((name) => [name, { enabled: false }]),
+        ),
+      },
+    },
+  },
+} as unknown as AkmConfig;
+
+function git(...args: string[]): string {
+  const result = spawnSync("git", ["-C", stashDir, ...args], { encoding: "utf8" });
+  expect(result.status).toBe(0);
+  return result.stdout;
+}
+
+/** A committed git-backed stash: `memories/human.md` is tracked at HEAD. */
+function initRepo(): void {
+  expect(spawnSync("git", ["init", "--initial-branch=main", stashDir], { encoding: "utf8" }).status).toBe(0);
+  git("config", "user.email", "test@example.com");
+  git("config", "user.name", "test");
+  fs.mkdirSync(path.join(stashDir, "memories"), { recursive: true });
+  fs.writeFileSync(path.join(stashDir, "memories", "human.md"), "---\ntype: memory\n---\n\nHuman note.\n", "utf8");
+  git("add", "-A");
+  git("commit", "-m", "seed");
+}
+
+function writeSource(): { source: WriteTargetSource; config: SourceConfigEntry } {
+  return {
+    source: { kind: "filesystem", name: "stash", path: stashDir },
+    config: { type: "filesystem", name: "stash", path: stashDir, writable: true } as SourceConfigEntry,
+  };
+}
+
+/** Write an asset through the production write path (which journals it). */
+async function writeAsset(ref: string, body: string): Promise<void> {
+  const target = writeSource();
+  await writeAssetToSource(target.source, target.config, parseRefInput(ref), `---\ntype: memory\n---\n\n${body}\n`);
+}
+
+/** Names touched by the newest commit, relative to its parent. */
+function lastCommitPaths(): string[] {
+  return git("show", "--name-status", "--format=", "HEAD")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.trim().replace(/^\w+\s+/, ""))
+    .sort();
+}
+
+function statusPaths(): string[] {
+  return git("status", "--porcelain", "--untracked-files=all")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.slice(3))
+    .sort();
+}
+
+function headCount(): number {
+  return git("rev-list", "--count", "HEAD").trim().length > 0 ? Number(git("rev-list", "--count", "HEAD").trim()) : 0;
+}
+
+/**
+ * Drive a real improve run whose preparation stage performs `mutate()` — the
+ * heavy passes are all disabled, so `mutate` is the only thing that writes.
+ */
+async function runImprove(
+  mutate: () => Promise<void> | void,
+  duringLoop?: () => void,
+): Promise<Awaited<ReturnType<typeof akmImprove>>> {
+  return akmImprove({
+    scope: "memory",
+    stashDir,
+    config,
+    ensureIndexFn: async () => undefined,
+    collectEligibleRefsFn: (async () => ({
+      plannedRefs: [{ ref: "memories/human" }],
+      memorySummary: { eligible: 1, derived: 0 },
+      strategyFilteredRefs: [],
+    })) as never,
+    runImprovePreparationStageFn: (async (args: { plannedRefs: Array<{ ref: string }> }) => {
+      await mutate();
+      return {
+        actionableRefs: args.plannedRefs,
+        loopRefs: args.plannedRefs,
+        distillOnlyRefs: [],
+        distillCooledRefs: new Set(),
+        signalBearingSet: new Set(),
+        utilityMap: new Map(),
+        actions: [],
+        cleanupWarnings: [],
+        validationFailures: [],
+        schemaRepairs: [],
+        coverageGaps: [],
+        recentErrors: {},
+        consolidation: {
+          schemaVersion: 1,
+          ok: true,
+          shape: "consolidate-result",
+          dryRun: false,
+          previewOnly: false,
+          target: "memory",
+          processed: 0,
+          merged: 0,
+          deleted: 0,
+          promoted: [],
+          contradicted: 0,
+          warnings: [],
+        },
+        consolidationRan: false,
+      };
+    }) as never,
+    runImproveLoopStageFn: (async () => {
+      duringLoop?.();
+      return { reflectsWithErrorContext: 0, memoryRefsForInference: new Set() };
+    }) as never,
+    runImprovePostLoopStageFn: (async () => ({
+      allWarnings: [],
+      memoryInferenceDurationMs: 0,
+      graphExtractionDurationMs: 0,
+    })) as never,
+  });
+}
+
+test("auto-sync commits only what the run wrote, leaving a concurrent managed edit dirty", async () => {
+  initRepo();
+
+  const result = await runImprove(
+    async () => {
+      await writeAsset("memories/alpha", "Alpha.");
+      await writeAsset("memories/beta", "Beta.");
+    },
+    () => {
+      // A human (or another tool) edits a DIFFERENT managed file mid-run. The
+      // pre-#652 dirty-diff swept this into akm's commit because it was not in
+      // the start-of-run baseline.
+      fs.writeFileSync(path.join(stashDir, "memories", "human.md"), "---\ntype: memory\n---\n\nEdited by hand.\n");
+    },
+  );
+
+  expect(result.ok).toBe(true);
+  expect(result.sync?.committed).toBe(true);
+  expect(lastCommitPaths()).toEqual(["memories/alpha.md", "memories/beta.md"]);
+  // The concurrent edit was never staged and is still sitting in the worktree.
+  expect(statusPaths()).toContain("memories/human.md");
+  expect(fs.readFileSync(path.join(stashDir, "memories", "human.md"), "utf8")).toContain("Edited by hand.");
+  // …and the run reports exactly what it wrote.
+  expect(result.writtenPaths).toEqual(["memories/alpha.md", "memories/beta.md"]);
+});
+
+test("the crash-path commit also stages only the run's own writes", async () => {
+  initRepo();
+
+  await expect(
+    runImprove(
+      async () => {
+        await writeAsset("memories/alpha", "Alpha.");
+      },
+      () => {
+        fs.writeFileSync(path.join(stashDir, "memories", "human.md"), "---\ntype: memory\n---\n\nEdited by hand.\n");
+        throw new Error("simulated mid-run crash");
+      },
+    ),
+  ).rejects.toThrow("simulated mid-run crash");
+
+  // #662's crash safety net banks the run's writes before rethrowing — under
+  // #652 it banks exactly those, not the edit that raced it.
+  expect(lastCommitPaths()).toEqual(["memories/alpha.md"]);
+  expect(statusPaths()).toContain("memories/human.md");
+});
+
+test("auto-sync commits a path that was already dirty before the run and rewritten by it", async () => {
+  initRepo();
+  // Pre-existing WIP on a tracked managed file — dirty BEFORE improve starts.
+  fs.writeFileSync(path.join(stashDir, "memories", "human.md"), "---\ntype: memory\n---\n\nUncommitted WIP.\n");
+
+  const result = await runImprove(async () => {
+    await writeAsset("memories/human", "Rewritten by improve.");
+  });
+
+  expect(result.sync?.committed).toBe(true);
+  // The pre-#652 baseline subtraction dropped this path entirely; the run wrote
+  // it, so the run owns it.
+  expect(lastCommitPaths()).toEqual(["memories/human.md"]);
+  expect(result.writtenPaths).toEqual(["memories/human.md"]);
+  expect(statusPaths()).not.toContain("memories/human.md");
+});
+
+test("auto-sync stages a deletion the run performed", async () => {
+  initRepo();
+
+  const result = await runImprove(async () => {
+    const target = writeSource();
+    await deleteAssetFromSource(target.source, target.config, parseRefInput("memories/human"));
+  });
+
+  expect(result.sync?.committed).toBe(true);
+  expect(lastCommitPaths()).toEqual(["memories/human.md"]);
+  expect(git("show", "--name-status", "--format=", "HEAD").trim().startsWith("D")).toBe(true);
+  expect(fs.existsSync(path.join(stashDir, "memories", "human.md"))).toBe(false);
+  expect(result.writtenPaths).toEqual(["memories/human.md"]);
+});
+
+test("a path written then removed again during the run produces no commit", async () => {
+  initRepo();
+  const before = headCount();
+
+  const result = await runImprove(async () => {
+    const target = writeSource();
+    await writeAsset("memories/scratch", "Transient.");
+    // A downstream pass reverts the write (proposal rollback / orphan purge).
+    await deleteAssetFromSource(target.source, target.config, parseRefInput("memories/scratch"));
+  });
+
+  // Journaled, but the final on-disk state is identical to HEAD — the exact-path
+  // commit short-circuits instead of creating an empty commit.
+  expect(result.writtenPaths).toEqual(["memories/scratch.md"]);
+  expect(result.sync?.committed).toBe(false);
+  expect(headCount()).toBe(before);
+});
+
+test("a run that writes nothing commits nothing — an empty set is not the managed fallback", async () => {
+  initRepo();
+  const before = headCount();
+  // Dirty managed content the run did not touch. `saveGitStash`'s managed
+  // pathspec fallback would sweep this up; an EMPTY explicit path list must not.
+  fs.writeFileSync(path.join(stashDir, "memories", "human.md"), "---\ntype: memory\n---\n\nSomeone else's WIP.\n");
+
+  const result = await runImprove(() => {});
+
+  expect(result.ok).toBe(true);
+  expect(result.writtenPaths).toBeUndefined();
+  expect(result.sync?.committed).toBe(false);
+  expect(headCount()).toBe(before);
+  expect(statusPaths()).toContain("memories/human.md");
+});
+
+test("saveGitStash with no explicit path list still falls back to managed pathspecs", () => {
+  initRepo();
+  fs.writeFileSync(path.join(stashDir, "memories", "human.md"), "---\ntype: memory\n---\n\nManaged edit.\n");
+  fs.writeFileSync(path.join(stashDir, "stray-report.html"), "<html></html>", "utf8");
+
+  const result = saveGitStash(undefined, "akm sync", true, { repoDir: stashDir, push: false });
+
+  expect(result.committed).toBe(true);
+  expect(lastCommitPaths()).toEqual(["memories/human.md"]);
+  // The stray non-akm file is neither committed nor a reason to refuse.
+  expect(statusPaths()).toEqual(["stray-report.html"]);
+});
+
+test("resolveSyncPathSet: provenance is authoritative, the dirty diff is the fallback", () => {
+  const repoDir = "/repo";
+  const changedPaths = ["memories/written.md", "memories/human.md", "memories/pre-existing.md", ".akm/improve.lock"];
+  const initialPaths = new Set(["memories/pre-existing.md"]);
+  const writtenPaths = [
+    "/repo/memories/written.md",
+    // Journaled but no longer different from HEAD (or ignored) — dropped.
+    "/repo/memories/no-op.md",
+    // Journaled outside the repo (a --target bundle) — out of staging scope.
+    "/elsewhere/memories/other.md",
+  ];
+
+  expect(
+    resolveSyncPathSet({ repoDir, assetPrefix: "", changedPaths, initialPaths, writtenPaths, provenance: true }),
+  ).toEqual({ paths: ["memories/written.md"], unattributed: ["memories/human.md"] });
+
+  // Without a journal the pre-#652 behaviour is preserved verbatim: everything
+  // dirty that was not dirty at start, minus lock files.
+  expect(
+    resolveSyncPathSet({ repoDir, assetPrefix: "", changedPaths, initialPaths, writtenPaths, provenance: false }),
+  ).toEqual({ paths: ["memories/written.md", "memories/human.md"], unattributed: [] });
+});
+
+test("resolveSyncPathSet: journaled paths outside the content root are not staged", () => {
+  expect(
+    resolveSyncPathSet({
+      repoDir: "/repo",
+      assetPrefix: "content",
+      changedPaths: ["content/memories/a.md", "docs/notes.md"],
+      initialPaths: new Set<string>(),
+      writtenPaths: ["/repo/content/memories/a.md", "/repo/docs/notes.md"],
+      provenance: true,
+    }),
+  ).toEqual({ paths: ["content/memories/a.md"], unattributed: [] });
+});

--- a/tests/integration/index-writer-lock.test.ts
+++ b/tests/integration/index-writer-lock.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
+import { isProcessAlive } from "../../src/core/common";
 import { getIndexWriterLockPath } from "../../src/core/paths";
 import {
   acquireIndexWriterLease,
@@ -8,6 +9,32 @@ import {
   withIndexWriterLease,
 } from "../../src/indexer/index-writer-lock";
 import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../_helpers/sandbox";
+
+/**
+ * Mirrors `INDEX_WRITER_LOCK_STALE_AFTER_MS` in `src/indexer/index-writer-lock.ts`.
+ * The production constant is module-private, so it is duplicated here on purpose:
+ * the age-reclaim tests below straddle this exact boundary, and changing the
+ * production threshold should trip them rather than silently widen the window in
+ * which a *live, still-working* writer can have its lease taken away.
+ */
+const INDEX_WRITER_LOCK_STALE_AFTER_MS = 12 * 60 * 60 * 1000;
+
+/**
+ * Plant an index-writer sentinel owned by a real, foreign, genuinely LIVE pid
+ * (our parent process — always alive for the duration of this run and never
+ * equal to `process.pid`; same trick as the timeout test below), with its mtime
+ * backdated by `ageMs`. Because `probeLock` checks liveness BEFORE age
+ * (`src/core/file-lock.ts:205-210`), the only branch that can ever classify this
+ * sentinel stale is the age branch — never `pid_dead`.
+ */
+function plantLiveHolderLock(ageMs: number): string {
+  const lockPath = getIndexWriterLockPath();
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  fs.writeFileSync(lockPath, String(process.ppid), "utf8");
+  const backdated = new Date(Date.now() - ageMs);
+  fs.utimesSync(lockPath, backdated, backdated);
+  return lockPath;
+}
 
 let storage: IsolatedAkmStorage;
 
@@ -60,6 +87,57 @@ describe("index writer lease", () => {
     await expect(acquireIndexWriterLease({ purpose: "waiter", maxWaitMs: 20 })).rejects.toThrow(
       "timed out waiting for index writer lease",
     );
+  });
+
+  test("reclaims a lease whose live holder has exceeded the stale window", async () => {
+    // Regression (#757): a genuinely alive holder — a slow `akm index --full`
+    // that is still working — loses its nominally-exclusive lease purely on
+    // age. This pins that behavior at the production threshold so the
+    // double-grant window cannot widen unnoticed.
+    const lockPath = plantLiveHolderLock(INDEX_WRITER_LOCK_STALE_AFTER_MS + 60_000);
+    expect(isProcessAlive(process.ppid)).toBe(true);
+
+    const before = probeIndexWriterLease();
+    expect(before.state).toBe("stale");
+    if (before.state === "stale") {
+      // Not "pid_dead": the holder is alive, so age is what makes it stale.
+      expect(before.reason).toBe("age_exceeded");
+      expect(before.holderPid).toBe(process.ppid);
+    }
+
+    // "try" mode never waits and never retries, so the only way it can return a
+    // lease is by reclaiming the planted sentinel.
+    const lease = await acquireIndexWriterLease({ purpose: "age-reclaim", mode: "try" });
+    expect(lease).toBeDefined();
+
+    const after = probeIndexWriterLease();
+    expect(after.state).toBe("held");
+    if (after.state === "held") expect(after.holderPid).toBe(process.pid);
+
+    lease?.release();
+    expect(fs.existsSync(lockPath)).toBe(false);
+    // The reclaimed sentinel is removed, not left behind as a quarantine file.
+    const leftovers = fs.readdirSync(path.dirname(lockPath)).filter((name) => name.includes(".stale-"));
+    expect(leftovers).toEqual([]);
+  });
+
+  test("does not reclaim a live holder's lease from inside the stale window", async () => {
+    // Negative control for the test above: same live foreign holder, same
+    // reclaim path, only the age differs. Without this, an implementation that
+    // reclaimed *every* contended lock would still pass the reclaim test.
+    const lockPath = plantLiveHolderLock(INDEX_WRITER_LOCK_STALE_AFTER_MS - 60_000);
+
+    const before = probeIndexWriterLease();
+    expect(before.state).toBe("held");
+    if (before.state === "held") expect(before.holderPid).toBe(process.ppid);
+
+    const lease = await acquireIndexWriterLease({ purpose: "no-reclaim", mode: "try" });
+    expect(lease).toBeUndefined();
+
+    const after = probeIndexWriterLease();
+    expect(after.state).toBe("held");
+    if (after.state === "held") expect(after.holderPid).toBe(process.ppid);
+    expect(fs.readFileSync(lockPath, "utf8")).toBe(String(process.ppid));
   });
 
   test("wait mode with maxWaitMs:0 still acquires an immediately-free lock", async () => {

--- a/tests/integration/indexer/reindex-generation-atomicity.test.ts
+++ b/tests/integration/indexer/reindex-generation-atomicity.test.ts
@@ -1,0 +1,158 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Issue #759 (1/3) — index GENERATIONS during a full reindex.
+ *
+ * `persistDirRecords` (src/indexer/indexer.ts) wraps the full-rebuild wipe and
+ * the re-insert in ONE `db.transaction(...)` specifically so that a concurrent
+ * reader never observes an empty or half-rebuilt index between the two. That
+ * guarantee had no direct test: by the time `akmIndex()` resolves, the commit
+ * has already collapsed both generations into a single observable state, so
+ * nothing outside the transaction can tell an atomic rebuild from a
+ * delete-then-insert one.
+ *
+ * These tests open a SECOND, independent read-only connection to the very same
+ * `index.db` file from inside the in-flight transaction (via the
+ * `_setIndexTransactionHookForTests` seam) and assert that reader sees exactly
+ * the PREVIOUS complete generation — never zero rows, never a mix of the two.
+ *
+ * Why the seam is unavoidable: SQLite is synchronous, the writer holds the JS
+ * thread for the whole transaction, and the property under test is only true
+ * *during* a window that does not exist once the call returns. The seam fires
+ * two `undefined?.()` calls per reindex in production.
+ */
+
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { saveConfig } from "../../../src/core/config/config";
+import { getDbPath } from "../../../src/core/paths";
+import { _setIndexTransactionHookForTests, akmIndex, type IndexTransactionPoint } from "../../../src/indexer/indexer";
+import { openReadonlyExistingDatabase } from "../../../src/storage/repositories/index-connection";
+import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../../_helpers/sandbox";
+import { overrideSeam } from "../../_helpers/seams";
+
+let storage: IsolatedAkmStorage;
+
+beforeEach(() => {
+  storage = withIsolatedAkmStorage();
+  saveConfig({
+    semanticSearchMode: "off",
+    bundles: {
+      primary: {
+        path: storage.stashDir,
+        writable: true,
+        components: { main: { root: ".", adapter: "akm", writable: true } },
+      },
+    },
+    defaultBundle: "primary",
+  });
+});
+
+afterEach(() => storage.cleanup());
+
+function writeKnowledge(name: string, body: string): void {
+  const file = path.join(storage.stashDir, "knowledge", `${name}.md`);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `---\ndescription: ${name}\n---\n\n# ${name}\n\n${body}\n`, "utf8");
+}
+
+/**
+ * Read `entries` through a SEPARATE connection to the same file — the whole
+ * point of the exercise, so this deliberately does not reuse the indexer's
+ * connection or any managed/cached opener.
+ */
+function readEntryNamesFromSecondConnection(): string[] {
+  const db = openReadonlyExistingDatabase(getDbPath());
+  if (!db) throw new Error("second reader could not open index.db");
+  try {
+    const rows = db.prepare("SELECT concept_id FROM entries ORDER BY concept_id").all() as {
+      concept_id: string;
+    }[];
+    return rows.map((row) => row.concept_id);
+  } finally {
+    db.close();
+  }
+}
+
+function currentEntryNames(): string[] {
+  return readEntryNamesFromSecondConnection();
+}
+
+test("a concurrent reader never observes an empty or partial index mid-reindex", async () => {
+  // Generation 1: four documents.
+  const generationOne = ["alpha", "bravo", "charlie", "delta"];
+  for (const name of generationOne) writeKnowledge(name, `Body for ${name}.`);
+  await akmIndex({ stashDir: storage.stashDir, full: true });
+  const beforeNames = currentEntryNames();
+  expect(beforeNames.length).toBe(generationOne.length);
+
+  // Generation 2 has a DIFFERENT row set: two survivors, two removals, two
+  // additions. A reader that saw a partial rebuild would report some blend of
+  // the two — the assertion below rejects anything that is not exactly gen 1.
+  fs.rmSync(path.join(storage.stashDir, "knowledge", "charlie.md"));
+  fs.rmSync(path.join(storage.stashDir, "knowledge", "delta.md"));
+  writeKnowledge("echo", "Body for echo.");
+  writeKnowledge("foxtrot", "Body for foxtrot.");
+  const generationTwo = ["alpha", "bravo", "echo", "foxtrot"].map((n) => `knowledge/${n}`);
+
+  const observations: { point: IndexTransactionPoint; names: string[] }[] = [];
+  overrideSeam(_setIndexTransactionHookForTests, (point: IndexTransactionPoint) => {
+    observations.push({ point, names: readEntryNamesFromSecondConnection() });
+  });
+
+  await akmIndex({ stashDir: storage.stashDir, full: true });
+
+  // THE property: at every point where the writer had already wiped and/or
+  // rewritten the tables, the concurrent reader still saw generation 1 whole.
+  // Never transiently empty, never a partial/mixed blend of the two.
+  for (const observation of observations) {
+    expect({ point: observation.point, empty: observation.names.length === 0 }).toEqual({
+      point: observation.point,
+      empty: false,
+    });
+    expect(observation.names).toEqual(beforeNames);
+  }
+
+  // The race really interleaved: both in-transaction points fired exactly
+  // once, including the one immediately after every DELETE of the wipe. A
+  // wipe that escaped the transaction would fire the point from outside it.
+  expect(observations.map((o) => o.point)).toEqual(["full-delete-applied", "records-persisted"]);
+
+  // And once committed, the new generation is fully visible.
+  expect(currentEntryNames()).toEqual(generationTwo);
+});
+
+test("the mid-transaction reader is a real second connection, not the writer's own", async () => {
+  writeKnowledge("solo", "Only document.");
+  await akmIndex({ stashDir: storage.stashDir, full: true });
+
+  // Sanity check on the harness itself: a WAL reader opened during the write
+  // transaction must be able to read at all (i.e. it is not silently throwing
+  // and being swallowed), and it must NOT see uncommitted writer state.
+  let sawEmptyDatabaseFile = false;
+  let openedInsideTransaction = 0;
+  writeKnowledge("second", "Added document.");
+  overrideSeam(_setIndexTransactionHookForTests, (point: IndexTransactionPoint) => {
+    if (point !== "full-delete-applied") return;
+    openedInsideTransaction++;
+    const db = openReadonlyExistingDatabase(getDbPath());
+    if (!db) throw new Error("second reader could not open index.db");
+    try {
+      const row = db.prepare("SELECT COUNT(*) AS n FROM entries").get() as { n: number };
+      sawEmptyDatabaseFile = row.n === 0;
+    } finally {
+      db.close();
+    }
+  });
+
+  await akmIndex({ stashDir: storage.stashDir, full: true });
+
+  // The writer had already run `DELETE FROM entries` when the hook fired; a
+  // reader that saw 0 rows would mean the wipe had escaped its transaction.
+  expect(sawEmptyDatabaseFile).toBe(false);
+  expect(openedInsideTransaction).toBe(1);
+  expect(currentEntryNames()).toEqual(["knowledge/second", "knowledge/solo"]);
+});

--- a/tests/integration/sync-exact-commit-cas.test.ts
+++ b/tests/integration/sync-exact-commit-cas.test.ts
@@ -1,0 +1,212 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Issue #759 (2/3) — `akm sync`'s compare-and-swap.
+ *
+ * `akm sync` commits through `saveGitStash` → `createExactPathCommit`
+ * (src/sources/providers/git-stash.ts), which is a SEPARATE publication path
+ * from the `ensureGitTransactionCommit` CAS in src/core/write-source.ts that
+ * tests/integration/git-source-safety.test.ts already races
+ * ("durable publication rejects a predecessor commit created after preflight").
+ * This file ports that pattern onto the `akm sync` path.
+ *
+ * Two guards exist on this path, and they are NOT interchangeable:
+ *
+ *  1. The `options.expectedBaseHead` PREFLIGHT check (git-stash.ts) — used by
+ *     the durable-transaction callers, which bind a base commit before they
+ *     mutate the worktree.
+ *  2. The `git update-ref <branch> <new> <old>` CAS inside
+ *     `createExactPathCommit` — the real atomic swap, and the ONLY guard on
+ *     the `akm sync` path, because `runSyncBody`
+ *     (src/commands/sources/sources-cli.ts) calls
+ *     `saveGitStash(name, message, writable, { push })` with no
+ *     `expectedBaseHead`. `saveGitStash` reads HEAD itself, so a commit that
+ *     lands BEFORE the call is simply adopted as the new base; only a commit
+ *     that lands DURING the publication has to be rejected.
+ *
+ * Guard 2's window is a few microseconds wide between two synchronous `git`
+ * invocations, so the racing commit is injected deterministically through the
+ * `_setGitExactCommitHookForTests` seam rather than by wall-clock luck. The
+ * racer is a REAL `git commit` in a REAL repository — nothing about the CAS
+ * itself is faked.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  _setGitExactCommitHookForTests,
+  type GitExactCommitPoint,
+  saveGitStash,
+} from "../../src/sources/providers/git";
+import {
+  type Cleanup,
+  sandboxStashDir,
+  sandboxXdgCacheHome,
+  sandboxXdgConfigHome,
+  sandboxXdgDataHome,
+} from "../_helpers/sandbox";
+import { overrideSeam } from "../_helpers/seams";
+
+function git(repoDir: string, args: string[]): string {
+  const result = spawnSync("git", ["-C", repoDir, ...args], { encoding: "utf8" });
+  if (result.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
+  return result.stdout.trim();
+}
+
+function initRepo(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  for (const args of [
+    ["init", "--initial-branch=main"],
+    ["config", "user.email", "test@akm.local"],
+    ["config", "user.name", "akm-test"],
+    ["config", "commit.gpgsign", "false"],
+  ]) {
+    git(dir, args);
+  }
+}
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+/** Seed a repo with one commit and return its repo dir + that commit's oid. */
+function seedRepo(): { repoDir: string; seedHead: string } {
+  const repoDir = process.env.AKM_BUNDLE_DIR as string;
+  initRepo(repoDir);
+  writeFile(path.join(repoDir, "README.md"), "seed\n");
+  git(repoDir, ["add", "."]);
+  git(repoDir, ["commit", "-m", "seed"]);
+  return { repoDir, seedHead: git(repoDir, ["rev-parse", "HEAD"]) };
+}
+
+/** Land an unrelated commit, exactly as a second process would. */
+function landPredecessorCommit(repoDir: string, name: string): string {
+  writeFile(path.join(repoDir, name), `${name}\n`);
+  git(repoDir, ["add", "--", name]);
+  git(repoDir, ["commit", "-m", `concurrent ${name}`]);
+  return git(repoDir, ["rev-parse", "HEAD"]);
+}
+
+/** Every commit subject reachable from HEAD, newest first. */
+function historySubjects(repoDir: string): string[] {
+  const out = git(repoDir, ["log", "--format=%s"]);
+  return out ? out.split("\n") : [];
+}
+
+let envCleanup: Cleanup = () => {};
+
+beforeEach(() => {
+  const cacheResult = sandboxXdgCacheHome();
+  const dataResult = sandboxXdgDataHome(cacheResult.cleanup);
+  const cfgResult = sandboxXdgConfigHome(dataResult.cleanup);
+  const stashResult = sandboxStashDir(cfgResult.cleanup);
+  envCleanup = stashResult.cleanup;
+});
+
+afterEach(() => {
+  envCleanup();
+  envCleanup = () => {};
+});
+
+describe("akm sync — createExactPathCommit compare-and-swap", () => {
+  test("rejects a commit whose base moved underneath it during publication", () => {
+    const { repoDir } = seedRepo();
+    writeFile(path.join(repoDir, "memories", "owned.md"), "AKM snapshot\n");
+    const baseHead = git(repoDir, ["rev-parse", "HEAD"]);
+
+    // The racer lands INSIDE the commit sequence: after the temporary index has
+    // been written, the commit object built, and every pre-check passed, but
+    // before the ref swap. This is the only moment at which the update-ref CAS
+    // is the thing that saves us.
+    const firedPoints: GitExactCommitPoint[] = [];
+    let racerHead = "";
+    let headAtRaceWindow = "";
+    overrideSeam(_setGitExactCommitHookForTests, (point: GitExactCommitPoint) => {
+      firedPoints.push(point);
+      headAtRaceWindow = git(repoDir, ["rev-parse", "HEAD"]);
+      racerHead = landPredecessorCommit(repoDir, "user.txt");
+    });
+
+    expect(() =>
+      // Exactly what `akm sync` calls: no expectedBaseHead, so guard 1 is inert
+      // and only the update-ref CAS can reject this.
+      saveGitStash(undefined, "sync race", undefined, { push: false, paths: ["memories/owned.md"] }),
+    ).toThrow(/advanced before its exact commit/);
+
+    // The race really interleaved: the hook fired once, and at that instant
+    // HEAD was still the base the commit had been built on — i.e. the racing
+    // commit landed strictly INSIDE the CAS window, not before it.
+    expect(firedPoints).toEqual(["before-update-ref"]);
+    expect(headAtRaceWindow).toBe(baseHead);
+    expect(racerHead).not.toBe(baseHead);
+
+    // HEAD is unchanged by the failed attempt: it is the racer's commit, and
+    // akm's commit was never attached to the branch.
+    expect(git(repoDir, ["rev-parse", "HEAD"])).toBe(racerHead);
+    expect(historySubjects(repoDir)).toEqual(["concurrent user.txt", "seed"]);
+    expect(git(repoDir, ["ls-tree", "-r", "--name-only", "HEAD"]).split("\n")).not.toContain("memories/owned.md");
+  });
+
+  test("the same publication succeeds when nothing races it", () => {
+    const { repoDir } = seedRepo();
+    writeFile(path.join(repoDir, "memories", "owned.md"), "AKM snapshot\n");
+    const baseHead = git(repoDir, ["rev-parse", "HEAD"]);
+
+    const result = saveGitStash(undefined, "sync clean", undefined, {
+      push: false,
+      paths: ["memories/owned.md"],
+    });
+
+    expect(result.committed).toBe(true);
+    expect(git(repoDir, ["rev-parse", "HEAD"])).not.toBe(baseHead);
+    expect(git(repoDir, ["rev-parse", "HEAD^"])).toBe(baseHead);
+    expect(git(repoDir, ["ls-tree", "-r", "--name-only", "HEAD"]).split("\n")).toContain("memories/owned.md");
+  });
+
+  test("a commit that lands BEFORE the call is adopted as the new base, not rejected", () => {
+    // Documents why the update-ref CAS is load-bearing for `akm sync`: without
+    // an `expectedBaseHead`, a predecessor that lands before `saveGitStash`
+    // starts is indistinguishable from an ordinary prior commit.
+    const { repoDir } = seedRepo();
+    writeFile(path.join(repoDir, "memories", "owned.md"), "AKM snapshot\n");
+    const predecessor = landPredecessorCommit(repoDir, "user.txt");
+
+    const result = saveGitStash(undefined, "sync after predecessor", undefined, {
+      push: false,
+      paths: ["memories/owned.md"],
+    });
+
+    expect(result.committed).toBe(true);
+    expect(git(repoDir, ["rev-parse", "HEAD^"])).toBe(predecessor);
+  });
+});
+
+describe("saveGitStash — expectedBaseHead preflight (durable-transaction callers)", () => {
+  test("rejects a predecessor commit created after preflight", () => {
+    const { repoDir } = seedRepo();
+    writeFile(path.join(repoDir, "memories", "owned.md"), "AKM snapshot\n");
+    // Preflight: the caller binds its transaction to this base …
+    const baseHead = git(repoDir, ["rev-parse", "HEAD"]);
+    // … and a concurrent process commits underneath it before publication.
+    const predecessor = landPredecessorCommit(repoDir, "user.txt");
+    expect(predecessor).not.toBe(baseHead);
+
+    expect(() =>
+      saveGitStash(undefined, "predecessor race", undefined, {
+        push: false,
+        paths: ["memories/owned.md"],
+        expectedBaseHead: baseHead,
+      }),
+    ).toThrow(/advanced before its exact-path commit/);
+
+    // HEAD is unchanged by the failed attempt.
+    expect(git(repoDir, ["rev-parse", "HEAD"])).toBe(predecessor);
+    expect(historySubjects(repoDir)).toEqual(["concurrent user.txt", "seed"]);
+    expect(git(repoDir, ["ls-tree", "-r", "--name-only", "HEAD"]).split("\n")).not.toContain("memories/owned.md");
+  });
+});

--- a/tests/integration/website-refresh-interruption.test.ts
+++ b/tests/integration/website-refresh-interruption.test.ts
@@ -1,0 +1,263 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Issue #759 (3/3) — website snapshot refresh interrupted mid-write.
+ *
+ * A refresh replaces the source's whole stash directory. It used to do that in
+ * place: `fs.rmSync(stashDir, …)` and then write the new pages one at a time,
+ * with no staging directory and no atomic rename. A process killed anywhere in
+ * that loop left the mirror empty or holding an arbitrary SUBSET of the new
+ * pages, with the previous snapshot already destroyed — and because the
+ * freshness marker is only rewritten on success, the marker still looked
+ * recent, so the next non-forced `sync()` could serve the wreckage for up to
+ * the 12-hour refresh interval instead of rebuilding it.
+ *
+ * `scrapeWebsiteToStash` / `writeSnapshotToStash` now build into a sibling
+ * staging directory and swap it in with renames. These tests interrupt a
+ * refresh partway through the page-write loop (via the
+ * `_setWebsiteSnapshotWriteHookForTests` seam, which is how a `kill -9` is
+ * simulated inside one synchronous burst) and pin both halves of the
+ * guarantee: the interrupted run leaves the previous COMPLETE snapshot in
+ * place, and the next run swaps in the new one with nothing from either the
+ * old snapshot or the aborted attempt mixed in.
+ */
+
+import { afterEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import type { SourceConfigEntry } from "../../src/core/config/config";
+import {
+  _setWebsiteSnapshotWriteHookForTests,
+  ensureWebsiteMirror,
+  getWebsiteCachePaths,
+  type WebsiteSnapshotWriteEvent,
+} from "../../src/sources/snapshot-fetchers/website-ingest";
+import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../_helpers/sandbox";
+import { withSeam } from "../_helpers/seams";
+
+// ── Fixture server ───────────────────────────────────────────────────────────
+
+const servers: Array<{ stop: (force: boolean) => void }> = [];
+let storage: IsolatedAkmStorage | undefined;
+
+/**
+ * A loopback site whose page set can be swapped between refreshes, so a
+ * "leftover from the previous generation" is observable as a file that must
+ * NOT survive the next run.
+ */
+function startMutableSite(initial: Record<string, string>): {
+  url: string;
+  setPages: (p: Record<string, string>) => void;
+} {
+  let pages = initial;
+  const server = Bun.serve({
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname === "/robots.txt") return new Response("not found", { status: 404 });
+      const body = pages[url.pathname];
+      if (body === undefined) return new Response("not found", { status: 404 });
+      return new Response(body, { status: 200, headers: { "content-type": "text/html; charset=utf-8" } });
+    },
+  });
+  servers.push(server);
+  return {
+    url: `http://127.0.0.1:${server.port}`,
+    setPages: (next) => {
+      pages = next;
+    },
+  };
+}
+
+function websiteEntry(url: string): SourceConfigEntry {
+  return { type: "website", url, options: { maxPages: 20, maxDepth: 2 } } as SourceConfigEntry;
+}
+
+/** Every `.md` file under the mirror's knowledge dir, stash-relative, sorted. */
+function snapshotFiles(stashDir: string): string[] {
+  const knowledgeDir = path.join(stashDir, "knowledge");
+  if (!fs.existsSync(knowledgeDir)) return [];
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith(".md")) out.push(path.relative(knowledgeDir, full));
+    }
+  };
+  walk(knowledgeDir);
+  return out.sort();
+}
+
+/** Sibling entries of the stash dir — staging/retired leftovers show up here. */
+function cacheRootEntries(rootDir: string): string[] {
+  return fs.readdirSync(rootDir).sort();
+}
+
+afterEach(() => {
+  for (const server of servers.splice(0)) server.stop(true);
+  storage?.cleanup();
+  storage = undefined;
+});
+
+const GENERATION_ONE: Record<string, string> = {
+  "/": '<html><body>Home<a href="/alpha">a</a><a href="/bravo">b</a><a href="/charlie">c</a></body></html>',
+  "/alpha": "<html><body>Alpha generation one</body></html>",
+  "/bravo": "<html><body>Bravo generation one</body></html>",
+  "/charlie": "<html><body>Charlie generation one</body></html>",
+};
+
+const GENERATION_TWO: Record<string, string> = {
+  "/": '<html><body>Home<a href="/alpha">a</a><a href="/delta">d</a></body></html>',
+  "/alpha": "<html><body>Alpha generation two</body></html>",
+  "/delta": "<html><body>Delta generation two</body></html>",
+};
+
+test("an interrupted refresh keeps the previous snapshot whole and is recovered by the next run", async () => {
+  storage = withIsolatedAkmStorage();
+  const site = startMutableSite(GENERATION_ONE);
+  const entry = websiteEntry(site.url);
+
+  // Generation 1: a complete four-page mirror.
+  const cachePaths = await ensureWebsiteMirror(entry, { allowPrivateHosts: true, requireStashDir: true });
+  const generationOneFiles = snapshotFiles(cachePaths.stashDir);
+  expect(generationOneFiles.length).toBe(4);
+  const manifestBefore = fs.readFileSync(cachePaths.manifestPath, "utf8");
+
+  // Generation 2 has a DIFFERENT page set: /bravo and /charlie are gone.
+  site.setPages(GENERATION_TWO);
+
+  // Kill the refresh in the middle of its page-write loop.
+  const events: WebsiteSnapshotWriteEvent[] = [];
+  const stashDuringWrite: string[][] = [];
+  await withSeam(
+    _setWebsiteSnapshotWriteHookForTests,
+    (event: WebsiteSnapshotWriteEvent) => {
+      events.push(event);
+      stashDuringWrite.push(snapshotFiles(cachePaths.stashDir));
+      if (event.index === 2) throw new Error("simulated kill -9 mid-refresh");
+    },
+    () => ensureWebsiteMirror(entry, { allowPrivateHosts: true, requireStashDir: true, force: true }),
+  );
+
+  // The interruption really landed MID-loop: at least one page of generation 2
+  // had already been written to disk when the process "died", and there was
+  // more still to write.
+  expect(events.map((e) => e.index)).toEqual([1, 2]);
+  expect(events[0]?.total).toBeGreaterThan(2);
+
+  // …and while those writes were happening, the live mirror still showed the
+  // complete previous generation. This is the property the in-place refresh
+  // could not offer: it had already deleted the whole directory by this point.
+  for (const observed of stashDuringWrite) expect(observed).toEqual(generationOneFiles);
+
+  // After the interrupted run: previous snapshot intact, nothing partial, and
+  // no abandoned staging directory left in the cache root.
+  expect(snapshotFiles(cachePaths.stashDir)).toEqual(generationOneFiles);
+  expect(cacheRootEntries(cachePaths.rootDir)).toEqual(["manifest.json", "stash"]);
+  // The freshness marker was NOT advanced by the failed refresh.
+  expect(fs.readFileSync(cachePaths.manifestPath, "utf8")).toBe(manifestBefore);
+
+  // The next run recovers: exactly generation 2, with no leftovers from either
+  // the old snapshot or the aborted attempt mixed in.
+  await ensureWebsiteMirror(entry, { allowPrivateHosts: true, requireStashDir: true, force: true });
+  const generationTwoFiles = snapshotFiles(cachePaths.stashDir);
+  expect(generationTwoFiles.length).toBe(3);
+  expect(generationTwoFiles).not.toEqual(generationOneFiles);
+  // Not one byte of generation 1 survives — a path reused by both generations
+  // (the index page, `/alpha`) carries the NEW content, not stale bytes.
+  for (const file of generationTwoFiles) {
+    const body = fs.readFileSync(path.join(cachePaths.stashDir, "knowledge", file), "utf8");
+    expect(body).not.toContain("generation one");
+    expect(body).not.toContain("/bravo");
+    expect(body).not.toContain("/charlie");
+  }
+  expect(generationTwoFiles.some((f) => f.includes("bravo"))).toBe(false);
+  expect(generationTwoFiles.some((f) => f.includes("charlie"))).toBe(false);
+  expect(generationTwoFiles.some((f) => f.includes("delta"))).toBe(true);
+  expect(cacheRootEntries(cachePaths.rootDir)).toEqual(["manifest.json", "stash"]);
+  expect(fs.readFileSync(cachePaths.manifestPath, "utf8")).not.toBe(manifestBefore);
+});
+
+test("a plain (non-forced) run after an interruption never serves a partial mirror", async () => {
+  // The freshness marker is only rewritten on success, so after an interrupted
+  // FORCED refresh the marker still looks recent and a plain `sync()` skips the
+  // refresh entirely. With the in-place write that meant serving whatever
+  // subset of pages happened to have landed; with staging the skipped refresh
+  // serves the previous COMPLETE snapshot instead.
+  storage = withIsolatedAkmStorage();
+  const site = startMutableSite(GENERATION_ONE);
+  const entry = websiteEntry(site.url);
+
+  const cachePaths = await ensureWebsiteMirror(entry, { allowPrivateHosts: true, requireStashDir: true });
+  const generationOneFiles = snapshotFiles(cachePaths.stashDir);
+  expect(generationOneFiles.length).toBe(4);
+
+  site.setPages(GENERATION_TWO);
+  await withSeam(
+    _setWebsiteSnapshotWriteHookForTests,
+    (event: WebsiteSnapshotWriteEvent) => {
+      if (event.index === 1) throw new Error("simulated kill -9 mid-refresh");
+    },
+    () => ensureWebsiteMirror(entry, { allowPrivateHosts: true, requireStashDir: true, force: true }),
+  );
+
+  await ensureWebsiteMirror(entry, { allowPrivateHosts: true, requireStashDir: true });
+
+  expect(snapshotFiles(cachePaths.stashDir)).toEqual(generationOneFiles);
+  expect(cacheRootEntries(cachePaths.rootDir)).toEqual(["manifest.json", "stash"]);
+});
+
+test("a staging directory abandoned by a hard kill is swept by the next refresh", async () => {
+  // The `finally` that discards a staging directory cannot run when the process
+  // is killed outright, so the next refresh must sweep it. Construct that
+  // mid-state directly rather than pretending a JS throw is a SIGKILL.
+  storage = withIsolatedAkmStorage();
+  const site = startMutableSite(GENERATION_ONE);
+  const entry = websiteEntry(site.url);
+
+  const cachePaths = await ensureWebsiteMirror(entry, { allowPrivateHosts: true, requireStashDir: true });
+  const generationOneFiles = snapshotFiles(cachePaths.stashDir);
+
+  const orphanName = ".stash.staging-999999-deadbeef";
+  const orphan = path.join(cachePaths.rootDir, orphanName);
+  fs.mkdirSync(path.join(orphan, "knowledge"), { recursive: true });
+  fs.writeFileSync(path.join(orphan, "knowledge", "half-written.md"), "abandoned\n", "utf8");
+  // The sweep is age-gated so it can never delete a sibling refresh that is
+  // still running; backdate this one past the gate to make it "abandoned".
+  const longAgo = new Date(Date.now() - 6 * 60 * 60 * 1000);
+  fs.utimesSync(orphan, longAgo, longAgo);
+  expect(cacheRootEntries(cachePaths.rootDir)).toContain(orphanName);
+
+  site.setPages(GENERATION_TWO);
+  await ensureWebsiteMirror(entry, { allowPrivateHosts: true, requireStashDir: true, force: true });
+
+  expect(cacheRootEntries(cachePaths.rootDir)).toEqual(["manifest.json", "stash"]);
+  const after = snapshotFiles(cachePaths.stashDir);
+  expect(after).not.toEqual(generationOneFiles);
+  expect(after.some((f) => f.includes("half-written"))).toBe(false);
+});
+
+test("a staging directory from a concurrent in-flight refresh is left alone", async () => {
+  // Nothing serializes refreshes of the same source, so an un-gated sweep would
+  // delete a sibling process's live staging directory and break a healthy run.
+  storage = withIsolatedAkmStorage();
+  const site = startMutableSite(GENERATION_ONE);
+  const entry = websiteEntry(site.url);
+
+  const cachePaths = await ensureWebsiteMirror(entry, { allowPrivateHosts: true, requireStashDir: true });
+
+  const inFlightName = ".stash.staging-424242-c0ffee";
+  const inFlight = path.join(cachePaths.rootDir, inFlightName);
+  fs.mkdirSync(path.join(inFlight, "knowledge"), { recursive: true });
+
+  site.setPages(GENERATION_TWO);
+  await ensureWebsiteMirror(entry, { allowPrivateHosts: true, requireStashDir: true, force: true });
+
+  expect(cacheRootEntries(cachePaths.rootDir)).toContain(inFlightName);
+  // …and it is invisible to the indexer regardless: dot-prefixed directories
+  // are skipped by the stash walk.
+  expect(inFlightName.startsWith(".")).toBe(true);
+});


### PR DESCRIPTION
## Summary

Second 0.9.1 milestone batch, five issues investigated. **Three land, one is documentation-only, and one is a reasoned no-go.**

Closes #757, closes #759, closes #652.

Also included, but **not** closing their issues: partial progress on #773 and a should-not-land verdict on #744 — both explained at the bottom.

The headline is that #759 was not merely a missing-coverage issue: writing the test the issue asked for exposed a **real data bug in website refresh**, fixed here.

---

### #759 — concurrency/atomicity coverage, and one real bug

Three regression tests, kept as one change per your comment on the issue.

1. **Reindex generations.** A second reader connection opened from *inside* `insertTransaction` now proves it observes the complete previous generation — never zero or partial rows. Hoisting the wipe out of the transaction makes it fail.
2. **`akm sync` CAS.** A real concurrent commit lands inside the `update-ref` window, mirroring the `git-source-safety.test.ts` pattern you cited. The test proves the interleave actually happened (HEAD at the hook instant equals `baseHead`; afterwards HEAD *is* the racer's commit). Dropping the old-value arg from `update-ref` makes it fail.
3. **Website refresh interruption — this one was a bug, not a gap.** `scrapeWebsiteToStash`/`writeSnapshotToStash` deleted the entire mirror and then wrote pages in place. Killing a refresh after page 1 of 4 left the mirror holding **one file with the three old pages destroyed** — and because the freshness marker is only rewritten on success, a subsequent **non-forced** run served that wreckage for the rest of the 12h TTL.

   Fixed with staging-dir-then-rename plus an age-gated sweep of abandoned staging dirs. Two details the safety argument rests on, both verified and both tested: the staging dir is a **dot-prefixed sibling inside the walked tree**, so `walker.ts:245`'s dot-dir skip is what keeps a half-written snapshot from being indexed (`includeAllDirectories` is only ever set for the `okf` adapter); and the sweep is **age-gated at 1h** so it cannot delete a concurrent refresh's live directory.

   Residual, documented in code: publication is two renames, so a kill in that one-syscall window leaves the mirror absent — `requireStashDir` callers refresh immediately, others recover on the next expiry or `--force`.

Three test seams were added (`indexer.ts`, `git-stash.ts`, `website-ingest.ts`), all `_set…ForTests` swap-and-restore, each compiling to one `undefined?.()` per iteration in production. Each is genuinely unavoidable — all three properties are microsecond-wide windows inside synchronous bursts.

### #757 — stale-lock reclaim of a live, still-working writer

Test-only. Plants a lock owned by a genuinely **alive** PID with a backdated mtime, for both the index-writer lease and the improve run lock, and asserts the reclaim at the *production* thresholds — the improve test passes no `staleAfterMs` at all, so `improve.ts`'s own budget-derived `max(MIN_IMPROVE_LOCK_STALE_MS, budgetMs + 10min)` is what decides. Each has a negative control just inside the window.

Verified non-vacuous by mutating `probeLock`'s age branch: disabling it fails both positive tests; making it unconditional fails both negative controls.

### #652 — run-scoped write provenance for improve auto-sync

Scoped to your 2026-07-22 audit comment rather than the (stale) issue body. One detail in the audit had itself gone stale: `git-stash.ts` no longer uses `git commit --only` — it builds a temp `GIT_INDEX_FILE` and returns `null` on `treeOid === baseTree`, so "deletions stage" and "empty commit short-circuits" were already satisfied and no change was needed there.

The remaining four items were genuinely open and are now fixed. Every akm write path records the file it mutated into a run-scoped journal (`src/core/write-provenance.ts`); the end-of-run and crash-path commits stage exactly `provenance ∩ git-changed ∩ in-scope`. So a managed file someone else edits *during* a long run stays dirty for its author, and a file already dirty at start that the run then rewrites is committed instead of skipped.

**One deliberate deviation from the issue text, flagged rather than silently taken:** the issue asks that an *empty* path list fall back to managed pathspecs. `undefined` (i.e. `akm sync` / `akm push`) does fall back, unchanged and tested. But `[]` still means "stage nothing", because making it fall back would reinstate exactly the sweeping this feature removes — a run that wrote nothing must not commit someone else's dirty files. Pinned by a test.

**Known structural risk, stated plainly:** provenance is now authoritative, so an un-instrumented write path would stop being auto-committed. The asset-write chokepoint (`writeAssetToSource`/`deleteAssetFromSource`) is covered, along with the proposal accept/revert/rollback paths, frontmatter mutation, memory inference and cleanup, session assets, and `RunContext.writeAsset`. The failure mode is degradation, not data loss — an unattributed file stays dirty on disk and `akm sync` still picks it up — and it is surfaced as an `unattributed` count on `stash_synced` plus a verbose listing. Worth a careful review pass on instrumentation coverage.

`akmImprove` crossed the absolute 220-line R31 size gate as a result; fixed by decomposing the journal lifecycle into a named `createRunWriteJournal()` factory, **not** by bumping the baseline (which is deliberately empty).

---

## Not closing their issues

**#773 — 2 of 3 acceptance boxes.** Every finding is dispositioned and the doc is retired (below), but the middle box — "every still-open finding has a corresponding tracked issue" — needs six cluster issues filed, which is a maintainer call. Leaving open until those exist.

**#744 — should-not-land.** No source change; the analysis is committed into the review the issue cites (`docs/architecture/reviews/env-secret-access.md` §8). Details below.

## Test plan

```
bun run lint              # OK — biome + all 14 repo gates
bunx tsc --noEmit         # clean
bun run test:unit         # 3573 pass / 0 fail (257 files)
bun run test:integration  # 5119 pass / 0 fail (401 files)
```

Beyond the suites, each behavioral claim was mutation-checked rather than assumed:

| Mutation | Expected | Observed |
| --- | --- | --- |
| `probeLock` age branch disabled | #757 positive tests fail | 2 fail |
| `probeLock` age branch unconditional | #757 negative controls fail | both fail |
| Website staging → in-place write | #759 website tests fail | 4/4 fail |
| Reindex wipe hoisted out of the transaction | generation test fails | fails (`empty: true`) |
| `update-ref` old-value arg dropped | CAS test fails | fails (`committed: true`) |
| Provenance flag off | #652 acceptance tests fail | exactly 2 fail |

Every mutated file was restored and re-verified byte-clean.

## Checklist

- [x] Tests pass (`bun run test:unit` + `bun run test:integration`)
- [x] Lint passes (`bun run lint`)
- [x] Docs updated — `CHANGELOG.md`, `docs/architecture/improvement.md` (the auto-sync section claimed "commits all changes"), `docs/reference/data-and-telemetry.md`, `docs/architecture/reviews/env-secret-access.md` (new §8), `tests/TESTS_REVIEW.md`, `docs/architecture/specs/0.9.0-open-items-register.md`, and `docs/architecture/testing/manual-testing-checklist.md` §24.2 (Durability row: four of five items discharged, now tracking only #758)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLQzxy3jXCFxHcuZ8N8etQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLQzxy3jXCFxHcuZ8N8etQ)_