### PR TITLE
Finish the 0.9.1 milestone and cut the release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,9 @@ dist
 .plans
 .dev
 tests/fixtures/openviking/workspace
+# Agent scratch state. `.claude/worktrees/` holds a full checkout per agent and
+# reached 738 MB in one session — without this the Docker release gate ships it
+# all as build context.
+.claude
+.akm
+.akm-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,23 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: bun install --frozen-lockfile
       - run: bun run build
+      # This job's whole point is to prove the binding npm users actually get
+      # works, so it must install the SPEC THE PACKAGE DECLARES rather than a
+      # range of its own. The version is read back out of package.json — the
+      # single source of truth — so the two cannot drift (#790: they had, and
+      # the job spent its time exercising a from-source build of an 11.x that
+      # has no Node 24 prebuild, which aborts at teardown on Node 24.19+).
       - name: Verify the Node fallback
         run: |
-          npm install --no-save better-sqlite3@^11.8.0
+          spec=$(node -p "require('./package.json').optionalDependencies['better-sqlite3']")
+          echo "node-smoke: installing better-sqlite3@$spec (declared in package.json)"
+          # Remove it first. `npm install pkg@version` is a NO-OP when that exact
+          # version is already present and does NOT re-run the install script, so
+          # the binding `bun install` built a moment ago — under whichever node
+          # its `prebuild-install` saw — would otherwise survive into this job
+          # with the wrong ABI. scripts/node-smoke.ts preflights that it loads.
+          rm -rf node_modules/better-sqlite3
+          npm install --no-save "better-sqlite3@$spec"
           bun run test:node-smoke
           bun run test:node-compat
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,16 +80,14 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: bun install --frozen-lockfile
       - run: bun run build
-      # This job's whole point is to prove the binding npm users actually get
-      # works, so it must install the SPEC THE PACKAGE DECLARES rather than a
-      # range of its own. The version is read back out of package.json — the
-      # single source of truth — so the two cannot drift (#790: they had, and
-      # the job spent its time exercising a from-source build of an 11.x that
-      # has no Node 24 prebuild, which aborts at teardown on Node 24.19+).
+      # Installs the SPEC THE PACKAGE DECLARES, read back out of package.json so
+      # the two cannot drift — this job exists to prove the binding npm users
+      # actually get works. Why it is pinned at all: package.json → pinNotes
+      # ["better-sqlite3@12.11.1"] (#790). scripts/node-smoke.ts preflights that
+      # what landed is that exact version and that it loads under this node.
       - name: Verify the Node fallback
         run: |
           spec=$(node -p "require('./package.json').optionalDependencies['better-sqlite3']")
-          echo "node-smoke: installing better-sqlite3@$spec (declared in package.json)"
           # Remove it first. `npm install pkg@version` is a NO-OP when that exact
           # version is already present and does NOT re-run the install script, so
           # the binding `bun install` built a moment ago — under whichever node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -361,6 +361,34 @@ what an upgrader reads first.
 
 ### Fixed
 
+- **akm's Node fallback no longer aborts at teardown on Node 24.** On Node
+  24.19.0 and later, any command that opened a database could intermittently
+  die with `node::RemoveEnvironmentCleanupHook … Assertion (env) != nullptr`
+  and exit 134 — after its work was done, so the failure looked random and
+  depended on garbage-collection timing.
+
+  The cause was upstream and nothing to do with akm's own code.
+  `better-sqlite3` ships one prebuilt binary per Node ABI and falls back to
+  `node-gyp rebuild` when none matches, and the 11.x line publishes no prebuild
+  for Node 24 — so installing it there silently compiled the driver from source.
+  Node 24.19.0 had just changed the public `node_object_wrap.h` so that
+  `ObjectWrap`'s constructor and destructor register and unregister an
+  environment cleanup hook; a binding compiled against those headers
+  unregisters the hook after the environment is already gone, and aborts from
+  V8's teardown path. Only the Node 24 line was affected, and only from that
+  release on.
+
+  akm now pins `better-sqlite3` to `12.11.1`, which publishes prebuilt binaries
+  for Node 22, 24, 25 and 26 — so no Node version akm supports compiles the
+  driver at all. This affected real installs, not just CI: an npm user on Node
+  24 LTS was getting the same crash-prone from-source build.
+
+  The Node-fallback CI job now installs the exact spec `package.json` declares
+  instead of carrying a range of its own, and both that job and the smoke
+  script fail loudly on a native crash banner — previously an abort was
+  reported only as missing output, and the one step that tolerates a non-zero
+  exit would not have failed at all.
+
 - **A website source interrupted mid-refresh no longer loses the snapshot it
   already had.** A refresh deleted the whole mirror and then rebuilt it page by
   page, so a process killed inside that loop left an empty or partial directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -401,9 +401,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     is dead" are opposite facts, and `akm improve` now stops rather than
     reclaiming a lease that may be genuinely held.
 
-- **akm does not manage file permissions, and no longer reports on them
-  either.** Everything akm writes takes your process umask; the mode of your
-  data directory is yours to set, and `chmod`/`umask` are your levers.
+- **akm no longer manages permissions on your data directory, its databases, or
+  your task logs — and no longer reports on them either.** Those take your
+  process umask; their mode is yours to set, and `chmod`/`umask` are your
+  levers.
+
+  This is scoped, not blanket: akm still creates a handful of files at
+  restrictive modes *at creation time*, as it always has — `env` and `secret`
+  assets and config backups at `0600`, their directories at `0700`, and the
+  scheduler invocation files it writes for cron/launchd/schtasks. Those are
+  files akm authors itself and whose contents are credentials; setting their
+  mode when creating them is not the same as re-permissioning a directory you
+  already owned.
 
   Two 0.9.1 pre-release changes are gone. The first chmodded akm's databases
   and task logs to `0600`/`0700` on every open — reverted because

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,57 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-08-13
+
+### Breaking changes & migration
+
+The 0.9.x series carries breaking changes as it works toward the 0.10.x
+stabilization line. Every item here is detailed further down; this section is
+what an upgrader reads first.
+
+- **A data directory akm cannot READ is now an error, not an empty result.**
+  Commands that previously returned `hits: []` / `entryCount: 0` / "nothing
+  eligible" at exit 0 for an index, lockfile or database they lacked permission
+  on now raise `DATA_DIR_UNREADABLE` (exit 78) naming the path, errno, mode,
+  owner and running uid. *Affected:* anyone whose data dir is partly unreadable
+  — most often a `$XDG_DATA_HOME` shared across uids. *Remedy:* fix the
+  ownership or mode the error names, or point `AKM_DATA_DIR` somewhere this
+  user owns. The old behaviour was a false success, so a script that treated
+  exit 0 as "no results" was already being lied to.
+
+- **Lockfile writes refuse to run against an unreadable `akm.lock`.**
+  `akm bundle add` / `remove` / `update` now fail closed instead of reading the
+  lock as empty and writing the single incoming entry over the whole record.
+  *Remedy:* as above. This one prevented real data loss — see Fixed.
+
+- **`akm workflow run` exits 1 when a run ends `blocked`.** Previously 0.
+  *Affected:* CI steps and scheduled wrappers that branched only on `failed`.
+  *Remedy:* treat nonzero as "not verified"; resume with
+  `akm workflow resume <id>`.
+
+- **`akm index --clean` no longer deletes entries whose file it cannot read.**
+  It keeps and names them. *Affected:* anyone relying on `--clean` to prune
+  aggressively; it is now conservative where it cannot see.
+
+- **Workflow documents are bounds-checked at authoring time.** `engine:` name
+  grammar, `retry.max` 0–100, `gate.max_loops` 1–100, `map.concurrency` and
+  `engines.<name>.concurrency` 1–64, and any `timeout:` ≤ 2 147 483 647 ms are
+  now enforced by the parser. *Affected:* documents that parsed at 0.9.0 but
+  could never actually run — the frozen-plan decoder already refused them.
+  *Remedy:* edit the offending field; the error is now line-anchored.
+
+- **`akm health` no longer emits `secret-file-perms`, and no longer exits 4 for
+  it.** The check is gone. *Affected:* anything parsing health output for that
+  check name.
+
+- **Command-target task logs are now redacted.** Output that previously
+  persisted verbatim may now contain `[REDACTED]`. *Affected:* anything
+  grepping task logs for values that are now recognised as secrets.
+
+- **Leftover `isolation: worktree` trees are garbage-collected after 7 days.**
+  *Remedy:* copy anything you want to keep out of a retained worktree within a
+  week.
+
 ### Added
 
 - **`exec` workflow units — run a shell command as a workflow step.** A step
@@ -147,6 +198,48 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **`akm workflow run` now exits non-zero when the run ends `blocked`.** A
+  verification judge that throws, cannot be resolved, or returns a malformed
+  verdict stops the run `blocked` — unverified, and resumable with `akm
+  workflow resume <id>`. That previously exited 0, so a CI step or scheduled
+  wrapper read an unverified run as a passing one. It now exits 1, matching
+  `failed` and gate rejections, and matching how the scheduled-task path
+  already reported it.
+
+- **Workflow dispatch bounds are enforced at authoring time, not only by the
+  frozen-plan decoder.** `engine:` names must match the decoder's own grammar
+  (lowercase dash-separated letters/digits, starting with a letter, ≤63
+  chars); `retry.max` is 0–100; `gate.max_loops` is 1–100; `map.concurrency`
+  and `engines.<name>.concurrency` are 1–64; any `timeout:` must resolve to at
+  most 2 147 483 647 ms (~24.8 days, `setTimeout`'s 32-bit ceiling). Every one
+  of these was already refused by the frozen-plan decoder, so such a document
+  could never actually run — but it *parsed*, so `akm lint`, `akm workflow
+  show` and `akm workflow create` all reported it clean and the failure arrived
+  at `workflow run` as an unlocated "Invalid frozen workflow plan". The error is
+  now line-anchored at parse time. Nothing changes for a document already
+  inside the bounds.
+
+- **`akm lint` gained an advisory channel.** The result envelope carries
+  `warnings: LintIssue[]` alongside `fixed`/`flagged`, `summary` gains a
+  `warnings` count, and text output prints a `warnings` section. Advisories
+  never route into `flagged`, so `--fail-on-flagged` cannot fail a run over
+  one. Workflow compile advisories (`workflow-warning`) are surfaced for the
+  first time — a step with no `output:` schema, a `params.<name>` reference to
+  an undeclared param, a `gate.max_loops` above 1 on an `exec` step — so a
+  bundle that linted clean at 0.9.0 may now report warnings without becoming a
+  failure. Findings that know a location carry `line` in `--format json` and
+  render as `file:line` in text. A new `lint-failed` code reports a file the
+  sweep reached but could not finish.
+
+- **Leftover `isolation: worktree` trees are now garbage-collected.** A run
+  that crashed, or one whose worktree was retained after a dirty unit, used to
+  leave its tree under the worktrees root forever. akm now opportunistically
+  removes such trees once they are 7 days old, confined to the worktrees root,
+  symlinks skipped, containment re-checked. A worktree still in use is never
+  collected: every live tree carries a liveness marker (pid, host, resolved
+  path) in git's administrative directory for it, and the sweep skips a
+  candidate whose holder is still running here.
+
 - **The workflow JSON Schema subset now enforces `allOf`/`anyOf`/`oneOf`/`not`.**
   A step `output:` or `params:` schema may use the combinators, and the runtime
   now evaluates them. Previously it ignored them: a schema using one was
@@ -267,6 +360,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   journal and hold across resumes.
 
 ### Fixed
+
+- **A website source interrupted mid-refresh no longer loses the snapshot it
+  already had.** A refresh deleted the whole mirror and then rebuilt it page by
+  page, so a process killed inside that loop left an empty or partial directory
+  with the old content already gone — and the freshness marker still looked
+  recent, so the next `sync()` served the wreckage instead of rebuilding. The
+  new snapshot is built in a dot-prefixed sibling directory and swapped in with
+  renames: an interrupted refresh leaves the PREVIOUS complete snapshot
+  untouched. Abandoned staging directories are dot-prefixed so the indexer's
+  walk skips them, and are swept by the next refresh once an hour old.
+
+- **A resumed workflow run no longer re-dispatches work that already ran.** The
+  single-driver guard was checked at the run level, so a run whose lease had
+  been stolen left its still-owned unit row `running` and discarded the real
+  outcome — the resume then re-dispatched a unit that had already executed its
+  side effects and already spent its tokens. The guard now lives on the row, so
+  a stale driver's finish matches nothing and a live outcome is never dropped.
+
+- **Lowering `retry.max` no longer re-runs finished work.** The completed-attempt
+  scan matched only attempts the *current* retry policy could have produced, so
+  reducing `retry.max` between invocations hid a journaled `~rN` row and the
+  unit was dispatched again. It now matches any journaled attempt of the unit.
 
 - **A scheduled `command` task no longer writes your secrets into its log.**
   Task logs were scrubbed for credential *shapes* — `Bearer …`, `sk-…`, webhook
@@ -401,6 +516,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     is dead" are opposite facts, and `akm improve` now stops rather than
     reclaiming a lease that may be genuinely held.
 
+  The same conflation existed on the write paths, where the consequence was
+  worse than a wrong answer:
+
+  - **An unreadable `akm.lock` could destroy every bundle record in it.** The
+    lockfile read that exists specifically so a write path never sees `[]`
+    returned `[]` for *any* read failure, permission errors included — and
+    every lockfile write is read-modify-write, so the next atomic write
+    replaced the operator's whole lock record with the single entry being
+    added. Verified by probe: the symlink was replaced by a regular file
+    holding one entry. Lockfile writes now refuse to run against a lock they
+    cannot read.
+  - **The migration recovery gate failed open.** "I cannot tell whether a
+    recovery is pending" cleared the gate exactly as "no recovery is pending"
+    did, so akm would open the canonical databases on top of a half-applied
+    migration. It now fails closed.
+  - **`akm index --clean` deleted rows for files it merely could not look at**,
+    and reported the deletions as a clean success. Unreadable entries are now
+    kept and named.
+  - `indexWrittenAssets` returned `true` — "the index is as you expect" — for
+    an index it could not open, on the strength of which `acceptProposal`
+    advanced its journal to `index-finalized`.
+  - `akm improve` eligibility, `akm feedback`, `akm bundle list` and the graph
+    loaders each turned a permission fault into an empty result, a zero count,
+    or the advice to "Run `akm index` first".
+
 - **akm no longer manages permissions on your data directory, its databases, or
   your task logs — and no longer reports on them either.** Those take your
   process umask; their mode is yours to set, and `chmod`/`umask` are your
@@ -527,6 +667,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   and order-preserving; a compile pass that filtered or reordered steps would
   have silently applied one step's overrides to another. Attribution is now
   keyed by `stepId`.
+
+### Security
+
+- **A gate judge's response is now scrubbed before it is journaled.** The judge
+  verdict is written into the gate row's `result_json`, and a judge failure's
+  message becomes the blocked step's notes — but the judge dispatch bypassed
+  the redaction contract every unit dispatch goes through, so a judge that
+  echoed a credential out of the promoted artifact persisted it unredacted into
+  the workflow journal. Both judge paths (agent and llm) now wrap their
+  dispatch in the same scrub, with the sensitive-value set collected per
+  dispatch rather than at build time, so a credential rotated between the two
+  reads is still caught. The dispatch also carries the real run/step/gate ids
+  instead of a synthetic `"gate"` placeholder, so a gate row and its telemetry
+  describe the same thing.
+
+- **Command-target task logs are scrubbed of exact secret values**, closing the
+  last redaction lane — see the `### Fixed` entry above for the full account.
 
 ## [0.9.0] - 2026-08-06
 

--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
       },
       "optionalDependencies": {
         "@huggingface/transformers": "^4.2.0",
-        "better-sqlite3": "^11.8.0",
+        "better-sqlite3": "12.11.1",
         "sqlite-vec": "^0.1.9",
       },
     },
@@ -152,7 +152,7 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "better-sqlite3": ["better-sqlite3@11.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ=="],
+    "better-sqlite3": ["better-sqlite3@12.11.1", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA=="],
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 

--- a/docs/architecture/testing/manual-testing-checklist.md
+++ b/docs/architecture/testing/manual-testing-checklist.md
@@ -2862,7 +2862,15 @@ bun test --timeout=120000 \
   tests/integration/npm-bin-contract.test.ts
 
 bun run build
-npm install --no-save better-sqlite3@^11.8.0
+# Install the exact spec package.json declares — never a range of your own.
+# better-sqlite3 compiles from source whenever there is no prebuilt binary for
+# the running Node's ABI, and a from-source build against Node 24.19+ headers
+# aborts at teardown (#790). CI does the same read-back. Remove it first:
+# `npm install pkg@version` is a no-op when that version is already installed
+# and will NOT rebuild the binding for the Node you are about to test with.
+rm -rf node_modules/better-sqlite3
+npm install --no-save \
+  "better-sqlite3@$(node -p "require('./package.json').optionalDependencies['better-sqlite3']")"
 AKM_SMOKE_NODE=node bun run test:node-smoke
 AKM_SMOKE_NODE=node bun run test:node-compat
 ```

--- a/docs/architecture/testing/manual-testing-checklist.md
+++ b/docs/architecture/testing/manual-testing-checklist.md
@@ -3014,8 +3014,10 @@ bun run release:check
       `src/commands/sources/migration-help.ts:84` resolves release notes by
       skipping the `Unreleased` heading, so shipping an un-renamed section makes
       the released binary's `akm help migrate latest` report the PREVIOUS
-      release's notes. Nothing in `release.yml`, `tests/release-check.sh` or any
-      lint gate enforces this; it is checked here or not at all.
+      release's notes. Enforced by `tests/integration/workflow-release.test.ts`
+      ("the changelog is cut…"), which `tests/release-check.sh` runs as
+      `run_step "Workflow Release Contract"` — so a missed cut fails the release
+      gate rather than depending on this checklist being read.
 - [ ] **[RELEASE]** Official workflow input version equals committed package
       version and targets the tested SHA. Stable uses npm `latest`; prerelease
       uses `next` and GitHub prerelease.

--- a/docs/architecture/testing/manual-testing-checklist.md
+++ b/docs/architecture/testing/manual-testing-checklist.md
@@ -2999,6 +2999,15 @@ bun run release:check
       partial unless a separate exact-commit matrix transcript exists.
 - [ ] **[RELEASE]** Run slow migration/workflow property gates separately with
       `AKM_RUN_SLOW_TESTS=1` and their 20-minute timeout.
+- [ ] **[RELEASE]** Cut the changelog BEFORE triggering the workflow: bump
+      `package.json` `version`, rename `## [Unreleased]` to
+      `## [<version>] - <YYYY-MM-DD>`, and leave a fresh empty `## [Unreleased]`
+      above it. This is functional, not cosmetic —
+      `src/commands/sources/migration-help.ts:84` resolves release notes by
+      skipping the `Unreleased` heading, so shipping an un-renamed section makes
+      the released binary's `akm help migrate latest` report the PREVIOUS
+      release's notes. Nothing in `release.yml`, `tests/release-check.sh` or any
+      lint gate enforces this; it is checked here or not at all.
 - [ ] **[RELEASE]** Official workflow input version equals committed package
       version and targets the tested SHA. Stable uses npm `latest`; prerelease
       uses `next` and GitHub prerelease.

--- a/docs/architecture/testing/manual-testing-checklist.md
+++ b/docs/architecture/testing/manual-testing-checklist.md
@@ -3182,9 +3182,11 @@ remaining gaps carry approved waivers with the expiries recorded below.
     full run heals them); whether to surface that gap at write time is a 0.10
     placement-era product decision, not a regression — tracked in
     [#772](https://github.com/itlackey/akm/issues/772).
-- [ ] **Durability:** atomic reader-visible index generations, live-lock age,
+- [x] **Durability:** atomic reader-visible index generations, live-lock age,
       full source lifecycle rollback, safe website/npm refresh, strict lockfile,
       registry stale fallback, and sync/write serialization.
+      **Closed for 0.9.1** — the last open item (#758) landed; see the
+      per-item history below.
   - Covered: strict lockfile (`tests/integration/lockfile.test.ts` corrupt-
     lockfile fail-closed + CAS cases).
   - **Fixed 2026-08-06** (fix-now directed at 0.9.0 triage): registry stale
@@ -3222,20 +3224,32 @@ remaining gaps carry approved waivers with the expiries recorded below.
       code: publication is two renames, so a kill in that one-syscall window
       leaves the mirror absent — `requireStashDir` callers refresh immediately,
       others recover on the next expiry or `--force`.
-  - Open: full source lifecycle rollback (no test walks
-    add→blocked-install→rollback against a dangerous fixture).
-  - Tracking: [#758](https://github.com/itlackey/akm/issues/758) (blocked-install rollback).
-  - issue: one recovery-path coverage gap (blocked-install rollback). impact:
-    the mixed-website-snapshot outcome this waiver was written for is now
-    fixed, not merely mitigated; what remains is untested rollback on a
-    blocked install, recoverable by re-running `akm bundle add`. owner:
-    itlackey. verification test: a test walking add→blocked-install→rollback
-    against a dangerous fixture, asserting config.json/akm.lock parity.
-    temporary mitigation: all paths recover via re-run (`akm bundle update`,
-    `akm index --full`); the dangerous-env audit already blocks the install
-    itself, so rollback fidelity is the only untested part.
-    waiver approver: itlackey — approved 2026-08-06 (0.9.0 release triage).
-    waiver expiry: 0.9.1.
+  - **Closed for 0.9.1** ([#758](https://github.com/itlackey/akm/issues/758)):
+    full source lifecycle rollback — the waiver's named verification test now
+    exists as `tests/integration/vault-dangerous-key-blocked-install-rollback.test.ts`.
+    It drives the real `akm bundle add` CLI end-to-end against a materialized
+    copy of `tests/fixtures/manual-qa/dangerous-bundle/` (whose
+    `env/runtime.env` carries `NODE_OPTIONS`), non-TTY and without
+    `--allow-insecure`, and asserts every lifecycle surface after the block:
+    **byte-level** parity of `config.json` and `akm.lock`, no surviving content
+    root, and no orphaned index row. Three workspace states are covered —
+    pristine, pre-existing operator config, and a bundle already installed —
+    the last of which pins the other direction too: a rollback that reverts
+    the FIRST bundle's records is as wrong as one that leaves the refused
+    bundle's behind.
+    Rollback was found already correct in every case constructible here; the
+    test's value is as a pin, so it was mutation-verified against five separate
+    breaks (skip the rollback; drop `removeLockEntry`; delete every bundle
+    instead of the target; leave the content root; skip the post-rollback
+    reindex) and fails on each.
+  - Residue accepted by design, asserted explicitly rather than left implicit:
+    (a) on a pristine workspace the attempt still SCAFFOLDS `config.json` and
+    `akm.lock` — the config/lock writers create their file on first mutation —
+    so the test pins that the created `config.json` deep-equals `DEFAULT_CONFIG`
+    with no `bundles` key and that `akm.lock` is the empty array, rather than
+    asserting absence; (b) the events stream keeps the `add` event for the
+    refused ref, because it is an append-only audit log of ATTEMPTS and an
+    operator investigating a blocked install needs it on record.
 - [ ] **Security:** Git/direct-write symlink containment, authenticated OpenCode
       listener, registry credential/control-data redaction, archive expansion
       budgets, universal redirect/SSRF policy, and unsuppressible update audit.

--- a/docs/architecture/testing/manual-testing-checklist.md
+++ b/docs/architecture/testing/manual-testing-checklist.md
@@ -2801,7 +2801,7 @@ Current known failing gates must be fixed or explicitly waived with expiry:
 | Source lifecycle rollback across config/lock/root/index/events | `FAIL` until atomic/recoverable |
 | OpenCode local-listener authentication/documentation | `FAIL` until authenticated |
 | Exact-value command-target task-log redaction | `PASS` — fixed in 0.9.1 (#755) |
-| Package-manager upgrade exact-version verification | `FAIL` until verified |
+| Package-manager upgrade exact-version verification | `PASS` — fixed 2026-08-06 (`self-update.ts`) |
 
 ---
 
@@ -3262,8 +3262,11 @@ remaining gaps carry approved waivers with the expiries recorded below.
     install; opencode listener binds loopback only. waiver approver:
     itlackey — approved 2026-08-06 (0.9.0 release triage). waiver expiry:
     0.10.0 (hardening series).
-- [ ] **Secrets/permissions:** exact-value task-log redaction; managed-file
-      permission coverage (rejected — see below).
+- [x] **Secrets/permissions:** exact-value task-log redaction; managed-file
+      permission coverage (rejected — see below). **Row closed in 0.9.1:** both
+      halves are resolved — the redaction gap is fixed, and permission
+      management is a rejected concept rather than outstanding work. No waiver
+      remains on this row.
   - Covered: exact-value redaction for prompt-target and workflow-target task
     logs (`tests/integration/tasks-runner.test.ts` "redacts echoed agent
     credentials before task logs are persisted", webhook-URL case).
@@ -3305,6 +3308,13 @@ remaining gaps carry approved waivers with the expiries recorded below.
     binary). Fail-open only when verification itself is unavailable.
     (`src/commands/sources/self-update.ts`; pinned in
     `tests/integration/self-update.test.ts`.)
+  - **Fixed** ([#771](https://github.com/itlackey/akm/issues/771), 0.9.1):
+    publication is gated on the real release-acceptance script.
+    `.github/workflows/release.yml` runs `./tests/release-check.sh
+    --skip-docker` before version-verify/build/publish, so the npm bin shim,
+    the migration bundle under both the Bun and Node entry points, and the
+    packed-artifact install are all checked by CI instead of depending on the
+    operator remembering `bun run release:check` locally.
   - Partial: installer coverage (install.sh harness-tested;
     install.ps1 manual-only), native scheduler (Linux standalone covered via
     release-check; macOS/Windows suites unreachable — no such CI runner).
@@ -3313,8 +3323,7 @@ remaining gaps carry approved waivers with the expiries recorded below.
     release assets).
   - Tracking: [#768](https://github.com/itlackey/akm/issues/768) (SHA-pin actions),
     [#769](https://github.com/itlackey/akm/issues/769) (post-publish artifact parity),
-    [#770](https://github.com/itlackey/akm/issues/770) (install.ps1 + macOS/Windows scheduler coverage),
-    [#771](https://github.com/itlackey/akm/issues/771) (gate publish on release-check.sh).
+    [#770](https://github.com/itlackey/akm/issues/770) (install.ps1 + macOS/Windows scheduler coverage).
   - issue: release-infrastructure hardening. impact: a clobbered release
     asset ships silently; tag-hijack of a third-party action could
     compromise the release job. owner: itlackey. verification test: per-item

--- a/docs/architecture/testing/manual-testing-checklist.md
+++ b/docs/architecture/testing/manual-testing-checklist.md
@@ -2733,8 +2733,9 @@ test "$(akm log --format json | jq -r '.events[-1].id // 0')" = "$before_event"
 - [ ] **[LOCAL]** JSON/YAML stay parseable; text/Markdown visibly encode terminal
       controls; HTML escapes attacker fields. Inspect captured bytes only.
 - [ ] **[LOCAL]** Env/secret directories and files akm creates are `0700`/`0600`
-      even under umask 022. Databases, task logs, and everything else akm writes
-      take the process umask: akm neither sets nor reports on those modes.
+      even under umask 022, as are config backups and scheduler invocation
+      files. The data directory, the databases and their sidecars, and per-run
+      task logs take the process umask: akm neither sets nor reports on those.
 - [ ] **[PLATFORM]** Windows ACL evidence replaces POSIX mode checks and is marked
       N/A only when genuinely unsupported.
 
@@ -3293,9 +3294,13 @@ remaining gaps carry approved waivers with the expiries recorded below.
     operator owns — on the most-traveled path in the CLI, including read-only
     opens — silently converted legacy `0755` data dirs and broke installs
     sharing `$XDG_DATA_HOME` across uids, which worked in 0.9.0.
-    **Decision: akm does not manage file permissions.** Everything it writes
-    takes the process umask; protecting the data directory is the operator's
-    call and umask/`chmod` is their lever. Nothing survives from that work:
+    **Decision: akm does not manage permissions on the data directory, the
+    databases, or task logs.** Those take the process umask; protecting the
+    data directory is the operator's call and umask/`chmod` is their lever.
+    This is scoped, not blanket — akm still creates `env`/`secret` assets,
+    config backups and scheduler invocation files at `0600`/`0700` at creation
+    time, which is a different act from re-permissioning a directory the
+    operator already owned. Nothing survives from that work:
     the health advisory that reported on those modes is gone too — akm does not
     nag about permissions it does not set.
   - **Fixed** ([#755](https://github.com/itlackey/akm/issues/755), 0.9.1).

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "license": "MPL-2.0",
   "pinNotes": {
-    "@opencode-ai/sdk@1.2.20": "Exact pin. The SDK surface we use (createOpencodeClient + session.create/prompt/delete in src/integrations/harnesses/opencode-sdk/sdk-runner.ts) is stable across 1.x, but the SDK has shipped 5+ minor versions of unrelated provider/registry churn. akm-cli is a global CLI install so the pin is isolated from user-project deps. Re-test sdk-runner before bumping. Note this package is an HTTP client only — it declares no dependencies and its own createOpencodeServer spawns `opencode serve` — so it does NOT make the opencode binary available; that install is separate and is what every SDK-path probe checks for."
+    "@opencode-ai/sdk@1.2.20": "Exact pin. The SDK surface we use (createOpencodeClient + session.create/prompt/delete in src/integrations/harnesses/opencode-sdk/sdk-runner.ts) is stable across 1.x, but the SDK has shipped 5+ minor versions of unrelated provider/registry churn. akm-cli is a global CLI install so the pin is isolated from user-project deps. Re-test sdk-runner before bumping. Note this package is an HTTP client only — it declares no dependencies and its own createOpencodeServer spawns `opencode serve` — so it does NOT make the opencode binary available; that install is separate and is what every SDK-path probe checks for.",
+    "better-sqlite3@12.11.1": "Exact pin (#790). This is the SQLite driver akm loads on Node (src/storage/database.ts); Bun never touches it. The pin is about PREBUILT BINARIES, not API surface. better-sqlite3 ships one prebuild per Node ABI as a GitHub release asset and its install script is `prebuild-install || node-gyp rebuild` — so any (version, Node ABI) pair with no prebuild silently COMPILES FROM SOURCE against the headers of whatever Node is on the machine that day. The 11.x line predates Node 24 and declares no `engines` at all: its newest release (11.10.0, 2025-05-08) publishes ABI 108/115/127/131 (Node 18/20/22/23) and nothing for ABI 137 (Node 24). Node 24.19.0 then changed the public `node_object_wrap.h` so `node::ObjectWrap`'s ctor/dtor register and unregister an environment cleanup hook; a from-source 11.x build against those headers aborts at teardown in `Statement::~Statement()` with `RemoveEnvironmentCleanupHook ... Assertion (env) != nullptr`, intermittently, depending on GC timing. 12.11.1 publishes ABI 127/137/141/147 (Node 22/24/25/26) and declares `engines: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x`, so every Node akm supports installs a prebuilt binary and never compiles. Before bumping: confirm the target version publishes a prebuild for EVERY Node major in `engines` (probe https://github.com/WiseLibs/better-sqlite3/releases/download/vX.Y.Z/better-sqlite3-vX.Y.Z-node-vABI-linux-x64.tar.gz), not just that the version is newer. 13.x is the eventual destination — it moved to node-addon-api/N-API with prebuilds bundled in the npm tarball and no install script, which retires this failure mode entirely — but it is a fresh major rewrite of the binding, so it wants its own soak, not a patch release. The CI node-smoke job installs this exact string by reading it back out of this file (.github/workflows/ci.yml), so the two cannot drift."
   },
   "files": [
     "dist",
@@ -106,7 +107,7 @@
   },
   "optionalDependencies": {
     "@huggingface/transformers": "^4.2.0",
-    "better-sqlite3": "^11.8.0",
+    "better-sqlite3": "12.11.1",
     "sqlite-vec": "^0.1.9"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akm-cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "description": "akm (Agent Knowledge Manager) — a portable, local-first capability library for AI agents. Discover, load, share, and improve reusable skills, scripts, workflows, and knowledge across any shell-capable coding agent, including Claude Code, OpenCode, and Cursor.",
   "keywords": [

--- a/scripts/node-runtime-markers.ts
+++ b/scripts/node-runtime-markers.ts
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Failure markers shared by the two gates that guard akm's Node fallback:
+ * `scripts/node-smoke.ts` and `tests/integration/node-compat.test.ts`.
+ *
+ * They exist in one place because both run in the same CI step
+ * (`bun run test:node-smoke && bun run test:node-compat`) and because the
+ * strings are UPSTREAM-owned — Node's crash banner and its error codes can
+ * change across majors. Duplicated, the two gates drift on that change: one
+ * keeps matching and one silently stops, and the step still reports green from
+ * the half that works. That is the shape of #790 itself, where a native abort
+ * was reported only as "stdout missing expected substring" and got re-run
+ * rather than diagnosed.
+ *
+ * Test/CI only — deliberately under `scripts/` rather than `src/`, so it is not
+ * shipped in the published bundle. Tests importing from `scripts/` is the
+ * established direction here (see tests/integration/package-install.test.ts);
+ * no script imports from `tests/`.
+ */
+
+/**
+ * Node's own banner when a native addon aborts the process (SIGABRT).
+ *
+ * Not a boundary leak — nothing in akm's JS produced it — but just as hard a
+ * failure, and one both gates previously swallowed whenever the command had
+ * already flushed enough stdout to satisfy their assertions.
+ */
+export const NATIVE_CRASH_MARKER = "----- Native stack trace -----";
+
+/**
+ * A Node-branch regression in the runtime boundary surfaces as one of these
+ * even when the command still prints a usable result, so they are hard
+ * failures rather than warnings.
+ *
+ * `appendEvent failed` is akm's own, not Node's: it is how a storage write that
+ * fails only on the Node path announces itself.
+ */
+export const BOUNDARY_MARKERS = [
+  "Bun is not defined",
+  "ERR_MODULE_NOT_FOUND",
+  "ERR_UNKNOWN_FILE_EXTENSION",
+  "appendEvent failed",
+] as const;

--- a/scripts/node-smoke.ts
+++ b/scripts/node-smoke.ts
@@ -30,21 +30,78 @@
 // shells out to `node`.
 
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { satisfies } from "semver";
 
 const repoRoot = path.resolve(import.meta.dir, "..");
 const cliEntry = path.join(repoRoot, "dist", "cli-node.mjs");
 const nodeBin = process.env.AKM_SMOKE_NODE ?? "node";
 
 // Fail fast with a clear message if the build artifact is missing.
+if (!existsSync(cliEntry)) {
+  console.error(`node-smoke: missing build artifact ${cliEntry} — run \`bun run build\` first.`);
+  process.exit(1);
+}
+
+/**
+ * Preflight the native SQLite binding before running a single step (#790).
+ *
+ * Two ways this suite can end up exercising the wrong binding, both of which
+ * used to surface only as a downstream mystery — an opaque `Unable to acquire
+ * config lock: … was compiled against a different Node.js version` from some
+ * unrelated command, or a teardown crash reported as a missing substring:
+ *
+ *   1. WRONG VERSION. `better-sqlite3` compiles from source whenever there is
+ *      no prebuilt binary for the running Node's ABI, and a from-source build
+ *      against Node 24.19+ headers aborts at teardown. The version under test
+ *      must therefore be the one package.json declares, not whatever happened
+ *      to be resolved.
+ *   2. WRONG ABI. `npm install <pkg>@<version>` is a NO-OP when that exact
+ *      version is already present — it does not re-run the install script. So
+ *      a binding built for a different Node (e.g. by `bun install`, whose
+ *      `prebuild-install` runs under whichever `node` is on PATH) survives
+ *      unrebuilt into a run against a different `AKM_SMOKE_NODE`.
+ *
+ * Loading the module under the smoke's own `node` catches both.
+ */
 {
-  const fs = await import("node:fs");
-  if (!fs.existsSync(cliEntry)) {
-    console.error(`node-smoke: missing build artifact ${cliEntry} — run \`bun run build\` first.`);
+  const declared = (
+    JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf8")) as {
+      optionalDependencies?: Record<string, string>;
+    }
+  ).optionalDependencies?.["better-sqlite3"];
+  const probe = spawnSync(
+    nodeBin,
+    [
+      "-e",
+      "const v=require('better-sqlite3/package.json').version;" +
+        "const D=require('better-sqlite3');new D(':memory:').close();" +
+        "process.stdout.write(v+' '+process.versions.modules)",
+    ],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+  if (probe.status !== 0) {
+    console.error(
+      "node-smoke: could not load 'better-sqlite3' under the smoke's node.\n" +
+        `  Install the declared binding for this runtime:\n` +
+        `    rm -rf node_modules/better-sqlite3 && npm install --no-save better-sqlite3@${declared ?? "<see package.json>"}\n` +
+        `  ${(probe.stderr ?? "").trim().split("\n").slice(0, 8).join("\n  ")}`,
+    );
     process.exit(1);
   }
+  const [installed = "", abi = ""] = probe.stdout.trim().split(" ");
+  if (declared && !satisfies(installed, declared)) {
+    console.error(
+      `node-smoke: better-sqlite3@${installed} is installed but package.json declares ${declared}.\n` +
+        "  This job exists to prove the binding npm users actually get works, so it must test\n" +
+        "  the declared spec. Reinstall it (npm skips its install script when the version already\n" +
+        `  matches): rm -rf node_modules/better-sqlite3 && npm install --no-save better-sqlite3@${declared}`,
+    );
+    process.exit(1);
+  }
+  console.log(`node-smoke: better-sqlite3 = ${installed} (node abi ${abi})`);
 }
 
 const root = mkdtempSync(path.join(tmpdir(), "akm-node-smoke-"));
@@ -109,6 +166,17 @@ function step(label: string, args: string[], opts: StepOptions = {}): string {
   if (opts.expect && !out.includes(opts.expect)) {
     ok = false;
     problems.push(`stdout missing expected substring ${JSON.stringify(opts.expect)}`);
+  }
+  // A native addon that aborts (SIGABRT) prints Node's own crash banner. #790:
+  // a `better-sqlite3` built from source against Node 24.19+ headers died in
+  // `Statement::~Statement()` at teardown, and this script reported it only as
+  // `stdout missing expected substring` — while the `search` step, which allows
+  // a non-zero exit, would not have failed at all. Name the crash for what it
+  // is so the next one is diagnosed instead of re-run.
+  if (err.includes("----- Native stack trace -----")) {
+    ok = false;
+    const assertion = err.split("\n").find((l) => l.includes("Assertion failed") || l.includes("FATAL ERROR"));
+    problems.push(`native crash under node${assertion ? `: ${assertion.trim()}` : ""}`);
   }
   // A Node-branch regression in the runtime boundary surfaces as these messages
   // even when the command still prints a result — treat them as hard failures.

--- a/scripts/node-smoke.ts
+++ b/scripts/node-smoke.ts
@@ -33,7 +33,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { satisfies } from "semver";
+import { BOUNDARY_MARKERS, NATIVE_CRASH_MARKER } from "./node-runtime-markers";
 
 const repoRoot = path.resolve(import.meta.dir, "..");
 const cliEntry = path.join(repoRoot, "dist", "cli-node.mjs");
@@ -72,6 +72,18 @@ if (!existsSync(cliEntry)) {
       optionalDependencies?: Record<string, string>;
     }
   ).optionalDependencies?.["better-sqlite3"];
+  // Absent means package.json changed shape, not that the check is optional.
+  // Threading `declared` through as possibly-undefined bought a degraded mode
+  // where the probe passes, the version check is silently skipped, and the
+  // script continues green — which is the outcome this preflight exists to
+  // prevent.
+  if (!declared) {
+    console.error(
+      "node-smoke: package.json declares no optionalDependencies['better-sqlite3'] — cannot verify the binding.",
+    );
+    process.exit(1);
+  }
+  const remedy = `rm -rf node_modules/better-sqlite3 && npm install --no-save better-sqlite3@${declared}`;
   const probe = spawnSync(
     nodeBin,
     [
@@ -86,18 +98,23 @@ if (!existsSync(cliEntry)) {
     console.error(
       "node-smoke: could not load 'better-sqlite3' under the smoke's node.\n" +
         `  Install the declared binding for this runtime:\n` +
-        `    rm -rf node_modules/better-sqlite3 && npm install --no-save better-sqlite3@${declared ?? "<see package.json>"}\n` +
+        `    ${remedy}\n` +
         `  ${(probe.stderr ?? "").trim().split("\n").slice(0, 8).join("\n  ")}`,
     );
     process.exit(1);
   }
-  const [installed = "", abi = ""] = probe.stdout.trim().split(" ");
-  if (declared && !satisfies(installed, declared)) {
+  const [installed, abi] = probe.stdout.trim().split(" ");
+  // EXACT equality, not a semver range match. `declared` is an exact pin by
+  // policy (package.json → pinNotes), and #790's whole lesson is that a range
+  // on a native dep is the hazard: `satisfies("11.10.0", "^11.8.0")` is true,
+  // so a range check would green-light the exact build that crashes on Node 24.
+  // If the spec is ever re-loosened, this fails and says so.
+  if (installed !== declared) {
     console.error(
       `node-smoke: better-sqlite3@${installed} is installed but package.json declares ${declared}.\n` +
         "  This job exists to prove the binding npm users actually get works, so it must test\n" +
-        "  the declared spec. Reinstall it (npm skips its install script when the version already\n" +
-        `  matches): rm -rf node_modules/better-sqlite3 && npm install --no-save better-sqlite3@${declared}`,
+        "  the declared spec exactly. Reinstall it (npm skips its install script when the\n" +
+        `  version already matches): ${remedy}`,
     );
     process.exit(1);
   }
@@ -173,19 +190,14 @@ function step(label: string, args: string[], opts: StepOptions = {}): string {
   // `stdout missing expected substring` — while the `search` step, which allows
   // a non-zero exit, would not have failed at all. Name the crash for what it
   // is so the next one is diagnosed instead of re-run.
-  if (err.includes("----- Native stack trace -----")) {
+  if (err.includes(NATIVE_CRASH_MARKER)) {
     ok = false;
     const assertion = err.split("\n").find((l) => l.includes("Assertion failed") || l.includes("FATAL ERROR"));
     problems.push(`native crash under node${assertion ? `: ${assertion.trim()}` : ""}`);
   }
   // A Node-branch regression in the runtime boundary surfaces as these messages
   // even when the command still prints a result — treat them as hard failures.
-  for (const marker of [
-    "appendEvent failed",
-    "ERR_MODULE_NOT_FOUND",
-    "ERR_UNKNOWN_FILE_EXTENSION",
-    "Bun is not defined",
-  ]) {
+  for (const marker of BOUNDARY_MARKERS) {
     if (err.includes(marker) || out.includes(marker)) {
       ok = false;
       problems.push(`runtime-boundary marker in output: ${marker}`);

--- a/src/storage/database.ts
+++ b/src/storage/database.ts
@@ -278,7 +278,12 @@ function loadBetterSqlite3(): BetterSqlite3Ctor {
     } catch (err) {
       throw new Error(
         "akm could not load 'better-sqlite3', the SQLite driver it needs on Node.js.\n" +
-          "  • Reinstall akm with a working C/C++ build toolchain so its optional\n" +
+          "  • If the error below says the module was compiled against a DIFFERENT Node.js\n" +
+          "    version, you upgraded Node after installing akm. Reinstall akm (or run\n" +
+          "    `npm rebuild better-sqlite3` in its install directory) so the binding is\n" +
+          "    rebuilt for the Node you are now running. This is the common case after a\n" +
+          "    Node major upgrade, and it is NOT a broken install.\n" +
+          "  • Otherwise, reinstall akm with a working C/C++ build toolchain so its optional\n" +
           "    'better-sqlite3' native binding rebuilds (a global `npm i -g better-sqlite3`\n" +
           "    will NOT be resolved — Node loads it from akm's own node_modules).\n" +
           "  • Or run akm under Bun, which has a built-in SQLite driver and needs no native build.\n" +

--- a/tests/_helpers/sandbox.ts
+++ b/tests/_helpers/sandbox.ts
@@ -167,6 +167,29 @@ export function withEnvSync<T>(overrides: Record<string, string | undefined>, fn
  * or to a subprocess env. Registering cleanup here keeps `fs.mkdtempSync` out of
  * test files (which the isolation lint flags).
  */
+/**
+ * Run `fn` with `process.stdin.isTTY` forced to `isTTY`, restoring it after.
+ *
+ * `isTTY` is process-global, so a hand-rolled save/override/restore that gets
+ * its restore wrong leaks into unrelated tests — and `tests/_preload.ts`'s leak
+ * tripwire guards env vars and tmpdirs, not stream descriptors, so nothing
+ * would catch it. This existed as four separate inline copies before it lived
+ * here; prefer this over writing a fifth.
+ *
+ * Restores by re-defining the property, which is also how the value was set —
+ * a getter on the original descriptor is not preserved, but no caller has ever
+ * needed one.
+ */
+export async function withTTY<T>(isTTY: boolean, fn: () => T | Promise<T>): Promise<T> {
+  const original = process.stdin.isTTY;
+  Object.defineProperty(process.stdin, "isTTY", { value: isTTY, configurable: true });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(process.stdin, "isTTY", { value: original, configurable: true });
+  }
+}
+
 export function makeStashDir(): SandboxedDir {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), `akm-sb-stash2-${sandboxCounter++}-`));
   for (const sub of STASH_SKELETON_SUBDIRS) {

--- a/tests/integration/migration-help.test.ts
+++ b/tests/integration/migration-help.test.ts
@@ -61,13 +61,21 @@ describe("migration help", () => {
     }
   });
 
-  test("latest alias resolves to the newest release changelog section", () => {
+  test("latest alias resolves to the changelog section for the shipping version", () => {
+    // Derived from package.json, NOT hardcoded. `resolveLatestVersion()`
+    // returns the first non-`Unreleased` heading, which makes this the one
+    // check that catches a release cut where `## [Unreleased]` was never
+    // renamed to `## [<version>]`: the shipped binary would then answer
+    // `akm help migrate latest` with the PREVIOUS release's notes, and a
+    // hardcoded expectation here would still pass because it names that
+    // previous release. Nothing in release.yml, tests/release-check.sh or any
+    // lint gate covers this.
+    const version = JSON.parse(fs.readFileSync(path.join(PROJECT_ROOT, "package.json"), "utf8")).version as string;
     const result = renderMigrationHelp("latest");
-    // The final [0.9.0] section must sit ABOVE the rc/beta history:
-    // resolveLatestVersion() returns the first non-Unreleased heading, so a
-    // misplaced section would make `akm help migrate latest` report an rc.
-    expect(result).toContain("## [0.9.0]");
-    expect(result).not.toContain("## [0.9.0-rc");
+    expect(result).toContain(`## [${version}]`);
+    // The stable section must also sit ABOVE the rc/beta history, or the alias
+    // reports a prerelease.
+    expect(result).not.toContain(`## [${version}-rc`);
   });
 
   test("renders dedicated message when no bundled note or changelog entry exists", () => {

--- a/tests/integration/migration-help.test.ts
+++ b/tests/integration/migration-help.test.ts
@@ -20,18 +20,6 @@ describe("migration help", () => {
     expect(result).toContain("## [0.5.0]");
   });
 
-  test("supports latest alias when changelog text is available", () => {
-    const result = renderMigrationHelp("latest");
-    // Derive the expected version from the changelog so this never re-breaks on a
-    // version bump: "latest" resolves to the newest RELEASED (non-Unreleased) section.
-    const changelog = fs.readFileSync(path.join(PROJECT_ROOT, "CHANGELOG.md"), "utf8");
-    const latest = [...changelog.matchAll(/^## \[([^\]]+)\]/gm)]
-      .map((m) => m[1])
-      .find((v) => v!.toLowerCase() !== "unreleased");
-    expect(latest).toBeTruthy();
-    expect(result).toContain(`## [${latest}]`);
-  });
-
   test("ensures published static files exist in the repo", () => {
     const packageJson = JSON.parse(fs.readFileSync(path.join(PROJECT_ROOT, "package.json"), "utf8")) as {
       files?: string[];
@@ -61,21 +49,22 @@ describe("migration help", () => {
     }
   });
 
-  test("latest alias resolves to the changelog section for the shipping version", () => {
-    // Derived from package.json, NOT hardcoded. `resolveLatestVersion()`
-    // returns the first non-`Unreleased` heading, which makes this the one
-    // check that catches a release cut where `## [Unreleased]` was never
-    // renamed to `## [<version>]`: the shipped binary would then answer
-    // `akm help migrate latest` with the PREVIOUS release's notes, and a
-    // hardcoded expectation here would still pass because it names that
-    // previous release. Nothing in release.yml, tests/release-check.sh or any
-    // lint gate covers this.
-    const version = JSON.parse(fs.readFileSync(path.join(PROJECT_ROOT, "package.json"), "utf8")).version as string;
+  test("supports latest alias when changelog text is available", () => {
+    // Behavior only: `latest` resolves to the newest RELEASED (non-Unreleased)
+    // section. The expectation is derived from the changelog so this never
+    // re-breaks on a version bump.
+    //
+    // Whether that section names the version actually being shipped is a
+    // property of the RELEASE, not of this renderer, and is asserted in
+    // tests/integration/workflow-release.test.ts — which is
+    // `run_step "Workflow Release Contract"` in tests/release-check.sh.
     const result = renderMigrationHelp("latest");
-    expect(result).toContain(`## [${version}]`);
-    // The stable section must also sit ABOVE the rc/beta history, or the alias
-    // reports a prerelease.
-    expect(result).not.toContain(`## [${version}-rc`);
+    const changelog = fs.readFileSync(path.join(PROJECT_ROOT, "CHANGELOG.md"), "utf8");
+    const latest = [...changelog.matchAll(/^## \[([^\]]+)\]/gm)]
+      .map((match) => match[1])
+      .find((heading) => heading?.toLowerCase() !== "unreleased");
+    expect(latest).toBeTruthy();
+    expect(result).toContain(`## [${latest}]`);
   });
 
   test("renders dedicated message when no bundled note or changelog entry exists", () => {

--- a/tests/integration/node-compat.test.ts
+++ b/tests/integration/node-compat.test.ts
@@ -38,6 +38,7 @@ import { type ChildProcess, spawn as nodeSpawn, spawnSync as nodeSpawnSync } fro
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { BOUNDARY_MARKERS, NATIVE_CRASH_MARKER } from "../../scripts/node-runtime-markers";
 import { runCliCapture } from "../_helpers/cli";
 import { withEnv, withIsolatedAkmStorage } from "../_helpers/sandbox";
 
@@ -103,23 +104,14 @@ function parseJson(text: string): unknown {
   }
 }
 
-// Runtime-boundary regression markers — any of these in output means the
-// Node path tried to call a Bun built-in directly.
-const BOUNDARY_MARKERS = ["Bun is not defined", "ERR_MODULE_NOT_FOUND", "ERR_UNKNOWN_FILE_EXTENSION"];
-
-// Node's own banner when a native addon aborts the process. Distinct from a
-// boundary leak — nothing in akm's JS produced it — but just as much a hard
-// failure, and one this suite previously swallowed whenever the command had
-// already flushed enough stdout to satisfy the assertion (#790).
-const NATIVE_CRASH_MARKER = "----- Native stack trace -----";
-
 function assertNoBoundaryLeak(result: NodeResult, label: string): void {
   for (const marker of BOUNDARY_MARKERS) {
     expect(result.stdout + result.stderr, `[${label}] boundary leak: ${marker}`).not.toContain(marker);
   }
-  expect(result.stderr, `[${label}] the node subprocess aborted in native code:\n${result.stderr}`).not.toContain(
-    NATIVE_CRASH_MARKER,
-  );
+  // Static message: bun prints the received string on failure anyway, and
+  // interpolating stderr here builds it on every passing call too — `nodeRun`
+  // allows a 32 MiB buffer, so that is unbounded work on the happy path.
+  expect(result.stderr, `[${label}] the node subprocess aborted in native code`).not.toContain(NATIVE_CRASH_MARKER);
 }
 
 // ── Shared state for each describe block ─────────────────────────────────────

--- a/tests/integration/node-compat.test.ts
+++ b/tests/integration/node-compat.test.ts
@@ -107,10 +107,19 @@ function parseJson(text: string): unknown {
 // Node path tried to call a Bun built-in directly.
 const BOUNDARY_MARKERS = ["Bun is not defined", "ERR_MODULE_NOT_FOUND", "ERR_UNKNOWN_FILE_EXTENSION"];
 
+// Node's own banner when a native addon aborts the process. Distinct from a
+// boundary leak — nothing in akm's JS produced it — but just as much a hard
+// failure, and one this suite previously swallowed whenever the command had
+// already flushed enough stdout to satisfy the assertion (#790).
+const NATIVE_CRASH_MARKER = "----- Native stack trace -----";
+
 function assertNoBoundaryLeak(result: NodeResult, label: string): void {
   for (const marker of BOUNDARY_MARKERS) {
     expect(result.stdout + result.stderr, `[${label}] boundary leak: ${marker}`).not.toContain(marker);
   }
+  expect(result.stderr, `[${label}] the node subprocess aborted in native code:\n${result.stderr}`).not.toContain(
+    NATIVE_CRASH_MARKER,
+  );
 }
 
 // ── Shared state for each describe block ─────────────────────────────────────

--- a/tests/integration/vault-dangerous-key-blocked-install-rollback.test.ts
+++ b/tests/integration/vault-dangerous-key-blocked-install-rollback.test.ts
@@ -1,0 +1,314 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Issue #758 — full `add → blocked-install → rollback` lifecycle against a
+ * dangerous fixture, asserting **config.json / akm.lock parity**.
+ *
+ * Relationship to `vault-dangerous-key-install-gate.test.ts`: that suite calls
+ * `auditInstalledStashForDangerousKeys` directly and proves the gate's decision
+ * is fail-CLOSED (the install is BLOCKED). It says nothing about what the
+ * blocked attempt LEFT BEHIND, because it never runs an install at all — it
+ * hands the audit a bare temp dir as both stash root and rollback target.
+ *
+ * That was the open waiver in
+ * `docs/architecture/testing/manual-testing-checklist.md` §24.2 ("Durability" →
+ * "full source lifecycle rollback", waiver expiry 0.9.1): *"no test walks
+ * add→blocked-install→rollback against a dangerous fixture"*, whose named
+ * verification is *"asserting config.json/akm.lock parity"*. The waiver lists
+ * the lifecycle surfaces as **config / lock / root / index / events**.
+ *
+ * These tests drive the REAL `akm bundle add` CLI end-to-end (`runCliCapture`)
+ * so every step the production path takes runs in order — `akmAdd` →
+ * config `bundles` upsert → `upsertLockEntry` → `akmIndex` → `appendEvent` →
+ * the dangerous-key audit → `akmRemove` rollback → reindex. The only seam is
+ * `syncFromRef`, spied so the "download" materializes a local copy of
+ * `tests/fixtures/manual-qa/dangerous-bundle/` instead of hitting a registry
+ * (the same seam `source-qa-fixes.test.ts` / `update-destructive-confirm.test.ts`
+ * already use to drive registry installs offline). A LOCAL-path add is
+ * deliberately NOT used: `akmAdd` routes local refs to `addLocalSource`, which
+ * writes no lock entry at all, so it cannot exercise lock parity.
+ *
+ * The fixture carries `NODE_OPTIONS=…` in `env/runtime.env` — a literal member
+ * of `DANGEROUS_ENV_KEYS` (`--require` module-load RCE), reached by the
+ * recursive `env/` scan — plus `knowledge/source-marker.md`, whose indexed row
+ * is what makes the "no orphaned index entry" assertion non-vacuous.
+ *
+ * Surfaces asserted per test: config.json (byte-level), akm.lock (byte-level),
+ * the materialized content root, and the search index. The events stream is
+ * deliberately NOT rolled back — see the comment on `readAddEventTargets`.
+ */
+
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { DEFAULT_CONFIG } from "../../src/core/config/config";
+import { readEvents } from "../../src/core/events";
+import { getDbPath } from "../../src/core/paths";
+import * as syncFromRefModule from "../../src/sources/providers/sync-from-ref";
+import { closeDatabase, openReadonlyExistingDatabase } from "../../src/storage/repositories/index-connection";
+import { getAllEntries } from "../../src/storage/repositories/index-entries-repository";
+import { runCliCapture } from "../_helpers/cli";
+import { type IsolatedAkmStorage, makeSandboxDir, withIsolatedAkmStorage } from "../_helpers/sandbox";
+
+/** The shipped dangerous fixture (`env/runtime.env` carries `NODE_OPTIONS`). */
+const DANGEROUS_FIXTURE = path.resolve(import.meta.dir, "../fixtures/manual-qa/dangerous-bundle");
+const DANGEROUS_REF = "npm:qa-dangerous-bundle";
+const SAFE_REF = "npm:qa-safe-bundle";
+
+let storage: IsolatedAkmStorage;
+const disposers: Array<() => void> = [];
+
+beforeEach(() => {
+  storage = withIsolatedAkmStorage();
+});
+
+afterEach(() => {
+  for (const dispose of disposers.splice(0)) dispose();
+  storage.cleanup();
+});
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+/** A disposable directory outside the storage sandbox, used as a content root. */
+function sandboxDir(prefix: string): string {
+  const created = makeSandboxDir(prefix);
+  disposers.push(created.cleanup);
+  return created.dir;
+}
+
+/**
+ * A materialized copy of the dangerous fixture. Copied, never used in place:
+ * the rollback deletes the content root, which against the repo path would
+ * delete the checked-in fixture.
+ */
+function materializeDangerousBundle(): string {
+  const root = sandboxDir("akm-758-danger");
+  fs.cpSync(DANGEROUS_FIXTURE, root, { recursive: true });
+  // Guard the premise rather than trusting the fixture: this whole suite is
+  // meaningless if the fixture stops carrying a dangerous key.
+  expect(fs.readFileSync(path.join(root, "env", "runtime.env"), "utf8")).toContain("NODE_OPTIONS=");
+  return root;
+}
+
+/** A materialized bundle with only benign env keys — the install that must SURVIVE. */
+function materializeSafeBundle(): string {
+  const root = sandboxDir("akm-758-safe");
+  fs.mkdirSync(path.join(root, "knowledge"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "knowledge", "safe-marker.md"),
+    "---\ntype: knowledge\ndescription: Marker proving the previously-installed bundle survived\n---\n\n# Safe Source Marker\n\nThe unique marker is `qa-safe-source-marker`.\n",
+  );
+  fs.mkdirSync(path.join(root, "env"), { recursive: true });
+  fs.writeFileSync(path.join(root, "env", "app.env"), "API_TOKEN=abc\nDB_URL=postgres://localhost/db\n");
+  return root;
+}
+
+/**
+ * Run `akm bundle add <ref>` with `syncFromRef` resolving to `contentRoot`, as
+ * a non-TTY stdin and without `--allow-insecure` — the fail-closed
+ * configuration the gate is specified for.
+ *
+ * stdin's TTY-ness is forced rather than inherited: on a TTY the audit takes
+ * the interactive branch and blocks on `p.confirm`, so a suite that merely
+ * assumed non-TTY would hang when someone ran `bun test` from a terminal.
+ */
+async function addBundleNonInteractive(ref: string, contentRoot: string): Promise<{ code: number; stderr: string }> {
+  const spy = spyOn(syncFromRefModule, "syncFromRef").mockResolvedValue({
+    id: ref,
+    source: "npm",
+    ref,
+    artifactUrl: `https://registry.npmjs.org/${ref.slice(4)}/-/${ref.slice(4)}-1.0.0.tgz`,
+    contentDir: contentRoot,
+    cacheDir: contentRoot,
+    extractedDir: contentRoot,
+    resolvedVersion: "1.0.0",
+    integrity: "sha512-qa-fixture",
+    syncedAt: "2026-08-10T00:00:00.000Z",
+    writable: false,
+  });
+  const originalIsTTY = process.stdin.isTTY;
+  Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+  try {
+    const result = await runCliCapture(["bundle", "add", ref]);
+    return { code: result.code, stderr: result.stderr };
+  } finally {
+    Object.defineProperty(process.stdin, "isTTY", { value: originalIsTTY, configurable: true });
+    spy.mockRestore();
+  }
+}
+
+// ── Surface readers ──────────────────────────────────────────────────────────
+
+function configPath(): string {
+  return path.join(storage.configDir, "akm", "config.json");
+}
+
+function lockfilePath(): string {
+  return path.join(storage.dataDir, "akm", "akm.lock");
+}
+
+/** Raw bytes of a lifecycle file, or `null` when the file does not exist. */
+function readOrNull(target: string): string | null {
+  return fs.existsSync(target) ? fs.readFileSync(target, "utf8") : null;
+}
+
+interface LifecycleSnapshot {
+  configJson: string | null;
+  lockfile: string | null;
+}
+
+function snapshotLifecycleFiles(): LifecycleSnapshot {
+  return { configJson: readOrNull(configPath()), lockfile: readOrNull(lockfilePath()) };
+}
+
+/** Every indexed row, as `{ bundleId, filePath }` — enough to spot an orphan. */
+function readIndexedRows(): Array<{ bundleId: string; filePath: string }> {
+  const db = openReadonlyExistingDatabase(getDbPath());
+  if (!db) return [];
+  try {
+    return getAllEntries(db).map((row) => ({ bundleId: row.bundleId, filePath: row.filePath }));
+  } finally {
+    closeDatabase(db);
+  }
+}
+
+/**
+ * `target` metadata of every recorded `add` event.
+ *
+ * The events stream is an append-only AUDIT LOG of attempts, not installed
+ * state, and `akm bundle add` appends its `add` event before the audit runs.
+ * A refused install therefore stays visible here on purpose — an operator
+ * investigating a blocked install needs the attempt on record. Asserted
+ * explicitly so this stays a decision rather than an accident: it is the one
+ * surface the rollback deliberately does not revert.
+ */
+function readAddEventTargets(): string[] {
+  return readEvents({ limit: 100 })
+    .events.filter((event) => event.eventType === "add")
+    .map((event) => String((event.metadata as { target?: unknown } | undefined)?.target ?? ""));
+}
+
+// ── Assertions ───────────────────────────────────────────────────────────────
+
+/** The blocked-install error envelope, named by its stable `code`. */
+function expectBlockedByDangerousKeyGate(result: { code: number; stderr: string }): void {
+  expect(result.code).toBe(1);
+  expect(result.stderr).toContain('"code": "DANGEROUS_ENV_KEY"');
+  expect(result.stderr).toContain("NODE_OPTIONS");
+  // The success envelope must not also be printed (F4).
+  expect(result.stderr).not.toContain('"ok": true');
+}
+
+/** No lifecycle surface may still reference the refused bundle's content root. */
+function expectNoTraceOfRefusedBundle(dangerousRoot: string): void {
+  expect(fs.existsSync(dangerousRoot)).toBe(false);
+  const configText = readOrNull(configPath()) ?? "";
+  expect(configText).not.toContain(dangerousRoot);
+  expect(configText).not.toContain(DANGEROUS_REF);
+  const lockText = readOrNull(lockfilePath()) ?? "[]";
+  expect(lockText).not.toContain(dangerousRoot);
+  expect(lockText).not.toContain(DANGEROUS_REF);
+  for (const row of readIndexedRows()) {
+    expect(row.filePath.startsWith(dangerousRoot)).toBe(false);
+  }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("dangerous-key blocked install — rollback leaves config.json/akm.lock parity (#758)", () => {
+  test("pristine workspace: a blocked install records the bundle in NEITHER file", async () => {
+    const before = snapshotLifecycleFiles();
+    expect(before.configJson).toBeNull();
+    expect(before.lockfile).toBeNull();
+
+    const dangerousRoot = materializeDangerousBundle();
+    expectBlockedByDangerousKeyGate(await addBundleNonInteractive(DANGEROUS_REF, dangerousRoot));
+
+    // Residue, precisely pinned. `akm bundle add` scaffolds config.json and
+    // akm.lock on its way in (the config/lock writers create their file on
+    // first mutation), so the two files DO exist afterwards where they did not
+    // before. What matters — and what is asserted here — is that neither
+    // carries a partial record of the refused bundle: config.json holds stock
+    // defaults with no `bundles` key at all, and akm.lock is the empty array.
+    // Comparing against the imported DEFAULT_CONFIG (rather than a frozen
+    // literal) keeps this exact even as defaults evolve.
+    const after = snapshotLifecycleFiles();
+    expect(after.configJson).not.toBeNull();
+    const parsedConfig = JSON.parse(after.configJson as string) as Record<string, unknown>;
+    expect(parsedConfig).toEqual(JSON.parse(JSON.stringify(DEFAULT_CONFIG)) as Record<string, unknown>);
+    expect(parsedConfig.bundles).toBeUndefined();
+    expect(JSON.parse(after.lockfile ?? "[]")).toEqual([]);
+
+    expectNoTraceOfRefusedBundle(dangerousRoot);
+    expect(readIndexedRows()).toEqual([]);
+    // The attempt itself stays on the audit trail — see readAddEventTargets.
+    expect(readAddEventTargets()).toEqual([DANGEROUS_REF]);
+  }, 30_000);
+
+  test("workspace with user config and no bundles: config.json is byte-identical afterwards", async () => {
+    // A pre-existing, non-default config.json — the rollback must not clobber
+    // unrelated operator settings on its way past. Seeded through the real
+    // `akm config set` so the baseline bytes come from the same canonical
+    // serializer the rollback will write with; a hand-written config.json
+    // would be re-serialized on the way through and fail parity for a reason
+    // that has nothing to do with rollback fidelity.
+    expect((await runCliCapture(["config", "set", "output.detail", "full"])).code).toBe(0);
+    const before = snapshotLifecycleFiles();
+    expect(before.configJson).toContain('"detail": "full"');
+
+    const dangerousRoot = materializeDangerousBundle();
+    expectBlockedByDangerousKeyGate(await addBundleNonInteractive(DANGEROUS_REF, dangerousRoot));
+
+    const after = snapshotLifecycleFiles();
+    expect(after.configJson).toBe(before.configJson);
+    expect(JSON.parse(after.lockfile ?? "[]")).toEqual([]);
+    expectNoTraceOfRefusedBundle(dangerousRoot);
+  }, 30_000);
+
+  test("a bundle already installed: the blocked second add leaves the FIRST bundle's records intact", async () => {
+    // A rollback that reverts too much is as wrong as one that reverts too
+    // little, so the pre-existing install is asserted whole — config entry,
+    // lock entry, content root, and indexed rows — not merely "still listed".
+    const safeRoot = materializeSafeBundle();
+    const firstAdd = await addBundleNonInteractive(SAFE_REF, safeRoot);
+    expect(firstAdd.code).toBe(0);
+
+    const before = snapshotLifecycleFiles();
+    expect(before.configJson).toContain(SAFE_REF);
+    expect(before.lockfile).toContain(SAFE_REF);
+    const safeBundleKeys = Object.keys(
+      (JSON.parse(before.configJson as string) as { bundles?: Record<string, unknown> }).bundles ?? {},
+    );
+    expect(safeBundleKeys).toHaveLength(1);
+    const indexedBefore = readIndexedRows();
+    expect(indexedBefore.some((row) => row.filePath.startsWith(safeRoot))).toBe(true);
+
+    const dangerousRoot = materializeDangerousBundle();
+    expectBlockedByDangerousKeyGate(await addBundleNonInteractive(DANGEROUS_REF, dangerousRoot));
+
+    // Byte-level parity of BOTH lifecycle files — the assertion the §24.2
+    // waiver names. Byte-level, not "deep-equal after parsing": a rollback
+    // that rewrote the surviving bundle's entry into an equivalent-but-
+    // different serialization would still be a rollback that touched records
+    // it had no business touching.
+    const after = snapshotLifecycleFiles();
+    expect(after.configJson).toBe(before.configJson);
+    expect(after.lockfile).toBe(before.lockfile);
+
+    // …and the refused bundle left nothing behind on any other surface.
+    expectNoTraceOfRefusedBundle(dangerousRoot);
+
+    // …while the first install is untouched: root on disk, indexed rows, and
+    // its visibility to `akm bundle list`.
+    expect(fs.existsSync(path.join(safeRoot, "knowledge", "safe-marker.md"))).toBe(true);
+    expect(readIndexedRows()).toEqual(indexedBefore);
+    const listed = await runCliCapture(["bundle", "list"]);
+    expect(listed.code).toBe(0);
+    expect(listed.stdout).toContain(SAFE_REF);
+    expect(listed.stdout).not.toContain(DANGEROUS_REF);
+
+    expect(readAddEventTargets()).toEqual([SAFE_REF, DANGEROUS_REF]);
+  }, 30_000);
+});

--- a/tests/integration/vault-dangerous-key-blocked-install-rollback.test.ts
+++ b/tests/integration/vault-dangerous-key-blocked-install-rollback.test.ts
@@ -45,12 +45,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { DEFAULT_CONFIG } from "../../src/core/config/config";
 import { readEvents } from "../../src/core/events";
-import { getDbPath } from "../../src/core/paths";
+import { getConfigPath, getDbPath, getLockfilePath } from "../../src/core/paths";
 import * as syncFromRefModule from "../../src/sources/providers/sync-from-ref";
 import { closeDatabase, openReadonlyExistingDatabase } from "../../src/storage/repositories/index-connection";
 import { getAllEntries } from "../../src/storage/repositories/index-entries-repository";
 import { runCliCapture } from "../_helpers/cli";
-import { type IsolatedAkmStorage, makeSandboxDir, withIsolatedAkmStorage } from "../_helpers/sandbox";
+import { type IsolatedAkmStorage, makeSandboxDir, withIsolatedAkmStorage, withTTY } from "../_helpers/sandbox";
 
 /** The shipped dangerous fixture (`env/runtime.env` carries `NODE_OPTIONS`). */
 const DANGEROUS_FIXTURE = path.resolve(import.meta.dir, "../fixtures/manual-qa/dangerous-bundle");
@@ -128,26 +128,25 @@ async function addBundleNonInteractive(ref: string, contentRoot: string): Promis
     syncedAt: "2026-08-10T00:00:00.000Z",
     writable: false,
   });
-  const originalIsTTY = process.stdin.isTTY;
-  Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
   try {
-    const result = await runCliCapture(["bundle", "add", ref]);
+    // Non-TTY is the fail-closed arm of the gate: no prompt, refuse outright.
+    const result = await withTTY(false, () => runCliCapture(["bundle", "add", ref]));
     return { code: result.code, stderr: result.stderr };
   } finally {
-    Object.defineProperty(process.stdin, "isTTY", { value: originalIsTTY, configurable: true });
     spy.mockRestore();
   }
 }
 
 // ── Surface readers ──────────────────────────────────────────────────────────
 
-function configPath(): string {
-  return path.join(storage.configDir, "akm", "config.json");
-}
-
-function lockfilePath(): string {
-  return path.join(storage.dataDir, "akm", "akm.lock");
-}
+// Resolved through the real helpers, NOT rebuilt from `storage.*`. `getConfigDir`
+// has three branches (AKM_CONFIG_DIR, XDG/APPDATA, transient-AKM_BUNDLE_DIR) and
+// `getDataDir` differs again on win32; a hand-joined path agrees with them only
+// by coincidence on Linux. It would fail OPEN if it ever stopped agreeing —
+// `readOrNull` returns null for a path that is simply wrong, and the
+// "no trace of the refused bundle" assertions below would pass against nothing.
+const configPath = getConfigPath;
+const lockfilePath = getLockfilePath;
 
 /** Raw bytes of a lifecycle file, or `null` when the file does not exist. */
 function readOrNull(target: string): string | null {
@@ -185,9 +184,11 @@ function readIndexedRows(): Array<{ bundleId: string; filePath: string }> {
  * surface the rollback deliberately does not revert.
  */
 function readAddEventTargets(): string[] {
-  return readEvents({ limit: 100 })
-    .events.filter((event) => event.eventType === "add")
-    .map((event) => String((event.metadata as { target?: unknown } | undefined)?.target ?? ""));
+  // Filtered by the query, not after a capped fetch: with `limit` the `add` rows
+  // could be pushed out of the window by unrelated event volume.
+  return readEvents({ type: "add" }).events.map((event) =>
+    String((event.metadata as { target?: unknown } | undefined)?.target ?? ""),
+  );
 }
 
 // ── Assertions ───────────────────────────────────────────────────────────────
@@ -204,10 +205,14 @@ function expectBlockedByDangerousKeyGate(result: { code: number; stderr: string 
 /** No lifecycle surface may still reference the refused bundle's content root. */
 function expectNoTraceOfRefusedBundle(dangerousRoot: string): void {
   expect(fs.existsSync(dangerousRoot)).toBe(false);
+  // `?? ""` deliberately: an absent file genuinely has no trace of the bundle,
+  // and only these two `not.toContain` readers may treat it that way. Callers
+  // asserting the lockfile's CONTENT assert on the value directly, so a missing
+  // file fails there instead of being papered over with a `?? "[]"` default.
   const configText = readOrNull(configPath()) ?? "";
   expect(configText).not.toContain(dangerousRoot);
   expect(configText).not.toContain(DANGEROUS_REF);
-  const lockText = readOrNull(lockfilePath()) ?? "[]";
+  const lockText = readOrNull(lockfilePath()) ?? "";
   expect(lockText).not.toContain(dangerousRoot);
   expect(lockText).not.toContain(DANGEROUS_REF);
   for (const row of readIndexedRows()) {
@@ -236,10 +241,10 @@ describe("dangerous-key blocked install — rollback leaves config.json/akm.lock
     // literal) keeps this exact even as defaults evolve.
     const after = snapshotLifecycleFiles();
     expect(after.configJson).not.toBeNull();
-    const parsedConfig = JSON.parse(after.configJson as string) as Record<string, unknown>;
-    expect(parsedConfig).toEqual(JSON.parse(JSON.stringify(DEFAULT_CONFIG)) as Record<string, unknown>);
-    expect(parsedConfig.bundles).toBeUndefined();
-    expect(JSON.parse(after.lockfile ?? "[]")).toEqual([]);
+    // `toEqual` against DEFAULT_CONFIG already proves `bundles` is absent —
+    // DEFAULT_CONFIG has no such key, so any bundle record fails the compare.
+    expect(JSON.parse(after.configJson ?? "")).toEqual(DEFAULT_CONFIG);
+    expect(JSON.parse(after.lockfile ?? "")).toEqual([]);
 
     expectNoTraceOfRefusedBundle(dangerousRoot);
     expect(readIndexedRows()).toEqual([]);
@@ -263,7 +268,7 @@ describe("dangerous-key blocked install — rollback leaves config.json/akm.lock
 
     const after = snapshotLifecycleFiles();
     expect(after.configJson).toBe(before.configJson);
-    expect(JSON.parse(after.lockfile ?? "[]")).toEqual([]);
+    expect(JSON.parse(after.lockfile ?? "")).toEqual([]);
     expectNoTraceOfRefusedBundle(dangerousRoot);
   }, 30_000);
 

--- a/tests/integration/workflow-release.test.ts
+++ b/tests/integration/workflow-release.test.ts
@@ -27,6 +27,36 @@ describe("release workflow", () => {
     expect(source).not.toContain("npm version");
   });
 
+  test("the changelog is cut: its newest released section names the shipping version", () => {
+    // The release-cut step nothing else enforces. `release.yml` verifies
+    // package.json against the workflow input, and the test above pins that —
+    // but nothing checks the CHANGELOG was cut alongside it, and the failure is
+    // silent and shipped: `resolveLatestVersion()`
+    // (src/commands/sources/migration-help.ts) resolves release notes by
+    // SKIPPING the `## [Unreleased]` heading, so a released binary whose
+    // changelog still says `Unreleased` answers `akm help migrate latest` with
+    // the PREVIOUS release's notes.
+    //
+    // Lives here rather than beside the renderer's own tests because this is a
+    // property of the release, not of `renderMigrationHelp` — and this file is
+    // `run_step "Workflow Release Contract"`, the first gate in
+    // tests/release-check.sh, so it fails in seconds under the name a release
+    // engineer is looking at.
+    const root = path.resolve(import.meta.dir, "../..");
+    const version = (JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")) as { version: string })
+      .version;
+    const changelog = fs.readFileSync(path.join(root, "CHANGELOG.md"), "utf8");
+    const newestReleased = [...changelog.matchAll(/^## \[([^\]]+)\]/gm)]
+      .map((match) => match[1])
+      .find((heading) => heading?.toLowerCase() !== "unreleased");
+
+    expect(
+      newestReleased,
+      `CHANGELOG.md's newest released section is [${newestReleased}] but package.json is ${version}. ` +
+        `Rename "## [Unreleased]" to "## [${version}] - <YYYY-MM-DD>" and leave a fresh empty Unreleased above it.`,
+    ).toBe(version);
+  });
+
   test("builds all supported standalone binaries", () => {
     for (const artifact of [
       "akm-linux-x64",


### PR DESCRIPTION
## Summary

Empties the 0.9.1 milestone and prepares the tag. Seven commits: the last two milestone issues, the release cut itself, and a quality pass over all of it.

### #758 — blocked-install rollback parity

The last waiver on the milestone (`manual-testing-checklist.md` §24.2, *"waiver expiry: 0.9.1"*). A new test walks add → blocked-install → rollback against a dangerous fixture across three shapes: a pristine workspace (a blocked install must not *create* `config.json`/`akm.lock` either), a workspace with user config (byte-identical afterwards), and a workspace with a bundle already installed — because **a rollback that reverts too much is as wrong as one that reverts too little**.

Mutation-verified: disabling `akmRemove` in the rollback path fails all three with 13, 13 and 11 lines of drift.

### #790 — `node-smoke (24)` was not flake

It reproduced **19 times in 20** under real Node 24.19.0, and **0 in 20** after the fix. It also reproduced with a 20-line script using only `better-sqlite3` and no akm code, which settles ours-vs-upstream.

`better-sqlite3` 11.x publishes no prebuilt binary for Node 24's ABI, and its install script falls back to `node-gyp rebuild` — so installing it there **silently compiled the driver from source**. Node 24.19.0 (released 2026-08-03, ten days before the issue was filed) changed the public `node_object_wrap.h` so `ObjectWrap`'s ctor/dtor register and unregister an environment cleanup hook; a binding compiled against those headers unregisters after the environment is gone and aborts from V8's teardown path. A 24.x-LTS-only backport — which is exactly why only the `24` leg broke, and only from that release on.

Independently confirmed by probing the release assets: `11.10.0` returns **200 for Node 22's ABI and 404 for Node 24's**; `12.11.1` returns 200 for both.

**This was reaching npm users, not just CI** — anyone on Node 24 LTS installing akm got the same crash-prone from-source build.

Pinned to `12.11.1` (prebuilds for Node 22/24/25/26, so nothing compiles). Two durability fixes alongside it: CI now reads the spec out of `package.json` instead of carrying its own range (they had already drifted, and that drift *was* the bug), and it `rm -rf`s the binding first — `npm install pkg@version` is a **no-op when the version is already present and does not re-run the install script**, so the binding `bun install` built moments earlier survived with the wrong ABI. Both the smoke script and `node-compat` now fail on Node's native crash banner; previously an abort was reported only as missing output, and the one step that tolerates a non-zero exit would not have failed at all.

### The release cut

Release-readiness audits found three ship-blockers:

1. **Nothing renamed `## [Unreleased]`, and nothing required it.** Functional, not cosmetic: `migration-help.ts:84` resolves release notes by *skipping* that heading, so a shipped 0.9.1 would answer `akm help migrate latest` with **0.9.0's** notes.
2. **Half the #791 sweep was unrecorded** — including an `akm.lock` data-loss fix (an unreadable lock read as `[]`, and the next read-modify-write replaced the whole record with one entry), a migration gate that failed open, and `index --clean` deleting rows for files it could not read.
3. **`akm workflow run` silently changed exit codes.** At `v0.9.0` the condition was `failed || gateRejection || aborted`; `blocked` was added this cycle, so a CI step reading exit 0 as success changed meaning.

Fixed: renamed to `## [0.9.1] - 2026-08-13` with a fresh empty `Unreleased`, bumped `package.json` (`release.yml:44` verifies the two agree), and recorded six previously-missing changes — website snapshot atomicity, two workflow-engine fixes from #779, authoring-time workflow bounds, the lint warnings channel, worktree GC. Adds `### Breaking changes & migration` (0.9.0 has one; STABILITY.md promises one per breaking change) and `### Security`, which the gate-judge redaction fix had been missing entirely.

The cut is now enforced rather than remembered: `workflow-release.test.ts` — which `tests/release-check.sh` runs as `run_step "Workflow Release Contract"` — fails in ~2ms with a message naming the fix. Mutation-verified.

Also corrects a claim from earlier in this cycle: the CHANGELOG said akm no longer manages permissions and that *"everything it writes takes your process umask"*. The first half is right; the second is false — `config-io.ts`, `scheduler-invocation.ts`, `git-provider.ts` and `website-ingest.ts` all still create files `0600`/`0700`. Both statements are now scoped to what #756 actually reverted.

`.dockerignore` excludes `.claude/`, `.akm/`, `.akm-run/` — agent worktrees reached 738 MB and were shipping as Docker build context.

### Quality pass

Four reviewers over the diff. The one worth calling out: the rollback test rebuilt config/lock paths by hand from `storage.*`, which agrees with `getConfigPath()`/`getLockfilePath()` only *by coincidence* on Linux — and would have failed **open**, since `readOrNull` returns null for a wrong path and every "no trace of the refused bundle" assertion would then pass against an empty string. Also: `satisfies()` was a *range* check on the pin, so it would have green-lit `11.10.0` against `^11.8.0` — the exact build that crashes.

## Test plan

Run on the final tree:

| | |
|---|---|
| `bun install --frozen-lockfile` | clean |
| `bunx tsc --noEmit` | exit 0 |
| `bun run lint` | exit 0 — all 14 gates, no baseline touched |
| `bun run test:unit` | **3583 pass / 0 fail** (258 files) |
| `bun run test:integration` | **5144 pass / 0 fail** (403 files) |
| `bun run test:node-smoke` (Node 22, real `dist/cli-node.mjs`) | **9/9 steps** |

Mutation-verified, each by reverting the fix and confirming failure: the rollback test (all three cases), the relocated release-cut gate (reports 0.9.0's notes when left un-cut), and — re-run after the quality pass, since simplifying assertions is exactly when you can quietly defang them — both again.

## Note on CI

`node-smoke (24)` passing on the current `release/0.9.1` head is **not** evidence the crash is gone: that state still has the floating `^11.8.0`, so it passed with the crash-prone build on a run that happened not to abort. This PR is the first time that job runs against the pin.

Separately, `lint-golden-captured-at-head` judges **0 of 17** pins in CI because both workflows check out shallow — tracked in #795, not fixed here.

Closes #758
Closes #790

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLQzxy3jXCFxHcuZ8N8etQ)_