### PR TITLE
fix(tasks): scope scheduler-sync removal by resolved bundle path, not name (#846)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`akm task sync` could compute another bundle's real scheduler entries as
+  drift and try to remove them (#846).** Removal was scoped by a bundle
+  *display name* (`bundleName`/`--bundle` target) — a value derived from a
+  directory basename that two unrelated bundles can legitimately share (an
+  unconfigured bundle's name is deduped only against its own config's
+  bundles, never against other bundles actually installed on the machine).
+  A primary/unconfigured-bundle sync now additionally confirms a
+  name-matching installed entry's *resolved bundle path*, recovered from
+  that entry's own scheduler-context descriptor, before treating it as
+  eligible for reconcile — and refuses (rather than assumes) when that path
+  can't be established. **Backward compatibility:** every entry installed by
+  this codebase already carries a scheduler-context descriptor (the
+  `--scheduler-context` file used to restore the scheduled process's
+  environment), so existing installations resolve correctly with no user
+  action required. An entry whose descriptor is missing, unreadable, or
+  owned by a different OS user is never assumed to belong to the invoking
+  bundle; such an entry is simply left untouched by sync (it will not be
+  auto-repaired or removed) until it is reinstalled or removed by hand.
+
 - **Scheduled tasks on Windows ran but recorded no output.** A task fired by
   Task Scheduler logged `exit_code=0` with an empty log: the command really
   ran, but nothing it printed was captured. Captured runs asked for their own

--- a/src/commands/tasks/tasks.ts
+++ b/src/commands/tasks/tasks.ts
@@ -494,18 +494,34 @@ export async function akmTasksSync(
   }
   const inspection = await sched.inspectBindings({ rebind: options.rebind === true });
   const rawEntries: Array<InstalledSchedulerBinding | RebindSchedulerBinding> = [...inspection.installed];
-  const allEntries: InstalledSchedulerBinding[] = rawEntries.map((entry) => ({
-    ...entry,
-    ...(entry.nativeId !== undefined ? { nativeId: entry.nativeId } : {}),
-    ...(entry.invocation !== undefined ? { invocation: Object.freeze([...entry.invocation]) } : {}),
-    binding: "binding" in entry ? [...entry.binding] : [],
-    contextPath: "contextPath" in entry ? entry.contextPath : "",
-  }));
+  const allEntries: InstalledSchedulerBinding[] = rawEntries.map((entry) => {
+    const contextPath = "contextPath" in entry ? entry.contextPath : "";
+    // #846: recover the resolved bundle path this entry was installed
+    // under from its own scheduler-context descriptor. Any failure (no
+    // descriptor, unreadable, corrupt, owned by another user) leaves
+    // ownerBundlePath unset — belongsToBundle must never treat that as
+    // "mine".
+    const ownerBundlePath = contextPath ? resolveInstalledOwnerPath(contextPath) : undefined;
+    return {
+      ...entry,
+      ...(entry.nativeId !== undefined ? { nativeId: entry.nativeId } : {}),
+      ...(entry.invocation !== undefined ? { invocation: Object.freeze([...entry.invocation]) } : {}),
+      binding: "binding" in entry ? [...entry.binding] : [],
+      contextPath,
+      ...(ownerBundlePath !== undefined ? { ownerBundlePath } : {}),
+    };
+  });
   const nativeArtifacts = inspection.artifacts;
   const common = {
     sourceRoot: stashDir,
     adapterId: resolved.source.adapterId ?? detectAdapterId(stashDir),
     bundleName: resolved.source.name,
+    // #846: only meaningful for a primary/unconfigured-bundle sync. A
+    // `--bundle <target>` entry's scheduler-context descriptor records the
+    // invoking process's OWN primary AKM_BUNDLE_DIR, not the targeted
+    // bundle's directory, so path-scoping stays gated on the case it's
+    // actually valid for (see belongsToBundle).
+    ...(syncTarget === undefined ? { bundlePath: path.resolve(stashDir) } : {}),
     ...(syncTarget ? { bundleTarget: syncTarget } : {}),
     backend: sched.name,
     installed: allEntries,
@@ -1125,6 +1141,15 @@ function groupInstalledBindings(
     });
   }
   return [...groups.values()].map((group) => ({ ...group, taskIds: group.taskIds.sort() }));
+}
+
+/** Best-effort recovery of an installed binding's owning bundle path (#846). */
+function resolveInstalledOwnerPath(contextPath: string): string | undefined {
+  try {
+    return validateSchedulerContextDescriptor(contextPath).environment.AKM_BUNDLE_DIR;
+  } catch {
+    return undefined;
+  }
 }
 
 function inspectInstalledBinding(entry: InstalledSchedulerBinding, invocation: TasksDoctorResult["akm"]): string[] {

--- a/src/tasks/scheduler-binding.ts
+++ b/src/tasks/scheduler-binding.ts
@@ -88,6 +88,14 @@ export interface InstalledSchedulerBinding {
   readonly target?: string;
   /** Parsed public CLI tail, used to attribute higher-ordinal task bindings. */
   readonly invocation?: readonly string[];
+  /**
+   * Resolved `AKM_BUNDLE_DIR` recovered from this entry's scheduler-context
+   * descriptor (#846), when the descriptor exists and can be validated.
+   * Absent whenever ownership cannot be established — a missing value must
+   * never be treated as "belongs to the invoking bundle" (see
+   * `belongsToBundle` in scheduler-sync.ts).
+   */
+  readonly ownerBundlePath?: string;
 }
 
 /** Existing native ownership visible during an explicit destructive rebind. */

--- a/src/tasks/scheduler-sync.ts
+++ b/src/tasks/scheduler-sync.ts
@@ -61,6 +61,14 @@ export interface SchedulerSyncPlanInput {
   readonly bundleName: string;
   /** CLI selector embedded only in task invocations for a non-primary bundle. */
   readonly bundleTarget?: string;
+  /**
+   * Resolved filesystem path of the invoking bundle (#846). When present,
+   * `belongsToBundle` scopes strictly by this path instead of the legacy
+   * name-based comparison — a display name derived from a directory
+   * basename is not an identity two bundles can't collide on, but a
+   * resolved path is.
+   */
+  readonly bundlePath?: string;
   readonly backend: ScheduleBackend;
   readonly installed: readonly InstalledSchedulerBinding[];
   /** Complete read-only backend inventory, including malformed artifacts. */
@@ -713,6 +721,21 @@ function installOptionsFor(
 }
 
 function belongsToBundle(entry: InstalledSchedulerBinding, input: SchedulerSyncPlanInput): boolean {
+  if (input.bundlePath !== undefined && entry.target === input.bundleName) {
+    // Path-scoped (#846), primary/unconfigured-bundle sync only: the name
+    // already matches, but a display name derived from a directory
+    // basename is not an identity — two unrelated bundles can legitimately
+    // share one. Require the entry's own scheduler-context descriptor to
+    // additionally confirm the resolved path. An entry whose owning path
+    // cannot be established is never assumed to be ours — that silent
+    // assumption is exactly what let an isolated/foreign bundle's sync
+    // reach for another bundle's real scheduler entries. (`bundlePath` is
+    // only set for a primary sync — a `--bundle <target>` entry's
+    // descriptor reflects the invoking process's OWN primary directory,
+    // not the targeted bundle's, so it is not a meaningful signal there;
+    // that case keeps relying on config-name uniqueness below.)
+    return entry.ownerBundlePath !== undefined && entry.ownerBundlePath === input.bundlePath;
+  }
   if (entry.target === input.bundleName || entry.target === input.bundleTarget) return true;
   return false;
 }
@@ -721,9 +744,14 @@ function assertNoForeignIds(desired: readonly SchedulerBinding[], input: Schedul
   const wanted = new Set(desired.map(({ id }) => id));
   const foreign = input.installed.find((entry) => wanted.has(entry.id) && !belongsToBundle(entry, input));
   if (!foreign) return;
-  const where = foreign.target ? `bundle ${JSON.stringify(foreign.target)}` : "the default bundle";
+  const where = foreign.ownerBundlePath
+    ? `the bundle at ${JSON.stringify(foreign.ownerBundlePath)}`
+    : foreign.target
+      ? `bundle ${JSON.stringify(foreign.target)}`
+      : "the default bundle";
+  const mine = input.bundlePath ? ` (this sync is scoped to ${JSON.stringify(input.bundlePath)})` : "";
   throw new UsageError(
-    `Scheduler id ${JSON.stringify(foreign.id)} is already scheduled from ${where}; desired source ids must not collide across bundles.`,
+    `Scheduler id ${JSON.stringify(foreign.id)} is already scheduled from ${where}${mine}; desired source ids must not collide across bundles.`,
     "RESOURCE_ALREADY_EXISTS",
   );
 }

--- a/tests/integration/commands/tasks-bundle-target.test.ts
+++ b/tests/integration/commands/tasks-bundle-target.test.ts
@@ -23,9 +23,11 @@ import { resetConfigCache, saveConfig } from "../../../src/core/config/config";
 import { buildCronLine, CRON_BACKEND, type CronExec, type CronExecResult } from "../../../src/tasks/backends/cron";
 import type { SchedulerBinding } from "../../../src/tasks/scheduler-binding";
 import {
+  resolveScheduledTaskContext,
   type ScheduledTaskContext,
   schedulerContextDescriptor,
   schedulerContextPath,
+  writeSchedulerContextDescriptor,
 } from "../../../src/tasks/scheduler-invocation";
 import {
   type IsolatedAkmStorage,
@@ -69,6 +71,24 @@ function cron() {
     akmArgv: ["/usr/local/bin/akm"],
     envPath: false,
     scheduledContext: SCHEDULED_CONTEXT,
+  });
+}
+
+/**
+ * #846: `SCHEDULED_CONTEXT` above is an intentionally unwritable fake path
+ * (exercising special-character handling in the default cron line), so
+ * belongsToBundle's owning-path check could never resolve it. Tests that
+ * need a primary-bundle entry to actually be recognized as this stash's
+ * own across more than one sync use this real, writable context instead.
+ */
+function cronRealContext() {
+  return CRON_BACKEND({
+    exec,
+    fs: { ensureDir() {} },
+    logDir: "/var/log/akm",
+    akmArgv: ["/usr/local/bin/akm"],
+    envPath: false,
+    scheduledContext: resolveScheduledTaskContext(),
   });
 }
 
@@ -159,13 +179,18 @@ describe("bundle-targeted tasks via --bundle", () => {
   });
 
   test("plain sync never removes a --bundle entry; sync --bundle reconciles only that bundle", async () => {
+    // #846: the primary ("bar") entry needs to be recognized as this
+    // stash's own across the two primary syncs below — use the real,
+    // writable context for it (see cronRealContext).
+    writeSchedulerContextDescriptor(schedulerContextDescriptor(resolveScheduledTaskContext(), ""));
+
     // A primary task and a work-bundle task, both scheduled.
-    await akmTasksAdd({ id: "bar", schedule: "@daily", command: "true" }, { backend: cron() });
+    await akmTasksAdd({ id: "bar", schedule: "@daily", command: "true" }, { backend: cronRealContext() });
     writeTaskFile(work.dir, "foo", taskYaml());
     await akmTasksSync({ backend: cron() }, "work");
 
     // Plain (primary) sync: reconciles only `bar`; `foo` (target work) is untouched.
-    const primarySync = await akmTasksSync({ backend: cron() });
+    const primarySync = await akmTasksSync({ backend: cronRealContext() });
     expect(primarySync.removed).toEqual([]);
     expect(cronBody(exec.current(), "foo")).toContain("--bundle work");
     expect(cronBody(exec.current(), "bar")).toBeDefined();

--- a/tests/integration/tasks-launchd-backend.test.ts
+++ b/tests/integration/tasks-launchd-backend.test.ts
@@ -11,9 +11,11 @@ import {
   schedulerNativeBindingId,
 } from "../../src/tasks/scheduler-binding";
 import {
+  resolveScheduledTaskContext,
   type ScheduledTaskContext,
   schedulerContextDescriptor,
   schedulerContextPath,
+  writeSchedulerContextDescriptor,
 } from "../../src/tasks/scheduler-invocation";
 import { sandboxStashDir } from "../_helpers/sandbox";
 import {
@@ -1725,7 +1727,17 @@ describe("LAUNCHD_BACKEND drift signatures", () => {
       const tasksDir = path.join(stash.dir, "tasks");
       fs.mkdirSync(tasksDir, { recursive: true });
       fs.writeFileSync(path.join(tasksDir, "ping.yml"), 'version: 4\nrun: echo ping\nschedule: "0 9 * * *"\n', "utf8");
-      const { backend, exec } = makeBackend();
+      // #846: this describe block's default SCHEDULED_CONTEXT points at an
+      // intentionally unwritable fake path (exercising special-character
+      // handling), so belongsToBundle's owning-path check could never
+      // resolve it. Use the real, writable sandboxed context instead, so
+      // the backend's own default scheduler-context descriptor is one this
+      // test can actually write and read back.
+      const { backend, exec } = makeBackend(undefined, undefined, resolveScheduledTaskContext());
+      // The backend falls back to its own default context descriptor path
+      // (no `schedulerRuntime` deps here) — write it for real so the
+      // second sync's owning-path lookup can read it back.
+      writeSchedulerContextDescriptor(schedulerContextDescriptor(resolveScheduledTaskContext(), ""));
       expect((await akmTasksSync({ backend })).installed).toEqual(["ping"]);
       exec.loadedLabels.delete("com.akm.task.ping");
       exec.calls.length = 0;
@@ -1748,7 +1760,11 @@ describe("LAUNCHD_BACKEND drift signatures", () => {
       const tasksDir = path.join(stash.dir, "tasks");
       fs.mkdirSync(tasksDir, { recursive: true });
       fs.writeFileSync(path.join(tasksDir, "ping.yml"), 'version: 4\nrun: echo ping\nschedule: "0 9 * * *"\n', "utf8");
-      const { backend, exec } = makeBackend();
+      // #846: same rationale as the previous test — this describe block's
+      // default SCHEDULED_CONTEXT can't back a resolvable owning path, so
+      // use the real, writable sandboxed context instead.
+      const { backend, exec } = makeBackend(undefined, undefined, resolveScheduledTaskContext());
+      writeSchedulerContextDescriptor(schedulerContextDescriptor(resolveScheduledTaskContext(), ""));
       expect((await akmTasksSync({ backend })).installed).toEqual(["ping"]);
 
       exec.disabledLabels.add("com.akm.task.ping");

--- a/tests/integration/tasks-runtime-binding.test.ts
+++ b/tests/integration/tasks-runtime-binding.test.ts
@@ -9,6 +9,8 @@ import { withIsolatedAkmStorage, writeSandboxConfig } from "../_helpers/sandbox"
 function completeSchedulerBackend(options: {
   binding: readonly string[];
   contextPath: string;
+  /** #846: resolved path of the "stash" bundle this fixture's entry belongs to. */
+  ownerBundlePath?: string;
   onInstall?: (installOptions: SchedulerInstallOptions | undefined) => void;
 }): SchedulerBackend {
   const invocation = ["task", "run", "ping", "--bundle", "stash", "--scheduled"] as const;
@@ -19,6 +21,7 @@ function completeSchedulerBackend(options: {
     target: "stash",
     binding: [...options.binding],
     contextPath: options.contextPath,
+    ...(options.ownerBundlePath !== undefined ? { ownerBundlePath: options.ownerBundlePath } : {}),
     invocation,
   };
   const artifact = {
@@ -112,6 +115,7 @@ describe("scheduler runtime binding", () => {
       const backend = completeSchedulerBackend({
         binding: ["/old/node", "/old/dist/akm"],
         contextPath: "/old/context.json",
+        ownerBundlePath: path.resolve(storage.stashDir),
         onInstall: (options) => installs.push(options),
       });
 
@@ -146,6 +150,7 @@ describe("scheduler runtime binding", () => {
       const backend = completeSchedulerBackend({
         binding: ["/old/node", "/old/dist/akm"],
         contextPath: "/old/context.json",
+        ownerBundlePath: path.resolve(storage.stashDir),
       });
 
       const result = await akmTasksSync(
@@ -180,6 +185,7 @@ describe("scheduler runtime binding", () => {
       const backend = completeSchedulerBackend({
         binding: ["/old/node", "/old/dist/akm"],
         contextPath: "/old/context.json",
+        ownerBundlePath: path.resolve(storage.stashDir),
       });
 
       const result = await akmTasksSync(
@@ -211,6 +217,7 @@ describe("scheduler runtime binding", () => {
       const backend = completeSchedulerBackend({
         binding: ["/old/node", "/old/dist/akm"],
         contextPath: "/old/context.json",
+        ownerBundlePath: path.resolve(storage.stashDir),
         onInstall: (options) => installs.push(options),
       });
 
@@ -246,6 +253,7 @@ describe("scheduler runtime binding", () => {
       const backend = completeSchedulerBackend({
         binding: ["/current/akm"],
         contextPath: "/current/context.json",
+        ownerBundlePath: path.resolve(storage.stashDir),
         onInstall: (options) => installs.push(options),
       });
 

--- a/tests/integration/tasks-scheduler-sync-v4.test.ts
+++ b/tests/integration/tasks-scheduler-sync-v4.test.ts
@@ -1242,3 +1242,145 @@ describe("whole-set scheduler sync planning — task+workflow composition and CA
     expect(signatures).toBe(0);
   });
 });
+
+describe("#846: belongsToBundle scopes by resolved bundle path, not display name", () => {
+  test("two bundles at different paths sharing the same display name: bundle A's sync does not compute bundle B's installed binding as removable", async () => {
+    const componentRoot = root();
+    const bundleAPath = "/home/user/work/akm";
+    const bundleBPath = "/home/user/personal/akm";
+    // Both bundles resolve to the same unconfigured display name ("akm" —
+    // the lowercased directory basename, bundle-id.ts:10-18) because
+    // ensureUniqueId only dedupes within its OWN config's bundle set
+    // (bundle-id.ts:46) and has no visibility into the other bundle.
+    const foreignInvocation = ["task", "run", "akm-dogfood-091-capture", "--bundle", "akm", "--scheduled"];
+    const foreignEntry = {
+      id: "akm-dogfood-091-capture",
+      nativeId: "task-foreign",
+      binding: ["/opt/akm"],
+      contextPath: "/data/context-b.json",
+      target: "akm",
+      ownerBundlePath: bundleBPath,
+      invocation: foreignInvocation,
+      signature: "foreign-fingerprint",
+    };
+
+    const plan = await planSchedulerSync({
+      sourceRoot: componentRoot,
+      adapterId: "akm-task",
+      bundleName: "akm",
+      bundlePath: bundleAPath,
+      backend: "cron",
+      installed: [foreignEntry],
+      nativeArtifacts: [
+        {
+          nativeId: "task-foreign",
+          bindingId: "akm-dogfood-091-capture",
+          invocation: foreignInvocation,
+          fingerprint: "foreign-fingerprint",
+        },
+      ],
+    });
+
+    // Bundle A has zero task ids in common with bundle B — bundle B's real
+    // binding must never show up as bundle A's drift to remove.
+    expect(plan.removed).toEqual([]);
+    expect(plan.operations).toEqual([]);
+  });
+
+  test("an installed binding whose owning path cannot be established is never treated as belonging to the invoking bundle", async () => {
+    const bundleRoot = root();
+    write(
+      path.join(bundleRoot, "tasks", "nightly.yml"),
+      "version: 4\nrun: echo nightly\nshell: sh\nschedule: '@daily'\n",
+    );
+
+    // Same id and same legacy `target` name as the invoking bundle, but its
+    // scheduler-context descriptor could not be read/validated (deleted,
+    // corrupted, owned by another OS user, or predates the descriptor
+    // mechanism) — ownerBundlePath is therefore absent. A missing owning
+    // path must never be assumed to mean "mine".
+    const installed = {
+      id: "nightly",
+      nativeId: "task-nightly",
+      binding: ["/opt/akm"],
+      contextPath: "/data/unreadable-context.json",
+      target: "team",
+      invocation: ["task", "run", "nightly", "--bundle", "team", "--scheduled"],
+      signature: "installed-fingerprint",
+    };
+
+    await expect(
+      planSchedulerSync({
+        sourceRoot: bundleRoot,
+        adapterId: "akm",
+        bundleName: "team",
+        bundlePath: "/home/user/work/akm",
+        backend: "cron",
+        installed: [installed],
+        nativeArtifacts: [
+          {
+            nativeId: "task-nightly",
+            bindingId: "nightly",
+            invocation: installed.invocation,
+            fingerprint: "installed-fingerprint",
+          },
+        ],
+        expectedSignature: (binding) => `sig:${binding.id}`,
+      }),
+    ).rejects.toThrow(/already scheduled/i);
+  });
+
+  test("a binding genuinely owned by the invoking bundle (matching resolved path) is still removed as drift", async () => {
+    const componentRoot = root();
+    const nativeId = "task-owned";
+    const bundlePath = "/home/user/work/akm";
+    const installed = {
+      id: "sub/nightly",
+      nativeId,
+      binding: ["/opt/akm"],
+      contextPath: "/data/context-a.json",
+      target: "team",
+      ownerBundlePath: bundlePath,
+      invocation: ["task", "run", "sub/nightly", "--bundle", "team", "--scheduled"],
+      signature: "installed-fingerprint",
+    };
+
+    const plan = await planSchedulerSync({
+      sourceRoot: componentRoot,
+      adapterId: "akm-task",
+      bundleName: "team",
+      bundlePath,
+      backend: "cron",
+      installed: [installed],
+      nativeArtifacts: [
+        {
+          nativeId,
+          bindingId: "sub/nightly",
+          invocation: installed.invocation,
+          fingerprint: "installed-fingerprint",
+        },
+      ],
+    });
+
+    // No desired source declares "sub/nightly" — it is genuinely orphaned
+    // drift owned by THIS bundle, and must still be reconciled away exactly
+    // as before the path-scoping fix.
+    expect(plan.removed).toEqual(["sub/nightly"]);
+    expect(plan.operations).toEqual([
+      {
+        kind: "remove",
+        id: "sub/nightly",
+        nativeId,
+        expected: {
+          state: "present",
+          bindingId: "sub/nightly",
+          nativeId,
+          logicalSource: { kind: "task", ref: "team//sub/nightly" },
+          ordinal: 0,
+          invocation: installed.invocation,
+          fingerprint: "installed-fingerprint",
+        },
+      },
+    ]);
+  });
+});

--- a/tests/integration/tasks-scheduler-transaction.test.ts
+++ b/tests/integration/tasks-scheduler-transaction.test.ts
@@ -92,6 +92,10 @@ function fakeBackend(
       contextPath: "/test/context.json",
       signature: fingerprint,
       target: "stash",
+      // #846: this fixture's entries are always this file's own primary
+      // ("stash") bundle — record its resolved path so belongsToBundle's
+      // path-scoped check recognizes them as such.
+      ownerBundlePath: path.resolve(storage.stashDir),
       invocation: item.invocation,
     }));
     const artifacts = [...stored.values()].map(({ binding: item, fingerprint }) => ({

--- a/tests/integration/tasks-sync.test.ts
+++ b/tests/integration/tasks-sync.test.ts
@@ -17,6 +17,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { akmTasksSync } from "../../src/commands/tasks/tasks";
 import { CRON_BACKEND, type CronExec, type CronExecResult } from "../../src/tasks/backends/cron";
+import {
+  resolveScheduledTaskContext,
+  schedulerContextDescriptor,
+  writeSchedulerContextDescriptor,
+} from "../../src/tasks/scheduler-invocation";
 import type { Cleanup } from "../_helpers/sandbox";
 import { sandboxStashDir, sandboxXdgConfigHome, sandboxXdgStateHome } from "../_helpers/sandbox";
 
@@ -63,14 +68,22 @@ afterEach(() => {
 });
 
 describe("akmTasksSync — schedule drift", () => {
-  const backendFor = (exec: CronExec) =>
-    CRON_BACKEND({
+  const backendFor = (exec: CronExec) => {
+    // #846: belongsToBundle now confirms a primary-bundle entry's owning
+    // path from its own scheduler-context descriptor. This backend never
+    // routes through the real launcher-eligibility path (no
+    // `schedulerRuntime` deps injected), so install operations fall back to
+    // CRON_BACKEND's own default context — write that descriptor for real,
+    // matching it exactly, so it resolves on the next sync.
+    writeSchedulerContextDescriptor(schedulerContextDescriptor(resolveScheduledTaskContext(), ""));
+    return CRON_BACKEND({
       exec,
       fs: { ensureDir() {} },
       logDir: "/var/log/akm",
       akmArgv: ["/usr/local/bin/akm"],
       envPath: false,
     });
+  };
 
   test("installs missing, then reports unchanged on a no-op re-sync", async () => {
     const exec = memoryExec();


### PR DESCRIPTION
## Summary

- `akm task sync` scoped which installed scheduler entries a bundle may reconcile/remove by a **display name** (`bundleName`/`--bundle` target) derived from a directory basename. Two unrelated, unconfigured bundles can legitimately share that name (an id is only deduped against its own config's bundle set, never against other bundles actually installed on the machine), so an isolated or foreign bundle's `sync` could compute another bundle's real, installed cron/launchd/schtasks entries as drift and attempt to remove them.
- For a **primary/unconfigured-bundle** sync, `belongsToBundle` (`src/tasks/scheduler-sync.ts`) now additionally requires a name-matching installed entry's **resolved bundle path** — recovered from that entry's own scheduler-context descriptor (the same `--scheduler-context <path>` file already written for every installed entry, used to restore the scheduled process's environment) — to match the invoking bundle's resolved path.
- An entry whose owning path can't be established (descriptor missing, unreadable, corrupt, or owned by a different OS user) is **never** assumed to belong to the invoking bundle. It's simply left out of scope (not reconciled, not removed) rather than silently treated as "mine." `assertNoForeignIds` also now names the resolved owner path (when known) in its collision error, alongside the invoking bundle's own path.
- A `--bundle <target>` sync of a **configured** bundle keeps relying on config-name uniqueness (unchanged) — that entry's scheduler-context descriptor reflects the invoking process's own primary `AKM_BUNDLE_DIR`, not the targeted bundle's directory, so it isn't a meaningful signal there.

## Backward compatibility

No user action required. Every scheduler entry this codebase installs already carries a scheduler-context descriptor, so existing installations resolve their owning path correctly. Only entries whose descriptor can't be read (e.g. deleted/corrupted externally) lose eligibility for automatic reconcile/removal until reinstalled or removed by hand — this is the deliberate fail-closed tradeoff requested by the issue, not a regression path any current install goes through.

## Tests

Added to `tests/integration/tasks-scheduler-sync-v4.test.ts` (describe: `#846: belongsToBundle scopes by resolved bundle path, not display name`):
1. **Regression** — two bundles at different resolved paths sharing the same display name (the `~/work/akm` vs `~/personal/akm` shape): bundle A's sync does not compute bundle B's installed binding as removable.
2. **Fail-closed** — an installed binding whose owning path can't be established (unreadable descriptor) is never treated as belonging to the invoking bundle, even when its legacy display name matches; `sync` refuses with a clear error instead of silently reconciling.
3. **Positive control** — a binding genuinely owned by the invoking bundle (matching resolved path) is still removed as drift exactly as before.

Mutation-tested: reverted `belongsToBundle` to the original name-only comparison, confirmed tests 1 and 2 fail (test 3 correctly still passes, since it doesn't depend on the defect), restored the fix, confirmed all three pass again.

Also updated several existing integration tests (`tasks-sync.test.ts`, `tasks-scheduler-transaction.test.ts`, `tasks-runtime-binding.test.ts`, `tasks-launchd-backend.test.ts`, `tasks-bundle-target.test.ts`) whose fixtures simulate a bundle's own already-installed entries without a real, readable scheduler-context descriptor (a test-only shortcut that never reflected real production behavior) — these now supply one so the new ownership check can correctly recognize them as the invoking bundle's own.

## Verification

- `bun run test:unit` — 4320 pass / 0 skip / 0 fail
- `bun run test:integration` — 5891 pass / 53 skip / 0 fail
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx biome check <changed files>` — no new warnings/errors (pre-existing repo-wide warnings untouched)
- CHANGELOG.md `[Unreleased]` entry added describing the fix and backward-compat consequence
- Real crontab on the dogfood machine verified byte-identical to the pre-work backup before and after this work — `akm task sync`/`akm task add` were never run against the real OS scheduler.

Closes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7CauuoYuv5ULR4igmU1Jx
