### PR TITLE
fix(extract): dedupe the doubled subagent conclusion, pin no-double-extraction (#839)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,30 +10,48 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Extract: deduped the doubled subagent conclusion in the extraction prompt**
   (#839). After #830 folded a session's subagent transcripts into its event
-  stream, a completed subagent's final report appeared twice in the same
+  stream, a completed subagent's final report could appear twice in the same
   extraction prompt: once as the subagent's own folded final message, once as
   the parent's `<task-notification>` record of that same call (#836 measured
-  ~92-99% textual overlap on a real pair). The parent's notification copy is
-  now stubbed to `[subagent <agentId> completed: <description>]` when its
-  `<result>` is a near-duplicate (Dice-bigram similarity ≥ 0.9, after
-  decoding the XML entities Claude Code escapes into `<result>`) of a folded
-  subagent transcript's own text; the subagent's original is untouched, per
-  #839's owner-decided direction (the inverse — dropping the subagent's own
-  terminal event — was evaluated and rejected in #836 because some subagent
-  transcripts consist only of that one event). Matching is scoped by
-  `<task-id>` to the one subagent transcript it names and still requires
-  content similarity, so an earlier notification for a *resumed* agent
-  (Claude Code re-notifies the same task-id on each stop) that carries a
-  genuinely different, intermediate result is left alone.
+  ~92-99% textual overlap on a real pair; reproduced here as a byte-identical
+  match after decoding the XML entities Claude Code escapes into `<result>`).
+  The parent's notification copy is now stubbed to `[subagent <agentId>
+  completed: <description>]` when its `<result>` is a near-duplicate
+  (Dice-bigram similarity ≥ 0.9) of a folded subagent transcript's own text;
+  the subagent's original is untouched, per #839's owner-decided direction
+  (the inverse — dropping the subagent's own terminal event — was evaluated
+  and rejected in #836 because some subagent transcripts consist only of
+  that one event). Matching is scoped by `<task-id>` to the one subagent
+  transcript it names and still requires content similarity, so an earlier
+  notification for a *resumed* agent (Claude Code re-notifies the same
+  task-id on each stop) that carries a genuinely different, intermediate
+  result is left alone.
+  **Scoped to the final, post-budget kept set — not the raw stream** (#840's
+  design-determination doc flagged this as a hazard while this PR was in
+  flight): the dedupe only fires when the subagent's own event ALSO survives
+  into the same kept set as the notification. #840 measured that today's
+  recency-biased 80k budget already evicts one side of nearly every raw
+  duplicate pair before dedupe would matter (0 of 89 raw pairs across four
+  real sessions had both sides survive); an unconditional raw-stream stub
+  would, under that same eviction pattern, sometimes delete a parent's
+  notification whose subagent copy never made the cut in the first place —
+  and would unconditionally delete the *only* surviving trace of delegated
+  work under #840's recommended future design (prompting from parent-origin
+  events only). Verified against the real session #836 and #839 both cite
+  (`4a0d9e9b…`): under the actual 80,000-char budget, 0 notifications are
+  stubbed today (consistent with #840's finding) because the cited pair's
+  subagent copy doesn't survive the budget; with the budget cap lifted,
+  1 of 10 raw duplicate pairs in that session both survive AND still exceed
+  the 0.9 similarity bar after the pre-filter's independent per-event
+  2000-char truncation (the other 9 exceed that per-event cap and truncate
+  down far enough to fall below the bar — a conservative miss, never a wrong
+  stub). The fix is real and correct for sessions/pairs small enough to avoid
+  both eviction and truncation, and is structurally inert wherever it would
+  be unsafe to fire.
   Implemented in the pre-filter (`preFilterSession`), which runs AFTER
   `hashSessionContent` — so **no `contentHash` moves and no re-extraction
   wave is triggered** (unlike #830's own folding change, which changed the
-  raw event stream #602's hash covers). Measured on the real session #836
-  used (`4a0d9e9b…`): 10 duplicate task-notifications deduped across its 35
-  folded subagents, reclaiming ~17.3k characters of pre-filter budget
-  (uncapped) that duplication had been consuming; under the current fixed
-  80,000-char budget that mostly reallocates to genuine content the budget
-  had been evicting rather than shrinking the final prompt outright.
+  raw event stream #602's hash covers).
 - **Extract: regression-tested the no-double-extraction guarantee** (#839).
   Discovery-mode extraction over a project with a parent + subagent
   transcripts now has an explicit end-to-end test proving exactly one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Extract: deduped the doubled subagent conclusion in the extraction prompt**
+  (#839). After #830 folded a session's subagent transcripts into its event
+  stream, a completed subagent's final report appeared twice in the same
+  extraction prompt: once as the subagent's own folded final message, once as
+  the parent's `<task-notification>` record of that same call (#836 measured
+  ~92-99% textual overlap on a real pair). The parent's notification copy is
+  now stubbed to `[subagent <agentId> completed: <description>]` when its
+  `<result>` is a near-duplicate (Dice-bigram similarity ≥ 0.9, after
+  decoding the XML entities Claude Code escapes into `<result>`) of a folded
+  subagent transcript's own text; the subagent's original is untouched, per
+  #839's owner-decided direction (the inverse — dropping the subagent's own
+  terminal event — was evaluated and rejected in #836 because some subagent
+  transcripts consist only of that one event). Matching is scoped by
+  `<task-id>` to the one subagent transcript it names and still requires
+  content similarity, so an earlier notification for a *resumed* agent
+  (Claude Code re-notifies the same task-id on each stop) that carries a
+  genuinely different, intermediate result is left alone.
+  Implemented in the pre-filter (`preFilterSession`), which runs AFTER
+  `hashSessionContent` — so **no `contentHash` moves and no re-extraction
+  wave is triggered** (unlike #830's own folding change, which changed the
+  raw event stream #602's hash covers). Measured on the real session #836
+  used (`4a0d9e9b…`): 10 duplicate task-notifications deduped across its 35
+  folded subagents, reclaiming ~17.3k characters of pre-filter budget
+  (uncapped) that duplication had been consuming; under the current fixed
+  80,000-char budget that mostly reallocates to genuine content the budget
+  had been evicting rather than shrinking the final prompt outright.
+- **Extract: regression-tested the no-double-extraction guarantee** (#839).
+  Discovery-mode extraction over a project with a parent + subagent
+  transcripts now has an explicit end-to-end test proving exactly one
+  session is processed, that `--session-id agent-<hash>` resolves to the
+  not-found result rather than an extraction, and that folded subagent
+  content is attributed only to the parent's session/contentHash. Pins
+  behavior already true since #830 (`listSessions()` excludes `subagents/`
+  dirs for both discovery and `--session-id` lookup); nothing tested it
+  end-to-end before.
+
 ## [0.9.2-alpha.3] - 2026-08-26
 
 ### Fixed

--- a/src/integrations/session-logs/pre-filter.ts
+++ b/src/integrations/session-logs/pre-filter.ts
@@ -8,10 +8,12 @@
  * testable — keeps the LLM call cheap and focused on content that might
  * actually carry durable signal.
  *
- * Pre-pass (before the per-event rules):
+ * Post-pass (after the per-event rules AND the total-budget cap, on the
+ * final kept set):
  *   0. stub a parent's `<task-notification>` event when its `<result>` is a
- *      near-duplicate of a subagent transcript folded into the same stream
- *      (#839) — see {@link dedupeTaskNotifications}.
+ *      near-duplicate of a subagent transcript's own event that ALSO
+ *      survived into that same kept set (#839) — see
+ *      {@link dedupeTaskNotifications}.
  *
  * Drop rules (in priority order):
  *   1. read-only `akm` meta-ops (show/search/curate/history/info/hints/...)
@@ -232,10 +234,11 @@ function diceSimilarity(a: string, b: string): number {
 
 /**
  * Stub out a parent's `<task-notification>` event when its `<result>` is a
- * near-duplicate of a subagent transcript's own folded final message (#839).
+ * near-duplicate of a subagent transcript's own event that ALSO survived
+ * into this same kept set (#839).
  *
  * After #830 folds a session's subagent transcripts into its event stream,
- * a completed subagent's report appears twice: once as the subagent's own
+ * a completed subagent's report can appear twice: once as the subagent's own
  * folded final event, once as the parent's `<task-notification>` record of
  * that same call — the notification wraps the subagent's own text almost
  * verbatim (Claude Code XML-escapes `<`/`>`/`&`/quotes in the `<result>`
@@ -244,6 +247,23 @@ function diceSimilarity(a: string, b: string): number {
  * original — the inverse was evaluated and rejected in #836 because some
  * subagent transcripts consist ONLY of their terminal event, so dropping it
  * would destroy the harvesting #830 added.
+ *
+ * **Runs on `kept` — the FINAL post-budget list — not the raw stream**, and
+ * only stubs a notification when a matching subagent event is ALSO present
+ * in that same `kept` list. This is required, not incidental: the recency-
+ * biased budget already evicts one side of most raw duplicate pairs before
+ * dedupe would matter (#840's design doc measured zero pairs where both
+ * copies reached the pre-dedupe prompt across four real sessions), and any
+ * future prompt-composition design that stops including subagent-origin
+ * events in the prompt at all (#840's recommended "harvest-without-
+ * prompting hybrid") makes the parent's `<task-notification>` the ONLY
+ * surviving trace of that delegated work. An unconditional raw-stream stub
+ * would delete that sole copy the moment the subagent's own event is absent
+ * for ANY reason — evicted by budget today, or never present by design
+ * tomorrow. Scoping to "both sides survived into the same kept set" makes
+ * this dedupe a no-op whenever there is only one copy left to dedupe
+ * against, which is exactly the case where deleting it would be a bug, not
+ * a fix.
  *
  * Matching is scoped by `<task-id>` (which is the subagent's agentId) to the
  * SPECIFIC subagent transcript it names, via the `agent-<agentId>.jsonl`
@@ -259,32 +279,30 @@ function diceSimilarity(a: string, b: string): number {
  * The event is kept (not dropped) so event counts/timestamps stay stable and
  * the parent's narrative — *why* it delegated — survives as a short stub:
  * `[subagent <agentId> completed: <description>]`.
- *
- * Runs BEFORE the per-event drop rules in {@link preFilterSession}, on the
- * events {@link preFilterSession} receives (post-`hashSessionContent`, per
- * extract.ts — see the module doc for why this seam doesn't move the hash).
  */
-function dedupeTaskNotifications(events: readonly SessionEvent[]): SessionEvent[] {
-  // Index folded subagent events by the agentId embedded in their transcript's
-  // filename, so a notification's <task-id> narrows the comparison to the ONE
-  // subagent it reports on instead of scanning the whole stream.
+function dedupeTaskNotifications(kept: readonly SessionEvent[]): SessionEvent[] {
+  // Index the KEPT subagent events by the agentId embedded in their
+  // transcript's filename, so a notification's <task-id> narrows the
+  // comparison to the ONE subagent it reports on — and so an agentId with no
+  // surviving event here means "nothing to dedupe against", not "assume it
+  // exists upstream".
   const byAgentId = new Map<string, SessionEvent[]>();
-  for (const event of events) {
+  for (const event of kept) {
     const agentId = event.filePath?.match(SUBAGENT_FILEPATH_RE)?.[1];
     if (!agentId) continue;
     const list = byAgentId.get(agentId);
     if (list) list.push(event);
     else byAgentId.set(agentId, [event]);
   }
-  if (byAgentId.size === 0) return events as SessionEvent[]; // no folded subagents — nothing to dedupe
+  if (byAgentId.size === 0) return kept as SessionEvent[]; // no folded subagent survived the budget — nothing to dedupe
 
-  return events.map((event) => {
+  return kept.map((event) => {
     if (event.role !== "user" || !TASK_NOTIFICATION_RE.test(event.text)) return event;
     const taskId = event.text.match(TASK_ID_RE)?.[1];
     const resultRaw = event.text.match(RESULT_RE)?.[1];
     if (!taskId || !resultRaw) return event; // no <result> (e.g. a background-command notification) — nothing to compare
     const candidates = byAgentId.get(taskId);
-    if (!candidates || candidates.length === 0) return event; // task-id names no folded subagent transcript
+    if (!candidates || candidates.length === 0) return event; // that subagent's own event didn't survive into this kept set
     const decodedResult = decodeXmlEntities(resultRaw);
     const isDuplicate = candidates.some(
       (c) => diceSimilarity(decodedResult, c.text.replace(PROVENANCE_PREFIX_RE, "")) >= DEDUPE_SIMILARITY_THRESHOLD,
@@ -301,16 +319,14 @@ export function preFilterSession(data: SessionData, options: PreFilterOptions = 
   const maxLen = options.maxEventTextLength ?? DEFAULT_MAX_EVENT_LENGTH;
   const maxTotalChars = options.maxTotalChars ?? DEFAULT_MAX_TOTAL_CHARS;
   const droppedByRule: Record<string, number> = {};
-  const kept: SessionEvent[] = [];
+  let kept: SessionEvent[] = [];
   let truncatedCount = 0;
-
-  const dedupedEvents = dedupeTaskNotifications(data.events);
 
   // First pass: apply per-event rules. Track running char total so the budget
   // pass can operate on already-truncated events.
   type KeptEvent = { event: SessionEvent; truncated: boolean; chars: number };
   const candidates: KeptEvent[] = [];
-  for (const event of dedupedEvents) {
+  for (const event of data.events) {
     const verdict = classifyEvent(event, akmReadOnlyOps, maxLen);
     if (!verdict.keep) {
       droppedByRule[verdict.reason] = (droppedByRule[verdict.reason] ?? 0) + 1;
@@ -349,6 +365,14 @@ export function preFilterSession(data: SessionData, options: PreFilterOptions = 
     if (c.truncated) truncatedCount += 1;
   }
 
+  // Post-pass (#839): dedupe a task-notification against a subagent event
+  // ONLY when both survived into this exact kept set — see
+  // dedupeTaskNotifications's doc for why that scoping is required. Recompute
+  // totalChars afterward since stubbing can only shrink kept text, never move
+  // anything across the budget boundary already decided above.
+  kept = dedupeTaskNotifications(kept);
+  const finalTotalChars = kept.reduce((sum, e) => sum + e.text.length, 0);
+
   return {
     events: kept,
     stats: {
@@ -356,7 +380,7 @@ export function preFilterSession(data: SessionData, options: PreFilterOptions = 
       outputCount: kept.length,
       droppedByRule,
       truncatedCount,
-      totalChars,
+      totalChars: finalTotalChars,
       budgetDroppedCount,
     },
   };

--- a/src/integrations/session-logs/pre-filter.ts
+++ b/src/integrations/session-logs/pre-filter.ts
@@ -8,6 +8,11 @@
  * testable — keeps the LLM call cheap and focused on content that might
  * actually carry durable signal.
  *
+ * Pre-pass (before the per-event rules):
+ *   0. stub a parent's `<task-notification>` event when its `<result>` is a
+ *      near-duplicate of a subagent transcript folded into the same stream
+ *      (#839) — see {@link dedupeTaskNotifications}.
+ *
  * Drop rules (in priority order):
  *   1. read-only `akm` meta-ops (show/search/curate/history/info/hints/...)
  *   2. tool-event aggregate patterns (`akm_search unknown` enumerations)
@@ -169,6 +174,128 @@ function classifyEvent(
   return { keep: true, event, truncated: false };
 }
 
+/**
+ * A parent-side `<task-notification>` event, as Claude Code writes it into a
+ * session's own transcript: a `role: "user"` event whose text is (or wraps)
+ * `<task-notification>...<task-id>ID</task-id>...<result>TEXT</result>...</task-notification>`.
+ * Matched on the tags themselves (not a dedicated field) because
+ * {@link SessionEvent} carries no structural provenance beyond `text`/`role`/
+ * `filePath` — the same constraint #830 (subagent provenance) worked within.
+ */
+const TASK_NOTIFICATION_RE = /<task-notification>[\s\S]*<\/task-notification>/;
+const TASK_ID_RE = /<task-id>([^<]+)<\/task-id>/;
+const RESULT_RE = /<result>([\s\S]*)<\/result>/;
+const SUMMARY_RE = /<summary>([^<]*)<\/summary>/;
+/** Claude Code's own `<summary>` phrasing for a finished agent: `Agent "<description>" finished`. */
+const AGENT_SUMMARY_DESCRIPTION_RE = /^Agent "(.*)" finished$/;
+/** Provenance {@link subagentProvenance} stamps on every folded subagent event; stripped before comparison. */
+const PROVENANCE_PREFIX_RE = /^\[subagent:[^\]]*\][^\n]*\n/;
+/** Claude Code's own agentId file naming: `<...>/subagents/<...>agent-<agentId>.jsonl`. */
+const SUBAGENT_FILEPATH_RE = /agent-([^/\\]+?)\.jsonl$/;
+/** Dice (bigram) similarity at/above this counts as "the same content" (#839). */
+const DEDUPE_SIMILARITY_THRESHOLD = 0.9;
+
+/** A handful of named-entity decodes — enough for what Claude Code escapes when it wraps `<result>` text in XML. */
+function decodeXmlEntities(text: string): string {
+  return text
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+/** Sørensen–Dice coefficient over character bigrams — a cheap, symmetric textual-overlap measure. */
+function diceSimilarity(a: string, b: string): number {
+  if (a.length < 2 || b.length < 2) return a === b ? 1 : 0;
+  const bigrams = (s: string): Map<string, number> => {
+    const counts = new Map<string, number>();
+    for (let i = 0; i < s.length - 1; i++) {
+      const bg = s.slice(i, i + 2);
+      counts.set(bg, (counts.get(bg) ?? 0) + 1);
+    }
+    return counts;
+  };
+  const bigramsA = bigrams(a);
+  const bigramsB = bigrams(b);
+  let intersection = 0;
+  let totalA = 0;
+  let totalB = 0;
+  for (const count of bigramsA.values()) totalA += count;
+  for (const count of bigramsB.values()) totalB += count;
+  for (const [bg, count] of bigramsA) {
+    const other = bigramsB.get(bg);
+    if (other) intersection += Math.min(count, other);
+  }
+  return totalA + totalB === 0 ? 1 : (2 * intersection) / (totalA + totalB);
+}
+
+/**
+ * Stub out a parent's `<task-notification>` event when its `<result>` is a
+ * near-duplicate of a subagent transcript's own folded final message (#839).
+ *
+ * After #830 folds a session's subagent transcripts into its event stream,
+ * a completed subagent's report appears twice: once as the subagent's own
+ * folded final event, once as the parent's `<task-notification>` record of
+ * that same call — the notification wraps the subagent's own text almost
+ * verbatim (Claude Code XML-escapes `<`/`>`/`&`/quotes in the `<result>`
+ * body, which {@link decodeXmlEntities} reverses before comparing). Direction
+ * is owner-decided (#839): drop the parent's copy, keep the subagent's
+ * original — the inverse was evaluated and rejected in #836 because some
+ * subagent transcripts consist ONLY of their terminal event, so dropping it
+ * would destroy the harvesting #830 added.
+ *
+ * Matching is scoped by `<task-id>` (which is the subagent's agentId) to the
+ * SPECIFIC subagent transcript it names, via the `agent-<agentId>.jsonl`
+ * filename #830's folding already stamps onto every folded event's
+ * `filePath` — then requires the decoded `<result>` to be a near-duplicate
+ * (Dice similarity ≥ {@link DEDUPE_SIMILARITY_THRESHOLD}) of that subagent's
+ * text, not merely a same-agent match. This matters because a task-notification
+ * fires every time an agent stops (Claude Code's own note in the event: "the
+ * same task-id may notify more than once") — an EARLIER notification for a
+ * resumed agent can carry a genuinely different (intermediate) result that
+ * must NOT be stubbed just because the ids line up.
+ *
+ * The event is kept (not dropped) so event counts/timestamps stay stable and
+ * the parent's narrative — *why* it delegated — survives as a short stub:
+ * `[subagent <agentId> completed: <description>]`.
+ *
+ * Runs BEFORE the per-event drop rules in {@link preFilterSession}, on the
+ * events {@link preFilterSession} receives (post-`hashSessionContent`, per
+ * extract.ts — see the module doc for why this seam doesn't move the hash).
+ */
+function dedupeTaskNotifications(events: readonly SessionEvent[]): SessionEvent[] {
+  // Index folded subagent events by the agentId embedded in their transcript's
+  // filename, so a notification's <task-id> narrows the comparison to the ONE
+  // subagent it reports on instead of scanning the whole stream.
+  const byAgentId = new Map<string, SessionEvent[]>();
+  for (const event of events) {
+    const agentId = event.filePath?.match(SUBAGENT_FILEPATH_RE)?.[1];
+    if (!agentId) continue;
+    const list = byAgentId.get(agentId);
+    if (list) list.push(event);
+    else byAgentId.set(agentId, [event]);
+  }
+  if (byAgentId.size === 0) return events as SessionEvent[]; // no folded subagents — nothing to dedupe
+
+  return events.map((event) => {
+    if (event.role !== "user" || !TASK_NOTIFICATION_RE.test(event.text)) return event;
+    const taskId = event.text.match(TASK_ID_RE)?.[1];
+    const resultRaw = event.text.match(RESULT_RE)?.[1];
+    if (!taskId || !resultRaw) return event; // no <result> (e.g. a background-command notification) — nothing to compare
+    const candidates = byAgentId.get(taskId);
+    if (!candidates || candidates.length === 0) return event; // task-id names no folded subagent transcript
+    const decodedResult = decodeXmlEntities(resultRaw);
+    const isDuplicate = candidates.some(
+      (c) => diceSimilarity(decodedResult, c.text.replace(PROVENANCE_PREFIX_RE, "")) >= DEDUPE_SIMILARITY_THRESHOLD,
+    );
+    if (!isDuplicate) return event;
+    const summary = event.text.match(SUMMARY_RE)?.[1]?.trim();
+    const description = (summary && (summary.match(AGENT_SUMMARY_DESCRIPTION_RE)?.[1] ?? summary)) || "completed";
+    return { ...event, text: `[subagent ${taskId} completed: ${description}]` };
+  });
+}
+
 export function preFilterSession(data: SessionData, options: PreFilterOptions = {}): PreFilterResult {
   const akmReadOnlyOps = options.akmReadOnlyOps ?? DEFAULT_AKM_READONLY_OPS;
   const maxLen = options.maxEventTextLength ?? DEFAULT_MAX_EVENT_LENGTH;
@@ -177,11 +304,13 @@ export function preFilterSession(data: SessionData, options: PreFilterOptions = 
   const kept: SessionEvent[] = [];
   let truncatedCount = 0;
 
+  const dedupedEvents = dedupeTaskNotifications(data.events);
+
   // First pass: apply per-event rules. Track running char total so the budget
   // pass can operate on already-truncated events.
   type KeptEvent = { event: SessionEvent; truncated: boolean; chars: number };
   const candidates: KeptEvent[] = [];
-  for (const event of data.events) {
+  for (const event of dedupedEvents) {
     const verdict = classifyEvent(event, akmReadOnlyOps, maxLen);
     if (!verdict.keep) {
       droppedByRule[verdict.reason] = (droppedByRule[verdict.reason] ?? 0) + 1;

--- a/tests/integration/extract-command.test.ts
+++ b/tests/integration/extract-command.test.ts
@@ -24,6 +24,7 @@ import { readEvents } from "../../src/core/events";
 import { createLockPayload } from "../../src/core/file-lock";
 import { getStateDbPath, openStateDatabase } from "../../src/core/state-db";
 import { detectTruncatedDescription } from "../../src/core/text-truncation";
+import { ClaudeCodeProvider } from "../../src/integrations/harnesses/claude/session-log";
 import type {
   SessionData,
   SessionLogHarness,
@@ -365,6 +366,105 @@ describe("akmExtract — single-session mode", () => {
     });
     expect(result.ok).toBe(false);
     expect(result.warnings.join(" ")).toMatch(/not found/);
+  });
+});
+
+describe("akmExtract — subagent transcripts are never extracted as their own session (#839)", () => {
+  // Real ClaudeCodeProvider (not the fake harness) driven against
+  // `withIsolatedAkmStorage()`'s isolated `AKM_CLAUDE_PROJECTS_DIR`, so
+  // `listSessions()`'s subagents-exclusion (#830) and the folding in
+  // `readSession()` both run for real. `chat` is still injected so no LLM
+  // call happens.
+  function writeClaudeSessionJsonl(filePath: string, lines: object[]): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, `${lines.map((l) => JSON.stringify(l)).join("\n")}\n`);
+  }
+
+  function seedParentAndSubagent(root: string): { parentId: string; subagentId: string } {
+    const project = path.join(root, "-home-user-akm");
+    const parentId = "session-1";
+    writeClaudeSessionJsonl(path.join(project, `${parentId}.jsonl`), [
+      {
+        type: "user",
+        timestamp: "2026-08-01T10:00:00.000Z",
+        message: { role: "user", content: "Please delegate the release-branch audit to a subagent." },
+      },
+      {
+        type: "assistant",
+        timestamp: "2026-08-01T10:30:00.000Z",
+        message: { role: "assistant", content: "Delegated it; the subagent reported back and the audit is done." },
+      },
+    ]);
+    const subagentId = "abc123";
+    writeClaudeSessionJsonl(path.join(project, parentId, "subagents", `agent-${subagentId}.jsonl`), [
+      {
+        type: "assistant",
+        timestamp: "2026-08-01T10:15:00.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "SUBAGENT_MARKER: audited every release branch, all clean." }],
+        },
+      },
+    ]);
+    fs.writeFileSync(
+      path.join(project, parentId, "subagents", `agent-${subagentId}.meta.json`),
+      JSON.stringify({ agentType: "general-purpose", description: "Audit release branches" }),
+    );
+    return { parentId, subagentId };
+  }
+
+  test("discovery mode processes exactly one session, with folded content attributed only to the parent", async () => {
+    const stash = makeStashDir();
+    const { parentId } = seedParentAndSubagent(storage.sessionLogsDir);
+
+    let chatCalls = 0;
+    let capturedPrompt = "";
+    const result = await akmExtract({
+      type: "claude",
+      stashDir: stash,
+      config: configEnabled(stash),
+      harnesses: [new ClaudeCodeProvider()],
+      since: "24h",
+      chat: async (_cfg, msgs) => {
+        chatCalls += 1;
+        capturedPrompt = msgs[0]?.content ?? "";
+        return JSON.stringify({ candidates: [] });
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    // Exactly one session — the subagent transcript never surfaces as its own.
+    expect(chatCalls).toBe(1);
+    expect(result.sessionsProcessed).toBe(1);
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]?.sessionId).toBe(parentId);
+    expect(result.sessions[0]?.contentHash).toBeDefined();
+    // The subagent's folded content actually reached the LLM prompt, filed
+    // under the parent's own extraction result — not skipped, not separate.
+    expect(capturedPrompt).toContain("SUBAGENT_MARKER");
+  });
+
+  test("--session-id agent-<hash> returns the not-found result, not an extraction", async () => {
+    const stash = makeStashDir();
+    const { subagentId } = seedParentAndSubagent(storage.sessionLogsDir);
+
+    let chatCalls = 0;
+    const result = await akmExtract({
+      type: "claude",
+      sessionId: `agent-${subagentId}`,
+      stashDir: stash,
+      config: configEnabled(stash),
+      harnesses: [new ClaudeCodeProvider()],
+      chat: async () => {
+        chatCalls += 1;
+        return JSON.stringify({ candidates: [] });
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.sessionsProcessed).toBe(0);
+    expect(result.warnings.join(" ")).toMatch(/not found/);
+    expect(chatCalls).toBe(0);
   });
 });
 

--- a/tests/session-logs-pre-filter.test.ts
+++ b/tests/session-logs-pre-filter.test.ts
@@ -212,6 +212,102 @@ describe("preFilterSession — total-character budget", () => {
   });
 });
 
+describe("preFilterSession — subagent task-notification dedupe (#839)", () => {
+  // A subagent transcript's folded final event, as #830's `readSession` stamps
+  // it: provenance prefix + the subagent's own last message.
+  const subagentFinalText =
+    "[subagent:general-purpose] Verify V28+V32: dead surface\n" +
+    'Verdict: CONFIRMED -> zero live callers found via grep across src/tests. {"ok":true}';
+  const subagentEvent = event({
+    role: "assistant",
+    text: subagentFinalText,
+    ts: 1700000000000,
+    filePath: "/proj/session-1/subagents/agent-a4f581608db6e05b1.jsonl",
+  });
+
+  function notification(resultBody: string, opts: { taskId?: string; summary?: string } = {}): SessionEvent {
+    const taskId = opts.taskId ?? "a4f581608db6e05b1";
+    const summary = opts.summary ?? 'Agent "Verify V28+V32: dead surface" finished';
+    return event({
+      role: "user",
+      ts: 1700000001000,
+      filePath: "/proj/session-1.jsonl",
+      text:
+        `<task-notification>\n<task-id>${taskId}</task-id>\n<tool-use-id>toolu_01</tool-use-id>\n` +
+        `<status>completed</status>\n<summary>${summary}</summary>\n<result>${resultBody}</result>\n</task-notification>`,
+    });
+  }
+
+  test("stubs a notification whose <result> duplicates the folded subagent's final message", () => {
+    // The <result> body is what Claude Code actually writes: the subagent's own
+    // final text, XML-entity-escaped (its `->` becomes `-&gt;`), with no
+    // provenance prefix (that's #830's own stamp, added only on the folded copy).
+    const resultBody = 'Verdict: CONFIRMED -&gt; zero live callers found via grep across src/tests. {"ok":true}';
+    const events = [subagentEvent, notification(resultBody)];
+    const result = preFilterSession(makeData(events));
+
+    expect(result.events).toHaveLength(2); // event is stubbed, not dropped
+    const stubbed = result.events.find((e) => e.role === "user");
+    expect(stubbed?.text).toBe("[subagent a4f581608db6e05b1 completed: Verify V28+V32: dead surface]");
+    // The subagent's own original is untouched.
+    const original = result.events.find((e) => e.role === "assistant");
+    expect(original?.text).toBe(subagentFinalText);
+  });
+
+  test("does not stub a notification with no <result> (e.g. a background-command notification)", () => {
+    const bgNotification = event({
+      role: "user",
+      filePath: "/proj/session-1.jsonl",
+      text:
+        "<task-notification>\n<task-id>b0pvowrru</task-id>\n<status>completed</status>\n" +
+        '<summary>Background command "Run tests" completed (exit code 0)</summary>\n</task-notification>',
+    });
+    const result = preFilterSession(makeData([subagentEvent, bgNotification]));
+    const kept = result.events.find((e) => e.role === "user");
+    expect(kept?.text).toBe(bgNotification.text);
+  });
+
+  test("does not stub when the <result> genuinely differs, even for the same <task-id> (resumed-agent false positive)", () => {
+    // Claude Code's own note: "A task-notification fires each time this agent
+    // stops ... the same task-id may notify more than once." An earlier
+    // notification for a resumed agent can carry a different, intermediate
+    // result — that must survive untouched.
+    const intermediateResult = "Still investigating V28a, no verdict yet. Continuing to grep for callers.";
+    const events = [subagentEvent, notification(intermediateResult)];
+    const result = preFilterSession(makeData(events));
+    const kept = result.events.find((e) => e.role === "user");
+    expect(kept?.text).toContain("<result>Still investigating");
+  });
+
+  test("does not stub when the <task-id> names no folded subagent transcript", () => {
+    const events = [subagentEvent, notification("some unrelated result text here", { taskId: "not-a-real-agent" })];
+    const result = preFilterSession(makeData(events));
+    const kept = result.events.find((e) => e.role === "user");
+    expect(kept?.text).toContain("<task-id>not-a-real-agent</task-id>");
+  });
+
+  test("is a no-op when the session has no folded subagent events at all", () => {
+    const resultBody = "anything";
+    const events = [notification(resultBody)];
+    const result = preFilterSession(makeData(events));
+    expect(result.events[0]?.text).toContain("<task-notification>");
+  });
+
+  test("falls back to a generic stub when the notification has no <summary>", () => {
+    const resultBody = 'Verdict: CONFIRMED -&gt; zero live callers found via grep across src/tests. {"ok":true}';
+    const noSummary = event({
+      role: "user",
+      filePath: "/proj/session-1.jsonl",
+      text:
+        "<task-notification>\n<task-id>a4f581608db6e05b1</task-id>\n<status>completed</status>\n" +
+        `<result>${resultBody}</result>\n</task-notification>`,
+    });
+    const result = preFilterSession(makeData([subagentEvent, noSummary]));
+    const stubbed = result.events.find((e) => e.role === "user");
+    expect(stubbed?.text).toBe("[subagent a4f581608db6e05b1 completed: completed]");
+  });
+});
+
 describe("preFilterSession — custom options", () => {
   test("custom akmReadOnlyOps lets the caller broaden what counts as noise", () => {
     // Treat `remember` as read-only too (just for this test) and confirm it

--- a/tests/session-logs-pre-filter.test.ts
+++ b/tests/session-logs-pre-filter.test.ts
@@ -293,6 +293,46 @@ describe("preFilterSession — subagent task-notification dedupe (#839)", () => 
     expect(result.events[0]?.text).toContain("<task-notification>");
   });
 
+  test("does not stub when the subagent's own event was evicted by the budget cap (#840 hazard)", () => {
+    // The recency-biased budget can (and per #840's measurement, usually does)
+    // evict one side of a raw duplicate pair before dedupe ever runs. If the
+    // NOTIFICATION survives but the subagent's own (older) event does not,
+    // stubbing the notification would delete the only surviving trace of that
+    // delegated work — exactly the hazard #840's design doc flags for any
+    // future prompt-composition design where the subagent's own copy is never
+    // in the prompt at all. The dedupe must be a no-op here.
+    const resultBody = 'Verdict: CONFIRMED -&gt; zero live callers found via grep across src/tests. {"ok":true}';
+    const notif = notification(resultBody);
+    const events = [subagentEvent, notif]; // subagentEvent is OLDER (ts 1700000000000 < 1700000001000)
+    // Budget just barely fits the (newer) notification alone — the older
+    // subagent event gets evicted by the recency-biased budget pass.
+    const tightBudget = notif.text.length + 10;
+    const result = preFilterSession(makeData(events), { maxTotalChars: tightBudget });
+
+    expect(result.events).toHaveLength(1);
+    expect(result.stats.budgetDroppedCount).toBe(1);
+    // The notification survives UNSTUBBED — its would-be duplicate never made it into this kept set.
+    expect(result.events[0]?.text).toBe(notif.text);
+    expect(result.events[0]?.text).toContain("<task-notification>");
+  });
+
+  test("does not stub when the subagent's own event was dropped by a per-event rule (not merely evicted)", () => {
+    // Same hazard as the budget case, via a different exclusion path: the
+    // subagent's folded event is dropped by an ordinary per-event rule
+    // (too-short) rather than the budget cap. Either way, if the subagent's
+    // own copy isn't in the kept set, the notification must survive untouched.
+    const resultBody = 'Verdict: CONFIRMED -&gt; zero live callers found via grep across src/tests. {"ok":true}';
+    const tooShortSubagentEvent = event({
+      role: "assistant",
+      text: "hi", // under the 10-char floor — dropped by classifyEvent's "too-short" rule
+      filePath: "/proj/session-1/subagents/agent-a4f581608db6e05b1.jsonl",
+    });
+    const result = preFilterSession(makeData([tooShortSubagentEvent, notification(resultBody)]));
+
+    expect(result.events).toHaveLength(1); // the too-short subagent event was dropped, not just the notification stubbed
+    expect(result.events[0]?.text).toContain("<task-notification>");
+  });
+
   test("falls back to a generic stub when the notification has no <summary>", () => {
     const resultBody = 'Verdict: CONFIRMED -&gt; zero live callers found via grep across src/tests. {"ok":true}';
     const noSummary = event({


### PR DESCRIPTION
Implements itlackey/akm#839: dedupes the doubled subagent conclusion #830's folding introduced, and pins the no-double-extraction guarantee with a regression test.

**Note on scope:** while this was in flight, #840's design-determination doc (PR #841, `docs/plans/subagent-extraction-design.md`) measured a real hazard in the first version of this dedupe and recommended a fix, which is included here (see "Scoping fix" below). #841 is doc/plan-only — no `src/` changes — and its recommended future architecture (prompting from parent-origin events only) is **not** implemented in this PR, per #840's own scope guidance.

## Part 1 — dedupe the doubled subagent conclusion

**Reproduced the cited pair first.** Session `4a0d9e9b…`, subagent `agent-a4f581608db6e05b1` (#836's own fixture, still on disk under this machine's `AKM_CLAUDE_PROJECTS_DIR`/scratchpad from that PR's measurement run — the live session's parent `.jsonl` itself has since rotated off disk, same as #840 found). Diffing the subagent's real folded final message against the parent's real `<task-notification>` record of it: after decoding the XML entities Claude Code escapes into `<result>` (`-&gt;` → `->`, etc.), the two are **byte-identical**.

**Matching rule.** A `<task-notification>` event (`role: "user"`, text containing `<task-notification>…</task-notification>`) is stubbed when:
1. its `<task-id>` matches the `agent-<agentId>.jsonl` filename stamped on a folded subagent event's `filePath` (#830's own folding already provides this), AND
2. its decoded `<result>` body has Dice-bigram similarity ≥ 0.9 against that subagent's (provenance-prefix-stripped) event text.

Both conditions are required. Claude Code's own event note says *"the same task-id may notify more than once"* (an agent can be resumed), so an **earlier** notification for a resumed agent can carry a genuinely different, intermediate result under the same task-id. **False-positive test** (`tests/session-logs-pre-filter.test.ts`): an intermediate result under the real task-id scores Dice ≈ 0.02 against the real final message and is correctly left untouched.

**Scoping fix (the #840 hazard).** The first version of this dedupe matched a notification against ANY subagent event present anywhere in the raw stream. #840's doc measured that the recency-biased 80k pre-filter budget already evicts one side of nearly every raw duplicate pair (**0 of 89 raw pairs across four real sessions had both sides survive into the pre-dedupe prompt**) — so an unconditional raw-stream stub can fire even when the subagent's own copy never makes the cut, and would unconditionally delete the sole surviving trace of delegated work under #840's recommended future design (prompting from parent-origin events only, where the subagent's own copy is never in the prompt to begin with).

Fixed: `dedupeTaskNotifications` now runs on `kept` — the pre-filter's own final list, after both the per-event drop/truncate rules AND the total-budget cap — and only stubs a notification when a matching subagent event is **also present in that exact same kept list**. This makes the dedupe a structural no-op everywhere it would be unsafe to fire: budget-evicted, per-event-rule-dropped, or (by construction) absent under any future design that never puts subagent-origin events in the prompt. Two new tests pin this: the notification survives unstubbed when its subagent copy is evicted by a tight budget, and when it's dropped by an ordinary per-event rule (too-short).

**Re-measured on the real session both #839 and #840 cite (`4a0d9e9b…`) after the scoping fix:**
- Under the actual 80,000-char budget: **0 notifications are stubbed today** — consistent with #840's finding, because this specific pair's subagent copy doesn't survive the budget cut.
- With the budget cap lifted (isolating the dedupe from budget interaction): 10 raw duplicate pairs exist in this session, all with both sides technically present once budget isn't a factor, but only **1** clears the 0.9 similarity bar — the other 9 exceed the pre-filter's independent per-event 2000-char truncation cap and get truncated down far enough that the comparison falls below threshold. That's a conservative *miss* (never a wrong stub), consistent with the pre-filter's documented philosophy of erring toward keeping content.

**Honest bottom line, correcting my own earlier (pre-#840-feedback) draft of this PR body: no prompt-char savings are claimed here.** The dedupe is a real, correct fix for the duplication defect #836/#839 describe, but on real data available today it will rarely change the prompt actually sent to the LLM, for the same reason #840 found for the unconditional version — the budget usually already resolves the duplication by eviction. Its value is: (a) correctness when a pair is small enough to avoid both eviction and per-event truncation, (b) the raw-stream defect no longer exists structurally, and (c) it composes safely with #840's recommended future design without needing to be revisited then.

**Stub vs. delete.** Deleting the event would shift event counts/timestamps. Stubbing to `[subagent <agentId> completed: <description>]` (from the notification's own `<summary>Agent "X" finished</summary>` text — no extra file I/O in a function documented as pure/deterministic) keeps the parent's narrative — *why it delegated* — intact.

**Where implemented, and the contentHash question.** `extract.ts` computes `hashSessionContent(data)` (extract.ts:565, hashing the RAW `readSession()` output) **before** calling `preFilterSession(data, …)` (extract.ts:570). The dedupe lives entirely inside `preFilterSession`, operating only on its own local `kept` array — it never touches `data.events`. **`contentHash` does not move; no re-extraction wave is triggered** — unlike #830's own folding change, which changed the raw stream itself and did move hashes (per #836's Q2).

## Part 2 — pin the no-double-extraction guarantee

Added `describe("akmExtract — subagent transcripts are never extracted as their own session (#839)")` to `tests/integration/extract-command.test.ts`, using the **real** `ClaudeCodeProvider` (not the fake harness) against `withIsolatedAkmStorage()`'s isolated `AKM_CLAUDE_PROJECTS_DIR`, with only `chat` faked (no LLM call). Two tests:

- **Discovery mode** processes exactly one session; `result.sessions[0].sessionId` is the parent id (never `agent-<hash>`); the subagent's folded content (a `SUBAGENT_MARKER` string) is verified present in the actual prompt sent to `chat`, proving it's attributed under the parent's own extraction, not skipped or separate.
- **`--session-id agent-<hash>`** returns `ok: false`, `sessionsProcessed: 0`, a "not found" warning, and the fake `chat` is never called.

This part is unaffected by the #840 coordination note.

## Verification

**Mutation testing** (each mutation applied, grepped to confirm, tests run, then reverted):
- Disabled the dedupe entirely → `tests/session-logs-pre-filter.test.ts`: **26 pass / 2 fail** (the two true-positive dedupe assertions fail with raw, un-stubbed `<task-notification>` XML).
- Reworked the match-set index to source from the raw stream instead of the post-budget `kept` list (reproducing the exact #840 hazard) → **27 pass / 1 fail** (the budget-eviction hazard test fails: the notification gets wrongly stubbed even though its subagent copy was evicted).
- Re-enabled subagent enumeration in `#walkJsonl` (Part 2) → the two `#839` regression tests in `extract-command.test.ts`: **0 pass / 2 fail**.
- All three restored → full suites green; `grep MUTATION` confirmed no artifacts remain in the final diff.

**Full suites:**
- `bun run test:unit` — 3865 pass / 0 fail (baseline 3857 + 8 new pre-filter dedupe tests)
- `bun run test:integration` — 5600 pass / 52 skip / 0 fail (baseline 5598 + 2 new #839 regression tests)
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx biome check` on the changed source/test files — clean (the pre-commit hook's ~1,300 pre-existing repo-wide warnings are untouched by this change)

Closes #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7CauuoYuv5ULR4igmU1Jx
