### PR TITLE
fix: preserve failing exit codes through inner powershell -Command (#845)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A failing Windows `shell: powershell`/`pwsh` task could lose its exit
+  code's fidelity through `-Command` (#845).** `-Command` derives its own
+  process exit code from `$?`, so a genuinely failing command already
+  produced a nonzero exit and `status: "failed"` — but any native exit code
+  outside `{0, 1}` was collapsed to `1`, discarding the real value reported
+  in task history. The inner shell invocation built by `shellCommand()` now
+  appends a guard that reads `$?` first (reproducing `-Command`'s own
+  completed/failed determination, immune to a stale `$LASTEXITCODE` from an
+  earlier native call in the same command) and only then upgrades to the
+  precise native exit code when the failing last statement actually set
+  one — a bare `exit $LASTEXITCODE` was rejected because `$LASTEXITCODE`
+  stays `$null` for a pure-PowerShell command, and `exit $null` is exit
+  code `0`, which would have turned a failed cmdlet into a false
+  `"completed"`. Verified via unit tests asserting the exact argv `-Command`
+  string on `platform: "win32"`; the runtime exit-code behavior itself is
+  unverified on a real Windows host pending the owner's manual run (see the
+  PR body for the procedure) — Windows scheduler paths still have no
+  automated coverage (#770).
+
 ## [0.9.2] - 2026-08-29
 
 ### Fixed

--- a/src/tasks/run/run-native-task.ts
+++ b/src/tasks/run/run-native-task.ts
@@ -79,12 +79,40 @@ export function shellCommand(
       return [task.shell, "-c", command];
     case "pwsh":
     case "powershell":
-      return [shellExecutable(task.shell, platform, env), "-NoProfile", "-NonInteractive", "-Command", command];
+      return [
+        shellExecutable(task.shell, platform, env),
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        withExitCodePropagation(command),
+      ];
     case "cmd":
       return [shellExecutable("cmd", platform, env), "/d", "/s", "/c", command];
     default:
       return assertNever(task.shell, "shellCommand");
   }
+}
+
+/**
+ * `-Command` (documented identically for powershell.exe 5.1 and pwsh 7+, in
+ * about_PowerShell_exe / about_Pwsh) already derives its own process exit
+ * code from `$?`, so a genuinely failing last statement already yields a
+ * nonzero exit and status "failed" — but any native exit code outside {0, 1}
+ * is collapsed to 1, discarding the real value that task history reports.
+ *
+ * Appending a bare `exit $LASTEXITCODE` to recover it is unsafe on its own:
+ * `$LASTEXITCODE` stays `$null` for a command that never runs a native
+ * executable (a pure PowerShell/cmdlet command), and `exit $null` resolves
+ * to exit code 0 — turning a failed cmdlet into a false "completed".
+ *
+ * Reading `$?` first, before anything else can run, reproduces -Command's
+ * own completed/failed determination exactly (immune to that regression and
+ * to a `$LASTEXITCODE` left stale by an earlier native call in the same
+ * command), then upgrades to the precise native exit code only when the
+ * failing last statement actually set one.
+ */
+function withExitCodePropagation(command: string): string {
+  return `${command}; if ($?) { exit 0 } elseif ($LASTEXITCODE -ne $null) { exit $LASTEXITCODE } else { exit 1 }`;
 }
 
 /**

--- a/tests/integration/tasks-runner.test.ts
+++ b/tests/integration/tasks-runner.test.ts
@@ -89,6 +89,12 @@ function shellWord(value: string): string {
   return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
+// Mirrors withExitCodePropagation() in run-native-task.ts (#845): appended to
+// every pwsh/powershell -Command invocation so a failing native exit code
+// isn't collapsed to 1 by -Command's own $?-based exit-code handling.
+const POWERSHELL_EXIT_CODE_SUFFIX =
+  "; if ($?) { exit 0 } elseif ($LASTEXITCODE -ne $null) { exit $LASTEXITCODE } else { exit 1 }";
+
 function writeTask(id: string, body: string): void {
   fs.writeFileSync(path.join(tasksDir, `${id}.yml`), body, "utf8");
 }
@@ -654,8 +660,20 @@ describe("runTask — command target", () => {
     expect(command).toBe(
       `& ${resolveAkmInvocation()
         .argv.map((p) => `'${p.replaceAll("'", "''")}'`)
-        .join(" ")} --version`,
+        .join(" ")} --version${POWERSHELL_EXIT_CODE_SUFFIX}`,
     );
+  });
+
+  test("shellCommand appends an exit-code-preserving guard for pwsh and powershell (#845)", () => {
+    // -Command's own exit code is $? -based (0/1) and collapses any other
+    // native exit code to 1 — see withExitCodePropagation() in
+    // run-native-task.ts for why a bare `exit $LASTEXITCODE` is unsafe
+    // (stays $null, and `exit $null` is 0, for a pure-PowerShell command).
+    const env = { SystemRoot: "C:\\Windows" };
+    for (const shell of ["powershell", "pwsh"] as const) {
+      const command = shellCommand({ command: "Write-Output hi", shell }, "win32", env);
+      expect(command.at(-1)).toBe(`Write-Output hi${POWERSHELL_EXIT_CODE_SUFFIX}`);
+    }
   });
 
   test("shellCommand resolves powershell and cmd to absolute Windows paths", () => {
@@ -683,7 +701,7 @@ describe("runTask — command target", () => {
       "-NoProfile",
       "-NonInteractive",
       "-Command",
-      "echo hi",
+      `echo hi${POWERSHELL_EXIT_CODE_SUFFIX}`,
     ]);
     const cmdCommand = shellCommand({ command: "echo hi", shell: "cmd" }, "win32", env);
     expect(cmdCommand).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/s", "/c", "echo hi"]);


### PR DESCRIPTION
## Summary

Investigation for #845. **Conclusion: the issue's central premise (a failing Windows PowerShell task recorded as `status: "completed"`) is not supported by PowerShell's own documented `-Command` exit-code semantics** — but there was a real, related fidelity bug, which this PR fixes.

## What I established (confidence: high — from primary sources, not re-testing on Windows)

Microsoft's own reference docs for `-Command` are **word-for-word identical** between `about_PowerShell_exe` (Windows PowerShell 5.1, `powershell.exe`) and `about_Pwsh` (PowerShell 7+, `pwsh`):

> The process exit code is determined by status of the last (executed) command within the input. The exit code is `0` when `$?` is `$true` or `1` when `$?` is `$false`. If the last command is an external program or a PowerShell script that explicitly sets an exit code other than `0` or `1`, that exit code is converted to `1` for process exit code... To preserve the specific exit code, add `exit $LASTEXITCODE` to your command string or script block.

This settles both open questions in the issue:

1. **5.1 vs 7+ do not differ here.** Both derive `-Command`'s own process exit code from `$?`, and both collapse any native exit code outside `{0, 1}` to `1`. (Separately, `PowerShell/PowerShell#11461` confirms this for pwsh and closed it "by design" — not a bug, not something that changed across versions.)
2. **A failing trailing native command does *not* produce a false `completed`.** `$?` is set to `$false` whenever the last statement's native exit code is nonzero, so `-Command`'s own exit code is already nonzero (specifically `1`) in that case — `run-native-task.ts`'s `exitCode === 0 ? "completed" : "failed"` already lands on `"failed"` correctly, today, with no code change.

**What *is* real:** the exact native exit code is lost. A task whose command exits `3` shows up in `akm task history` as `exitCode: 1`, not `3`. That's a genuine fidelity bug worth fixing, just not the "false completed" scenario the issue worried about most.

## The naive-fix hazard (issue's own callout) is real and I hit it

A bare `; exit $LASTEXITCODE` (matching the outer `schtasks.ts:710` arm) is unsafe here: `$LASTEXITCODE` stays `$null` until a native command has run in the session. For a task whose command is pure PowerShell/cmdlets (e.g. `run: Write-Output hi`, or a cmdlet that fails via a non-terminating error), `$LASTEXITCODE` is `$null`, and `exit $null` evaluates to exit code `0` — which would turn an already-correctly-detected `"failed"` into a false `"completed"`. That's a regression *introduced by* the naive fix, worse than the bug the issue was investigating.

Why the outer `schtasks.ts:710` arm doesn't have this problem: its script always ends with `& <akm invocation>` — a real native executable call — so `$LASTEXITCODE` is never `$null` there. The inner arm's `command` is arbitrary user-authored text, so it can't make that assumption.

## The fix

`src/tasks/run/run-native-task.ts`, `shellCommand()`'s `pwsh`/`powershell` arm:

```diff
     case "pwsh":
     case "powershell":
-      return [shellExecutable(task.shell, platform, env), "-NoProfile", "-NonInteractive", "-Command", command];
+      return [
+        shellExecutable(task.shell, platform, env),
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        withExitCodePropagation(command),
+      ];
```

```ts
function withExitCodePropagation(command: string): string {
  return `${command}; if ($?) { exit 0 } elseif ($LASTEXITCODE -ne $null) { exit $LASTEXITCODE } else { exit 1 }`;
}
```

Applied identically to **both** `pwsh` and `powershell` — the docs establish they don't differ in this respect, so there's no reason to special-case one.

**Design, and how each edge case is handled:**

- `$?` is read **first**, as the very first thing the appended statement does — before anything else can run or change it. This reproduces `-Command`'s own completed/failed determination exactly, so:
  - **Pure-PowerShell/cmdlet success** (`$?` true, `$LASTEXITCODE` null or stale): `exit 0`. No regression — matches today's behavior.
  - **Pure-PowerShell/cmdlet failure via non-terminating error** (`$?` false, `$LASTEXITCODE` null): falls through the `elseif` (null) to `exit 1` — same as today's implicit behavior, **no `exit $null` regression**.
  - **Native command success** (`$?` true): `exit 0`, regardless of any stale `$LASTEXITCODE` from an earlier native call in the same command — this is what stops a stale `$LASTEXITCODE` from turning a real success into a false failure.
  - **Native command failure** (`$?` false, `$LASTEXITCODE` freshly set to the real code): `exit <real code>` — this is the fidelity fix.
- **Non-terminating errors are covered** by the `$?`-based path above (same as `-Command`'s own default), not by anything new here.
- **Script-terminating errors** (`throw`, `-ErrorAction Stop`) abort the runspace before the appended statement ever runs; `-Command`'s documented fallback (`exit 1`) applies untouched — still correctly `"failed"`, just without a specific code (there isn't one to recover).
- **Known limitation, stated plainly:** if a command runs a native call early and then a *later* cmdlet statement fails via non-terminating error while `$LASTEXITCODE` is left stale-nonzero from that earlier call, the reported exit code will be the stale native code, not `1`. The *status* is still correctly `"failed"` either way (both are nonzero) — only the numeric code's precision is affected in that specific multi-statement scenario. This is an inherent limitation of `$LASTEXITCODE` in PowerShell, not something introduced by this change, and out of scope to fully close per the issue's exit criteria (which asked only to guard the null case).

## Testing

**This was done on a Linux host — Windows PowerShell was never executed.** All verification below is either (a) research against primary Microsoft documentation and the PowerShell repo, or (b) unit tests of the constructed argv string, run under Bun/Node on Linux — `shellCommand()` takes `platform`/`env` as injectable parameters precisely for this.

- Added `tests/integration/tasks-runner.test.ts`: **"shellCommand appends an exit-code-preserving guard for pwsh and powershell (#845)"** — asserts the exact appended suffix for both `powershell` and `pwsh` on `platform: "win32"`.
- Updated the two pre-existing tests that asserted an exact `-Command` string (`"shellCommand resolves powershell and cmd to absolute Windows paths"` and `"a bare akm run task under a PowerShell shell gets the call operator"`) to expect the new suffix.
- **Mutation test:** reverted `run-native-task.ts` only (`git stash`), reran the suite — all 3 changed/new assertions failed with diffs showing exactly the missing suffix (`"echo hi"` vs `"echo hi; if ($?) ..."`), confirming the tests actually exercise the change. Restored the fix (`git stash pop`) and reran — all pass again.
- `bun run test:unit`: **4320 pass / 0 skip / 0 fail** (319/319 files, 8 shards)
- `bun run test:integration`: **5893 pass / 53 skip / 0 fail** (443/443 files, 8 shards) — includes the updated `tests/integration/tasks-runner.test.ts` (48/48 pass)
- `npx tsc --noEmit -p tsconfig.json`: clean
- `npx biome check src/tasks/run/run-native-task.ts tests/integration/tasks-runner.test.ts`: 0 warnings on either changed file (the repo-wide run surfaces ~1377 pre-existing `noNonNullAssertion` warnings, none on lines this PR touches)

**The runtime exit-code behavior itself is unverified on a real Windows host and needs the owner's manual run before merge.** Per #770, Windows scheduler paths have no automated CI coverage — the manual procedure below is the real verification gate.

## Manual verification procedure (run on a real Windows machine)

```powershell
# --- Setup: a throwaway task with an obviously-named id ---
akm task add akm-845-manual-check --shell powershell --run "exit 7"

# --- Run it and check history ---
akm task run akm-845-manual-check
akm task history akm-845-manual-check --json
# Expect: status: "failed", detail.exitCode: 7   (NOT "completed" / 0)

# --- Sanity check: a pure-PowerShell command that fails via a non-terminating error still fails ---
akm task add akm-845-manual-check-cmdlet --shell powershell --run "Get-Item C:\definitely-does-not-exist-845.txt"
akm task run akm-845-manual-check-cmdlet
akm task history akm-845-manual-check-cmdlet --json
# Expect: status: "failed" (exact exitCode may be 1 -- that's fine, this checks no exit-$null regression)

# --- Sanity check: a pure-PowerShell command that succeeds still reports completed ---
akm task add akm-845-manual-check-ok --shell powershell --run "Write-Output hi"
akm task run akm-845-manual-check-ok
akm task history akm-845-manual-check-ok --json
# Expect: status: "completed", detail.exitCode: 0

# --- Repeat the first check with pwsh if installed, to confirm parity ---
akm task add akm-845-manual-check-pwsh --shell pwsh --run "exit 7"
akm task run akm-845-manual-check-pwsh
akm task history akm-845-manual-check-pwsh --json
# Expect: status: "failed", detail.exitCode: 7

# --- Cleanup ---
akm task remove akm-845-manual-check
akm task remove akm-845-manual-check-cmdlet
akm task remove akm-845-manual-check-ok
akm task remove akm-845-manual-check-pwsh
```

If any of the "Expect" lines don't hold, the fix (or my understanding of `-Command`'s semantics) is wrong and this needs another look before merge.

## Notes for reviewers

- Base branch is `release/0.9.3`; #853 (`fix/852-config-extraparams-migration`) is also open against it and touches `CHANGELOG.md` — expect a possible conflict in the `[Unreleased]` section on merge order, resolve by keeping both entries.
- Not closing #845 with this PR (`Closes` keyword intentionally omitted) — leaving that to the owner pending the manual Windows run above, per the task instructions for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7CauuoYuv5ULR4igmU1Jx
