### PR TITLE
Remove secret-permission reporting, finish the #791 sweep, redact command task logs (#755)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,58 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **A scheduled `command` task no longer writes your secrets into its log.**
+  Task logs were scrubbed for credential *shapes* — `Bearer …`, `sk-…`, webhook
+  URLs — but only prompt- and workflow-target runs also scrubbed exact secret
+  *values*. A command that echoed a configured secret shaped like nothing in
+  particular persisted it verbatim into both the run `.log` and `logs.db`, for
+  the whole retention window. Exact-value redaction now runs in the one sink all
+  three target kinds share, so every task kind is covered.
+
+  akm treats a value as secret when your config declares it
+  (`engines.<name>.apiKey`, `embedding.apiKey`, and the
+  `AKM_ENGINE_<NAME>_API_KEY` / `AKM_LLM_API_KEY` / `AKM_EMBED_API_KEY`
+  recipes), and infers others from the variable name (`*_TOKEN`, `*_SECRET`,
+  `*_API_KEY`, `*_PASSWORD`, …) when the value is at least 8 characters. The
+  floor applies only to the *guesses*: a declared secret is redacted at any
+  length. Redaction replaces substrings, so an over-eager rule does real damage
+  — treating every non-allowlisted variable in the inherited environment as a
+  secret classified 127 of 132 variables as credentials, 25 of them one
+  character long, and turned `3 tests passed, 0 failed` into `[REDACTED] tests
+  passed, [REDACTED] failed`.
+
+  For a secret exported under a name none of those rules recognise, any task may
+  name it:
+
+  ```yaml
+  command: ./deploy.sh
+  redact: [ACME_DEPLOY_TOKEN]   # NAMES, never values — max 32
+  ```
+
+  Names only, and a name that is unset at run time contributes nothing. A
+  literal secret in a task file would leak far more widely than the redaction
+  closes: task files are indexed into the search database, can be sent to an
+  embedding provider, are printed verbatim by `akm show`, and ship inside
+  bundles over git and npm — the same rule exec units' `pass_env:` follows.
+
+- **Redacting a log can no longer explode it.** Exact-value redaction took a
+  fast path that rewrote the text once per secret, over an accumulator it had
+  already rewritten — so a secret containing any of the letters in `[REDACTED]`
+  matched the tokens it had just inserted, and the output grew geometrically.
+  Fifty characters against six single-letter values produced 32,450 characters,
+  a 649x blowup reachable from ordinary command output. Matches are now found
+  against the original text and the result emitted once. Overlapping matches
+  merge into a single `[REDACTED]`, and the two redaction paths no longer
+  disagree about output shape depending on whether the text happened to contain
+  a `%`.
+
+- **Redacting a structured value no longer drops fields.** When two distinct
+  object keys redacted to the same string, the rebuilt object silently kept only
+  the last — `{a, b, ab}` came back with two entries, one of them simply gone
+  rather than redacted. Colliding keys are now suffixed, so the value survives
+  with its key still hidden. This affected persisted improve results and
+  journaled workflow outcomes.
+
 - **`akm improve` auto-sync now commits exactly the files the run wrote.**
   Every akm write path records the file it mutated into a run-scoped
   write-provenance journal, and the end-of-run (and crash-path) commit stages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,20 +349,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     is dead" are opposite facts, and `akm improve` now stops rather than
     reclaiming a lease that may be genuinely held.
 
-- **`akm health` checks every configured bundle for loose secret permissions,
-  not just the default one.** The `secret-file-perms` advisory scans `env` and
-  `secrets` across all configured bundles plus `config-backups`. Its scope is
-  deliberately "files akm writes `0600` that are no longer `0600`" — a looser
-  mode there means something else changed them.
+- **akm does not manage file permissions, and no longer reports on them
+  either.** Everything akm writes takes your process umask; the mode of your
+  data directory is yours to set, and `chmod`/`umask` are your levers.
 
-  akm does **not** manage file permissions. Everything it writes takes your
-  process umask, and the mode of your data directory is yours to set; the
-  advisory does not flag umask-default databases or task logs. An earlier
-  0.9.1 pre-release chmodded these paths to `0600`/`0700` on every open — that
-  was reverted before release, because re-permissioning a directory akm did not
-  create silently broke installs that share `$XDG_DATA_HOME` between two uids
-  (agent sandboxes, containers, service accounts). If a pre-release tightened
-  your data directory, `chmod` it back.
+  Two 0.9.1 pre-release changes are gone. The first chmodded akm's databases
+  and task logs to `0600`/`0700` on every open — reverted because
+  re-permissioning a directory akm did not create silently broke installs that
+  share `$XDG_DATA_HOME` between two uids (agent sandboxes, containers, service
+  accounts). If a pre-release tightened your data directory, `chmod` it back.
+  The second was an `akm health` advisory (`secret-file-perms`) that reported
+  group/other-readable `env`, `secrets` and `config-backups` paths — removed
+  too: it is meaningless on Windows, and nagging about modes akm does not set
+  is not health reporting. `akm health` no longer emits this check, and no
+  longer exits `4` on account of it.
 
 - **`timeout: none` on an exec unit is genuinely unbounded again.** The
   stream-drain safety net — a one-hour bound on a pipe still being read after

--- a/docs/architecture/testing/manual-testing-checklist.md
+++ b/docs/architecture/testing/manual-testing-checklist.md
@@ -2732,9 +2732,9 @@ test "$(akm log --format json | jq -r '.events[-1].id // 0')" = "$before_event"
       task logs, databases, reports, proposals, workflows, backups, and config.
 - [ ] **[LOCAL]** JSON/YAML stay parseable; text/Markdown visibly encode terminal
       controls; HTML escapes attacker fields. Inspect captured bytes only.
-- [ ] **[LOCAL]** Sensitive directories/files are `0700`/`0600` under umask 022.
-      Health scans every bundle plus config, DB/WAL/SHM, backup, and task-log
-      surfaces; lax mode warns exit `4`.
+- [ ] **[LOCAL]** Env/secret directories and files akm creates are `0700`/`0600`
+      even under umask 022. Databases, task logs, and everything else akm writes
+      take the process umask: akm neither sets nor reports on those modes.
 - [ ] **[PLATFORM]** Windows ACL evidence replaces POSIX mode checks and is marked
       N/A only when genuinely unsupported.
 
@@ -3262,8 +3262,8 @@ remaining gaps carry approved waivers with the expiries recorded below.
     install; opencode listener binds loopback only. waiver approver:
     itlackey — approved 2026-08-06 (0.9.0 release triage). waiver expiry:
     0.10.0 (hardening series).
-- [ ] **Secrets/permissions:** exact-value task-log redaction and managed DB/log/
-      backup permission coverage across every configured bundle.
+- [ ] **Secrets/permissions:** exact-value task-log redaction; managed-file
+      permission coverage (rejected — see below).
   - Covered: exact-value redaction for prompt-target and workflow-target task
     logs (`tests/integration/tasks-runner.test.ts` "redacts echoed agent
     credentials before task logs are persisted", webhook-URL case).
@@ -3278,27 +3278,21 @@ remaining gaps carry approved waivers with the expiries recorded below.
     sharing `$XDG_DATA_HOME` across uids, which worked in 0.9.0.
     **Decision: akm does not manage file permissions.** Everything it writes
     takes the process umask; protecting the data directory is the operator's
-    call and umask/`chmod` is their lever.
-  - Retained from that work: `akm health`'s `secret-file-perms` advisory scans
-    `env`/`secrets` under **every configured bundle**, not just the default one.
-    It does NOT scan the databases or task logs — akm no longer sets their mode,
-    so umask-default `0644` is the correct state and flagging it would exit 4 on
-    nearly every install. The advisory's scope is now exactly "files akm wrote
-    `0600` that are no longer `0600`". Pinned by
-    `tests/integration/commands/health/surfaces.test.ts`; POSIX only.
+    call and umask/`chmod` is their lever. Nothing survives from that work:
+    the health advisory that reported on those modes is gone too — akm does not
+    nag about permissions it does not set.
   - Open: command-target task logs (a secret echoed by a scheduled command is
     persisted verbatim when it is not pattern-shaped).
   - Tracking: [#755](https://github.com/itlackey/akm/issues/755) (command-target log redaction).
   - issue: one redaction lane. impact: a multi-user host could read a
     non-pattern-shaped secret out of a command task's history; single-user
-    machines unaffected, and the log/DB files are now `0600` regardless.
-    owner: itlackey. verification test: an exact-value redaction test for the
-    command arm mirroring the existing prompt-arm test in
+    machines unaffected. owner: itlackey. verification test: an exact-value
+    redaction test for the command arm mirroring the existing prompt-arm test in
     `tests/integration/tasks-runner.test.ts`. temporary mitigation:
     pattern-based redaction already catches the common credential shapes for
-    every task kind; the data dir lives under the user's `$XDG_DATA_HOME` and
-    is now `0700`. waiver approver: itlackey — approved 2026-08-06 (0.9.0
-    release triage). waiver expiry: 0.9.1.
+    every task kind; the data dir lives under the user's `$XDG_DATA_HOME`, whose
+    mode is the operator's to set. waiver approver: itlackey — approved
+    2026-08-06 (0.9.0 release triage). waiver expiry: 0.9.1.
 - [ ] **Package/release:** exact package-manager upgrade version verification,
       native installer/scheduler coverage, action/dependency provenance hardening,
       and post-publication artifact parity.

--- a/docs/architecture/testing/manual-testing-checklist.md
+++ b/docs/architecture/testing/manual-testing-checklist.md
@@ -2800,7 +2800,7 @@ Current known failing gates must be fixed or explicitly waived with expiry:
 | Suppressible/add-only dangerous-key audit and event ordering | `FAIL` until pre-publication |
 | Source lifecycle rollback across config/lock/root/index/events | `FAIL` until atomic/recoverable |
 | OpenCode local-listener authentication/documentation | `FAIL` until authenticated |
-| Exact-value command-target task-log redaction | `FAIL` until contained |
+| Exact-value command-target task-log redaction | `PASS` — fixed in 0.9.1 (#755) |
 | Package-manager upgrade exact-version verification | `FAIL` until verified |
 
 ---
@@ -3281,18 +3281,19 @@ remaining gaps carry approved waivers with the expiries recorded below.
     call and umask/`chmod` is their lever. Nothing survives from that work:
     the health advisory that reported on those modes is gone too — akm does not
     nag about permissions it does not set.
-  - Open: command-target task logs (a secret echoed by a scheduled command is
-    persisted verbatim when it is not pattern-shaped).
-  - Tracking: [#755](https://github.com/itlackey/akm/issues/755) (command-target log redaction).
-  - issue: one redaction lane. impact: a multi-user host could read a
-    non-pattern-shaped secret out of a command task's history; single-user
-    machines unaffected. owner: itlackey. verification test: an exact-value
-    redaction test for the command arm mirroring the existing prompt-arm test in
-    `tests/integration/tasks-runner.test.ts`. temporary mitigation:
-    pattern-based redaction already catches the common credential shapes for
-    every task kind; the data dir lives under the user's `$XDG_DATA_HOME`, whose
-    mode is the operator's to set. waiver approver: itlackey — approved
-    2026-08-06 (0.9.0 release triage). waiver expiry: 0.9.1.
+  - **Fixed** ([#755](https://github.com/itlackey/akm/issues/755), 0.9.1).
+    Exact-value redaction now runs in `persistRunLog`, the one sink all three
+    target kinds funnel through, so the command arm is covered alongside the
+    other two. Secret values come from three places, and the distinction matters:
+    config-declared credentials and a task's own `redact:` names are redacted at
+    any length, while values merely *inferred* from a variable's name must clear
+    an 8-character floor. Applying the naive rule the issue proposed — treat
+    every non-allowlisted value in the inherited environment as secret —
+    classified 127 of 132 variables as credentials, 25 of them one character
+    long, and rewrote `3 tests passed` into `[REDACTED] tests passed`. Pinned by
+    `tests/tasks/log-redaction.test.ts` and the `runTask — command target` cases
+    in `tests/integration/tasks-runner.test.ts`, including an over-redaction
+    guard that fails if ordinary build output is ever mangled.
 - [ ] **Package/release:** exact package-manager upgrade version verification,
       native installer/scheduler coverage, action/dependency provenance hardening,
       and post-publication artifact parity.

--- a/docs/architecture/testing/manual-testing-checklist.md
+++ b/docs/architecture/testing/manual-testing-checklist.md
@@ -2800,7 +2800,7 @@ Current known failing gates must be fixed or explicitly waived with expiry:
 | Suppressible/add-only dangerous-key audit and event ordering | `FAIL` until pre-publication |
 | Source lifecycle rollback across config/lock/root/index/events | `FAIL` until atomic/recoverable |
 | OpenCode local-listener authentication/documentation | `FAIL` until authenticated |
-| Exact-value task-log/DB permission coverage | `FAIL` until contained |
+| Exact-value command-target task-log redaction | `FAIL` until contained |
 | Package-manager upgrade exact-version verification | `FAIL` until verified |
 
 ---

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2283,6 +2283,34 @@ Prompt targets dispatch through `--engine` or `defaults.engine` and may set
 task sync`). A v1 task is diagnosed by sync and doctor but is never rewritten
 or executed.
 
+**Task-log redaction and `redact:`.** A task's persisted output — the run `.log`
+file and its `logs.db` rows — is scrubbed before it is written. Two passes run:
+credential *shapes* (`Bearer …`, `sk-…`, webhook URLs) are matched by pattern,
+and exact secret values are matched by value. akm knows a value is secret when
+the config declares it (`engines.<name>.apiKey`, `embedding.apiKey`, and the
+`AKM_ENGINE_<NAME>_API_KEY` / `AKM_LLM_API_KEY` / `AKM_EMBED_API_KEY` recipes),
+and it infers others from the variable name (`*_TOKEN`, `*_SECRET`, `*_API_KEY`,
+`*_PASSWORD`, …) provided the value is at least 8 characters — a short one is
+far more likely to be a flag than a credential, and redaction replaces
+substrings, so guessing wrong mangles the log.
+
+Any task kind may add `redact:` for a secret exported under a name none of those
+rules recognise:
+
+```yaml
+version: 2
+schedule: "0 3 * * *"
+command: ./deploy.sh
+redact: [ACME_DEPLOY_TOKEN]   # NAMES, never values — max 32
+```
+
+akm looks each name up in the environment the run is given; a name that is unset
+contributes nothing. **Names only.** A literal secret in a task file would leak
+far more widely than the redaction closes: task files are indexed into the search
+database, can be sent to an embedding provider, are printed verbatim by `akm
+show`, and ship inside bundles over git and npm. This is the same rule exec
+units' `pass_env:` follows.
+
 A workflow-target task executes the same native orchestration as `akm workflow
 run`; it does not stop after creating a run. Completion maps to task
 `completed`, while workflow failure or verifier rejection maps to task

--- a/schemas/akm-task.json
+++ b/schemas/akm-task.json
@@ -42,7 +42,13 @@
       "maximum": 100,
       "description": "Workflow tasks only: retry a failed workflow step this many additional times (`akm workflow run --max-retries`)."
     },
-    "llm": { "$ref": "#/definitions/llm" }
+    "llm": { "$ref": "#/definitions/llm" },
+    "redact": {
+      "type": "array",
+      "maxItems": 32,
+      "items": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$" },
+      "description": "NAMES ONLY: environment variable names whose values are scrubbed from this task's persisted run log and logs.db rows. Values never appear in a task file — a task file is indexed, searchable, and printed verbatim by `akm show`, so a literal secret here would leak more widely than the redaction closes. akm already scrubs config-declared credentials and infers others from the variable name; this is the escape hatch for a secret exported under a name none of those rules recognise. A name unset at run time contributes nothing."
+    }
   },
   "oneOf": [
     {

--- a/src/commands/feedback-cli.ts
+++ b/src/commands/feedback-cli.ts
@@ -13,6 +13,7 @@ import { FEEDBACK_FAILURE_MODES, loadConfig } from "../core/config/config";
 import { NotFoundError, UsageError } from "../core/errors";
 import { appendEvent } from "../core/events";
 import { resolveMutationTarget } from "../core/mutation-target";
+import { isPathAbsent } from "../core/path-access";
 import { getDbPath } from "../core/paths";
 import { withStateDb } from "../core/state-db";
 import { warn } from "../core/warn";
@@ -353,7 +354,12 @@ export const feedbackCommand = defineJsonCommand({
     // background process that holds the writer lock, causing the feedback write
     // to spin-wait for the full reindex duration. If the DB is absent we give a
     // clear error below rather than silently triggering a rebuild.
-    if (!fs.existsSync(getDbPath())) {
+    // "Run 'akm index' first" is only true advice for an index that was never
+    // built. Told to someone whose index exists but is unreadable it is a lie
+    // that sends them to rebuild a file they may not have permission to touch
+    // (#791), so that case falls through to `openExistingDatabase` below, which
+    // names the path, errno, mode/owner and uid instead.
+    if (isPathAbsent(getDbPath())) {
       throw new UsageError(
         "Index not found. Run 'akm index' first to build the index before recording feedback.",
         "MISSING_REQUIRED_ARGUMENT",

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -11,10 +11,9 @@ import { readEvents } from "../core/events";
 import { listTxnJournalsTolerant, TXN_SWEEP_GRACE_MS } from "../core/fs-txn";
 import { openLogsDatabase } from "../core/logs-db";
 import { classifyPathAccess, describeInaccessiblePath } from "../core/path-access";
-import { getCacheDir, getConfigPath, getDataDir, getStateDbPathInDataDir } from "../core/paths";
+import { getConfigPath, getDataDir, getStateDbPathInDataDir } from "../core/paths";
 import { listExistingTableNames, openStateDatabase } from "../core/state-db";
 import { DURATION_UNITS, parseDuration, parseSinceToIso } from "../core/time";
-import { resolveSourceEntries } from "../indexer/search/search-source";
 import { readSemanticStatus } from "../indexer/search/semantic-status";
 import type { SessionLogEntry } from "../integrations/session-logs";
 import { getExecutionLogCandidates } from "../integrations/session-logs";
@@ -367,27 +366,10 @@ function gatherImproveSummaryPhase(
 /**
  * The three best-effort advisory groups beyond the health-check registry:
  * improve advisories, the `stash-git-exposure` probe, and the 08 surfaces
- * group (secret-file-perms, binary-config-skew, egress-endpoints). Order
- * matches emission order in the returned array. A
- * probe/filesystem failure in either try/catch must not abort the health
- * report — each group degrades to "no advisory" independently.
+ * group (binary-config-skew, egress-endpoints). Order matches emission order in
+ * the returned array. A probe/filesystem failure in either try/catch must not
+ * abort the health report — each group degrades to "no advisory" independently.
  */
-/**
- * Configured bundle roots other than `primary`, for the permission sweep.
- * Best-effort: a config that cannot be resolved yields none rather than
- * aborting the (already best-effort) advisory group.
- */
-function secondaryStashDirs(primary: string): string[] {
-  try {
-    const primaryResolved = path.resolve(primary);
-    return resolveSourceEntries()
-      .map((source) => path.resolve(source.path))
-      .filter((dir) => dir !== primaryResolved && fs.existsSync(dir));
-  } catch {
-    return [];
-  }
-}
-
 function gatherAncillaryAdvisories(
   db: Database,
   stateDbPath: string,
@@ -416,18 +398,12 @@ function gatherAncillaryAdvisories(
     // Non-fatal — a git/probe failure must not abort the health report.
   }
 
-  // 08 surfaces: the remaining read-only advisory group (secret-file-perms,
-  // binary-config-skew, egress-endpoints). Best-effort — a
-  // filesystem probe failure must not abort the health report.
+  // 08 surfaces: the remaining read-only advisory group (binary-config-skew,
+  // egress-endpoints). Best-effort — a filesystem probe failure must not abort
+  // the health report.
   try {
-    const primaryStashDir = options.stashDir ?? resolveStashDir();
     advisories.push(
       ...collectSurfacesAdvisories({
-        stashDir: primaryStashDir,
-        // Secondary bundles hold env/secret assets too (issue #756) — the
-        // advisory used to stop at the primary stash.
-        extraStashDirs: secondaryStashDirs(primaryStashDir),
-        cacheDir: getCacheDir(),
         configPath: getConfigPath(),
         config: egressConfigView,
       }),
@@ -576,8 +552,8 @@ export function akmHealth(options: AkmHealthOptions = {}): AkmHealthResult {
   // #791: an UNREADABLE state.db is the one failure `akm health` most needs to
   // be able to report, because it is the command an operator runs to find out
   // why everything else is behaving oddly. Dying here with exit 78 meant health
-  // could not diagnose the very permission problem it is meant to surface — the
-  // secret-file-perms advisory never even ran. Report it as a finding instead.
+  // could not diagnose that state at all — not even the checks that never touch
+  // state.db got to run. Report it as a finding instead.
   let db: ReturnType<typeof openStateDatabase>;
   try {
     db = openStateDatabase(stateDbPath);

--- a/src/commands/health/surfaces.ts
+++ b/src/commands/health/surfaces.ts
@@ -5,9 +5,8 @@
 /**
  * The remaining `surfaces` advisory group for `akm health` (meta-review 08).
  * `stash-git-exposure` (08-F1) shipped first in ./stash-exposure.ts; this
- * module adds the other three read-only checks the adjudication approved:
+ * module adds the other two read-only checks the adjudication approved:
  *
- *   - `secret-file-perms`   — env/secret/backup files not 0600, dirs not 0700 (F4)
  *   - `binary-config-skew`  — config.json written by a NEWER akm than this binary (F3)
  *   - `egress-endpoints`    — the remote-destination list, for eyeball diff (surfaces 3/9)
  *
@@ -17,110 +16,10 @@
  * (pass-status) entry: it emits whenever any remote endpoint is configured.
  */
 
-import fs from "node:fs";
-import path from "node:path";
 import { MAX_CONFIG_FILE_BYTES, readTextFileWithLimit } from "../../core/common";
 import { CURRENT_CONFIG_VERSION } from "../../core/config/config-schema";
 import { compareConfigVersion } from "../../core/config/config-version";
 import type { HealthCheckResult } from "./types";
-
-/** POSIX permission checks are meaningless on Windows. */
-type PlatformLike = NodeJS.Platform | string;
-
-const GROUP_OTHER_BITS = 0o077;
-const OFFENDER_EVIDENCE_CAP = 50;
-
-function modeOctal(mode: number): string {
-  return (mode & 0o777).toString(8).padStart(3, "0");
-}
-
-interface PermOffenderScan {
-  /** Directories walked recursively; every entry within is checked. */
-  roots: string[];
-}
-
-function checkPathMode(abs: string, offenders: string[], expectDirectory?: boolean): fs.Stats | undefined {
-  let stat: fs.Stats;
-  try {
-    stat = fs.statSync(abs);
-  } catch {
-    return undefined; // absent → nothing to protect
-  }
-  if ((stat.mode & GROUP_OTHER_BITS) === 0) return stat;
-  const isDir = expectDirectory ?? stat.isDirectory();
-  offenders.push(isDir ? `${abs}/ (${modeOctal(stat.mode)}, want 700)` : `${abs} (${modeOctal(stat.mode)}, want 600)`);
-  return stat;
-}
-
-/**
- * `secret-file-perms` (08-F4): flag files that are not 0600 and directories
- * that are not 0700, anywhere akm stores credentials or captured content.
- *
- * Scans `env` and `secrets` under every configured bundle, plus
- * `<cache>/config-backups`. Silent when every path is tight (or absent).
- *
- * ── What this check is, and what it deliberately is NOT (#791) ──
- *
- * It flags files whose mode deviates from the mode **akm itself wrote them
- * with**. Env and secret assets and config backups are pinned to `0600` by
- * `writeFileAtomic` at the moment akm creates them, so finding one at `0644`
- * means something else changed it — that is real signal.
- *
- * It deliberately does NOT scan the managed databases or the per-run task logs.
- * A previous revision did (#756, alongside a chmod that has since been
- * reverted); with akm no longer setting those modes they are written at the
- * process umask, so `0644` is simply the correct default state on a typical
- * `022` machine. Flagging it would make `akm health` exit 4 on essentially
- * every single-user install — an alarm that fires always is not an alarm.
- * Protecting the data directory is the operator's call; umask and `chmod` are
- * their levers, and akm has no business either enforcing a mode there or
- * nagging about the default one.
- */
-export function collectSecretPermsAdvisory(
-  input: { stashDir: string; extraStashDirs?: readonly string[]; cacheDir: string },
-  platform: PlatformLike = process.platform,
-): HealthCheckResult | undefined {
-  if (platform === "win32") return undefined;
-
-  // Every CONFIGURED bundle, not only the primary one: a secondary bundle's
-  // `env`/`secrets` hold exactly the same akm-written `0600` material, and an
-  // operator running `akm health` has no reason to expect the check stops at
-  // the default bundle.
-  const stashDirs = [input.stashDir, ...(input.extraStashDirs ?? [])];
-  const scan: PermOffenderScan = {
-    roots: [
-      ...stashDirs.flatMap((dir) => [path.join(dir, "env"), path.join(dir, "secrets")]),
-      path.join(input.cacheDir, "config-backups"),
-    ],
-  };
-
-  const offenders: string[] = [];
-
-  for (const root of scan.roots) {
-    if (checkPathMode(root, offenders, true) === undefined) continue;
-    let entries: string[];
-    try {
-      entries = fs.readdirSync(root, { recursive: true }) as string[];
-    } catch {
-      continue;
-    }
-    for (const entry of entries) checkPathMode(path.join(root, entry), offenders);
-  }
-
-  if (offenders.length === 0) return undefined;
-  const preview = offenders.slice(0, 5).join("; ") + (offenders.length > 5 ? `; +${offenders.length - 5} more` : "");
-  return {
-    name: "secret-file-perms",
-    kind: "deterministic",
-    status: "warn",
-    confidence: "high",
-    message:
-      `${offenders.length} env/secret/backup path(s) are readable by group/other: ${preview}. ` +
-      "Tighten with chmod 600 (files) / chmod 700 (dirs) — these hold tokens, keys, and config snapshots, " +
-      "and akm writes them 0600, so a looser mode means something else changed them.",
-    evidence: { offenders: offenders.slice(0, OFFENDER_EVIDENCE_CAP) },
-  };
-}
 
 /**
  * `binary-config-skew` (08-F3): warn when config.json carries a configVersion
@@ -213,29 +112,13 @@ export function collectEgressAdvisory(config: EgressConfigView | undefined): Hea
 }
 
 /**
- * Aggregate the three collectors into the advisories array shape `akmHealth`
- * consumes. Order is fixed: perms → skew → egress.
+ * Aggregate the two collectors into the advisories array shape `akmHealth`
+ * consumes. Order is fixed: skew → egress.
  */
 export function collectSurfacesAdvisories(input: {
-  stashDir: string;
-  /** Secondary configured bundle roots, scanned for `env/`/`secrets/` alongside the primary. */
-  extraStashDirs?: readonly string[];
-  cacheDir: string;
   configPath: string;
   config: EgressConfigView | undefined;
-  platform?: PlatformLike;
 }): HealthCheckResult[] {
-  const results = [
-    collectSecretPermsAdvisory(
-      {
-        stashDir: input.stashDir,
-        ...(input.extraStashDirs ? { extraStashDirs: input.extraStashDirs } : {}),
-        cacheDir: input.cacheDir,
-      },
-      input.platform ?? process.platform,
-    ),
-    collectConfigSkewAdvisory(input.configPath),
-    collectEgressAdvisory(input.config),
-  ];
+  const results = [collectConfigSkewAdvisory(input.configPath), collectEgressAdvisory(input.config)];
   return results.filter((r): r is HealthCheckResult => r !== undefined);
 }

--- a/src/commands/improve/eligibility.ts
+++ b/src/commands/improve/eligibility.ts
@@ -11,6 +11,7 @@ import { loadConfig } from "../../core/config/config";
 import { NotFoundError, rethrowIfTestIsolationError, UsageError } from "../../core/errors";
 import { readEvents } from "../../core/events";
 import type { ImproveEligibleRef } from "../../core/improve-types";
+import { isPathAbsent } from "../../core/path-access";
 import { getDbPath } from "../../core/paths";
 import { deriveInstallations } from "../../indexer/installations";
 import { getWritableStashDirs, resolveSourceEntries } from "../../indexer/search/search-source";
@@ -37,10 +38,15 @@ import { improveStateReadRefs } from "./source-identity";
  * yet. `openExistingDatabase` refuses to create a missing `index.db` (see
  * index-connection.ts) — for eligibility, "no index" simply means nothing is
  * eligible, exactly like the readOnly arm's `undefined`.
+ *
+ * `undefined` is reserved for a genuinely ABSENT index. The readOnly arm has
+ * refused to conflate that with an unreadable one since #791; this arm used
+ * `fs.existsSync`, so the same run reported "nothing eligible to improve" at
+ * exit 0 depending only on which branch it took. Both arms now raise.
  */
 function openEligibilityDb(readOnly: boolean): Database | undefined {
   if (readOnly) return openReadonlyExistingDatabase();
-  return fs.existsSync(getDbPath()) ? openExistingDatabase() : undefined;
+  return isPathAbsent(getDbPath()) ? undefined : openExistingDatabase();
 }
 
 export function resolveImproveScope(scope: string | undefined): { mode: "all" | "type" | "ref"; value?: string } {

--- a/src/commands/sources/installed-stashes.ts
+++ b/src/commands/sources/installed-stashes.ts
@@ -21,6 +21,7 @@ import { isWithin, resolveStashDir } from "../../core/common";
 import type { AkmConfig, BundleConfigEntry } from "../../core/config/config";
 import { getSources, loadConfig } from "../../core/config/config";
 import { ConfigError, NotFoundError, UsageError } from "../../core/errors";
+import { isPathAbsent } from "../../core/path-access";
 import { getDbPath } from "../../core/paths";
 import { warn } from "../../core/warn";
 import { withAssetMutationLease } from "../../indexer/index-writer-lock";
@@ -169,7 +170,11 @@ interface BundleCounts {
 function readBundleCounts(): Map<string, BundleCounts> {
   const counts = new Map<string, BundleCounts>();
   const dbPath = getDbPath();
-  if (!fs.existsSync(dbPath)) return counts;
+  // An empty map renders as `itemCount: 0` for every bundle — indistinguishable
+  // from "these bundles really are empty". Only a never-built index gets to say
+  // that silently; an unreadable one falls through to the opener and is
+  // reported by the `warn` in the catch below (#791).
+  if (isPathAbsent(dbPath)) return counts;
 
   let db: Database | undefined;
   try {

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -260,3 +260,29 @@ export function rethrowIfTestIsolationError(err: unknown): void {
     throw err;
   }
 }
+
+/**
+ * Unreadable-data-dir guard helper — the #791 sibling of the test-isolation
+ * pair above, and it exists for the same reason.
+ *
+ * `DATA_DIR_UNREADABLE` says "this path is there and I am not allowed to read
+ * it". It is raised by `assertIndexPathReadable` and friends precisely so a
+ * permission fault stops being indistinguishable from "nothing indexed yet".
+ * That distinction is destroyed again the moment a best-effort `catch` around
+ * the open collapses it into the same `null`/`[]`/`0` the absent case returns —
+ * which is how `akm search` came to answer "No search index available. Run
+ * 'akm index'" at exit 0 for a populated index sitting right there on disk.
+ *
+ * Call `rethrowIfDataDirUnreadable(err)` from any catch block that returns a
+ * fallback value after touching a data-dir path. Absent stays absent; a fault
+ * the operator has to fix keeps travelling.
+ */
+export function isDataDirUnreadableError(err: unknown): err is ConfigError {
+  return err instanceof ConfigError && err.code === "DATA_DIR_UNREADABLE";
+}
+
+export function rethrowIfDataDirUnreadable(err: unknown): void {
+  if (isDataDirUnreadableError(err)) {
+    throw err;
+  }
+}

--- a/src/core/migration-operation.ts
+++ b/src/core/migration-operation.ts
@@ -3,9 +3,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import crypto from "node:crypto";
-import fs from "node:fs";
 import path from "node:path";
 import { ConfigError } from "./errors";
+import { classifyPathAccess, describeInaccessiblePath } from "./path-access";
 import { getConfigPath, getDataDir } from "./paths";
 
 let afterPendingCheckHook: (() => void) | undefined;
@@ -54,12 +54,30 @@ export function getMigrationGeneratedConfigPath(): string {
   return path.join(getMigrationOperationRoot(), "generated-config.json");
 }
 
+/**
+ * Refuse canonical config/database access while a migration or restore is
+ * mid-flight.
+ *
+ * This is a SAFETY gate, so "I could not tell" must fail the same way "yes"
+ * does. `fs.existsSync` answered `false` for an unreadable journal exactly as
+ * for an absent one (#791), which meant a permission fault on the journal
+ * silently CLEARED the gate and let akm open the canonical databases on top of
+ * a half-applied migration. Absence is the only answer that may open the door.
+ */
 export function assertNoPendingMigrationOperation(): void {
   for (const [kind, journalPath] of [
     ["restore", getMigrationRestoreJournalPath()],
     ["migration apply", getMigrationApplyJournalPath()],
   ] as const) {
-    if (fs.existsSync(journalPath)) {
+    const { access, code } = classifyPathAccess(journalPath);
+    if (access === "inaccessible") {
+      throw new ConfigError(
+        `Cannot determine whether an AKM ${kind} recovery is pending: ${describeInaccessiblePath(journalPath, code)}. ` +
+          "Refusing canonical config/database access — proceeding could write on top of a half-applied migration.",
+        "DATA_DIR_UNREADABLE",
+      );
+    }
+    if (access === "present") {
       throw new ConfigError(
         `AKM ${kind} recovery is pending at ${journalPath}; refusing canonical config/database access until recovery completes.`,
         "INVALID_CONFIG_FILE",

--- a/src/core/redaction.ts
+++ b/src/core/redaction.ts
@@ -305,6 +305,25 @@ function addMappedMatches(coverageDelta: Int32Array, haystack: NormalizedText, n
 }
 
 /**
+ * Mark every occurrence of `needle` in `text` — no encoding normalization, for
+ * text that contains neither `%` nor `+` and so cannot carry an encoded form.
+ *
+ * Matching against the ORIGINAL text (rather than an accumulator being rewritten
+ * in place) is the whole point: see {@link redactSensitiveText}.
+ */
+function addPlainMatches(coverageDelta: Int32Array, text: string, needle: string): void {
+  if (!needle) return;
+  let offset = 0;
+  while (offset <= text.length - needle.length) {
+    const match = text.indexOf(needle, offset);
+    if (match < 0) break;
+    coverageDelta[match] = coverageDelta[match]! + 1;
+    coverageDelta[match + needle.length] = coverageDelta[match + needle.length]! - 1;
+    offset = match + needle.length;
+  }
+}
+
+/**
  * Redact credential-shaped substrings from arbitrary text by pattern alone —
  * unlike {@link redactSensitiveText}, which requires the exact secret value
  * up front, this catches credentials no caller ever knew to list. No
@@ -341,28 +360,41 @@ export function redactCredentialPatterns(input: string): string {
 }
 
 /**
- * Replace exact sensitive values in text. Longer values are replaced first so
- * an overlapping prefix cannot expose the suffix of a longer credential.
+ * Replace exact sensitive values in text.
+ *
+ * Every match is located against the ORIGINAL text and the result is emitted
+ * once, so overlapping matches merge into a single `[REDACTED]` and no needle
+ * can ever match inside a token an earlier needle produced.
+ *
+ * That last property is load-bearing. This function used to take a `replaceAll`
+ * fast path that chained over a *mutating* accumulator, which meant any needle
+ * drawn from the letters of `[REDACTED]` re-matched the tokens already injected
+ * and the output grew geometrically: `redactSensitiveText("a".repeat(50),
+ * ["a","E","D","T","C","R"])` returned 32,450 characters — 649x the input. On a
+ * path where the needle set is derived from configuration or the environment,
+ * that is a memory-exhaustion hazard reachable from ordinary command output.
+ * The encoded-form path never had the bug because it always worked this way.
  */
 export function redactSensitiveText(text: string, sensitiveValues: Iterable<string>): string {
   const values = [...new Set(sensitiveValues)]
     .filter((value) => value.length > 0)
     .sort((a, b) => b.length - a.length || a.localeCompare(b));
   if (values.length === 0) return text;
-  if (!text.includes("%") && !text.includes("+")) {
-    let redacted = text;
-    for (const value of values) redacted = redacted.replaceAll(value, "[REDACTED]");
-    return redacted;
-  }
   const coverageDelta = new Int32Array(text.length + 1);
-  const addMatchesForMode = (plusAsSpace: boolean): void => {
-    const haystack = normalizeEncodedText(text, plusAsSpace);
-    for (const value of values) {
-      addMappedMatches(coverageDelta, haystack, normalizeEncodedText(value, plusAsSpace).text);
-    }
-  };
-  addMatchesForMode(false);
-  if (text.includes("+")) addMatchesForMode(true);
+  if (text.includes("%") || text.includes("+")) {
+    // Percent-/plus-encoded text: match needle and haystack in their decoded
+    // forms, mapping hits back to source offsets.
+    const addMatchesForMode = (plusAsSpace: boolean): void => {
+      const haystack = normalizeEncodedText(text, plusAsSpace);
+      for (const value of values) {
+        addMappedMatches(coverageDelta, haystack, normalizeEncodedText(value, plusAsSpace).text);
+      }
+    };
+    addMatchesForMode(false);
+    if (text.includes("+")) addMatchesForMode(true);
+  } else {
+    for (const value of values) addPlainMatches(coverageDelta, text, value);
+  }
   let redacted = "";
   let coverage = 0;
   let offset = 0;
@@ -388,9 +420,19 @@ export function redactSensitiveValue<T>(value: T, sensitiveValues: Iterable<stri
     if (typeof entry === "string") return redactSensitiveText(entry, values);
     if (Array.isArray(entry)) return entry.map(redact);
     if (entry && typeof entry === "object") {
-      return Object.fromEntries(
-        Object.entries(entry).map(([key, child]) => [redactSensitiveText(key, values), redact(child)]),
-      );
+      const out: Record<string, unknown> = {};
+      for (const [key, child] of Object.entries(entry)) {
+        const redactedKey = redactSensitiveText(key, values);
+        // Two DISTINCT keys can redact to the same string (`{a, b, ab}` under
+        // needles `a`/`b` all collapse toward `[REDACTED]`). Building this with
+        // `Object.fromEntries` kept only the last of each colliding group, so a
+        // field was silently DROPPED rather than redacted — data loss disguised
+        // as redaction. Suffix instead: the value stays, the key stays hidden.
+        let finalKey = redactedKey;
+        for (let n = 2; Object.hasOwn(out, finalKey); n++) finalKey = `${redactedKey} (${n})`;
+        out[finalKey] = redact(child);
+      }
+      return out;
     }
     return entry;
   };

--- a/src/indexer/db/graph-db.ts
+++ b/src/indexer/db/graph-db.ts
@@ -2,8 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import fs from "node:fs";
-import { rethrowIfTestIsolationError } from "../../core/errors";
+import { rethrowIfDataDirUnreadable, rethrowIfTestIsolationError } from "../../core/errors";
+import { isPathAbsent } from "../../core/path-access";
 import { getDbPath } from "../../core/paths";
 import type { GraphRelation } from "../../llm/graph-extract";
 import type { Database } from "../../storage/database";
@@ -34,7 +34,11 @@ export interface StoredGraphMeta {
 function withReadableGraphDb<T>(db: Database | undefined, fn: (db: Database) => T): T {
   if (db) return fn(db);
   const dbPath = getDbPath();
-  if (!fs.existsSync(dbPath)) throw new Error("GRAPH_DB_MISSING");
+  // `GRAPH_DB_MISSING` is the loaders' "nothing extracted yet" sentinel — every
+  // caller below turns it into `null`/`[]`. Reserve it for a genuinely ABSENT
+  // index: an index that exists and cannot be read must reach the caller as the
+  // ConfigError `openExistingDatabase` raises, not as "no graph data" (#791).
+  if (isPathAbsent(dbPath)) throw new Error("GRAPH_DB_MISSING");
   const opened = openExistingDatabase(dbPath);
   try {
     return fn(opened);
@@ -382,8 +386,11 @@ export function loadGraphFilesOnly(
       }
     });
   } catch (err) {
-    // Never mask the bun-test isolation guard as "no stored graph files".
+    // Never mask the bun-test isolation guard as "no stored graph files",
+    // and never mask an index we are not allowed to read as one with no
+    // graph in it (#791) — `GRAPH_DB_MISSING` above is the only "absent".
     rethrowIfTestIsolationError(err);
+    rethrowIfDataDirUnreadable(err);
     return [];
   }
 }
@@ -474,8 +481,10 @@ export function loadStoredGraphMeta(stashPath: string, db?: Database): StoredGra
       }
     });
   } catch (err) {
-    // Never mask the bun-test isolation guard as "no stored graph meta".
+    // Never mask the bun-test isolation guard as "no stored graph meta",
+    // nor an unreadable index as one that simply has no graph (#791).
     rethrowIfTestIsolationError(err);
+    rethrowIfDataDirUnreadable(err);
     return null;
   }
 }
@@ -586,8 +595,10 @@ export function loadStoredGraphSnapshot(stashPath: string, db?: Database): Store
       }
     });
   } catch (err) {
-    // Never mask the bun-test isolation guard as "no stored graph snapshot".
+    // Never mask the bun-test isolation guard as "no stored graph snapshot",
+    // nor an unreadable index as one that simply has no graph (#791).
     rethrowIfTestIsolationError(err);
+    rethrowIfDataDirUnreadable(err);
     return null;
   }
 }

--- a/src/indexer/index-written-assets.ts
+++ b/src/indexer/index-written-assets.ts
@@ -24,8 +24,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { akmAdapter } from "../core/adapter/adapters/akm-adapter";
+import { isDataDirUnreadableError } from "../core/errors";
+import { isPathAbsent } from "../core/path-access";
 import { getDbPath } from "../core/paths";
-import { warnVerbose } from "../core/warn";
+import { warn, warnVerbose } from "../core/warn";
 import { closeDatabase, openExistingDatabase } from "../storage/repositories/index-connection";
 import {
   deleteEntriesByIds,
@@ -74,7 +76,12 @@ export async function indexWrittenAssets(
   try {
     return await withIndexWriterLease({ purpose: "index-written-assets" }, async () => {
       const dbPath = getDbPath();
-      if (!fs.existsSync(dbPath)) return true;
+      // `true` here means "the index is in the state the caller expects" — and
+      // `acceptProposal` advances its journal to `index-finalized` on the
+      // strength of it. Only a genuinely ABSENT index earns that answer: an
+      // index we cannot read has NOT been updated, so it falls through to
+      // `openExistingDatabase` and surfaces as the honest `false` (#791).
+      if (isPathAbsent(dbPath)) return true;
 
       // The full walk never descends into dot-directories (for example `.meta/`)
       // — mirror that dot-segment skip here so this fast path indexes exactly
@@ -174,6 +181,16 @@ export async function indexWrittenAssets(
       return true;
     });
   } catch (error) {
+    // A permission fault is the one failure the next full index will NOT heal,
+    // so it does not get the verbose-only treatment the other skips do: fail
+    // open (the caller's write still stands) but say so where an operator can
+    // see it (#791).
+    if (isDataDirUnreadableError(error)) {
+      warn(
+        `Write-path index update skipped — ${error.message} The asset will not appear in search until that is fixed.`,
+      );
+      return false;
+    }
     warnVerbose(
       "Write-path index update skipped (asset appears after the next full index):",
       error instanceof Error ? error.message : String(error),

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -12,6 +12,7 @@ import { isHttpUrl, toErrorMessage } from "../core/common";
 import { concurrentMap } from "../core/concurrent";
 import type { AkmConfig, LlmConnectionConfig } from "../core/config/config";
 import { isLoopbackEndpoint } from "../core/loopback";
+import { classifyPathAccess, describeInaccessiblePath } from "../core/path-access";
 import { getDbPath } from "../core/paths";
 import { SCRIPT_EXTENSIONS } from "../core/recognition-util";
 import { withStateDb } from "../core/state-db";
@@ -513,6 +514,14 @@ export function reconcileBodyOpeningIndexState(
  *
  * Only rows with a non-empty `file_path` are checked — remote/virtual entries
  * that have no local path are always skipped.
+ *
+ * "No longer exists" means ABSENT, never merely unreadable (#791). This pass
+ * DELETES rows, and `fs.existsSync` reported `false` for a file akm lacked
+ * permission to look at exactly as for one that had been removed — so a
+ * bundle temporarily mounted read-restricted (a uid mismatch, a tightened
+ * parent directory) had its whole index wiped, and the run reported the
+ * deletions as a clean success. Unreadable files keep their rows and are
+ * reported instead.
  */
 function runCleanPass(db: Database, dryRun: boolean): IndexCleanResult {
   const allEntries = db.prepare("SELECT id, entry_key AS ref, file_path AS path FROM entries").all() as {
@@ -524,7 +533,20 @@ function runCleanPass(db: Database, dryRun: boolean): IndexCleanResult {
   // Only check entries that have a non-empty local path (skip remote/virtual).
   const localEntries = allEntries.filter((e) => typeof e.path === "string" && e.path.trim() !== "");
 
-  const missing = localEntries.filter((e) => !fs.existsSync(e.path));
+  const missing: typeof localEntries = [];
+  const unreadable: Array<{ path: string; code?: string }> = [];
+  for (const entry of localEntries) {
+    const { access, code } = classifyPathAccess(entry.path);
+    if (access === "absent") missing.push(entry);
+    else if (access === "inaccessible") unreadable.push({ path: entry.path, ...(code ? { code } : {}) });
+  }
+  if (unreadable.length > 0) {
+    const shown = unreadable.slice(0, 5).map((u) => describeInaccessiblePath(u.path, u.code));
+    warn(
+      `Index clean pass kept ${unreadable.length} entr${unreadable.length === 1 ? "y" : "ies"} whose file akm cannot ` +
+        `read (unreadable is not deleted): ${shown.join("; ")}${unreadable.length > shown.length ? "; …" : ""}`,
+    );
+  }
 
   if (!dryRun && missing.length > 0) {
     deleteEntriesByIds(

--- a/src/integrations/lockfile.ts
+++ b/src/integrations/lockfile.ts
@@ -8,6 +8,7 @@ import { writeFileAtomic } from "../core/common";
 import { ConfigError, rethrowIfTestIsolationError } from "../core/errors";
 import { createLockPayload, probeLock, reclaimStaleLock, releaseLock, tryAcquireLockSync } from "../core/file-lock";
 import { acquireMaintenanceBarrier } from "../core/maintenance-barrier";
+import { classifyPathAccess, describeInaccessiblePath } from "../core/path-access";
 import { getDataDir, getLockfileLockPath, getLockfilePath } from "../core/paths";
 import type { InstallKind } from "../registry/types";
 // `InstallKind` is the install/registry source discriminator — exactly the
@@ -107,6 +108,32 @@ export function readLockfile(): LockfileEntry[] {
 }
 
 /**
+ * Refuse to treat an UNREADABLE lockfile (or data dir) as an absent one (#791).
+ *
+ * Every write path here is read-modify-WRITE: it loads the current entries and
+ * writes the whole array back. An unreadable `akm.lock` that reads as `[]`
+ * therefore does not merely lose information — the very next
+ * `writeFileAtomic` replaces the operator's entire lock record with the single
+ * entry this call happened to be adding. That is the same catastrophe R-012
+ * guards against for a *corrupt* file, reached instead through a permission
+ * fault, and `fs.existsSync`/a swallowed `readFileSync` could not tell the two
+ * apart from "the file was never created".
+ *
+ * No-op when the path is genuinely absent — that case really does have nothing
+ * to preserve.
+ */
+function assertLockfilePathReadable(target: string): void {
+  const { access, code } = classifyPathAccess(target);
+  if (access !== "inaccessible") return;
+  throw new ConfigError(
+    `Refusing to modify the lockfile: ${describeInaccessiblePath(target, code)}. akm cannot read the existing lock ` +
+      "records, and writing over them would destroy every bundle they track. Fix the ownership or mode of that " +
+      "path (or point AKM_DATA_DIR / XDG_DATA_HOME somewhere this user owns) and retry.",
+    "DATA_DIR_UNREADABLE",
+  );
+}
+
+/**
  * Like {@link readLockfile}, but THROWS instead of silently degrading to `[]`
  * when the on-disk lockfile exists yet is not parseable JSON or not a JSON
  * array (R-012).
@@ -133,7 +160,15 @@ function readLockfileOrThrow(): LockfileEntry[] {
     raw = fs.readFileSync(lockfilePath, "utf8");
   } catch (err) {
     rethrowIfTestIsolationError(err);
-    return []; // File does not exist (or is otherwise unreadable) — nothing to preserve.
+    // "Missing file" is the only failure with nothing to preserve. An
+    // UNREADABLE lockfile has everything to preserve and we cannot see it —
+    // degrading it to `[]` here is precisely the destructive overwrite this
+    // function was written to prevent, only triggered by a permission fault
+    // instead of a corrupt file (#791). Classify AFTER the failed read so the
+    // happy path costs no extra syscall and the answer describes the failure
+    // we actually got.
+    assertLockfilePathReadable(lockfilePath);
+    return [];
   }
   let parsed: unknown;
   try {
@@ -229,6 +264,11 @@ export async function upsertLockEntry(entry: LockfileEntry): Promise<void> {
 function readLockEntriesForMigration(): LockfileEntry[] {
   let existing: LockfileEntry[] = [];
   const lockfilePath = getLockfilePath();
+  // `mergeLockEntriesSync` writes `existing` straight back out, so an
+  // unreadable lockfile read as absent would be overwritten with just the
+  // migrator's sparse entries (#791). This is also what
+  // `assertMigrationLockfileReadable` promises to have checked.
+  assertLockfilePathReadable(lockfilePath);
   if (fs.existsSync(lockfilePath)) {
     let raw: unknown;
     try {
@@ -275,7 +315,13 @@ export function mergeLockEntriesSync(entries: LockfileEntry[]): void {
 }
 
 export async function removeLockEntry(id: string): Promise<void> {
-  if (!fs.existsSync(getDataDir())) return;
+  // Returning early says "there is no lock record to remove", and the uninstall
+  // that called us reports success on that basis. Only an absent data dir earns
+  // it — one we cannot read may hold the very entry we were asked to drop, and
+  // silently leaving it behind is how a bundle stays "installed" forever (#791).
+  const dataDir = getDataDir();
+  assertLockfilePathReadable(dataDir);
+  if (!fs.existsSync(dataDir)) return;
   const release = await acquireLockSentinel();
   try {
     // R-012: see upsertLockEntry — same destructive-overwrite risk on a

--- a/src/storage/managed-db.ts
+++ b/src/storage/managed-db.ts
@@ -62,9 +62,7 @@ export interface ManagedDbSpec {
  *     "No search index available" at exit 0 rather than an error (#791).
  *
  * Files akm creates here get the process umask, which is the operator's lever
- * for this and always was. `akm health`'s `secret-file-perms` advisory still
- * REPORTS group/other-readable databases and task logs — informing the operator
- * is the appropriate scope; enforcing against their wishes is not.
+ * for this and always was. akm neither sets these modes nor reports on them.
  */
 export function openManagedDatabase(spec: ManagedDbSpec): Database {
   const dir = path.dirname(spec.path);

--- a/src/storage/repositories/index-entries-repository.ts
+++ b/src/storage/repositories/index-entries-repository.ts
@@ -15,6 +15,7 @@ import path from "node:path";
 import { parseBundleRef } from "../../core/asset/asset-ref";
 import { conceptIdFromTypeName } from "../../core/asset/resolve-ref";
 import { bestEffort } from "../../core/best-effort";
+import { isPathAbsent } from "../../core/path-access";
 import { getStateDbPath, withStateDb } from "../../core/state-db";
 import { warn } from "../../core/warn";
 import type { IndexDocument } from "../../indexer/passes/metadata";
@@ -361,7 +362,11 @@ export function rekeyEntryInPlace(db: Database, opts: RekeyEntryOptions): number
  * history (live-asset-wins). Best-effort + guarded on state.db's existence.
  */
 function rewriteUsageEventRefForMove(opts: RekeyEntryOptions): void {
-  if (!fs.existsSync(getStateDbPath())) return;
+  // Every other failure in here throws (see the catch below) precisely because
+  // a move that quietly drops its usage history is a wrong answer wearing a
+  // success. An unreadable state.db must not be the one silent exception —
+  // only a state.db that was never created skips (#791).
+  if (isPathAbsent(getStateDbPath())) return;
   // `usage_events.entry_ref` is the fully-qualified item_ref
   // (`<bundle>//<conceptId>`).
   const rename = (stateDb: Database, oldR: string, newR: string): void => {

--- a/src/tasks/log-redaction.ts
+++ b/src/tasks/log-redaction.ts
@@ -1,0 +1,172 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Decide which exact values must be scrubbed from a task's persisted run log
+ * (issue #755).
+ *
+ * # The gap
+ *
+ * All three task target kinds funnel through `persistRunLog`, which applied
+ * only `redactCredentialPatterns` — credential *shapes* (`Bearer …`, `sk-…`,
+ * webhook URLs). Prompt- and workflow-target runs additionally redact the exact
+ * secret values reachable by the run before their output ever reaches the log.
+ * Command-target runs did not: a scheduled command that echoed a configured
+ * secret whose value is not credential-shaped persisted it verbatim, into both
+ * the `.log` file and `logs.db`, for the whole retention window.
+ *
+ * # Why the obvious fix is wrong
+ *
+ * The issue proposed reusing {@link isEnvPassthroughValueSafeToExpose} — the
+ * filter the prompt path uses — over the env handed to the child. That filter
+ * fails CLOSED for any name outside a 22-entry allowlist, which is right where
+ * it currently runs: the prompt path filters `envPassthrough`, a short list the
+ * operator explicitly declared. A command task inherits the WHOLE ambient
+ * environment, so the same rule classifies essentially everything as secret.
+ * Measured on a developer machine: 127 of 132 variables, 25 of them with
+ * one-character values (`SHLVL=1`, `OLDPWD=/`, `GIT_TERMINAL_PROMPT=0`).
+ * Redaction is substring replacement, so those become live needles:
+ *
+ *     Build finished in 12.4s        ->  Build finished in [REDACTED]2.[REDACTED]s
+ *     3 tests passed, 0 failed       ->  [REDACTED] tests passed, [REDACTED] failed
+ *     wrote dist/index.js (48 KB)    ->  wrote dist[REDACTED]index.js ([REDACTED]8 KB)
+ *
+ * A fix that destroys every command log is not a fix.
+ *
+ * # What this does instead
+ *
+ * Three sources, and the distinction between them is the whole design:
+ *
+ *  1. **Declared by config** — the config names which variables hold
+ *     credentials (`engines.<n>.apiKey: ${VAR}`, `embedding.apiKey`, and the
+ *     implicit `AKM_ENGINE_<NAME>_API_KEY` / `AKM_LLM_API_KEY` /
+ *     `AKM_EMBED_API_KEY` recipes). akm KNOWS these are secret.
+ *  2. **Declared by the task** — the `redact:` list, names only.
+ *  3. **Inferred** — a name-shape heuristic over the remaining environment, for
+ *     the ambient credential akm was never told about.
+ *
+ * Only (3) is a guess, so only (3) carries {@link MIN_INFERRED_SECRET_LENGTH}.
+ * A declared secret is redacted at ANY length, because the operator told us
+ * what it is; applying a floor to declared values would silently stop redacting
+ * short secrets that are scrubbed today. The floor exists solely to stop a
+ * *guess* from mangling a log, and 8 clears every real credential format (AWS
+ * key id 20, GitHub PAT 40, `sk-…` 40+) while excluding the flags and counters
+ * that a name heuristic occasionally catches.
+ *
+ * Note what is deliberately NOT collected: the akm secret store on disk. A
+ * spawned command sees `process.env`, not akm's stores — a stored secret can
+ * only be echoed if it is already in the environment, where the rules above
+ * catch it by name. Walking every bundle's `secrets/` on each task firing would
+ * cost a recursive readdir plus an unbounded read for values the child cannot
+ * reach anyway. `redact:` is the escape hatch for a secret injected under a
+ * name none of the rules recognise.
+ */
+
+import { collectSensitiveValues, isEnvPassthroughValueSafeToExpose } from "../core/redaction";
+import { collectEngineCredentialValues, type EngineResolutionConfig } from "../integrations/agent/engine-resolution";
+
+/**
+ * Shortest value an INFERRED (name-heuristic) match may contribute as a
+ * redaction needle. Declared secrets bypass this entirely.
+ *
+ * Redaction replaces substrings, so a short needle is not merely useless — it
+ * corrupts unrelated output. Below 8 the noise tier is fully intact (`1`, `0`,
+ * `/`, `80`, `true`, `xhigh`, `31999`); at 8 a chance collision with ordinary
+ * log vocabulary is negligible, and every credential format in real use is far
+ * longer. It also matches the conventional minimum password length, so a
+ * secret shorter than this is already outside normal policy.
+ */
+export const MIN_INFERRED_SECRET_LENGTH = 8;
+
+/**
+ * Environment names whose VALUE is treated as a credential on shape alone.
+ *
+ * The keyword must be a whole `_`-delimited word. Anchoring on only one side
+ * would drag in ordinary configuration from whichever side is left open:
+ * a leading anchor alone matches `KEYBOARD_LAYOUT` and `AUTHOR`, a trailing one
+ * matches `MONKEY` and `BYPASS`. Whole-word matching gets `GH_TOKEN`,
+ * `NPM_AUTH_TOKEN`, `MY_API_KEY`, `DB_PASS` and `AWS_SECRET_ACCESS_KEY` right.
+ */
+const INFERRED_SECRET_NAME = /(?:^|_)(?:API_?KEY|KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASS|CREDENTIALS?|AUTH)(?:_|$)/i;
+
+/**
+ * Credential variables whose name is a single glued word, which no
+ * word-boundary rule can see. Enumerated rather than matched: loosening the
+ * pattern enough to catch `PGPASSWORD` also catches `MONKEY`.
+ *
+ * `PWD` cannot be a keyword above for the same reason it appears here as part
+ * of `MYSQL_PWD` — on its own it is the working directory.
+ */
+const KNOWN_SECRET_NAMES = new Set(["PGPASSWORD", "MYSQL_PWD"]);
+
+/** True when the NAME alone marks this variable as holding a credential. */
+export function isInferredSecretName(name: string): boolean {
+  return KNOWN_SECRET_NAMES.has(name.toUpperCase()) || INFERRED_SECRET_NAME.test(name);
+}
+
+/**
+ * The config this module reads: engine resolution's own view (so the engine
+ * credential recipes stay defined in exactly one place), plus the embedding key
+ * that view does not cover.
+ */
+export interface TaskLogRedactionConfig extends EngineResolutionConfig {
+  embedding?: { apiKey?: string };
+}
+
+/** Resolve `${VAR}` / `$VAR` to the variable NAME, or undefined for anything else. */
+function envRefName(spec: string | undefined): string | undefined {
+  if (!spec) return undefined;
+  const match = /^\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?$/.exec(spec.trim());
+  return match?.[1];
+}
+
+/**
+ * Every value that must be scrubbed from one task's persisted output.
+ *
+ * `declaredNames` comes from the task's `redact:` list. A name that is unset in
+ * `env` simply contributes nothing — naming a variable you do not currently
+ * export is not an error.
+ */
+export function collectTaskLogSensitiveValues(input: {
+  env: NodeJS.ProcessEnv;
+  config?: TaskLogRedactionConfig | undefined;
+  declaredNames?: readonly string[] | undefined;
+}): string[] {
+  const { env, config, declaredNames } = input;
+  const values = new Set<string>();
+  const addDeclared = (value: string | undefined): void => {
+    if (value === undefined) return;
+    const trimmed = value.trim();
+    // Both spellings: `resolveSecret` does not trim but `resolveCredentialFromEnv`
+    // does, so a variable with trailing whitespace reaches an output boundary in
+    // either form depending on which path materialized it.
+    if (value.length > 0) values.add(value);
+    if (trimmed.length > 0) values.add(trimmed);
+  };
+
+  // (1) Declared by config — engine credentials, via the collector the prompt
+  // path already uses, plus the embedding key it does not cover.
+  if (config) {
+    for (const value of collectEngineCredentialValues(config, env)) values.add(value);
+    addDeclared(env[envRefName(config.embedding?.apiKey) ?? "AKM_EMBED_API_KEY"]);
+  }
+
+  // (2) Declared by the task's `redact:` list — names only, never values.
+  for (const name of declaredNames ?? []) addDeclared(env[name]);
+
+  // (3) Inferred from the name shape. The only guessing tier, so the only one
+  // with a length floor — and still subject to the value-level check that keeps
+  // an allowlisted name from being treated as secret.
+  for (const [name, value] of Object.entries(env)) {
+    if (value === undefined || value.length < MIN_INFERRED_SECRET_LENGTH) continue;
+    if (!isInferredSecretName(name)) continue;
+    if (isEnvPassthroughValueSafeToExpose(name, value)) continue;
+    values.add(value);
+  }
+
+  // Expands credential-bearing URLs into their embedded components. Can yield
+  // needles shorter than the floor (a URL's password), which is correct: the
+  // operator's own value implied them.
+  return collectSensitiveValues(values);
+}

--- a/src/tasks/parser.ts
+++ b/src/tasks/parser.ts
@@ -32,6 +32,8 @@
  * description: …
  * when_to_use: …
  * tags: [scheduled, backup]
+ * redact: [ACME_DEPLOY_TOKEN]     # optional: env var NAMES (never values) to
+ *                                 # scrub from this task's persisted log
  * ```
  *
  * Validation lives in {@link validateTaskDocument}. The parser enforces the
@@ -44,8 +46,9 @@ import { parse as parseYaml } from "yaml";
 import { isFullRefInput } from "../core/asset/resolve-ref";
 import { UsageError } from "../core/errors";
 import { formatExtraParamsIssue, validateExtraParams } from "../core/extra-params";
-import { WORKFLOW_MAX_RETRIES } from "../workflows/resource-limits";
+import { WORKFLOW_ENV_VAR_NAME_PATTERN, WORKFLOW_MAX_RETRIES } from "../workflows/resource-limits";
 import {
+  TASK_MAX_REDACT_NAMES,
   TASK_MAX_TIMEOUT_MS,
   TASK_SCHEMA_VERSION,
   type TaskDocument,
@@ -165,6 +168,7 @@ export function parseTaskDocument(input: ParseTaskInput): TaskDocument {
   }
 
   const timeoutMs = hasCommand ? readTimeout(data.timeoutMs, filePath) : undefined;
+  const redact = readRedactNames(data.redact, filePath);
 
   return {
     version: TASK_SCHEMA_VERSION,
@@ -179,6 +183,7 @@ export function parseTaskDocument(input: ParseTaskInput): TaskDocument {
     ...(tags ? { tags } : {}),
     source: { path: filePath },
     timeoutMs,
+    ...(redact ? { redact } : {}),
   };
 }
 
@@ -200,8 +205,19 @@ const TASK_KEYS = new Set([
   "maxSteps",
   "maxRetries",
   "llm",
+  "redact",
 ]);
-const SHARED_KEYS = new Set(["version", "name", "description", "when_to_use", "tags", "schedule", "enabled"]);
+const SHARED_KEYS = new Set([
+  "version",
+  "name",
+  "description",
+  "when_to_use",
+  "tags",
+  "schedule",
+  "enabled",
+  // `redact:` is target-agnostic: every kind funnels through the same log sink.
+  "redact",
+]);
 
 function requireVersion(data: Record<string, unknown>, id: string, filePath: string): void {
   if (data.version === TASK_SCHEMA_VERSION) return;
@@ -348,6 +364,37 @@ function readTimeout(value: unknown, filePath: string): number | null | undefine
     `Key "timeoutMs" must be an integer from 1 through ${TASK_MAX_TIMEOUT_MS}, or null. File: ${filePath}`,
     "INVALID_FLAG_VALUE",
   );
+}
+
+/**
+ * Read the `redact:` opt-in list — environment variable NAMES whose values are
+ * scrubbed from this task's persisted log (#755).
+ *
+ * A value that looks like a secret rather than a name is rejected outright, not
+ * silently accepted: a literal in a task file would be indexed, searchable and
+ * printed verbatim by `akm show`, so accepting one would leak the secret
+ * through a wider channel than the redaction closes.
+ */
+function readRedactNames(value: unknown, filePath: string): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  const invalid = (detail: string): never => {
+    throw new UsageError(`Key "redact" ${detail}. File: ${filePath}`, "INVALID_FLAG_VALUE");
+  };
+  if (!Array.isArray(value)) return invalid("must be a list of environment variable names");
+  if (value.length > TASK_MAX_REDACT_NAMES) {
+    return invalid(`accepts at most ${TASK_MAX_REDACT_NAMES} names (got ${value.length})`);
+  }
+  const names: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string" || !WORKFLOW_ENV_VAR_NAME_PATTERN.test(entry)) {
+      return invalid(
+        `takes environment variable NAMES only (matching ${WORKFLOW_ENV_VAR_NAME_PATTERN.source}), not values — ` +
+          `got ${JSON.stringify(entry)}. A secret written here would be indexed and printed by \`akm show\``,
+      );
+    }
+    if (!names.includes(entry)) names.push(entry);
+  }
+  return names.length > 0 ? names : undefined;
 }
 
 function readBoundedInteger(

--- a/src/tasks/runner.ts
+++ b/src/tasks/runner.ts
@@ -49,7 +49,7 @@ import {
   type TaskLogStream,
 } from "../core/logs-db";
 import { getTaskLogDir } from "../core/paths";
-import { redactCredentialPatterns } from "../core/redaction";
+import { redactCredentialPatterns, redactSensitiveText } from "../core/redaction";
 import { withStateDb } from "../core/state-db";
 import { runManagedSubprocess, type SpawnFn } from "../core/subprocess";
 import type { AgentRunResult, RunAgentOptions } from "../integrations/agent";
@@ -76,6 +76,7 @@ import {
 } from "../storage/repositories/task-history-repository";
 import { runWorkflowSteps } from "../workflows/exec/run-workflow";
 import { findBareAkmExecutableIndex } from "./command-executable";
+import { collectTaskLogSensitiveValues } from "./log-redaction";
 import { parseTaskDocument } from "./parser";
 import { resolveAkmInvocation } from "./resolve-akm-bin";
 import type { TaskDocument } from "./schema";
@@ -204,6 +205,7 @@ export async function runTask(id: string, options: RunTaskOptions): Promise<Task
         logPath,
         fileText: `${disabledLine}\n`,
         dbLines: [{ line: disabledLine }],
+        redactNames: task.redact,
       });
       appendHistory(result, attempt.historyReserved);
       return result;
@@ -339,6 +341,7 @@ async function runCommandTask(input: {
     logPath,
     fileText: `${logLines.join("\n")}\n`,
     dbLines,
+    redactNames: task.redact,
   });
   const status: TaskRunStatus = exitCode === 0 ? "completed" : "failed";
   const result: TaskRunResult = {
@@ -493,6 +496,7 @@ async function runWorkflowTask(input: {
     logPath,
     fileText: log.fileText,
     dbLines: log.dbLines,
+    redactNames: task.redact,
   });
 
   const result: TaskRunResult = {
@@ -666,6 +670,7 @@ async function runPromptTask(input: {
     logPath,
     fileText: log.fileText,
     dbLines: log.dbLines,
+    redactNames: task.redact,
   });
 
   const status: TaskRunStatus = result.ok ? "completed" : "failed";
@@ -794,6 +799,34 @@ function streamLines(text: string, stream: TaskLogStream, level: TaskLogLevel): 
  * The DB write is best-effort, mirroring {@link appendHistory}: an unwritable
  * logs.db must never fail a task run.
  */
+/**
+ * Exact secret values to scrub from this run's persisted output (#755).
+ *
+ * Best-effort by construction: this runs on the persistence path of a run that
+ * has already finished, so a config that will not load must degrade to
+ * "pattern-based redaction only" rather than fail the run. It does NOT degrade
+ * to "log it anyway with no redaction at all" — `redactCredentialPatterns`
+ * still runs unconditionally in the caller.
+ */
+function taskLogSensitiveValues(redactNames: readonly string[] | undefined): string[] {
+  try {
+    return collectTaskLogSensitiveValues({
+      env: process.env,
+      config: loadConfig(),
+      declaredNames: redactNames,
+    });
+  } catch (error) {
+    rethrowIfTestIsolationError(error);
+    // No config — the name heuristic and the task's own `redact:` list still apply.
+    try {
+      return collectTaskLogSensitiveValues({ env: process.env, declaredNames: redactNames });
+    } catch (fallbackError) {
+      rethrowIfTestIsolationError(fallbackError);
+      return [];
+    }
+  }
+}
+
 function persistRunLog(input: {
   taskId: string;
   startedAtIso: string;
@@ -801,15 +834,30 @@ function persistRunLog(input: {
   logPath: string;
   fileText: string;
   dbLines: readonly TaskLogLineInput[];
+  /** The task's `redact:` names, if any (#755). */
+  redactNames?: readonly string[] | undefined;
 }): void {
-  const fileText = redactCredentialPatterns(input.fileText);
-  const dbLines = input.dbLines.map((entry) => ({ ...entry, line: redactCredentialPatterns(entry.line) }));
+  // Two arms, and both are needed. `redactCredentialPatterns` catches
+  // credential SHAPES nobody listed; the exact-value pass catches configured
+  // secrets whose value is shaped like nothing in particular (#755). The
+  // command target had only the first, so a scheduled command that echoed an
+  // ordinary-looking secret persisted it verbatim to both sinks. Applying the
+  // exact pass here — the one sink all three target kinds funnel through —
+  // covers every arm once rather than per-arm; prompt/workflow runs already
+  // scrub upstream, and redaction is idempotent, so the overlap is free.
+  const sensitive = taskLogSensitiveValues(input.redactNames);
+  const scrub = (text: string): string =>
+    sensitive.length > 0
+      ? redactSensitiveText(redactCredentialPatterns(text), sensitive)
+      : redactCredentialPatterns(text);
+  const fileText = scrub(input.fileText);
+  const dbLines = input.dbLines.map((entry) => ({ ...entry, line: scrub(entry.line) }));
   if (input.logPath) {
     try {
       // Written at the process umask. #756 pinned 0600/0700 here; that went out
       // with the rest of akm's permission enforcement (#791) — the operator owns
-      // the mode of their own data directory. `akm health` still reports a
-      // group/other-readable task log rather than silently changing it.
+      // the mode of their own data directory, and akm neither sets nor reports
+      // on it.
       fs.mkdirSync(path.dirname(input.logPath), { recursive: true });
       fs.writeFileSync(input.logPath, fileText);
     } catch (error) {

--- a/src/tasks/schema.ts
+++ b/src/tasks/schema.ts
@@ -15,7 +15,7 @@
  */
 
 import { parse as parseYaml } from "yaml";
-import { WORKFLOW_MAX_TIMEOUT_MS } from "../workflows/resource-limits";
+import { WORKFLOW_MAX_EXEC_PASS_ENV, WORKFLOW_MAX_TIMEOUT_MS } from "../workflows/resource-limits";
 
 export const TASK_SCHEMA_VERSION = 2;
 
@@ -40,6 +40,14 @@ export const TASK_NEAR_MISS_EXTENSION = ".yaml";
  * `timeoutMs` in `schemas/akm-task.json`.
  */
 export const TASK_MAX_TIMEOUT_MS = WORKFLOW_MAX_TIMEOUT_MS;
+
+/**
+ * Most names a task's `redact:` list may carry. Shares its bound with exec
+ * units' `pass_env:` — both are "name the one or two the defaults miss", not a
+ * way to declare the whole environment secret. Mirrored as `maxItems` on
+ * `redact` in `schemas/akm-task.json`.
+ */
+export const TASK_MAX_REDACT_NAMES = WORKFLOW_MAX_EXEC_PASS_ENV;
 
 /**
  * Lint-level shape problems for a parsed task YAML mapping: the field rules
@@ -198,4 +206,22 @@ export interface TaskDocument {
    * where that kind's dispatch consumes it.
    */
   timeoutMs?: number | null;
+  /**
+   * Environment variable NAMES whose values are scrubbed from this task's
+   * persisted output (the run `.log` and `logs.db`) before it is written.
+   *
+   * NAMES ONLY, never values. akm looks each name up in the environment the run
+   * is given and feeds the value to the log redactor. A literal secret here
+   * would leak through a channel far wider than the one it closes: a task file
+   * is an indexed, searchable asset whose raw text lands in the FTS `content`
+   * column and can be sent to an embedding provider, `akm show` prints it
+   * verbatim, and bundles ship over git and npm. This is the same ruling
+   * `pass_env:` states for exec units.
+   *
+   * The escape hatch, not the mechanism: akm already redacts config-declared
+   * credentials and infers others from the variable name. Use this for a secret
+   * exported under a name none of those rules recognise. A name that is unset
+   * at run time contributes nothing. Present only when non-empty.
+   */
+  redact?: string[];
 }

--- a/tests/_helpers/unreadable-path.ts
+++ b/tests/_helpers/unreadable-path.ts
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Making a path unreadable in a test — the uid-independent way (issue #791).
+ *
+ * The #791 suites all need the same fixture: a path that EXISTS as a name and
+ * that the process cannot resolve or read. The obvious `chmod 0000` is a trap:
+ * permission bits are unenforced for uid 0, and these suites run as root in
+ * containers, so a chmod-only test passes for the wrong reason in exactly the
+ * environment CI uses — which is how the bug shipped in the first place.
+ *
+ * A **symlink loop** (`a -> b -> a`) raises `ELOOP` from `stat`/`open` for
+ * every uid, root included. That is the "present as far as anyone knows, and
+ * unusable" case the classifier must never report as absent, and it is the
+ * primary technique across the #791 tests. Keep {@link enforcesPermissionBits}
+ * for the chmod variants that are worth running *in addition* wherever bits
+ * actually bite.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+/** Permission bits are unenforced for uid 0; the ELOOP cases cover every uid. */
+export const enforcesPermissionBits = !(typeof process.getuid === "function" && process.getuid() === 0);
+
+/**
+ * Create `<dir>/<name>` as a path that exists but cannot be resolved: it and a
+ * `<name>.partner` sibling point at each other, so any attempt to follow either
+ * raises `ELOOP` regardless of uid. Returns the absolute path to `<name>`.
+ */
+export function makeUnresolvablePath(dir: string, name: string): string {
+  const target = path.join(dir, name);
+  const partner = path.join(dir, `${name}.partner`);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.symlinkSync(partner, target);
+  fs.symlinkSync(target, partner);
+  return target;
+}
+
+/**
+ * Replace an existing file with an unresolvable path of the same name — the
+ * "this asset went read-restricted between runs" fixture. Returns the path.
+ */
+export function makePathUnresolvableInPlace(target: string): string {
+  fs.rmSync(target, { force: true });
+  return makeUnresolvablePath(path.dirname(target), path.basename(target));
+}

--- a/tests/integration/commands/health/surfaces.test.ts
+++ b/tests/integration/commands/health/surfaces.test.ts
@@ -3,93 +3,22 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 /**
- * 08 "surfaces" advisory group for `akm health` (secret-file-perms,
- * binary-config-skew, egress-endpoints). Every collector is
- * silent (`undefined`) when there is nothing to report, mirroring the shipped
- * `stash-git-exposure` advisory; only `egress-endpoints` emits a pass-status
- * informational entry whenever any remote endpoint is configured.
+ * 08 "surfaces" advisory group for `akm health` (binary-config-skew,
+ * egress-endpoints). Every collector is silent (`undefined`) when there is
+ * nothing to report, mirroring the shipped `stash-git-exposure` advisory; only
+ * `egress-endpoints` emits a pass-status informational entry whenever any
+ * remote endpoint is configured.
  */
 
 import { describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import {
-  collectConfigSkewAdvisory,
-  collectEgressAdvisory,
-  collectSecretPermsAdvisory,
-} from "../../../../src/commands/health/surfaces";
+import { collectConfigSkewAdvisory, collectEgressAdvisory } from "../../../../src/commands/health/surfaces";
 
 function makeTempDir(prefix: string): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 }
-
-describe("collectSecretPermsAdvisory (08-F4)", () => {
-  test("warns on group/other-readable env files and dirs", () => {
-    const stashDir = makeTempDir("akm-surfaces-perms-");
-    const cacheDir = makeTempDir("akm-surfaces-cache-");
-    fs.mkdirSync(path.join(stashDir, "env"), { mode: 0o755 });
-    fs.writeFileSync(path.join(stashDir, "env", "prod.env"), "K=v", { mode: 0o644 });
-
-    const adv = collectSecretPermsAdvisory({ stashDir, cacheDir }, "linux");
-    expect(adv?.name).toBe("secret-file-perms");
-    expect(adv?.status).toBe("warn");
-    const offenders = adv?.evidence?.offenders as string[];
-    expect(offenders.some((o) => o.includes("env"))).toBe(true);
-    expect(offenders.some((o) => o.includes("prod.env"))).toBe(true);
-  });
-
-  test("silent when env/secrets/backups are 0600/0700 (or absent)", () => {
-    const stashDir = makeTempDir("akm-surfaces-perms-");
-    const cacheDir = makeTempDir("akm-surfaces-cache-");
-    fs.mkdirSync(path.join(stashDir, "secrets"), { mode: 0o700 });
-    fs.writeFileSync(path.join(stashDir, "secrets", "signing.key"), "s", { mode: 0o600 });
-    const backups = path.join(cacheDir, "config-backups");
-    fs.mkdirSync(backups, { mode: 0o700 });
-    fs.writeFileSync(path.join(backups, "config-1.json"), "{}", { mode: 0o600 });
-
-    expect(collectSecretPermsAdvisory({ stashDir, cacheDir }, "linux")).toBeUndefined();
-  });
-
-  test("silent on win32 (POSIX modes are meaningless there)", () => {
-    const stashDir = makeTempDir("akm-surfaces-perms-");
-    fs.mkdirSync(path.join(stashDir, "env"), { mode: 0o755 });
-    expect(collectSecretPermsAdvisory({ stashDir, cacheDir: stashDir }, "win32")).toBeUndefined();
-  });
-
-  // #791: the databases and per-run task logs are deliberately NOT scanned.
-  // akm no longer sets their mode (the #756 chmod was reverted), so they carry
-  // the process umask — `0644` on a typical `022` machine is the correct
-  // default, and warning about it would make `akm health` exit 4 on nearly
-  // every single-user install.
-
-  test("does not flag umask-default databases or task logs", () => {
-    const stashDir = makeTempDir("akm-surfaces-perms-");
-    const cacheDir = makeTempDir("akm-surfaces-cache-");
-    const dataDir = makeTempDir("akm-surfaces-data-");
-    fs.chmodSync(dataDir, 0o755);
-    for (const name of ["state.db", "state.db-wal", "index.db", "logs.db"]) {
-      fs.writeFileSync(path.join(dataDir, name), "sqlite", { mode: 0o644 });
-    }
-    const runDir = path.join(cacheDir, "tasks", "logs", "nightly");
-    fs.mkdirSync(runDir, { recursive: true, mode: 0o755 });
-    fs.writeFileSync(path.join(runDir, "run.log"), "output", { mode: 0o644 });
-
-    expect(collectSecretPermsAdvisory({ stashDir, cacheDir }, "linux")).toBeUndefined();
-  });
-
-  test("still flags a loose env file in a SECONDARY configured bundle", () => {
-    const stashDir = makeTempDir("akm-surfaces-perms-");
-    const second = makeTempDir("akm-surfaces-second-");
-    const cacheDir = makeTempDir("akm-surfaces-cache-");
-    fs.mkdirSync(path.join(second, "env"), { mode: 0o700 });
-    fs.writeFileSync(path.join(second, "env", "prod.env"), "K=v", { mode: 0o644 });
-
-    const adv = collectSecretPermsAdvisory({ stashDir, extraStashDirs: [second], cacheDir }, "linux");
-    const offenders = (adv?.evidence?.offenders as string[]) ?? [];
-    expect(offenders.some((o) => o.includes("prod.env"))).toBe(true);
-  });
-});
 
 describe("collectConfigSkewAdvisory (08-F3)", () => {
   test("warns when the on-disk configVersion is newer than this binary's", () => {

--- a/tests/integration/data-dir-unreadable-sweep.test.ts
+++ b/tests/integration/data-dir-unreadable-sweep.test.ts
@@ -1,0 +1,407 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * The rest of the #791 sweep: every remaining gate that answered "absent" for a
+ * path it merely could not READ.
+ *
+ * `tests/integration/index-unreadable-not-absent.test.ts` pins the primary read
+ * path (the search/curate openers, `probeLock`, `akm health`). This file pins
+ * the sites the first pass did not reach — the ones where an `fs.existsSync`
+ * gate over a data-dir / DB / lock / managed-asset path turned a permission
+ * fault into a confident wrong answer:
+ *
+ *   - the migration-recovery gate silently CLEARING (`assertNoPendingMigrationOperation`)
+ *   - the lockfile write paths reading `[]` and then OVERWRITING the operator's
+ *     lock records with it
+ *   - `--clean` DELETING index rows for files it merely cannot look at
+ *   - improve reporting "nothing eligible", feedback advising "run 'akm index'",
+ *     `bundle list` reporting zero items, the graph loaders reporting no graph,
+ *     and the write-path indexer reporting a successful no-op
+ *
+ * Every case here is written so it FAILS against the pre-sweep code — each one
+ * was mutation-checked by reverting its call site. On the fixture technique
+ * (why `chmod` is not enough) see `tests/_helpers/unreadable-path.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { collectEligibleRefs } from "../../src/commands/improve/eligibility";
+import { akmListSources } from "../../src/commands/sources/installed-stashes";
+import { type AkmConfig, saveConfig } from "../../src/core/config/config";
+import { ConfigError } from "../../src/core/errors";
+import { assertNoPendingMigrationOperation, getMigrationApplyJournalPath } from "../../src/core/migration-operation";
+import { getDataDir, getDbPath } from "../../src/core/paths";
+import { getStateDbPath } from "../../src/core/state-db";
+import { _setWarnSinkForTests } from "../../src/core/warn";
+import { loadGraphFilesOnly, loadStoredGraphMeta } from "../../src/indexer/db/graph-db";
+import { indexWrittenAssets } from "../../src/indexer/index-written-assets";
+import { akmIndex } from "../../src/indexer/indexer";
+import {
+  assertMigrationLockfileReadable,
+  mergeLockEntriesSync,
+  removeLockEntry,
+  upsertLockEntry,
+} from "../../src/integrations/lockfile";
+import { closeDatabase, openExistingDatabase } from "../../src/storage/repositories/index-connection";
+import { rekeyEntryInPlace } from "../../src/storage/repositories/index-entries-repository";
+import { runCliCapture } from "../_helpers/cli";
+import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../_helpers/sandbox";
+import { makePathUnresolvableInPlace, makeUnresolvablePath } from "../_helpers/unreadable-path";
+
+let storage: IsolatedAkmStorage;
+
+beforeEach(() => {
+  storage = withIsolatedAkmStorage();
+});
+
+afterEach(() => {
+  _setWarnSinkForTests(undefined);
+  storage.cleanup();
+});
+
+/** Collect everything routed through the `warn` seam while `fn` runs. */
+async function captureWarnings(fn: () => Promise<void> | void): Promise<string[]> {
+  const lines: string[] = [];
+  _setWarnSinkForTests((level, args) => {
+    if (level === "warn") lines.push(args.map((a) => String(a)).join(" "));
+  });
+  try {
+    await fn();
+  } finally {
+    _setWarnSinkForTests(undefined);
+  }
+  return lines;
+}
+
+/** An unreadable `index.db` in the sandboxed data dir. Returns its path. */
+function unreadableIndexDb(): string {
+  const dbPath = getDbPath();
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  return makeUnresolvablePath(path.dirname(dbPath), path.basename(dbPath));
+}
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function stashConfig(stashDir: string): AkmConfig {
+  return {
+    semanticSearchMode: "off",
+    bundles: { stash: { path: stashDir, writable: true } },
+    defaultBundle: "stash",
+    defaultWriteTarget: "stash",
+  } as AkmConfig;
+}
+
+// ── The migration-recovery gate ─────────────────────────────────────────────
+
+describe("assertNoPendingMigrationOperation fails closed on an unreadable journal (#791)", () => {
+  test("an unreadable journal refuses canonical DB access instead of clearing the gate", () => {
+    const journalPath = getMigrationApplyJournalPath();
+    makeUnresolvablePath(path.dirname(journalPath), path.basename(journalPath));
+
+    // Pre-sweep this returned normally: `existsSync` said `false`, so the guard
+    // concluded "no recovery pending" and let akm open the canonical databases
+    // on top of a possibly half-applied migration.
+    let raised: unknown;
+    try {
+      assertNoPendingMigrationOperation();
+    } catch (error) {
+      raised = error;
+    }
+    expect(raised).toBeInstanceOf(ConfigError);
+    expect((raised as ConfigError).code).toBe("DATA_DIR_UNREADABLE");
+    expect((raised as Error).message).toContain(journalPath);
+    expect((raised as Error).message).toContain("ELOOP");
+  });
+
+  test("absent still clears the gate and a real pending journal still reports as pending", () => {
+    expect(() => assertNoPendingMigrationOperation()).not.toThrow();
+
+    const journalPath = getMigrationApplyJournalPath();
+    fs.mkdirSync(path.dirname(journalPath), { recursive: true });
+    fs.writeFileSync(journalPath, "{}");
+    let raised: unknown;
+    try {
+      assertNoPendingMigrationOperation();
+    } catch (error) {
+      raised = error;
+    }
+    expect((raised as ConfigError).code).toBe("INVALID_CONFIG_FILE");
+    expect((raised as Error).message).toMatch(/recovery is pending/);
+  });
+});
+
+// ── The lockfile write paths ────────────────────────────────────────────────
+
+describe("the lockfile write paths refuse to overwrite what they cannot read (#791)", () => {
+  const entry = { id: "demo", source: "npm", ref: "demo@1.0.0" } as const;
+
+  test("mergeLockEntriesSync throws and leaves the lockfile untouched", () => {
+    const lockfilePath = path.join(getDataDir(), "akm.lock");
+    makeUnresolvablePath(path.dirname(lockfilePath), path.basename(lockfilePath));
+
+    let raised: unknown;
+    try {
+      mergeLockEntriesSync([{ ...entry }]);
+    } catch (error) {
+      raised = error;
+    }
+    expect(raised).toBeInstanceOf(ConfigError);
+    expect((raised as ConfigError).code).toBe("DATA_DIR_UNREADABLE");
+    // The real damage the old code did: it read `[]`, then wrote `[entry]` over
+    // the top — replacing the operator's whole lock record with one row. The
+    // path must still be the symlink we made, not a fresh regular file.
+    expect(fs.lstatSync(lockfilePath).isSymbolicLink()).toBe(true);
+  });
+
+  test("assertMigrationLockfileReadable actually asserts readability", () => {
+    const lockfilePath = path.join(getDataDir(), "akm.lock");
+    makeUnresolvablePath(path.dirname(lockfilePath), path.basename(lockfilePath));
+
+    expect(() => assertMigrationLockfileReadable()).toThrow(ConfigError);
+  });
+
+  test("upsertLockEntry rejects rather than replacing an unreadable lockfile", async () => {
+    const lockfilePath = path.join(getDataDir(), "akm.lock");
+    makeUnresolvablePath(path.dirname(lockfilePath), path.basename(lockfilePath));
+
+    await expect(upsertLockEntry({ ...entry })).rejects.toThrow(/not readable|ELOOP/);
+    expect(fs.lstatSync(lockfilePath).isSymbolicLink()).toBe(true);
+  });
+
+  test("removeLockEntry rejects on an unreadable data dir instead of reporting success", async () => {
+    // getDataDir() is `<XDG_DATA_HOME>/akm` and withIsolatedAkmStorage leaves it
+    // uncreated, so the loop lands exactly on the data dir itself.
+    const dataDir = getDataDir();
+    makeUnresolvablePath(path.dirname(dataDir), path.basename(dataDir));
+
+    // Pre-sweep: `existsSync(dataDir)` was false, so this resolved silently and
+    // the uninstall that called it reported the bundle as removed.
+    await expect(removeLockEntry("demo")).rejects.toThrow(ConfigError);
+  });
+
+  test("an absent data dir still makes removeLockEntry a no-op", async () => {
+    expect(fs.existsSync(getDataDir())).toBe(false);
+    await removeLockEntry("demo");
+    expect(fs.existsSync(getDataDir())).toBe(false);
+  });
+});
+
+// ── The graph loaders ───────────────────────────────────────────────────────
+
+describe("the graph loaders separate 'no graph' from 'no access' (#791)", () => {
+  test("loadStoredGraphMeta raises instead of returning null", () => {
+    unreadableIndexDb();
+    let raised: unknown;
+    try {
+      loadStoredGraphMeta("/some/stash");
+    } catch (error) {
+      raised = error;
+    }
+    expect(raised).toBeInstanceOf(ConfigError);
+    expect((raised as ConfigError).code).toBe("DATA_DIR_UNREADABLE");
+  });
+
+  test("loadGraphFilesOnly raises instead of returning []", () => {
+    unreadableIndexDb();
+    expect(() => loadGraphFilesOnly("/some/stash")).toThrow(ConfigError);
+  });
+
+  test("a genuinely absent index still reads as 'nothing extracted yet'", () => {
+    expect(loadStoredGraphMeta("/some/stash")).toBeNull();
+    expect(loadGraphFilesOnly("/some/stash")).toEqual([]);
+  });
+});
+
+// ── The write-path indexer ──────────────────────────────────────────────────
+
+describe("indexWrittenAssets stops reporting an unreadable index as a successful no-op (#791)", () => {
+  test("returns false and says so where an operator can see it", async () => {
+    const stashDir = storage.stashDir;
+    const assetPath = path.join(stashDir, "knowledge", "note.md");
+    writeFile(assetPath, "---\ndescription: a note\n---\nbody\n");
+    saveConfig(stashConfig(stashDir));
+    unreadableIndexDb();
+
+    let result: boolean | undefined;
+    const warnings = await captureWarnings(async () => {
+      // Pre-sweep this returned `true` — "the index is as the caller expects" —
+      // which `acceptProposal` uses to advance its journal to `index-finalized`.
+      result = await indexWrittenAssets(stashDir, [assetPath], { bundleId: "stash" });
+    });
+
+    expect(result).toBe(false);
+    expect(warnings.join("\n")).toMatch(/not readable|ELOOP/);
+  });
+
+  test("a genuinely absent index is still a silent, successful skip", async () => {
+    const stashDir = storage.stashDir;
+    const assetPath = path.join(stashDir, "knowledge", "note.md");
+    writeFile(assetPath, "---\ndescription: a note\n---\nbody\n");
+    saveConfig(stashConfig(stashDir));
+
+    const warnings = await captureWarnings(async () => {
+      expect(await indexWrittenAssets(stashDir, [assetPath], { bundleId: "stash" })).toBe(true);
+    });
+    expect(warnings.join("\n")).not.toMatch(/not readable/);
+  });
+});
+
+// ── improve eligibility ─────────────────────────────────────────────────────
+
+describe("improve stops reporting 'nothing eligible' for an index it cannot read (#791)", () => {
+  test("collectEligibleRefs raises rather than planning zero refs", async () => {
+    const stashDir = storage.stashDir;
+    writeFile(path.join(stashDir, "knowledge", "note.md"), "---\ndescription: a note\n---\nbody\n");
+    const config = stashConfig(stashDir);
+    saveConfig(config);
+    unreadableIndexDb();
+
+    // The read-only arm has refused this since the first pass; the write arm
+    // still used `fs.existsSync` and answered `{ plannedRefs: [] }` at exit 0.
+    let raised: unknown;
+    try {
+      await collectEligibleRefs({ mode: "all" }, stashDir, undefined, config);
+    } catch (error) {
+      raised = error;
+    }
+    expect(raised).toBeInstanceOf(ConfigError);
+    expect((raised as ConfigError).code).toBe("DATA_DIR_UNREADABLE");
+  });
+});
+
+// ── akm feedback ────────────────────────────────────────────────────────────
+
+describe("akm feedback stops advising a rebuild the user cannot perform (#791)", () => {
+  test("an unreadable index is reported as unreadable, not as a missing index", async () => {
+    const stashDir = storage.stashDir;
+    writeFile(path.join(stashDir, "memories", "note.md"), "---\ndescription: a note\n---\nbody\n");
+    saveConfig(stashConfig(stashDir));
+    unreadableIndexDb();
+
+    const { stdout, stderr, code } = await runCliCapture(["feedback", "memories/note", "--positive", "--format=json"]);
+    const payload = JSON.parse((stdout.trim() || stderr.trim()) as string) as Record<string, unknown>;
+
+    expect(payload.ok).toBe(false);
+    // Pre-sweep: exit 2 with "Index not found. Run 'akm index' first…" — advice
+    // that would not have helped and that they may not have permission to take.
+    expect(String(payload.error)).not.toMatch(/Run 'akm index' first/);
+    expect(String(payload.error)).toMatch(/not readable/);
+    expect(payload.code).toBe("DATA_DIR_UNREADABLE");
+    expect(code).toBe(78);
+  });
+});
+
+// ── akm bundle list ─────────────────────────────────────────────────────────
+
+describe("bundle listing does not report zero items for an index it cannot read (#791)", () => {
+  test("the unreadable index is surfaced rather than rendered as empty bundles", async () => {
+    const stashDir = storage.stashDir;
+    writeFile(path.join(stashDir, "knowledge", "note.md"), "---\ndescription: a note\n---\nbody\n");
+    saveConfig(stashConfig(stashDir));
+    const dbPath = unreadableIndexDb();
+
+    const warnings = await captureWarnings(async () => {
+      await akmListSources({ stashDir });
+    });
+    // Pre-sweep the `existsSync` gate returned an empty count map with no
+    // warning at all, so every bundle rendered as `itemCount: 0`.
+    expect(warnings.join("\n")).toContain(dbPath);
+    expect(warnings.join("\n")).toMatch(/not readable|ELOOP/);
+  });
+});
+
+// ── the --clean pass ────────────────────────────────────────────────────────
+
+describe("akm index --clean deletes absent files, never unreadable ones (#791)", () => {
+  test("an unreadable asset keeps its index row and is reported", async () => {
+    const stashDir = storage.stashDir;
+    const keep = path.join(stashDir, "scripts", "keep", "keep.sh");
+    const restricted = path.join(stashDir, "scripts", "restricted", "restricted.sh");
+    writeFile(keep, "#!/usr/bin/env bash\necho keep\n");
+    writeFile(restricted, "#!/usr/bin/env bash\necho restricted\n");
+    saveConfig(stashConfig(stashDir));
+
+    const first = await akmIndex({ stashDir, full: true });
+    expect(first.totalEntries).toBe(2);
+
+    // The asset is still there; akm just cannot look at it any more.
+    makePathUnresolvableInPlace(restricted);
+
+    let result: Awaited<ReturnType<typeof akmIndex>> | undefined;
+    const warnings = await captureWarnings(async () => {
+      result = await akmIndex({ stashDir, clean: true });
+    });
+
+    // Pre-sweep: `existsSync` said the file was gone, so --clean DELETED its
+    // index row and reported the deletion as a clean success.
+    expect(result?.clean?.removed).toBe(0);
+    expect(result?.clean?.removedRefs).toEqual([]);
+    expect(warnings.join("\n")).toContain(restricted);
+    expect(warnings.join("\n")).toMatch(/ELOOP/);
+  });
+
+  test("a genuinely deleted asset is still cleaned", async () => {
+    const stashDir = storage.stashDir;
+    const keep = path.join(stashDir, "scripts", "keep", "keep.sh");
+    const gone = path.join(stashDir, "scripts", "gone", "gone.sh");
+    writeFile(keep, "#!/usr/bin/env bash\necho keep\n");
+    writeFile(gone, "#!/usr/bin/env bash\necho gone\n");
+    saveConfig(stashConfig(stashDir));
+
+    await akmIndex({ stashDir, full: true });
+    fs.unlinkSync(gone);
+
+    const result = await akmIndex({ stashDir, clean: true });
+    expect(result.clean?.removed).toBe(1);
+    expect(result.clean?.removedRefs[0]).toContain("gone");
+  });
+});
+
+// ── the usage-history rewrite behind a rename ───────────────────────────────
+
+describe("a rename does not silently drop usage history it cannot reach (#791)", () => {
+  test("rekeyEntryInPlace surfaces an unreadable state.db instead of skipping the rewrite", async () => {
+    const stashDir = storage.stashDir;
+    writeFile(path.join(stashDir, "knowledge", "note.md"), "---\ndescription: a note\n---\nbody\n");
+    saveConfig(stashConfig(stashDir));
+    await akmIndex({ stashDir, full: true });
+
+    // state.db is a separate file from index.db and can be separately
+    // unreadable (different owner, tightened mode). Drop its sidecars too so
+    // nothing resolves through them.
+    for (const suffix of ["-wal", "-shm"]) fs.rmSync(`${getStateDbPath()}${suffix}`, { force: true });
+    makePathUnresolvableInPlace(getStateDbPath());
+
+    const db = openExistingDatabase();
+    try {
+      const row = db.prepare("SELECT item_ref FROM entries WHERE item_ref IS NOT NULL LIMIT 1").get() as
+        | { item_ref: string }
+        | undefined;
+      expect(row?.item_ref).toBeDefined();
+      const [sourceName, oldRef] = (row as { item_ref: string }).item_ref.split("//");
+
+      // Pre-sweep: `existsSync` said state.db was absent, so the usage-history
+      // rewrite was skipped without a word and the rename reported success.
+      expect(() =>
+        rekeyEntryInPlace(db, {
+          oldEntryKey: `${stashDir}:knowledge:note`,
+          newEntryKey: `${stashDir}:knowledge:renamed`,
+          newName: "renamed",
+          newFilePath: path.join(stashDir, "knowledge", "renamed.md"),
+          oldRef: oldRef as string,
+          newRef: "knowledge/renamed",
+          sourceName: sourceName as string,
+          sourceRoot: stashDir,
+        }),
+      ).toThrow(/Failed to rewrite usage events for move/);
+    } finally {
+      closeDatabase(db);
+    }
+  });
+});

--- a/tests/integration/index-unreadable-not-absent.test.ts
+++ b/tests/integration/index-unreadable-not-absent.test.ts
@@ -33,22 +33,7 @@ import { probeLock } from "../../src/core/file-lock";
 import { classifyPathAccess, describeInaccessiblePath } from "../../src/core/path-access";
 import { openExistingDatabase, openReadonlyExistingDatabase } from "../../src/storage/repositories/index-connection";
 import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../_helpers/sandbox";
-
-/** Permission bits are unenforced for uid 0; the ELOOP cases cover every uid. */
-const enforcesPermissionBits = !(typeof process.getuid === "function" && process.getuid() === 0);
-
-/**
- * A path that exists as a name but cannot be resolved: `a -> b -> a`. `statSync`
- * raises `ELOOP` for any uid, which is the "present as far as anyone knows, and
- * unusable" case the classifier must NOT report as absent.
- */
-function makeUnresolvablePath(dir: string, name: string): string {
-  const target = path.join(dir, name);
-  const partner = path.join(dir, `${name}.partner`);
-  fs.symlinkSync(partner, target);
-  fs.symlinkSync(target, partner);
-  return target;
-}
+import { enforcesPermissionBits, makeUnresolvablePath } from "../_helpers/unreadable-path";
 
 describe("classifyPathAccess (#791)", () => {
   let storage: IsolatedAkmStorage;

--- a/tests/integration/tasks-runner.test.ts
+++ b/tests/integration/tasks-runner.test.ts
@@ -721,6 +721,142 @@ describe("runTask — command target", () => {
     for (const row of rows) expect(row.line).not.toContain("abcDEF-123_token");
     expect(rows.some((row) => row.line.includes("discord.com/api/webhooks/123456789012345678/[REDACTED]"))).toBe(true);
   });
+
+  // ── #755: exact-value redaction for the command arm ──────────────────────
+  //
+  // The pattern arm above only catches credential SHAPES. A configured secret
+  // whose value looks like nothing in particular went to disk verbatim.
+
+  const echoTask = (id: string, text: string, extraYaml: readonly string[] = []): void => {
+    writeTask(
+      id,
+      [
+        "version: 2",
+        'schedule: "@daily"',
+        `command: ${JSON.stringify([process.execPath, "-e", `console.log(${JSON.stringify(text)})`])}`,
+        ...extraYaml,
+        "",
+      ].join("\n"),
+    );
+  };
+
+  const assertAbsentFromBothSinks = (id: string, logPath: string, secret: string): void => {
+    expect(fs.readFileSync(logPath, "utf8")).not.toContain(secret);
+    const rows = readRunLogRows(id);
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) expect(row.line).not.toContain(secret);
+  };
+
+  test("redacts a config-declared engine credential that is not credential-shaped", async () => {
+    // Deliberately shaped like nothing: no `sk-`, no `Bearer`, no webhook URL.
+    // The pattern arm cannot see this, which is the whole point of #755.
+    const secret = "wolfram-tuesday-lantern";
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, "config.json"),
+      JSON.stringify({
+        configVersion: "0.9.0",
+        engines: { main: { kind: "llm", apiKey: "${ACME_LLM_KEY}", endpoint: "https://api.example.com" } },
+      }),
+    );
+    echoTask("leaky-config-secret", `calling out with ${secret}`);
+
+    const result = await withEnv({ ACME_LLM_KEY: secret }, () => runTask("leaky-config-secret", { stashDir, logDir }));
+
+    expect(result.status).toBe("completed");
+    assertAbsentFromBothSinks("leaky-config-secret", result.log, secret);
+    expect(fs.readFileSync(result.log, "utf8")).toContain("[REDACTED]");
+  });
+
+  test("redacts an ambient credential inferred from its variable name", async () => {
+    const secret = "opalescent-badger-parade";
+    echoTask("leaky-ambient-secret", `deploying with ${secret}`);
+
+    const result = await withEnv({ ACME_DEPLOY_TOKEN: secret }, () =>
+      runTask("leaky-ambient-secret", { stashDir, logDir }),
+    );
+
+    expect(result.status).toBe("completed");
+    assertAbsentFromBothSinks("leaky-ambient-secret", result.log, secret);
+  });
+
+  test("`redact:` names a secret no rule would otherwise recognise", async () => {
+    // Neither config-declared nor name-shaped — the escape hatch is the only
+    // thing that can catch this one.
+    const secret = "harbour-lantern-drift";
+    echoTask("leaky-declared-secret", `token is ${secret}`, ["redact: [ACME_UNGUESSABLE]"]);
+
+    const result = await withEnv({ ACME_UNGUESSABLE: secret }, () =>
+      runTask("leaky-declared-secret", { stashDir, logDir }),
+    );
+
+    expect(result.status).toBe("completed");
+    assertAbsentFromBothSinks("leaky-declared-secret", result.log, secret);
+
+    // And without the declaration the same value would have leaked — otherwise
+    // this test proves nothing about `redact:`.
+    echoTask("leaky-undeclared-secret", `token is ${secret}`);
+    const leaked = await withEnv({ ACME_UNGUESSABLE: secret }, () =>
+      runTask("leaky-undeclared-secret", { stashDir, logDir }),
+    );
+    expect(fs.readFileSync(leaked.log, "utf8")).toContain(secret);
+  });
+
+  test("redaction survives a secret reaching the spawn_error path", async () => {
+    const secret = "cinnabar-thicket-verso";
+    writeTask(
+      "leaky-spawn-error",
+      ["version: 2", 'schedule: "@daily"', `command: [${JSON.stringify(`/nonexistent/${secret}/bin`)}]`, ""].join("\n"),
+    );
+
+    const result = await withEnv({ ACME_API_TOKEN: secret }, () => runTask("leaky-spawn-error", { stashDir, logDir }));
+
+    expect(result.status).toBe("failed");
+    assertAbsentFromBothSinks("leaky-spawn-error", result.log, secret);
+  });
+
+  test("ordinary command output is left intact", async () => {
+    // The over-redaction guard. Treating every non-allowlisted env value as a
+    // secret — the fix #755 literally proposed — turns this log into confetti:
+    // `SHLVL=1` alone rewrites every "1" in the output.
+    echoTask("clean-output", "Build finished in 12.4s | 3 tests passed, 0 failed | wrote dist/index.js (48 KB)");
+
+    const result = await withEnv({ ACME_DEPLOY_TOKEN: "opalescent-badger-parade" }, () =>
+      runTask("clean-output", { stashDir, logDir }),
+    );
+
+    const log = fs.readFileSync(result.log, "utf8");
+    expect(log).toContain("Build finished in 12.4s");
+    expect(log).toContain("3 tests passed, 0 failed");
+    expect(log).toContain("wrote dist/index.js (48 KB)");
+  });
+
+  test("redacts regardless of which configured bundle the task came from", async () => {
+    // Acceptance criterion 3: the fixtures elsewhere in this suite use a single
+    // default bundle, so a per-bundle regression would go unnoticed.
+    const secret = "meridian-thistle-vault";
+    const secondaryStash = path.join(tmpRoot, "stash-secondary");
+    fs.rmSync(secondaryStash, { recursive: true, force: true });
+    fs.mkdirSync(path.join(secondaryStash, "tasks"), { recursive: true });
+    fs.mkdirSync(path.join(secondaryStash, "workflows"), { recursive: true });
+    fs.writeFileSync(
+      path.join(secondaryStash, "tasks", "secondary-leak.yml"),
+      [
+        "version: 2",
+        'schedule: "@daily"',
+        `command: ${JSON.stringify([process.execPath, "-e", `console.log(${JSON.stringify(`shipping ${secret}`)})`])}`,
+        "redact: [ACME_SECONDARY_VALUE]",
+        "",
+      ].join("\n"),
+    );
+
+    const result = await withEnv({ ACME_SECONDARY_VALUE: secret }, () =>
+      runTask("secondary-leak", { stashDir: secondaryStash, logDir }),
+    );
+
+    expect(result.status).toBe("completed");
+    assertAbsentFromBothSinks("secondary-leak", result.log, secret);
+  });
 });
 
 describe("runTask — prompt target", () => {

--- a/tests/tasks/log-redaction.test.ts
+++ b/tests/tasks/log-redaction.test.ts
@@ -1,0 +1,149 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Which values a task log scrubs, and — just as load-bearing — which it does
+ * not (issue #755).
+ *
+ * The failure this guards against in BOTH directions: a configured secret
+ * echoed by a scheduled command was persisted verbatim, and the obvious fix
+ * (treat every non-allowlisted env value as secret) would have turned ordinary
+ * build output into `[REDACTED]` confetti. The over-redaction cases below are
+ * not padding — they are the reason the collector is shaped the way it is.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { redactSensitiveText } from "../../src/core/redaction";
+import {
+  collectTaskLogSensitiveValues,
+  isInferredSecretName,
+  MIN_INFERRED_SECRET_LENGTH,
+} from "../../src/tasks/log-redaction";
+
+describe("secret-name inference (#755)", () => {
+  test("matches credential-ish names without swallowing ordinary configuration", () => {
+    for (const name of [
+      "GH_TOKEN",
+      "NPM_AUTH_TOKEN",
+      "AWS_SECRET_ACCESS_KEY",
+      "MY_API_KEY",
+      "PGPASSWORD",
+      "DB_PASS",
+      "GOOGLE_CREDENTIALS",
+      "api_key",
+    ]) {
+      expect(isInferredSecretName(name)).toBe(true);
+    }
+    // A heuristic that fires on these would redact the operator's own prose.
+    // MONKEY and BYPASS are why the keyword must be a whole `_`-delimited word
+    // rather than merely a suffix; KEYBOARD_LAYOUT is why it cannot be a prefix.
+    for (const name of [
+      "KEYBOARD_LAYOUT",
+      "AUTHOR",
+      "PASSAGE",
+      "MONKEY",
+      "BYPASS",
+      "TOKENIZER",
+      "PATH",
+      "HOME",
+      "SHLVL",
+      "PWD",
+    ]) {
+      expect(isInferredSecretName(name)).toBe(false);
+    }
+  });
+
+  test("glued credential names are enumerated, since no boundary rule can see them", () => {
+    // Loosening the pattern enough to catch these would also catch MONKEY.
+    expect(isInferredSecretName("PGPASSWORD")).toBe(true);
+    expect(isInferredSecretName("MYSQL_PWD")).toBe(true);
+  });
+});
+
+describe("collectTaskLogSensitiveValues (#755)", () => {
+  test("collects a config-declared engine credential at any length", () => {
+    const values = collectTaskLogSensitiveValues({
+      env: { AKM_ENGINE_MAIN_API_KEY: "xy" },
+      config: { engines: { main: { kind: "llm", endpoint: "https://api.example.com", model: "m" } } },
+    });
+    // Two characters — a DECLARED secret has no length floor, because the
+    // operator told us what it is rather than akm guessing.
+    expect(values).toContain("xy");
+  });
+
+  test("collects the embedding key the engine collector does not cover", () => {
+    const declared = collectTaskLogSensitiveValues({
+      env: { CUSTOM_EMBED: "embed-secret-value" },
+      config: { embedding: { apiKey: "${CUSTOM_EMBED}" } },
+    });
+    expect(declared).toContain("embed-secret-value");
+
+    const implicit = collectTaskLogSensitiveValues({
+      env: { AKM_EMBED_API_KEY: "implicit-embed-secret" },
+      config: {},
+    });
+    expect(implicit).toContain("implicit-embed-secret");
+  });
+
+  test("collects a task-declared name at any length, and ignores one that is unset", () => {
+    const values = collectTaskLogSensitiveValues({
+      env: { ACME_DEPLOY: "s3cret" },
+      declaredNames: ["ACME_DEPLOY", "NEVER_EXPORTED"],
+    });
+    expect(values).toContain("s3cret"); // 6 chars, under the inferred floor
+    expect(values).not.toContain(undefined as unknown as string);
+  });
+
+  test("infers an ambient credential from its name once it clears the floor", () => {
+    const values = collectTaskLogSensitiveValues({ env: { ACME_TOKEN: "abcdefghij" } });
+    expect(values).toContain("abcdefghij");
+  });
+
+  test("does NOT infer a short value — the floor applies to guesses only", () => {
+    const values = collectTaskLogSensitiveValues({ env: { ACME_TOKEN: "short" } });
+    expect(values).not.toContain("short");
+    expect("short".length).toBeLessThan(MIN_INFERRED_SECRET_LENGTH);
+  });
+
+  test("leaves ordinary environment values alone, however long", () => {
+    // The regression the naive fix would cause. Every one of these is longer
+    // than the floor; none is a credential, and redacting any of them mangles
+    // the log the operator is reading.
+    const env = {
+      PWD: "/home/user/akm",
+      SHELL: "/bin/bash",
+      LANG: "en_US.UTF-8",
+      SHLVL: "1",
+      TERM: "xterm-256color",
+      NODE_VERSION: "24.3.0",
+      CI: "true",
+      npm_config_registry: "https://registry.npmjs.org/",
+    };
+    expect(collectTaskLogSensitiveValues({ env })).toEqual([]);
+  });
+
+  test("an allowlisted name is not treated as secret even when its shape matches", () => {
+    // LLM_BASE_URL is policy-allowlisted; a plain URL there is configuration.
+    const values = collectTaskLogSensitiveValues({ env: { LLM_BASE_URL: "https://api.example.com/v1" } });
+    expect(values).not.toContain("https://api.example.com/v1");
+  });
+
+  test("end to end: the secret goes, the log survives", () => {
+    const env = {
+      ACME_DEPLOY_TOKEN: "quietly-ordinary-looking-value",
+      PWD: "/home/user/akm",
+      SHLVL: "1",
+      TERM: "xterm-256color",
+    };
+    const values = collectTaskLogSensitiveValues({ env, declaredNames: ["ACME_DEPLOY_TOKEN"] });
+    const output = redactSensitiveText(
+      "Build finished in 12.4s\n3 tests passed, 0 failed\ndeploying with quietly-ordinary-looking-value\nwrote dist/index.js (48 KB)",
+      values,
+    );
+    expect(output).not.toContain("quietly-ordinary-looking-value");
+    expect(output).toContain("Build finished in 12.4s");
+    expect(output).toContain("3 tests passed, 0 failed");
+    expect(output).toContain("wrote dist/index.js (48 KB)");
+  });
+});


### PR DESCRIPTION
## Summary

Three related pieces of 0.9.1 milestone work, all in the "akm tells the truth about secrets and permissions" area.

### 1. `secret-file-perms` is deleted, not narrowed

akm briefly chmodded its own databases and task logs (#756); that enforcement was reverted in `b5a4c6ca` because re-permissioning a directory akm did not create silently broke installs sharing `$XDG_DATA_HOME` across uids. The health advisory that *reported* on those modes is now gone too — it is meaningless on Windows, and nagging about modes akm does not set is not health reporting.

253 lines removed: `collectSecretPermsAdvisory`, `checkPathMode`, `GROUP_OTHER_BITS`, `OFFENDER_EVIDENCE_CAP`, `modeOctal`, `PermOffenderScan`, the `secondaryStashDirs` plumbing in `health.ts`, 5 tests, and the doc claims. `collectSurfacesAdvisories` now takes only `{configPath, config}` — `stashDir`/`extraStashDirs`/`cacheDir`/`platform` existed solely to feed the perms check. `akm health` no longer exits `4` on account of it.

No golden moved, which is correct: golden sandboxes scaffold `env`/`secrets` through akm's own writers at `0700`/`0600`, so the advisory was already silent there.

### 2. The #791 sweep is finished — and it turned up two latent data-loss bugs

`fe44b4d0` fixed the read path. This converts the remaining `fs.existsSync` gates over data-dir / DB / lock / managed-asset paths — but only the ones where "absent" was a **wrong answer that presented as success**. 12 of 22 candidate sites converted; the other 10 were deliberately left alone (fire-and-forget telemetry, a parse cache that falls back to the source of truth, pre-create probes whose syscall is the race-free backstop), with reasons recorded in the commit body.

Two of the conversions are not #791 hygiene but real bugs:

- **`readLockfileOrThrow` was destroying lock records.** Its docstring says it exists so a write path never reads `[]` and overwrites the file — but its `catch` returned `[]` for *any* read failure. With an unreadable `akm.lock`, `mergeLockEntriesSync` replaced the symlink with a regular file containing only the single incoming entry. Every tracked bundle gone, from a permission fault. This is the exact catastrophe R-012 exists to prevent, reached through EACCES instead of corruption.
- **`assertNoPendingMigrationOperation` failed open.** A safety gate answering "I could not tell" as "no recovery pending", letting akm open the canonical databases on top of a half-applied migration.

Also: `akm index --clean` deleted index rows for files it merely could not look at, and reported the deletions as a clean success. `indexWrittenAssets` returned `true` ("index is as you expect") for an index it could not open, on the strength of which `acceptProposal` advanced its journal to `index-finalized`.

Adds `isDataDirUnreadableError` / `rethrowIfDataDirUnreadable` so best-effort catches cannot re-collapse the distinction the classifier just made.

### 3. #755 — exact-value redaction for command task logs

Task logs were scrubbed for credential *shapes* (`Bearer …`, `sk-…`, webhook URLs), but only the prompt and workflow arms also scrubbed exact secret *values*. A scheduled command that echoed a configured secret shaped like nothing in particular persisted it verbatim into both the run `.log` and `logs.db` for the whole retention window.

Exact-value redaction now runs in `persistRunLog`, the one sink all three target kinds funnel through.

**The fix as literally proposed in the issue would have shipped a disaster.** It said to reuse `isEnvPassthroughValueSafeToExpose` over the env handed to the child. That filter fails closed outside a 22-name allowlist — correct where it runs today (the prompt path filters a short, operator-declared `envPassthrough` list) and catastrophic over an inherited environment. Measured: **127 of 132 variables classified as secret, 25 of them with one-character values.** Since redaction is substring replacement:

```
Build finished in 12.4s      ->  Build finished in [REDACTED]2.[REDACTED]s
3 tests passed, 0 failed     ->  [REDACTED] tests passed, [REDACTED] failed
wrote dist/index.js (48 KB)  ->  wrote dist[REDACTED]index.js ([REDACTED]8 KB)
```

So secret values come from three places, and keeping them distinct is the design: config-declared credentials and a task's own `redact:` names are redacted at **any length**; values merely *inferred* from a variable's name must clear an 8-character floor, because that tier is a guess.

`redact:` takes **NAMES, never values** — a task file is indexed into the search database, can be sent to an embedding provider, is printed verbatim by `akm show`, and ships inside bundles over git and npm, so a literal secret there would leak through a far wider channel than the redaction closes. Same rule exec units' `pass_env:` already states, and the same 32-name bound.

Two latent bugs in the redaction primitives, found while measuring the above:

- **`redactSensitiveText` could explode its own output.** The fast path chained `replaceAll` over a *mutating* accumulator, so a needle drawn from the letters of `[REDACTED]` matched tokens it had just inserted. Reproduced: 50 characters against 6 single-letter needles returned **32,450 characters, a 649× blowup** — a memory hazard on any path whose needles come from config or the environment. Matches are now found against the original text and emitted once, which also makes the encoded and plain paths agree on output shape.
- **`redactSensitiveValue` silently dropped fields.** Objects were rebuilt with `Object.fromEntries`, so two keys redacting to the same string kept only the last. Reproduced: `{a: 1, b: 2, ab: 3}` came back with 2 of 3 entries — one *gone*, not redacted. Affected persisted improve results and journaled workflow outcomes. Colliding keys are now suffixed.

**One deliberate departure worth review.** A length floor at the sink was the obvious placement and I did not do it: it would have silently stopped redacting short *declared* secrets that are scrubbed today (a workflow step's `env: { DB_PASS: "hunter2" }`, an agent profile's `env`, a short local-provider LLM key). Fixing the amplification bug removes the hazard the floor was proposed for, without reducing anyone's coverage. The floor applies only to the guessing tier.

## Test plan

Full gates run on the final tree, not per-commit:

| | |
|---|---|
| `bunx tsc --noEmit` | exit 0 |
| `bun run lint` | exit 0 — all 14 custom gates, no baseline touched |
| `bun run test:unit` | **3583 pass / 0 fail** (258 files) |
| `bun run test:integration` | **5141 pass / 0 fail** (402 files) |

Every new test was mutation-verified — reverted the fix, confirmed the test fails, restored:

- Disabling the exact-value pass fails all five #755 leak tests (config-declared credential, name-inferred credential, `redact:` opt-in, `spawn_error` path, secondary bundle).
- Substituting the issue's literal proposal fails the over-redaction guard, producing exactly the mangled output shown above.
- The `redact:` test also asserts the same value **does** leak without the declaration — otherwise it would prove nothing about the opt-in.
- The #791 sweep sites were each mutation-checked individually; the `readLockfileOrThrow` case was verified by direct probe (`PROBE isSymlink: false isFile: true` — the symlink replaced by a one-entry regular file).

Permission tests use an `ELOOP` symlink loop rather than `chmod`, because these suites run as **uid 0** in CI where `chmod 0000` is unenforced and a chmod-only test would pass for the wrong reason.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Lint passes (`bun run lint`)
- [x] Docs updated — `docs/reference/cli.md` (task-log redaction + `redact:`), `schemas/akm-task.json`, CHANGELOG, and `manual-testing-checklist.md` (§24.2 waiver closed, release-gate row flipped to `PASS`)

Closes #755
Closes #791

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLQzxy3jXCFxHcuZ8N8etQ)_