### PR TITLE
docs: benchmark harness consolidation brief and decision register

### DIFF
--- a/docs/plans/benchmark-harness-consolidation.md
+++ b/docs/plans/benchmark-harness-consolidation.md
@@ -257,6 +257,10 @@ Each phase ends in a gate that produces a number or a proof, not a refactor.
 
 ## 8. Open decisions — these need your call
 
+> **Live status:** decisions and their consequences are tracked in
+> [`benchmark-harness-decisions.md`](./benchmark-harness-decisions.md).
+> As of 2026-08-22, D1/D2/D4/D6/D7 are decided; the rest remain open.
+
 Ordered by blast radius. Several change what earlier phases emit, so they cannot be deferred past P2.
 
 1. **Do the longitudinal workflows survive?** *(biggest scoping decision)* Harbor gives every trial an isolated container. `evolve` (train → feedback → improve → accept → reindex → eval in pre/post/synthetic arms) and `attribute` (leave-one-out asset masking over a saved report) are **multi-run orchestrations with no Harbor primitive**. Six tasks carry `repeated_failure_group` requiring two tasks in one pass to accumulate feedback against the same asset. Options: Harbor multi-step tasks, orchestrate outside Harbor in akm-bench, or **explicitly kill them**. "akm-bench becomes a thin Harbor wrapper" silently kills both — say which we mean. (There is also a third arm, `synthetic`, in `src/run-config.ts:362`, unaccounted for in this plan.)

--- a/docs/plans/benchmark-harness-consolidation.md
+++ b/docs/plans/benchmark-harness-consolidation.md
@@ -1,0 +1,294 @@
+# Implementation Brief: Rebuilding `akm-bench` and `akm-eval` on Upstream Harnesses
+
+**Status:** Draft — awaiting review
+**Scope:** [`itlackey/akm-bench`](https://github.com/itlackey/akm-bench) (rewrite), [`itlackey/akm-eval`](https://github.com/itlackey/akm-eval) (strip + finish)
+**Targets:** `akm-cli >= 0.9.1`, `akm-opencode >= 0.9.x`, Harbor `0.22.x`
+**Branch (this doc):** `claude/akm-benchmark-measurement-75rpsg`
+**Evidence basis:** Harbor source @ `39b8587` (v0.22.0), akm 0.9.1 source (exercised live), both repos read in full, upstream memory-benchmark survey. Claims below carry file:line or URL citations.
+
+---
+
+## 1. The split
+
+| Repo | Owns | Executed by | Answers |
+| --- | --- | --- | --- |
+| **`akm-bench`** | Standard agentic-coding benchmarks + akm's own task corpus | **Harbor** | "Does the akm-opencode plugin change scores on benchmarks the field recognizes?" |
+| **`akm-eval`** | Memory / long-term-recall benchmarks | **Upstream dataset harnesses** (LongMemEval, LoCoMo, BEAM) | "Does akm hold up as a memory layer against mem0 / Zep / raw vector?" |
+
+Both emit the same normalized per-trial record and share one statistics module. Neither owns a container runtime, an agent driver, or a benchmark scorer.
+
+### 1.1 The honest framing
+
+"Thin wrapper" is true of **execution** and false of **analysis**. Harbor replaces containers, agent install, parallelism, retries, resume, trajectories and artifact layout. It supplies **zero** statistics: no pass@1, no confidence intervals, no significance tests, no bootstrap, no CSV export, and no local `job compare` CLI (`src/harbor/metrics/`, `src/harbor/utils/pass_at_k.py`). Every number in an A/B report is code we write.
+
+Plan for roughly: **execution → upstream, analysis → ours.** Section 6 sizes what "ours" means.
+
+---
+
+## 2. Why rewrite, not port
+
+### 2.1 `akm-bench` — legacy against a retired akm interface
+
+| Fact | Evidence |
+| --- | --- |
+| Pins `akm-cli ^0.7.1` | `package.json` |
+| Whole AKM toggle is retired in 0.9: `AKM_STASH_DIR` (zero refs in akm 0.9.1), `stashDir` config key ("retired in 0.9", `akm/src/core/config/config-schema.ts:169`), `akm distill` / `akm reflect` (hard-removed, `akm/src/cli/retired-commands.ts`) | `src/environment.ts:205,232`, `src/evolve.ts:568-620` |
+| Hard-codes `plugin: []` specifically to keep `akm-opencode` out | `src/environment.ts:29-49` (`BENCH_OPENCODE_INVARIANTS`) |
+| ~5,100 LOC of container/exec/verifier machinery duplicating Harbor | `driver.ts`, `environment.ts`, `runner.ts`, `verifier.ts`, `corpus.ts`, `tmp.ts`, `cleanup.ts` |
+| Published v1 reference run has **no** measured baseline arm (`arms: ["akm"]` only) | `results/reference/v1/SUMMARY.md:55-70` |
+
+It benchmarks an akm generation the plugin cannot run against. Rewrite is correct.
+
+### 2.2 `akm-eval` — mis-scoped, not rotten
+
+Correcting an earlier assumption: **akm-eval is already most of the way to being the memory-eval repo.**
+
+- `locomo`, `longmemeval`, `beam` and `tau-bench` packs all exist and all instantiate a `MemoryBackend` (`src/memory/types.ts` — a 4-method interface: `add`/`search`/`reset`/`healthCheck`).
+- `src/packs/locomo/adapter.ts:309-370` already runs the exact `reset() → add(documents) → search(question) → answer` pipeline this plan wants.
+- LoCoMo already downloads the official `locomo10.json` and shells out to a wrapper around the **official** scorer (`src/packs/locomo/dataset.ts`, `scripts/locomo-evaluator.py`) — the recommended shape, already done.
+- The A/B path is **proven live**: `config/common/locomo-smoke.json` defines two arms (`baseline` + `raw-vector`) with different memory backends. (My earlier statement that every committed config defines only `baseline` was wrong.)
+
+What is actually wrong with it:
+
+| Problem | Evidence |
+| --- | --- |
+| `swe-bench` pack is a **one-shot patch completion**, not an agentic run — a session-lifecycle plugin has no surface to act on | `src/packs/swe-bench/adapter.ts:71-72,522-548` |
+| `terminal-bench` pack rides the **frozen** legacy `tb` CLI (PyPI `terminal-bench` last released 0.2.18, 2025-09) — can never produce TB2-comparable numbers | `scripts/setup-terminal-bench-runtime.sh` |
+| `plugin` is a **forbidden** config key; every materialized config gets `plugin: []` | `src/opencode-config.ts:71-92,283-288` |
+| The `akm` memory backend is a deliberate throwing stub that probes `akm memory --help` — **a command that has never existed** in any akm version | `src/memory/backends/akm.ts:29-51` |
+| `docs/operator-blockers.md` item 3 blames an "upstream add/search contract" that akm 0.9.1 ships today (`akm remember` + `akm search`, JSON by default) | stale doc |
+| `src/memory/judge.ts` is a **heuristic** judge (max of exactMatch/tokenF1/contains, pass ≥ 0.6) feeding `judgedPass` — directly contradicting the README's "no synthetic or heuristic success metrics" | `src/memory/judge.ts`, `src/packs/longmemeval/scorer.ts` |
+
+So: **strip the coding half, delete the heuristic judge, implement the akm backend.** Not a from-scratch rewrite.
+
+### 2.3 The common failure
+
+Neither repo can measure the thing we care about. Both deliberately exclude `akm-opencode` from every run, and `akm-plugins/evals` never launches a real opencode binary (in-process mock client). **Zero existing first-party tooling exercises the plugin in a real opencode session.**
+
+---
+
+## 3. What upstream gives us — and what it doesn't
+
+### 3.1 Harbor (v0.22.0) — verified
+
+**Free:**
+- Built-in `opencode` agent (`src/harbor/agents/installed/opencode.py`): installs Node + `npm i -g opencode-ai@<version>`, runs `opencode --model=<p/m> run --format=json`, parses to ATIF-v1.7 trajectory with per-step tool calls, token counts and `cost_usd`. `SUPPORTS_ATIF = True`, `SUPPORTS_RESUME = True`.
+- **Plugin injection is a config kwarg**: `opencode_config` is deep-merged into the container's `~/.config/opencode/opencode.json` (`opencode.py:478`), `_DEFAULT_CONFIG` is empty, arbitrary keys pass through. Confirmed from source, not inferred.
+- Custom agents via `--agent module.path:ClassName` (`src/harbor/cli/jobs.py:548-556`) — the supported extension point for an `AkmOpenCode(OpenCode)` subclass overriding `install()`.
+- Local task dirs run with **zero** hub involvement: `harbor run -p <dir>` (`jobs.py:1774-1798`). A local `registry.json` gives named+versioned local datasets (`src/harbor/models/registry.py`).
+- Per-trial provenance: `<trial>/result.json` carries `agent_info` (name/version/model), **`config.agent.kwargs`** (our arm's full config), `verifier_result.rewards`, `agent_result.{n_input_tokens,n_cache_tokens,n_output_tokens,cost_usd}`, `exception_info.exception_type`, per-phase `TimingInfo`. `<trial>/lock.json` adds content digests of task + agent + skills + harbor version.
+- **Resume is real and cost-safe**: `harbor job resume -p <job_dir>` reuses every trial with a parseable `result.json` (`src/harbor/job.py:237-320`). Critical for 500-instance runs.
+
+**Not free — and each is a trap:**
+- `jobs/<job>/result.json` on disk **never** contains `trial_results` (always written with `exclude_trial_results=True`, `job.py:712-720`). Walk trial subdirs.
+- `pass@1` is **unreachable**: k starts at 2, and `pass_at_k` returns `{}` unless every trial has exactly one reward key valued exactly 0 or 1 (`utils/pass_at_k.py`).
+- Default `Mean` metric folds errored trials in as **0** (`metrics/base.py:36-40`).
+- `-k N` records **no attempt index** — trials differ only by a random 7-char suffix. Attempt *i* of arm A **cannot** be paired with attempt *i* of arm B. Paired statistics must be redesigned as per-(task, arm) aggregates.
+- `task.toml` `[metadata]` **never reaches** `result.json` at any level. Every grouping we care about (domain, slice, difficulty, memory_ability) requires a left-join from our corpus onto `TrialResult.task_name`. There is no hook to smuggle it through (`src/harbor/cli/plugins/` contains only `harbor_hub.py`).
+- `ctrf.json` is written by the **task's** `tests/test.sh`, never by Harbor, which stores it as opaque text (`viewer/server.py:2661`). Per-test granularity is ours to guarantee and parse.
+- Retries `rmtree` the failed trial dir and reuse the name — failure forensics are destroyed. Run `--max-retries 0` if transient-failure analysis matters.
+- Resume demands a **byte-identical** `JobConfig`; regenerating a config with any changed field (even `n_concurrent_trials`) breaks resume mid-sweep.
+- `harbor run -p <dir>` scans **exactly one directory level**. Our current `tasks/<domain>/<task-id>/` layout resolves to **zero tasks**.
+
+### 3.2 Dataset IDs — correction
+
+The shipped `registry.json` at v0.22.0 (80 datasets) uses `name@version`, resolved from pinned git commits:
+
+- `terminal-bench@2.0` (89 tasks), `terminal-bench-sample@2.0` (10), `terminal-bench-pro@1.0` (200)
+- `swebench-verified@1.0` (500), `swebenchpro@1.0` (731), `swebench_multilingual@1.0` (300)
+
+Hub packages use a separate `org/name` form (`PackageTaskId`, `models/task/id.py:35`). **Both mechanisms are real**; earlier drafts of this analysis quoted only the hub form. Confirm the exact spelling for the installed version with `harbor dataset list` before pinning anything. Note: every shipped registry entry has `metrics: []`.
+
+### 3.3 Memory evals — there is no Harbor equivalent
+
+Verified: **no neutral multi-backend memory-eval harness exists** that we can adopt as a dependency.
+
+- Harbor's registry has **zero** memory/conversational-QA datasets. Its one LoCoMo adapter (`adapters/locomo`, parity-verified) is **closed-book long-context** — the transcript is mounted at `/app/conversation.md`, there is no ingest/query protocol — and its dataset PR is still open. Not the memory harness.
+- `supermemoryai/memorybench` (MIT, Bun/TS — our stack) is the closest: one `Provider` (~200 LOC: initialize/ingest/awaitIndexing/search/clear) buys LoCoMo + LongMemEval + ConvoMem, three judges, checkpointed phases, and `compare -p akm,mem0,zep`. But providers are a static in-tree `Record`, so integration = submodule/fork or upstream PR, not a dependency.
+- `mem0ai/memory-benchmarks` (Apache-2.0) covers LoCoMo + LongMemEval + BEAM but hardcodes a Mem0 client — escapable via a 3-endpoint (`POST /memories`, `POST /search`, `DELETE /memories`) mem0-OSS-compatible shim. Highest coverage per line, but it is mem0's harness and mem0's prompts: publish as "akm under mem0's protocol", never as neutral.
+- `LongMemEval v1` (MIT) has the **thinnest contract of any memory benchmark**: write JSONL of `{question_id, hypothesis}`, shell out to `src/evaluation/evaluate_qa.py`. Zero scoring code owned.
+- `BEAM` has **no plugin interface** at all (hardcoded retrieval families, torch/qdrant/FAISS/Bedrock deps). Fork or shim only. Its reusable part is the per-ability rubric judge.
+- `OpenDataBox/MemoryData` is the most unified suite but ships **no LICENSE** — legally unusable.
+- **Never write a LoCoMo scorer.** Import the pinned upstream, or lift Harbor's parity-verified `adapters/locomo/.../verifier.py`.
+
+---
+
+## 4. Target: `akm-bench`
+
+### 4.1 Architecture
+
+```
+akm-bench/
+  agents/akm_opencode.py     # AkmOpenCode(OpenCode): install() override      (~40 LOC Python)
+  tasks/                     # 46 tasks, Harbor format, ONE level deep
+  registry.json              # akm-tasks-train@1.0 / akm-tasks-eval@1.0
+  arms/*.yaml                # Harbor job configs: baseline vs akm
+  analysis/                  # trial loader, corpus join, metrics, statistics  (TS)
+  bin/akm-bench              # argv builder over `harbor run` / `harbor job resume`
+```
+
+No executor, no container code, no verifier dispatcher, no agent driver.
+
+### 4.2 Delete (~5,100 LOC)
+
+`src/driver.ts`, `src/environment.ts`, `src/runner.ts`, `src/verifier.ts`, `src/corpus.ts`, `src/opencode-config.ts`, `src/support/agent.ts`, `src/trajectory.ts`, `src/tmp.ts`, `src/cleanup.ts`, `src/doctor.ts`, `src/fixture-index-*.ts`, `src/build-fixture-indexes.ts`, `Dockerfile`, `bin/docker-entrypoint.sh`, all 13 `config/*.json` run configs.
+
+### 4.3 Keep and re-point (~8,500 LOC — this is the repo's actual value)
+
+Harbor replaces **none** of `src/metrics/` (13 modules), `src/report/`, `src/workflow-*.ts`, `evolve*.ts`. What changes is only their **input adapter**:
+
+| Analysis input (today) | Becomes |
+| --- | --- |
+| bespoke `RunResult.events` | akm's own `state.db` — `akm log --since @offset:<N> --detail full --format json` + the `usage_events` table |
+| scraped agent stdout for `akm show <ref>` | `<trial>/agent/trajectory.json` ATIF `tool_calls` (structured, with arguments) |
+| `verifierStdout` | `<trial>/verifier/{reward.json,ctrf.json}` |
+| `workspaceWrites` | trajectory tool calls + `/logs/artifacts/` |
+
+`src/workflow-trace.ts` already normalizes exactly this evidence set behind one interface, so the change is confined to its source adapters. **This is a strict upgrade in fidelity**: `src/metrics/attribution.ts` today admits all three of its detection strategies are heuristic regex over stdout; akm's `usage_events` table gives per-query attribution natively (`event_type`, `entry_ref`, `query`, `source`). Set `AKM_EVENT_SOURCE=audit` on all harness-side akm calls so the agent's own traffic stays separable as `source='user'` — that one env var is what makes the metric honest.
+
+### 4.4 Corpus conversion — mechanical except for one part
+
+46 tasks → Harbor format (`task.toml` + `instruction.md` + `environment/` + `tests/test.sh`). Census: az-cli 6, docker-homelab 6, drillbit 7, inkwell 9, opencode 6, workflow-compliance 11, `_example` 1. Verifier: script 29 / pytest 17. Slice: train 27 / eval 19.
+
+The verifier contract is permissive — `tests/test.sh` need only write `/logs/verifier/reward.json` (flat `{key: number}`) or `reward.txt` (a bare float). Harbor does **not** wrap pytest. Existing `verify.sh` scripts port nearly as-is.
+
+**The non-mechanical part:** no `task.yaml` carries an instruction or prompt beyond a one-line `title` — the actual prompt is synthesized today by the driver. An `instruction.md` must be authored for all 46, and **the derivation rule materially changes task difficulty**. Budget real time here; it is the least mechanical part of a "mechanical" conversion.
+
+Also required: flatten to one directory level (or ship `registry.json`); rewrite 43 `gold_ref` values from the pre-0.9 `type:name` grammar to `[bundle//]conceptId[#fragment]` (a migrator exists at `akm/scripts/akm-migrate/migrate/legacy-ref-grammar.ts`); map `budget.tokens` and `slice` into `[metadata]` (Harbor has neither concept) knowing they will need the corpus join to be usable.
+
+Good news: the 7 fixture bundles are already akm-retrievable (frontmatter `description:` + headings), so §5.4's indexing ceiling does **not** bite here.
+
+### 4.5 Arms
+
+```sh
+# Baseline
+harbor run -d terminal-bench@2.0 -a opencode -m <provider/model> \
+  --ak version=<pinned-opencode-ai> -k 5 -n 8
+
+# Treatment
+harbor run -d terminal-bench@2.0 -a akm_opencode:AkmOpenCode -m <provider/model> \
+  --ak version=<pinned-opencode-ai> -k 5 -n 8
+```
+
+**Load-bearing detail:** any `opencode_config` we write must carry the permission block (`permission: {bash: allow, edit: allow, write: allow}`). In non-interactive `opencode run`, opencode **silently skips** tool calls lacking explicit grants — the failure looks like agent incompetence, not misconfiguration. This is why `BENCH_OPENCODE_INVARIANTS` exists; carry it forward.
+
+---
+
+## 5. Target: `akm-eval`
+
+### 5.1 Delete (~1,400 LOC + runtime plumbing)
+
+`src/packs/swe-bench/` (736), `src/packs/terminal-bench/` (725), `src/packs/akm-bench/` (36 — a circular dependency the split kills), `src/opencode-config.ts` (the plugin-forbidding materializer), `tools/terminal_bench_agent.py`, `tools/terminal-bench-opencode-setup.sh.j2`, `scripts/setup-{swe-bench,terminal-bench}-runtime.sh`, `scripts/swebench_list_instances.py`, `bin/{swe-bench-eval,terminal-bench-eval}`, the coding-benchmark entries in `src/variants/registry.ts`.
+
+**Also delete `src/memory/judge.ts`** and the heuristic paths in `answer-metrics.ts` / `retrieval-metrics.ts` that feed `judgedPass`. Replace with upstream evaluators. Keeping them silently inherits a metric the repo's own README disavows.
+
+### 5.2 Keep
+
+`src/packs/{locomo,longmemeval,beam}`, `src/memory/` interface + registry, `src/variants/`, `src/reporting/`, `src/config/`, `src/core/`, the Docker CLI image. Decide `tau-bench`'s fate (§8).
+
+Note the surviving half is the **expensive** half: `beam/official.ts` alone is 777 LOC of upstream repo discovery, dataset prep and judge credential checking. BEAM has no plugin interface, so that is irreducible vendor plumbing.
+
+### 5.3 Build: the akm memory backend
+
+The interface is 4 methods. Subprocess form, verified live against 0.9.1:
+
+```
+add(text, metadata) → akm remember "<text>" --name <id> --description "<md>" --tag k:v --format json
+                      → {ok, ref, path}          # auto-indexes; no separate `akm index` needed
+search(query)       → akm search "<q>" --limit N --shape agent --format json
+                      → hits[].{ref, name, type, path, score, description, estimatedTokens}
+get(ref)            → akm show <ref> --shape agent --format json → .content
+```
+
+Verified gotchas:
+- `--format json` is already the **default** on every command; errors are a uniform JSON envelope on **stderr**; exit codes are a stable 5-value table (0/1/2/4/70/78).
+- **`--detail normal` silently drops `ref`** (`akm/src/output/shapes/helpers.ts:295-306`). Use default `brief` or `--shape agent`, never `normal`.
+- There is no `snippet` field. `--shape agent` returns an absolute `path`, so read the file directly rather than paying a second `akm show`.
+- In-process fast path exists (`akm-cli/dist/commands/read/{search,show,curate}.js`) but only on the **npm** install (the standalone binary ships no `dist/*.js`), and under Node it needs `dist/text-import-hook.mjs` registered first. Make it an opt-in flag; subprocess is the always-correct default. Note `dist/akm` is a launcher that re-spawns `bun dist/cli.js` — each CLI call is up to **two** processes.
+
+### 5.4 Two things that are not thin
+
+**(a) akm does not index body prose.** FTS and embedding fields are name, frontmatter `description`, tags/aliases, hints and **headings** (+ optionally the first ~280 chars of body via `index.indexBodyOpening`). Verified empirically: a word appearing only in body prose returns **zero** hits, and embeddings do not help — `buildSearchText` concatenates the same fields. A naive `add(raw conversational turn)` is therefore near-unretrievable, and the arm would measure ~0 recall and blame akm.
+
+akm-eval must own a per-document **description/tag synthesis** step. Either an LLM (cost, non-determinism, and a confound: you are now partly measuring the synthesis prompt) or a documented deterministic heuristic. **This step sets the ceiling of every retrieval metric and must be declared in every published number.**
+
+**(b) Bulk ingest and `reset()` have no cheap primitive.** `akm remember` re-indexes after **every** write, so per-turn ingest of a LongMemEval-m haystack (~500 sessions) is O(n) reindex per document. The bulk path is "write N markdown files, then `akm bundle add <dir>` / `akm index`" — different code from the per-document `add()` the interface assumes. And `reset()` has **no akm command**: it means `rm -rf` the bundle + `$DATA` + `$STATE` and re-init, per instance.
+
+### 5.5 Integration surface, per benchmark
+
+| Benchmark | Surface | Effort |
+| --- | --- | --- |
+| **LongMemEval v1** | JSONL of `{question_id, hypothesis}` → pinned `evaluate_qa.py` | Thinnest. **Do this first.** The `oracle` variant gives a retrieval-free ceiling that separates "akm retrieval is bad" from "the answering LLM is bad". |
+| **LoCoMo** | Already done — keep `dataset.ts` + `locomo-evaluator.py` | Zero |
+| **BEAM** | No plugin interface; fork or mem0-shim | Highest; `official.ts` stays |
+| **memorybench** (optional) | One `Provider` (~200 LOC) buys LoCoMo + LongMemEval + ConvoMem **plus** head-to-head vs mem0/zep under one protocol | Best leverage per line; needs submodule/fork |
+
+---
+
+## 6. The shared piece
+
+One normalized per-trial record, one loader, one statistics module, used by both repos.
+
+- **Record:** keep akm-eval's `NormalizedRunResult` shape (`schemaVersion`, arm id, pack/dataset, metrics, telemetry, artifacts) and extend it to carry Harbor's per-trial provenance (`agent_info`, `config.agent.kwargs`, `task_checksum`, lock digests).
+- **Loader:** walk `<job>/<trial>/result.json`; group by `(task_name, arm)`; left-join corpus `[metadata]` on `task_name`. Do **not** trust Harbor's `evals` key (`{agent}__{model}__{dataset}`, ambiguous if any component contains `__`).
+- **Statistics (all ours):** pass@1, per-arm mean ± CI, paired-by-task bootstrap over per-(task, arm) aggregates (attempt-level pairing is impossible — §3.1), and a declared minimum detectable effect. Harbor's `Mean` counting errors as 0 must be replaced with an explicit errored-trial policy.
+- **Reproducibility manifest** on every published number: pinned Harbor version, opencode-ai version, akm-cli version, plugin version, dataset ref/commit, model, judge model, protocol flags, seed count, cost. For LoCoMo specifically, protocol (upstream F1 + Porter stem vs LLM-judge), judge model, and cat-5 inclusion (1,986 vs 1,540 QA pairs) are **required** fields — that label is what makes our numbers defensible against mem0's 92.5% and Zep's 94.7%.
+
+Ship it as one small package consumed by both repos, not two copies.
+
+---
+
+## 7. Phased plan
+
+Each phase ends in a gate that produces a number or a proof, not a refactor.
+
+| Phase | Deliverable | Gate |
+| --- | --- | --- |
+| **P0 — Pilot** | `AkmOpenCode` agent + one Harbor job on a 1-task subset | `/logs/agent/opencode.txt` shows the model actually calling `akm_*` tools in-container. **Nothing else starts until this passes.** |
+| **P1 — Shared analysis** | Record schema, trial loader, corpus join, statistics module | Loader reproduces a known job's rewards; bootstrap CI on synthetic data |
+| **P2 — akm-bench standard arms** | Harbor job configs for `terminal-bench@2.0` and `swebench-verified@1.0`, baseline + akm | A/B on a 10-task subset with CIs; resume verified after a kill |
+| **P3 — Corpus conversion** | 46 tasks in Harbor format + `registry.json` slices + authored `instruction.md` | All 46 run green under the oracle/solution path; reward parity vs the old harness on a sample |
+| **P4 — akm-bench analysis re-point** | metrics/report re-sourced from trajectory + `state.db` | Attribution reproduces a hand-checked trial; workflow-compliance scores a known-violating run |
+| **P5 — akm-eval strip** | Coding packs, heuristic judge, plugin-stripping deleted | Repo runs locomo + longmemeval green; boundary check passes |
+| **P6 — akm memory backend** | `add`/`search`/`reset` + bulk ingest + description synthesis | LongMemEval **oracle** ceiling measured first, then `s`; akm vs raw-vector vs none with CIs |
+| **P7 — Decide** | Attribution / evolve / BEAM / memorybench per §8 | — |
+
+---
+
+## 8. Open decisions — these need your call
+
+Ordered by blast radius. Several change what earlier phases emit, so they cannot be deferred past P2.
+
+1. **Do the longitudinal workflows survive?** *(biggest scoping decision)* Harbor gives every trial an isolated container. `evolve` (train → feedback → improve → accept → reindex → eval in pre/post/synthetic arms) and `attribute` (leave-one-out asset masking over a saved report) are **multi-run orchestrations with no Harbor primitive**. Six tasks carry `repeated_failure_group` requiring two tasks in one pass to accumulate feedback against the same asset. Options: Harbor multi-step tasks, orchestrate outside Harbor in akm-bench, or **explicitly kill them**. "akm-bench becomes a thin Harbor wrapper" silently kills both — say which we mean. (There is also a third arm, `synthetic`, in `src/run-config.ts:362`, unaccounted for in this plan.)
+2. **How does akm get into each trial container?** (a) custom agent `install()` override — clean arm/task separation, real Python in akm-bench; (b) task `environment/Dockerfile` — contaminates 46 arm-neutral tasks and makes the baseline arm run an image containing akm; (c) `--skill` upload — portable but files, not a global install. **(a) is recommended.** Decide before conversion starts: (b) changes what the converter emits.
+3. **Network policy for the akm arm.** opencode resolves `plugin: ["akm-opencode"]` from npm **at session start**; TB2 tasks commonly restrict egress. Pre-install at image build (offline-safe, couples image to plugin version) vs allow `registry.npmjs.org` (changes the environment relative to baseline — itself a confound). Note `akm-opencode` depends on `akm-cli ^0.9.0`, so one install brings both.
+4. **Canonical reward shape.** Single `reward` key (Harbor's aggregates work) vs multi-key (all Harbor aggregates silently degrade and we own 100% of scoring). Workflow-compliance sub-scores are the forcing case.
+5. **Where is workflow-compliance scored?** In-container `tests/test.sh` (it **can** read `/logs/agent/trajectory.json` — verified: `_sync_agent_output` runs before `_run_verifier`, and cloud envs upload logs back in — and can read akm's `state.db` directly) puts compliance into the reward; post-hoc in analysis keeps it out of every Harbor artifact and regrade path.
+6. **Cold-start library content** *(carried over — still unanswered)*. Nothing in any repo provides a knowledge library relevant to SWE-bench repos or TB2 tasks. An empty-but-configured library is **not** a null treatment: the plugin injects a ~2KB doctrine block every turn and registers 5 tools regardless, so it measures pure overhead and likely shows a *negative* delta. Options: generic SWE skills bundle, per-domain `akm import` (watch contamination for SWE-bench), or a learned library harvested from a train split.
+7. **Cross-task accumulation policy.** Shared mutable bundle across trials (the "akm learns" story) needs a mounted volume and introduces ordering effects and concurrent-write races at `-n > 1`; per-trial read-only copies give clean statistics but measure only static retrieval. **This changes the claim the numbers can support.**
+8. **Which upstream memory harness akm-eval adapts** (§5.5), and whether to invest the ~200 LOC in a memorybench `Provider` for head-to-head vs mem0/zep.
+9. **Judge-model cost budget.** LongMemEval-V2 defaults to a gpt-5.2 medium-reasoning judge; BEAM-10M ingest is likely the single most expensive item in the suite; Harbor's own LoCoMo parity run cost ~$35 for 5×10 trials on gpt-5-mini. No estimate exists for a full akm sweep — **force a number before P6.**
+10. **Slice representation, bundle fixture delivery, token budgets, attribution masking** — mechanical but each needs a call; see §4.4.
+11. **What happens to `akm-plugins/evals`?** A third eval surface this plan never mentions (tier2 deterministic plugin metrics against a fake-akm shim; tier3 LLM-judge scenarios). It holds akm's ranker constant so it does not overlap akm-bench, but ownership and CI wiring need a decision.
+12. **Harbor version pin.** Every behavior above is **internal, not a documented contract** (`[metadata]` exclusion, agent-then-verifier ordering, reward parsing, one-level `-p` scanning), all read at v0.22.0/`39b8587`. Pin a version and add a CI check that re-verifies these on bump.
+
+---
+
+## 9. Risks
+
+- **P0 fails.** Harbor invokes `opencode run` once per task; the plugin's per-prompt curation lands on the *next* turn, which never arrives. The treatment effect rides on the session-start curate (a pointer to a tmp file the model must read), the doctrine block, and the model choosing to call `akm_*` itself. If P0 shows no tool calls, the whole premise needs rework before any spend.
+- **Analysis is the long pole, not execution.** ~8,500 LOC survives in akm-bench and every statistic is ours. A brief that reads as "delete it all" will produce a repo that runs benchmarks and cannot say anything about them.
+- **Version pinning everywhere.** Harbor's default and akm-eval's setup both install `opencode-ai@latest`. Pin opencode-ai, akm-cli, akm-opencode, Harbor, and the dataset commit in **both** arms, set `OPENCODE_DISABLE_AUTOUPDATE=true`, and set the plugin kill switches (`AKM_AUTO_MEMORY=0` — memory harvest exits 78 without a configured LLM engine — and `AKM_INDEX_ON_SESSION_END=0`).
+- **Determinism.** Use `AKM_EMBED_DETERMINISTIC=1` with `semanticSearchMode: "auto"` (384-dim feature hashing, offline, byte-identical across machines) so ranking deltas are attributable to akm source changes rather than embedding drift. Set `registries: []` to kill registry network. akm has **no** outbound analytics — nothing to opt out of.
+- **Container traps** (verified live): `akm setup --dir /tmp/...` is refused without `AKM_FORCE_SETUP_TMP_STASH=1`; bare `akm setup` hard-fails on a non-TTY without `--yes`.
+- **LoCoMo dataset quality is contested** (a 2026 third-party audit claims 6.4% of the answer key is wrong). Expect LoCoMo numbers to be challenged regardless of harness — which is why the protocol label in §6 is non-negotiable.
+- **Image economics flip.** akm-bench today is one Docker image for the whole harness; Harbor's model is one environment image **per task**. Either publish a shared base image resolvable from cloud sandbox providers, or rebuild 46. Most cloud providers support Dockerfile-defined environments only, not compose.
+
+---
+
+## 10. Non-goals
+
+- Building a fourth generic benchmark harness. The differentiator is the akm adapter plus the reproducibility manifest, not new metric code.
+- Terminal-Bench 1.x comparisons (frozen, legacy `tb` CLI only).
+- Making akm-eval run coding benchmarks, or akm-bench run memory benchmarks. The split in §1 is the point.
+- Publishing to the TB2 leaderboard. Out of scope until P2 produces stable internal numbers.

--- a/docs/plans/benchmark-harness-decisions.md
+++ b/docs/plans/benchmark-harness-decisions.md
@@ -12,10 +12,10 @@ can be checked against it without re-litigating.
 | --- | --- | --- | --- |
 | D1 | Longitudinal workflows (`evolve`, `attribute`) | **DECIDED** | P7 |
 | D2 | How akm reaches the trial container | **DECIDED** | P0 |
-| D3 | Network policy for the akm arm | OPEN | P2 |
+| D3 | Network policy for the akm arm | **PARTIALLY RESOLVED** | P2 |
 | D4 | Canonical reward shape | **DECIDED (provisional)** | P3 |
 | D5 | Where workflow-compliance is scored | OPEN | P4 |
-| D6 | Cold-start library content | **DECIDED** | P2 |
+| D6 | Cold-start library content | **DECIDED + built** | P2 |
 | D7 | Cross-task accumulation policy | **DECIDED** | P2 |
 | D8 | Which upstream memory harness `akm-eval` adapts | OPEN | P6 |
 | D9 | Judge-model cost budget | OPEN | P6 |
@@ -76,7 +76,15 @@ metrics actually need.
 - Anything richer than pass/fail is invisible in Harbor's artifacts and depends
   entirely on our artifact join. That join must exist before P4 can revisit this.
 
-### D6 — Cold-start library: a hand-authored generic SWE skills bundle
+### D6 — Cold-start library: BUILT (2026-08-23)
+
+Shipped as `akm-bench/harbor/treatment-library/`: 26 assets (knowledge 20,
+skills 3, lessons 3), contamination-free, retrieval-verified against real
+akm 0.9.1, wired into both A/B job yamls' akm-static arms. Seed
+expectations in the agent self-check are now derived from the configured
+library. The original decision text follows.
+
+### D6 (original) — a hand-authored generic SWE skills bundle
 
 ~20–40 assets of general software-engineering practice (debugging, test running,
 git, build systems, common CLI tooling). Contamination-free, reusable across both
@@ -116,13 +124,18 @@ retrieval value from learning value.
 
 ## Open
 
-### D3 — Network policy for the akm arm *(blocks P2)*
-opencode resolves `plugin: ["akm-opencode"]` from npm **at session start**, and
-terminal-bench 2.x tasks commonly restrict egress. Pre-install at image build
-(offline-safe, couples the image to a plugin version) vs allow
-`registry.npmjs.org` through the policy (changes the environment relative to
-baseline — itself a confound). Needs a call once P0 shows whether the runtime
-install actually works inside a task container.
+### D3 — Network policy: partially resolved by implementation (2026-08-23)
+
+The agent pre-installs and cache-warms everything at install() time, so a
+session-start npm fetch is only needed when the warm boot failed (and the
+self-check aborts setup in that case). Residual: install() itself needs npm
+egress, and whether TB2/SWE-bench task network policies permit it is a
+first-live-run question. A related finding closed the in-process pin hole:
+live npm probing showed opencode installs plugins under
+`~/.cache/opencode/packages/`, making the documented config-dir overrides
+file INERT - the effective fix (shipped) is a post-warm-boot realign step
+that force-reinstalls the pinned akm-cli into the plugin's hoisted tree,
+plus probe 7c verifying the hoisted package version.
 
 ### D5 — Where workflow-compliance is scored *(blocks P4)*
 In-container `tests/test.sh` — which **can** read `/logs/agent/trajectory.json`
@@ -205,6 +218,23 @@ CI (see Open questions below).
   on main before this work (legacy src/ typecheck + 5 pre-existing
   tests/leakage.test.ts failures against fixtures/corpus). Nothing new is
   CI-gated until this is addressed.
+- **RESOLVED (2026-08-23): LongMemEval retrieval is now wired** through
+  MemoryBackend.search() with real retrieval metrics vs evidence session ids;
+  the inert-arm warning became a regression tripwire. The A/B config is now
+  meaningful.
+- **VALIDITY RISK - natural-language query shape vs akm's conjunctive-AND
+  FTS** (measured independently in BOTH gates): akm FTS is an implicit AND
+  over every query token with no stopword removal, so sentence-shaped
+  queries ("how do I run just one failing test quickly") return zero hits
+  while keyword/hint-shaped queries hit rank 1. The treatment library
+  compensates with question-form searchHints (0/8 -> 7/8 rank-1), and
+  akm-eval discloses zero-hit rates in every artifact - but if the MODEL
+  issues sentence-shaped akm_search queries mid-benchmark, the treatment arm
+  sees mostly empty results and a null result becomes attributable to query
+  shape rather than akm's value. Pre-run lever: the akm-opencode plugin's
+  tool description (how it steers query phrasing) - that lives in
+  akm-plugins, outside these branches. An OR/fuzzy search mode in akm
+  itself is the deeper fix.
 - **LongMemEval retrieval is not yet wired through the memory backend** (D8):
   the akm backend and the three-variant A/B config landed, but the longmemeval
   pipeline feeds full haystack context to the model and never calls
@@ -232,6 +262,7 @@ CI (see Open questions below).
 
 ## Changelog
 
+- **2026-08-23 (final)** - D6 built and wired; D3 partially resolved; in-process akm-cli pin hole closed via realign (overrides file proven inert); LongMemEval wiring landed; CI green on all three PRs' gated jobs; the FTS query-shape validity risk recorded from both gates.
 - **2026-08-23 (later)** - P5/P6 landed on akm-eval `claude/memory-eval-refactor`; four further open items recorded (longmemeval retrieval wiring, evaluator provenance, judgedPass naming, opencode-config retention).
 - **2026-08-23** - D10 and D12 decided by implementation (P1-P3 landed on
   akm-bench `claude/harbor-akm-agent-p0`); five new open questions recorded

--- a/docs/plans/benchmark-harness-decisions.md
+++ b/docs/plans/benchmark-harness-decisions.md
@@ -218,6 +218,33 @@ CI (see Open questions below).
   on main before this work (legacy src/ typecheck + 5 pre-existing
   tests/leakage.test.ts failures against fixtures/corpus). Nothing new is
   CI-gated until this is addressed.
+- **P0 GATE PASSED (2026-08-24, live containers, x86_64 + Docker 29.1.3)**:
+  on corpus task `opencode--select-correct-skill` the treatment arm made
+  real `akm_curate` x2 + `akm_show` x3 calls (both evidence sources agree;
+  control arm zero akm activity; both arms reward 1.0 - plumbing proven,
+  benefit unmeasured). Nuance: on `hello-world` the plugin's own activation
+  heuristic declined to curate (`prompt_recall skip-low-signal`), so that
+  task structurally cannot answer P0 - `harbor/jobs/p0-corpus.yaml` exists
+  for the corpus-task variant. Phase 3 also green: oracle 46/46 reward 1.0,
+  nop fail-path 3/3 reward 0, registry slice 19/19. Live execution surfaced
+  and fixed (akm-bench `1b527df`, 181 tests): the self-check derived seed
+  expectations from `seed_library_dir` while the bundle is actually seeded
+  from `AKM_TASK_STASH` (would have blocked the corpus programme), two
+  hardcoded probe assumptions, and a pre-existing invalid-bash bug that
+  would have killed every accumulating-arm trial at setup.
+- **NEW MODEL-COMPAT CONSTRAINT (arm-asymmetric hard failure)**: the
+  akm-opencode plugin injects context as ADDITIONAL entries in opencode's
+  `system` array, so the treatment arm sends multiple system messages. Chat
+  templates requiring a single leading system message (observed:
+  `qwen3.6-35b-a3b`, `devstral-small-2`) return HTTP 500 on the treatment
+  arm ONLY. Verified accepting: `qwen3-30b-a3b-2507`, `qwen3-coder-30b`,
+  `gpt-oss-20b`. Screen the model before any paid A/B; the deeper fix
+  (merging into one system message) lives in akm-plugins.
+- **RESOLVED (2026-08-24): akm-eval container caveat closed** (`0d66642`):
+  `docker/akm-eval.Dockerfile` now ships Node 22 + `akm-cli@0.9.1` (pinned,
+  asserted at build time), and `bin/doctor` reports the akm backend OK
+  in-container. The three-variant locomo/longmemeval A/B remains the last
+  unexecuted step (judge budget).
 - **RESOLVED (2026-08-23): LongMemEval retrieval is now wired** through
   MemoryBackend.search() with real retrieval metrics vs evidence session ids;
   the inert-arm warning became a regression tripwire. The A/B config is now
@@ -262,6 +289,7 @@ CI (see Open questions below).
 
 ## Changelog
 
+- **2026-08-24** - First live container runs on the maintainer's machine: P0 gate PASSED, corpus oracle validation green (46/46), four live-run defects fixed upstream (akm-bench `1b527df`), akm-eval container caveat closed (`0d66642`), and the multi-system-message model-compat constraint recorded.
 - **2026-08-23 (final)** - D6 built and wired; D3 partially resolved; in-process akm-cli pin hole closed via realign (overrides file proven inert); LongMemEval wiring landed; CI green on all three PRs' gated jobs; the FTS query-shape validity risk recorded from both gates.
 - **2026-08-23 (later)** - P5/P6 landed on akm-eval `claude/memory-eval-refactor`; four further open items recorded (longmemeval retrieval wiring, evaluator provenance, judgedPass naming, opencode-config retention).
 - **2026-08-23** - D10 and D12 decided by implementation (P1-P3 landed on

--- a/docs/plans/benchmark-harness-decisions.md
+++ b/docs/plans/benchmark-harness-decisions.md
@@ -205,6 +205,25 @@ CI (see Open questions below).
   on main before this work (legacy src/ typecheck + 5 pre-existing
   tests/leakage.test.ts failures against fixtures/corpus). Nothing new is
   CI-gated until this is addressed.
+- **LongMemEval retrieval is not yet wired through the memory backend** (D8):
+  the akm backend and the three-variant A/B config landed, but the longmemeval
+  pipeline feeds full haystack context to the model and never calls
+  MemoryBackend.search(). Until the adapter routes retrieval through the
+  backend, its akm arm is inert - now disclosed by an unconditional warning
+  stamped into result.json/summary.md, but the wiring itself is the remaining
+  P6 work before longmemeval-akm-ab is worth judge budget. locomo's akm arm IS
+  live (queries the backend, reports zero-hit rates and ceiling metadata).
+- **longmemeval evaluator provenance**: scripts/longmemeval-evaluator.py is a
+  repo-local reimplementation of the upstream rubric, not a pinned shell-out
+  to LongMemEval's evaluate_qa.py as plan section 5.5 recommends. A real LLM
+  judge (policy-compliant) but without upstream commit provenance.
+- **locomo judgedPass naming**: the value is upstream LoCoMo's mean token-F1
+  (correct metric, no judge involved) carried in a schema field named
+  "judgedPass" - rename or annotate before publishing cross-pack tables.
+- **src/opencode-config.ts kept** (deviation from brief section 5.1's delete):
+  still used by the opencode runner for memory packs; its plugin-stripping
+  comment now states the honest scope. Revisit only if the opencode runner
+  itself is retired.
 - **One unindexable legacy asset**: `workflow:configure-inkwell-service` fails
   akm 0.9.1 workflow schema validation and is absent from the inkwell stash
   index (recorded in harbor/stashes-meta/gold-ref-map.json).
@@ -213,6 +232,7 @@ CI (see Open questions below).
 
 ## Changelog
 
+- **2026-08-23 (later)** - P5/P6 landed on akm-eval `claude/memory-eval-refactor`; four further open items recorded (longmemeval retrieval wiring, evaluator provenance, judgedPass naming, opencode-config retention).
 - **2026-08-23** - D10 and D12 decided by implementation (P1-P3 landed on
   akm-bench `claude/harbor-akm-agent-p0`); five new open questions recorded
   from the implementation gates.

--- a/docs/plans/benchmark-harness-decisions.md
+++ b/docs/plans/benchmark-harness-decisions.md
@@ -1,0 +1,182 @@
+# Decision Register: Benchmark Harness Consolidation
+
+**Status:** Live — updated as decisions are made
+**Companion to:** [`benchmark-harness-consolidation.md`](./benchmark-harness-consolidation.md) §8
+**Branch:** `claude/akm-benchmark-measurement-75rpsg`
+
+Each decision is numbered to match §8 of the brief. `DECIDED` entries carry the
+consequence that follows from them — the point of this file is that later phases
+can be checked against it without re-litigating.
+
+| # | Decision | Status | Blocks |
+| --- | --- | --- | --- |
+| D1 | Longitudinal workflows (`evolve`, `attribute`) | **DECIDED** | P7 |
+| D2 | How akm reaches the trial container | **DECIDED** | P0 |
+| D3 | Network policy for the akm arm | OPEN | P2 |
+| D4 | Canonical reward shape | **DECIDED (provisional)** | P3 |
+| D5 | Where workflow-compliance is scored | OPEN | P4 |
+| D6 | Cold-start library content | **DECIDED** | P2 |
+| D7 | Cross-task accumulation policy | **DECIDED** | P2 |
+| D8 | Which upstream memory harness `akm-eval` adapts | OPEN | P6 |
+| D9 | Judge-model cost budget | OPEN | P6 |
+| D10 | Slice / fixture delivery / token budgets / masking | OPEN | P3 |
+| D11 | Ownership of `akm-plugins/evals` | OPEN | — |
+| D12 | Harbor version pin | OPEN | P2 |
+
+---
+
+## Decided
+
+### D1 — Longitudinal workflows: keep, orchestrated outside Harbor
+
+`evolve` and `attribute` stay. akm-bench keeps a thin multi-run orchestrator that
+calls `harbor run` repeatedly and performs the feedback / improve / accept /
+reindex / mask steps *between* jobs. Harbor owns each individual job; the loop
+around them is ours.
+
+**Consequences**
+- ~1,600 LOC of orchestration (`evolve.ts`, `evolve-metrics.ts`, masking in
+  `metrics/attribution.ts`) survives the rewrite and must be ported to akm 0.9.1
+  verbs. Note `akm distill` / `akm reflect` are **retired** — both fold into
+  `akm improve <ref>`, which **requires a configured LLM engine** (exit 78
+  otherwise). The evolve arm therefore cannot run LLM-free.
+- The six `repeated_failure_group` tasks need two tasks in one orchestrated pass;
+  that sequencing is the orchestrator's job, not Harbor's.
+- Harbor's `resume` semantics apply per job, not across the loop — the
+  orchestrator needs its own checkpoint of which jobs in a sequence completed.
+
+### D2 — akm reaches the container via a custom Harbor agent
+
+`AkmOpenCode(OpenCode)` subclass overriding `install()`, invoked as
+`--agent <module>:AkmOpenCode`. Chosen over baking akm into task
+`environment/Dockerfile`s (which would contaminate 46 arm-neutral task
+definitions and make the *baseline* arm run an image containing akm) and over
+`--skill` upload (files, not a global install).
+
+**Consequences**
+- Task definitions stay arm-neutral: the same task runs under both arms.
+- Real Python lives in akm-bench. It is small (one file) but it is a second
+  language in a Bun/TS repo and needs its own test path.
+- Every job must pass `--agent`; a job config that forgets it silently runs the
+  baseline. The agent must force-inject its own config rather than trusting the
+  job to supply it.
+
+### D4 — Single `reward` key now; revisit at P4 *(provisional)*
+
+Tasks emit exactly one `reward` key valued 0 or 1. Compliance sub-scores and
+diagnostics go to `/logs/artifacts/` and are joined post-hoc by our analysis
+layer. Revisit once the analysis layer exists and we know what the compliance
+metrics actually need.
+
+**Consequences**
+- Harbor's own `pass_at_k` and `Mean` keep working as an independent sanity check
+  against our statistics — worth keeping until our layer is trusted.
+- The viewer's comparison grid (which hardcodes `rewards.get('reward', 0)`)
+  stays usable.
+- Anything richer than pass/fail is invisible in Harbor's artifacts and depends
+  entirely on our artifact join. That join must exist before P4 can revisit this.
+
+### D6 — Cold-start library: a hand-authored generic SWE skills bundle
+
+~20–40 assets of general software-engineering practice (debugging, test running,
+git, build systems, common CLI tooling). Contamination-free, reusable across both
+terminal-bench and SWE-bench, and honest about what it claims.
+
+**Consequences**
+- The bundle's quality **caps the measurable effect**. A weak library produces a
+  null result that says nothing about akm — so authoring effort is not overhead,
+  it is the experiment.
+- Assets must carry frontmatter `description` and headings. akm's FTS and
+  embeddings do **not** index body prose (verified: body-only terms return zero
+  hits), so an asset whose value lives in its prose is unretrievable.
+- Explicitly rejected: per-domain `akm import` of real repo docs for SWE-bench
+  instances (task leakage), and learned-from-train-split (needs an in-container
+  LLM engine; revisit once D1's evolve arm exists — the two share machinery).
+- The P0 smoke library (copied from `akm-plugins/evals/fixtures/stash/`) is a
+  placeholder to prove the plumbing, **not** this bundle.
+
+### D7 — Accumulation: run both static and accumulating as separate arms
+
+Three arms total: baseline (no plugin), akm-static (pristine per-trial copy of the
+library), akm-accumulating (shared mutable bundle across trials). Isolates
+retrieval value from learning value.
+
+**Consequences**
+- **Run cost roughly triples.** Fold this into D9's budget before any full sweep.
+- The shared-volume machinery is now required, not optional: a mount, plus a
+  concurrency policy. Harbor's `--mounts` semantics were verified for the local
+  Docker backend only; cloud sandbox backends are unverified.
+- The accumulating arm's trials are **statistically non-independent** (ordering
+  effects, concurrent-write races at `-n > 1`). It needs its own analysis
+  treatment — do not pool it with the static arm, and consider `-n 1` for it.
+- P0 implements per-trial seeding only (the static arm). The accumulating arm is
+  additional work in P2.
+
+---
+
+## Open
+
+### D3 — Network policy for the akm arm *(blocks P2)*
+opencode resolves `plugin: ["akm-opencode"]` from npm **at session start**, and
+terminal-bench 2.x tasks commonly restrict egress. Pre-install at image build
+(offline-safe, couples the image to a plugin version) vs allow
+`registry.npmjs.org` through the policy (changes the environment relative to
+baseline — itself a confound). Needs a call once P0 shows whether the runtime
+install actually works inside a task container.
+
+### D5 — Where workflow-compliance is scored *(blocks P4)*
+In-container `tests/test.sh` — which **can** read `/logs/agent/trajectory.json`
+(verified: `_sync_agent_output` runs before `_run_verifier`, and cloud envs upload
+logs back in) and akm's own `state.db` — puts compliance into the reward.
+Post-hoc in our analysis keeps it out of every Harbor artifact and regrade path.
+Coupled to D4; decide both together at P4.
+
+### D8 — Which upstream memory harness `akm-eval` adapts *(blocks P6)*
+Per-benchmark, and the surfaces differ: LongMemEval v1 is thinnest (JSONL +
+shell out to `evaluate_qa.py`); LoCoMo is already done; BEAM has no plugin
+interface (fork or mem0-shim); `supermemoryai/memorybench` costs ~200 LOC for one
+`Provider` and buys three benchmarks plus head-to-head vs mem0/zep.
+Recommendation on the table: LongMemEval v1 first, memorybench second.
+
+### D9 — Judge-model cost budget *(blocks P6)*
+No estimate exists. Reference points: Harbor's own LoCoMo parity run cost ~$35
+for 5×10 trials on gpt-5-mini; LongMemEval-V2 defaults to a gpt-5.2
+medium-reasoning judge; BEAM-10M ingest is likely the single most expensive item
+in the suite. **D7 triples the coding-benchmark side.** Force a number before P6.
+
+### D10 — Corpus mechanics *(blocks P3)*
+Four sub-decisions, all mechanical but none free:
+- **Slice representation** — Harbor has no slice primitive; `-i`/`-x` glob on task
+  *name* only. Two `registry.json` DatasetSpecs (`akm-train@1.0` / `akm-eval@1.0`)
+  is the versioned-reproducible option.
+- **Fixture delivery** — 7 bundles across 46 tasks: one shared base image with an
+  env var selecting which, vs per-task `environment/` COPY, vs `--skill`.
+- **Token budgets** — all 46 tasks declare `budget.tokens`; Harbor has no token or
+  cost budget, only `[agent].timeout_sec`. Drop the concept, or keep it in
+  `[metadata]` and enforce post-hoc. Do not leave implicit: "budget" currently
+  reads as enforced.
+- **Attribution masking** — N generated task variants (changes `task_checksum`,
+  so they become different tasks) vs env-var-driven masking consumed by an
+  in-container setup step. D1 makes this an orchestrator concern.
+
+### D11 — Ownership of `akm-plugins/evals`
+A third eval surface neither repo covers: tier2 deterministic plugin metrics
+against a fake-akm shim, tier3 LLM-judge scenarios. It holds akm's ranker constant
+so it does not overlap akm-bench, but ownership and CI wiring need a call. Note
+`evals/README.md:50` claims a git-ref pairwise A/B mode that **does not exist** in
+`tier3/runner.ts` — a doc/code mismatch to fix or drop.
+
+### D12 — Harbor version pin *(blocks P2)*
+Every Harbor behavior this plan leans on is **internal, not a documented
+contract**: `[metadata]` exclusion from results, agent-then-verifier ordering,
+reward-file parsing, one-level `-p` scanning, `opencode_config` deep-merge. All
+read at **v0.22.0 / commit `39b8587`**. Pin that version and add a CI check that
+re-verifies these behaviors on bump.
+
+---
+
+## Changelog
+
+- **2026-08-22** — D1, D2, D4 (provisional), D6, D7 decided. D2 was settled by the
+  instruction to implement the Harbor agent. D7 chose three arms over the
+  recommended two, which adds the shared-volume requirement and raises D9's cost.

--- a/docs/plans/benchmark-harness-decisions.md
+++ b/docs/plans/benchmark-harness-decisions.md
@@ -19,9 +19,9 @@ can be checked against it without re-litigating.
 | D7 | Cross-task accumulation policy | **DECIDED** | P2 |
 | D8 | Which upstream memory harness `akm-eval` adapts | OPEN | P6 |
 | D9 | Judge-model cost budget | OPEN | P6 |
-| D10 | Slice / fixture delivery / token budgets / masking | OPEN | P3 |
+| D10 | Slice / fixture delivery / token budgets / masking | **DECIDED (by implementation)** | P3 |
 | D11 | Ownership of `akm-plugins/evals` | OPEN | — |
-| D12 | Harbor version pin | OPEN | P2 |
+| D12 | Harbor version pin | **DECIDED + implemented** | P2 |
 
 ---
 
@@ -144,20 +144,25 @@ for 5×10 trials on gpt-5-mini; LongMemEval-V2 defaults to a gpt-5.2
 medium-reasoning judge; BEAM-10M ingest is likely the single most expensive item
 in the suite. **D7 triples the coding-benchmark side.** Force a number before P6.
 
-### D10 — Corpus mechanics *(blocks P3)*
-Four sub-decisions, all mechanical but none free:
-- **Slice representation** — Harbor has no slice primitive; `-i`/`-x` glob on task
-  *name* only. Two `registry.json` DatasetSpecs (`akm-train@1.0` / `akm-eval@1.0`)
-  is the versioned-reproducible option.
-- **Fixture delivery** — 7 bundles across 46 tasks: one shared base image with an
-  env var selecting which, vs per-task `environment/` COPY, vs `--skill`.
-- **Token budgets** — all 46 tasks declare `budget.tokens`; Harbor has no token or
-  cost budget, only `[agent].timeout_sec`. Drop the concept, or keep it in
-  `[metadata]` and enforce post-hoc. Do not leave implicit: "budget" currently
-  reads as enforced.
-- **Attribution masking** — N generated task variants (changes `task_checksum`,
-  so they become different tasks) vs env-var-driven masking consumed by an
-  in-container setup step. D1 makes this an orchestrator concern.
+### D10 — Corpus mechanics: decided by implementation (2026-08-23)
+
+All four sub-decisions were settled during the P3 conversion:
+- **Slices** — two `registry.json` DatasetSpecs: `akm-tasks-train@1.0` (27) and
+  `akm-tasks-eval@1.0` (19), disjoint, union = the full corpus; the flat
+  `harbor/tasks/` dir also resolves via `-p` (46 incl. the reference task).
+- **Fixture delivery** — the AkmOpenCode agent uploads `harbor/stashes/` once
+  and the container-side seed step selects the stash named by the task's
+  `[environment].env.AKM_TASK_STASH`; unknown names abort setup loudly. Task
+  environments stay arm-neutral (zero akm/opencode/node in any Dockerfile).
+  Benchmark metadata lives in `harbor/stashes-meta/` (never uploaded), and the
+  agent additionally purges non-directory entries from the uploaded root
+  in-container — a stray answer-key file cannot become an arm-asymmetric
+  channel.
+- **Token budgets** — carried in `[metadata]` (`budget_tokens`, `budget_wall_ms`),
+  not enforced by Harbor; the analysis layer reads per-trial token totals and
+  can report violations post-hoc.
+- **Attribution masking** — an orchestrator concern under D1; not expressed in
+  task format.
 
 ### D11 — Ownership of `akm-plugins/evals`
 A third eval surface neither repo covers: tier2 deterministic plugin metrics
@@ -166,17 +171,51 @@ so it does not overlap akm-bench, but ownership and CI wiring need a call. Note
 `evals/README.md:50` claims a git-ref pairwise A/B mode that **does not exist** in
 `tier3/runner.ts` — a doc/code mismatch to fix or drop.
 
-### D12 — Harbor version pin *(blocks P2)*
-Every Harbor behavior this plan leans on is **internal, not a documented
-contract**: `[metadata]` exclusion from results, agent-then-verifier ordering,
-reward-file parsing, one-level `-p` scanning, `opencode_config` deep-merge. All
-read at **v0.22.0 / commit `39b8587`**. Pin that version and add a CI check that
-re-verifies these behaviors on bump.
+### D12 — Harbor version pin: decided and implemented (2026-08-23)
+
+Harbor is pinned to **0.22.0** (`akm-bench/harbor/requirements.txt`), and
+`akm-bench/bin/check-harbor-contract` executes **14 assertions** over the
+internal behaviors the stack depends on (trial_results exclusion, pass@k k-set,
+exclude-after-include log filtering, result.json naming, config deep-merge
+layering, metadata exclusion from results, agent-log sync ordering, reward-file
+parsing, one-level task scanning, provider/model splitting, trial-dir layout,
+XDG log path, and sync-before-populate ordering). Run it on every Harbor bump;
+a failure names exactly which load-bearing behavior moved. Not yet wired into
+CI (see Open questions below).
+
+---
+
+## Open questions raised by implementation (2026-08-23)
+
+- **Baseline-arm "skill" pointers**: 11 shipped workspace READMEs (drillbit x7,
+  inkwell x4) keep legacy-verbatim "Consult the `<domain>` skill" prose. Both
+  arms see it, as under the legacy driver, but the baseline arm cannot access
+  any skill. Deleting would change difficulty vs the legacy corpus - corpus
+  owner call (docs/corpus-conversion.md section 10.4).
+- **Retired ref spelling as graded content**: 3 workflow-compliance tasks grade
+  the literal `akm-show-ref: skill:opencode` (0.7 grammar). Legacy-faithful and
+  verifier-consistent, but akm 0.9.1 rejects that spelling live - changing it
+  means changing verifier + instruction together.
+- **akm-cli in-process pin hole**: probe 7b makes the exec-path candidate-2
+  bypass fail loudly, but the plugin's in-process tools import akm-cli directly
+  and remain uncovered; the stronger npm-overrides mitigation is documented in
+  docs/harbor-p0.md but NOT implemented. Latent until a newer 0.9.x publishes.
+- **CI wiring**: akm-bench CI does not run the harbor pytest suite, the
+  contract check, or the analysis tests - and `bun run check` was already red
+  on main before this work (legacy src/ typecheck + 5 pre-existing
+  tests/leakage.test.ts failures against fixtures/corpus). Nothing new is
+  CI-gated until this is addressed.
+- **One unindexable legacy asset**: `workflow:configure-inkwell-service` fails
+  akm 0.9.1 workflow schema validation and is absent from the inkwell stash
+  index (recorded in harbor/stashes-meta/gold-ref-map.json).
 
 ---
 
 ## Changelog
 
+- **2026-08-23** - D10 and D12 decided by implementation (P1-P3 landed on
+  akm-bench `claude/harbor-akm-agent-p0`); five new open questions recorded
+  from the implementation gates.
 - **2026-08-22** — D1, D2, D4 (provisional), D6, D7 decided. D2 was settled by the
   instruction to implement the Harbor agent. D7 chose three arms over the
   recommended two, which adds the shared-volume requirement and raises D9's cost.

--- a/docs/plans/benchmark-tuning-findings.md
+++ b/docs/plans/benchmark-tuning-findings.md
@@ -1,0 +1,186 @@
+# Benchmark findings: what the first real A/B says about tuning akm
+
+**Status:** live findings, updated as runs land.
+**Source runs:** `akm-bench` branch `claude/harbor-akm-agent-p0`,
+`results/harbor/2026-08-24/`.
+**Companions:** `benchmark-harness-consolidation.md` (the plan),
+`benchmark-harness-decisions.md` (decision register).
+
+## 1. The headline, and what it is not
+
+19-task eval slice, baseline (`opencode`) vs akm-static (`akm-opencode`),
+k=3, 114 trials, `opencode/qwen3.5-plus`, zero errors and zero timeouts.
+
+| metric | akm arm | baseline |
+| --- | --- | --- |
+| pass@1 | **75.4%** [0.579, 0.895] | 52.6% [0.316, 0.737] |
+| paired delta | **+0.228 [0.070, 0.404]** | — |
+| akm tool engagement | 28.1% | 0.0% |
+
+The CI excludes zero. Split by what each task family is built to measure:
+
+| family | tasks | baseline | akm | delta |
+| --- | --- | --- | --- | --- |
+| retrieval (`drillbit--*`, `inkwell--*`) | 12 | 0.33 | 0.67 | **+0.33** |
+| compliance (`workflow-compliance--*`) | 4 | 0.75 | 0.83 | +0.08 |
+| other (`opencode--*`) | 3 | 1.00 | 1.00 | 0.00 |
+
+`drillbit` and `inkwell` are fictional tools whose syntax exists ONLY in the
+per-task stash, so the baseline must invent it. The compliance family tests
+the opposite reflex (a `noisy` stash of plausible-but-wrong material, or a
+`minimal` stash with no answer at all) where NOT reaching for akm is correct,
+so it dilutes the aggregate by design.
+
+**What this is not:** one model, n=19 tasks, k=3. The CI is ±0.17 wide. It is
+evidence that akm helps where retrieval is the only path, not a general
+capability claim.
+
+## 2. The biggest finding: akm is invisible on "edit an existing file"
+
+Engagement is not uniformly low — it is **bimodal by task shape**. Counting
+every akm-arm trial in the eval slice, split by whether the task's workspace
+ships a pre-existing artifact to edit:
+
+| task shape | trials engaging akm | trials | rate |
+| --- | --- | --- | --- |
+| create-new (workspace has no artifact) | 16 | 33 | **48%** |
+| edit-existing (workspace ships `service.yaml`) | **0** | 24 | **0%** |
+
+Zero out of twenty-four. Not one akm call across every edit-shaped task.
+
+**The plugin's own framing predicts this.** `AKM_HINTS_PREFIX`
+(`akm-plugins/opencode/index.ts`) opens with:
+
+> "Before writing anything **from scratch**, call `akm_curate` ..."
+
+Editing an existing file is not "from scratch". The trigger condition, read
+literally, *excludes* the exact case where engagement collapses.
+
+The failure is legible in the trajectories. On `inkwell--configure-scaling`
+(0.00 on both arms) the akm arm did:
+
+```
+read  /app/service.yaml
+edit  /app/service.yaml   (invented a `scaling:` block)
+text  "Done. Added autoscaling configuration with min: 2, max: 20, ..."
+```
+
+The task spells out every value (`min: 2`, `max: 20`, `metric: rps`,
+`target: 100`); the only unknown is the key name and nesting, which lives in
+the stash. A visible file makes the task *look* self-sufficient, so the model
+never suspects there is a convention to look up. **The model does not know
+what it does not know**, and nothing in the current framing tells it that an
+unfamiliar *format* is as much a lookup trigger as an unfamiliar *tool*.
+
+Three of the six edit-shaped tasks scored 0.00 on both arms
+(`inkwell--configure-scaling`, `--cpu-scaling`, `--workflow-configure-scaling`)
+— i.e. retrieval would plausibly have flipped them. The other three were
+guessable and passed on both arms.
+
+## 3. Recommended changes
+
+Ordered by expected value. Every one changes the TREATMENT (the product), not
+the measurement — see §4 for why that distinction is what keeps the number
+honest.
+
+### akm-plugins (highest value, smallest change)
+
+1. **Rewrite the `AKM_HINTS_PREFIX` trigger so it covers editing.**
+   "Before writing anything from scratch" is the single highest-leverage
+   string in the plugin, and it currently gates out 24 of 57 trials. It should
+   name the case that actually fails: writing or editing a config file,
+   manifest, or command for a tool whose exact syntax you are not certain of.
+   Cheap to change, directly falsifiable on the train slice.
+
+2. **Make the `akm_curate` description compete with the built-ins.**
+   On edit-shaped tasks the model reaches for `read`/`glob`/`edit` because
+   those obviously act on the visible file. `akm_curate`'s description
+   ("PRIMARY discovery entry point for the stash ... describe the task in
+   natural language") reads as project-discovery, not as "check this format's
+   conventions before you write it". Paid models went further and preferred
+   opencode's built-in `skill` tool.
+
+3. **Consider a targeted nudge when an unfamiliar format is in play.**
+   The plugin already runs `experimental.chat.system.transform` on every
+   request and already tracks a curated file per session. A line that names
+   the *concrete* asset types available for the current stash would convert
+   "there is a stash" into "there is a documented schema for the file you are
+   about to edit".
+
+### akm (CLI / retrieval)
+
+4. **Query shaping is a known ceiling.** akm's FTS is a conjunctive AND with
+   no stopword removal, so sentence-shaped queries zero-hit while keyword
+   queries rank 1. Anything that makes the plugin's generated query keyword-
+   shaped (or that makes akm tolerant of sentence-shaped input) raises the
+   payoff of every engagement that does happen.
+
+5. **Body prose is never indexed** — only name/description/tags/hints/
+   headings. Question-form `searchHints` recovered most of this in the
+   treatment library (0/8 -> 7/8). Worth making that authoring rule explicit
+   in the docs, since it decides retrieval outcomes more than ranking does.
+
+### akm-bench (corpus quality, not tuning)
+
+6. **`drillbit--backup-policy`'s verifier is too lenient.** Both arms wrote
+   `drillbit backup configure --cluster ...` against a gold of
+   `drillbit backup --cluster ...` and both scored 1.0. A task that accepts an
+   invented form cannot discriminate; it under-reports akm's effect whenever a
+   model guesses close.
+
+7. **The edit-shaped inkwell tasks are the corpus's most valuable assets** —
+   they are the only ones that isolate the blind spot in §2. Keep them, and
+   consider adding edit-shaped `drillbit` equivalents so the shape is not
+   confounded with the tool family.
+
+## 4. How to tune without invalidating the benchmark
+
+The rule: **change the treatment, never the measurement.**
+
+Legitimate (ships to real users): tool descriptions, injected framing,
+retrieval quality, indexing, query shaping. A model that consults akm more
+because the tools are better described is a product improvement.
+
+Invalidating: putting akm instructions in task prompts (contaminates the
+baseline or becomes a treatment-only confound), touching verifiers or
+timeouts, giving the treatment arm anything unrelated to akm.
+
+**The real risk is iterating against the eval slice.** Tune until eval
+improves and the plugin is fitted to those 19 tasks; the number keeps looking
+rigorous while it stops generalizing. The corpus already solves this:
+
+```
+akm-tasks-train  27 tasks
+akm-tasks-eval   19 tasks
+overlap: NONE          (same families, disjoint instances)
+```
+
+Protocol:
+
+1. Iterate on **train** (`harbor/jobs/.corpus-train-ab-local.yaml`), freely.
+2. Decide the change and predict its effect **before** touching eval.
+3. Measure on **eval** rarely — ideally once per meaningful plugin change.
+   Today's `+0.228 [0.070, 0.404]` at 28.1% engagement is the pre-registered
+   baseline.
+4. **Always re-run both arms together.** The baseline moves too when opencode,
+   the corpus, or the harness changes; comparing a new treatment against a
+   stored baseline silently confounds.
+5. At n=19/k=3 the CI is ±0.17. Small engagement gains will not separate from
+   noise on eval — another reason to do the tuning where looking is free, and
+   to raise k when you need to resolve a smaller effect.
+
+## 5. Environment notes that affect any rerun
+
+- **Model choice is not neutral.** The plugin injects its context as
+  ADDITIONAL entries in opencode's `system` array, so the treatment arm sends
+  more than one system message. Chat templates that require a single leading
+  system message (`qwen3.6-35b-a3b`, `devstral-small-2`) return HTTP 500 on the
+  treatment arm ONLY — an arm-asymmetric hard failure, not a score.
+- **Engagement varies by model far more than reward does.** On the same
+  akm-relevant task: `qwen3.5-plus` and `qwen3-30b-a3b-2507` called akm tools;
+  `kimi-k2.7-code`, `deepseek-v4-pro`, `glm-5.2`, `hy3-free` and
+  `nemotron-3-ultra-free` did not, despite the plugin curating successfully
+  (`prompt_recall: ok, reason=explicit-akm`) in every case. Any engagement
+  number must name its model.
+- **Agent-phase timeouts are benchmark-defined.** Each task's own
+  `[agent] timeout_sec` governs; the harness no longer overrides it.

--- a/docs/plans/benchmark-tuning-findings.md
+++ b/docs/plans/benchmark-tuning-findings.md
@@ -182,7 +182,18 @@ Protocol:
 2. Decide the change and predict its effect **before** touching eval.
 3. Measure on **eval** rarely — ideally once per meaningful plugin change.
    Today's `+0.228 [0.070, 0.404]` at 28.1% engagement is the pre-registered
-   baseline.
+   baseline. **SUPERSEDED as of akm-bench `0578025`** — see the note below.
+
+> **The eval baseline was invalidated on purpose, once.** Fixing akm-bench#6
+> tightened the verifiers of **11 of the 19 eval-slice tasks** (5 drillbit +
+> 6 inkwell). The task LIST is unchanged, but the scoring is not, so the
+> `+0.228 [0.070, 0.404]` figure is no longer comparable to anything measured
+> after that commit. That was the right trade — a correct verifier beats a
+> comparable-but-wrong one, and the old one scored an invented
+> `drillbit backup configure ...` as a pass — but it means the NEXT eval run
+> re-establishes the baseline rather than testing against it. Since both arms
+> are always re-run together, the new run is internally valid on its own; only
+> the cross-run comparison is lost.
 4. **Always re-run both arms together.** The baseline moves too when opencode,
    the corpus, or the harness changes; comparing a new treatment against a
    stored baseline silently confounds.

--- a/docs/plans/benchmark-tuning-findings.md
+++ b/docs/plans/benchmark-tuning-findings.md
@@ -136,6 +136,46 @@ az-cli               0/17 =   0%
 docker-homelab       0/15 =   0%
 ```
 
+## 2c. Engagement is the mechanism, not a proxy metric
+
+Pooling both post-fix runs (`jobs/akm-corpus-eval-ab` and
+`jobs/akm-corpus-train-ab-postfix`, 48 tasks, errored trials excluded) and
+splitting tasks by whether the akm arm EVER called an `akm_*` tool, then
+pairing each group against the baseline arm on the same tasks:
+
+| group | tasks | mean paired delta (akm - baseline) |
+| --- | --- | --- |
+| tasks where akm was NEVER called | 29 | **-0.011** |
+| tasks where akm WAS called | 19 | **+0.561** |
+
+Trial-level, for the record: akm-arm trials WITH an `akm_*` call mean reward
+**0.857** (n=49); WITHOUT, **0.800** (n=90).
+
+**Injected context alone contributes nothing.** Where the model does not call
+a tool, the treatment arm is statistically indistinguishable from baseline
+(-0.011). The hints block, the curated-file pointer and the rest of the
+injected context net to zero by themselves.
+
+Therefore **engagement is the mechanism, not a proxy metric**: the entire
+measured +0.246 eval delta is carried by trials that actually invoked `akm_*`.
+
+**Caveat that has to be stated.** The +0.561 is confounded by task selection —
+the model engages precisely on the tasks where retrieval is needed and the
+baseline fails, so it is NOT a clean causal estimate of what a call is worth.
+The **-0.011 is the clean half**: same tasks, both arms, paired, and the
+treatment's extra context changes nothing.
+
+The within-task comparison does not settle the other half either. Across the 6
+tasks that had both engaged and non-engaged akm-arm trials, the mean
+engaged-minus-non-engaged delta is +0.250, but it splits 2 higher / 1 lower /
+3 tied — not decisive on its own.
+
+**Consequence for prioritisation.** A fix for akm-plugins#99 must produce
+actual TOOL CALLS; more or better injected context is already known to be
+worth ~0. And akm#819 (retrieval ceiling) is a multiplier that only pays off
+once engagement rises — the calls that do happen already convert well, so
+retrieval quality is not the current binding constraint.
+
 ## 3. Recommended changes
 
 Ordered by expected value. Every one changes the TREATMENT (the product), not

--- a/docs/plans/benchmark-tuning-findings.md
+++ b/docs/plans/benchmark-tuning-findings.md
@@ -98,6 +98,44 @@ Three of the six edit-shaped tasks scored 0.00 on both arms
 — i.e. retrieval would plausibly have flipped them. The other three were
 guessable and passed on both arms.
 
+## 2b. CORRECTION: shape was confounded with tool familiarity
+
+The §2 finding ("akm is invisible on edit-shaped tasks") is **half right, and
+the half that is wrong matters**. Shape is real, but it was measured on a
+corpus where every edit-shaped task also happened to involve a tool the model
+already knows. Pooling both post-fix runs and cross-tabbing (workflow-compliance
+excluded — it tests the opposite reflex):
+
+| | create-shaped | edit-shaped |
+| --- | --- | --- |
+| **fictional** tools (`drillbit`, `inkwell` — syntax exists ONLY in the stash) | **96%** (27/28) | **20%** (4/20) |
+| **real/known** tools (`az-cli`, `docker-homelab`) | 29% (5/17) | **0%** (0/35) |
+
+Shape survives as an effect (96% vs 20% *within* fictional tools), but 35 of
+the trials dragging the old "edit-shaped" aggregate down were `az-cli` and
+`docker-homelab`, where **declining to consult a stash is correct** — the model
+knows docker compose. Those were never a miss.
+
+The sharper, and more useful, statement:
+
+> akm is under-consulted specifically when **editing an existing file for a
+> tool the model does not actually know**. That is the 20% cell, and it is the
+> only cell where non-engagement is a genuine miss.
+
+This is exactly the confound akm-bench#6 called out, and it only became visible
+because that issue's fix added an edit-shaped `drillbit` task — which engaged
+**3/3**. Without it the effect would still read as pure shape.
+
+Per-family edit-shaped engagement on the post-fix train slice, for the record:
+
+```
+drillbit             3/3  = 100%   (the new decoupling task)
+inkwell              1/3  =  33%
+workflow-compliance  3/14 =  21%
+az-cli               0/17 =   0%
+docker-homelab       0/15 =   0%
+```
+
 ## 3. Recommended changes
 
 Ordered by expected value. Every one changes the TREATMENT (the product), not

--- a/docs/plans/benchmark-tuning-findings.md
+++ b/docs/plans/benchmark-tuning-findings.md
@@ -48,6 +48,27 @@ ships a pre-existing artifact to edit:
 
 Zero out of twenty-four. Not one akm call across every edit-shaped task.
 
+**Replicated on the disjoint train slice** (27 tasks, k=3, 162 trials, zero
+errors). Same model, different task instances, same direction:
+
+| slice | shape | tasks | engagement | baseline -> akm |
+| --- | --- | --- | --- | --- |
+| eval | create-new | 11 | **48%** | 0.45 -> 0.88 (**+0.42**) |
+| train | create-new | 8 | **38%** | 0.58 -> 0.71 (+0.12) |
+| eval | edit-existing | 8 | **0%** | 0.62 -> 0.58 (-0.04) |
+| train | edit-existing | 19 | **5%** | 0.77 -> 0.81 (+0.04) |
+
+The train slice's aggregate paired delta is **+0.062 [-0.012, 0.148]** — the
+CI includes zero. That is not a contradiction of eval's +0.228: train is 19 of
+27 edit-shaped, i.e. dominated by the shape where akm never fires.
+
+**Consequence for the tuning protocol:** train is a poor surface for tuning the
+DELTA (its aggregate is diluted by inert tasks and its CI spans zero) but a good
+surface for tuning ENGAGEMENT, which is the mechanism actually under change.
+Tune against engagement on train; spend an eval measurement only to confirm the
+delta moved. The 5% on train (vs 0% on eval) also shows nothing structurally
+PREVENTS engagement on edit tasks — the model simply rarely thinks to.
+
 **The plugin's own framing predicts this.** `AKM_HINTS_PREFIX`
 (`akm-plugins/opencode/index.ts`) opens with:
 

--- a/docs/plans/local-docker-execution-brief.md
+++ b/docs/plans/local-docker-execution-brief.md
@@ -1,0 +1,276 @@
+# Execution Brief: Remaining Benchmark Work (Local Machine, Docker Required)
+
+**Audience:** the agent running on the maintainer's machine (`~/code/github/*`, Docker daemon available)
+**Status:** Ready to execute — everything below is the work this environment was built for but could not run (the build environment had no Docker daemon)
+**Companions:** `benchmark-harness-consolidation.md` (the plan), `benchmark-harness-decisions.md` (decisions + open risks)
+
+Everything that does NOT need Docker is already done, adversarially reviewed,
+CI-gated, and green. Your job is the container-side validation and the real
+A/B runs. Work the phases in order — each is a gate for the next.
+
+---
+
+## 0. Ground rules
+
+- **Branches, not main.** All work lives on open PRs:
+
+  | Repo | Branch | PR |
+  | --- | --- | --- |
+  | `itlackey/akm-bench` | `claude/harbor-akm-agent-p0` | #5 |
+  | `itlackey/akm-eval` | `claude/memory-eval-refactor` | #3 |
+  | `itlackey/akm` | `claude/akm-benchmark-measurement-75rpsg` | #818 (docs) |
+
+- **Never weaken a loud failure to get past it.** The entire design converts
+  "silently invalid measurement" into "loud setup abort". If an install
+  self-check probe fails, that probe just did its job — fix the cause, not
+  the probe. Every probe's failure message names what to look at.
+- **Pin check before anything paid.** The stack pins `opencode-ai@1.18.21`,
+  `akm-cli@0.9.1`, `akm-opencode@0.9.202808220049`, `harbor==0.22.0`. Run
+  `npm view akm-cli dist-tags.latest` (and the other two) first. If a newer
+  version shipped, the self-check probes (7b/7c/realign) will fail loudly on
+  drift — that is correct behavior; update the pins in
+  `harbor/akm_opencode.py` module constants + both job yamls together, or
+  proceed knowing the pins still hold.
+- **Record outcomes** as PR comments on #5/#3 and, for milestone results, a
+  changelog entry in `akm/docs/plans/benchmark-harness-decisions.md`. Do not
+  commit raw `jobs/` trees (large); commit only the analysis reports
+  (`report.md`/`report.json`) under `akm-bench/results/harbor/<date>/`.
+- **Hardware:** x86_64 Linux strongly preferred. SWE-bench images are
+  x86_64-only (full Verified needs ~120GB disk; subsets far less). On Apple
+  Silicon expect emulation pain — prefer a Linux box for Phase 4+.
+
+## 1. Setup and static sanity (~15 min, no cost)
+
+```sh
+cd ~/code/github/akm-bench && git fetch && git checkout claude/harbor-akm-agent-p0 && git pull
+cd ~/code/github/akm-eval  && git fetch && git checkout claude/memory-eval-refactor && git pull
+cd ~/code/github/akm       && git fetch && git checkout claude/akm-benchmark-measurement-75rpsg && git pull
+
+# Harbor in a repo-local venv (Python >= 3.12 required; harbor is pinned)
+cd ~/code/github/akm-bench
+uv venv .venv --python 3.12
+uv pip install --python .venv/bin/python -r harbor/requirements.txt pytest pyyaml
+
+# Reproduce the green gates locally before spending anything:
+PYTHONPATH="$(pwd)" .venv/bin/python -m pytest harbor/tests -q   # expect: 174 passed
+HARBOR_PYTHON=.venv/bin/python bin/check-harbor-contract         # expect: 14/14
+bun install && bun run check                                     # expect: exit 0
+docker info                                                      # daemon up
+```
+
+If the contract check fails, harbor's internals moved — STOP; every
+downstream assumption is suspect (decision D12).
+
+## 2. Phase P0 — the gate everything else waits on (~$1, 30 min)
+
+Goal: prove, in a real container, that the model actually calls `akm_*`
+tools. **"Nothing else starts until this passes"** (plan §7).
+
+1. Edit `harbor/jobs/p0-smoke.yaml`: fill the `PROVIDER/MODEL` placeholders
+   (e.g. `anthropic/claude-sonnet-4-5`) and any `/ABSOLUTE/PATH/TO/...`
+   placeholders. **Gotcha:** `-m` on the CLI does NOT override a
+   config-file agent's model — edit the YAML.
+2. Export the provider key (`ANTHROPIC_API_KEY` or `OPENAI_API_KEY` /
+   `OPENROUTER_API_KEY` — opencode is passthrough).
+3. Run from the repo root — `PYTHONPATH` is load-bearing (the custom agent
+   resolves as a cwd-relative import `harbor.akm_opencode:AkmOpenCode`):
+
+```sh
+PYTHONPATH="$(pwd)" .venv/bin/harbor run -c harbor/jobs/p0-smoke.yaml   # or: .venv/bin/python -m harbor ...
+```
+
+4. **Success criteria** (all three, per `docs/harbor-p0.md` §0 — read that
+   section first; it exists because "zero akm calls" has two very different
+   causes):
+   - The akm arm's install self-check passed (setup did not abort).
+   - The run-phase proof did not raise (`AkmPluginNotLoadedError` absent —
+     the trial `result.json` has no `exception_info`).
+   - `jobs/<job>/<akm-trial>/agent/opencode.txt` shows `akm_*` tool calls,
+     AND the events ledger confirms it:
+     `jq -r 'select(.event=="tool_observation" and (.input.tool|startswith("akm_")))' .../xdg-state/akm-opencode/events.jsonl`
+     (the obvious `.event|startswith("akm.")` filter matches NOTHING — documented trap).
+5. If the model never calls the tools on `hello-world`, that is a P0 signal,
+   not noise: check the plugin's session-start hints landed in the prompt
+   before concluding anything. `docs/harbor-p0.md` §4 lists every evidence
+   source and the failure-mode table.
+6. Comment the outcome on PR #5. If P0 fails structurally, stop and report.
+
+## 3. Phase P3-gate — corpus oracle validation (no model cost, ~1-2 h of builds)
+
+The 46 converted tasks have never had their Docker images built. The oracle
+agent runs each task's `solution/solve.sh` — no LLM, no API key.
+
+```sh
+cd ~/code/github/akm-bench
+PYTHONPATH="$(pwd)" .venv/bin/harbor run -p harbor/tasks -a oracle -n 4 -o jobs/oracle-sweep
+# (confirm the oracle agent's exact name with `harbor run --help` / agent list if it differs)
+```
+
+**Success:** 46/46 trials reward 1.0. Then spot-check the fail path: run 2-3
+tasks with the `nop` agent (or oracle with solutions temporarily absent) and
+confirm reward 0 — never a crash. Registry slices must also resolve:
+
+```sh
+PYTHONPATH="$(pwd)" .venv/bin/harbor run --registry-path harbor/registry.json -d akm-tasks-eval@1.0 -a oracle -o jobs/oracle-eval-slice
+```
+
+Failures here are Dockerfile/verifier-port bugs (the reward logic itself was
+proven against a pinned host venv): typical culprits are `pip install` inside
+the 17 pytest-task images and `apt-get jq` in 2 tasks. Fix, rerun, push.
+
+## 4. Phase P2-live — Terminal-Bench 2.0 A/B (first paid run)
+
+1. Edit `harbor/jobs/tb2-ab.yaml`: model placeholders; **comment out the
+   `akm-accumulating` arm for the first run** (it needs a pre-populated
+   `--mounts` volume and `n_concurrent: 1`; add it back per its header
+   comments once static-vs-baseline works).
+2. Subset first: add `-l 10` (or `-i` globs) so both arms run 10 tasks.
+   k is set in the yaml (`n_attempts`); keep >= 3.
+3. `PYTHONPATH="$(pwd)" .venv/bin/harbor run -c harbor/jobs/tb2-ab.yaml -l 10`
+4. Checks before scaling to the full 89 tasks:
+   - Every akm-arm trial's self-check passed (any abort = real config issue).
+   - The run-phase plugin proof raised on zero trials.
+   - `bin/akm-bench-analyze jobs/<job> --corpus harbor/tasks --md report.md`
+     produces sane numbers (pass@1 per arm, paired CI, errored-trial
+     disclosure). The analysis layer is the ONLY honest aggregator —
+     harbor's own mean folds errors as 0 and its pass@k never emits pass@1.
+   - Network note: task images restricting egress will break the plugin's
+     session-start npm resolve IF the warm-boot cache missed — the
+     self-check asserts the cache, so a green setup means no runtime npm
+     needed. If setup itself can't reach npm, see `--allow-agent-host` and
+     the D3 note in the decision register.
+5. Cost anchor: sonnet-class ~$0.5–1.5 per instance per arm. 89 tasks x 2
+   arms x k=3 is a real bill — get the 10-task run clean first.
+6. Resume discipline: `harbor job resume -p jobs/<job>` reuses finished
+   trials but requires a byte-identical job config — do not edit the yaml
+   between resume attempts. Keep `--max-retries 0` (default) so failure
+   forensics survive (retries rmtree the failed trial dir).
+
+## 5. Phase P2-live — SWE-bench Verified A/B
+
+Same shape as Phase 4 with `harbor/jobs/swebench-ab.yaml`. Constraints:
+x86_64 + big disk; subset via `-l 25` or a fixed instance list first (the
+50-instance "Verified Mini" distribution-matched subset is the standard
+cheap slice). Harbor grades in-container with the official SWE-bench test
+scripts (~1-2pp parity vs the official leaderboard, documented in harbor's
+adapter README). If official-harness numbers are wanted later, collect each
+trial's final git diff into `{instance_id, model_name_or_path, model_patch}`
+JSONL and run `swebench eval verified -p preds.jsonl` — scoring is
+generation-independent.
+
+## 6. Analysis and reporting
+
+```sh
+bin/akm-bench-analyze <jobs-dir> --corpus harbor/tasks --md results/harbor/<date>/report.md --json results/harbor/<date>/report.json
+```
+
+Read the disclosure blocks before the headline number: errored-trial policy
+(both variants are always printed), null-token counts, and the corpus-join
+coverage. Commit the reports, push, summarize on PR #5 with the
+reproducibility manifest (pins, dataset ref, model, k, subset).
+
+## 7. akm-eval memory A/B (independent of Phases 2-6; needs Docker + OPENAI key)
+
+```sh
+cd ~/code/github/akm-eval
+bin/build-image
+bin/doctor --pack locomo
+```
+
+**The container caveat that will bite first:** `AKM_EVAL_AKM_CMD` must
+resolve INSIDE the CLI container (`docs/memory-backends.md`). Either extend
+`docker/akm-eval.Dockerfile` with `npm i -g akm-cli@0.9.1`, or mount an akm
+checkout and point the var at it. `bin/doctor` reports the truth — WARN
+means the akm variant will fail loudly, not fake results.
+
+Then, smoke-scale first (the configs default to smoke limits):
+
+```sh
+export OPENAI_API_KEY=...   # provider + judging
+for v in baseline raw-vector akm-memory; do
+  bin/eval --pack locomo --variant $v --config config/common/locomo-akm-ab.json --out runs/locomo-ab/$v
+done
+bin/compare --baseline runs/locomo-ab/baseline --candidate runs/locomo-ab/akm-memory
+bin/summary --runs runs/locomo-ab
+```
+
+Repeat for `config/common/longmemeval-akm-ab.json` (retrieval is now truly
+wired — the inert-arm era is over, and a regression tripwire guards it).
+**Read the zero-hit disclosures before scaling**: akm's FTS is a conjunctive
+AND with no stopword removal, so expect high zero-hit rates on
+natural-language queries (see Lessons, and the validity-risk entry in the
+decision register). A high zero-hit run is a true measurement of the current
+retrieval ceiling — publish it as that, or first improve `buildAkmSearchQuery`
+/ the plugin's tool description, then re-run.
+
+## 8. Exit criteria
+
+- [ ] P0: model provably calls `akm_*` in-container (evidence linked on PR #5)
+- [ ] Oracle: 46/46 converted tasks reward 1.0 in real containers
+- [ ] TB2: 10-task 2-arm run clean, then full-scale run + analysis report committed
+- [ ] SWE-bench: subset 2-arm run + analysis report committed
+- [ ] Accumulating arm: attempted once with mount + n_concurrent 1, results labeled non-independent
+- [ ] akm-eval: locomo + longmemeval three-variant runs, compare/summary committed
+- [ ] Decision register changelog updated; PRs merged or explicitly held
+
+---
+
+## Lessons learned (from building this stack — read before debugging anything)
+
+1. **The failure class that matters is silent degradation, not crashes.**
+   Every serious defect found in review was a path where the treatment arm
+   quietly became the baseline while producing a plausible score: the
+   plugin fails warn-only at session start; invalid permission keys were
+   silently stripped; the pinned CLI was silently outranked by an unpinned
+   copy; the longmemeval "akm arm" never queried the backend; hardcoded
+   seed expectations would have aborted or — worse — been loosened. The fix
+   pattern is always the same: make the invalid state raise, and put the
+   disclosure in the artifact (result.json/warnings), never only in docs.
+2. **Verify against primary sources; claims decay.** The overrides-file pin
+   mitigation was documented as the strongest fix and proven inert by one
+   live npm probe (opencode installs plugins under `~/.cache/opencode/
+   packages/`, not the config dir). Dataset ids differed between harbor's
+   registry and hub. A "VERIFIED" docstring claim was false. When a step
+   matters, run it once for real before trusting the description of it.
+3. **Mutation-check load-bearing tests.** A test that passes proves little;
+   a test that fails when its guarded line is reverted proves the guard.
+   Every safety-critical behavior here (purges, probes, tripwires, skips)
+   was mutation-verified — do the same for anything you add.
+4. **Audit arm symmetry explicitly.** Confounds found and removed: a PATH
+   replacement in one arm only, a 120s timeout binding only the slower arm,
+   warm caches on treatment vs cold on baseline, metadata files uploaded to
+   one arm containing literal answer keys. Before any paid run, diff what
+   each arm's container actually receives.
+5. **akm indexing has sharp edges that decide retrieval outcomes:** body
+   prose is never indexed (only name/description/tags/hints/headings);
+   heading indexing applies to `knowledge` assets only; `keywords:`
+   frontmatter is ignored (`tags:` is not); a literal `$1`/`$ARGUMENTS`
+   anywhere in a body reclassifies the file as a `command`; search is
+   implicit-AND with no stopword removal, so sentence-shaped queries
+   zero-hit while keyword queries rank 1. Question-form `searchHints`
+   recover most of it (0/8 -> 7/8 in the treatment library). This is the
+   single biggest validity lever for the whole experiment.
+6. **CI lies in specific, checkable ways.** The repo's CI had been red on
+   main since May, masking everything; the first-ever run of akm-eval's PR
+   CI exposed tests that silently depended on `python3.11` and `uv`
+   existing on dev machines; and `pytest.skip` on a missing hard dependency
+   let CI go green on exactly the omission that would abort every trial
+   (now a fail). Treat "green" as "green on THIS runner for THESE gates".
+7. **Pin the harness and make the pin executable.** Everything this stack
+   relies on in Harbor is internal behavior, not documented contract.
+   `bin/check-harbor-contract` (14 assertions) is the tripwire — run it
+   after any harbor upgrade before believing anything else.
+8. **When a check contradicts content, the design intent decides which is
+   wrong.** The leakage tests vs the az-cli skill: the verifier's own
+   header ("the required command goes well beyond the gold ref's coverage")
+   proved the *content* was the bug. Conversely the repeated-failure pair
+   overlap was *by design*, so the *check* was the bug. Read the artifact's
+   own stated intent before editing either side.
+9. **Reports from sub-agents (and from yourself) need execution-verification.**
+   Multiple implementer claims were falsified only by running things — and
+   the session lead itself once misread an empty output file as a completed
+   workflow. Trust nothing that has not produced output in front of you.
+10. **Docker-less pre-validation works if — and only if — every container
+    assumption fails loud.** That discipline is why this handoff is safe:
+    anything the build environment got wrong about containers will stop
+    your run at setup with a named probe, not corrupt a number.


### PR DESCRIPTION
## Summary

Adds two planning documents under `docs/plans/`:

- **`benchmark-harness-consolidation.md`** — the implementation brief for rebuilding `akm-bench` (standard coding benchmarks, executed by Harbor) and `akm-eval` (memory evals against upstream harnesses) as thin wrappers over upstream tooling, targeting akm 0.9.1+. Documents what Harbor does and does not provide (no pass@1, no CIs, no attempt pairing, task metadata dropped from results), the corpus-conversion gaps, deletion/survival inventories for both repos, and a phased plan with gates.
- **`benchmark-harness-decisions.md`** — the live decision register: D1–D12 with status, consequences, and a changelog. D1/D2/D4/D6/D7 decided by maintainer; D10/D12 decided by implementation; remaining items tracked with the phase they block, plus open questions raised by the implementation gates.

Companion implementation PRs: `itlackey/akm-bench` (`claude/harbor-akm-agent-p0`) and `itlackey/akm-eval` (`claude/memory-eval-refactor`).

## Test plan

Docs-only change. `bun scripts/lint-doc-examples.ts` and `bun scripts/lint-active-docs-terminology.ts` both pass (`docs/plans/` is deliberately outside the terminology linter's scan set, matching existing plan docs).

## Checklist

- [x] Tests pass (`bun test`) — no code changed; doc linters pass
- [x] Lint passes (`bun run lint`) — doc-lint scripts pass; no source touched
- [x] Docs updated (if applicable) — this PR is the docs

---
_Generated by [Claude Code](https://claude.ai/code/session_013LLo1ygvbaX7v3AHu3b5j9)_