### PR TITLE
health: report Claude harness plugin version, warn on stale/out-of-range

### DIFF
--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -18,6 +18,7 @@ import { readSemanticStatus } from "../indexer/search/semantic-status";
 import type { Database } from "../storage/database";
 import { closeDatabase, openReadonlyExistingDatabase } from "../storage/repositories/index-connection";
 import { queryTaskHistory } from "../storage/repositories/task-history-repository";
+import { pkgVersion } from "../version";
 import { collectImproveAdvisories } from "./health/advisories";
 import { HEALTH_CHECKS, type HealthCheckContext, runHealthEngineProbes } from "./health/checks";
 import {
@@ -35,6 +36,7 @@ import {
   computeEnrichmentMintingRollup,
   probeStateDbRoundTrip,
 } from "./health/metrics";
+import { collectPluginStalenessAdvisories } from "./health/plugin-staleness";
 import { collectStashExposureAdvisory, type GitRunner } from "./health/stash-exposure";
 import { collectSurfacesAdvisories, type EgressConfigView } from "./health/surfaces";
 import { buildPerRunSummaries } from "./health/task-runs";
@@ -361,11 +363,12 @@ function gatherImproveSummaryPhase(
 }
 
 /**
- * The three best-effort advisory groups beyond the health-check registry:
- * improve advisories, the `stash-git-exposure` probe, and the 08 surfaces
- * group (binary-config-skew, egress-endpoints). Order matches emission order in
- * the returned array. A probe/filesystem failure in either try/catch must not
- * abort the health report — each group degrades to "no advisory" independently.
+ * The four best-effort advisory groups beyond the health-check registry:
+ * improve advisories, the `stash-git-exposure` probe, the 08 surfaces group
+ * (binary-config-skew, egress-endpoints), and `plugin-version` (itlackey/akm#832).
+ * Order matches emission order in the returned array. A probe/filesystem
+ * failure in any try/catch must not abort the health report — each group
+ * degrades to "no advisory" independently.
  */
 function gatherAncillaryAdvisories(
   db: Database,
@@ -408,6 +411,17 @@ function gatherAncillaryAdvisories(
         config: egressConfigView,
       }),
     );
+  } catch {
+    // Non-fatal.
+  }
+
+  // itlackey/akm#832: report installed Claude Code harness plugin version(s)
+  // and warn when stale or when the plugin's own akm-cli version range no
+  // longer admits this CLI. Best-effort — no plugin installed, an unreadable
+  // manifest, or a network failure while checking the newest tag must not
+  // abort the health report.
+  try {
+    advisories.push(...collectPluginStalenessAdvisories({ cliVersion: pkgVersion }));
   } catch {
     // Non-fatal.
   }

--- a/src/commands/health/plugin-staleness.ts
+++ b/src/commands/health/plugin-staleness.ts
@@ -1,0 +1,254 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `plugin-version` advisory for `akm health` (itlackey/akm#832).
+ *
+ * #828 was filed as a CLI bug — session extraction failing on 232/234 runs —
+ * and took a full investigation to resolve. The actual cause: the harness
+ * plugin (`akm@akm-plugins`, installed in Claude Code's plugin cache) was
+ * three days stale relative to the fix, and its own `AKM_VERSION_RANGE` gate
+ * had nothing to do with it — the plugin was simply running old code. Every
+ * fact needed to reach that conclusion in one step was already on disk:
+ *
+ *   - installed plugin version: `~/.claude/plugins/cache/<marketplace>/akm/<version>/.claude-plugin/plugin.json`
+ *   - the plugin's own akm-cli compatibility contract: `<pluginDir>/shared/akm-version.ts`'s `AKM_VERSION_RANGE`
+ *   - the running CLI's version: `../../version.ts`'s `pkgVersion`
+ *
+ * Nothing correlated them, so a stale plugin was indistinguishable from a
+ * broken CLI. This module closes that gap with three checks, one per
+ * detected plugin:
+ *
+ *   1. report the installed version;
+ *   2. compare it against the newest tag published to the plugin's git
+ *      remote, and warn (naming the update command) when behind;
+ *   3. the sharp one — check whether the *installed plugin's* declared
+ *      `AKM_VERSION_RANGE` admits the *running* CLI version. When it does
+ *      not, the plugin has silently disabled itself (both surfaces log
+ *      `version_out_of_range` / `akm_version_mismatch` and degrade quietly)
+ *      and there was previously no way to know that from the CLI side.
+ *
+ * Read-only: this never fetches, writes, or mutates the plugin cache or
+ * marketplace clone. Check 2 is the one deliberate exception to "`akm
+ * health` makes no network call" (see `./health-advisories.md`): a plugin's
+ * local marketplace clone is not proof of what is newest upstream — the
+ * incident above involved a clone that hadn't seen the fix's tag at all — so
+ * the only way to ever detect drift is to ask the remote what tags exist.
+ * That query is a `git ls-remote --tags` (lists refs; fetches nothing,
+ * writes nothing) with a short timeout, and any failure (offline, no
+ * remote, timeout) degrades to "installed version reported, no staleness
+ * claim" rather than a false positive or a hang.
+ *
+ * Every collector here is best-effort and silent on missing/unreadable
+ * input: no Claude plugin installed, no marketplace clone, an unreadable
+ * manifest, or a malformed version range must never crash `akm health` and
+ * must never produce a false "stale" or "inactive" warning.
+ */
+
+import { type SpawnSyncReturns, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { isExactSemver, isSemverRange, maxSatisfying, satisfiesRange } from "../../registry/semver";
+import type { HealthCheckResult } from "./types";
+
+/**
+ * Root directory holding Claude Code's plugin cache + marketplace clones.
+ * Resolved per call (not memoized) so `AKM_CLAUDE_PLUGINS_DIR` can be set
+ * after import — the override exists so tests point this at an empty
+ * fixture directory instead of the real `~/.claude/plugins`, matching
+ * `AKM_CLAUDE_PROJECTS_DIR` in `../../integrations/harnesses/claude/session-log.ts`.
+ */
+function claudePluginsDir(): string {
+  return process.env.AKM_CLAUDE_PLUGINS_DIR ?? path.join(os.homedir(), ".claude", "plugins");
+}
+
+/** One `akm` plugin found in the Claude Code plugin cache. */
+interface DetectedPlugin {
+  harness: "claude";
+  marketplace: string;
+  pluginName: string;
+  version: string;
+  pluginDir: string;
+}
+
+/**
+ * Scan `<pluginsRoot>/cache/<marketplace>/akm/<version>/` for every
+ * `akm` plugin cache entry, picking the highest cached version per
+ * marketplace when more than one is present. Returns `[]` (never throws)
+ * when the cache directory is absent, empty, or unreadable — that is the
+ * ordinary "no Claude plugin installed" case, not an error.
+ */
+function detectInstalledPlugins(pluginsRoot: string): DetectedPlugin[] {
+  const cacheDir = path.join(pluginsRoot, "cache");
+  let marketplaces: string[];
+  try {
+    marketplaces = fs.readdirSync(cacheDir);
+  } catch {
+    return [];
+  }
+
+  const detected: DetectedPlugin[] = [];
+  for (const marketplace of marketplaces) {
+    const pluginDir = path.join(cacheDir, marketplace, "akm");
+    let versions: string[];
+    try {
+      versions = fs.readdirSync(pluginDir).filter(isExactSemver);
+    } catch {
+      continue;
+    }
+    if (versions.length === 0) continue;
+    const latest = maxSatisfying(versions, "*") ?? versions.sort().at(-1);
+    if (!latest) continue;
+    const versionDir = path.join(pluginDir, latest);
+    const manifestPath = path.join(versionDir, ".claude-plugin", "plugin.json");
+    try {
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as Record<string, unknown>;
+      if (typeof manifest.version !== "string") continue;
+      detected.push({
+        harness: "claude",
+        marketplace,
+        pluginName: "akm",
+        version: manifest.version,
+        pluginDir: versionDir,
+      });
+    } catch {
+      // Unreadable/malformed manifest — skip this entry rather than crash.
+    }
+  }
+  return detected;
+}
+
+/**
+ * Extract `AKM_VERSION_RANGE` from the installed plugin's vendored
+ * `shared/akm-version.ts`. Returns `undefined` when the file is missing,
+ * unreadable, or does not contain the expected declaration — callers must
+ * treat that as "compatibility unknown", never as a mismatch.
+ */
+function readVersionRange(pluginDir: string): string | undefined {
+  const versionFilePath = path.join(pluginDir, "shared", "akm-version.ts");
+  let text: string;
+  try {
+    text = fs.readFileSync(versionFilePath, "utf8");
+  } catch {
+    return undefined;
+  }
+  const match = text.match(/export\s+const\s+AKM_VERSION_RANGE\s*=\s*["']([^"']+)["']/);
+  return match?.[1];
+}
+
+/** Injectable seam for the one network read this module performs. Real impl below; tests supply a fake. */
+export type ListRemoteTagsFn = (marketplaceDir: string) => string[] | undefined;
+
+const LS_REMOTE_TIMEOUT_MS = 5_000;
+
+/**
+ * `git ls-remote --tags origin` against the marketplace clone's configured
+ * remote — lists refs only, fetches no objects, writes no local refs.
+ * Returns `undefined` (never throws) when the directory is not a git
+ * checkout, has no `origin` remote, or the command fails/times out (e.g.
+ * offline) — all "cannot determine availability", not "up to date".
+ */
+const realListRemoteTags: ListRemoteTagsFn = (marketplaceDir) => {
+  let result: SpawnSyncReturns<string>;
+  try {
+    result = spawnSync("git", ["-C", marketplaceDir, "ls-remote", "--tags", "origin"], {
+      encoding: "utf8",
+      timeout: LS_REMOTE_TIMEOUT_MS,
+    });
+  } catch {
+    return undefined;
+  }
+  if (result.status !== 0 || !result.stdout) return undefined;
+  const tags = result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.split("\t")[1])
+    .filter((ref): ref is string => typeof ref === "string" && ref.startsWith("refs/tags/"))
+    .map((ref) => ref.replace(/^refs\/tags\//, "").replace(/\^\{\}$/, ""))
+    .map((tag) => tag.replace(/^v/, ""))
+    .filter(isExactSemver);
+  return [...new Set(tags)];
+};
+
+/** Options for {@link collectPluginStalenessAdvisories}. */
+export interface PluginStalenessOptions {
+  /** Root of the Claude plugin tree (contains `cache/` and `marketplaces/`). Defaults to `claudePluginsDir()`. */
+  pluginsRoot?: string;
+  /** The running akm-cli version to check plugin compatibility against. */
+  cliVersion: string;
+  /** Injectable remote-tag lister; defaults to the real `git ls-remote`. */
+  listRemoteTags?: ListRemoteTagsFn;
+}
+
+/**
+ * Build one `plugin-version` advisory per detected `akm` harness plugin.
+ * Returns `[]` when no plugin is installed — the benign, common case.
+ */
+export function collectPluginStalenessAdvisories(options: PluginStalenessOptions): HealthCheckResult[] {
+  const pluginsRoot = options.pluginsRoot ?? claudePluginsDir();
+  const listRemoteTags = options.listRemoteTags ?? realListRemoteTags;
+  const plugins = detectInstalledPlugins(pluginsRoot);
+
+  return plugins.map((plugin) => buildAdvisory(plugin, options.cliVersion, pluginsRoot, listRemoteTags));
+}
+
+function buildAdvisory(
+  plugin: DetectedPlugin,
+  cliVersion: string,
+  pluginsRoot: string,
+  listRemoteTags: ListRemoteTagsFn,
+): HealthCheckResult {
+  const pluginRef = `${plugin.pluginName}@${plugin.marketplace}`;
+
+  // Point 2: newest available vs. installed, via the marketplace clone's remote.
+  const marketplaceDir = path.join(pluginsRoot, "marketplaces", plugin.marketplace);
+  let availableVersion: string | undefined;
+  try {
+    const tags = fs.existsSync(marketplaceDir) ? listRemoteTags(marketplaceDir) : undefined;
+    availableVersion = tags && tags.length > 0 ? maxSatisfying(tags, "*") : undefined;
+  } catch {
+    availableVersion = undefined;
+  }
+  const stale =
+    availableVersion !== undefined &&
+    plugin.version !== availableVersion &&
+    maxSatisfying([plugin.version, availableVersion], "*") === availableVersion;
+
+  // Point 3: does the plugin's own declared range admit the running CLI?
+  const versionRange = readVersionRange(plugin.pluginDir);
+  const rangeKnown = versionRange !== undefined && isSemverRange(versionRange);
+  const admitted = rangeKnown ? satisfiesRange(cliVersion, versionRange as string) : undefined;
+
+  const messageParts = [`${pluginRef}: installed ${plugin.version}`];
+  if (availableVersion !== undefined) {
+    messageParts.push(stale ? `available ${availableVersion} (STALE)` : `available ${availableVersion} (up to date)`);
+  }
+  if (stale) messageParts.push(`-> claude plugin update ${pluginRef}`);
+  if (rangeKnown && admitted === false) {
+    messageParts.push(
+      `installed plugin requires akm-cli ${versionRange}; running ${cliVersion} -> NOT ADMITTED (plugin is inactive)`,
+    );
+  }
+
+  return {
+    name: "plugin-version",
+    kind: "deterministic",
+    status: stale || admitted === false ? "warn" : "pass",
+    confidence: "high",
+    message: messageParts.join(" — "),
+    evidence: {
+      harness: plugin.harness,
+      marketplace: plugin.marketplace,
+      plugin: plugin.pluginName,
+      installedVersion: plugin.version,
+      availableVersion: availableVersion ?? null,
+      stale,
+      versionRange: versionRange ?? null,
+      cliVersion,
+      admitted: admitted ?? null,
+    },
+  };
+}

--- a/src/registry/semver.ts
+++ b/src/registry/semver.ts
@@ -46,3 +46,8 @@ export function isSemverRange(input: string): boolean {
 export function maxSatisfying(versions: string[], range: string): string | undefined {
   return semver.maxSatisfying(versions, range) ?? undefined;
 }
+
+/** True when `version` satisfies `range` (both real semver forms). False for an invalid version or range. */
+export function satisfiesRange(version: string, range: string): boolean {
+  return semver.satisfies(version, range);
+}

--- a/tests/_helpers/sandbox.ts
+++ b/tests/_helpers/sandbox.ts
@@ -328,6 +328,8 @@ export interface IsolatedAkmStorage {
   readonly stateDir: string;
   /** Isolated Claude session-log root (`AKM_CLAUDE_PROJECTS_DIR`), empty by default. */
   readonly sessionLogsDir: string;
+  /** Isolated Claude plugins root (`AKM_CLAUDE_PLUGINS_DIR`), empty by default. */
+  readonly claudePluginsDir: string;
   /** The single per-call temp root that contains every dir above. */
   readonly root: string;
   /** Restore every overridden env var and remove the temp root. Idempotent. */
@@ -383,6 +385,9 @@ export function withIsolatedAkmStorage(overrides?: Record<string, string | undef
   const sessionLogsDir = path.join(root, "claude-projects");
   fs.mkdirSync(sessionLogsDir, { recursive: true });
 
+  const claudePluginsDir = path.join(root, "claude-plugins");
+  fs.mkdirSync(claudePluginsDir, { recursive: true });
+
   const env: Record<string, string> = {
     AKM_BUNDLE_DIR: stashDir,
     XDG_DATA_HOME: dataDir,
@@ -393,6 +398,10 @@ export function withIsolatedAkmStorage(overrides?: Record<string, string | undef
     // synchronous `akm health` session-log scan stays hermetic and fast
     // instead of walking the host's real (and potentially huge) history.
     AKM_CLAUDE_PROJECTS_DIR: sessionLogsDir,
+    // Same reasoning for the `plugin-version` advisory (itlackey/akm#832): an
+    // empty fixture dir means "no plugin installed" instead of scanning the
+    // host's real `~/.claude/plugins` cache.
+    AKM_CLAUDE_PLUGINS_DIR: claudePluginsDir,
   };
 
   // Snapshot + apply env (managed defaults first, then caller overrides so they
@@ -420,7 +429,7 @@ export function withIsolatedAkmStorage(overrides?: Record<string, string | undef
     }
   };
 
-  return { stashDir, dataDir, cacheDir, configDir, stateDir, sessionLogsDir, root, cleanup };
+  return { stashDir, dataDir, cacheDir, configDir, stateDir, sessionLogsDir, claudePluginsDir, root, cleanup };
 }
 
 // ── Config writer ────────────────────────────────────────────────────────────

--- a/tests/integration/commands/health/plugin-staleness.test.ts
+++ b/tests/integration/commands/health/plugin-staleness.test.ts
@@ -1,0 +1,217 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `plugin-version` advisory for `akm health` (itlackey/akm#832). Real
+ * filesystem fixtures (plugin cache manifests + `akm-version.ts`), an
+ * injected `listRemoteTags` seam so no subprocess/network call is ever made.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  collectPluginStalenessAdvisories,
+  type ListRemoteTagsFn,
+} from "../../../../src/commands/health/plugin-staleness";
+
+function makeTempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/** Write a fake cached plugin under `<pluginsRoot>/cache/<marketplace>/akm/<version>/`. */
+function installPlugin(
+  pluginsRoot: string,
+  opts: {
+    marketplace?: string;
+    version?: string;
+    manifestVersion?: string;
+    versionRange?: string | null;
+  } = {},
+): void {
+  const marketplace = opts.marketplace ?? "akm-plugins";
+  const version = opts.version ?? "0.9.1";
+  const pluginDir = path.join(pluginsRoot, "cache", marketplace, "akm", version);
+  fs.mkdirSync(path.join(pluginDir, ".claude-plugin"), { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginDir, ".claude-plugin", "plugin.json"),
+    JSON.stringify({ name: "akm", version: opts.manifestVersion ?? version }),
+  );
+  if (opts.versionRange !== null) {
+    fs.mkdirSync(path.join(pluginDir, "shared"), { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "shared", "akm-version.ts"),
+      `export const AKM_VERSION_RANGE = "${opts.versionRange ?? "^0.9.0"}"\n`,
+    );
+  }
+}
+
+function makeMarketplaceDir(pluginsRoot: string, marketplace = "akm-plugins"): void {
+  fs.mkdirSync(path.join(pluginsRoot, "marketplaces", marketplace), { recursive: true });
+}
+
+function fakeTags(tags: string[] | undefined): ListRemoteTagsFn {
+  return () => tags;
+}
+
+describe("collectPluginStalenessAdvisories (itlackey/akm#832)", () => {
+  test("stale plugin detected: installed 0.9.1, newest tag 0.9.1202608250804", () => {
+    const pluginsRoot = makeTempDir("akm-plugin-stale-");
+    installPlugin(pluginsRoot, { version: "0.9.1" });
+    makeMarketplaceDir(pluginsRoot);
+
+    const [adv] = collectPluginStalenessAdvisories({
+      pluginsRoot,
+      cliVersion: "0.9.2",
+      listRemoteTags: fakeTags(["0.9.1", "0.9.1202608250804"]),
+    });
+
+    expect(adv?.name).toBe("plugin-version");
+    expect(adv?.status).toBe("warn");
+    expect(adv?.evidence?.stale).toBe(true);
+    expect(adv?.evidence?.availableVersion).toBe("0.9.1202608250804");
+    expect(adv?.message).toContain("STALE");
+    expect(adv?.message).toContain("claude plugin update akm@akm-plugins");
+  });
+
+  test("up-to-date plugin is not flagged", () => {
+    const pluginsRoot = makeTempDir("akm-plugin-uptodate-");
+    installPlugin(pluginsRoot, { version: "0.9.1202608250804" });
+    makeMarketplaceDir(pluginsRoot);
+
+    const [adv] = collectPluginStalenessAdvisories({
+      pluginsRoot,
+      cliVersion: "0.9.2",
+      listRemoteTags: fakeTags(["0.9.1", "0.9.1202608250804"]),
+    });
+
+    expect(adv?.status).toBe("pass");
+    expect(adv?.evidence?.stale).toBe(false);
+    expect(adv?.message).not.toContain("STALE");
+  });
+
+  test("range-rejects-CLI detected: ^0.9.0 does not admit 0.9.2-alpha.3", () => {
+    const pluginsRoot = makeTempDir("akm-plugin-range-");
+    installPlugin(pluginsRoot, { version: "0.9.1", versionRange: "^0.9.0" });
+    makeMarketplaceDir(pluginsRoot);
+
+    const [adv] = collectPluginStalenessAdvisories({
+      pluginsRoot,
+      cliVersion: "0.9.2-alpha.3",
+      listRemoteTags: fakeTags(["0.9.1"]),
+    });
+
+    expect(adv?.status).toBe("warn");
+    expect(adv?.evidence?.admitted).toBe(false);
+    expect(adv?.message).toContain("NOT ADMITTED");
+    expect(adv?.message).toContain("^0.9.0");
+  });
+
+  test("running CLI admitted by the range is not flagged on that basis", () => {
+    const pluginsRoot = makeTempDir("akm-plugin-admitted-");
+    installPlugin(pluginsRoot, { version: "0.9.1", versionRange: "^0.9.0" });
+    makeMarketplaceDir(pluginsRoot);
+
+    const [adv] = collectPluginStalenessAdvisories({
+      pluginsRoot,
+      cliVersion: "0.9.2",
+      listRemoteTags: fakeTags(["0.9.1"]),
+    });
+
+    expect(adv?.status).toBe("pass");
+    expect(adv?.evidence?.admitted).toBe(true);
+  });
+
+  test("nothing installed degrades benignly (empty plugins root)", () => {
+    const pluginsRoot = makeTempDir("akm-plugin-empty-");
+    const result = collectPluginStalenessAdvisories({ pluginsRoot, cliVersion: "0.9.2" });
+    expect(result).toEqual([]);
+  });
+
+  test("no Claude plugins directory at all degrades benignly", () => {
+    const pluginsRoot = path.join(os.tmpdir(), `akm-plugin-missing-${Date.now()}-${Math.random()}`);
+    const result = collectPluginStalenessAdvisories({ pluginsRoot, cliVersion: "0.9.2" });
+    expect(result).toEqual([]);
+  });
+
+  test("no marketplace clone: reports installed version, no stale claim, no crash", () => {
+    const pluginsRoot = makeTempDir("akm-plugin-no-marketplace-");
+    installPlugin(pluginsRoot, { version: "0.9.1" });
+    // Deliberately no marketplaces/ dir at all.
+
+    let calls = 0;
+    const [adv] = collectPluginStalenessAdvisories({
+      pluginsRoot,
+      cliVersion: "0.9.2",
+      listRemoteTags: () => {
+        calls += 1;
+        return ["9.9.9"]; // if this were ever consulted, it would (wrongly) look newer
+      },
+    });
+
+    expect(calls).toBe(0);
+    expect(adv?.status).toBe("pass");
+    expect(adv?.evidence?.availableVersion).toBeNull();
+    expect(adv?.evidence?.stale).toBe(false);
+  });
+
+  test("remote lookup failure (offline/timeout) degrades benignly, no false STALE", () => {
+    const pluginsRoot = makeTempDir("akm-plugin-offline-");
+    installPlugin(pluginsRoot, { version: "0.9.1" });
+    makeMarketplaceDir(pluginsRoot);
+
+    const [adv] = collectPluginStalenessAdvisories({
+      pluginsRoot,
+      cliVersion: "0.9.2",
+      listRemoteTags: fakeTags(undefined),
+    });
+
+    expect(adv?.status).toBe("pass");
+    expect(adv?.evidence?.availableVersion).toBeNull();
+    expect(adv?.evidence?.stale).toBe(false);
+  });
+
+  test("unreadable/malformed plugin.json is skipped, not a crash", () => {
+    const pluginsRoot = makeTempDir("akm-plugin-badmanifest-");
+    const pluginDir = path.join(pluginsRoot, "cache", "akm-plugins", "akm", "0.9.1", ".claude-plugin");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, "plugin.json"), "{not valid json");
+
+    const result = collectPluginStalenessAdvisories({ pluginsRoot, cliVersion: "0.9.2" });
+    expect(result).toEqual([]);
+  });
+
+  test("malformed AKM_VERSION_RANGE degrades to 'unknown compatibility', never a false NOT ADMITTED", () => {
+    const pluginsRoot = makeTempDir("akm-plugin-badrange-");
+    installPlugin(pluginsRoot, { version: "0.9.1", versionRange: "not-a-real-range!!" });
+    makeMarketplaceDir(pluginsRoot);
+
+    const [adv] = collectPluginStalenessAdvisories({
+      pluginsRoot,
+      cliVersion: "0.9.2-alpha.3",
+      listRemoteTags: fakeTags(["0.9.1"]),
+    });
+
+    expect(adv?.status).toBe("pass");
+    expect(adv?.evidence?.admitted).toBeNull();
+    expect(adv?.message).not.toContain("NOT ADMITTED");
+  });
+
+  test("missing shared/akm-version.ts degrades to 'unknown compatibility'", () => {
+    const pluginsRoot = makeTempDir("akm-plugin-norange-");
+    installPlugin(pluginsRoot, { version: "0.9.1", versionRange: null });
+    makeMarketplaceDir(pluginsRoot);
+
+    const [adv] = collectPluginStalenessAdvisories({
+      pluginsRoot,
+      cliVersion: "0.9.2-alpha.3",
+      listRemoteTags: fakeTags(["0.9.1"]),
+    });
+
+    expect(adv?.status).toBe("pass");
+    expect(adv?.evidence?.admitted).toBeNull();
+    expect(adv?.evidence?.versionRange).toBeNull();
+  });
+});

--- a/tests/integration/health-plugin-version-wiring.test.ts
+++ b/tests/integration/health-plugin-version-wiring.test.ts
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * itlackey/akm#832: `akmHealth()` must actually surface the `plugin-version`
+ * advisory end-to-end (not just the standalone collector unit-tested in
+ * `tests/integration/commands/health/plugin-staleness.test.ts`). Deliberately
+ * exercises only the local, network-free path here — no `marketplaces/` dir
+ * is written, so the "newest available" lookup (the one path that shells out
+ * to `git ls-remote`) never fires and this stays a pure filesystem test.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { akmHealth } from "../../src/commands/health";
+import type { HealthCheckResult } from "../../src/commands/health/types";
+import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "../_helpers/sandbox";
+
+let storage: IsolatedAkmStorage;
+
+beforeEach(() => {
+  storage = withIsolatedAkmStorage();
+});
+
+afterEach(() => {
+  storage.cleanup();
+});
+
+function findChecks(checks: HealthCheckResult[], name: string): HealthCheckResult[] {
+  return checks.filter((c) => c.name === name);
+}
+
+function findCheck(checks: HealthCheckResult[], name: string): HealthCheckResult {
+  const found = checks.find((c) => c.name === name);
+  if (!found) throw new Error(`expected an advisory named ${name}`);
+  return found;
+}
+
+function installPlugin(pluginsRoot: string, version: string, versionRange: string): void {
+  const pluginDir = path.join(pluginsRoot, "cache", "akm-plugins", "akm", version);
+  fs.mkdirSync(path.join(pluginDir, ".claude-plugin"), { recursive: true });
+  fs.writeFileSync(path.join(pluginDir, ".claude-plugin", "plugin.json"), JSON.stringify({ name: "akm", version }));
+  fs.mkdirSync(path.join(pluginDir, "shared"), { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginDir, "shared", "akm-version.ts"),
+    `export const AKM_VERSION_RANGE = "${versionRange}"\n`,
+  );
+}
+
+describe("plugin-version advisory wiring (itlackey/akm#832)", () => {
+  test("no Claude plugin installed produces no plugin-version advisory", () => {
+    const result = akmHealth({ since: "7d" });
+    expect(findChecks(result.advisories, "plugin-version")).toEqual([]);
+  });
+
+  test("an installed plugin whose range rejects the running CLI is surfaced as a warn advisory", () => {
+    installPlugin(storage.claudePluginsDir, "0.9.1", "^0.9.0");
+
+    const result = akmHealth({ since: "7d" });
+    const advisory = findCheck(result.advisories, "plugin-version");
+
+    expect(advisory.status).toBe("warn");
+    expect(advisory.evidence?.admitted).toBe(false);
+    expect(advisory.message).toContain("NOT ADMITTED");
+    expect(result.status).toBe("warn");
+  });
+});


### PR DESCRIPTION
## Summary
- `akm health` now reports installed Claude Code `akm` harness plugin version(s) and warns when a plugin is behind the newest published tag (naming the update command) or when the plugin's own declared `AKM_VERSION_RANGE` no longer admits the running CLI (the plugin has silently disabled itself).
- Hooked into the existing `gatherAncillaryAdvisories` best-effort pipeline in `src/commands/health.ts`, next to `stash-git-exposure` / `binary-config-skew` — same shape, same degrade-to-benign-on-missing-input contract. New collector lives in `src/commands/health/plugin-staleness.ts`.
- Read-only: never installs, updates, fetches, or writes to the plugin cache or marketplace clone. The one network read (`git ls-remote --tags origin` against the marketplace clone's remote, 5s timeout, injectable seam) lists refs only — it's the one deliberate exception to "`akm health` makes no network call," because a local marketplace clone can't prove what's newest upstream (that's exactly how #828 happened).
- Added `AKM_CLAUDE_PLUGINS_DIR` env override (mirrors the existing `AKM_CLAUDE_PROJECTS_DIR` pattern) so the plugin cache/marketplace root resolves portably instead of hardcoding `~/.claude/plugins`, and wired it into `withIsolatedAkmStorage` so existing health tests stay hermetic.
- Added `satisfiesRange` to `src/registry/semver.ts` (thin wrapper over `semver.satisfies`).

## Real output on the (verified stale) dev machine
```
⚠ plugin-version  [warn, deterministic, high]  akm@akm-plugins: installed 0.9.1 — available 0.9.1202608250804 (STALE) — -> claude plugin update akm@akm-plugins — installed plugin requires akm-cli ^0.9.0; running 0.9.2-alpha.3 -> NOT ADMITTED (plugin is inactive)
```

Closes #832

## Test plan
- [x] `bun test tests/integration/commands/health/plugin-staleness.test.ts tests/integration/health-plugin-version-wiring.test.ts` — 13 pass / 0 fail
- [x] Mutation-tested the core detection logic (stale computation, range-admission check, malformed-manifest skip, malformed-range degrade, existsSync network guard, cache-dir-missing degrade) — each mutation broke ≥1 test; all reverted and green again
- [x] `bun run test:unit` — 3857 pass / 0 skip / 0 fail
- [x] `bun run test:integration` — 5611 pass / 52 skip / 0 fail (13 more than baseline ~5598, matching the new tests)
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx biome check` on changed files — clean (repo-wide pre-existing warnings untouched)
- [x] Ran `akm health` for real against this machine's actual `~/.claude/plugins` — confirmed the stale/inactive plugin is surfaced as shown above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7CauuoYuv5ULR4igmU1Jx
