### PR TITLE
release: 0.9.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,67 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.9.13] - 2026-09-04
+
+### Added
+
+- **A stable `results` alias on every list-returning command (#922).** `search`,
+  `curate`, `proposal list`, `bundle list`, `env list`, `secret list`,
+  `registry search`, `registry list`, `workflow list`, `task history` and
+  `log list` each keep their existing semantic key (`hits`, `items`,
+  `proposals`, …) and now also expose the same array as `results`, in every
+  shape including `--shape agent`. It is the same array, not a copy. A caller
+  reading `hits` from a `curate` response previously got nothing back and could
+  reasonably read that as "no results" — there was no error and the `summary`
+  alongside it still reported that results were selected. Commands carrying
+  several heterogeneous collections (`health`, `task doctor`) are deliberately
+  excluded.
+- **Engine and embedding credentials can resolve from the secret store
+  (#917).** `apiKey` accepts `secret://<name>` alongside `$VAR` / `${VAR}`,
+  resolved through the existing store-backed resolver. A detached SessionEnd
+  hook or a cron job — the two contexts least able to supply an environment
+  variable and most likely to need extraction — no longer requires editing the
+  login environment for a value akm already stores. Literal keys in
+  `config.json` are still refused, and an unresolvable reference fails loudly,
+  naming the reference and never the secret.
+- **`akm proposal drain` reports what failed (#921).** The envelope carries a
+  `failed[]` naming each proposal and why it was refused (stale target,
+  validation), instead of reporting `failed: 0` while the same run printed five
+  failures to stderr. `--dry-run` now applies the same stale-target check the
+  real run does, so its prediction stops disagreeing with the outcome. The
+  refusals themselves are correct and unchanged: declining to overwrite a target
+  modified since the proposal was created is the desired behaviour. `akm
+  improve`'s triage pre-pass reports the same count.
+- **Workflow step output is checked against its declared schema (#923).** A step
+  whose returned object does not match its `outputSchema` now says so, naming
+  the step and the specific problem (a missing required field, say). This is a
+  warning: the run continues and its status is unchanged, because a workflow is
+  a guide rather than a contract. Previously an author got neither enforcement
+  nor feedback — the only signal was a notice saying akm was not checking, which
+  is a different fact from whether the output matched.
+
+### Changed
+
+- **A held run lease no longer reports as database corruption (#924).** `akm
+  workflow run` surfaced raw SQLite text — `database is locked`, `database disk
+  image is malformed`, `disk I/O error` — for what was simply another
+  invocation holding the lease. `disk image is malformed` in particular reads as
+  data loss and sent one reporter through integrity checks and a WAL review
+  before finding the real cause. The lease message now appears at default
+  verbosity and carries a dedicated `RUN_LEASE_HELD` code, so a wrapper can tell
+  "retry shortly" from "you passed bad input". Genuine SQLite errors still
+  report as themselves.
+- **`akm lint` stops flagging templated output paths (#927).** A documented
+  run-time filename such as `reports/review-<timestamp>.md` is no longer
+  reported as a `stale-path` broken reference. Angle-bracket and brace
+  placeholders, `${VAR}`, date-format runs like `YYYYMMDD`, and glob characters
+  are all recognised as parameterised rather than missing. Genuinely broken
+  literal paths are still reported.
+- **The workflow level-2 heading rule is discoverable before you trip it
+  (#926).** The `workflow create` template states that `##` headings are step
+  ids and points at `###` for cross-cutting notes, and the compiler's rejection
+  now carries the remedy rather than only the diagnosis.
+
 ## [0.9.12] - 2026-09-03
 
 ### Added

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -79,6 +79,24 @@ For local materialized assets, `editHint` is added only when `editable` is
 or use `action` (or curate `followUp`). Registry-only results have no local
 `path`, `editable`, or `editHint`.
 
+### The `results` collection alias
+
+Every list-returning command names its collection field differently —
+`search` returns `hits`, `curate` returns `items`, `proposal list` returns
+`proposals`, `bundle list` returns `sources`, `env list` returns `envs`,
+`secret list` returns `secrets`, `registry list` returns `registries`,
+`registry search` returns `hits`, `workflow list` returns `runs`,
+`task history` returns `rows`, `log list` returns `events`. A caller that does
+not already know each command's key cannot write one accessor across all of
+them.
+
+Every one of these commands also carries a `results` field — the identical
+array, not a copy — alongside its semantic key, in every `--format`/`--detail`
+combination and both `--shape human` (the default) and `--shape agent`. Code
+written against a single command should keep using its semantic key for
+clarity; code that needs to handle several list commands uniformly can read
+`results` and never maintain a per-command lookup table.
+
 ### `--shape summary`
 
 Valid **only on `akm show`**. Every other command rejects `--shape summary`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akm-cli",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "type": "module",
   "description": "akm (Agent Knowledge Manager) — a portable, local-first capability library for AI agents. Discover, load, share, and improve reusable skills, scripts, workflows, and knowledge across any shell-capable coding agent, including Claude Code, OpenCode, and Cursor.",
   "keywords": [

--- a/src/assets/workflows/workflow-template.md
+++ b/src/assets/workflows/workflow-template.md
@@ -16,6 +16,10 @@ steps:
 Free preamble prose describing what this workflow does. It is indexed for
 search and shown in `akm show`, but it is never dispatched to a step.
 
+Level-2 (`##`) headings below are step ids and must exactly match one
+declared in `steps:` above — for cross-cutting notes that aren't a step
+(shared context, prerequisites), use a level-3 (`###`) heading instead.
+
 ## first-step
 
 Describe what to do in this step. Refer to run parameters in plain

--- a/src/commands/improve/improve.ts
+++ b/src/commands/improve/improve.ts
@@ -108,7 +108,7 @@ export function renderSyncCommitMessage(
     scope: { mode: string; value?: string };
     plannedRefs: unknown[];
     gateAutoAcceptedCount?: number;
-    triage?: { promoted: number; rejected: number; deferred: number; skippedByCap: number };
+    triage?: { promoted: number; rejected: number; deferred: number; failed: number; skippedByCap: number };
     runId?: string;
   },
   nowMs: number,
@@ -1733,6 +1733,7 @@ function finalizeImproveResult(args: {
             promoted: triageDrain.promoted.length,
             rejected: triageDrain.rejected.length,
             deferred: triageDrain.deferred.length,
+            failed: triageDrain.failed.length,
             skippedByCap: triageDrain.skippedByCap.length,
           },
         }

--- a/src/commands/lint/base-linter.ts
+++ b/src/commands/lint/base-linter.ts
@@ -147,6 +147,15 @@ function fixMissingUpdated(raw: string, mtime: Date): string {
 
 // ── stale-path helpers ────────────────────────────────────────────────────────
 
+/**
+ * A path segment shaped like a run-time filename template rather than a
+ * literal reference: `<timestamp>`-style angle brackets, `{stamp}`/`${VAR}`
+ * braces, a `YYYYMMDD`/`HHMMSS`-style run of date-format letters, or a glob
+ * character. Such a path never exists under its literal spelling, so
+ * `stale-path` skips it instead of flagging it.
+ */
+const PATH_PLACEHOLDER_PATTERN = /[<{]|[*?]|[YMDHS]{4,}/;
+
 function checkStalePath(body: string): string[] {
   const pathRe = /(?:\/home\/|\/tmp\/|\/var\/|\/root\/|\/opt\/)[^\s"'`)\]>,\n]+/g;
   let match: RegExpExecArray | null;
@@ -154,6 +163,7 @@ function checkStalePath(body: string): string[] {
   // biome-ignore lint/suspicious/noAssignInExpressions: idiomatic regex loop
   while ((match = pathRe.exec(body)) !== null) {
     const candidate = match[0];
+    if (PATH_PLACEHOLDER_PATTERN.test(candidate)) continue;
     if (!fs.existsSync(candidate)) {
       stale.push(candidate);
     }

--- a/src/commands/proposal/drain.ts
+++ b/src/commands/proposal/drain.ts
@@ -169,6 +169,14 @@ export interface DrainResult {
    * the `triage_deferred` event. Empty outside queue mode.
    */
   staged: string[];
+  /**
+   * Proposals the deterministic reject/promote/preflight loops attempted and
+   * could not complete, with a stable reason code plus the raw error text.
+   * These ids land in none of `promoted`/`rejected`/`deferred`/`staged` — they
+   * stay pending, and this is the only place that fact is recorded anywhere
+   * other than a stderr `warn()` line.
+   */
+  failed: Array<{ id: string; reason: string; detail: string }>;
   /** Stable, secret-free notices emitted while lowering judgment requests. */
   notices?: readonly Readonly<LoweringNotice>[];
 }
@@ -294,6 +302,49 @@ export function classifyProposal(
 
 function deferReasonForSource(source: string): DrainDeferReason {
   return source === "distill" ? "possible-dup" : "mid-band";
+}
+
+/**
+ * Map a thrown error's message to one of `DrainResult.failed`'s stable reason
+ * codes, falling back to `fallback` for anything not specifically recognized.
+ * Recognizes the write-time guards a proposal can trip during promotion
+ * (see repository.ts's `promoteProposalWithLease` / `preflightProposalPromotion`).
+ */
+function categorizeDrainFailure(message: string, fallback: string): string {
+  if (/target (?:changed after|was created after) proposal/.test(message)) return "stale-target";
+  if (/failed validation:/.test(message)) return "validation";
+  return fallback;
+}
+
+function pushDrainFailure(result: DrainResult, id: string, err: unknown, fallbackReason: string): string {
+  const message = err instanceof Error ? err.message : String(err);
+  result.failed.push({ id, reason: categorizeDrainFailure(message, fallbackReason), detail: message });
+  return message;
+}
+
+/**
+ * Mirror repository.ts's `promoteProposalWithLease` stale-target guard so a
+ * dry-run preflight predicts the same refusal a real promote would hit,
+ * without writing anything. `assetPath` is the path `preflightProposalPromotion`
+ * already resolved for this proposal.
+ */
+function assertProposalTargetFresh(proposal: Proposal, assetPath: string): void {
+  const backup = fs.existsSync(assetPath) ? fs.readFileSync(assetPath) : undefined;
+  const currentHash = backup ? createHash("sha256").update(backup).digest("hex") : undefined;
+  if (proposal.beforeHash !== undefined && (!backup || currentHash !== proposal.beforeHash)) {
+    throw new Error(
+      `Proposal target changed after proposal ${proposal.id} was created; refusing to overwrite newer content.`,
+    );
+  }
+  if (
+    proposal.beforeHash === undefined &&
+    backup !== undefined &&
+    proposal.changes.some((change) => change.op === "create")
+  ) {
+    throw new Error(
+      `Proposal target was created after proposal ${proposal.id} was created; refusing to overwrite newer content.`,
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -753,6 +804,7 @@ export async function drainProposals(
     deferred: classification.deferred,
     skippedByCap: [],
     staged: [],
+    failed: [],
   };
 
   // A configured judgment runner makes every deferred item dispatch-eligible.
@@ -779,7 +831,8 @@ export async function drainProposals(
         });
         result.rejected.push(target.id);
       } catch (err) {
-        warn(`[triage] reject failed for ${target.id}: ${err instanceof Error ? err.message : String(err)}`);
+        const message = pushDrainFailure(result, target.id, err, "reject-error");
+        warn(`[triage] reject failed for ${target.id}: ${message}`);
       }
     }
 
@@ -814,19 +867,21 @@ export async function drainProposals(
           result.promoted.push(id);
           deterministicPromoted += 1;
         } catch (err) {
-          warn(`[triage] promote failed for ${id}: ${err instanceof Error ? err.message : String(err)}`);
+          const message = pushDrainFailure(result, id, err, "promote-error");
+          warn(`[triage] promote failed for ${id}: ${message}`);
         }
       }
     } else if (opts.applyMode === "promote" && opts.dryRun) {
-      // Exercise the same stamped candidate and lint boundary as real promotion.
-      // Tests that omit config retain the classification-only seam.
+      // Exercise the same stamped candidate, lint, and stale-target boundary as
+      // real promotion so a dry-run's predicted promotions match what a real
+      // run would do. Tests that omit config retain the classification-only seam.
       const byId = new Map(pending.map((proposal) => [proposal.id, proposal]));
       for (const id of withinCap) {
         try {
           if (opts.config) {
             const proposal = byId.get(id);
             if (!proposal) throw new Error(`Proposal ${id} disappeared during drain preflight.`);
-            preflightProposalPromotion(opts.config, proposal, {
+            const preflight = preflightProposalPromotion(opts.config, proposal, {
               ...(opts.target ? { target: opts.target } : {}),
               gateDecision: {
                 outcome: "auto-accepted",
@@ -834,11 +889,13 @@ export async function drainProposals(
                 gate: gateLabel,
               },
             });
+            assertProposalTargetFresh(proposal, preflight.assetPath);
           }
           result.promoted.push(id);
           deterministicPromoted += 1;
         } catch (err) {
-          warn(`[triage] preflight failed for ${id}: ${err instanceof Error ? err.message : String(err)}`);
+          const message = pushDrainFailure(result, id, err, "promote-error");
+          warn(`[triage] preflight failed for ${id}: ${message}`);
         }
       }
     }

--- a/src/commands/proposal/proposal-cli.ts
+++ b/src/commands/proposal/proposal-cli.ts
@@ -547,6 +547,7 @@ const proposalDrainCommand = defineJsonCommand({
       deferred: result.deferred,
       skippedByCap: result.skippedByCap,
       staged: result.staged,
+      failed: result.failed,
     });
   },
 });

--- a/src/core/config/config-walker.ts
+++ b/src/core/config/config-walker.ts
@@ -28,6 +28,7 @@ import { hasRegistryUrlCredentials, REGISTRY_CREDENTIALS_UNSUPPORTED } from "../
 import { warnOnce } from "../warn";
 import { AkmConfigBaseSchema, type AkmConfigShape, EngineConfigSchema, listTopLevelConfigKeys } from "./config-schema";
 import { deepMergeConfig } from "./deep-merge";
+import { isApiKeyReference } from "./schema/primitives";
 
 type Path = string[];
 
@@ -239,9 +240,12 @@ export function configSet(config: Record<string, unknown>, dotted: string, raw: 
     path[0] === "engines" && path.length === 2
       ? EngineConfigSchema.safeParse(value)
       : symbolicApiKey
-        ? /^\$[A-Za-z_][A-Za-z0-9_]*$|^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/.test(raw)
+        ? isApiKeyReference(raw)
           ? { success: true as const, data: value }
-          : { success: false as const, error: { issues: [{ path: [], message: `apiKey must be $VAR or \${VAR}` }] } }
+          : {
+              success: false as const,
+              error: { issues: [{ path: [], message: "apiKey must be $VAR, ${VAR}, or secret://<name>" }] },
+            }
         : isUnknownKey
           ? { success: true as const, data: value }
           : (schema as z.ZodTypeAny).safeParse(candidate);
@@ -337,7 +341,7 @@ function rejectLiteralApiKeyInWholeObjectSet(path: Path, raw: string, dotted: st
     return; // Malformed JSON — the caller's own parse/coercion reports this.
   }
   if (!isRecord(parsed) || typeof parsed.apiKey !== "string") return;
-  if (/^\$[A-Za-z_][A-Za-z0-9_]*$|^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/.test(parsed.apiKey)) return;
+  if (isApiKeyReference(parsed.apiKey)) return;
   throw new UsageError(
     `apiKey cannot be persisted in config; export ${recipeForApiKey([...path, "apiKey"], `${dotted}.apiKey`)} instead. (key: ${dotted}.apiKey)`,
     "INVALID_FLAG_VALUE",

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -29,6 +29,7 @@ import type {
 import { upgradeConfigVersion } from "./config-version-shim";
 import { deepMergeConfig } from "./deep-merge";
 import { migrateLegacySourceShape } from "./legacy-source-shape-shim";
+import { isApiKeyReference, SECRET_STORE_REFERENCE_PATTERN } from "./schema/primitives";
 
 export { stripJsonComments } from "./config-io";
 
@@ -404,7 +405,7 @@ export function sanitizeConfigForWrite(config: AkmConfig): Record<string, unknow
 
   if (config.embedding?.apiKey !== undefined) {
     const apiKey = config.embedding.apiKey;
-    if (isEnvReference(apiKey)) {
+    if (isApiKeyReference(apiKey)) {
       // Preserve reference verbatim — not a secret.
       sanitized.embedding = { ...config.embedding };
     } else {
@@ -419,7 +420,7 @@ export function sanitizeConfigForWrite(config: AkmConfig): Record<string, unknow
   if (config.engines) {
     const engines: Record<string, unknown> = {};
     for (const [name, engine] of Object.entries(config.engines)) {
-      if (engine.kind !== "llm" || engine.apiKey === undefined || isEnvReference(engine.apiKey)) {
+      if (engine.kind !== "llm" || engine.apiKey === undefined || isApiKeyReference(engine.apiKey)) {
         engines[name] = { ...engine };
         continue;
       }
@@ -454,22 +455,21 @@ export function sanitizeConfigForWrite(config: AkmConfig): Record<string, unknow
   return sanitized;
 }
 
-/** Matches the only 0.9 symbolic secret forms: `${VAR}` or `$VAR`. */
-function isEnvReference(value: string): boolean {
-  return /^\$\{[A-Za-z_][A-Za-z0-9_]*\}$|^\$[A-Za-z_][A-Za-z0-9_]*$/.test(value);
-}
-
 export function updateConfig(partial: Partial<AkmConfig>): AkmConfig {
   return mutateConfig((current) => deepMergeConfig(current, partial) as AkmConfig).config;
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
+/** Looks up a `secret://<name>` reference's stored value, or `null` if it isn't there. Implemented by `resolveSecretFromStore` in `sources/snapshot-fetchers/secret-seam.ts`; passed in rather than imported here to avoid a cycle (that module's dependencies import this one). */
+export type SecretStoreResolver = (ref: string) => string | null;
+
 /**
- * Resolve a single secret value by expanding `${VAR}` / `$VAR` references
- * against `process.env`. Use this at apiKey /
- * authorization-header consumption sites (LLM client, embedder, agent SDK
- * runner) — NOT on the load path. Non-string inputs pass through unchanged.
+ * Resolve a single secret value: expand `${VAR}` / `$VAR` against
+ * `process.env`, or look up `secret://<name>` via `resolveFromStore`. Use this
+ * at apiKey / authorization-header consumption sites (LLM client, embedder,
+ * agent SDK runner) — NOT on the load path. Non-string inputs pass through
+ * unchanged.
  *
  * Returns the input unchanged when no substitution markers are present, so
  * literal API key strings (already-resolved secrets) are zero-cost.
@@ -477,10 +477,25 @@ export function updateConfig(partial: Partial<AkmConfig>): AkmConfig {
  * Other config string values (URLs, endpoints, model names, prompts) are
  * preserved verbatim on read — only fields explicitly routed through this
  * helper are expanded.
+ *
+ * A `secret://<name>` value that fails to resolve throws `ConfigError`
+ * (naming the ref, never the secret) rather than silently sending an unusable
+ * credential.
  */
-export function resolveSecret(value: string | undefined): string | undefined {
+export function resolveSecret(value: string | undefined, resolveFromStore?: SecretStoreResolver): string | undefined {
   if (value === undefined) return undefined;
   if (typeof value !== "string") return value;
+  const storeRef = SECRET_STORE_REFERENCE_PATTERN.exec(value)?.[1];
+  if (storeRef !== undefined) {
+    const resolved = resolveFromStore?.(storeRef) ?? null;
+    if (resolved === null) {
+      throw new ConfigError(
+        `Secret store reference "${value}" did not resolve to a stored value.`,
+        "SECRET_REFERENCE_UNRESOLVED",
+      );
+    }
+    return resolved;
+  }
   if (!value.includes("$")) return value;
   return value.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g, (_match, braced, bare) => {
     return process.env[(braced ?? bare) as string] ?? "";

--- a/src/core/config/schema/primitives.ts
+++ b/src/core/config/schema/primitives.ts
@@ -36,18 +36,25 @@ export const httpUrl = z.string().refine((v) => v.startsWith("http://") || v.sta
 
 const ENGINE_NAME_PATTERN = new RegExp(ENGINE_NAME_PATTERN_SOURCE);
 export const ENV_REFERENCE_PATTERN = /^\$[A-Za-z_][A-Za-z0-9_]*$|^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/;
+/** `secret://<name>` — an apiKey reference into the akm secret store, resolved via `resolveSecretFromStore`. */
+export const SECRET_STORE_REFERENCE_PATTERN = /^secret:\/\/(.+)$/;
 
 export const engineName = z
   .string()
   .max(63)
   .regex(ENGINE_NAME_PATTERN, "names must be lowercase kebab-case and must not begin with reserved akm-");
 
+/** The two symbolic apiKey forms akm accepts: an env-var reference or a secret-store reference. Never matches a literal key. */
+export function isApiKeyReference(value: string): boolean {
+  return ENV_REFERENCE_PATTERN.test(value) || SECRET_STORE_REFERENCE_PATTERN.test(value);
+}
+
 export function symbolicOrWarnApiKey(label: string) {
   return z.string().superRefine((value) => {
-    if (ENV_REFERENCE_PATTERN.test(value)) return;
+    if (isApiKeyReference(value)) return;
     warnOnce(
       `config:literal-api-key:${label}`,
-      `A ${label} in config.json is a literal API key, not a $VAR/\${VAR} reference; using it as configured. Prefer \`akm config set ...apiKey '$VAR'\` (with the corresponding env var set) — see docs/reference/data-and-telemetry.md.`,
+      `A ${label} in config.json is a literal API key, not a $VAR/\${VAR}/secret:// reference; using it as configured. Prefer \`akm config set ...apiKey '$VAR'\` (with the corresponding env var set) or \`secret://<name>\` (with \`akm secret set <name> ...\`) — see docs/reference/data-and-telemetry.md.`,
     );
   });
 }

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -127,7 +127,14 @@ export type UsageErrorCode =
   // from `completeWorkflowStep`'s write transaction, which SQLite rolls back
   // whole: the step stays pending, the run stays active, fail-before-mutation
   // preserved.
-  | "WORKFLOW_OUTPUT_INVALID";
+  | "WORKFLOW_OUTPUT_INVALID"
+  // A run's single-driver engine lease (R2) is live and held by another
+  // engine invocation — refusing to acquire it (`akm workflow run` racing an
+  // in-flight one) or to advance its step spine manually (`akm workflow
+  // complete` racing the engine). Distinct from every other UsageError code:
+  // a caller branching on `code` can retry this one once the named expiry
+  // passes, which is never true of a bad flag or malformed input.
+  | "RUN_LEASE_HELD";
 
 /** Stable, machine-readable codes for NotFoundError. */
 export type NotFoundErrorCode =
@@ -234,6 +241,8 @@ const USAGE_HINTS: Partial<Record<UsageErrorCode, string>> = {
   // P3b (docs/plans/specs/p3b-child-executor.md §4.3).
   WORKFLOW_OUTPUT_INVALID:
     "Check each `outputs:` entry's `from:` against the step artifact it names, and its `schema:` against the value that step actually promotes.",
+  RUN_LEASE_HELD:
+    "Wait for the named engine invocation to finish or for the lease to expire, then retry. `akm workflow status <id>` shows the current lease.",
 };
 
 /** Default hint for each NotFoundError code. */

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -55,7 +55,11 @@ export type ConfigErrorCode =
   // `akm upgrade` refused: the environment blocks the upgrade (version
   // contract, filesystem permissions, or leftover upgrade state). The error
   // message carries the specific remediation.
-  | "UPGRADE_BLOCKED";
+  | "UPGRADE_BLOCKED"
+  // A `secret://<name>` apiKey reference did not resolve to a stored value —
+  // the named secret does not exist, or no store-backed resolver was wired at
+  // the call site.
+  | "SECRET_REFERENCE_UNRESOLVED";
 
 /** Stable, machine-readable codes for UsageError. */
 export type UsageErrorCode =
@@ -162,6 +166,8 @@ const CONFIG_HINTS: Partial<Record<ConfigErrorCode, string>> = {
   UNKNOWN_IMPROVE_STRATEGY:
     "Pass one of the listed strategy names to `--strategy`, or define it under `improve.strategies`. Names are case-sensitive.",
   EXECUTION_NOT_AUTHORIZED: "Change the selected tools or update the machine/user execution policy, then retry.",
+  SECRET_REFERENCE_UNRESOLVED:
+    "Check the secret exists (`akm secret list`) and the name after `secret://` matches, or run `akm secret set <name> <value>` to store it.",
 };
 
 // Code-review finding: COMPOSITION_INVALID covers several unrelated causes

--- a/src/core/improve-types.ts
+++ b/src/core/improve-types.ts
@@ -887,7 +887,7 @@ export interface AkmImproveResult {
    * (non-dry-run, triage process enabled, whole-stash / type-scoped run);
    * omitted entirely otherwise to keep the envelope tidy.
    */
-  triage?: { promoted: number; rejected: number; deferred: number; skippedByCap: number };
+  triage?: { promoted: number; rejected: number; deferred: number; failed: number; skippedByCap: number };
   /**
    * Layer 2 proactive-maintenance selector outcome. Present only when the
    * `proactiveMaintenance` process is enabled and the run was whole-stash / type

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -11,11 +11,12 @@
 
 import { fetchWithTimeout, readBodyWithByteCap } from "../core/common";
 import { type LlmConnectionConfig, resolveSecret } from "../core/config/config";
-import { ENV_REFERENCE_PATTERN } from "../core/config/schema/primitives";
+import { isApiKeyReference } from "../core/config/schema/primitives";
 import { formatExtraParamsIssue, validateExtraParams } from "../core/extra-params";
 import { redactErrorBody, redactSensitiveText } from "../core/redaction";
 import { warn, warnVerbose } from "../core/warn";
 import { DEFAULT_LLM_TIMEOUT_MS } from "../integrations/agent/config";
+import { resolveSecretFromStore } from "../sources/snapshot-fetchers/secret-seam";
 import {
   emitLlmUsage,
   extractUsageTokens,
@@ -396,13 +397,16 @@ async function chatCompletionAttemptOnce(
     if (issue) throw new Error(formatExtraParamsIssue("LLM extraParams", issue));
   }
   const headers: Record<string, string> = { "Content-Type": "application/json" };
-  // Resolve ONLY a whole-string env reference. The execution boundary normally
-  // hands us a materialized credential after resolving `$VAR` upstream, so
-  // re-running the substitution over a literal key mangled any credential
-  // containing `$` — `sk-live$ecret` lost everything from the `$` onward, and
-  // the request failed with an opaque 401. The narrow check keeps the symbolic
-  // form working for any direct caller that still passes one.
-  const resolvedKey = ENV_REFERENCE_PATTERN.test(config.apiKey ?? "") ? resolveSecret(config.apiKey) : config.apiKey;
+  // Resolve ONLY a whole-string reference ($VAR/${VAR} or secret://<name>).
+  // The execution boundary normally hands us a materialized credential after
+  // resolving the reference upstream, so re-running the substitution over a
+  // literal key mangled any credential containing `$` — `sk-live$ecret` lost
+  // everything from the `$` onward, and the request failed with an opaque
+  // 401. The narrow check keeps the symbolic form working for any direct
+  // caller that still passes one.
+  const resolvedKey = isApiKeyReference(config.apiKey ?? "")
+    ? resolveSecret(config.apiKey, resolveSecretFromStore)
+    : config.apiKey;
   if (resolvedKey) {
     headers.Authorization = `Bearer ${resolvedKey}`;
   }

--- a/src/llm/embedders/remote.ts
+++ b/src/llm/embedders/remote.ts
@@ -13,6 +13,7 @@ import { fetchWithTimeout, isHttpUrl, readBodyWithByteCap } from "../../core/com
 import { type EmbeddingConnectionConfig, resolveSecret } from "../../core/config/config";
 import { redactErrorBody, redactSensitiveText } from "../../core/redaction";
 import { warnVerbose } from "../../core/warn";
+import { resolveSecretFromStore } from "../../sources/snapshot-fetchers/secret-seam";
 import type { Embedder, EmbeddingVector } from "./types";
 
 /**
@@ -284,7 +285,7 @@ export class RemoteEmbedder implements Embedder {
 
   private buildHeaders(): Record<string, string> {
     const headers: Record<string, string> = { "Content-Type": "application/json" };
-    const resolvedKey = resolveSecret(this.config.apiKey);
+    const resolvedKey = resolveSecret(this.config.apiKey, resolveSecretFromStore);
     if (resolvedKey) {
       headers.Authorization = `Bearer ${resolvedKey}`;
     }
@@ -301,7 +302,7 @@ export class RemoteEmbedder implements Embedder {
    * far unredacted and uncapped, at readBodyWithByteCap's 10 MB default.
    */
   private safeErrorBody(body: string): string {
-    const resolvedKey = resolveSecret(this.config.apiKey);
+    const resolvedKey = resolveSecret(this.config.apiKey, resolveSecretFromStore);
     return redactSensitiveText(redactErrorBody(body), resolvedKey ? [resolvedKey] : []);
   }
 }

--- a/src/output/shapes.ts
+++ b/src/output/shapes.ts
@@ -91,7 +91,7 @@ export type OutputCommandName = string;
  */
 const SHAPE_SUMMARY_COMMANDS = new Set(["show"]);
 
-// ── `results` collection alias (#922) ───────────────────────────────────────
+// ── `results` collection alias ──────────────────────────────────────────────
 //
 // Every list-returning command names its collection differently (`hits`,
 // `items`, `proposals`, `sources`, ...) — a caller cannot write one accessor

--- a/src/output/shapes.ts
+++ b/src/output/shapes.ts
@@ -91,6 +91,49 @@ export type OutputCommandName = string;
  */
 const SHAPE_SUMMARY_COMMANDS = new Set(["show"]);
 
+// ── `results` collection alias (#922) ───────────────────────────────────────
+//
+// Every list-returning command names its collection differently (`hits`,
+// `items`, `proposals`, `sources`, ...) — a caller cannot write one accessor
+// across commands without a per-command lookup table, and the wrong guess
+// (`d.get("hits")` against a `curate` response) reads as "no results" rather
+// than "wrong key", with nothing in the envelope to correct it.
+//
+// This maps each list-returning command to the field already holding its
+// collection, and `withResultsAlias` below adds a `results` key pointing at
+// that SAME array (not a copy) to the shaped output — in every `--shape` /
+// `--detail` combination, `human` included, so `--shape agent` needs no
+// separate handling to "guarantee" it. A new list-returning command MUST add
+// an entry here; there is no way to detect a missed one automatically, so the
+// survey deliberately lives in this one place rather than scattered per
+// handler.
+const LIST_RESULT_COLLECTION_KEYS: Readonly<Record<string, string>> = {
+  search: "hits",
+  curate: "items",
+  "registry-search": "hits",
+  "proposal-list": "proposals",
+  list: "sources", // `akm bundle list`
+  "env-list": "envs",
+  "secret-list": "secrets",
+  "registry-list": "registries",
+  "workflow-list": "runs",
+  "task-history": "rows",
+  "log-list": "events", // `akm log list`
+};
+
+function withResultsAlias(command: OutputCommandName, shaped: unknown): unknown {
+  const key = LIST_RESULT_COLLECTION_KEYS[command];
+  if (!key) return shaped;
+  if (shaped === null || typeof shaped !== "object" || Array.isArray(shaped)) return shaped;
+  const obj = shaped as Record<string, unknown>;
+  if ("results" in obj) return shaped;
+  const collection = obj[key];
+  if (!Array.isArray(collection)) return shaped;
+  // Same array reference as `obj[key]`, never a copy, so `results` cannot
+  // silently drift out of sync with the semantic key it aliases.
+  return { ...obj, results: collection };
+}
+
 export function shapeForCommand(
   command: OutputCommandName,
   result: unknown,
@@ -107,7 +150,7 @@ export function shapeForCommand(
   }
   const handler = getOutputShapeHandler(command);
   if (handler) {
-    return handler(result, detail, effectiveShape);
+    return withResultsAlias(command, handler(result, detail, effectiveShape));
   }
   // v1 spec §9 (output-shape registry exhaustive): no silent JSON.stringify
   // fallback. A missing case here is a registration bug — fail loudly so

--- a/src/output/text/proposal-format.ts
+++ b/src/output/text/proposal-format.ts
@@ -188,6 +188,7 @@ export function formatProposalDrainPlain(r: Record<string, unknown>): string {
   const deferred = Array.isArray(r.deferred) ? (r.deferred as Array<Record<string, unknown>>) : [];
   const skippedByCap = Array.isArray(r.skippedByCap) ? (r.skippedByCap as unknown[]) : [];
   const staged = Array.isArray(r.staged) ? (r.staged as unknown[]) : [];
+  const failed = Array.isArray(r.failed) ? (r.failed as Array<Record<string, unknown>>) : [];
   const prefix = r.dryRun === true ? "[dry-run] " : "";
   const lines = [
     `${prefix}Drained proposal queue (strategy=${String(r.strategy ?? "?")}, policy=${policy}, applyMode=${applyMode})`,
@@ -196,9 +197,13 @@ export function formatProposalDrainPlain(r: Record<string, unknown>): string {
     `  deferred: ${deferred.length}`,
     `  skippedByCap: ${skippedByCap.length}`,
     `  staged: ${staged.length}`,
+    `  failed: ${failed.length}`,
   ];
   for (const d of deferred) {
     lines.push(`    - ${String(d.id ?? "?")} (${String(d.reason ?? "?")})`);
+  }
+  for (const f of failed) {
+    lines.push(`    ! ${String(f.id ?? "?")} (${String(f.reason ?? "?")}): ${String(f.detail ?? "?")}`);
   }
   appendLoweringNotices(lines, r);
   return lines.join("\n").trimEnd();

--- a/src/storage/repositories/workflow-runs-repository.ts
+++ b/src/storage/repositories/workflow-runs-repository.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "node:crypto";
 import { NotFoundError, UsageError } from "../../core/errors";
 import { openStateDatabase, withImmediateTransaction } from "../../core/state-db";
 import { borrowScopedStateDb, withStateDbScope } from "../../core/state-db-scope";
+import { sleepSync } from "../../runtime";
 import type { WorkflowRunStatus, WorkflowRunStepStatus } from "../../sources/types";
 import type { Database } from "../database";
 import { escapeLikePattern } from "../like-pattern";
@@ -321,6 +322,52 @@ export interface ListRunsFilter {
    * is byte-identical regardless of this flag.
    */
   includeChildren?: boolean;
+}
+
+/**
+ * Whether `error` is one of the specific SQLite conditions a run-lease
+ * statement can throw under real cross-process contention on the same row:
+ * `SQLITE_BUSY`/`SQLITE_LOCKED` (both drivers), or the message text a
+ * transient contention blip has been observed producing, "database is
+ * locked", "disk I/O error", or "database disk image is malformed".
+ * Matching on this set alone is never sufficient to call something lease
+ * contention — see {@link WorkflowRunsRepository.acquireEngineLease}, which
+ * additionally requires a fresh read confirming a live lease before
+ * substituting the lease-held message for the original error.
+ */
+function isLeaseContentionSqliteError(error: unknown): boolean {
+  const code = (error as { code?: unknown } | undefined)?.code;
+  if (code === "SQLITE_BUSY" || code === "SQLITE_LOCKED") return true;
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("database is locked") ||
+    message.includes("disk I/O error") ||
+    message.includes("database disk image is malformed")
+  );
+}
+
+const LEASE_RETRY_ATTEMPTS = 4;
+const LEASE_RETRY_BASE_DELAY_MS = 15;
+
+/**
+ * Retry a single lease statement across a short, bounded set of attempts when
+ * it throws one of {@link isLeaseContentionSqliteError}'s conditions —
+ * absorbing a blip that a fresh attempt on the same connection clears on its
+ * own. Any other error, or the same error surviving every attempt, propagates
+ * unchanged; this never converts a persistent failure into a false success.
+ */
+function runLeaseStatementWithRetry<T>(fn: () => T): T {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < LEASE_RETRY_ATTEMPTS; attempt += 1) {
+    try {
+      return fn();
+    } catch (error) {
+      if (!isLeaseContentionSqliteError(error)) throw error;
+      lastError = error;
+      if (attempt < LEASE_RETRY_ATTEMPTS - 1) sleepSync(LEASE_RETRY_BASE_DELAY_MS * 2 ** attempt);
+    }
+  }
+  throw lastError;
 }
 
 /**
@@ -797,30 +844,67 @@ export class WorkflowRunsRepository {
    * A live lease held by anyone (including a stale copy of the same holder)
    * is NOT reclaimable through this method; the single UPDATE is the whole
    * claim, so two racing invocations cannot both win.
+   *
+   * The UPDATE can throw instead of cleanly returning `changes: 0` under real
+   * cross-process contention on this row: a `SQLITE_BUSY`/`SQLITE_LOCKED`
+   * from two engines racing the same statement, occasionally surfacing as
+   * "database is locked" or even "database disk image is malformed" text that
+   * reads as corruption but is not. `runLeaseStatementWithRetry` absorbs a
+   * blip that a fresh attempt clears on its own. If it is still failing after
+   * every retry, the row is read fresh (a plain SELECT, far less likely to
+   * trip whatever the write hit) to get independent evidence of what is
+   * actually going on: a live lease there means this really was contention,
+   * so the caller gets the same lease-held message `akm workflow run` already
+   * shows for the clean (non-throwing) case, now with `RUN_LEASE_HELD`. No
+   * live lease — or the verifying read itself fails — means the error was
+   * never actually about the lease, so it is rethrown exactly as raised.
+   * Nothing here invents a diagnosis from error text alone or suppresses a
+   * genuine SQLite failure.
    */
   acquireEngineLease(runId: string, holder: string, until: string, now: string): boolean {
-    const result = this.db
-      .prepare(
-        `UPDATE workflow_runs
-           SET engine_lease_holder = ?, engine_lease_until = ?
-           WHERE id = ? AND status = 'active'
-             AND (engine_lease_holder IS NULL OR engine_lease_until IS NULL OR engine_lease_until < ?)`,
-      )
-      .run(holder, until, runId, now);
-    return Number(result.changes) > 0;
+    try {
+      const result = runLeaseStatementWithRetry(() =>
+        this.db
+          .prepare(
+            `UPDATE workflow_runs
+               SET engine_lease_holder = ?, engine_lease_until = ?
+               WHERE id = ? AND status = 'active'
+                 AND (engine_lease_holder IS NULL OR engine_lease_until IS NULL OR engine_lease_until < ?)`,
+          )
+          .run(holder, until, runId, now),
+      );
+      return Number(result.changes) > 0;
+    } catch (error) {
+      if (!isLeaseContentionSqliteError(error)) throw error;
+      const row = this.tryReadLeaseColumns(runId);
+      if (row?.engine_lease_holder && row.engine_lease_until && row.engine_lease_until >= now) {
+        throw new UsageError(
+          `Workflow run ${runId} is already being driven by engine ${row.engine_lease_holder} ` +
+            `(run lease expires ${row.engine_lease_until}). A second \`akm workflow run\` would race it — ` +
+            `wait for that invocation to finish or for the lease to expire.`,
+          "RUN_LEASE_HELD",
+        );
+      }
+      throw error;
+    }
   }
 
   /**
    * Extend the lease expiry — only while `holder` still owns it. Returns
    * false when the lease was lost (expired and claimed by another engine),
-   * so the caller can stop driving instead of racing the new owner.
+   * so the caller can stop driving instead of racing the new owner. Wrapped
+   * in the same transient-error retry as {@link acquireEngineLease}; a
+   * renewal that still fails after retries is rethrown as-is (no confirmed
+   * "lost lease" diagnosis to substitute, unlike the acquire case above).
    */
   renewEngineLease(runId: string, holder: string, until: string): boolean {
-    const result = this.db
-      .prepare(
-        "UPDATE workflow_runs SET engine_lease_until = ? WHERE id = ? AND engine_lease_holder = ? AND status = 'active'",
-      )
-      .run(until, runId, holder);
+    const result = runLeaseStatementWithRetry(() =>
+      this.db
+        .prepare(
+          "UPDATE workflow_runs SET engine_lease_until = ? WHERE id = ? AND engine_lease_holder = ? AND status = 'active'",
+        )
+        .run(until, runId, holder),
+    );
     return Number(result.changes) > 0;
   }
 
@@ -835,6 +919,44 @@ export class WorkflowRunsRepository {
         "UPDATE workflow_runs SET engine_lease_holder = NULL, engine_lease_until = NULL WHERE id = ? AND engine_lease_holder = ? AND status <> 'failed'",
       )
       .run(runId, holder);
+  }
+
+  /**
+   * Self-heal an engine lease its holder crashed without releasing: once
+   * `engine_lease_until` has passed, clear it so a read (`workflow status`,
+   * `workflow list`) stops reporting a run as engine-driven when the engine is
+   * long gone — mirroring the maintenance barrier's self-reclaim of a wedged
+   * sentinel (`tryAcquireMaintenanceBarrier`) rather than a bespoke mechanism.
+   * The WHERE clause repeats the exact (holder, until) snapshot the caller
+   * read, so a lease renewed or re-acquired in between never gets clobbered —
+   * same compare-and-swap shape as the claim above. Never touches a lease
+   * that is still live.
+   */
+  reclaimExpiredEngineLease(runId: string, holder: string, until: string, now: string): boolean {
+    if (until >= now) return false;
+    const result = this.db
+      .prepare(
+        `UPDATE workflow_runs
+           SET engine_lease_holder = NULL, engine_lease_until = NULL
+           WHERE id = ? AND engine_lease_holder = ? AND engine_lease_until = ? AND engine_lease_until < ?`,
+      )
+      .run(runId, holder, until, now);
+    return Number(result.changes) > 0;
+  }
+
+  /** Best-effort lease-column read used only to confirm genuine contention after {@link acquireEngineLease} exhausts its retries. `undefined` on any failure — never a diagnosis, just "couldn't confirm". */
+  private tryReadLeaseColumns(
+    runId: string,
+  ): Pick<WorkflowRunRow, "engine_lease_holder" | "engine_lease_until"> | undefined {
+    try {
+      return (
+        (this.db.prepare("SELECT engine_lease_holder, engine_lease_until FROM workflow_runs WHERE id = ?").get(runId) as
+          | Pick<WorkflowRunRow, "engine_lease_holder" | "engine_lease_until">
+          | undefined) ?? undefined
+      );
+    } catch {
+      return undefined;
+    }
   }
 
   // ── durable v4 append-only dispatch attempts (migration 022) ─────────────

--- a/src/workflows/exec/run-workflow.ts
+++ b/src/workflows/exec/run-workflow.ts
@@ -382,6 +382,7 @@ async function acquireRunLease(runId: string, holder: string): Promise<void> {
         `Workflow run ${runId} is already being driven by engine ${row?.engine_lease_holder ?? "(unknown)"} ` +
           `(run lease expires ${row?.engine_lease_until ?? "(unknown)"}). A second \`akm workflow run\` would race it — ` +
           `wait for that invocation to finish or for the lease to expire.`,
+        "RUN_LEASE_HELD",
       );
     }),
   );

--- a/src/workflows/exec/step-work.ts
+++ b/src/workflows/exec/step-work.ts
@@ -887,9 +887,7 @@ export function unitSchemaWarning(plan: IrStepPlanV4, units: readonly UnitOutcom
     if (errors.length > 0) mismatches.push(`unit "${unit.unitId}": ${errors.join("; ")}`);
   }
   if (mismatches.length === 0) return undefined;
-  return (
-    `Output does not match the unit's declared schema (advisory; the run continued): ` + `${mismatches.join("; ")}.`
-  );
+  return `Output does not match the unit's declared schema (advisory; the run continued): ${mismatches.join("; ")}.`;
 }
 
 /**

--- a/src/workflows/exec/step-work.ts
+++ b/src/workflows/exec/step-work.ts
@@ -20,6 +20,7 @@ import { createHash, randomUUID } from "node:crypto";
 import unitPreambleTemplate from "../../assets/prompts/workflow-unit-preamble.md" with { type: "text" };
 import { UsageError } from "../../core/errors";
 import { validateJsonSchemaSubset } from "../../core/json-schema";
+import { parseEmbeddedJsonResponse } from "../../core/parse";
 import { canonicalInputJson, type TaskInputBinding, validateInputs } from "../../execution/input-contract";
 import type { LoweringNotice } from "../../execution/resolved-request";
 import type { WorkflowRunStatus } from "../../sources/types";
@@ -857,6 +858,41 @@ export function validateStepArtifact(plan: IrStepPlanV4, evidence: Record<string
 }
 
 /**
+ * Warn-only check of each successful unit's own promoted value against its
+ * template's declared `schema` (`unit.output`) — the one field a harness that
+ * cannot request structured output drops during lowering (`untranslated-field`,
+ * field `outputSchema`), after which nothing else ever compares the returned
+ * text to it. Unlike {@link validateStepArtifact} this never fails the step:
+ * a harness that DID honor the schema already returned a compliant `result`
+ * (this re-check then finds nothing), and one that could not is exactly the
+ * case this exists to surface — the run continues either way.
+ */
+export function unitSchemaWarning(plan: IrStepPlanV4, units: readonly UnitOutcome[]): string | undefined {
+  const schema = stepTemplate(plan)?.schema;
+  if (!schema) return undefined;
+  const mismatches: string[] = [];
+  for (const unit of units) {
+    if (!unit.ok) continue;
+    const candidate =
+      unit.result !== undefined
+        ? unit.result
+        : unit.text !== undefined
+          ? parseEmbeddedJsonResponse(unit.text)
+          : undefined;
+    if (candidate === undefined) {
+      mismatches.push(`unit "${unit.unitId}" produced no structured output to check`);
+      continue;
+    }
+    const errors = validateJsonSchemaSubset(candidate, schema);
+    if (errors.length > 0) mismatches.push(`unit "${unit.unitId}": ${errors.join("; ")}`);
+  }
+  if (mismatches.length === 0) return undefined;
+  return (
+    `Output does not match the unit's declared schema (advisory; the run continued): ` + `${mismatches.join("; ")}.`
+  );
+}
+
+/**
  * Build the summary the completion-criteria gate judges for a step (addendum
  * R2, "typed artifacts, honest gates"): a one-line unit count followed by the
  * promoted step artifact as canonical JSON, clipped at {@link GATE_ARTIFACT_CLIP}
@@ -1042,6 +1078,11 @@ export function reduceStepOutcomes(
       summary = schemaFailure;
       artifactSchemaFailure = true;
     }
+  }
+
+  if (!artifactSchemaFailure) {
+    const schemaWarning = unitSchemaWarning(plan, units);
+    if (schemaWarning !== undefined) summary += ` ${schemaWarning}`;
   }
 
   // P3b §3.4: a composed child workflow that blocked is carried on the

--- a/src/workflows/parser.ts
+++ b/src/workflows/parser.ts
@@ -374,7 +374,7 @@ function bindStepSections(
     if (!declaredIds.has(h.text)) {
       errors.push({
         line: h.line,
-        message: `Unexpected level-2 heading "## ${h.text}" on line ${h.line} — no step "${h.text}" is declared in frontmatter "steps:". Level-2 headings must exactly match a declared step id.`,
+        message: `Unexpected level-2 heading "## ${h.text}" on line ${h.line} — no step "${h.text}" is declared in frontmatter "steps:". Level-2 headings must exactly match a declared step id. To document something that is not a step, use a level-3 heading.`,
       });
       continue;
     }

--- a/src/workflows/runtime/runs.ts
+++ b/src/workflows/runtime/runs.ts
@@ -931,7 +931,7 @@ export async function resolveWorkflowRunTarget(specifier: string): Promise<strin
 function readWorkflowRunOrPrefix(repo: WorkflowRunsRepository, specifier: string): WorkflowRunRow {
   const run = findRunByIdOrPrefix(repo, specifier);
   if (!run) throw new NotFoundError(`Workflow run "${specifier}" not found.`, "WORKFLOW_NOT_FOUND");
-  return run;
+  return reclaimOrphanedEngineLease(repo, run);
 }
 
 function readWorkflowRun(repo: WorkflowRunsRepository, runId: string): WorkflowRunRow {
@@ -939,7 +939,25 @@ function readWorkflowRun(repo: WorkflowRunsRepository, runId: string): WorkflowR
   if (!run) {
     throw new NotFoundError(`Workflow run "${runId}" not found.`, "WORKFLOW_NOT_FOUND");
   }
-  return run;
+  return reclaimOrphanedEngineLease(repo, run);
+}
+
+/**
+ * Self-heal a run's engine lease once it has expired — the orphaned-lease
+ * case where an engine crashed without releasing it — mirroring the
+ * maintenance barrier's self-reclaim of a wedged sentinel, applied at the
+ * points a caller actually asks "what is this run's state". Never touches a
+ * live lease: {@link WorkflowRunsRepository.reclaimExpiredEngineLease} is a
+ * compare-and-swap on the exact (holder, until) this call observed, so a
+ * lease renewed or re-acquired between the read and this write is left alone.
+ */
+function reclaimOrphanedEngineLease(repo: WorkflowRunsRepository, run: WorkflowRunRow): WorkflowRunRow {
+  const { engine_lease_holder: holder, engine_lease_until: until } = run;
+  if (!holder || !until) return run;
+  const now = new Date().toISOString();
+  if (until >= now) return run;
+  repo.reclaimExpiredEngineLease(run.id, holder, until, now);
+  return { ...run, engine_lease_holder: null, engine_lease_until: null };
 }
 
 function readWorkflowRunSteps(repo: WorkflowRunsRepository, runId: string): WorkflowRunStepRow[] {
@@ -1066,8 +1084,13 @@ function toWorkflowRunSummary(run: WorkflowRunRow): WorkflowRunSummary {
     executionSupport: plan.support,
     // Surface the engine lease (holder id + expiry — never workflow-authored
     // content) so `workflow run`/`status` show which native execution
-    // invocation currently holds the run lease.
-    ...(run.engine_lease_holder && run.engine_lease_until
+    // invocation currently holds the run lease. Gated on `until` still being
+    // in the future: a crashed engine's lease self-expires, and a run
+    // whose holder is provably gone must stop reading as engine-driven the
+    // instant that happens, not just once something next attempts to acquire
+    // it (`readWorkflowRun`/`readWorkflowRunOrPrefix` also reclaim the DB
+    // columns outright on the same condition).
+    ...(run.engine_lease_holder && run.engine_lease_until && run.engine_lease_until >= new Date().toISOString()
       ? { engineLease: { holder: run.engine_lease_holder, until: run.engine_lease_until } }
       : {}),
     // P3b (spec §4.5): all three optional and conditionally spread, so every
@@ -1094,6 +1117,7 @@ function assertLeaseAllowsSpineAdvance(run: WorkflowRunRow, leaseHolder: string 
     `Workflow run ${run.id} is being driven by engine ${run.engine_lease_holder} ` +
       `(run lease expires ${run.engine_lease_until}). The engine owns the step spine while it runs — ` +
       `wait for it to finish or for the lease to expire before advancing steps manually.`,
+    "RUN_LEASE_HELD",
   );
 }
 

--- a/tests/commands/improve/improve-sync-message.test.ts
+++ b/tests/commands/improve/improve-sync-message.test.ts
@@ -19,7 +19,7 @@ function fakeResult(
     scope: { mode: string; value?: string };
     plannedRefs: unknown[];
     gateAutoAcceptedCount?: number;
-    triage?: { promoted: number; rejected: number; deferred: number; skippedByCap: number };
+    triage?: { promoted: number; rejected: number; deferred: number; failed: number; skippedByCap: number };
     runId?: string;
   }> = {},
 ) {
@@ -62,7 +62,7 @@ describe("renderSyncCommitMessage", () => {
       "akm improve {runId}: +{triage_promoted} triaged, -{triage_rejected}, {accepted} accepted @ {timestamp}",
       fakeResult({
         gateAutoAcceptedCount: 4,
-        triage: { promoted: 5, rejected: 2, deferred: 1, skippedByCap: 0 },
+        triage: { promoted: 5, rejected: 2, deferred: 1, failed: 0, skippedByCap: 0 },
         runId: "run-abc123",
       }),
       NOW,

--- a/tests/commands/proposal-cli.test.ts
+++ b/tests/commands/proposal-cli.test.ts
@@ -136,6 +136,36 @@ describe("akm proposal drain strategy selector", () => {
     expect(explicit.status).toBe(0);
     expect(JSON.parse(explicit.stdout)).toMatchObject({ judgmentEngine: "reviewer", judgmentKind: "agent" });
   });
+
+  test("reports a stale-target refusal under `failed` instead of failed:0 (#921)", async () => {
+    const stashDir = makeStashDir();
+    const assetPath = path.join(stashDir, "lessons", "cli-stale.md");
+    fs.writeFileSync(
+      assetPath,
+      "---\ndescription: Original on-disk content.\nwhen_to_use: Testing.\n---\n\nOriginal.\n",
+      "utf8",
+    );
+    const created = createProposal(stashDir, {
+      ref: "lessons/cli-stale",
+      source: "extract",
+      force: true,
+      sourceRun: "run-x",
+      target: { source: slugForPath(stashDir), root: stashDir },
+      payload: { content: VALID_LESSON, frontmatter: { description: "cli-stale fixture" } },
+    });
+    if (isProposalSkipped(created)) throw new Error("unexpected skip");
+    fs.writeFileSync(
+      assetPath,
+      "---\ndescription: Someone else edited this.\nwhen_to_use: Testing.\n---\n\nNewer.\n",
+      "utf8",
+    );
+
+    const result = await runCli(["proposal", "drain", "--promote", "-y", "--format=json"], { stashDir });
+    expect(result.status).toBe(0);
+    const envelope = JSON.parse(result.stdout);
+    expect(envelope.promoted).toEqual([]);
+    expect(envelope.failed).toEqual([expect.objectContaining({ id: created.id, reason: "stale-target" })]);
+  });
 });
 
 function seedProposal(stash: string, ref = "lessons/rg-over-grep") {

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -323,6 +323,41 @@ describe("apiKey rejection (#454)", () => {
       "$LOCAL_API_KEY",
     );
   });
+
+  test("setConfigValue accepts a secret:// store reference for engine and embedding apiKey", () => {
+    const base: AkmConfig = { configVersion: "0.9.0", semanticSearchMode: "auto" };
+    expect(setConfigValue(base, "engines.lab.apiKey", "secret://lab-api-key").engines?.lab?.apiKey).toBe(
+      "secret://lab-api-key",
+    );
+    expect(setConfigValue(base, "embedding.apiKey", "secret://embed-key").embedding?.apiKey).toBe("secret://embed-key");
+  });
+
+  test("setConfigValue whole-engine-object set accepts a secret:// apiKey and still rejects a literal", () => {
+    const base: AkmConfig = { configVersion: "0.9.0", semanticSearchMode: "auto" };
+    const withSecretRef = setConfigValue(
+      base,
+      "engines.lab",
+      JSON.stringify({
+        kind: "llm",
+        endpoint: "https://lab.example/v1/chat/completions",
+        model: "x",
+        apiKey: "secret://lab-api-key",
+      }),
+    );
+    expect(withSecretRef.engines?.lab?.apiKey).toBe("secret://lab-api-key");
+    expect(() =>
+      setConfigValue(
+        base,
+        "engines.lab",
+        JSON.stringify({
+          kind: "llm",
+          endpoint: "https://lab.example/v1/chat/completions",
+          model: "x",
+          apiKey: "sk-literal",
+        }),
+      ),
+    ).toThrow(/apiKey cannot be persisted/);
+  });
 });
 
 // ── #455: every nested schema key is settable ───────────────────────────────

--- a/tests/config-sanitize-secrets.test.ts
+++ b/tests/config-sanitize-secrets.test.ts
@@ -88,6 +88,20 @@ describe("sanitizeConfigForWrite — secret handling (#474)", () => {
     expect(persisted).toContain("${OPENAI_API_KEY}");
   });
 
+  it("preserves a secret:// store reference", () => {
+    saveConfig(
+      makeConfig({
+        embedding: {
+          endpoint: "https://example.com",
+          model: "x",
+          apiKey: "secret://embed-key",
+        },
+      }),
+    );
+    const persisted = fs.readFileSync(path.join(configDir, "config.json"), "utf8");
+    expect(persisted).toContain("secret://embed-key");
+  });
+
   it("preserves $VAR (no braces) reference", () => {
     saveConfig(
       makeConfig({

--- a/tests/core/errors-run-lease-held.test.ts
+++ b/tests/core/errors-run-lease-held.test.ts
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `RUN_LEASE_HELD` is the dedicated `UsageErrorCode` a workflow run-lease
+ * refusal carries, distinct from the generic `INVALID_FLAG_VALUE` default —
+ * a caller branching on `code` can retry this one, unlike a bad flag.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { UsageError } from "../../src/core/errors";
+
+describe("RUN_LEASE_HELD", () => {
+  test("constructible, kind usage, code round-trips, and carries its own default hint", () => {
+    const error = new UsageError("Workflow run x is already being driven by engine y.", "RUN_LEASE_HELD");
+    expect(error).toBeInstanceOf(UsageError);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.kind).toBe("usage");
+    expect(error.code).toBe("RUN_LEASE_HELD");
+    expect(error.hint()).toBeDefined();
+    expect(error.hint()).not.toBe(new UsageError("x").hint());
+  });
+
+  test("an explicit constructor hint still overrides the default", () => {
+    const error = new UsageError("x", "RUN_LEASE_HELD", "explicit override");
+    expect(error.hint()).toBe("explicit override");
+  });
+
+  test("distinct from the default INVALID_FLAG_VALUE code a caller might otherwise conflate it with", () => {
+    expect(new UsageError("x", "RUN_LEASE_HELD").code).not.toBe(new UsageError("x").code);
+  });
+});

--- a/tests/integration/commands/improve/improve-triage-prepass.test.ts
+++ b/tests/integration/commands/improve/improve-triage-prepass.test.ts
@@ -73,7 +73,7 @@ function triageEnabledConfig(enabled: boolean): AkmConfig {
 }
 
 function emptyDrainResult(): DrainResult {
-  return { promoted: [], rejected: [], deferred: [], skippedByCap: [], staged: [] };
+  return { promoted: [], rejected: [], deferred: [], skippedByCap: [], staged: [], failed: [] };
 }
 
 beforeEach(() => {

--- a/tests/integration/embedder.test.ts
+++ b/tests/integration/embedder.test.ts
@@ -137,11 +137,11 @@ describe("remote embed", () => {
 
   test("resolves a secret:// apiKey from the store at header-building time (#917)", async () => {
     const storage = withIsolatedAkmStorage();
-    let capturedAuth: ReturnType<Headers["get"]> = null;
+    let capturedAuth = "";
     const server = Bun.serve({
       port: 0,
       async fetch(request) {
-        capturedAuth = request.headers.get("authorization");
+        capturedAuth = request.headers.get("authorization") ?? "";
         await request.json();
         return new Response(
           JSON.stringify({

--- a/tests/integration/embedder.test.ts
+++ b/tests/integration/embedder.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import path from "node:path";
+import { setSecret } from "../../src/commands/env/secret";
 import type { EmbeddingConnectionConfig } from "../../src/core/config/config";
 import { setQuiet } from "../../src/core/warn";
 import {
@@ -12,7 +13,7 @@ import {
 } from "../../src/llm/embedder";
 import { LocalEmbedder } from "../../src/llm/embedders/local";
 import { buildTokenBoundedBatches, estimateTokenCount, RemoteEmbedder } from "../../src/llm/embedders/remote";
-import { withEnv } from "../_helpers/sandbox";
+import { withEnv, withIsolatedAkmStorage } from "../_helpers/sandbox";
 import { overrideSeam } from "../_helpers/seams";
 
 let pipelineImpl: ((task: string, model: string, options?: { dtype?: string }) => Promise<unknown>) | undefined;
@@ -131,6 +132,39 @@ describe("remote embed", () => {
       });
     } finally {
       server.stop(true);
+    }
+  });
+
+  test("resolves a secret:// apiKey from the store at header-building time (#917)", async () => {
+    const storage = withIsolatedAkmStorage();
+    let capturedAuth: ReturnType<Headers["get"]> = null;
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        capturedAuth = request.headers.get("authorization");
+        await request.json();
+        return new Response(
+          JSON.stringify({
+            data: [{ embedding: [0.1, 0.2, 0.3] }],
+            model: "test",
+            usage: { prompt_tokens: 1, total_tokens: 1 },
+          }),
+          { headers: { "Content-Type": "application/json", Connection: "close" } },
+        );
+      },
+    });
+    try {
+      setSecret(path.join(storage.stashDir, "secrets", "embed-key"), Buffer.from("store-secret-value"));
+      const config: EmbeddingConnectionConfig = {
+        endpoint: `http://localhost:${server.port}`,
+        model: "test-model",
+        apiKey: "secret://embed-key",
+      };
+      await embed("secret store apiKey header test", config);
+      expect(capturedAuth).toBe("Bearer store-secret-value");
+    } finally {
+      server.stop(true);
+      storage.cleanup();
     }
   });
 

--- a/tests/integration/proposal/proposal-drain.test.ts
+++ b/tests/integration/proposal/proposal-drain.test.ts
@@ -461,6 +461,87 @@ describe("drainProposals — dry-run", () => {
   });
 });
 
+describe("drainProposals — failed reporting (#921)", () => {
+  test("a promote failure lands in result.failed, not silently as failed:0", async () => {
+    const stash = makeStashDir();
+    const accepted = seed(stash, "lessons/promote-boom", "extract", VALID_LESSON);
+    const promoteFn = mock(async () => {
+      throw new Error("simulated write failure");
+    });
+
+    const result = await drainProposals(baseOpts(stash), promoteFn, fakeReject());
+
+    expect(result.promoted).toEqual([]);
+    expect(result.failed).toEqual([{ id: accepted.id, reason: "promote-error", detail: "simulated write failure" }]);
+  });
+
+  test("a reject failure lands in result.failed", async () => {
+    const stash = makeStashDir();
+    const empty = seed(stash, "lessons/reject-boom", "extract", EMPTY_LESSON);
+    const rejectFn = mock(() => {
+      throw new Error("simulated reject failure");
+    });
+
+    const result = await drainProposals(baseOpts(stash), fakeAccept(), rejectFn);
+
+    expect(result.rejected).toEqual([]);
+    expect(result.failed).toEqual([{ id: empty.id, reason: "reject-error", detail: "simulated reject failure" }]);
+  });
+
+  test("a stale-target refusal is categorized by its message, not lost as a generic failure", async () => {
+    const stash = makeStashDir();
+    const accepted = seed(stash, "lessons/promote-stale", "extract", VALID_LESSON);
+    const promoteFn = mock(async () => {
+      throw new Error(
+        `Proposal target changed after proposal ${accepted.id} was created; refusing to overwrite newer content.`,
+      );
+    });
+
+    const result = await drainProposals(baseOpts(stash), promoteFn, fakeReject());
+
+    expect(result.failed).toEqual([
+      {
+        id: accepted.id,
+        reason: "stale-target",
+        detail: `Proposal target changed after proposal ${accepted.id} was created; refusing to overwrite newer content.`,
+      },
+    ]);
+  });
+
+  test("dry-run predicts the same stale-target refusal a real promote hits (parity)", async () => {
+    const stash = makeStashDir();
+    const assetPath = path.join(stash, "lessons", "dry-run-stale.md");
+    fs.writeFileSync(assetPath, VALID_LESSON.replace("Prefer rg", "Original: prefer rg"), "utf8");
+    const created = createProposal(stash, {
+      ref: "lessons/dry-run-stale",
+      source: "extract",
+      force: true,
+      sourceRun: "run-x",
+      target: { source: "stash", root: stash },
+      payload: { content: VALID_LESSON, frontmatter: { description: "dry-run-stale fixture" } },
+    });
+    if (isProposalSkipped(created)) throw new Error(`unexpected skip: ${created.message}`);
+    // The target changes again after the proposal is minted — the exact
+    // condition both the dry-run preflight and the real promote must refuse.
+    fs.writeFileSync(assetPath, VALID_LESSON.replace("Prefer rg", "Newer: someone else edited this"), "utf8");
+
+    const dryRunResult = await drainProposals(
+      baseOpts(stash, { dryRun: true, config: makeConfig(stash) }),
+      fakeAccept(),
+      fakeReject(),
+    );
+    expect(dryRunResult.promoted).toEqual([]);
+    expect(dryRunResult.failed).toEqual([expect.objectContaining({ id: created.id, reason: "stale-target" })]);
+
+    // The real run (no promote/reject seams — exercises the actual write path)
+    // must refuse the exact same candidate, so the two never disagree.
+    const realResult = await drainProposals(baseOpts(stash, { config: makeConfig(stash) }));
+    expect(realResult.promoted).toEqual([]);
+    expect(realResult.failed).toEqual([expect.objectContaining({ id: created.id, reason: "stale-target" })]);
+    expect(fs.readFileSync(assetPath, "utf8")).toContain("Newer: someone else edited this");
+  });
+});
+
 // ── Judgment tier (Phase 3) ─────────────────────────────────────────────────
 //
 // The judgment tier adjudicates the *deferred* items. PERSONAL_STASH defers

--- a/tests/integration/workflows/run-lease.test.ts
+++ b/tests/integration/workflows/run-lease.test.ts
@@ -5,6 +5,7 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
+import { UsageError } from "../../../src/core/errors";
 import { openStateDatabase } from "../../../src/core/state-db";
 import { resolveStorageLocations } from "../../../src/storage/locations";
 import {
@@ -812,5 +813,209 @@ describe("engine lease heartbeat (long-running steps)", () => {
     // Refused, and the refusal names the engine holder the heartbeat kept alive.
     expect(manualRefusal).toMatch(/is being driven by engine/);
     expect(manualRefusal).toMatch(/run lease expires/);
+  });
+});
+
+/**
+ * A driver-level throw from the lease UPDATE (SQLITE_BUSY/SQLITE_LOCKED, or
+ * the "database is locked" / "disk I/O error" / "database disk image is
+ * malformed" message text a real cross-process race can surface) must never
+ * reach a caller as raw corruption-shaped text when the row itself is fine.
+ * `runLeaseErrorAfter` makes the acquire statement throw for the next `throwCount`
+ * attempts against the SAME open connection, then behave normally.
+ */
+function runLeaseErrorAfter(
+  db: ReturnType<typeof openStateDatabase>,
+  throwCount: number,
+  build: () => Error & { code?: string },
+): () => void {
+  const originalPrepare = db.prepare.bind(db);
+  let remaining = throwCount;
+  const spy = spyOn(db, "prepare").mockImplementation((sql: string, ...rest: unknown[]) => {
+    // biome-ignore lint/suspicious/noExplicitAny: forwarding prepare's own rest args across both drivers
+    const stmt = (originalPrepare as any)(sql, ...rest);
+    if (sql.includes("engine_lease_until < ?")) {
+      const originalRun = stmt.run.bind(stmt);
+      stmt.run = (...args: unknown[]) => {
+        if (remaining > 0) {
+          remaining -= 1;
+          throw build();
+        }
+        return originalRun(...args);
+      };
+    }
+    return stmt;
+  });
+  return () => spy.mockRestore();
+}
+
+describe("lease-acquire resilience against transient SQLite errors", () => {
+  test("a transient SQLITE_BUSY on the acquire statement is retried and resolved — no exception escapes", async () => {
+    writeWorkflow("lease-retry-busy");
+    const started = await startWorkflowRun("workflows/lease-retry-busy", {});
+    const runId = started.run.id;
+    const db = openStateDatabase(resolveStorageLocations().stateDb);
+    try {
+      const restore = runLeaseErrorAfter(db, 2, () =>
+        Object.assign(new Error("database is locked"), { code: "SQLITE_BUSY" }),
+      );
+      try {
+        const repo = new WorkflowRunsRepository(db);
+        expect(repo.acquireEngineLease(runId, "engine-A", isoIn(90_000), new Date().toISOString())).toBe(true);
+      } finally {
+        restore();
+      }
+    } finally {
+      db.close();
+    }
+  });
+
+  test("a persistent SQLITE_BUSY that survives every retry, with a confirmed live lease, reports the lease-held message under RUN_LEASE_HELD", async () => {
+    writeWorkflow("lease-retry-confirmed");
+    const started = await startWorkflowRun("workflows/lease-retry-confirmed", {});
+    const runId = started.run.id;
+    await plantLease(runId, "engine-A", isoIn(90_000));
+
+    const db = openStateDatabase(resolveStorageLocations().stateDb);
+    try {
+      const restore = runLeaseErrorAfter(db, 99, () =>
+        Object.assign(new Error("database is locked"), { code: "SQLITE_BUSY" }),
+      );
+      try {
+        const repo = new WorkflowRunsRepository(db);
+        let caught: unknown;
+        try {
+          repo.acquireEngineLease(runId, "engine-B", isoIn(90_000), new Date().toISOString());
+        } catch (error) {
+          caught = error;
+        }
+        expect(caught).toBeInstanceOf(UsageError);
+        expect((caught as UsageError).code).toBe("RUN_LEASE_HELD");
+        expect((caught as Error).message).toMatch(/is already being driven by engine engine-A/);
+        expect((caught as Error).message).toMatch(/run lease expires/);
+      } finally {
+        restore();
+      }
+    } finally {
+      db.close();
+    }
+  });
+
+  test("a persistent 'disk image is malformed' with NO confirmed live lease is rethrown exactly as raised, never suppressed or reclassified", async () => {
+    writeWorkflow("lease-retry-unconfirmed");
+    const started = await startWorkflowRun("workflows/lease-retry-unconfirmed", {});
+    const runId = started.run.id; // never leased
+
+    const db = openStateDatabase(resolveStorageLocations().stateDb);
+    try {
+      const restore = runLeaseErrorAfter(db, 99, () => new Error("database disk image is malformed"));
+      try {
+        const repo = new WorkflowRunsRepository(db);
+        let caught: unknown;
+        try {
+          repo.acquireEngineLease(runId, "engine-A", isoIn(90_000), new Date().toISOString());
+        } catch (error) {
+          caught = error;
+        }
+        // The original driver error, untouched — not a UsageError, not RUN_LEASE_HELD.
+        expect(caught).not.toBeInstanceOf(UsageError);
+        expect((caught as Error).message).toBe("database disk image is malformed");
+      } finally {
+        restore();
+      }
+    } finally {
+      db.close();
+    }
+  });
+
+  test("a non-lease-shaped error (e.g. a constraint violation) is never retried or reclassified", async () => {
+    writeWorkflow("lease-retry-unrelated");
+    const started = await startWorkflowRun("workflows/lease-retry-unrelated", {});
+    const runId = started.run.id;
+
+    const db = openStateDatabase(resolveStorageLocations().stateDb);
+    try {
+      const restore = runLeaseErrorAfter(db, 1, () => new Error("SQLITE_CONSTRAINT: NOT NULL constraint failed"));
+      try {
+        const repo = new WorkflowRunsRepository(db);
+        expect(() => repo.acquireEngineLease(runId, "engine-A", isoIn(90_000), new Date().toISOString())).toThrow(
+          /NOT NULL constraint failed/,
+        );
+      } finally {
+        restore();
+      }
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe("orphaned engine lease reclaim (crashed engine, self-heal on read)", () => {
+  test("reclaimExpiredEngineLease clears only a lease matching the exact expired snapshot passed in", async () => {
+    writeWorkflow("lease-reclaim-cas");
+    const started = await startWorkflowRun("workflows/lease-reclaim-cas", {});
+    const runId = started.run.id;
+
+    await withWorkflowRunsRepo((repo) => {
+      expect(repo.acquireEngineLease(runId, "engine-A", isoIn(90_000), new Date().toISOString())).toBe(true);
+      // Backdate it, simulating a crashed engine whose lease has since expired.
+      const expiredUntil = isoIn(-5_000);
+      expect(repo.renewEngineLease(runId, "engine-A", expiredUntil)).toBe(true);
+
+      // A stale snapshot naming a lease another engine has since replaced with a
+      // LIVE one must never be reclaimed out from under it (compare-and-swap).
+      expect(repo.acquireEngineLease(runId, "engine-B", isoIn(90_000), new Date().toISOString())).toBe(true);
+      expect(repo.reclaimExpiredEngineLease(runId, "engine-A", expiredUntil, new Date().toISOString())).toBe(false);
+      expect(repo.getRunById(runId)?.engine_lease_holder).toBe("engine-B");
+
+      // A genuinely still-live lease is never reclaimed, whatever snapshot is passed.
+      const live = repo.getRunById(runId);
+      expect(
+        repo.reclaimExpiredEngineLease(runId, "engine-B", live?.engine_lease_until as string, new Date().toISOString()),
+      ).toBe(false);
+
+      // Expire engine-B's own lease for real, then reclaim it against its exact snapshot.
+      const nowExpiredUntil = isoIn(-1_000);
+      expect(repo.renewEngineLease(runId, "engine-B", nowExpiredUntil)).toBe(true);
+      expect(repo.reclaimExpiredEngineLease(runId, "engine-B", nowExpiredUntil, new Date().toISOString())).toBe(true);
+      const cleared = repo.getRunById(runId);
+      expect(cleared?.engine_lease_holder).toBeNull();
+      expect(cleared?.engine_lease_until).toBeNull();
+
+      // Reclaiming again against the same (now-absent) snapshot is a no-op.
+      expect(repo.reclaimExpiredEngineLease(runId, "engine-B", nowExpiredUntil, new Date().toISOString())).toBe(false);
+    });
+  });
+
+  test("workflow status self-heals an orphaned (expired) lease: engineLease disappears AND the DB columns clear", async () => {
+    writeWorkflow("lease-reclaim-status");
+    const started = await startWorkflowRun("workflows/lease-reclaim-status", {});
+    const runId = started.run.id;
+    await withWorkflowRunsRepo((repo) => {
+      expect(repo.acquireEngineLease(runId, "dead-engine", isoIn(90_000), new Date().toISOString())).toBe(true);
+      expect(repo.renewEngineLease(runId, "dead-engine", isoIn(-1_000))).toBe(true); // crashed, never released
+    });
+
+    const status = await getWorkflowStatus(runId);
+    expect(status.run.engineLease).toBeUndefined();
+
+    const row = await withWorkflowRunsRepo((repo) => repo.getRunById(runId));
+    expect(row?.engine_lease_holder).toBeNull();
+    expect(row?.engine_lease_until).toBeNull();
+  });
+
+  test("workflow status leaves a genuinely LIVE lease untouched", async () => {
+    writeWorkflow("lease-reclaim-live");
+    const started = await startWorkflowRun("workflows/lease-reclaim-live", {});
+    const runId = started.run.id;
+    const until = isoIn(90_000);
+    await plantLease(runId, "live-engine", until);
+
+    const status = await getWorkflowStatus(runId);
+    expect(status.run.engineLease).toEqual({ holder: "live-engine", until });
+
+    const row = await withWorkflowRunsRepo((repo) => repo.getRunById(runId));
+    expect(row?.engine_lease_holder).toBe("live-engine");
+    expect(row?.engine_lease_until).toBe(until);
   });
 });

--- a/tests/lint-stale-path-placeholder.test.ts
+++ b/tests/lint-stale-path-placeholder.test.ts
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// #927 — `stale-path` flagged a run-time filename template (e.g.
+// `/reports/portfolio-review-<timestamp>.md`) as a broken literal path. These
+// pin the placeholder forms that must be skipped, and that a genuinely
+// missing literal path is still reported.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { runBaseChecks } from "../src/commands/lint/base-linter";
+import { type IsolatedAkmStorage, withIsolatedAkmStorage } from "./_helpers/sandbox";
+
+function staleIssues(storage: IsolatedAkmStorage, body: string) {
+  const issues = runBaseChecks({
+    filePath: `${storage.stashDir}/workflows/w.md`,
+    relPath: "workflows/w.md",
+    raw: `---\nname: w\n---\n\n${body}`,
+    data: { name: "w" },
+    body,
+    frontmatter: "name: w",
+    fix: false,
+    stashRoot: storage.stashDir,
+  });
+  return issues.filter((issue) => issue.issue === "stale-path");
+}
+
+describe("stale-path skips run-time filename templates (#927)", () => {
+  let storage: IsolatedAkmStorage;
+  afterEach(() => storage?.cleanup());
+
+  test.each([
+    ["angle-bracket placeholder", "Write to /home/founder3/akm/reports/portfolio-review-<timestamp>.md."],
+    ["brace placeholder", "Write to /home/founder3/akm/reports/portfolio-review-{stamp}.md."],
+    ["${VAR} placeholder", "Write to /home/founder3/akm/reports/portfolio-review-${STAMP}.md."],
+    ["YYYYMMDD date-format run", "Write to /home/founder3/akm/reports/portfolio-review-YYYYMMDD.md."],
+    ["HHMMSS date-format run", "Write to /home/founder3/akm/reports/portfolio-review-HHMMSS.md."],
+    ["glob star", "Write to /home/founder3/akm/reports/portfolio-review-*.md."],
+    ["glob question mark", "Write to /home/founder3/akm/reports/portfolio-review-?.md."],
+  ])("%s is not reported", (_label, body) => {
+    storage = withIsolatedAkmStorage();
+    expect(staleIssues(storage, body)).toEqual([]);
+  });
+
+  test("a genuinely missing literal path is still reported", () => {
+    storage = withIsolatedAkmStorage();
+    const issues = staleIssues(storage, "Write to /home/founder3/akm/reports/portfolio-review-final.md.");
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.detail).toContain("portfolio-review-final");
+  });
+
+  test("an existing literal path is not reported", () => {
+    storage = withIsolatedAkmStorage();
+    expect(staleIssues(storage, `Read from \`${storage.stashDir}\` for config.`)).toEqual([]);
+  });
+});

--- a/tests/output-shapes-unit.test.ts
+++ b/tests/output-shapes-unit.test.ts
@@ -629,6 +629,42 @@ describe("shapeForCommand: unknown command", () => {
   });
 });
 
+// ── #922: every list-returning command aliases its collection as `results` ──
+
+describe("shapeForCommand — `results` collection alias (#922)", () => {
+  // command -> [collection key, minimal valid raw result]
+  const LIST_COMMANDS: Array<[string, string, Record<string, unknown>]> = [
+    ["search", "hits", { hits: [{ type: "skill", name: "x", action: "a" }], registryHits: [] }],
+    ["curate", "items", { items: [{ type: "skill", name: "x" }], query: "q", summary: "s" }],
+    ["registry-search", "hits", { hits: [{ name: "x", installRef: "x" }], assetHits: [] }],
+    ["proposal-list", "proposals", { totalCount: 1, proposals: [{ id: "p1", ref: "lessons/x", status: "pending" }] }],
+    ["list", "sources", { sources: [{ name: "b1" }] }],
+    ["env-list", "envs", { envs: [{ name: "e1" }] }],
+    ["secret-list", "secrets", { secrets: [{ name: "s1" }] }],
+    ["registry-list", "registries", { registries: [{ name: "r1" }] }],
+    ["workflow-list", "runs", { runs: [{ id: "w1" }] }],
+    ["task-history", "rows", { rows: [{ id: "t1" }] }],
+    ["log-list", "events", { events: [{ eventType: "add", ref: "lessons/x", ts: "2024-01-01T00:00:00Z" }] }],
+  ];
+
+  for (const [command, key, raw] of LIST_COMMANDS) {
+    for (const shapeMode of ["human", "agent"] as const) {
+      test(`akm ${command} --shape ${shapeMode} carries \`results\` as the SAME array as \`${key}\``, () => {
+        const out = shapeForCommand(command, raw, "normal", shapeMode) as Record<string, unknown>;
+        expect(Array.isArray(out.results)).toBe(true);
+        // Not merely equal in content — the identical reference, so `results`
+        // can never silently diverge from the semantic key it aliases.
+        expect(out.results).toBe(out[key]);
+      });
+    }
+  }
+
+  test("a command with no registered collection key is untouched", () => {
+    const out = shapeForCommand("info", { something: "untouched" }, "full", "human") as Record<string, unknown>;
+    expect(out).not.toHaveProperty("results");
+  });
+});
+
 // ── #284 GAP-MED 1: shapeProposal* — proposal commands ─────────────────────
 
 describe("shapeProposal* — proposal commands", () => {

--- a/tests/resolve-secret.test.ts
+++ b/tests/resolve-secret.test.ts
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// #917 — engine/embedding credentials could only resolve from process.env.
+// `resolveSecret` now also accepts a `secret://<name>` reference, resolved
+// through an injected store lookup (kept out of this module's own imports to
+// avoid a cycle through `env-secret-ref.ts`, which already depends on it).
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { resolveSecret } from "../src/core/config/config";
+import { ConfigError } from "../src/core/errors";
+
+const ENV_VAR = "AKM_TEST_RESOLVE_SECRET_VAR";
+
+describe("resolveSecret (#917)", () => {
+  beforeEach(() => {
+    delete process.env[ENV_VAR];
+  });
+  afterEach(() => {
+    delete process.env[ENV_VAR];
+  });
+
+  test("$VAR and ${VAR} still resolve from process.env", () => {
+    process.env[ENV_VAR] = "from-env";
+    expect(resolveSecret(`$${ENV_VAR}`)).toBe("from-env");
+    expect(resolveSecret(`\${${ENV_VAR}}`)).toBe("from-env");
+  });
+
+  test("a literal value (no $ marker) passes through unchanged", () => {
+    expect(resolveSecret("sk-literal-value")).toBe("sk-literal-value");
+  });
+
+  test("undefined passes through unchanged", () => {
+    expect(resolveSecret(undefined)).toBeUndefined();
+  });
+
+  test("secret:// resolves through the injected store resolver", () => {
+    const resolved = resolveSecret("secret://lab-api-key", (ref) => (ref === "lab-api-key" ? "store-value" : null));
+    expect(resolved).toBe("store-value");
+  });
+
+  test("secret:// with no matching stored value throws an actionable ConfigError, never the ref's value", () => {
+    let caught: unknown;
+    try {
+      resolveSecret("secret://missing-key", () => null);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ConfigError);
+    const err = caught as ConfigError;
+    expect(err.code).toBe("SECRET_REFERENCE_UNRESOLVED");
+    expect(err.message).toContain("secret://missing-key");
+    expect(err.hint()).toBeDefined();
+  });
+
+  test("secret:// with no resolver supplied throws rather than sending the raw ref as the credential", () => {
+    expect(() => resolveSecret("secret://lab-api-key")).toThrow(ConfigError);
+  });
+});

--- a/tests/workflows/unit-schema-warning.test.ts
+++ b/tests/workflows/unit-schema-warning.test.ts
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import { describe, expect, test } from "bun:test";
-import { reduceStepOutcomes, unitSchemaWarning, type UnitOutcome } from "../../src/workflows/exec/step-work";
+import { reduceStepOutcomes, type UnitOutcome, unitSchemaWarning } from "../../src/workflows/exec/step-work";
 import type { IrStepPlanV4 } from "../../src/workflows/ir/schema-v4";
 
 const SCHEMA = {

--- a/tests/workflows/unit-schema-warning.test.ts
+++ b/tests/workflows/unit-schema-warning.test.ts
@@ -1,0 +1,96 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { describe, expect, test } from "bun:test";
+import { reduceStepOutcomes, unitSchemaWarning, type UnitOutcome } from "../../src/workflows/exec/step-work";
+import type { IrStepPlanV4 } from "../../src/workflows/ir/schema-v4";
+
+const SCHEMA = {
+  type: "object",
+  properties: {
+    verified: { type: "boolean" },
+    research_path: { type: "string", minLength: 1 },
+  },
+  required: ["verified", "research_path"],
+};
+
+function planWithUnitSchema(schema?: Record<string, unknown>): IrStepPlanV4 {
+  return {
+    stepId: "research",
+    title: "research",
+    sequenceIndex: 0,
+    gate: { kind: "gate", id: "research.gate", stepId: "research", criteria: [] },
+    root: { kind: "agent", id: "research.unit", instructions: "", onError: "fail", ...(schema ? { schema } : {}) },
+  } as unknown as IrStepPlanV4;
+}
+
+describe("unitSchemaWarning — advisory per-unit output check", () => {
+  test("no declared unit schema: nothing to check", () => {
+    const plan = planWithUnitSchema(undefined);
+    const units: UnitOutcome[] = [{ unitId: "u1", ok: true, text: "anything at all" }];
+    expect(unitSchemaWarning(plan, units)).toBeUndefined();
+  });
+
+  test("a compliant structured result produces no warning", () => {
+    const plan = planWithUnitSchema(SCHEMA);
+    const units: UnitOutcome[] = [{ unitId: "u1", ok: true, result: { verified: true, research_path: "WORK/r.json" } }];
+    expect(unitSchemaWarning(plan, units)).toBeUndefined();
+  });
+
+  test("free text embedding JSON that omits a required field is caught and named", () => {
+    const plan = planWithUnitSchema(SCHEMA);
+    const units: UnitOutcome[] = [
+      {
+        unitId: "research",
+        ok: true,
+        text: 'Dispatched but could not find manifest.json.\n```json\n{"verified": true, "positions_covered": 0}\n```',
+      },
+    ];
+    const warning = unitSchemaWarning(plan, units);
+    expect(warning).toBeDefined();
+    expect(warning).toContain('unit "research"');
+    expect(warning).toContain("research_path");
+    expect(warning).toContain("advisory");
+  });
+
+  test("output with no parseable structure at all is flagged too", () => {
+    const plan = planWithUnitSchema(SCHEMA);
+    const units: UnitOutcome[] = [{ unitId: "u1", ok: true, text: "report creation was blocked" }];
+    const warning = unitSchemaWarning(plan, units);
+    expect(warning).toContain('unit "u1" produced no structured output');
+  });
+
+  test("a failed unit is never checked against the schema", () => {
+    const plan = planWithUnitSchema(SCHEMA);
+    const units: UnitOutcome[] = [{ unitId: "u1", ok: false, failureReason: "dispatch_error" }];
+    expect(unitSchemaWarning(plan, units)).toBeUndefined();
+  });
+});
+
+describe("reduceStepOutcomes — the schema warning never fails the run", () => {
+  test("a mismatching unit's step still completes ok, with the warning appended to the summary", () => {
+    const plan = planWithUnitSchema(SCHEMA);
+    const units: UnitOutcome[] = [{ unitId: "research", ok: true, result: { verified: true, positions_covered: 0 } }];
+    const outcome = reduceStepOutcomes(plan, "collect", false, "fail", units);
+    expect(outcome.ok).toBe(true);
+    expect(outcome.artifactSchemaFailure).toBeUndefined();
+    expect(outcome.summary).toContain("research_path");
+    expect(outcome.summary).toContain("advisory");
+  });
+
+  test("a matching unit's step completes ok with no warning text in the summary", () => {
+    const plan = planWithUnitSchema(SCHEMA);
+    const units: UnitOutcome[] = [{ unitId: "research", ok: true, result: { verified: true, research_path: "x" } }];
+    const outcome = reduceStepOutcomes(plan, "collect", false, "fail", units);
+    expect(outcome.ok).toBe(true);
+    expect(outcome.summary).not.toContain("advisory");
+  });
+
+  test("a step with no declared unit schema is unchanged", () => {
+    const plan = planWithUnitSchema(undefined);
+    const units: UnitOutcome[] = [{ unitId: "u1", ok: true, result: { anything: 1 } }];
+    const outcome = reduceStepOutcomes(plan, "collect", false, "fail", units);
+    expect(outcome.summary).not.toContain("advisory");
+  });
+});


### PR DESCRIPTION
## Summary

Seven of the nine issues on milestone 0.9.13. Two are deliberately held — see below.

- **#922** — every list-returning command exposes its collection under a stable `results` key alongside its semantic one (`hits`, `items`, `proposals`, …), in every shape including `--shape agent`. Same array, not a copy. Eleven commands covered, not the five named in the issue; `health` and `task doctor` are excluded because they carry several heterogeneous collections and picking one would be arbitrary.
- **#917** — `apiKey` accepts `secret://<name>` alongside `$VAR`/`${VAR}`, resolved through the existing store-backed resolver, on both the engine and embedding paths. Literal keys in `config.json` are still refused; an unresolvable reference fails loudly, naming the reference and never the secret.
- **#921** — `proposal drain` reports a `failed[]` naming each refused proposal and why, instead of `failed: 0` alongside five stderr failures. `--dry-run` applies the same stale-target check as the real run, so the two stop disagreeing. `akm improve`'s triage pre-pass reports the same count. The refusals themselves were always correct and are unchanged.
- **#923** — a step whose returned object does not match its declared `outputSchema` now says so, naming the step and the specific problem. A warning: the run continues and its status is unchanged, because a workflow is a guide rather than a contract.
- **#924** — a held run lease reports as itself at default verbosity with a dedicated `RUN_LEASE_HELD` code, rather than as `database is locked` / `disk image is malformed` / `disk I/O error`. Genuine SQLite errors still report as themselves.
- **#927** — `akm lint` recognises templated output paths (`<timestamp>`, `{stamp}`, `${VAR}`, `YYYYMMDD`, globs) as parameterised rather than broken. Genuinely missing literal paths are still reported.
- **#926** — the `workflow create` template states the level-2-heading rule, and the compiler's rejection now carries the remedy rather than only the diagnosis.

## Held back: #929 and #930

Both change retrieval and are measurable only against the external LongMemEval corpus, which cannot be run in this environment, so they are being evaluated together rather than shipped blind. #930 was deferred by decision before work started; #929 was implemented and then held on evidence. The work is preserved on `issue/0.9.13-search` at `8c61f1f0`.

Investigation after this PR opened found the two issues are **the same failure — candidate starvation, not ranking**. Both cite the same "1.11 results retrieved" figure, and #930's own text says the needed document "was never a candidate at all rather than being ranked too low". Because `runFtsQuery` ends in `ORDER BY bm25Score, e.id ASC LIMIT ?`, #930's 10:1 title-to-body weighting gates which rows are returned at all, not merely their order — it is a recall lever, not a ranking preference.

It also identified a defect underneath both, which neither issue names. `normalizeFtsScores` (`ranking.ts:71-86`) reads `results[0]` and `results[length-1]` as best/worst, assuming a sorted array — that assumption is what forced synthetic bm25 offsets in the #929 attempt — and then min-max normalizes over the candidate set, so a document's score depends on what else matched. Measured: three additional weak candidates compress leader separation by 85% and push mid-pack scores toward the 1.0 clamp in `db-search.ts:577`. `ranking-contributors.ts:165-186` already documents this pathology and works around it with hard-coded belief-state score ceilings.

The two failing tests are not equivalent, and an earlier revision of this description overstated them as both being ranking-quality tradeoffs:

- `graph-boost-ranking` "maxHops=2" is a real defect exposed by the change: it fails with `oneHopScore` and `twoHopScore` **both exactly `1`** — the base score saturates the clamp, leaving the boost no headroom to differentiate. Reachable today with a narrower pool, just less often.
- `improve-memory` "prefers the current derived memory" **still passes its headline assertion at position 0**. Only the runner-up changed, because a previously starved parent memory now legitimately surfaces. That assertion encodes the starvation and should be rewritten, not treated as a regression.

Fix order, once the corpus is available: repair the normalization first (it is the prerequisite, and it lets the synthetic offsets be deleted), then #929's union becomes safe, then #930's weights measured as a recall change.

## Test plan

- `bun run lint`, `bunx tsc --noEmit`, `bun run test:unit`, full `bun run test:integration` green on the candidate.
- Release candidate evidence (exact SHA, Gated CI run, local `./tests/release-check.sh --skip-docker`) posted as a comment and refreshed on every candidate.

Do not merge until the evidence comment names the current head. Publishing is a separate step (Release workflow with `version: 0.9.13`) and is not part of this PR.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Lint passes (`bun run lint`)
- [x] Docs updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdS26JcJ5A9Hqxxe3jo31x