### PR TITLE
release: merge 0.9.3 into main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ scripts/akm-eval/cases/real-query.manifest.json
 # The prompts + README + runner (the reusable kit) ARE meant to be tracked.
 docs/reviews/akm-meta-review/findings/
 .akm/
+docs/.pending/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **A failing Windows `shell: powershell`/`pwsh` task could lose its exit
+  code's fidelity through `-Command` (#845).** `-Command` derives its own
+  process exit code from `$?`, so a genuinely failing command already
+  produced a nonzero exit and `status: "failed"` — but any native exit code
+  outside `{0, 1}` was collapsed to `1`, discarding the real value reported
+  in task history. The inner shell invocation built by `shellCommand()` now
+  appends a guard that reads `$?` first (reproducing `-Command`'s own
+  completed/failed determination, immune to a stale `$LASTEXITCODE` from an
+  earlier native call in the same command) and only then upgrades to the
+  precise native exit code when the failing last statement actually set
+  one — a bare `exit $LASTEXITCODE` was rejected because `$LASTEXITCODE`
+  stays `$null` for a pure-PowerShell command, and `exit $null` is exit
+  code `0`, which would have turned a failed cmdlet into a false
+  `"completed"`. Verified via unit tests asserting the exact argv `-Command`
+  string on `platform: "win32"`; the runtime exit-code behavior itself is
+  unverified on a real Windows host pending the owner's manual run (see the
+  PR body for the procedure) — Windows scheduler paths still have no
+  automated coverage (#770).
 - **A valid 0.9.1 config hard-failed to load after upgrading to 0.9.2
   (#852).** `reasoningEffort` became a first-class `engines.<name>` field in
   0.9.2 (#815), so `extraParams.reasoning_effort` — the documented 0.9.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-08-29
+
 ### Fixed
 
 - **A failing Windows `shell: powershell`/`pwsh` task could lose its exit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A valid 0.9.1 config hard-failed to load after upgrading to 0.9.2
+  (#852).** `reasoningEffort` became a first-class `engines.<name>` field in
+  0.9.2 (#815), so `extraParams.reasoning_effort` — the documented 0.9.1
+  workaround for LM Studio, where `enableThinking` is a no-op — started
+  tripping the extraParams protected-key check and hard-failing every
+  command that loads config, with no migration. Config load now lifts
+  `extraParams.{reasoning_effort,temperature,maxtokens,enablethinking}`
+  onto their first-class field automatically (in-memory only; the file is
+  not rewritten, and a warning names each lifted key) unless the
+  extraParams value and the first-class field disagree, in which case
+  config load still fails, now naming both values and the field to keep.
+  Any other protected `extraParams` key without a first-class equivalent
+  still hard-fails, but the error now names the fix instead of only the
+  rule.
+
 ## [0.9.2] - 2026-08-29
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akm-cli",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "description": "akm (Agent Knowledge Manager) — a portable, local-first capability library for AI agents. Discover, load, share, and improve reusable skills, scripts, workflows, and knowledge across any shell-capable coding agent, including Claude Code, OpenCode, and Cursor.",
   "keywords": [

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -5,6 +5,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { ConfigError } from "../errors";
+import { liftLegacyEngineExtraParams } from "../extra-params";
 import {
   acquireConfigLock,
   backupExistingConfig,
@@ -203,18 +204,42 @@ export function acquireConfigReadFence(): { config: AkmConfig; release: () => vo
  * canonical shape before defaults are merged.
  */
 export function parseAndValidateConfigText(text: string, sourcePath?: string): AkmConfig {
-  const raw = parseConfigText(text, sourcePath);
-  if (raw.configVersion !== CURRENT_CONFIG_VERSION) {
+  const parsedRaw = parseConfigText(text, sourcePath);
+  if (parsedRaw.configVersion !== CURRENT_CONFIG_VERSION) {
     throw new ConfigError(
       `Unsupported configVersion${sourcePath ? ` at ${sourcePath}` : ""}: expected "${CURRENT_CONFIG_VERSION}".`,
       "UNSUPPORTED_CONFIG_VERSION",
       "Recreate engines and improve.strategies manually for AKM 0.9.0; profile-based configuration is not translated automatically.",
     );
   }
+
+  // #852 (following #815): lift legacy `extraParams` keys — e.g.
+  // `reasoning_effort`, a documented 0.9.1 workaround — onto the first-class
+  // engine field they now shadow, before the protected-key check in
+  // `ExtraParamsSchema` gets a chance to hard-reject them. In-memory only;
+  // never written back to the file.
+  const { config: raw, lifted, conflicts } = liftLegacyEngineExtraParams(parsedRaw);
+  const where = sourcePath ? ` at ${sourcePath}` : "";
+  if (conflicts.length > 0) {
+    const lines = conflicts
+      .map(
+        (c) =>
+          `  - engines.${c.engine}.extraParams.${c.key} (${JSON.stringify(c.extraParamsValue)}) conflicts with engines.${c.engine}.${c.field} (${JSON.stringify(c.fieldValue)})`,
+      )
+      .join("\n");
+    throw new ConfigError(
+      `Invalid config${where}: extraParams and the first-class field disagree:\n${lines}\n\nEach extraParams key above has a first-class equivalent and akm will not guess which value you meant — remove the extraParams entry once the field carries the value you want.`,
+      "INVALID_CONFIG_FILE",
+    );
+  }
+  if (lifted.length > 0) {
+    warn(
+      `Config${where} uses deprecated extraParams keys with first-class equivalents; treating them as the first-class fields for this run (not written back to the file):\n  - ${lifted.join("\n  - ")}`,
+    );
+  }
   const parsed = AkmConfigSchema.safeParse(raw);
   if (!parsed.success) {
     const lines = parsed.error.issues.map((i) => `  - ${i.path.join(".") || "(root)"}: ${i.message}`).join("\n");
-    const where = sourcePath ? ` at ${sourcePath}` : "";
     throw new ConfigError(`Invalid config${where}:\n${lines}`, "INVALID_CONFIG_FILE");
   }
   const merged = deepMergeConfig(DEFAULT_CONFIG, parsed.data as Partial<AkmConfig>) as AkmConfig;

--- a/src/core/extra-params.ts
+++ b/src/core/extra-params.ts
@@ -29,6 +29,51 @@ export const EXTRA_PARAMS_CREDENTIAL_KEYS = [
 const PROTECTED_TOP_LEVEL_KEYS = new Set<string>(EXTRA_PARAMS_PROTECTED_TOP_LEVEL_KEYS);
 const CREDENTIAL_KEYS = new Set<string>(EXTRA_PARAMS_CREDENTIAL_KEYS);
 
+// ── Protected-key remedies (#852) ───────────────────────────────────────────
+//
+// `EXTRA_PARAMS_PROTECTED_TOP_LEVEL_KEYS` rightly stops a provider extra from
+// shadowing an AKM-managed field, but naming the rule without naming the fix
+// leaves the reader stuck (#852). Every protected key gets a one-line remedy
+// baked into its issue message; keys with a genuine scalar first-class field
+// are also eligible for the automatic config-load lift below.
+
+/** normalizeExtraParamKey(key) -> the first-class engine field it shadows. */
+const LEGACY_EXTRA_PARAMS_FIELD: Readonly<Record<string, string>> = {
+  model: "model",
+  temperature: "temperature",
+  maxtokens: "maxTokens",
+  enablethinking: "enableThinking",
+  reasoningeffort: "reasoningEffort",
+};
+
+/**
+ * Subset of {@link LEGACY_EXTRA_PARAMS_FIELD} that {@link liftLegacyEngineExtraParams}
+ * will move onto the first-class field automatically. `model` is deliberately
+ * excluded: unlike the others it was never a "no first-class field yet"
+ * workaround (`model` has always been required on an LLM engine), so a
+ * mismatch is far more likely a genuine mistake than a stale 0.9.1 config —
+ * it stays a hard rejection rather than being silently reinterpreted.
+ */
+const LIFTABLE_EXTRA_PARAMS_KEYS = new Set<string>(["temperature", "maxtokens", "enablethinking", "reasoningeffort"]);
+
+/** Remedies for protected keys with no scalar first-class field to lift onto. */
+const EXTRA_PARAMS_NO_FIELD_REMEDY: Readonly<Record<string, string>> = {
+  messages: "AKM builds the request messages internally — remove it from extraParams",
+  responseformat: "AKM controls the response format internally — remove it from extraParams",
+  stream: "AKM controls streaming internally — remove it from extraParams",
+  streamoptions: "AKM controls streaming internally — remove it from extraParams",
+  chattemplatekwargs: "set engines.<name>.enableThinking instead of chat_template_kwargs.enable_thinking",
+};
+
+function protectedKeyRemedy(normalized: string): string | undefined {
+  const field = LEGACY_EXTRA_PARAMS_FIELD[normalized];
+  if (field) {
+    const note = normalized === "reasoningeffort" ? " (moved to a first-class field in 0.9.2)" : "";
+    return `set engines.<name>.${field} instead${note}`;
+  }
+  return EXTRA_PARAMS_NO_FIELD_REMEDY[normalized];
+}
+
 export interface ExtraParamsIssue {
   path: (string | number)[];
   message: string;
@@ -65,7 +110,11 @@ export function validateExtraParams(value: unknown): ExtraParamsIssue[] {
     for (const [key, child] of Object.entries(entry as Record<string, unknown>)) {
       const normalized = normalizeExtraParamKey(key);
       if (path.length === 0 && PROTECTED_TOP_LEVEL_KEYS.has(normalized)) {
-        issues.push({ path: [key], message: `${key} is protected by AKM` });
+        const remedy = protectedKeyRemedy(normalized);
+        issues.push({
+          path: [key],
+          message: remedy ? `${key} is protected by AKM — ${remedy}.` : `${key} is protected by AKM`,
+        });
       }
       if (CREDENTIAL_KEYS.has(normalized)) {
         issues.push({ path: [...path, key], message: `${key} cannot carry credentials` });
@@ -80,4 +129,104 @@ export function validateExtraParams(value: unknown): ExtraParamsIssue[] {
 export function formatExtraParamsIssue(label: string, issue: ExtraParamsIssue): string {
   const suffix = issue.path.map((part) => (typeof part === "number" ? `[${part}]` : `.${part}`)).join("");
   return `${label}${suffix} ${issue.message}`;
+}
+
+// ── Legacy extraParams -> first-class field lift (#852) ─────────────────────
+
+/** One `engines.<name>.extraParams.<key>` vs `engines.<name>.<field>` mismatch found during the lift. */
+export interface ExtraParamsLiftConflict {
+  engine: string;
+  key: string;
+  field: string;
+  extraParamsValue: unknown;
+  fieldValue: unknown;
+}
+
+export interface LiftLegacyExtraParamsResult {
+  /** The raw config, with liftable keys moved onto their first-class field. Same object when nothing changed. */
+  config: Record<string, unknown>;
+  /** One human-readable line per key actually lifted (or dropped as a redundant duplicate). */
+  lifted: string[];
+  /**
+   * Engines where an `extraParams` key and its first-class field were both
+   * set to different values. Non-empty means `config` was left untouched for
+   * that engine — the caller should reject rather than guess which value wins.
+   */
+  conflicts: ExtraParamsLiftConflict[];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Lift legacy `extraParams` keys onto their first-class engine field before
+ * schema validation runs, so a 0.9.1-shaped config using (e.g.)
+ * `extraParams.reasoning_effort` keeps loading now that `reasoningEffort` is
+ * a first-class — and therefore protected — field (#852, following #815).
+ *
+ * In-memory only: this never rewrites the config file. Callers should warn
+ * using the returned `lifted` descriptions so the user knows to update the
+ * file by hand, and reject using `conflicts` rather than silently preferring
+ * either value.
+ */
+export function liftLegacyEngineExtraParams(raw: Record<string, unknown>): LiftLegacyExtraParamsResult {
+  const lifted: string[] = [];
+  const conflicts: ExtraParamsLiftConflict[] = [];
+  const rawEngines = raw.engines;
+  if (!isPlainObject(rawEngines)) {
+    return { config: raw, lifted, conflicts };
+  }
+
+  const engines: Record<string, unknown> = {};
+  let anyEngineChanged = false;
+
+  for (const [name, engineValue] of Object.entries(rawEngines)) {
+    if (!isPlainObject(engineValue) || !isPlainObject(engineValue.extraParams)) {
+      engines[name] = engineValue;
+      continue;
+    }
+    const engine: Record<string, unknown> = { ...engineValue };
+    const extraParams: Record<string, unknown> = { ...(engineValue.extraParams as Record<string, unknown>) };
+    let engineChanged = false;
+
+    for (const [rawKey, value] of Object.entries(engineValue.extraParams as Record<string, unknown>)) {
+      const normalized = normalizeExtraParamKey(rawKey);
+      if (!LIFTABLE_EXTRA_PARAMS_KEYS.has(normalized)) continue;
+      const field = LEGACY_EXTRA_PARAMS_FIELD[normalized];
+      if (!field) continue;
+      const existing = engine[field];
+      if (existing !== undefined && existing !== value) {
+        conflicts.push({ engine: name, key: rawKey, field, extraParamsValue: value, fieldValue: existing });
+        continue;
+      }
+      delete extraParams[rawKey];
+      engineChanged = true;
+      if (existing === value) {
+        lifted.push(
+          `engines.${name}.extraParams.${rawKey} is redundant — engines.${name}.${field} is already set to the same value; dropped the extraParams entry`,
+        );
+        continue;
+      }
+      engine[field] = value;
+      lifted.push(`engines.${name}.extraParams.${rawKey} -> engines.${name}.${field}`);
+    }
+
+    if (!engineChanged) {
+      engines[name] = engineValue;
+      continue;
+    }
+    anyEngineChanged = true;
+    if (Object.keys(extraParams).length > 0) {
+      engine.extraParams = extraParams;
+    } else {
+      delete engine.extraParams;
+    }
+    engines[name] = engine;
+  }
+
+  if (!anyEngineChanged) {
+    return { config: raw, lifted, conflicts };
+  }
+  return { config: { ...raw, engines }, lifted, conflicts };
 }

--- a/src/tasks/run/run-native-task.ts
+++ b/src/tasks/run/run-native-task.ts
@@ -79,12 +79,40 @@ export function shellCommand(
       return [task.shell, "-c", command];
     case "pwsh":
     case "powershell":
-      return [shellExecutable(task.shell, platform, env), "-NoProfile", "-NonInteractive", "-Command", command];
+      return [
+        shellExecutable(task.shell, platform, env),
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        withExitCodePropagation(command),
+      ];
     case "cmd":
       return [shellExecutable("cmd", platform, env), "/d", "/s", "/c", command];
     default:
       return assertNever(task.shell, "shellCommand");
   }
+}
+
+/**
+ * `-Command` (documented identically for powershell.exe 5.1 and pwsh 7+, in
+ * about_PowerShell_exe / about_Pwsh) already derives its own process exit
+ * code from `$?`, so a genuinely failing last statement already yields a
+ * nonzero exit and status "failed" — but any native exit code outside {0, 1}
+ * is collapsed to 1, discarding the real value that task history reports.
+ *
+ * Appending a bare `exit $LASTEXITCODE` to recover it is unsafe on its own:
+ * `$LASTEXITCODE` stays `$null` for a command that never runs a native
+ * executable (a pure PowerShell/cmdlet command), and `exit $null` resolves
+ * to exit code 0 — turning a failed cmdlet into a false "completed".
+ *
+ * Reading `$?` first, before anything else can run, reproduces -Command's
+ * own completed/failed determination exactly (immune to that regression and
+ * to a `$LASTEXITCODE` left stale by an earlier native call in the same
+ * command), then upgrades to the precise native exit code only when the
+ * failing last statement actually set one.
+ */
+function withExitCodePropagation(command: string): string {
+  return `${command}; if ($?) { exit 0 } elseif ($LASTEXITCODE -ne $null) { exit $LASTEXITCODE } else { exit 1 }`;
 }
 
 /**

--- a/tests/config-extraparams-migration.test.ts
+++ b/tests/config-extraparams-migration.test.ts
@@ -1,0 +1,143 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// #852 (following #815): a 0.9.1-shaped config using the documented
+// `extraParams.reasoning_effort` workaround must keep loading now that
+// `reasoningEffort` is a first-class — and therefore protected — engine
+// field. `parseAndValidateConfigText` is pure (no filesystem), so these run
+// directly against it rather than through the tmp-XDG-dir config-load
+// integration harness.
+import { describe, expect, test } from "bun:test";
+import { parseAndValidateConfigText } from "../src/core/config/config";
+import { ConfigError } from "../src/core/errors";
+import { _setWarnSinkForTests } from "../src/core/warn";
+
+function withWarnSink(): { warnings: string[]; restore: () => void } {
+  const warnings: string[] = [];
+  _setWarnSinkForTests((level, args) => {
+    if (level === "warn") warnings.push(args.map(String).join(" "));
+  });
+  return { warnings, restore: () => _setWarnSinkForTests(undefined) };
+}
+
+function configWithEngine(engine: Record<string, unknown>): string {
+  return JSON.stringify({
+    configVersion: "0.9.0",
+    engines: {
+      default: {
+        kind: "llm",
+        endpoint: "https://example.com/v1/chat/completions",
+        model: "test-model",
+        ...engine,
+      },
+    },
+  });
+}
+
+describe("legacy extraParams -> first-class field migration (#852)", () => {
+  test("a real 0.9.1-shaped config (extraParams.reasoning_effort) loads and lands in reasoningEffort", () => {
+    const { warnings, restore } = withWarnSink();
+    try {
+      const text = configWithEngine({ extraParams: { reasoning_effort: "none" } });
+      const config = parseAndValidateConfigText(text);
+      const engine = config.engines?.default as Record<string, unknown>;
+      expect(engine.reasoningEffort).toBe("none");
+      expect(engine.extraParams).toBeUndefined();
+      expect(warnings.some((w) => w.includes("extraParams.reasoning_effort -> engines.default.reasoningEffort"))).toBe(
+        true,
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test("extraParams.temperature lifts onto the first-class temperature field", () => {
+    const { restore } = withWarnSink();
+    try {
+      const text = configWithEngine({ extraParams: { temperature: 0.2 } });
+      const config = parseAndValidateConfigText(text);
+      const engine = config.engines?.default as Record<string, unknown>;
+      expect(engine.temperature).toBe(0.2);
+      expect(engine.extraParams).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  test("extraParams.maxtokens lifts onto the first-class maxTokens field", () => {
+    const { restore } = withWarnSink();
+    try {
+      const text = configWithEngine({ extraParams: { maxtokens: 512 } });
+      const config = parseAndValidateConfigText(text);
+      const engine = config.engines?.default as Record<string, unknown>;
+      expect(engine.maxTokens).toBe(512);
+      expect(engine.extraParams).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  test("extraParams.enable_thinking lifts onto the first-class enableThinking field", () => {
+    const { restore } = withWarnSink();
+    try {
+      const text = configWithEngine({ extraParams: { enable_thinking: false } });
+      const config = parseAndValidateConfigText(text);
+      const engine = config.engines?.default as Record<string, unknown>;
+      expect(engine.enableThinking).toBe(false);
+      expect(engine.extraParams).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  test("a lifted key alongside an unrelated, still-protected extraParams key leaves the latter rejected", () => {
+    const text = configWithEngine({ extraParams: { reasoning_effort: "none", stream: true } });
+    expect(() => parseAndValidateConfigText(text)).toThrow(ConfigError);
+    try {
+      parseAndValidateConfigText(text);
+      throw new Error("expected parseAndValidateConfigText to throw");
+    } catch (err) {
+      expect(String(err)).toContain("stream is protected by AKM");
+    }
+  });
+
+  test("a protected key with no first-class equivalent still rejects, and the error names the remedy", () => {
+    const text = configWithEngine({ extraParams: { stream: true } });
+    try {
+      parseAndValidateConfigText(text);
+      throw new Error("expected parseAndValidateConfigText to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigError);
+      expect(String(err)).toContain("stream is protected by AKM");
+      expect(String(err)).toContain("AKM controls streaming internally");
+    }
+  });
+
+  test("extraParams.reasoning_effort conflicting with a different first-class reasoningEffort value rejects, naming both", () => {
+    const text = configWithEngine({ reasoningEffort: "high", extraParams: { reasoning_effort: "none" } });
+    try {
+      parseAndValidateConfigText(text);
+      throw new Error("expected parseAndValidateConfigText to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigError);
+      const message = String(err);
+      expect(message).toContain('extraParams.reasoning_effort ("none")');
+      expect(message).toContain('engines.default.reasoningEffort ("high")');
+    }
+  });
+
+  test("extraParams.reasoning_effort matching the same first-class value is dropped as redundant, not a conflict", () => {
+    const { warnings, restore } = withWarnSink();
+    try {
+      const text = configWithEngine({ reasoningEffort: "none", extraParams: { reasoning_effort: "none" } });
+      const config = parseAndValidateConfigText(text);
+      const engine = config.engines?.default as Record<string, unknown>;
+      expect(engine.reasoningEffort).toBe("none");
+      expect(engine.extraParams).toBeUndefined();
+      expect(warnings.some((w) => w.includes("redundant"))).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/integration/config-v09.test.ts
+++ b/tests/integration/config-v09.test.ts
@@ -171,7 +171,11 @@ describe("0.9 config contract", () => {
     expect(() => loadUserConfig()).toThrow(ConfigError);
   });
 
-  test("rejects reasoning_effort extraParams overrides", () => {
+  // #852 (following #815): `extraParams.reasoning_effort` was the documented
+  // 0.9.1 workaround for LM Studio, where `enableThinking` is a no-op.
+  // `reasoningEffort` became a first-class — and therefore protected — field
+  // in 0.9.2, so this now lifts onto it on load instead of hard-failing.
+  test("lifts a legacy reasoning_effort extraParams override onto the first-class field", () => {
     writeConfig({
       configVersion: "0.9.0",
       engines: {
@@ -179,6 +183,24 @@ describe("0.9 config contract", () => {
           kind: "llm",
           endpoint: "https://example.test/v1/chat/completions",
           model: "test",
+          extraParams: { reasoning_effort: "high" },
+        },
+      },
+    });
+    const config = loadUserConfig();
+    expect(config.engines?.fast?.reasoningEffort).toBe("high");
+    expect((config.engines?.fast as Record<string, unknown>).extraParams).toBeUndefined();
+  });
+
+  test("rejects a reasoning_effort extraParams override that conflicts with a different first-class reasoningEffort", () => {
+    writeConfig({
+      configVersion: "0.9.0",
+      engines: {
+        fast: {
+          kind: "llm",
+          endpoint: "https://example.test/v1/chat/completions",
+          model: "test",
+          reasoningEffort: "none",
           extraParams: { reasoning_effort: "high" },
         },
       },

--- a/tests/integration/tasks-runner.test.ts
+++ b/tests/integration/tasks-runner.test.ts
@@ -89,6 +89,12 @@ function shellWord(value: string): string {
   return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
+// Mirrors withExitCodePropagation() in run-native-task.ts (#845): appended to
+// every pwsh/powershell -Command invocation so a failing native exit code
+// isn't collapsed to 1 by -Command's own $?-based exit-code handling.
+const POWERSHELL_EXIT_CODE_SUFFIX =
+  "; if ($?) { exit 0 } elseif ($LASTEXITCODE -ne $null) { exit $LASTEXITCODE } else { exit 1 }";
+
 function writeTask(id: string, body: string): void {
   fs.writeFileSync(path.join(tasksDir, `${id}.yml`), body, "utf8");
 }
@@ -654,8 +660,20 @@ describe("runTask — command target", () => {
     expect(command).toBe(
       `& ${resolveAkmInvocation()
         .argv.map((p) => `'${p.replaceAll("'", "''")}'`)
-        .join(" ")} --version`,
+        .join(" ")} --version${POWERSHELL_EXIT_CODE_SUFFIX}`,
     );
+  });
+
+  test("shellCommand appends an exit-code-preserving guard for pwsh and powershell (#845)", () => {
+    // -Command's own exit code is $? -based (0/1) and collapses any other
+    // native exit code to 1 — see withExitCodePropagation() in
+    // run-native-task.ts for why a bare `exit $LASTEXITCODE` is unsafe
+    // (stays $null, and `exit $null` is 0, for a pure-PowerShell command).
+    const env = { SystemRoot: "C:\\Windows" };
+    for (const shell of ["powershell", "pwsh"] as const) {
+      const command = shellCommand({ command: "Write-Output hi", shell }, "win32", env);
+      expect(command.at(-1)).toBe(`Write-Output hi${POWERSHELL_EXIT_CODE_SUFFIX}`);
+    }
   });
 
   test("shellCommand resolves powershell and cmd to absolute Windows paths", () => {
@@ -683,7 +701,7 @@ describe("runTask — command target", () => {
       "-NoProfile",
       "-NonInteractive",
       "-Command",
-      "echo hi",
+      `echo hi${POWERSHELL_EXIT_CODE_SUFFIX}`,
     ]);
     const cmdCommand = shellCommand({ command: "echo hi", shell: "cmd" }, "win32", env);
     expect(cmdCommand).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/s", "/c", "echo hi"]);


### PR DESCRIPTION
Merges the shipped **0.9.3** release branch back into `main`.

`akm-cli@0.9.3` is already published (npm `latest`, tag `v0.9.3`); this PR reconciles `main` with what shipped.

## ⚠️ Merge with a MERGE COMMIT, not a squash

**#845** and **#852** close via `Closes` keywords in commits that have not reached the default branch. GitHub fires those keywords only on merges to the default branch — a **squash discards the individual commit messages**, so both issues would silently stay open.

This exact situation was handled correctly for 0.9.2 (PR #822), where a merge commit auto-closed nine issues. Do the same here.

## What's in it

- **#852 / PR #853** — `fix(config): lift legacy extraParams keys onto their first-class engine field`

  The urgent one. `reasoningEffort` became a first-class `engines.<name>` field in 0.9.2 (#815), which made `extraParams.reasoning_effort` — the workaround #815 itself documents for LM Studio, where `enableThinking` is a no-op — a hard config-load failure. Every command was blocked for affected upgraders. Legacy keys (`reasoning_effort`, `temperature`, `maxtokens`, `enable_thinking`) now lift onto their first-class fields in memory; conflicting values are rejected naming both rather than silently resolved; the user's file is never rewritten.

- **#845 / PR #854** — `fix: preserve failing exit codes through inner powershell -Command`

  The investigation refuted the issue's premise: `-Command` derives its exit code from `$?`, so a failing task already recorded `status: "failed"`. What was lost was the *exact* native code (collapsed to `1`). Notably, the obvious fix would have introduced the very bug the issue feared — a bare `exit $LASTEXITCODE` returns **0** after a failing cmdlet, because `$LASTEXITCODE` is `$null` for pure-PowerShell commands. The shipped guard reads `$?` first, then upgrades to the precise native code only when one exists.

## Verification

- `Gated / Native Scheduler / Windows` — **pass** (real `windows-2022` runner, so #845 did not need a manual Windows run)
- Full release gate green; release workflow succeeded first attempt
- Verified against the **published npm artifact**: a 0.9.1-shaped config hard-fails on 0.9.2 and loads cleanly on 0.9.3, with the on-disk file byte-for-byte unchanged (SHA-256 compared)
- PowerShell exit semantics confirmed empirically on PowerShell 7 (`mcr.microsoft.com/powershell`): native `exit 7` → `1` unguarded, → `7` with the guard; failing cmdlet → `0` with the naive fix, → `1` with the guard

## Not included

#849 (sync dry-run) and #851 (task prune) moved to **0.9.4** — 0.9.3 was cut as a focused patch so the config-load fix would not wait behind two features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7CauuoYuv5ULR4igmU1Jx