### PR TITLE
fix(extract): build the LLM prompt from parent-origin events only (#840)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,52 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Extract: LLM prompt is now built from parent-origin events only —
+  "harvest-without-prompting hybrid" (#840).** #830 folds a session's
+  subagent transcripts into its event stream for hashing and inline-ref
+  harvesting; the prompt sent to the extraction LLM previously included that
+  folded subagent content too, competing with the parent's own transcript
+  for the 80,000-char pre-filter budget. #840's design-determination doc
+  (`docs/plans/subagent-extraction-design.md`) measured that this "fold"
+  approach evicts up to 28.6% of parent-origin content on real sessions to
+  make room for subagent noise that mostly gets evicted anyway, while a
+  "harvest-without-prompting hybrid" — keep folding for hashing/inline-ref
+  purposes, but filter the prompt down to `data.events` whose `filePath`
+  matches the session's own (`data.ref.filePath`) — matches or beats the
+  folded prompt's size with zero eviction on every session measured, and
+  recovers the exact same inline refs (`akm remember`/`akm feedback` calls
+  the agent made inside a subagent), because that harvesting already runs on
+  the raw stream independent of what reaches the prompt. Only
+  `runPreLlmSessionGates`'s call into `preFilterSession` changed; folding
+  (`session-log.ts`) and `buildExtractPrompt` are untouched.
+  - **No forced re-extraction wave.** `hashSessionContent` still hashes the
+    full folded `data` (parent + subagents), computed before the
+    parent-origin view is built — no previously-computed session hash
+    changes, so no session already extracted under the fold prompt shape is
+    automatically re-processed. Use `--force` to re-process a specific
+    session under the new, parent-only prompt shape.
+  - **`processes.extract.maxTotalChars` is unchanged in meaning and default**
+    — it still caps the single-call prompt built from parent-origin events;
+    it simply no longer has to compete against subagent-origin noise for
+    that budget.
+  - **`minContentChars`** (the raw-size skip gate, #595/#596) is still
+    measured on the FULL folded `data.events` (parent + subagents),
+    deliberately left unchanged: narrowing it to parent-origin chars would
+    newly skip delegation-heavy sessions with a thin parent transcript
+    before extraction runs at all, even though their subagent-origin work is
+    still fully harvested via inline refs. The full-stream measurement is
+    today's existing behavior; the worst case it preserves is an LLM call
+    over a small parent-only prompt, not a missed extraction.
+  - #839's task-notification dedupe (which stubs a parent's
+    `<task-notification>` only when the matching subagent's own event ALSO
+    survives into the same kept prompt set) composes safely with this
+    change without modification: subagent-origin events never reach
+    `preFilterSession` on this path, so the dedupe's own scoping check
+    naturally makes it a no-op — the parent's notification (the only
+    remaining trace of delegated work in the prompt) survives untouched.
+
 ### Fixed
 
 - **Extract: deduped the doubled subagent conclusion in the extraction prompt**

--- a/src/commands/improve/extract.ts
+++ b/src/commands/improve/extract.ts
@@ -567,7 +567,20 @@ function runPreLlmSessionGates(args: {
     return { skip: alreadyExtractedResult(harness.name, sessionRef.sessionId, prior, contentHash) };
   }
 
-  const filtered = preFilterSession(data, {
+  // #840 — harvest-without-prompting hybrid: the LLM prompt is built only from
+  // parent-origin events (folding stays as infrastructure for hashing above
+  // and inline-ref harvesting on `data.inlineRefs`, both of which still see
+  // the FULL folded stream). Subagent-origin events never reach
+  // `preFilterSession`, so #839's `dedupeTaskNotifications` naturally becomes
+  // a no-op on this path — a subagent's own event can no longer be in the
+  // kept set for a notification to be deduped against, leaving the parent's
+  // `<task-notification>` (the only surviving trace of that delegated work)
+  // untouched. See docs/plans/subagent-extraction-design.md §6.
+  const parentOriginData: typeof data = {
+    ...data,
+    events: data.events.filter((e) => e.filePath === data.ref.filePath),
+  };
+  const filtered = preFilterSession(parentOriginData, {
     ...(typeof maxTotalChars === "number" ? { maxTotalChars } : {}),
   });
 
@@ -579,6 +592,14 @@ function runPreLlmSessionGates(args: {
   // fix gated on `filtered.stats.inputCount`, which is an EVENT count, not a
   // char count — this port measures actual raw chars so the threshold matches
   // the config key's documented unit.
+  // #840 — deliberately measured on the FULL folded `data.events` (parent +
+  // subagents), not the parent-origin view above: narrowing this to
+  // parent-origin chars would newly skip delegation-heavy sessions with a
+  // thin parent transcript before extraction runs at all, even though their
+  // subagent work is still fully harvested via `data.inlineRefs` above. The
+  // full-stream measurement is today's unchanged behavior, so the worst case
+  // this preserves is an LLM call over a small parent-only prompt, not a
+  // missed extraction.
   const rawContentChars = data.events.reduce((sum, event) => sum + event.text.length, 0);
   if (minContentChars > 0 && rawContentChars < minContentChars) {
     return {

--- a/tests/integration/extract-command.test.ts
+++ b/tests/integration/extract-command.test.ts
@@ -413,7 +413,7 @@ describe("akmExtract — subagent transcripts are never extracted as their own s
     return { parentId, subagentId };
   }
 
-  test("discovery mode processes exactly one session, with folded content attributed only to the parent", async () => {
+  test("discovery mode processes exactly one session, subagent transcript never surfaced as its own", async () => {
     const stash = makeStashDir();
     const { parentId } = seedParentAndSubagent(storage.sessionLogsDir);
 
@@ -439,9 +439,13 @@ describe("akmExtract — subagent transcripts are never extracted as their own s
     expect(result.sessions).toHaveLength(1);
     expect(result.sessions[0]?.sessionId).toBe(parentId);
     expect(result.sessions[0]?.contentHash).toBeDefined();
-    // The subagent's folded content actually reached the LLM prompt, filed
-    // under the parent's own extraction result — not skipped, not separate.
-    expect(capturedPrompt).toContain("SUBAGENT_MARKER");
+    // #840 — harvest-without-prompting hybrid: the folded subagent transcript
+    // is still read and hashed under the parent's identity (no double
+    // extraction), but its raw text is never sent to the LLM — only
+    // parent-origin events reach the prompt. The subagent's provenance-
+    // prefixed text ("[subagent:...]") must NOT appear here.
+    expect(capturedPrompt).not.toContain("SUBAGENT_MARKER");
+    expect(capturedPrompt).not.toContain("[subagent:");
   });
 
   test("--session-id agent-<hash> returns the not-found result, not an extraction", async () => {

--- a/tests/integration/extract-session-tracking.test.ts
+++ b/tests/integration/extract-session-tracking.test.ts
@@ -25,7 +25,9 @@ import type { AkmConfig } from "../../src/core/config/config";
 import { tryAcquireLockSync } from "../../src/core/file-lock";
 import { openStateDatabase } from "../../src/core/state-db";
 import type {
+  InlineRefMention,
   SessionData,
+  SessionEvent,
   SessionLogHarness,
   SessionRef,
   SessionSummary,
@@ -235,6 +237,157 @@ describe("hashSessionContent", () => {
       { harness: "claude", text: "second", role: "assistant", sessionId: "ses_forge_b" },
     ];
     expect(hashSessionContent(single)).not.toBe(hashSessionContent(split));
+  });
+});
+
+// ── #840 harvest-without-prompting hybrid — prompt-composition invariants ───
+//
+// docs/plans/subagent-extraction-design.md §6: the LLM prompt is built from
+// parent-origin events only (`data.events.filter(e => e.filePath ===
+// data.ref.filePath)` inside `runPreLlmSessionGates`), while
+// `hashSessionContent` and `data.inlineRefs` keep seeing the FULL folded
+// stream (parent + subagents). These three tests exercise the real
+// `akmExtract` pipeline end-to-end (fake harness, no filesystem, `chat`
+// mocked to capture the built prompt) against one folded fixture that
+// carries all three ingredients at once: a subagent-origin folded event, a
+// subagent-only inline ref, and a parent `<task-notification>` whose
+// `<result>` near-duplicates that same subagent's own text (the #839/#842
+// dedupe's exact trigger shape).
+describe("akmExtract — harvest-without-prompting hybrid prompt composition (#840)", () => {
+  const PARENT_PATH = "/proj/parent.jsonl";
+  const SUBAGENT_PATH = "/proj/parent/subagents/agent-agentXYZ.jsonl";
+  const SUBAGENT_RESULT_TEXT = "Audited every release branch, all clean. SUBAGENT_UNIQUE_MARKER_9f3a";
+  const SUBAGENT_ONLY_REF_TEXT = "release branch audit checklist should include tag verification";
+
+  function buildHybridSession(): SessionData {
+    const t0 = 1_800_000_000_000;
+    const events: SessionEvent[] = [
+      {
+        harness: "claude",
+        role: "user",
+        ts: t0,
+        filePath: PARENT_PATH,
+        sessionId: "ses_hybrid",
+        text: "Please delegate the release-branch audit to a subagent and report back with the finding.",
+      },
+      {
+        harness: "claude",
+        role: "assistant",
+        ts: t0 + 1000,
+        filePath: PARENT_PATH,
+        sessionId: "ses_hybrid",
+        text: "Delegating the release-branch audit now via the Task tool.",
+      },
+      // Subagent's own folded event (#830) — provenance-prefixed, on the
+      // subagent's own `agent-<id>.jsonl` filePath.
+      {
+        harness: "claude",
+        role: "assistant",
+        ts: t0 + 2000,
+        filePath: SUBAGENT_PATH,
+        sessionId: "ses_hybrid",
+        text: `[subagent:general-purpose] Audit release branches\n${SUBAGENT_RESULT_TEXT}`,
+      },
+      // Parent's own <task-notification> record of that same delegated call —
+      // a parent-origin event whose <result> near-duplicates the subagent's
+      // own text above (this is exactly what #839's dedupeTaskNotifications
+      // matches on when BOTH copies reach the same kept set).
+      {
+        harness: "claude",
+        role: "user",
+        ts: t0 + 3000,
+        filePath: PARENT_PATH,
+        sessionId: "ses_hybrid",
+        text:
+          "<task-notification>\n<task-id>agentXYZ</task-id>\n<tool-use-id>toolu_1</tool-use-id>\n" +
+          '<status>completed</status>\n<summary>Agent "Audit release branches" finished</summary>\n' +
+          `<result>${SUBAGENT_RESULT_TEXT}</result>\n</task-notification>`,
+      },
+      {
+        harness: "claude",
+        role: "assistant",
+        ts: t0 + 4000,
+        filePath: PARENT_PATH,
+        sessionId: "ses_hybrid",
+        text: "Great, the audit is done and every release branch is clean. Wrapping up.",
+      },
+    ];
+    // Harvested from the subagent's own transcript (#830) — its only source is
+    // the subagent, never the parent's own text.
+    const inlineRefs: InlineRefMention[] = [{ kind: "remember", text: SUBAGENT_ONLY_REF_TEXT, ts: t0 + 2500 }];
+    return {
+      ref: {
+        harness: "claude",
+        sessionId: "ses_hybrid",
+        filePath: PARENT_PATH,
+        startedAt: t0,
+        endedAt: t0 + 4000,
+        title: "Hybrid prompt filter fixture",
+      },
+      events,
+      inlineRefs,
+    };
+  }
+
+  async function runAndCapturePrompt(session: SessionData): Promise<{ prompt: string; contentHash?: string }> {
+    const stash = makeStashDir();
+    const db = openStateDatabase(":memory:");
+    let prompt = "";
+    const result = await akmExtract({
+      type: "claude",
+      stashDir: stash,
+      config: configEnabled(stash),
+      harnesses: [makeHarness([session])],
+      stateDb: db,
+      chat: async (_cfg, msgs) => {
+        prompt = msgs[0]?.content ?? "";
+        return JSON.stringify({ candidates: [] });
+      },
+    });
+    db.close();
+    expect(result.sessionsProcessed).toBe(1); // sanity: the model path actually ran, nothing skipped
+    return { prompt, contentHash: result.sessions[0]?.contentHash };
+  }
+
+  // Invariant 1 (hash stability): the recorded contentHash — computed inside
+  // runPreLlmSessionGates via `hashSessionContent(data)` BEFORE the
+  // parent-origin view is built — must equal hashing the same FULL folded
+  // SessionData directly, unaffected by the parent-origin filter applied
+  // later for `preFilterSession`. Reverting the filter (passing the full
+  // `data` straight to `preFilterSession`) does NOT change this: the hash
+  // call site is untouched either way, so this test does not distinguish the
+  // two — see invariants 2/3 for that.
+  test("contentHash equals hashSessionContent of the full folded session", async () => {
+    const session = buildHybridSession();
+    const expectedHash = hashSessionContent(session);
+    const { contentHash } = await runAndCapturePrompt(session);
+    expect(contentHash).toBe(expectedHash);
+  });
+
+  // Invariant 2 (prompt composition): no subagent-provenance text reaches the
+  // transcript section, but the subagent-only inline ref still reaches the
+  // "Already preserved" section (built from `data.inlineRefs`, which keeps
+  // seeing the full folded harvest regardless of the prompt filter).
+  test("prompt has no [subagent:-prefixed transcript text, but Already-preserved includes the subagent-only ref", async () => {
+    const { prompt } = await runAndCapturePrompt(buildHybridSession());
+    expect(prompt).not.toContain("[subagent:");
+    expect(prompt).toContain(SUBAGENT_ONLY_REF_TEXT);
+  });
+
+  // Invariant 3 (#842 composition hazard): under the hybrid filter, the
+  // subagent's own event never reaches `preFilterSession`, so
+  // `dedupeTaskNotifications`'s `byAgentId` map is built from an empty kept
+  // set and the stub never fires (see pre-filter.ts's own "#840 hazard"
+  // unit test for the same mechanism at the preFilterSession layer). The
+  // parent's <task-notification> — the ONLY surviving trace of the delegated
+  // work — must reach the prompt untouched, not stubbed to
+  // `[subagent agentXYZ completed: ...]`.
+  test("keeps the parent's <task-notification> un-stubbed (composes safely with #842's dedupe)", async () => {
+    const { prompt } = await runAndCapturePrompt(buildHybridSession());
+    expect(prompt).toContain("<task-notification>");
+    expect(prompt).toContain("<task-id>agentXYZ</task-id>");
+    expect(prompt).toContain(SUBAGENT_RESULT_TEXT);
+    expect(prompt).not.toContain("[subagent agentXYZ completed:");
   });
 });
 


### PR DESCRIPTION
## Summary

Implements Candidate 3 ("harvest-without-prompting hybrid") from
`docs/plans/subagent-extraction-design.md` §6 — the winning design from
#840. Folding (#830) stays as infrastructure for `hashSessionContent` and
inline-ref harvesting; only the LLM-prompt composition step in
`runPreLlmSessionGates` (`src/commands/improve/extract.ts`) changes.

## The change

```diff
-  const filtered = preFilterSession(data, {
+  const parentOriginData: typeof data = {
+    ...data,
+    events: data.events.filter((e) => e.filePath === data.ref.filePath),
+  };
+  const filtered = preFilterSession(parentOriginData, {
     ...(typeof maxTotalChars === "number" ? { maxTotalChars } : {}),
   });
```

- `hashSessionContent(data)` (just above) is untouched — still hashes the
  full folded stream, computed *before* the parent-origin view is built. No
  previously-computed session hash changes; no forced re-extraction wave.
  `--force` re-processes a specific session under the new prompt shape.
- `session-log.ts` (folding) and `extract-prompt.ts` (`buildExtractPrompt`)
  are untouched, per §6's scope — `buildExtractPrompt` already takes
  `filtered.events` and `data.inlineRefs` as separate params, so
  `data.inlineRefs` keeps carrying the full folded harvest into the "Already
  preserved" section regardless of what reaches the transcript.
- `processes.extract.maxTotalChars` is unchanged in meaning and default — it
  still caps the single-call prompt built from parent-origin events; it just
  no longer competes against subagent-origin noise for that budget.

### `minContentChars` decision (deliberate, not touched)

The raw-size skip gate (~line 592, #595/#596) is still measured on the
**full** folded `data.events` (parent + subagents), not narrowed to the
parent-origin view. Reasoning: the gate's intent is "is there enough raw
material in this session to be worth an LLM call at all" — narrowing it to
parent-origin chars would newly **skip extraction entirely** for
delegation-heavy sessions with a thin parent transcript, even though their
subagent-origin work is still fully harvested via inline refs (which run
unconditionally, independent of this gate and independent of the prompt).
Keeping it on the full stream is today's existing, unchanged behavior; the
worst case it preserves is an LLM call over a small parent-only prompt —
never a missed extraction. Narrowing it would be the "wrong" direction named
in the design doc's coordination note; leaving it as-is is the "wrong" (but
already-shipped, non-regressing) direction. I chose not to introduce a new
skip-entirely failure mode for a case with no measured benefit.

## Composition with #842 — verified, not assumed

#842's `dedupeTaskNotifications` stubs a parent's `<task-notification>` only
when the subagent's own event is *also* in the same `preFilterSession` kept
set. Under this change, subagent-origin events never reach
`preFilterSession` at all, so `byAgentId` is built from an empty candidate
pool and the dedupe is naturally inert — the parent's notification (the sole
remaining trace of delegated work) survives untouched. Pinned by a new
end-to-end regression test (`tests/integration/extract-session-tracking.test.ts`,
describe block `"akmExtract — harvest-without-prompting hybrid prompt
composition (#840)"`) with a folded fixture carrying: a subagent-origin
event, a subagent-only inline ref, and a parent `<task-notification>` whose
`<result>` near-duplicates that subagent's own text (the exact #839/#842
trigger shape).

## Regression tests + mutation results

Three tests added, each run against the real `akmExtract` → `chat`-mock
pipeline:

1. **Hash stability** — `contentHash` recorded by `akmExtract` equals
   `hashSessionContent` of the full folded session, independent of the
   parent-origin prompt filter.
2. **Prompt composition** — built prompt contains **no** `[subagent:`
   -prefixed text, while "Already preserved" **does** include a ref whose
   only source is the subagent transcript.
3. **#842 composition** — the parent's `<task-notification>` reaches the
   prompt un-stubbed (not `[subagent agentXYZ completed: ...]`).

**Mutation test** (reverted `preFilterSession(parentOriginData, ...)` back
to `preFilterSession(data, ...)`, verified via `grep` before running):

- Test 1 (hash): **still PASSES** — `hashSessionContent(data)` is computed
  on the untouched `data` regardless of which argument later goes to
  `preFilterSession`; this test can't distinguish the two by design (noted
  in its own comment).
- Test 2 (prompt composition): **FAILS** — `[subagent:` text now appears in
  the transcript.
- Test 3 (#842 composition): **FAILS** — the notification is stubbed to
  `[subagent agentXYZ completed: Audit release branches]`.

Restored the fix afterward — all three green again.

Also updated one pre-existing test
(`tests/integration/extract-command.test.ts`, "discovery mode processes
exactly one session...") whose old assertion (`capturedPrompt` contains
`SUBAGENT_MARKER`) encoded the old fold-prompt behavior; it now asserts the
opposite (no subagent-origin text in the prompt), matching the new intended
behavior.

## Real-session reproduction (§7 script)

Ran the real pipeline (`ClaudeCodeProvider.readSession` →
`preFilterSession` → `buildExtractPrompt`, no LLM calls) against
`578b2d47-2382-4593-9423-950c7f4826f1` in
`~/.claude/projects/-home-founder3-code-github-itlackey-akm/` (4 subagent
files, same as originally measured):

| | design doc (§3) | this run |
| --- | --- | --- |
| C2 (link) prompt chars | 92,044 | 92,056 |
| C1 (fold+dedupe) prompt chars | 93,781 | 93,793 |
| C3 (hybrid) prompt chars | 94,160 | 94,172 |
| inline refs (fold / hybrid) | 38 / 38 | 38 / 38 |

Structure matches exactly: hybrid's prompt contains **no** `[subagent:`
text; hybrid's kept-event set is byte-identical (by text) to the
parent-alone (link) kept-event set, confirming zero eviction; inline refs
recovered are identical to fold's (38/38). All three prompt-char counts
drifted by a consistent **+12 chars** from the design doc's numbers (session
log has grown slightly since #841's measurement — a few chars somewhere in
a fixed-size field, not a structural change), same drift direction and
magnitude across C1/C2/C3, so the comparison is apples-to-apples.

## Verification

- `bun run test:unit` — **3884 pass / 0 skip / 0 fail** (baseline: 3884/0/0 — unchanged)
- `bun run test:integration` — **5621 pass / 52 skip / 0 fail** (baseline: 5618/52/0 — +3 for the new tests)
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx biome check` on the 3 changed source/test files (plus CHANGELOG.md,
  not lint-checked) — clean after `--write` (one formatting fix in
  `extract.ts`); the ~1300 warnings biome reports repo-wide are pre-existing
  and untouched by this change.

Closes #840

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7CauuoYuv5ULR4igmU1Jx
