### PR TITLE
health: flag assets whose resolved type disagrees with their directory

### DIFF
--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -17,6 +17,7 @@ import { DURATION_UNITS, parseDuration, parseSinceToIso } from "../core/time";
 import { readSemanticStatus } from "../indexer/search/semantic-status";
 import type { Database } from "../storage/database";
 import { closeDatabase, openReadonlyExistingDatabase } from "../storage/repositories/index-connection";
+import { getAllEntries } from "../storage/repositories/index-entries-repository";
 import { queryTaskHistory } from "../storage/repositories/task-history-repository";
 import { collectImproveAdvisories } from "./health/advisories";
 import { HEALTH_CHECKS, type HealthCheckContext, runHealthEngineProbes } from "./health/checks";
@@ -38,6 +39,7 @@ import {
 import { collectStashExposureAdvisory, type GitRunner } from "./health/stash-exposure";
 import { collectSurfacesAdvisories, type EgressConfigView } from "./health/surfaces";
 import { buildPerRunSummaries } from "./health/task-runs";
+import { buildTypeDirectoryAdvisory } from "./health/type-directory-check";
 import {
   ACTIVE_RUN_WARN_MS,
   type AkmHealthResult,
@@ -412,7 +414,47 @@ function gatherAncillaryAdvisories(
     // Non-fatal.
   }
 
+  // #831: flag indexed assets whose resolved type disagrees with the type
+  // their containing directory declares (see health/type-directory-check.ts).
+  // Best-effort — an unreadable index must not abort the health report.
+  try {
+    const typeDirMismatch = detectTypeDirectoryDisagreements(options.stashDir ?? resolveStashDir());
+    if (typeDirMismatch) advisories.push(typeDirMismatch);
+  } catch {
+    // Non-fatal.
+  }
+
   return advisories;
+}
+
+/**
+ * Open index.db read-only, project every entry to `{ filePath, type }`, and
+ * build the `type-directory-disagreement` advisory. `stashRoot` is used only
+ * to shorten displayed paths (relative to the stash) when it's an ancestor of
+ * the entry's path; falls back to the absolute path otherwise. Returns
+ * `undefined` when the index is absent/unreadable or nothing disagrees —
+ * mirrors {@link detectIndexStateGenerationMismatch}'s best-effort shape.
+ */
+function detectTypeDirectoryDisagreements(stashRoot: string): HealthCheckResult | undefined {
+  let indexDb: ReturnType<typeof openReadonlyExistingDatabase>;
+  try {
+    indexDb = openReadonlyExistingDatabase(getDbPath());
+    if (!indexDb) return undefined;
+    const entries = getAllEntries(indexDb).map((entry) => ({ filePath: entry.filePath, type: entry.type }));
+    return buildTypeDirectoryAdvisory(entries, undefined, (absPath) =>
+      absPath.startsWith(stashRoot) ? path.relative(stashRoot, absPath) : absPath,
+    );
+  } catch {
+    return undefined;
+  } finally {
+    if (indexDb) {
+      try {
+        closeDatabase(indexDb);
+      } catch {
+        // Best-effort advisory: a close failure must not abort health.
+      }
+    }
+  }
 }
 
 /**

--- a/src/commands/health/type-directory-check.ts
+++ b/src/commands/health/type-directory-check.ts
@@ -1,0 +1,204 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `type-directory-disagreement` advisory for `akm health` (#831).
+ *
+ * The invariant "a file's directory declares its type" is load-bearing for
+ * refs, namespace listings, and `akm show` paths (see #824: three files
+ * written to `memories/` were indexed as `type: command`, moved their refs
+ * under `commands/memories/<slug>`, and silently vanished from the
+ * `memories/` namespace — nothing on any normal surface said so). This
+ * advisory re-checks that invariant against every currently indexed entry.
+ *
+ * Legitimate disagreements exist by design — a `knowledge/` file containing
+ * `$ARGUMENTS` is deliberately a `command`, and an `agents/` file with an
+ * `agent:` frontmatter key is deliberately a `command` (both asserted in
+ * `tests/integration/commands/show.test.ts`). So this is never a hard
+ * failure: every disagreement is reported with a `winner` naming which
+ * classifier signal produced the resolved type, so a deliberate override
+ * reads differently from an unexplained one.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { parseFrontmatter } from "../../core/asset/frontmatter";
+import type { HealthCheckResult } from "./types";
+
+/**
+ * Directory → declared-type map, mirroring `DIR_TYPE_MAP` in
+ * `src/indexer/walk/matchers.ts` minus its per-directory extension test —
+ * this check only needs "which type does this directory declare", not which
+ * extensions it accepts. Keep in sync if `DIR_TYPE_MAP` gains, renames, or
+ * removes a directory.
+ */
+const DECLARED_DIR_TYPES: Readonly<Record<string, string>> = {
+  memories: "memory",
+  knowledge: "knowledge",
+  commands: "command",
+  agents: "agent",
+  workflows: "workflow",
+  facts: "fact",
+  lessons: "lesson",
+  sessions: "session",
+  instructions: "instruction",
+  scripts: "script",
+  env: "env",
+  secrets: "secret",
+  tasks: "task",
+};
+
+/** The minimal shape this check needs from an indexed `entries` row. */
+export interface TypeDirectoryEntry {
+  filePath: string;
+  type: string;
+}
+
+export interface TypeDirectoryDisagreement {
+  path: string;
+  resolved: string;
+  expected: string;
+  /** Which classifier signal produced `resolved`, or "unknown" when none was found. */
+  winner: string;
+  /** True for the two documented deliberate-override contracts (and their frontmatter siblings). */
+  knownGoodOverride: boolean;
+}
+
+/** Injectable file-read seam so the pure collector never needs a real filesystem in tests. */
+export type ReadFileFn = (absPath: string) => string | undefined;
+
+const realReadFile: ReadFileFn = (absPath) => {
+  try {
+    return fs.readFileSync(absPath, "utf8");
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * The type a file's directory declares, mirroring the `classifyByDirectory` /
+ * `classifyByParentDirHint` precedence in matchers.ts: the immediate parent
+ * directory wins when it is itself typed (parentDirHint, specificity 15);
+ * otherwise the outermost typed ancestor wins (directoryMatcher, specificity
+ * 10, which walks root-to-leaf and returns on the first hit).
+ */
+function declaredTypeForPath(absPath: string): { dir: string; type: string } | undefined {
+  const segments = path
+    .dirname(absPath)
+    .split(path.sep)
+    .filter((seg) => seg.length > 0);
+  const immediateParent = segments.at(-1);
+  if (immediateParent) {
+    const parentType = DECLARED_DIR_TYPES[immediateParent];
+    if (parentType) return { dir: immediateParent, type: parentType };
+  }
+  for (const seg of segments) {
+    const type = DECLARED_DIR_TYPES[seg];
+    if (type) return { dir: seg, type };
+  }
+  return undefined;
+}
+
+/**
+ * Best-effort explanation for why `classifyBySmartMd` (matchers.ts) would
+ * have produced `resolvedType` for this content, in the SAME precedence
+ * order the real function checks them. Returns `undefined` when no known
+ * override signal is found — that absence is itself the accident signal:
+ * nothing in the file explains why its type disagrees with its directory.
+ *
+ * The numeric-placeholder branch is flagged `knownGoodOverride: false` on
+ * purpose: since #826, that heuristic is guarded to never fire when the file
+ * sits under a declared-type directory, so seeing it win here would mean the
+ * guard regressed, not that this is a sanctioned override.
+ */
+function explainOverride(
+  resolvedType: string,
+  content: string,
+): { winner: string; knownGoodOverride: boolean } | undefined {
+  const fm = parseFrontmatter(content).data;
+
+  if (fm.type === "workflow" && resolvedType === "workflow") {
+    return { winner: "smart-md:workflow-frontmatter", knownGoodOverride: true };
+  }
+  if ("tools" in fm && resolvedType === "agent") {
+    return { winner: "smart-md:tools-frontmatter", knownGoodOverride: true };
+  }
+  if ("agent" in fm && resolvedType === "command") {
+    return { winner: "smart-md:agent-frontmatter", knownGoodOverride: true };
+  }
+  if (resolvedType === "command" && content.includes("$ARGUMENTS")) {
+    return { winner: "smart-md:$ARGUMENTS", knownGoodOverride: true };
+  }
+  if (resolvedType === "command" && /\$[123](?!\d|[.,]\d)/.test(content)) {
+    return { winner: "smart-md:numeric-placeholder", knownGoodOverride: false };
+  }
+  if ("model" in fm && resolvedType === "agent") {
+    return { winner: "smart-md:model-frontmatter", knownGoodOverride: true };
+  }
+  return undefined;
+}
+
+/**
+ * Compare every indexed entry's resolved type against the type its
+ * directory declares (see {@link DECLARED_DIR_TYPES}), and return one
+ * {@link TypeDirectoryDisagreement} per mismatch, sorted by path. Entries
+ * outside any declared-type directory are not checked — this is only the
+ * "directory declares type" invariant.
+ */
+export function collectTypeDirectoryDisagreements(
+  entries: readonly TypeDirectoryEntry[],
+  readFile: ReadFileFn = realReadFile,
+): TypeDirectoryDisagreement[] {
+  const disagreements: TypeDirectoryDisagreement[] = [];
+  for (const entry of entries) {
+    const declared = declaredTypeForPath(entry.filePath);
+    if (!declared || declared.type === entry.type) continue;
+    const content = readFile(entry.filePath);
+    const explanation = content === undefined ? undefined : explainOverride(entry.type, content);
+    disagreements.push({
+      path: entry.filePath,
+      resolved: entry.type,
+      expected: declared.type,
+      winner: explanation?.winner ?? "unknown",
+      knownGoodOverride: explanation?.knownGoodOverride ?? false,
+    });
+  }
+  return disagreements.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+const MAX_DETAIL_LINES = 10;
+
+/**
+ * Build the `type-directory-disagreement` advisory, or `undefined` when
+ * every indexed entry agrees with its directory. Always `status: "warn"`
+ * (never `"fail"`) — a deliberate override is still a disagreement worth
+ * seeing, just not a gate.
+ */
+export function buildTypeDirectoryAdvisory(
+  entries: readonly TypeDirectoryEntry[],
+  readFile: ReadFileFn = realReadFile,
+  displayPath: (absPath: string) => string = (p) => p,
+): HealthCheckResult | undefined {
+  const disagreements = collectTypeDirectoryDisagreements(entries, readFile);
+  if (disagreements.length === 0) return undefined;
+
+  const lines = disagreements.slice(0, MAX_DETAIL_LINES).map((d) => {
+    const note = d.knownGoodOverride ? " (known-good override)" : "";
+    return `${displayPath(d.path)} resolved=${d.resolved} expected=${d.expected} winner=${d.winner}${note}`;
+  });
+  if (disagreements.length > MAX_DETAIL_LINES) {
+    lines.push(`+${disagreements.length - MAX_DETAIL_LINES} more`);
+  }
+
+  return {
+    name: "type-directory-disagreement",
+    kind: "deterministic",
+    status: "warn",
+    confidence: "high",
+    message: `${disagreements.length} indexed asset(s) have a resolved type that disagrees with the type their directory declares: ${lines.join("; ")}`,
+    evidence: {
+      disagreements: disagreements.map((d) => ({ ...d, path: displayPath(d.path) })),
+    },
+  };
+}

--- a/tests/commands/health/type-directory-check.test.ts
+++ b/tests/commands/health/type-directory-check.test.ts
@@ -1,0 +1,151 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * #831: the `type-directory-disagreement` health advisory must flag every
+ * indexed asset whose resolved type disagrees with the type its directory
+ * declares, while naming which classifier signal won so a deliberate
+ * override (the two contracts asserted in
+ * tests/integration/commands/show.test.ts) reads differently from an
+ * unexplained one. Never a hard failure — always `status: "warn"`, never
+ * `"fail"`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  buildTypeDirectoryAdvisory,
+  collectTypeDirectoryDisagreements,
+  type TypeDirectoryEntry,
+} from "../../../src/commands/health/type-directory-check";
+
+describe("collectTypeDirectoryDisagreements (#831)", () => {
+  test("reports nothing when every entry's type matches its directory", () => {
+    const entries: TypeDirectoryEntry[] = [
+      { filePath: "/stash/memories/note.md", type: "memory" },
+      { filePath: "/stash/knowledge/guide.md", type: "knowledge" },
+      { filePath: "/stash/commands/deploy.md", type: "command" },
+    ];
+    expect(collectTypeDirectoryDisagreements(entries, () => "")).toEqual([]);
+  });
+
+  test("does not check entries outside a DIR_TYPE_MAP directory", () => {
+    const entries: TypeDirectoryEntry[] = [{ filePath: "/stash/skills/my-skill/SKILL.md", type: "skill" }];
+    expect(collectTypeDirectoryDisagreements(entries, () => "")).toEqual([]);
+  });
+
+  test("real defect shape: a memories/ note resolved as command is reported even without the old regex bug", () => {
+    // #826 fixed the numeric-placeholder regex so this can no longer happen via
+    // the old bug — construct the disagreement directly (mismatched type on the
+    // entry) instead of relying on a body that would trip the old heuristic.
+    const entries: TypeDirectoryEntry[] = [{ filePath: "/stash/memories/910ed479-3-f4f94df3.md", type: "command" }];
+    const readFile = () => "Ordering fee is $2,000 due at signing.";
+    const result = collectTypeDirectoryDisagreements(entries, readFile);
+    expect(result).toEqual([
+      {
+        path: "/stash/memories/910ed479-3-f4f94df3.md",
+        resolved: "command",
+        expected: "memory",
+        winner: "unknown",
+        knownGoodOverride: false,
+      },
+    ]);
+  });
+
+  test("legitimate override: knowledge/ file containing $ARGUMENTS is named, not silently accepted or mislabeled", () => {
+    const entries: TypeDirectoryEntry[] = [{ filePath: "/stash/knowledge/deploy-cmd.md", type: "command" }];
+    const readFile = () => "Usage: /deploy $ARGUMENTS\n";
+    const result = collectTypeDirectoryDisagreements(entries, readFile);
+    expect(result).toEqual([
+      {
+        path: "/stash/knowledge/deploy-cmd.md",
+        resolved: "command",
+        expected: "knowledge",
+        winner: "smart-md:$ARGUMENTS",
+        knownGoodOverride: true,
+      },
+    ]);
+  });
+
+  test("legitimate override: agents/ file with `agent:` frontmatter is named, not silently accepted or mislabeled", () => {
+    const entries: TypeDirectoryEntry[] = [{ filePath: "/stash/agents/reviewer.md", type: "command" }];
+    const readFile = () => "---\nagent: reviewer\n---\nBody.\n";
+    const result = collectTypeDirectoryDisagreements(entries, readFile);
+    expect(result).toEqual([
+      {
+        path: "/stash/agents/reviewer.md",
+        resolved: "command",
+        expected: "agent",
+        winner: "smart-md:agent-frontmatter",
+        knownGoodOverride: true,
+      },
+    ]);
+  });
+
+  test("unreadable file still reports the disagreement with an unknown reason", () => {
+    const entries: TypeDirectoryEntry[] = [{ filePath: "/stash/memories/gone.md", type: "command" }];
+    const result = collectTypeDirectoryDisagreements(entries, () => undefined);
+    expect(result).toEqual([
+      {
+        path: "/stash/memories/gone.md",
+        resolved: "command",
+        expected: "memory",
+        winner: "unknown",
+        knownGoodOverride: false,
+      },
+    ]);
+  });
+
+  test("sorts disagreements by path", () => {
+    const entries: TypeDirectoryEntry[] = [
+      { filePath: "/stash/memories/z.md", type: "command" },
+      { filePath: "/stash/memories/a.md", type: "command" },
+    ];
+    const result = collectTypeDirectoryDisagreements(entries, () => "");
+    expect(result.map((d) => d.path)).toEqual(["/stash/memories/a.md", "/stash/memories/z.md"]);
+  });
+});
+
+describe("buildTypeDirectoryAdvisory (#831)", () => {
+  test("returns undefined when nothing disagrees", () => {
+    const entries: TypeDirectoryEntry[] = [{ filePath: "/stash/memories/note.md", type: "memory" }];
+    expect(buildTypeDirectoryAdvisory(entries, () => "")).toBeUndefined();
+  });
+
+  test("is always a warning, never a hard failure, even for an accidental-looking disagreement", () => {
+    const entries: TypeDirectoryEntry[] = [{ filePath: "/stash/memories/910ed479-3-f4f94df3.md", type: "command" }];
+    const advisory = buildTypeDirectoryAdvisory(entries, () => "$2,000 due at signing.");
+    expect(advisory?.name).toBe("type-directory-disagreement");
+    expect(advisory?.status).toBe("warn");
+    expect(advisory?.status).not.toBe("fail");
+    expect(advisory?.message).toContain("winner=unknown");
+    expect(advisory?.evidence?.disagreements).toEqual([
+      {
+        path: "/stash/memories/910ed479-3-f4f94df3.md",
+        resolved: "command",
+        expected: "memory",
+        winner: "unknown",
+        knownGoodOverride: false,
+      },
+    ]);
+  });
+
+  test("marks a known-good override in the message so it reads differently from an accident", () => {
+    const entries: TypeDirectoryEntry[] = [{ filePath: "/stash/knowledge/deploy-cmd.md", type: "command" }];
+    const advisory = buildTypeDirectoryAdvisory(entries, () => "Usage: /deploy $ARGUMENTS\n");
+    expect(advisory?.status).toBe("warn");
+    expect(advisory?.message).toContain("winner=smart-md:$ARGUMENTS (known-good override)");
+  });
+
+  test("uses the displayPath projection for both message and evidence", () => {
+    const entries: TypeDirectoryEntry[] = [{ filePath: "/stash/memories/note.md", type: "command" }];
+    const advisory = buildTypeDirectoryAdvisory(
+      entries,
+      () => "",
+      (p) => p.replace("/stash/", ""),
+    );
+    expect(advisory?.message).toContain("memories/note.md");
+    expect(advisory?.message).not.toContain("/stash/");
+    expect((advisory?.evidence?.disagreements as Array<{ path: string }>)[0]?.path).toBe("memories/note.md");
+  });
+});

--- a/tests/integration/health-type-directory-check.test.ts
+++ b/tests/integration/health-type-directory-check.test.ts
@@ -1,0 +1,164 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * #831 end-to-end: `akm health` must flag any REAL indexed asset whose
+ * resolved type disagrees with the type its directory declares, using the
+ * actual indexer/index.db, not synthetic entries. It must:
+ *   - stay silent when the indexed stash agrees with its directories,
+ *   - name the correct classifier + "known-good override" for the two
+ *     deliberate-override contracts asserted in
+ *     tests/integration/commands/show.test.ts, and
+ *   - flag the #824 defect shape (an entry's indexed type disagreeing with
+ *     its directory) as an unexplained ("unknown") disagreement, and never
+ *     as a hard failure.
+ *
+ * #826 already fixed the numeric-placeholder regex, so the defect shape can
+ * no longer be reproduced by writing a body that trips it — the corrupted
+ * row is constructed directly against index.db instead, mirroring how #824
+ * actually manifested: a correctly-placed file whose indexed `type` ended up
+ * wrong.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { akmHealth } from "../../src/commands/health";
+import type { HealthCheckResult } from "../../src/commands/health/types";
+import { getDbPath } from "../../src/core/paths";
+import { akmIndex } from "../../src/indexer/indexer";
+import { openIndexDatabase } from "../../src/storage/repositories/index-connection";
+import { type IsolatedAkmStorage, withIsolatedAkmStorage, writeSandboxConfig } from "../_helpers/sandbox";
+
+let storage: IsolatedAkmStorage;
+
+function setUpStash(): void {
+  storage = withIsolatedAkmStorage();
+  writeSandboxConfig({
+    semanticSearchMode: "off",
+    defaultBundle: "fixture",
+    bundles: { fixture: { path: storage.stashDir, components: { main: { root: ".", adapter: "akm" } } } },
+  });
+}
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function findAdvisory(checks: HealthCheckResult[], name: string): HealthCheckResult | undefined {
+  return checks.find((c) => c.name === name);
+}
+
+describe("type-directory-disagreement advisory (#831, end-to-end)", () => {
+  test("stays silent when every real indexed asset agrees with its directory", async () => {
+    setUpStash();
+    try {
+      writeFile(path.join(storage.stashDir, "memories", "plain.md"), "Just a plain note.\n");
+      await akmIndex({ stashDir: storage.stashDir, full: true });
+
+      const result = akmHealth({ since: "7d" });
+      expect(findAdvisory(result.advisories, "type-directory-disagreement")).toBeUndefined();
+    } finally {
+      storage.cleanup();
+    }
+  });
+
+  test("names the two documented deliberate overrides as known-good, and never hard-fails", async () => {
+    setUpStash();
+    try {
+      // Same fixture shapes as tests/integration/commands/show.test.ts's
+      // "$ARGUMENTS in body classifies .md as command even outside commands/"
+      // and "agent frontmatter classifies .md as command even outside agents/".
+      writeFile(
+        path.join(storage.stashDir, "knowledge", "deploy-cmd.md"),
+        ["---", "description: Deploy helper", "---", "Deploy $ARGUMENTS to staging."].join("\n"),
+      );
+      writeFile(
+        path.join(storage.stashDir, "agents", "build-cmd.md"),
+        ["---", "agent: build", "description: Build dispatch", "---", "Build the project."].join("\n"),
+      );
+      await akmIndex({ stashDir: storage.stashDir, full: true });
+
+      const result = akmHealth({ since: "7d" });
+      const advisory = findAdvisory(result.advisories, "type-directory-disagreement");
+      expect(advisory).toBeDefined();
+      expect(advisory?.status).toBe("warn");
+      expect(advisory?.status).not.toBe("fail");
+      expect(result.status).not.toBe("fail");
+
+      const disagreements = (advisory?.evidence?.disagreements ?? []) as Array<{
+        path: string;
+        resolved: string;
+        expected: string;
+        winner: string;
+        knownGoodOverride: boolean;
+      }>;
+      const deployCmd = disagreements.find((d) => d.path.includes("deploy-cmd.md"));
+      expect(deployCmd).toMatchObject({
+        resolved: "command",
+        expected: "knowledge",
+        winner: "smart-md:$ARGUMENTS",
+        knownGoodOverride: true,
+      });
+      const buildCmd = disagreements.find((d) => d.path.includes("build-cmd.md"));
+      expect(buildCmd).toMatchObject({
+        resolved: "command",
+        expected: "agent",
+        winner: "smart-md:agent-frontmatter",
+        knownGoodOverride: true,
+      });
+    } finally {
+      storage.cleanup();
+    }
+  });
+
+  test("flags the #824 defect shape (indexed type disagreeing with its directory) as unexplained, without hard-failing", async () => {
+    setUpStash();
+    try {
+      const notePath = path.join(storage.stashDir, "memories", "910ed479-3-f4f94df3.md");
+      writeFile(notePath, "The invoice was $2,000 due at signing.\n");
+      await akmIndex({ stashDir: storage.stashDir, full: true });
+
+      // #826 already fixed the numeric-placeholder regex, so this body no
+      // longer misclassifies through the indexer — construct the #824 defect
+      // directly by corrupting the indexed type, the same durable symptom the
+      // bug actually produced.
+      const dbPath = getDbPath();
+      const writableDb = openIndexDatabase(dbPath);
+      try {
+        const changed = writableDb
+          .prepare("UPDATE entries SET type = 'command' WHERE file_path = ?")
+          .run(notePath).changes;
+        expect(changed).toBe(1);
+      } finally {
+        writableDb.close();
+      }
+
+      const result = akmHealth({ since: "7d" });
+      const advisory = findAdvisory(result.advisories, "type-directory-disagreement");
+      expect(advisory).toBeDefined();
+      expect(advisory?.status).toBe("warn");
+      expect(advisory?.status).not.toBe("fail");
+      expect(result.status).not.toBe("fail");
+
+      const disagreements = (advisory?.evidence?.disagreements ?? []) as Array<{
+        path: string;
+        resolved: string;
+        expected: string;
+        winner: string;
+        knownGoodOverride: boolean;
+      }>;
+      const note = disagreements.find((d) => d.path.includes("910ed479-3-f4f94df3.md"));
+      expect(note).toMatchObject({
+        resolved: "command",
+        expected: "memory",
+        winner: "unknown",
+        knownGoodOverride: false,
+      });
+    } finally {
+      storage.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `type-directory-disagreement` advisory to `akm health` that flags any indexed asset whose resolved type disagrees with the type its `DIR_TYPE_MAP` directory declares (`memories/`, `knowledge/`, `commands/`, `agents/`, `workflows/`, `facts/`, `lessons/`, `sessions/`, `instructions/`, `scripts/`, `env/`, `secrets/`, `tasks/`).
- This is the diagnostic that would have caught #824 (three `memories/` files silently indexed as `command`s and lost from the `memories/` namespace) the day it was introduced, instead of five months later.
- Never a hard failure: `knowledge/` + `$ARGUMENTS` and `agents/` + `agent:` frontmatter are deliberate overrides (asserted in `tests/integration/commands/show.test.ts`). Every disagreement is reported as a warning naming the `winner` classifier signal and whether it's a `knownGoodOverride`, so a sanctioned override reads differently from an accident.

## Where it lives, and why

Implemented as an `akm health` advisory (`src/commands/health/type-directory-check.ts`, wired into `gatherAncillaryAdvisories` in `src/commands/health.ts`), matching the existing `stash-git-exposure` / `binary-config-skew` / `index-state-generation` best-effort-advisory pattern already in that file — open a database read-only, project rows, return `undefined` when nothing to report or the read fails. `akm doctor` doesn't exist in this repo, and a `scripts/lint-*.ts` script lints the akm repo's own source (import cycles, doc examples, etc.), not a user's indexed stash — this check is about runtime index state, which is squarely `akm health`'s job.

## Distinguishing a deliberate override from an accident

`explainOverride()` re-checks the file for the same signals `classifyBySmartMd` uses, in the same precedence order, and labels the result:

- `smart-md:$ARGUMENTS`, `smart-md:agent-frontmatter`, `smart-md:tools-frontmatter`, `smart-md:workflow-frontmatter`, `smart-md:model-frontmatter` → `knownGoodOverride: true`
- `smart-md:numeric-placeholder` → `knownGoodOverride: false` (this heuristic is guarded since #826 to never fire under a declared-type directory, so seeing it here would mean the guard regressed)
- no signal found → `winner: "unknown"`, `knownGoodOverride: false` — the accident case

## Verification

- New file `src/commands/health/type-directory-check.ts` + unit tests `tests/commands/health/type-directory-check.test.ts` (11 tests, pure functions with an injectable file-read seam) + end-to-end integration test `tests/integration/health-type-directory-check.test.ts` (3 tests, real `akmIndex()` + `akmHealth()`).
- **Mutation testing** (break → confirm red → restore → confirm green):
  - Disabled disagreement detection entirely → 8/11 unit tests failed.
  - Forced `explainOverride` to always return `undefined` → 3/11 unit tests failed (exactly the known-good-override assertions).
  - Changed `status: "warn"` to `"fail"` → 2/11 unit tests failed (the hard-failure-constraint assertions).
  - Disabled the `health.ts` wiring (never pushing the advisory) → 2/3 integration tests failed.
  - All four mutations restored; full suite green again (11/11, 3/3).
- Real defect shape: since #826 already fixed the numeric-placeholder regex, a `memories/*.md` body containing `$2,000` can no longer be misclassified through the real indexer — so the disagreement is constructed directly (unit test: synthetic entry with a mismatched `type`; integration test: a genuinely indexed `memories/` file whose `entries.type` row is corrupted to `command` via direct SQL, mirroring the actual #824 symptom). Both report `winner: "unknown"`, `status: "warn"`.
- The two legitimate overrides (`knowledge/deploy-cmd.md` + `$ARGUMENTS`, `agents/build-cmd.md` + `agent:` frontmatter — same fixture shapes as `tests/integration/commands/show.test.ts`) are proven end-to-end via real `akmIndex()`: both are reported with the correct `winner` and `knownGoodOverride: true`, and `status` is `"warn"`, never `"fail"`.
- `bun run test:unit` → 3868 pass / 0 skip / 0 fail (baseline ~3857 pass + 11 new).
- `bun run test:integration` → 5601 pass / 52 skip / 0 fail (baseline ~5598 pass + 3 new).
- `npx tsc --noEmit -p tsconfig.json` → clean.
- `npx biome check` on changed files → clean (2 pre-existing `noNonNullAssertion` warnings remain in `health.ts` at an untouched line, confirmed present before this change via `git stash`).

## Sample output

```json
{
  "name": "type-directory-disagreement",
  "kind": "deterministic",
  "status": "warn",
  "confidence": "high",
  "message": "2 indexed asset(s) have a resolved type that disagrees with the type their directory declares: agents/build-cmd.md resolved=command expected=agent winner=smart-md:agent-frontmatter (known-good override); knowledge/deploy-cmd.md resolved=command expected=knowledge winner=smart-md:$ARGUMENTS (known-good override)",
  "evidence": {
    "disagreements": [
      { "path": "agents/build-cmd.md", "resolved": "command", "expected": "agent", "winner": "smart-md:agent-frontmatter", "knownGoodOverride": true },
      { "path": "knowledge/deploy-cmd.md", "resolved": "command", "expected": "knowledge", "winner": "smart-md:$ARGUMENTS", "knownGoodOverride": true }
    ]
  }
}
```

Closes #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7CauuoYuv5ULR4igmU1Jx
