### PR TITLE
fix(claude): stop listing subagent transcripts as sessions, fold them into the parent

### DIFF
--- a/src/integrations/harnesses/claude/session-log.ts
+++ b/src/integrations/harnesses/claude/session-log.ts
@@ -31,6 +31,39 @@ function claudeProjectsDir(): string {
 }
 
 /**
+ * Directory Claude Code writes a session's subagent transcripts into, as
+ * `<project>/<parent-session-id>/subagents/agent-<agentId>.jsonl` (sometimes a
+ * level deeper, under a `workflows/<workflowId>/` subdirectory). These
+ * are not sessions of their own — every record inside carries the *parent's*
+ * `sessionId` — so they are excluded from `listSessions` and folded into the
+ * parent by `readSession`.
+ */
+const SUBAGENTS_DIR = "subagents";
+
+/**
+ * Provenance prefix for events read out of a subagent transcript, built from
+ * the `agent-<agentId>.meta.json` sidecar Claude Code writes next to it.
+ * Stamped onto the event text because {@link SessionEvent} has no dedicated
+ * field for it, and per-event (not once per transcript) so the provenance
+ * survives the extractor's per-event pre-filter.
+ */
+function subagentProvenance(jsonlPath: string): string {
+  let agentType: string | undefined;
+  let description: string | undefined;
+  try {
+    const meta = JSON.parse(fs.readFileSync(jsonlPath.replace(/\.jsonl$/, ".meta.json"), "utf8")) as Record<
+      string,
+      unknown
+    >;
+    if (typeof meta.agentType === "string") agentType = meta.agentType;
+    if (typeof meta.description === "string") description = meta.description;
+  } catch {
+    // missing / unreadable sidecar — fall back to an untyped marker
+  }
+  return `[subagent:${agentType ?? "unknown"}]${description ? ` ${description}` : ""}`;
+}
+
+/**
  * Parse a single Claude Code JSONL event into a normalized {@link SessionEvent}.
  * Returns `undefined` for events that don't carry textual content (file
  * snapshots, attachments, queue metadata). Tool calls are flattened from the
@@ -135,13 +168,62 @@ export class ClaudeCodeProvider extends AbstractSessionLogProvider implements Se
 
   readSession(ref: SessionRef): SessionData {
     const stat = fs.statSync(ref.filePath);
-    const lines = fs.readFileSync(ref.filePath, "utf8").split("\n").filter(Boolean);
+    const projectHint = path.basename(path.dirname(ref.filePath));
+
+    const parent = this.#readTranscript(ref.filePath, ref.sessionId, stat.mtimeMs);
+    const events = parent.events;
+    const inlineRefs = parent.inlineRefs;
+    // Fold in this session's subagent transcripts: they record work delegated
+    // *during* this session and every record inside carries this session's id,
+    // so they are harvested under the parent's identity.
+    for (const subagentPath of this.walkFiles(
+      path.join(path.dirname(ref.filePath), path.basename(ref.filePath, ".jsonl"), SUBAGENTS_DIR),
+      (name) => name.endsWith(".jsonl"),
+    )) {
+      const subagent = this.#readTranscript(
+        subagentPath,
+        ref.sessionId,
+        stat.mtimeMs,
+        subagentProvenance(subagentPath),
+      );
+      events.push(...subagent.events);
+      inlineRefs.push(...subagent.inlineRefs);
+    }
+    // Merge chronologically rather than appending: the delegated work happened
+    // during the parent session, consumers document events as time-ordered,
+    // and the pre-filter's budget pass drops from the head (oldest first),
+    // which only samples sensibly on a time-ordered stream.
+    events.sort((a, b) => (a.ts ?? 0) - (b.ts ?? 0));
+
+    return {
+      ref: this.sessionRef({
+        sessionId: ref.sessionId,
+        filePath: ref.filePath,
+        startedAt: events[0]?.ts ?? stat.ctimeMs,
+        endedAt: events[events.length - 1]?.ts ?? stat.mtimeMs,
+        projectHint,
+        title: parent.title,
+      }),
+      events,
+      inlineRefs,
+    };
+  }
+
+  /**
+   * Parse one JSONL transcript (a session's own, or one of its subagents')
+   * into normalized events plus the inline `akm` invocations they contain.
+   * `provenance`, when given, is prefixed to every event's text.
+   */
+  #readTranscript(
+    filePath: string,
+    sessionId: string | undefined,
+    fallbackTsMs: number,
+    provenance?: string,
+  ): { events: SessionEvent[]; inlineRefs: InlineRefMention[]; title?: string } {
     const events: SessionEvent[] = [];
     const inlineRefs: InlineRefMention[] = [];
     let title: string | undefined;
-    let firstTsMs: number | undefined;
-    let lastTsMs: number | undefined;
-    const projectHint = path.basename(path.dirname(ref.filePath));
+    const lines = fs.readFileSync(filePath, "utf8").split("\n").filter(Boolean);
 
     for (const line of lines) {
       let entry: Record<string, unknown> | undefined;
@@ -155,27 +237,14 @@ export class ClaudeCodeProvider extends AbstractSessionLogProvider implements Se
         title = entry.customTitle;
         continue;
       }
-      const parsed = parseClaudeEvent(entry, ref.sessionId, ref.filePath, stat.mtimeMs);
+      const parsed = parseClaudeEvent(entry, sessionId, filePath, fallbackTsMs);
       if (!parsed) continue;
-      events.push(parsed);
-      if (firstTsMs === undefined || (parsed.ts ?? 0) < firstTsMs) firstTsMs = parsed.ts;
-      if (lastTsMs === undefined || (parsed.ts ?? 0) > lastTsMs) lastTsMs = parsed.ts;
+      events.push(provenance ? { ...parsed, text: `${provenance}\n${parsed.text}` } : parsed);
       // Extract inline akm-remember/feedback invocations from this event's text.
       inlineRefs.push(...extractInlineRefMentions(parsed.text, parsed.ts));
     }
 
-    return {
-      ref: this.sessionRef({
-        sessionId: ref.sessionId,
-        filePath: ref.filePath,
-        startedAt: firstTsMs ?? stat.ctimeMs,
-        endedAt: lastTsMs ?? stat.mtimeMs,
-        projectHint,
-        title,
-      }),
-      events,
-      inlineRefs,
-    };
+    return { events, inlineRefs, ...(title ? { title } : {}) };
   }
 
   /**
@@ -243,8 +312,18 @@ export class ClaudeCodeProvider extends AbstractSessionLogProvider implements Se
     return result;
   }
 
-  /** Session JSONL files under `dir`, excluding the shared journal file. */
-  #walkJsonl(dir: string): Generator<string> {
-    return this.walkFiles(dir, (name) => name.endsWith(".jsonl") && name !== "journal.jsonl");
+  /**
+   * Session JSONL files under `dir`, excluding the shared journal file and
+   * subagent transcripts (folded into their parent by {@link readSession}).
+   * Only the directories *between* the project directory and the file are
+   * tested for {@link SUBAGENTS_DIR}, so a session file — which always sits
+   * directly in its project directory — can never be excluded.
+   */
+  *#walkJsonl(dir: string): Generator<string> {
+    for (const filePath of this.walkFiles(dir, (name) => name.endsWith(".jsonl") && name !== "journal.jsonl")) {
+      const segments = path.relative(dir, filePath).split(path.sep);
+      if (segments.slice(1, -1).includes(SUBAGENTS_DIR)) continue;
+      yield filePath;
+    }
   }
 }

--- a/tests/integration/session-logs-providers.test.ts
+++ b/tests/integration/session-logs-providers.test.ts
@@ -131,6 +131,26 @@ describe("ClaudeCodeProvider.listSessions", () => {
     expect(sessions.map((s) => s.sessionId)).toEqual(["new"]);
   });
 
+  test("excludes subagent transcripts, which are not sessions (#829)", () => {
+    const root = makeTempDir("akm-claude-subagents-list-");
+    const project = path.join(root, "-home-user-project-a");
+    writeClaudeSessionJsonl(path.join(project, "session-aaa.jsonl"), [
+      { type: "user", timestamp: "2026-05-26T10:00:00.000Z", message: { role: "user", content: "parent work" } },
+    ]);
+    writeClaudeSessionJsonl(path.join(project, "session-aaa", "subagents", "agent-abc123.jsonl"), [
+      { type: "user", timestamp: "2026-05-26T10:01:00.000Z", message: { role: "user", content: "delegated work" } },
+    ]);
+    // Workflow-spawned subagents nest one level deeper under `subagents/`.
+    writeClaudeSessionJsonl(
+      path.join(project, "session-aaa", "subagents", "workflows", "wf_123", "agent-def456.jsonl"),
+      [{ type: "user", timestamp: "2026-05-26T10:02:00.000Z", message: { role: "user", content: "nested work" } }],
+    );
+
+    const provider = new ClaudeCodeProvider();
+    const sessions = provider.listSessions({ location: root });
+    expect(sessions.map((s) => s.sessionId)).toEqual(["session-aaa"]);
+  });
+
   test("returns sessions sorted by endedAt descending", () => {
     const root = makeTempDir("akm-claude-sort-");
     writeClaudeSessionJsonl(path.join(root, "p", "older.jsonl"), [
@@ -190,6 +210,60 @@ describe("ClaudeCodeProvider.readSession", () => {
     // Inline-ref extraction sees the tool_use input flattened as `[tool:Bash] {...}`
     expect(data.inlineRefs).toHaveLength(1);
     expect(data.inlineRefs[0]).toMatchObject({ kind: "remember", text: "deploy needs VPN" });
+  });
+
+  test("folds subagent transcripts into the parent session (#829)", () => {
+    const root = makeTempDir("akm-claude-subagents-read-");
+    const project = path.join(root, "proj");
+    writeClaudeSessionJsonl(path.join(project, "session-1.jsonl"), [
+      {
+        type: "user",
+        timestamp: "2026-05-26T10:00:00.000Z",
+        message: { role: "user", content: "Delegate the audit." },
+      },
+      {
+        type: "assistant",
+        timestamp: "2026-05-26T10:30:00.000Z",
+        message: { role: "assistant", content: "The audit is done." },
+      },
+    ]);
+    const subagentPath = path.join(project, "session-1", "subagents", "agent-abc123.jsonl");
+    writeClaudeSessionJsonl(subagentPath, [
+      {
+        type: "assistant",
+        timestamp: "2026-05-26T10:10:00.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", name: "Bash", input: { command: `akm remember "audits need a clean tree"` } }],
+        },
+      },
+    ]);
+    fs.writeFileSync(
+      path.join(project, "session-1", "subagents", "agent-abc123.meta.json"),
+      JSON.stringify({ agentType: "general-purpose", description: "Audit the release branches", spawnDepth: 1 }),
+    );
+
+    const provider = new ClaudeCodeProvider();
+    const summary = provider.listSessions({ location: root })[0];
+    if (!summary) throw new Error("test fixture missing session summary");
+    const data = provider.readSession(summary);
+
+    // Subagent work lands under the parent's identity, merged in timestamp order.
+    expect(data.events).toHaveLength(3);
+    expect(data.events.map((e) => e.ts)).toEqual([
+      Date.parse("2026-05-26T10:00:00.000Z"),
+      Date.parse("2026-05-26T10:10:00.000Z"),
+      Date.parse("2026-05-26T10:30:00.000Z"),
+    ]);
+    expect(data.events.every((e) => e.sessionId === "session-1")).toBe(true);
+    // Sidecar `agentType`/`description` ride along as provenance on the text,
+    // and the event still points at the subagent transcript it came from.
+    expect(data.events[1]?.text).toStartWith("[subagent:general-purpose] Audit the release branches\n");
+    expect(data.events[1]?.filePath).toBe(subagentPath);
+    expect(data.events[0]?.text).toBe("Delegate the audit.");
+    // Inline invocations made by the subagent are harvested too.
+    expect(data.inlineRefs).toHaveLength(1);
+    expect(data.inlineRefs[0]).toMatchObject({ kind: "remember", text: "audits need a clean tree" });
   });
 
   test("skips events without text content", () => {


### PR DESCRIPTION
Fixes both defects in `ClaudeCodeProvider` reported in #829.

## 1. Phantom sessions (bug fix)

`#walkJsonl` recursed into `<project>/<parent-session-id>/subagents/**`, and `listSessions` derived `sessionId` from the filename — so every subagent transcript surfaced as a fabricated `agent-<hash>` session with `projectHint: "subagents"`.

`#walkJsonl` now skips any transcript under a `subagents/` directory. The check inspects only the path segments *between* the project directory and the file, so it cannot over-exclude: a real session file always sits directly in its project directory (`<project>/<id>.jsonl`, zero intermediate segments), and the filename itself is never tested. `walkFiles` in the shared base class is untouched, so no other provider changes behaviour.

Measured on the reporter's machine (`listSessions({ sinceMs: 0 })`):

| | total | `agent-<hash>` | real |
|---|---|---|---|
| before | 872 | 797 | 75 |
| after | **75** | **0** | 75 |

## 2. Subagent work is now harvested under the parent

`readSession` folds a session's own subagent transcripts into its result. The linkage is a directory lookup, not a search: the transcripts live at `<parent-session-id>/subagents/` alongside the parent transcript, and every record inside already carries the parent's `sessionId`.

- **Merged chronologically, not appended.** The delegated work happened *during* the parent session; consumers document the event stream as time-ordered, and the extractor pre-filter drops from the head (oldest first) when over its character budget — which only samples sensibly on a time-ordered stream. Appending would park hours-old subagent events at the "most recent" end and let the budget pass discard the parent's own opening instead.
- **Size needs nothing new.** The existing pre-filter already truncates long events and enforces `maxTotalChars` across the merged stream.
- **Provenance without new types.** `agentType`/`description` from the `agent-<agentId>.meta.json` sidecar ride along as a `[subagent:<type>] <description>` prefix on each folded event's text, and each event's `filePath` still points at the transcript it came from. `SessionEvent` has no provenance field and this PR does not add one; stamping per-event rather than emitting one header event keeps provenance attached through the extractor's per-event filtering (a `role: "system"` header event would be dropped by the pre-filter's boilerplate rule).

## Verification

Two regression tests, one per defect, both mutation-tested:

| mutation | result |
|---|---|
| revert the `#walkJsonl` exclusion | part-1 test **fails** (19 pass / 1 fail) — lists `agent-abc123`, `agent-def456` |
| remove the `readSession` folding loop | part-2 test **fails** (19 pass / 1 fail) — 2 events instead of 3 |
| keep folding but drop the chronological sort | part-2 test **fails** (19 pass / 1 fail) |
| fix restored | 20 pass / 0 fail |

- `bun run test:unit` — 3857 pass / 0 fail (baseline)
- `bun run test:integration` — 5598 pass / 52 skip / 0 fail (baseline 5596, +2 new tests)
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx biome check` on both changed files — clean

Closes #829

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7CauuoYuv5ULR4igmU1Jx
