### PR TITLE
fix(search): order clamped relaxed candidates by their pre-clamp score

### DIFF
--- a/src/indexer/search/db-search.ts
+++ b/src/indexer/search/db-search.ts
@@ -327,6 +327,11 @@ function buildSearchResultComparator(query: string): (a: RankedEntryInput, b: Ra
     if (scoreDiff !== 0) return scoreDiff;
     const rawScoreDiff = stableRankScore(b.score) - stableRankScore(a.score);
     if (rawScoreDiff !== 0) return rawScoreDiff;
+    // Both scores were clamped to the same ceiling. Order by what they scored
+    // BEFORE the clamp rather than falling through to the alphabetical
+    // filePath tie-break, which is not a relevance signal at all.
+    const ceilingDiff = stableRankScore(b.preCeilingScore ?? b.score) - stableRankScore(a.preCeilingScore ?? a.score);
+    if (ceilingDiff !== 0) return ceilingDiff;
     const nameDiff = bNameTier - aNameTier;
     if (nameDiff !== 0) return nameDiff;
     const typeDiff = typeBoostFor(b.entry.type) - typeBoostFor(a.entry.type);

--- a/src/indexer/search/ranking.ts
+++ b/src/indexer/search/ranking.ts
@@ -232,8 +232,21 @@ export function lexicalNameMatchTier(entry: IndexDocument, queryTokens: string[]
  * A relaxed OR query admits intentionally weak candidates. Candidates with no
  * query token in their name remain visible for body-only recall, but cannot
  * saturate at the same displayed score as stronger name-bearing recoveries.
+ *
+ * The pre-clamp score is recorded as `preCeilingScore` (the same idiom
+ * `applyBeliefStateScoreCeiling` uses) so the clamp demotes without also
+ * DESTROYING the relative order of what it demotes. On a corpus whose names
+ * carry no query tokens at all — any conversational or memory corpus, where
+ * `name` is an opaque id — every candidate clamps to the identical ceiling,
+ * every comparison inside the clamped set falls through to the alphabetical
+ * `filePath` tie-break, and the ranking stops measuring relevance entirely.
+ * Measured on the LoCoMo probe before this fix: 109 of 200 returned hits
+ * scored exactly 0.65 and 24 of 40 questions had a fully tied top-5.
  */
 function applyRelaxedLexicalScoreCeiling(item: RankedEntryInput, queryTokens: string[]): void {
   if (item.lexicalMatch !== "relaxed" || lexicalNameMatchTier(item.entry, queryTokens) > 0) return;
-  item.score = Math.min(item.score, RELAXED_NON_NAME_SCORE_CEILING);
+  if (item.score > RELAXED_NON_NAME_SCORE_CEILING) {
+    item.preCeilingScore = item.score;
+    item.score = RELAXED_NON_NAME_SCORE_CEILING;
+  }
 }

--- a/tests/scoring-pipeline.test.ts
+++ b/tests/scoring-pipeline.test.ts
@@ -561,6 +561,50 @@ describe("Issue #14: Deterministic sort on tied scores", () => {
   });
 });
 
+describe("Issue #930: the relaxed non-name ceiling must not flatten body ranking", () => {
+  test("clamped candidates order by body relevance, not by filename", async () => {
+    const stashDir = tmpStash();
+
+    // Every name here is an opaque id carrying NO query token, so
+    // `applyRelaxedLexicalScoreCeiling` clamps all three to the SAME ceiling.
+    // Before the pre-clamp tie-break, every comparison then fell through to
+    // the alphabetical filePath compare and "aaa" won regardless of content —
+    // which is how a corpus of dialogue turns (LoCoMo, LongMemEval) lost its
+    // ranking entirely: 24 of 40 probe questions came back fully tied.
+    //
+    // No document carries all three query tokens, so the exact and prefix
+    // tiers come back empty and every candidate is admitted on the relaxed
+    // tier — the one the ceiling applies to. Alphabetical order is
+    // aaa < mmm < zzz; body relevance is the exact reverse.
+    writeFile(
+      path.join(stashDir, "knowledge", "aaa-id.md"),
+      "---\ndescription: A note that mentions kestrel once and nothing more\n---\n",
+    );
+    writeFile(
+      path.join(stashDir, "knowledge", "mmm-id.md"),
+      "---\ndescription: A note about kestrel migration over open water\n---\n",
+    );
+    writeFile(
+      path.join(stashDir, "knowledge", "zzz-id.md"),
+      "---\ndescription: kestrel migration and kestrel migration and kestrel migration again\n---\n",
+    );
+
+    await withTestIndex(stashDir, async () => {
+      const result = await akmSearch({ query: "kestrel migration ecology", source: "local", skipLogging: true });
+      const order = result.hits
+        .filter((h): h is SourceSearchHit => h.type !== "registry")
+        .map((h) => h.name)
+        .filter((n) => n.endsWith("-id"));
+
+      expect(order.length).toBe(3);
+      // The densest body match must lead. Asserting the exact inverse of
+      // alphabetical order is the point: if the ceiling ever flattens the
+      // ranking again, this comes back as ["aaa-id", ...].
+      expect(order).toEqual(["zzz-id", "mmm-id", "aaa-id"]);
+    });
+  });
+});
+
 // ── Issue #15: "semantic" label for hybrid results ──────────────────────────
 
 describe("Issue #15: Hybrid ranking mode label", () => {


### PR DESCRIPTION
Closes #940. Unblocks #930.

## Problem

`applyRelaxedLexicalScoreCeiling` clamps relaxed-tier candidates whose name holds no query token to `RELAXED_NON_NAME_SCORE_CEILING = 0.65` and throws the pre-clamp score away. On a corpus where *no* name holds a query token — any conversational or memory corpus, and both benchmark packs — every candidate clamps to the same value and `buildSearchResultComparator` falls through to `a.filePath.localeCompare(b.filePath)`.

Measured on the LoCoMo probe at 0.9.13: **109 of the returned hits scored exactly 0.65, and 24 of 40 questions had a fully tied top-5.** Filename order was deciding ~60% of the pack.

## Change

Two files, 20 lines. The ceiling records `preCeilingScore` (the idiom `applyBeliefStateScoreCeiling` already uses), and the comparator orders on it before reaching the filename compare.

**Displayed scores are unchanged** — only the order within an already-clamped set moves. That is why no existing score assertion shifts.

## Measured effect

LoCoMo retrieval probe, published 0.9.13 → this branch:

| metric | 0.9.13 | this branch | change |
|---|---|---|---|
| evidenceRecall@5 | 0.564 | **0.692** | +22.7% |
| recall@5 | 0.485417 | **0.591667** | +21.9% |
| precision@5 | 0.227917 | **0.257917** | +13.2% |
| MRR | 0.36625 | **0.4725** | +29.0% |
| nDCG@5 | 0.380024 | **0.492014** | +29.5% |

LongMemEval unchanged on every metric (0.95 / 0.676667 / 0.95). Three consecutive probe runs on this branch are identical to every digit.

Recall improves as well as ordering because the clamped pool is reordered *before* truncation to top-K, so better candidates now survive the cut.

## Tests

New red-checked regression test in `tests/scoring-pipeline.test.ts`, alongside the existing "Issue #14: Deterministic sort on tied scores" block. Three documents whose names carry no query token and whose body relevance is the exact inverse of alphabetical order; it fails on `main` and passes here.

Full suite compared against clean `origin/main`:

- `origin/main` (1cd0ee4b): 139 pass, **5 fail**
- this branch: 140 pass, **4 fail**

The failures are a strict subset — all pre-existing (two workflow canonical-ref collisions, one `resolveJudge` freeze, one SSRF DNS case) plus one network flake that happened not to fire on this run. **No new failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5kmHWR6yvkSMEpFGCMEnt