### PR TITLE
Diagnose a Node-ABI mismatch where it actually surfaces, and cut 0.9.1-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -361,6 +361,23 @@ what an upgrader reads first.
 
 ### Fixed
 
+- **Upgrading Node after installing akm now explains itself.** A native binding
+  is built for the Node ABI present at install time, so upgrading Node major
+  versions afterwards leaves akm reporting a bare Node internals message —
+  *"The module … was compiled against a different Node.js version"*, or on a
+  second attempt the even less helpful *"Module did not self-register"*. akm now
+  recognises that failure and answers with the one command that fixes it
+  (`npm rebuild better-sqlite3`), names the ABI actually running, and says
+  plainly that this is not a broken install.
+
+  The diagnostic had to move to do this. It wrapped the `require`, but
+  `require("better-sqlite3")` **succeeds** against a mismatched binding — the
+  package resolves its `.node` file lazily — so the error lands at
+  `new Database(...)` and the loader's handler never saw it. The previous text
+  telling the user to look for a version mismatch "in the error below" was
+  unreachable. Found by installing the published build under Node 22 and running
+  it under Node 24.
+
 - **akm's Node fallback no longer aborts at teardown on Node 24.** On Node
   24.19.0 and later, any command that opened a database could intermittently
   die with `node::RemoveEnvironmentCleanupHook … Assertion (env) != nullptr`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-## [0.9.1-beta.1] - 2026-08-13
+## [0.9.1-beta.2] - 2026-08-14
 
 ### Breaking changes & migration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akm-cli",
-  "version": "0.9.1-beta.1",
+  "version": "0.9.1-beta.2",
   "type": "module",
   "description": "akm (Agent Knowledge Manager) — a portable, local-first capability library for AI agents. Discover, load, share, and improve reusable skills, scripts, workflows, and knowledge across any shell-capable coding agent, including Claude Code, OpenCode, and Cursor.",
   "keywords": [

--- a/src/storage/database.ts
+++ b/src/storage/database.ts
@@ -265,6 +265,52 @@ interface BetterSqliteDatabase {
 }
 
 let betterSqlite3Ctor: BetterSqlite3Ctor | undefined;
+/**
+ * The binding is absent or unbuildable — a toolchain/install problem.
+ */
+const MISSING_BINDING_REMEDY =
+  "akm could not load 'better-sqlite3', the SQLite driver it needs on Node.js.\n" +
+  "  • Reinstall akm with a working C/C++ build toolchain so its optional\n" +
+  "    'better-sqlite3' native binding builds (a global `npm i -g better-sqlite3`\n" +
+  "    will NOT be resolved — Node loads it from akm's own node_modules).\n" +
+  "  • Or run akm under Bun, which has a built-in SQLite driver and needs no native build.";
+
+/**
+ * Recognize a binding built for a DIFFERENT Node ABI than the one now running,
+ * and answer with the one command that fixes it.
+ *
+ * This is the most likely failure a real user hits, and it is not a broken
+ * install: a native addon is compiled (or a prebuilt binary is selected) for
+ * the Node major present at `npm install` time. Upgrade Node afterwards and the
+ * same file no longer loads.
+ *
+ * It is matched rather than described because the symptom text varies and the
+ * previous wording only named ONE of them. The prebuilt-binary path — which is
+ * now the normal path, since better-sqlite3 is pinned to a version publishing a
+ * prebuild for every supported Node (see package.json → pinNotes) — reports
+ * `Module did not self-register`, saying nothing about versions at all. A
+ * from-source build reports the explicit `NODE_MODULE_VERSION` mismatch. Asking
+ * the user to decide which bullet applies is the step worth deleting.
+ */
+export function abiMismatchRemedy(message: string): string | undefined {
+  const ABI_MISMATCH_SHAPES = [
+    "did not self-register", // prebuilt binary for another ABI
+    "NODE_MODULE_VERSION", // explicit mismatch, from-source build
+    "was compiled against a different", // same, older phrasing
+    "invalid ELF header", // binary for another platform/arch entirely
+  ];
+  if (!ABI_MISMATCH_SHAPES.some((shape) => message.includes(shape))) return undefined;
+  return (
+    "akm could not load 'better-sqlite3': its native binding was built for a different\n" +
+    `Node.js version than the one now running (this Node is ABI ${process.versions.modules}).\n` +
+    "This is what happens when Node is upgraded after akm is installed. It is NOT a\n" +
+    "broken install, and reinstalling akm is not required.\n" +
+    "  Fix: npm rebuild better-sqlite3        # in akm's install directory\n" +
+    "  Or:  npm install -g akm-cli            # reinstall, rebuilding against this Node\n" +
+    "  Or:  run akm under Bun, whose built-in SQLite driver needs no native binding."
+  );
+}
+
 function loadBetterSqlite3(): BetterSqlite3Ctor {
   if (!betterSqlite3Ctor) {
     // Runtime-gated dynamic require: only reached when NOT on Bun, so Bun never
@@ -276,19 +322,13 @@ function loadBetterSqlite3(): BetterSqlite3Ctor {
     try {
       mod = nodeRequire("better-sqlite3") as BetterSqlite3Ctor | { default: BetterSqlite3Ctor };
     } catch (err) {
-      throw new Error(
-        "akm could not load 'better-sqlite3', the SQLite driver it needs on Node.js.\n" +
-          "  • If the error below says the module was compiled against a DIFFERENT Node.js\n" +
-          "    version, you upgraded Node after installing akm. Reinstall akm (or run\n" +
-          "    `npm rebuild better-sqlite3` in its install directory) so the binding is\n" +
-          "    rebuilt for the Node you are now running. This is the common case after a\n" +
-          "    Node major upgrade, and it is NOT a broken install.\n" +
-          "  • Otherwise, reinstall akm with a working C/C++ build toolchain so its optional\n" +
-          "    'better-sqlite3' native binding rebuilds (a global `npm i -g better-sqlite3`\n" +
-          "    will NOT be resolved — Node loads it from akm's own node_modules).\n" +
-          "  • Or run akm under Bun, which has a built-in SQLite driver and needs no native build.\n" +
-          `  Underlying load error: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      // An ABI mismatch does NOT arrive here — `require` succeeds and the
+      // failure lands at construction (see openNodeDatabase). This path is a
+      // genuinely absent or unresolvable module. `abiMismatchRemedy` is still
+      // consulted because a from-source build CAN fail at load with the
+      // explicit NODE_MODULE_VERSION message.
+      const raw = err instanceof Error ? err.message : String(err);
+      throw new Error(`${abiMismatchRemedy(raw) ?? MISSING_BINDING_REMEDY}\n  Underlying load error: ${raw}`);
     }
     betterSqlite3Ctor = (mod as { default?: BetterSqlite3Ctor }).default ?? (mod as BetterSqlite3Ctor);
   }
@@ -304,7 +344,22 @@ function openNodeDatabase(path: string, opts?: OpenDatabaseOptions): Database {
   const options: { readonly?: boolean; fileMustExist?: boolean } = {};
   if (opts?.readonly !== undefined) options.readonly = opts.readonly;
   if (opts?.create === false) options.fileMustExist = true;
-  const db = opts ? new BetterSqlite3(path, options) : new BetterSqlite3(path);
+  // Construction, not `require`, is where an ABI mismatch surfaces.
+  // `require("better-sqlite3")` SUCCEEDS against a binding built for another
+  // Node ABI — the package resolves its `.node` file lazily — so the loader's
+  // catch never sees this error and cannot explain it. Verified against a real
+  // ABI-127 binding under Node 24 (ABI 137): `require()` returned a function
+  // and `new Database(...)` threw. Wrapping the require alone left the most
+  // likely real-world failure reported as a bare Node internals message.
+  let db: BetterSqliteDatabase;
+  try {
+    db = opts ? new BetterSqlite3(path, options) : new BetterSqlite3(path);
+  } catch (err) {
+    const raw = err instanceof Error ? err.message : String(err);
+    const remedy = abiMismatchRemedy(raw);
+    if (!remedy) throw err;
+    throw new Error(`${remedy}\n  Underlying error: ${raw}`);
+  }
   return {
     prepare: db.prepare.bind(db),
     exec: db.exec.bind(db),

--- a/tests/storage/abi-mismatch-diagnostic.test.ts
+++ b/tests/storage/abi-mismatch-diagnostic.test.ts
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * The Node-upgrade diagnostic, and where it has to live.
+ *
+ * A native binding is built for the Node ABI present at install time. Upgrade
+ * Node afterwards and the same file no longer loads — the single most likely
+ * failure a real npm user hits, and one akm reported as a bare Node internals
+ * message ("The module … was compiled against a different Node.js version").
+ *
+ * The subtlety this pins: `require("better-sqlite3")` SUCCEEDS against a
+ * mismatched binding, because the package resolves its `.node` file lazily. The
+ * error lands at `new Database(...)`. A diagnostic wrapped around the require —
+ * which is where akm's was — can therefore never see it, and the prose telling
+ * the user to look for a version mismatch in "the error below" was unreachable
+ * text. Verified against a real ABI-127 binding under Node 24 (ABI 137).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { abiMismatchRemedy } from "../../src/storage/database";
+
+describe("ABI-mismatch diagnostic (#790 follow-up)", () => {
+  test("recognises every shape a mismatched binding reports", () => {
+    // Verbatim from Node 24.19.0 loading an ABI-127 build:
+    const explicit =
+      "The module '/x/better_sqlite3.node'\nwas compiled against a different Node.js version using\n" +
+      "NODE_MODULE_VERSION 127. This version of Node.js requires\nNODE_MODULE_VERSION 137.";
+    // What a SECOND load attempt in the same process reports instead:
+    const selfRegister = "Module did not self-register: '/x/better_sqlite3.node'.";
+    // A binding for another platform/arch entirely:
+    const elf = "/x/better_sqlite3.node: invalid ELF header";
+
+    for (const message of [explicit, selfRegister, elf]) {
+      const remedy = abiMismatchRemedy(message);
+      expect(remedy, `no remedy for: ${message.slice(0, 40)}`).toBeDefined();
+      // It must name the command that fixes it — verified to actually work.
+      expect(remedy).toContain("npm rebuild better-sqlite3");
+      // And say this is not a broken install, because it is not.
+      expect(remedy).toContain("NOT a\nbroken install");
+      // Naming the running ABI saves a round trip.
+      expect(remedy).toContain(`ABI ${process.versions.modules}`);
+    }
+  });
+
+  test("leaves unrelated load failures to the missing-binding path", () => {
+    for (const message of [
+      "Cannot find module 'better-sqlite3'",
+      "gyp ERR! build error",
+      "EACCES: permission denied, open '/x/better_sqlite3.node'",
+    ]) {
+      expect(abiMismatchRemedy(message), `false positive on: ${message}`).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Found by manual-testing the published `0.9.1-beta.1`: install under Node 22, run under Node 24, and akm reports a bare Node internals message with no guidance.

```
Module did not self-register: '/…/better_sqlite3.node'
```

**This is not a #790 regression.** Installing *under* Node 24 fetches the ABI-137 prebuild and passes 40/40 runs. This is the ordinary native-module rule that every such package has — akm just didn't explain it.

## The diagnostic was in the wrong place, and its wording was unreachable

akm already had a bullet for this:

> • If the error below says the module was compiled against a DIFFERENT Node.js version…

That text could **never** appear, because **`require("better-sqlite3")` succeeds against a mismatched binding** — the package resolves its `.node` file lazily, so the failure lands at `new Database(...)`, well past the loader's `catch`. Verified directly under Node 24 (ABI 137) against a real ABI-127 binding:

```
require() SUCCEEDED — typeof: function
construction THREW: The module '…/better_sqlite3.node'
```

So the fix is not better prose around the require — it is wrapping construction, which is where the error actually arrives.

## Matched, not described

The symptom text varies, and the old wording named only one variant:

| shape | when |
|---|---|
| `Module did not self-register` | prebuilt binary for another ABI — says nothing about versions at all |
| `NODE_MODULE_VERSION` | explicit mismatch, from-source build |
| `invalid ELF header` | binary for another platform/arch |

Asking the operator to work out which bullet applies is the step worth deleting. Before → after, same mismatched install:

```
The module '/…/better_sqlite3.node' was compiled against a different Node.js version…
```
```
akm could not load 'better-sqlite3': its native binding was built for a different
Node.js version than the one now running (this Node is ABI 137).
This is what happens when Node is upgraded after akm is installed. It is NOT a
broken install, and reinstalling akm is not required.
  Fix: npm rebuild better-sqlite3        # in akm's install directory
  Or:  npm install -g akm-cli            # reinstall, rebuilding against this Node
  Or:  run akm under Bun, whose built-in SQLite driver needs no native binding.
```

I ran `npm rebuild better-sqlite3` on the broken install before shipping that advice — it does fix it (`after npm rebuild: binding works on ABI 137`).

## Beta.2 cut

`package.json` → `0.9.1-beta.2` and the changelog heading renamed to match, in the same commit, because `workflow-release.test.ts` requires them to agree and `release.yml:44` verifies `package.json` against the workflow input. Betas are checkpoints on the one 0.9.1 section rather than separate entries, so the heading is renamed rather than a section added — it becomes `## [0.9.1]` at the final cut.

Note beta.1 was cut before #796 and #797 merged, so it did not contain the `/simplify` work or the #795 gate fixes. **beta.2 is the first prerelease that reflects the branch.**

## Test plan

`tests/storage/abi-mismatch-diagnostic.test.ts` pins all three symptom shapes — using the Node 24.19.0 error text verbatim — plus the absence of false positives on missing-module, gyp-failure and `EACCES`, so the remedy can't silently start matching everything.

| | |
|---|---|
| `bunx tsc --noEmit` | exit 0 |
| `bun run lint` | exit 0 — 14 gates, 17/17 golden pins judged |
| `bun run test:unit` | **3585 pass / 2 skip / 0 fail** |
| `bun run test:integration` | **5144 pass / 57 skip / 0 fail** |

Also verified against the published beta, by hand: #791 returns exit 78 with a full diagnostic, #755 redacts both tiers in both sinks (and leaks without `redact:`, so the opt-in is load-bearing), `secret-file-perms` is gone and health exits 0 with loose modes, and `akm help migrate latest` resolves to the shipping version rather than the previous release.

## Not in this PR

The five transitive advisories under the optional `@huggingface/transformers` are filed as #798 for 0.9.2, with a tested `overrides` recipe that takes `npm audit` from 5 high to zero. Deliberately not landed here: it needs a real embedding round-trip to verify, and this environment blocks model egress.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLQzxy3jXCFxHcuZ8N8etQ)_