### PR TITLE
release: cut 0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,128 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.9.8] - 2026-09-01
+
+A cleanup and stabilization release. 58 commits, **492 files, +4,963 /
+-25,798 — net -20,835 lines**. Almost all of it is deletion of machinery that
+policed the codebase's shape rather than its behaviour.
+
+### Fixed
+
+- **Pruning a memory no longer leaves dangling belief edges (#885).**
+  `writeContradictEdge` — the hardened, test-covered `contradictedBy` writer —
+  had no production caller; its docstring named three that did not exist. The
+  live pass used a private near-copy that had drifted on exactly the two
+  behaviours the original was hardened for: it read the key with
+  `Array.isArray` only, so a SCALAR edge (live data the indexer accepts and
+  lint never flags) read as "no edges" and was overwritten out of existence;
+  and it set `beliefState: "contradicted"` unconditionally, promoting an
+  `archived` memory back up the ranking. The tests for both behaviours were
+  guarding dead code. The copy is gone.
+
+  `persistBeliefStateTransition` is deliberately NOT routed through the shared
+  primitive: it is a state-transition writer that replaces the edge list
+  wholesale and can clear it, which an append-only, never-weaken primitive
+  cannot express.
+
+- **`git worktree` operations no longer fail on a busy machine (#891).** The
+  module's internal `GIT_TIMEOUT_MS` was a flat 30s with no margin, so a
+  healthy `git worktree remove` on a loaded host returned
+  `{ removed: false, error: "timed out after 30000ms" }`. Anyone running a
+  workflow with `isolation: worktree` alongside other git activity could hit
+  spurious create failures, or have a clean worktree wrongly retained as
+  unremovable. Raised to 120s, matching the existing `GIT_PUSH_TIMEOUT_MS`
+  precedent. Note `scripts/test-integration.sh` had already raised *bun's*
+  per-test timeout for this reason, but that never touched the production
+  subprocess timeout, which fires first.
+
+- **`akm health`'s dead-link check no longer reports an unearned all-clear
+  (#892).** `checkDeadUrls` capped at 20 URLs across the whole bundle, plus an
+  undocumented `slice(0, 3)` per entry, then the caller logged "URL check
+  complete (0 dead)". A bundle with thousands of links got a clean bill of
+  health after twenty were examined. Both caps removed; every URL is checked
+  and a failed request surfaces instead of being swallowed.
+
+- **`akm lint --fix` no longer breaks on gitignored drafts (#887).** The doc
+  linter walked `docs/` with no gitignore awareness, so unpublished drafts
+  under `docs/.pending/` were held to the published-docs contract —
+  `bun run lint` failed locally while CI, which never has those files, stayed
+  green.
+
+### Changed
+
+- **Search no longer truncates long queries (#892).** `MAX_LEXICAL_QUERY_TOKENS
+  = 16` silently dropped every token past the sixteenth, and tokens are
+  collected in order, so the discarded half was the tail — for
+  natural-language input, usually where the discriminating words are. It also
+  fed ranking, so token-overlap scoring ran on the truncated set too. It was
+  unexplained in the code and in the commit that introduced it, and unreachable
+  from any flag, config key, or environment variable. Removed: the planner
+  handles 10,000 tokens in 9ms, so no performance cliff was being protected.
+
+- **Content and memory bodies are no longer silently truncated.**
+  `MAX_CONTENT_CHARS` (100k, duplicated across 8 adapters) cut indexed content
+  so the tail of a long document was unsearchable; `MAX_BODY_CHARS` (4000) cut
+  the text sent for memory inference, so on a large-context engine the model
+  saw a fraction of the input while the derived memory looked complete. Both
+  removed.
+
+- **GitHub Actions are pinned to commit SHAs (#768).** All 29 `uses:` steps
+  across every workflow, with the tag preserved in a trailing comment.
+
+- **Gated CI runs on schedule, dispatch, and candidate tags only.** The
+  `detect-changes` job that selected suites by regex-matching a PR diff is
+  gone — its path patterns had gone stale and still named test files this
+  release moved or deleted, so it was silently under-selecting suites. Release
+  evidence is unchanged; the checklist always required an exact-SHA dispatch.
+
+- **`akm-eval` in CI is now a determinism check only.** Its score gates are
+  removed. Measured before cutting: the baseline scored a perfect 1.0 against
+  a 0.75 gate, and seven of nine case types never ran — CI has no LLM and no
+  run history, so everything the eval exists to measure was skipped while the
+  job reported green. The harness itself is unchanged and remains a genuine
+  quality signal when run against a real bundle.
+
+### Removed
+
+- **14 architecture ratchets, 15 golden/snapshot suites, 12 characterization
+  suites.** Function-size and import-cycle ratchets that failed on refactors
+  harming nothing; byte-for-byte snapshots "fixed" by regenerating; tests that
+  pinned "what the code does today" by definition.
+- **11 of 14 lint scripts (-3,988 lines).** `lint-tests-isolation` alone was
+  717 lines standing in front of `src/core/paths.ts`, which already throws
+  `TEST_ISOLATION_MISSING` at runtime. Also removed: the `gen-config-schema
+  --check` gate (`build` regenerates the schema anyway, so what ships is always
+  current), and `lint-devto-posts` (322 lines that were wired to nothing and
+  duplicated checks `devto-cli` performs itself). The three kept catch
+  user-visible problems: secrets must route through the resolver, no dead refs
+  in shipped assets, no docs teaching commands that do not exist.
+- **Both `MIN_TESTS` floors** — arbitrary numbers whose only job was to fail
+  the suite when test count dropped.
+- **`release-workflow-syntax.yml`** — a workflow that ran actionlint over the
+  other workflows. A broken workflow file already fails at GitHub.
+- **Dead `$STASH/.akm` residue is now reportable (#889).** `akm health` gains a
+  read-only `stash-dead-residue` advisory naming each stale path and its size;
+  deletion is gated behind an explicit `akm health --clean-dead-residue`. On a
+  real bundle 82% of `.akm` (135 MB) was pre-0.9.0 leftovers no code reads.
+
+### Testing
+
+- Test isolation grandfather list drained 58 -> 2 (#785); the two retained
+  entries are the helper-definitions file and a meta-test of the guard itself.
+- The test tree now has a stated unit/integration rule and ~250 files were
+  reclassified by evidence — real DB, network, or process spawn — rather than
+  by filename (#786).
+- 31 status-only `not.toBe(0)` assertions replaced with exact exit codes and
+  machine-readable error codes, every value observed rather than inferred
+  (#787).
+- Near-duplicate clusters drained (#788); real-server timing flakes removed or
+  made deterministic (#789).
+- Kept deliberately: `registry-network-boundary.test.ts`, which enforces that
+  only `pinned-transport.ts` may import `node:http`/`node:https` — the control
+  that stops a raw request bypassing address-pinned fetching. No lint script
+  covers that boundary.
+
 ## [0.9.7] - 2026-08-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akm-cli",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "type": "module",
   "description": "akm (Agent Knowledge Manager) \u2014 a portable, local-first capability library for AI agents. Discover, load, share, and improve reusable skills, scripts, workflows, and knowledge across any shell-capable coding agent, including Claude Code, OpenCode, and Cursor.",
   "keywords": [


### PR DESCRIPTION
Cuts 0.9.8: version bump + CHANGELOG. Everything else in this release is already on `main`.

**58 commits since `v0.9.7` — 492 files, +4,963 / −25,798, net −20,835 lines.** A cleanup and stabilization release; almost all of it is deletion of machinery that policed the codebase's *shape* rather than its behaviour.

## Two product bugs, both found while chasing what looked like test problems

**Dangling belief edges after a prune (#885).** `writeContradictEdge` — the hardened, test-covered writer — had no production caller. The live pass used a private near-copy that had drifted on exactly the two behaviours the original was hardened for: an `Array.isArray`-only read destroyed scalar `contradictedBy` edges, and an unconditional `beliefState: "contradicted"` promoted archived memories back up the ranking. Both behaviours had tests; the tests were guarding dead code.

**`GIT_TIMEOUT_MS` was a flat 30s (#891).** A healthy `git worktree remove` on a loaded machine returned `{ removed: false, error: "timed out after 30000ms" }`. Anyone running `isolation: worktree` alongside other git activity could hit spurious failures. The issue's own theory — a lock racing across processes — was **refuted** by load testing (20–65× slower under contention, never a wrong result); the real cause was reproduced deterministically with a slow-`git` shim.

Also: **search stopped silently truncating queries** past 16 tokens, dropping the tail where the discriminating words usually are. It fed ranking too, so scoring ran on the truncated set.

## What was deleted

14 architecture ratchets · 15 golden/snapshot suites · 12 characterization suites · **11 of 14 lint scripts** · both `MIN_TESTS` floors · the Gated CI changed-path detector · a workflow that linted workflows · silent truncation caps in 10 places.

`lint-tests-isolation` is the representative case: 717 lines standing in front of `src/core/paths.ts`, which *already* throws `TEST_ISOLATION_MISSING` at runtime. A constraint in front of a constraint.

## What was kept, deliberately

- **`registry-network-boundary.test.ts`** — removed by the ratchet sweep, restored on review. It enforces that only `pinned-transport.ts` may import `node:http`/`node:https`, which stops a raw request bypassing address-pinned fetching. No lint script covers that boundary.
- **3 lint scripts** that catch user-visible problems: secrets route through the resolver, no dead refs in shipped assets, no docs teaching commands that don't exist.
- **`scripts/akm-eval/`** — its CI score gates are gone (the baseline scored a perfect 1.0 against a 0.75 gate while seven of nine case types never ran), but the harness is a real quality signal against a real bundle. Only the determinism replay remains in CI, on PRs to `main`.
- **Contract, envelope, and spec-conformance tests.** Two deletion passes came back nearly empty and both were verified rather than accepted: all 54 CLI-envelope tests have unique names asserting different commands end-to-end, and the robots.txt suite is numbered spec conformance. Cutting those removes real coverage.

## Suite

| | before | after |
|---|---|---|
| unit | 4,401 | 6,326 (29s) |
| integration | 5,855 | 3,421 (66s) |
| lint scripts | 14 | 3 |
| workflows | 6 | 5 |

Unit grew only because the classification sweep moved ~230 files out of integration; totals fell.

## Release readiness

- `bun run lint` clean · `tsc --noEmit` clean
- unit 6,317 / 0 fail · integration 3,421 / 0 fail on consecutive runs
- `bun run build` succeeds; built CLI reports `0.9.8`

**Not yet done** — these are the release steps proper, per `docs/maintainers/release-checklist.md`:
1. exact-SHA Gated CI evidence for the merge commit (`workflow_dispatch` with the full 40-char SHA)
2. `./tests/release-check.sh`
3. dispatch the `Release` workflow with `0.9.8`