### PR TITLE
Make four release gates actually check what they claim (#795)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
+        # Full history: scripts/lint-golden-captured-at-head.ts resolves recorded
+        # `capturedAtHead` commits, and under the default fetch-depth: 1 none of
+        # them exist in the clone — the gate then takes its own "inconclusive"
+        # branch for EVERY pin and reports OK having judged nothing (#795).
+        with:
+          fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.sha }}
+          # Full history — release-check.sh runs lint, and the golden pin gate
+          # judges nothing in a shallow clone (#795).
+          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/scripts/lint-golden-captured-at-head.ts
+++ b/scripts/lint-golden-captured-at-head.ts
@@ -64,11 +64,13 @@ const SHA_RE = /^[0-9a-f]{7,40}$/i;
  * never add a NEW one; a fresh violation should fail lint like any other.
  */
 const KNOWN_STALE: Record<string, string> = {
-  "tests/fixtures/goldens/lint/all-types.json":
-    "flagged 2026-07-30 (#730 capturedAtHead guard introduction): recorded capturedAtHead " +
-    "cd94d26c6de251fa5dcadd9e9e40f6991bf87eb5 does not exist in this clone's object database at all. " +
-    "Pre-existing and unrelated to #730 — this guard's author did not attempt to reconstruct which " +
-    "chunk-3 commit it should name; its surface owner should repoint or re-capture it.",
+  // Empty, and worth keeping that way. The last entry
+  // (tests/fixtures/goldens/lint/all-types.json) was retired in 0.9.1 (#795) by
+  // repointing the pin to 2d0e39c5, the commit that produced the golden's
+  // current bytes. Its grandfather note had itself gone stale: it claimed the
+  // recorded commit "does not exist in this clone's object database at all",
+  // but cd94d26c resolves fine — it was simply a July-21 docs commit that never
+  // touched the golden, which the two reachability checks below cannot see.
 };
 
 function git(args: string[]): { ok: boolean; stdout: string } {

--- a/scripts/lint-goldens-presence.ts
+++ b/scripts/lint-goldens-presence.ts
@@ -123,8 +123,16 @@ for (const [rel, src] of consumerContents) {
   if (!src.includes("expectGolden(") && !src.includes("loadGolden(")) {
     problems.push(`consumer suite no longer calls expectGolden/loadGolden (gutted?): ${rel}`);
   }
-  if (/\b(?:describe|test|it)\.skip\(/.test(src)) {
-    problems.push(`consumer suite contains .skip( — golden coverage silently disabled: ${rel}`);
+  // No trailing `(`: that required an immediate call, so `describe.skipIf(...)`
+  // slipped past (an `I` follows `skip`) and so did the alias form already used
+  // in this tree — `const d = platform === "win32" ? describe.skip : describe`
+  // (tests/integration/akm-eval-snapshot-cli.test.ts). Either disables a whole
+  // golden consumer suite while this gate still reports "consumer suites
+  // intact" (#795). `.todo` and `.failing` are the same hole by another name.
+  // A golden consumer has no legitimate reason to be conditional.
+  const disabled = /\b(?:describe|test|it)\.(skip|skipIf|todo|failing)\b/.exec(src);
+  if (disabled) {
+    problems.push(`consumer suite contains .${disabled[1]} — golden coverage silently disabled: ${rel}`);
   }
 }
 

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -34,6 +34,14 @@ bun run sweep:tmp >/dev/null 2>&1 || true
 # Deterministic file list; sort so every machine shards identically.
 mapfile -t files < <(find tests/integration -name '*.test.ts' | sort)
 total="${#files[@]}"
+
+# Floor on tests actually executed (pass + skip), checked after aggregation.
+# The files-ran cross-check below cannot see this: a file whose every test is
+# skipped still counts toward `across N files`. The header above records the bun
+# `--shard` incident where shards 2-4 ran ZERO tests at exit 0 — this is the
+# same hole reached through skips instead of sharding (#795). Set below the
+# current integration count with room for churn; raise it as the suite grows.
+MIN_TESTS="${AKM_MIN_INTEGRATION_TESTS:-5000}"
 if [ "$total" -eq 0 ]; then
   echo "── integration: no test files found under tests/integration" >&2
   exit 1
@@ -68,13 +76,15 @@ for p in "${pids[@]}"; do
 done
 
 # Aggregate and surface results.
-pass=0 fail=0 filecount=0
+pass=0 fail=0 skip=0 filecount=0
 for t in "${tmps[@]}"; do
   p="$(grep -oE '[0-9]+ pass' "$t" | tail -1 | grep -oE '[0-9]+' || true)"
   f="$(grep -oE '[0-9]+ fail' "$t" | tail -1 | grep -oE '[0-9]+' || true)"
+  s="$(grep -oE '[0-9]+ skip' "$t" | tail -1 | grep -oE '[0-9]+' || true)"
   c="$(grep -oE 'across [0-9]+ files' "$t" | tail -1 | grep -oE '[0-9]+' || true)"
   pass=$((pass + ${p:-0}))
   fail=$((fail + ${f:-0}))
+  skip=$((skip + ${s:-0}))
   filecount=$((filecount + ${c:-0}))
   # Surface any real failures from this shard — summary lines first, then the
   # full tail so assertion diffs survive aggregation (a flake with no diff is
@@ -86,7 +96,18 @@ for t in "${tmps[@]}"; do
   fi
 done
 
-echo "── integration: ${pass} pass / ${fail} fail across ${N} process-shards (${filecount}/${total} files)"
+echo "── integration: ${pass} pass / ${skip} skip / ${fail} fail across ${N} process-shards (${filecount}/${total} files)"
+# `filecount` counts files RAN, not tests executed — a file whose every test is
+# skipped still contributes to `across N files`, so it clears that check while
+# asserting nothing. Pin the executed+skipped total against a floor so a suite
+# that silently loses tests fails instead of just reporting a smaller number
+# nobody diffs (#795). Raise the floor when the suite legitimately grows;
+# LOWERING it is the thing to argue about in review.
+executed=$((pass + skip))
+if [ "$executed" -lt "$MIN_TESTS" ]; then
+  echo "── integration: only ${executed} tests ran+skipped, floor is ${MIN_TESTS} — tests disappeared rather than failed."
+  rc=1
+fi
 if [ "$rc" -ne 0 ] || [ "$fail" -ne 0 ] || [ "$filecount" -ne "$total" ]; then
   echo "── integration: shard logs kept for diagnosis: ${logdir}"
   exit 1

--- a/scripts/test-unit.sh
+++ b/scripts/test-unit.sh
@@ -42,6 +42,14 @@ bun run sweep:tmp >/dev/null 2>&1 || true
 # per its own charter; the full suite always runs, local and CI alike.)
 mapfile -t files < <(find tests -name '*.test.ts' -not -path 'tests/integration/*' | sort)
 total="${#files[@]}"
+
+# Floor on tests actually executed (pass + skip), checked after aggregation.
+# The files-ran cross-check below cannot see this: a file whose every test is
+# skipped still counts toward `across N files`. The header above records the bun
+# `--shard` incident where shards 2-4 ran ZERO tests at exit 0 — this is the
+# same hole reached through skips instead of sharding (#795). Set below the
+# current unit count with room for churn; raise it as the suite grows.
+MIN_TESTS="${AKM_MIN_UNIT_TESTS:-3500}"
 if [ "$total" -eq 0 ]; then
   echo "── unit: no test files found under tests/ (excluding integration)" >&2
   exit 1
@@ -76,13 +84,15 @@ for p in "${pids[@]}"; do
 done
 
 # Aggregate and surface results.
-pass=0 fail=0 filecount=0
+pass=0 fail=0 skip=0 filecount=0
 for t in "${tmps[@]}"; do
   p="$(grep -oE '[0-9]+ pass' "$t" | tail -1 | grep -oE '[0-9]+' || true)"
   f="$(grep -oE '[0-9]+ fail' "$t" | tail -1 | grep -oE '[0-9]+' || true)"
+  s="$(grep -oE '[0-9]+ skip' "$t" | tail -1 | grep -oE '[0-9]+' || true)"
   c="$(grep -oE 'across [0-9]+ files' "$t" | tail -1 | grep -oE '[0-9]+' || true)"
   pass=$((pass + ${p:-0}))
   fail=$((fail + ${f:-0}))
+  skip=$((skip + ${s:-0}))
   filecount=$((filecount + ${c:-0}))
   # Surface any real failures from this shard — summary lines first, then the
   # full tail so assertion diffs survive aggregation (a flake with no diff is
@@ -94,7 +104,18 @@ for t in "${tmps[@]}"; do
   fi
 done
 
-echo "── unit: ${pass} pass / ${fail} fail across ${N} process-shards (${filecount}/${total} files)"
+echo "── unit: ${pass} pass / ${skip} skip / ${fail} fail across ${N} process-shards (${filecount}/${total} files)"
+# `filecount` counts files RAN, not tests executed — a file whose every test is
+# skipped still contributes to `across N files`, so it clears that check while
+# asserting nothing. Pin the executed+skipped total against a floor so a suite
+# that silently loses tests fails instead of just reporting a smaller number
+# nobody diffs (#795). Raise the floor when the suite legitimately grows;
+# LOWERING it is the thing to argue about in review.
+executed=$((pass + skip))
+if [ "$executed" -lt "$MIN_TESTS" ]; then
+  echo "── unit: only ${executed} tests ran+skipped, floor is ${MIN_TESTS} — tests disappeared rather than failed."
+  rc=1
+fi
 if [ "$rc" -ne 0 ] || [ "$fail" -ne 0 ] || [ "$filecount" -ne "$total" ]; then
   echo "── unit: shard logs kept for diagnosis: ${logdir}"
   exit 1

--- a/tests/fixtures/goldens/lint/all-types.json
+++ b/tests/fixtures/goldens/lint/all-types.json
@@ -18,7 +18,7 @@
       }
     ]
   },
-  "capturedAtHead": "cd94d26c6de251fa5dcadd9e9e40f6991bf87eb5",
+  "capturedAtHead": "2d0e39c5a253b869bc51267403e66a1fd0c6daf6",
   "notes": [
     "RE-BASELINED @ chunk-3 (plan §12): the 9 per-type linter classes + LINTER_MAP/getLinterForType were collapsed into runBaseChecks (base-linter.ts) + the akm adapter's per-type validate rules (core/adapter/adapters/akm-lint.ts), reached by the CLI through lintAssetFile(ctx, subdir). The former `linterUsed` (dispatched class name) field is GONE — no classes remain. Every finding is byte-identical (all fixtures still lint clean; akmLintFullSweep unchanged).",
     "RE-BASELINED for workflow-format-unification: the two-workflow-form split (workflowMd vs workflowProgramYaml, the latter carrying a raw parseWorkflowProgram({ok, program|errors}) correctness check alongside its own lintIssues) is GONE along with the YAML program format itself (spec §3) — src/workflows/program/parser.ts and isWorkflowProgramPath no longer exist, WORKFLOW_EXTENSIONS is ['.md'] only (src/core/recognition-util.ts), and akmLint()'s workflows walk collects only .md files. tests/fixtures/stashes/all-types/workflows/ now holds ONE fixture (all-types-workflow.md, converted to the unified frontmatter+body format; all-types-workflow-program.yaml deleted). `workflow` is now an ordinary perType entry ({subdir, relPath, issues}) exactly like every other type — no special-cased LintContext construction, no second result/correctnessCheck field. perType now has exactly 13 keys (skill additionally carries lintDirectoryIssues); the fixture stash shrank from 15 files to 14 (one per ASSET_SPECS_INTERNAL type). Every finding is still empty (the converted fixture is lint-clean); akmLintFullSweep's flagged/fixed stay empty too.",

--- a/tests/integration/goldens-lint-output.test.ts
+++ b/tests/integration/goldens-lint-output.test.ts
@@ -94,7 +94,13 @@ import { expectGolden } from "../_helpers/golden";
 
 const STASH_ROOT = path.resolve(__dirname, "../fixtures/stashes/all-types");
 const LINT_GOLDEN_PATH = "tests/fixtures/goldens/lint/all-types.json";
-const HEAD_SHA = "cd94d26c6de251fa5dcadd9e9e40f6991bf87eb5";
+// The commit whose tree produced this golden's current bytes. Repointed in
+// 0.9.1 (#795): it named a 2026-07-21 docs commit that never touched the
+// golden, while the file had been re-captured twice since. That is invisible to
+// scripts/lint-golden-captured-at-head.ts, which only checks the SHA is real
+// and branch-reachable — both of which an unrelated commit satisfies. Update
+// this alongside any re-capture; the fixture is generated from it.
+const HEAD_SHA = "2d0e39c5a253b869bc51267403e66a1fd0c6daf6";
 
 /** [type key, stash subdir, relPath] for all 14 `ASSET_SPECS_INTERNAL` types (workflow is one form now). */
 const ALL_TYPE_CASES: Array<[type: string, subdir: string, relPath: string]> = [


### PR DESCRIPTION
## Summary

Four checks that pass without establishing what they claim. Pulled into 0.9.1 because they narrow what every green run this cycle actually meant — including the one 0.9.1 shipped behind.

### 1. The golden-pin gate judged **0 of 17** in CI, and in the release job

`lint-golden-captured-at-head` treats a pin it cannot resolve as *inconclusive* rather than a finding, because a shallow clone genuinely cannot tell "orphaned" from "never fetched". Both workflows check out shallow, so that branch fired for every pin.

Measured on a depth-1 clone of this repo: **0 of 53 pins resolvable**, versus 17 with full history. The gate reported OK having judged nothing. The "17 of 17 judged" line is what a maintainer's laptop prints.

`fetch-depth: 0` on the two checkouts that run lint (`ci.yml` `check`, `release.yml`). The other two CI jobs don't run lint and keep the fast clone.

### 2. A golden's pin named a commit that never touched it

`tests/fixtures/goldens/lint/all-types.json` pinned `cd94d26c` — a **2026-07-21 docs commit** — while the golden was re-captured twice on 08-08 (`1e8cfbec`, `2d0e39c5`). Real and branch-reachable, so both existing checks passed it happily.

The pin turned out to be generated from `HEAD_SHA` in `goldens-lint-output.test.ts`, not stored only in the fixture, so it's repointed at that source and the fixture follows. Its `KNOWN_STALE` entry is gone, leaving the table **empty** — and that entry's own text had gone stale too, asserting the commit "does not exist in this clone's object database at all" when it resolves fine.

### 3. The shard runners hid skips, and the under-run guard counts files

Both runners parsed `N pass` and `N fail` and never `N skip`. The only under-run guard compares *files ran* against expected — and a file whose every test is skipped still contributes to `across N files`, so a suite degrading to all-skipped was indistinguishable from green.

This is the same hole `test-unit.sh`'s own header already documents for bun `--shard`, where shards 2-4 ran **zero tests at exit 0** — "a silent 75% coverage hole the aggregate pass line masked". Reached through skips instead of sharding.

Both runners now print skips and enforce a floor on `pass+skip` (`AKM_MIN_UNIT_TESTS` / `AKM_MIN_INTEGRATION_TESTS`, overridable so the mutation test is cheap). Surfacing them immediately showed **2 unit and 57 integration skips** that no summary line had ever printed.

### 4. The anti-gutting regex missed two spellings already in this tree

`lint-goldens-presence` required `.skip(` with the paren, so `describe.skipIf(...)` slipped past (an `I` follows `skip`), as did the alias form in `akm-eval-snapshot-cli.test.ts` (`? describe.skip : describe`). Either disables a whole golden consumer suite while the gate reports "consumer suites intact". Widened to `.skip` / `.skipIf` / `.todo` / `.failing`.

## What I did *not* do, and why

**The issue's suggested fourth check is not implementable as proposed.** It asked that the commit last touching a golden be ancestor-or-equal of its pin. Measured across all 17 judged pins, **every one is "pin BEFORE last"** — capture happens at HEAD, then the golden is committed, so the pin is always an ancestor of the commit that wrote it. The proposed direction would fail all 17.

I then tried the inverse (pin must not predate an earlier touch). That fails **15 of 17**, because goldens are also touched by batch edits and refactors that don't re-derive the bytes.

Whether a commit *re-captured* a golden or merely edited the file is not recoverable from git metadata. The check would either cry wolf or need 15 grandfather entries — which is the exact weakening this issue exists to complain about. Dropped rather than shipped weak. The one genuinely stale pin is fixed directly instead.

## Test plan

Each fix verified by **making the gate fail on purpose first** — a gate nobody has watched fail is the problem here:

| Fix | Proof |
|---|---|
| Shallow checkout | depth-1 clone resolves **0 of 53** pins; full history resolves 17 |
| Stale pin | gate green with `KNOWN_STALE` now empty |
| Test floor | `AKM_MIN_UNIT_TESTS=99999` → *"only 3585 tests ran+skipped, floor is 99999"*, exit 1 |
| Widened regex | injecting `describe.skipIf(false)(` into a real consumer trips it; the old regex provably cannot match `.skipIf(` |

Full suite on the final tree:

| | |
|---|---|
| `bunx tsc --noEmit` | exit 0 |
| `bun run lint` | exit 0 — all 14 gates, `17 of 17` pins judged, `KNOWN_STALE` empty |
| `bun run test:unit` | **3583 pass / 2 skip / 0 fail** |
| `bun run test:integration` | **5144 pass / 57 skip / 0 fail** |

The 59 skips are newly *visible*, not newly created.

Refs #795

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLQzxy3jXCFxHcuZ8N8etQ)_